### PR TITLE
feat: add v1 agent-scoped memory scope for LCM tools

### DIFF
--- a/src/plugins/agent-memory-scope/config.ts
+++ b/src/plugins/agent-memory-scope/config.ts
@@ -1,0 +1,34 @@
+export type AgentMemoryScopeOptions = {
+  baseEngine: "lcm";
+  defaultScope: "current" | "agent";
+  allowAgentScope: boolean;
+  maxAgentConversations: number;
+  maxScopeResults: number;
+  sortAgentConversationsBy: "updated_at" | "created_at";
+};
+
+export const DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS: AgentMemoryScopeOptions = {
+  baseEngine: "lcm",
+  defaultScope: "current",
+  allowAgentScope: true,
+  maxAgentConversations: 200,
+  maxScopeResults: 200,
+  sortAgentConversationsBy: "updated_at",
+};
+
+export function resolveAgentMemoryScopeOptions(
+  raw?: Partial<AgentMemoryScopeOptions>,
+): AgentMemoryScopeOptions {
+  return {
+    ...DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS,
+    ...(raw ?? {}),
+    maxAgentConversations: Math.max(
+      1,
+      Math.floor(raw?.maxAgentConversations ?? DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.maxAgentConversations),
+    ),
+    maxScopeResults: Math.max(
+      1,
+      Math.floor(raw?.maxScopeResults ?? DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.maxScopeResults),
+    ),
+  };
+}

--- a/src/plugins/agent-memory-scope/index.ts
+++ b/src/plugins/agent-memory-scope/index.ts
@@ -1,0 +1,11 @@
+export {
+  DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS,
+  resolveAgentMemoryScopeOptions,
+  type AgentMemoryScopeOptions,
+} from "./config.js";
+export {
+  resolveAgentScopedConversations,
+  type AgentScopeResolutionInput,
+  type AgentScopeResolutionResult,
+} from "./scope-resolver.js";
+export { makeScopeResultProvenance, type ScopeResultProvenance } from "./provenance.js";

--- a/src/plugins/agent-memory-scope/provenance.ts
+++ b/src/plugins/agent-memory-scope/provenance.ts
@@ -1,0 +1,23 @@
+import type { SessionMeta } from "../../types.js";
+
+export type ScopeResultProvenance = {
+  conversationId: number;
+  sessionId?: string;
+  sessionKey?: string;
+  channel?: string;
+  chatType?: string;
+};
+
+export function makeScopeResultProvenance(params: {
+  conversationId: number;
+  sessionId?: string;
+  meta?: SessionMeta;
+}): ScopeResultProvenance {
+  return {
+    conversationId: params.conversationId,
+    sessionId: params.sessionId,
+    sessionKey: params.meta?.sessionKey,
+    channel: params.meta?.channel,
+    chatType: params.meta?.chatType,
+  };
+}

--- a/src/plugins/agent-memory-scope/register.ts
+++ b/src/plugins/agent-memory-scope/register.ts
@@ -1,0 +1,9 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { LcmContextEngine } from "../../engine.js";
+
+/**
+ * Register the alias context engine id used by the OpenClaw integration branch.
+ */
+export function registerAgentMemoryScopeContextEngine(api: OpenClawPluginApi, lcm: LcmContextEngine): void {
+  api.registerContextEngine("agent-memory-scope", () => lcm);
+}

--- a/src/plugins/agent-memory-scope/scope-resolver.ts
+++ b/src/plugins/agent-memory-scope/scope-resolver.ts
@@ -1,0 +1,121 @@
+import type { LcmContextEngine } from "../../engine.js";
+import type { LcmDependencies } from "../../types.js";
+import type { ScopeResultProvenance } from "./provenance.js";
+import { makeScopeResultProvenance } from "./provenance.js";
+
+export type AgentScopeResolutionInput = {
+  deps?: Pick<
+    LcmDependencies,
+    | "resolveAgentIdFromSessionKey"
+    | "listAgentSessionIds"
+    | "resolveSessionMeta"
+    | "normalizeAgentId"
+  >;
+  lcm: LcmContextEngine;
+  sessionKey?: string;
+  agentIdOverride?: string;
+  maxAgentConversations: number;
+  sortBy: "updated_at" | "created_at";
+};
+
+export type AgentScopeResolutionResult = {
+  conversationIds: number[];
+  agentId?: string;
+  provenance: ScopeResultProvenance[];
+  fallbackReason?: string;
+};
+
+export async function resolveAgentScopedConversations(
+  input: AgentScopeResolutionInput,
+): Promise<AgentScopeResolutionResult> {
+  const explicitAgentId = input.agentIdOverride?.trim();
+
+  let resolvedAgentId = explicitAgentId;
+  if (!resolvedAgentId && input.sessionKey && input.deps?.resolveAgentIdFromSessionKey) {
+    resolvedAgentId = await input.deps.resolveAgentIdFromSessionKey(input.sessionKey.trim());
+  }
+  const normalizedAgentId = input.deps?.normalizeAgentId
+    ? input.deps.normalizeAgentId(resolvedAgentId)
+    : resolvedAgentId?.trim();
+
+  if (!normalizedAgentId) {
+    return {
+      conversationIds: [],
+      provenance: [],
+      fallbackReason: "agent-id-unresolved",
+    };
+  }
+
+  if (!input.deps?.listAgentSessionIds) {
+    return {
+      conversationIds: [],
+      agentId: normalizedAgentId,
+      provenance: [],
+      fallbackReason: "list-agent-sessions-unavailable",
+    };
+  }
+
+  const sessionIds = Array.from(
+    new Set(
+      (await input.deps.listAgentSessionIds(normalizedAgentId))
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (sessionIds.length === 0) {
+    return {
+      conversationIds: [],
+      agentId: normalizedAgentId,
+      provenance: [],
+      fallbackReason: "agent-has-no-sessions",
+    };
+  }
+
+  const conversationStore = input.lcm.getConversationStore();
+  const mapped = await Promise.all(
+    sessionIds.map(async (sessionId) => {
+      const conversation = await conversationStore.getConversationBySessionId(sessionId);
+      if (!conversation) {
+        return undefined;
+      }
+      const meta = input.deps?.resolveSessionMeta
+        ? await input.deps.resolveSessionMeta(conversation.sessionId)
+        : undefined;
+      return {
+        conversation,
+        provenance: makeScopeResultProvenance({
+          conversationId: conversation.conversationId,
+          sessionId: conversation.sessionId,
+          meta,
+        }),
+      };
+    }),
+  );
+
+  const rows = mapped.filter(
+    (value): value is { conversation: { conversationId: number; createdAt: Date; updatedAt: Date }; provenance: ScopeResultProvenance } =>
+      Boolean(value),
+  );
+
+  rows.sort((a, b) => {
+    const aTs =
+      input.sortBy === "created_at"
+        ? a.conversation.createdAt.getTime()
+        : a.conversation.updatedAt.getTime();
+    const bTs =
+      input.sortBy === "created_at"
+        ? b.conversation.createdAt.getTime()
+        : b.conversation.updatedAt.getTime();
+    return bTs - aTs;
+  });
+
+  const limited = rows.slice(0, Math.max(1, input.maxAgentConversations));
+
+  return {
+    conversationIds: limited.map((row) => row.conversation.conversationId),
+    agentId: normalizedAgentId,
+    provenance: limited.map((row) => row.provenance),
+    fallbackReason: limited.length === 0 ? "agent-conversations-empty" : undefined,
+  };
+}

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -44,6 +44,7 @@ export interface GrepInput {
   mode: "regex" | "full_text";
   scope: "messages" | "summaries" | "both";
   conversationId?: number;
+  conversationIds?: number[];
   since?: Date;
   before?: Date;
   limit?: number;
@@ -179,9 +180,9 @@ export class RetrievalEngine {
    * Depending on `scope`, searches messages, summaries, or both (in parallel).
    */
   async grep(input: GrepInput): Promise<GrepResult> {
-    const { query, mode, scope, conversationId, since, before, limit } = input;
+    const { query, mode, scope, conversationId, conversationIds, since, before, limit } = input;
 
-    const searchInput = { query, mode, conversationId, since, before, limit };
+    const searchInput = { query, mode, conversationId, conversationIds, since, before, limit };
 
     let messages: MessageSearchResult[] = [];
     let summaries: SummarySearchResult[] = [];

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -1,9 +1,19 @@
+import {
+  DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS,
+  resolveAgentScopedConversations,
+  type ScopeResultProvenance,
+} from "../plugins/agent-memory-scope/index.js";
 import type { LcmContextEngine } from "../engine.js";
 import type { LcmDependencies } from "../types.js";
 
 export type LcmConversationScope = {
   conversationId?: number;
+  conversationIds?: number[];
   allConversations: boolean;
+  mode: "current" | "agent" | "all" | "explicit";
+  agentId?: string;
+  warnings: string[];
+  provenance: ScopeResultProvenance[];
 };
 
 /**
@@ -36,14 +46,23 @@ export function parseIsoTimestampParam(
  * Priority:
  * 1. Explicit conversationId parameter
  * 2. allConversations=true (cross-conversation mode)
- * 3. Current session's LCM conversation
+ * 3. requestedScope=agent (same-agent cross-conversation mode)
+ * 4. Current session's LCM conversation
  */
 export async function resolveLcmConversationScope(input: {
   lcm: LcmContextEngine;
   params: Record<string, unknown>;
+  requestedScope?: "current" | "agent";
   sessionId?: string;
   sessionKey?: string;
-  deps?: Pick<LcmDependencies, "resolveSessionIdFromSessionKey">;
+  deps?: Pick<
+    LcmDependencies,
+    | "resolveSessionIdFromSessionKey"
+    | "resolveAgentIdFromSessionKey"
+    | "listAgentSessionIds"
+    | "resolveSessionMeta"
+    | "normalizeAgentId"
+  >;
 }): Promise<LcmConversationScope> {
   const { lcm, params } = input;
 
@@ -52,25 +71,113 @@ export async function resolveLcmConversationScope(input: {
       ? Math.trunc(params.conversationId)
       : undefined;
   if (explicitConversationId != null) {
-    return { conversationId: explicitConversationId, allConversations: false };
+    return {
+      conversationId: explicitConversationId,
+      allConversations: false,
+      mode: "explicit",
+      warnings: [],
+      provenance: [{ conversationId: explicitConversationId }],
+    };
   }
 
   if (params.allConversations === true) {
-    return { conversationId: undefined, allConversations: true };
+    return {
+      conversationId: undefined,
+      allConversations: true,
+      mode: "all",
+      warnings: [],
+      provenance: [],
+    };
   }
+
+  const requestedScope = input.requestedScope ?? DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.defaultScope;
+  const warnings: string[] = [];
 
   let normalizedSessionId = input.sessionId?.trim();
   if (!normalizedSessionId && input.sessionKey && input.deps) {
     normalizedSessionId = await input.deps.resolveSessionIdFromSessionKey(input.sessionKey.trim());
   }
-  if (!normalizedSessionId) {
-    return { conversationId: undefined, allConversations: false };
+
+  const getCurrentConversationScope = async (): Promise<LcmConversationScope> => {
+    if (!normalizedSessionId) {
+      return {
+        conversationId: undefined,
+        allConversations: false,
+        mode: "current",
+        warnings,
+        provenance: [],
+      };
+    }
+
+    const conversation = await lcm
+      .getConversationStore()
+      .getConversationBySessionId(normalizedSessionId);
+    if (!conversation) {
+      return {
+        conversationId: undefined,
+        allConversations: false,
+        mode: "current",
+        warnings,
+        provenance: [],
+      };
+    }
+
+    const sessionMeta = input.deps?.resolveSessionMeta
+      ? await input.deps.resolveSessionMeta(conversation.sessionId)
+      : undefined;
+
+    return {
+      conversationId: conversation.conversationId,
+      allConversations: false,
+      mode: "current",
+      warnings,
+      provenance: [
+        {
+          conversationId: conversation.conversationId,
+          sessionId: conversation.sessionId,
+          sessionKey: sessionMeta?.sessionKey,
+          channel: sessionMeta?.channel,
+          chatType: sessionMeta?.chatType,
+        },
+      ],
+    };
+  };
+
+  if (!DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.allowAgentScope || requestedScope !== "agent") {
+    return getCurrentConversationScope();
   }
 
-  const conversation = await lcm.getConversationStore().getConversationBySessionId(normalizedSessionId);
-  if (!conversation) {
-    return { conversationId: undefined, allConversations: false };
+  const agentScope = await resolveAgentScopedConversations({
+    deps: input.deps,
+    lcm,
+    sessionKey: input.sessionKey,
+    agentIdOverride: typeof params.agentId === "string" ? params.agentId : undefined,
+    maxAgentConversations: DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.maxAgentConversations,
+    sortBy: DEFAULT_AGENT_MEMORY_SCOPE_OPTIONS.sortAgentConversationsBy,
+  });
+
+  if (agentScope.conversationIds.length > 0) {
+    return {
+      conversationId: undefined,
+      conversationIds: agentScope.conversationIds,
+      allConversations: false,
+      mode: "agent",
+      agentId: agentScope.agentId,
+      warnings,
+      provenance: agentScope.provenance,
+    };
   }
 
-  return { conversationId: conversation.conversationId, allConversations: false };
+  warnings.push(
+    "No conversations found for inferred agent scope; falling back to current conversation.",
+  );
+  if (agentScope.fallbackReason) {
+    warnings.push(`Agent scope fallback reason: ${agentScope.fallbackReason}.`);
+  }
+
+  const current = await getCurrentConversationScope();
+  return {
+    ...current,
+    warnings,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,12 @@ export type ParseAgentSessionKeyFn = (sessionKey: string) => {
 
 export type IsSubagentSessionKeyFn = (sessionKey: string) => boolean;
 
+export type SessionMeta = {
+  sessionKey?: string;
+  channel?: string;
+  chatType?: string;
+};
+
 /**
  * Dependencies injected into the LCM engine at registration time.
  * These replace all direct imports from OpenClaw core.
@@ -110,6 +116,12 @@ export interface LcmDependencies {
 
   /** Resolve runtime session id from an agent session key */
   resolveSessionIdFromSessionKey: (sessionKey: string) => Promise<string | undefined>;
+  /** Resolve runtime agent id from an agent session key */
+  resolveAgentIdFromSessionKey?: (sessionKey: string) => Promise<string | undefined>;
+  /** List runtime session ids for one agent */
+  listAgentSessionIds?: (agentId: string) => Promise<string[]>;
+  /** Resolve optional session metadata for provenance fields */
+  resolveSessionMeta?: (sessionId: string) => Promise<SessionMeta | undefined>;
 
   /** Agent lane constant for subagents */
   agentLaneSubagent: string;

--- a/test/agent-memory-scope.test.ts
+++ b/test/agent-memory-scope.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
+import { resolveLcmConversationScope } from "../src/tools/lcm-conversation-scope.js";
+import type { LcmDependencies } from "../src/types.js";
+
+function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 120,
+      largeFileTokenThreshold: 25_000,
+      autocompactDisabled: false,
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+    },
+    complete: vi.fn(),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: () => ({ provider: "anthropic", model: "claude-opus-4-5" }),
+    getApiKey: () => undefined,
+    requireApiKey: () => "",
+    parseAgentSessionKey: (sessionKey: string) => {
+      const trimmed = sessionKey.trim();
+      if (!trimmed.startsWith("agent:")) {
+        return null;
+      }
+      const parts = trimmed.split(":");
+      if (parts.length < 3) {
+        return null;
+      }
+      return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+    },
+    isSubagentSessionKey: () => false,
+    normalizeAgentId: (id?: string) => (id?.trim() ? id.trim() : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => "/tmp/openclaw-agent",
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveAgentIdFromSessionKey: async () => undefined,
+    listAgentSessionIds: async () => [],
+    resolveSessionMeta: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    ...overrides,
+  } as LcmDependencies;
+}
+
+describe("agent memory scope resolver", () => {
+  it("resolves scope=agent across same-agent conversations", async () => {
+    const conversationStore = {
+      getConversationBySessionId: vi.fn(async (sessionId: string) => {
+        if (sessionId === "sid-1") {
+          return {
+            conversationId: 11,
+            sessionId,
+            title: null,
+            bootstrappedAt: null,
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+          };
+        }
+        if (sessionId === "sid-2") {
+          return {
+            conversationId: 22,
+            sessionId,
+            title: null,
+            bootstrappedAt: null,
+            createdAt: new Date("2026-01-03T00:00:00.000Z"),
+            updatedAt: new Date("2026-01-04T00:00:00.000Z"),
+          };
+        }
+        return null;
+      }),
+    };
+
+    const deps = makeDeps({
+      resolveAgentIdFromSessionKey: async () => "alpha",
+      listAgentSessionIds: async () => ["sid-1", "sid-2"],
+      resolveSessionMeta: async (sessionId: string) => ({
+        sessionKey: `agent:alpha:${sessionId}`,
+        channel: "matrix",
+        chatType: "dm",
+      }),
+    });
+
+    const result = await resolveLcmConversationScope({
+      lcm: {
+        getConversationStore: () => conversationStore,
+      } as never,
+      deps,
+      params: {},
+      sessionKey: "agent:alpha:main",
+      requestedScope: "agent",
+    });
+
+    expect(result.mode).toBe("agent");
+    expect(result.agentId).toBe("alpha");
+    expect(result.conversationIds).toEqual([22, 11]);
+    expect(result.provenance[0]).toMatchObject({
+      conversationId: 22,
+      sessionId: "sid-2",
+      sessionKey: "agent:alpha:sid-2",
+      channel: "matrix",
+      chatType: "dm",
+    });
+  });
+
+  it("falls back to current conversation when agent scope is empty", async () => {
+    const deps = makeDeps({
+      resolveSessionIdFromSessionKey: async () => "sid-current",
+      resolveAgentIdFromSessionKey: async () => "alpha",
+      listAgentSessionIds: async () => [],
+    });
+
+    const result = await resolveLcmConversationScope({
+      lcm: {
+        getConversationStore: () => ({
+          getConversationBySessionId: vi.fn(async () => ({
+            conversationId: 7,
+            sessionId: "sid-current",
+            title: null,
+            bootstrappedAt: null,
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          })),
+        }),
+      } as never,
+      deps,
+      params: {},
+      sessionKey: "agent:alpha:main",
+      requestedScope: "agent",
+    });
+
+    expect(result.mode).toBe("current");
+    expect(result.conversationId).toBe(7);
+    expect(result.warnings.join(" ")).toContain("falling back to current conversation");
+  });
+});
+
+describe("lcm_grep agent memory scope", () => {
+  it("passes conversationIds to retrieval and returns scope/provenance details", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+    };
+
+    const deps = makeDeps({
+      resolveAgentIdFromSessionKey: async () => "alpha",
+      listAgentSessionIds: async () => ["sid-1", "sid-2"],
+      resolveSessionMeta: async (sessionId: string) => ({
+        sessionKey: `agent:alpha:${sessionId}`,
+        channel: "telegram",
+      }),
+    });
+
+    const tool = createLcmGrepTool({
+      deps,
+      lcm: {
+        getRetrieval: () => retrieval,
+        getConversationStore: () => ({
+          getConversationBySessionId: vi.fn(async (sessionId: string) => {
+            if (sessionId === "sid-1") {
+              return {
+                conversationId: 101,
+                sessionId,
+                title: null,
+                bootstrappedAt: null,
+                createdAt: new Date("2026-01-01T00:00:00.000Z"),
+                updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+              };
+            }
+            if (sessionId === "sid-2") {
+              return {
+                conversationId: 102,
+                sessionId,
+                title: null,
+                bootstrappedAt: null,
+                createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+              };
+            }
+            return null;
+          }),
+        }),
+      } as never,
+      sessionKey: "agent:alpha:main",
+    });
+
+    const result = await tool.execute("call-agent-scope", {
+      pattern: "deploy",
+      scope: "agent",
+      searchScope: "summaries",
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "summaries",
+        conversationIds: [102, 101],
+        conversationId: undefined,
+      }),
+    );
+
+    expect(result.details).toMatchObject({
+      scope: {
+        mode: "agent",
+        conversationIds: [102, 101],
+        agentId: "alpha",
+      },
+      provenance: [
+        expect.objectContaining({ conversationId: 102, sessionId: "sid-2", channel: "telegram" }),
+        expect.objectContaining({ conversationId: 101, sessionId: "sid-1", channel: "telegram" }),
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add initial agent-scoped memory plugin helpers under `src/plugins/agent-memory-scope`
- extend scope resolution and retrieval/store paths to support same-agent multi-conversation lookups
- add/adjust tests for agent scope and expand-query behavior

## Test
- `npx vitest run test/agent-memory-scope.test.ts test/lcm-tools.test.ts test/lcm-expand-query-tool.test.ts`

## Notes
- default behavior remains unchanged when scope is omitted
- follow-up can wire runtime config knobs (`allowAgentScope`, `maxAgentConversations`) from OpenClaw
