### PR TITLE
fix: move pi-ai and pi-agent-core from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
     "@sinclair/typebox": "0.34.48"
   },
   "devDependencies": {
@@ -31,9 +33,7 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": "*",
-    "@mariozechner/pi-agent-core": "*",
-    "@mariozechner/pi-ai": "*"
+    "openclaw": "*"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
Fixes #7

OpenClaw's plugin installer runs `npm install --omit=peer`, so plugin peer dependencies are never installed. Plugins also live in an isolated directory, so Node resolves `await import("@mariozechner/pi-ai")` from the plugin filesystem location and cannot reach packages installed with the host app.

This moves `@mariozechner/pi-ai` and `@mariozechner/pi-agent-core` into `dependencies` while keeping `openclaw` as a peer dependency.