### PR TITLE
fix: move pi-ai and pi-agent-core from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
     "@sinclair/typebox": "0.34.48"
   },
   "devDependencies": {
@@ -31,9 +33,7 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": "*",
-    "@mariozechner/pi-agent-core": "*",
-    "@mariozechner/pi-ai": "*"
+    "openclaw": "*"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
Fixes #7

## Problem

`index.ts` dynamically imports `@mariozechner/pi-ai` at runtime (`await import("@mariozechner/pi-ai")`). This package is listed as a `peerDependency`, but OpenClaw's plugin installer runs `npm install --omit=peer`, so it's never installed in the plugin directory.

Node's module resolution walks up the directory tree from the plugin's location (`~/.openclaw/extensions/lossless-claw/`), which never intersects with OpenClaw's global install path — regardless of whether the user installed via npm or bun. The dynamic `import()` is not intercepted by OpenClaw's jiti loader (jiti only aliases `openclaw/plugin-sdk` paths).

This causes every fresh install to fail with `Cannot find module '@mariozechner/pi-ai'`, and summarization silently falls back to deterministic truncation.

## Fix

Move `@mariozechner/pi-ai` and `@mariozechner/pi-agent-core` from `peerDependencies` to `dependencies`. `openclaw` correctly remains as a peer dep since its SDK paths are aliased by the host's jiti loader.

## Workaround (for users on current version)

```bash
cd ~/.openclaw/extensions/lossless-claw
npm install --ignore-scripts @mariozechner/pi-ai @mariozechner/pi-agent-core
openclaw gateway restart
```