### PR TITLE
fix: stop reporting live overflow as already under target

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1509,6 +1509,10 @@ export class LcmContextEngine implements ContextEngine {
         observedTokens !== undefined
           ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
           : await this.compaction.evaluate(conversationId, tokenBudget);
+      const targetTokens =
+        params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
+      const liveContextStillExceedsTarget =
+        observedTokens !== undefined && observedTokens >= targetTokens;
 
       if (!forceCompaction && !decision.shouldCompact) {
         return {
@@ -1533,27 +1537,28 @@ export class LcmContextEngine implements ContextEngine {
         });
 
         return {
-          ok: true,
+          ok: sweepResult.actionTaken || !liveContextStillExceedsTarget,
           compacted: sweepResult.actionTaken,
           reason: sweepResult.actionTaken
             ? "compacted"
             : manualCompactionRequested
               ? "nothing to compact"
-              : "already under target",
+              : liveContextStillExceedsTarget
+                ? "live context still exceeds target"
+                : "already under target",
           result: {
             tokensBefore: decision.currentTokens,
             tokensAfter: sweepResult.tokensAfter,
             details: {
               rounds: sweepResult.actionTaken ? 1 : 0,
-              targetTokens:
-                params.compactionTarget === "threshold" ? decision.threshold : tokenBudget,
+              targetTokens,
             },
           },
         };
       }
 
       // When forced, use the token budget as target
-      const targetTokens = forceCompaction
+      const convergenceTargetTokens = forceCompaction
         ? tokenBudget
         : params.compactionTarget === "threshold"
           ? decision.threshold
@@ -1562,7 +1567,7 @@ export class LcmContextEngine implements ContextEngine {
       const compactResult = await this.compaction.compactUntilUnder({
         conversationId,
         tokenBudget,
-        targetTokens,
+        targetTokens: convergenceTargetTokens,
         ...(observedTokens !== undefined ? { currentTokens: observedTokens } : {}),
         summarize,
       });
@@ -1581,7 +1586,7 @@ export class LcmContextEngine implements ContextEngine {
           tokensAfter: compactResult.finalTokens,
           details: {
             rounds: compactResult.rounds,
-            targetTokens,
+            targetTokens: convergenceTargetTokens,
           },
         },
       };

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1621,4 +1621,57 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.compacted).toBe(false);
     expect(result.reason).toBe("already under target");
   });
+
+  it("reports live overflow when a forced sweep cannot compact stored context", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 277_403,
+      threshold: 150_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 17_561,
+      tokensAfter: 17_561,
+      condensed: false,
+    });
+
+    await engine.ingest({
+      sessionId: "forced-sweep-live-overflow",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "forced-sweep-live-overflow",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 200_000,
+      currentTokenCount: 277_403,
+      force: true,
+      compactionTarget: "budget",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("live context still exceeds target");
+    expect(result.result?.tokensBefore).toBe(277_403);
+    expect(result.result?.tokensAfter).toBe(17_561);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        rounds: 0,
+        targetTokens: 200_000,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## What
This PR stops `lossless-claw` from reporting a forced no-op compaction sweep as "already under target" when the caller has observed a live prompt that still exceeds the model budget.

## Why
In the overflow case we investigated, the stored LCM context was small after summarization, but the live prompt sent to the model was still far over the context window because it contained very large tool payloads. A forced sweep that found nothing else to compact returned a benign success reason, which was false and made the failure hard to diagnose.

## Changes
- Preserve observed live token counts across forced sweep compaction
- Return a failing live-over-target reason for no-op forced sweeps
- Add targeted engine coverage for the forced live-overflow case

## Testing
- `pnpm install`
- `pnpm dlx tsx --eval '...engine.compact({ currentTokenCount: 277403, force: true, compactionTarget: "budget" })...'`
- Expected: result returns `ok: false` and `reason: "live context still exceeds target"`
- `pnpm vitest test/engine.test.ts -t "reports live overflow when a forced sweep cannot compact stored context"`
- Current repo note: the test harness still fails to resolve `@mariozechner/pi-coding-agent` after a fresh install, so the runtime check above was used to verify behavior directly
