### PR TITLE
fix: preserve toolName in toolResult messages for Gemini compatibility

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -399,6 +399,10 @@ function pickToolCallId(parts: MessagePartRecord[]): string | undefined {
     if (!decoded || typeof decoded !== "object") {
       continue;
     }
+    const metadataToolCallId = (decoded as { toolCallId?: unknown }).toolCallId;
+    if (typeof metadataToolCallId === "string" && metadataToolCallId.length > 0) {
+      return metadataToolCallId;
+    }
     const raw = (decoded as { raw?: unknown }).raw;
     if (!raw || typeof raw !== "object") {
       continue;
@@ -424,6 +428,10 @@ function pickToolName(parts: MessagePartRecord[]): string | undefined {
     if (!decoded || typeof decoded !== "object") {
       continue;
     }
+    const metadataToolName = (decoded as { toolName?: unknown }).toolName;
+    if (typeof metadataToolName === "string" && metadataToolName.length > 0) {
+      return metadataToolName;
+    }
     const raw = (decoded as { raw?: unknown }).raw;
     if (!raw || typeof raw !== "object") {
       continue;
@@ -435,6 +443,20 @@ function pickToolName(parts: MessagePartRecord[]): string | undefined {
     const maybeCamel = (raw as { toolName?: unknown }).toolName;
     if (typeof maybeCamel === "string" && maybeCamel.length > 0) {
       return maybeCamel;
+    }
+  }
+  return undefined;
+}
+
+function pickToolIsError(parts: MessagePartRecord[]): boolean | undefined {
+  for (const part of parts) {
+    const decoded = parseJson(part.metadata);
+    if (!decoded || typeof decoded !== "object") {
+      continue;
+    }
+    const metadataIsError = (decoded as { isError?: unknown }).isError;
+    if (typeof metadataIsError === "boolean") {
+      return metadataIsError;
     }
   }
   return undefined;
@@ -706,6 +728,7 @@ export class ContextAssembler {
     const isToolResult = roleFromStore === "toolResult";
     const toolCallId = isToolResult ? pickToolCallId(parts) : undefined;
     const toolName = isToolResult ? (pickToolName(parts) ?? "unknown") : undefined;
+    const toolIsError = isToolResult ? pickToolIsError(parts) : undefined;
     // Tool results without a call id cannot be serialized for Anthropic-compatible APIs.
     // This happens for legacy/bootstrap rows that have role=tool but no message_parts.
     // Preserve the text by degrading to assistant content instead of emitting invalid toolResult.
@@ -745,7 +768,7 @@ export class ContextAssembler {
               content,
               ...(toolCallId ? { toolCallId } : {}),
               ...(toolName ? { toolName } : {}),
-              ...(role === "toolResult" ? { isError: false } : {}),
+              ...(role === "toolResult" && toolIsError !== undefined ? { isError: toolIsError } : {}),
             } as AgentMessage),
       tokens: tokenCount,
       isMessage: true,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -60,6 +60,10 @@ function safeString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function safeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function appendTextValue(value: unknown, out: string[]): void {
   if (typeof value === "string") {
     out.push(value);
@@ -267,6 +271,9 @@ function buildMessageParts(params: {
   const topLevelToolName =
     safeString(topLevel.toolName) ??
     safeString(topLevel.tool_name);
+  const topLevelIsError =
+    safeBoolean(topLevel.isError) ??
+    safeBoolean(topLevel.is_error);
 
   // BashExecutionMessage: preserve a synthetic text part so output is round-trippable.
   if (!("content" in message) && "command" in message && "output" in message) {
@@ -310,6 +317,9 @@ function buildMessageParts(params: {
         textContent: message.content,
         metadata: toJson({
           originalRole: role,
+          toolCallId: topLevelToolCallId,
+          toolName: topLevelToolName,
+          isError: topLevelIsError,
         }),
       },
     ];
@@ -372,6 +382,9 @@ function buildMessageParts(params: {
             : (safeString(metadataRecord?.tool_output) ?? null),
       metadata: toJson({
         originalRole: role,
+        toolCallId: topLevelToolCallId,
+        toolName: topLevelToolName,
+        isError: topLevelIsError,
         rawType: block.type,
         raw: metadataRecord ?? message.content[ordinal],
       }),

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1142,6 +1142,117 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(result.isError).toBe(false);
   });
 
+  it("preserves toolResult error state through ingest-assemble round-trip", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_457", name: "bash", input: { command: "false" } }],
+      } as AgentMessage,
+    });
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_457",
+        toolName: "bash",
+        content: [{ type: "text", text: "command failed" }],
+        isError: true,
+      } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const storedMessages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const parts = await engine
+      .getConversationStore()
+      .getMessageParts(storedMessages[1].messageId);
+    expect(JSON.parse(parts[0].metadata ?? "{}")).toMatchObject({ isError: true });
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+
+    const result = assembled.messages[1] as {
+      role: string;
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+    };
+    expect(result.role).toBe("toolResult");
+    expect(result.toolCallId).toBe("call_457");
+    expect(result.toolName).toBe("bash");
+    expect(result.isError).toBe(true);
+  });
+
+  it("preserves top-level tool metadata for string-content tool results", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_458", name: "bash", input: { command: "pwd" } }],
+      } as AgentMessage,
+    });
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_458",
+        toolName: "bash",
+        content: "/tmp/project",
+        isError: false,
+      } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const storedMessages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const parts = await engine
+      .getConversationStore()
+      .getMessageParts(storedMessages[1].messageId);
+    expect(parts[0].partType).toBe("text");
+    expect(JSON.parse(parts[0].metadata ?? "{}")).toMatchObject({
+      toolCallId: "call_458",
+      toolName: "bash",
+      isError: false,
+    });
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+
+    const result = assembled.messages[1] as {
+      role: string;
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: unknown;
+    };
+    expect(result.role).toBe("toolResult");
+    expect(result.toolCallId).toBe("call_458");
+    expect(result.toolName).toBe("bash");
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "/tmp/project" }]);
+  });
+
   it("reconstructs OpenAI reasoning and function call blocks when raw metadata is missing", async () => {
     const engine = createEngine();
     const sessionId = randomUUID();


### PR DESCRIPTION
## Summary

Fixes #20. The Gemini API requires `function_response.name` to be non-empty, but assembled `toolResult` messages were missing `toolName`, causing HTTP 400 errors.

**Root cause:** `toolResultBlockFromPart()` never emitted `block.name` (unlike `toolCallBlockFromPart` which does), and `resolveMessageItem()` omitted `toolName` from the reconstructed message envelope. Additionally, during ingestion the top-level `message.toolName` was not captured as a fallback for the per-part tool name.

## Changes

**`src/assembler.ts`**
- `toolResultBlockFromPart`: emit `block.name = part.toolName`, mirroring `toolCallBlockFromPart`
- `pickToolName`: extract tool name from stored parts (parallel to `pickToolCallId`)
- `resolveMessageItem`: include `toolName` (fallback `"unknown"`) and `isError` in reconstructed `toolResult` messages

**`src/engine.ts`**
- `buildMessageParts`: capture `message.toolName` from the message envelope as fallback for the per-part `toolName` field during ingestion

**`test/engine.test.ts`**
- New test verifying `toolName` survives the ingest → assemble round-trip

## Why only Gemini is affected

Anthropic identifies tool results by `tool_use_id` alone — `name` is optional. Gemini strictly requires `function_response.name`. This bug is invisible on Anthropic but a hard 400 on Gemini.

## Test plan

- [x] All 237 existing tests pass
- [x] New round-trip test verifies `toolName` and `isError` are preserved
- [x] Verified fix on a live OpenClaw deployment with 4 bots using Gemini 3.1 Pro