### PR TITLE
Add legacy auth fallback when runtime.modelAuth is unavailable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -805,10 +805,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
                 maxTokens: 8_000,
               };
 
-        let resolvedApiKey = apiKey?.trim() || resolveApiKey(providerId, readEnv);
-        if (!resolvedApiKey && typeof mod.getEnvApiKey === "function") {
-          resolvedApiKey = mod.getEnvApiKey(providerId)?.trim();
-        }
+        let resolvedApiKey = apiKey?.trim();
         if (!resolvedApiKey && modelAuth) {
           try {
             resolvedApiKey = resolveApiKeyFromAuthResult(
@@ -825,7 +822,13 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
             );
           }
         }
-        if (!resolvedApiKey) {
+        if (!resolvedApiKey && !modelAuth) {
+          resolvedApiKey = resolveApiKey(providerId, readEnv);
+        }
+        if (!resolvedApiKey && !modelAuth && typeof mod.getEnvApiKey === "function") {
+          resolvedApiKey = mod.getEnvApiKey(providerId)?.trim();
+        }
+        if (!resolvedApiKey && !modelAuth) {
           resolvedApiKey = await resolveApiKeyFromAuthProfiles({
             provider: providerId,
             authProfileId,
@@ -958,11 +961,6 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
       return { provider, model: raw };
     },
     getApiKey: async (provider, model, options) => {
-      const envKey = resolveApiKey(provider, readEnv);
-      if (envKey) {
-        return envKey;
-      }
-
       if (modelAuth) {
         try {
           const modelAuthKey = resolveApiKeyFromAuthResult(
@@ -981,6 +979,11 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
         }
       }
 
+      const envKey = resolveApiKey(provider, readEnv);
+      if (envKey) {
+        return envKey;
+      }
+
       const piAiModuleId = "@mariozechner/pi-ai";
       const mod = (await import(piAiModuleId)) as PiAiModule;
       return resolveApiKeyFromAuthProfiles({
@@ -994,11 +997,6 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
     },
     requireApiKey: async (provider, model, options) => {
       const key = await (async () => {
-        const envKey = resolveApiKey(provider, readEnv);
-        if (envKey) {
-          return envKey;
-        }
-
         if (modelAuth) {
           try {
             const modelAuthKey = resolveApiKeyFromAuthResult(
@@ -1015,6 +1013,11 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
           } catch {
             // Fall through to auth-profile lookup for older OpenClaw runtimes.
           }
+        }
+
+        const envKey = resolveApiKey(provider, readEnv);
+        if (envKey) {
+          return envKey;
         }
 
         const piAiModuleId = "@mariozechner/pi-ai";

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -104,6 +104,7 @@ describe("lcm plugin registration", () => {
       closeLcmConnection(dbPath);
     }
     dbPaths.clear();
+    vi.unstubAllEnvs();
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -249,7 +250,39 @@ describe("lcm plugin registration", () => {
     expect(warnLog).toHaveBeenCalledWith(expect.stringContaining("runtime.modelAuth is unavailable"));
   });
 
+  it("prefers runtime.modelAuth over provider env keys when available", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "env-anthropic-key");
+
+    const { api, getFactory } = buildApi({
+      enabled: true,
+    });
+    api.config = defaultModelConfig("anthropic/claude-sonnet-4-6") as OpenClawPluginApi["config"];
+    const modelAuth = (
+      api.runtime as OpenClawPluginApi["runtime"] & {
+        modelAuth: {
+          getApiKeyForModel: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).modelAuth;
+    modelAuth.getApiKeyForModel.mockResolvedValue({
+      apiKey: "model-auth-key",
+    });
+
+    lcmPlugin.register(api);
+
+    const factory = getFactory();
+    expect(factory).toBeTypeOf("function");
+
+    const engine = factory!() as {
+      deps?: { getApiKey: (provider: string, model: string) => Promise<string | undefined> };
+    };
+    await expect(engine.deps?.getApiKey("anthropic", "claude-sonnet-4-6")).resolves.toBe(
+      "model-auth-key",
+    );
+  });
+
   it("falls back to auth-profiles.json when runtime.modelAuth is unavailable", { timeout: 20000 }, async () => {
+    const provider = "lossless-test-provider";
     const agentDir = mkdtempSync(join(tmpdir(), "lossless-claw-auth-"));
     tempDirs.add(agentDir);
     writeFileSync(
@@ -258,14 +291,14 @@ describe("lcm plugin registration", () => {
         {
           version: 1,
           profiles: {
-            "anthropic:test": {
-              type: "token",
-              provider: "anthropic",
-              token: "token-from-auth-store",
+            "lossless-test-provider:test": {
+              type: "api_key",
+              provider,
+              key: "token-from-auth-store",
             },
           },
           order: {
-            anthropic: ["anthropic:test"],
+            [provider]: ["lossless-test-provider:test"],
           },
         },
         null,
@@ -280,7 +313,7 @@ describe("lcm plugin registration", () => {
       },
       { includeModelAuth: false, agentDir },
     );
-    api.config = defaultModelConfig("anthropic/claude-sonnet-4-6") as OpenClawPluginApi["config"];
+    api.config = defaultModelConfig(`${provider}/claude-sonnet-4-6`) as OpenClawPluginApi["config"];
 
     lcmPlugin.register(api);
 
@@ -290,7 +323,7 @@ describe("lcm plugin registration", () => {
     const engine = factory!() as {
       deps?: { getApiKey: (provider: string, model: string) => Promise<string | undefined> };
     };
-    await expect(engine.deps?.getApiKey("anthropic", "claude-sonnet-4-6")).resolves.toBe(
+    await expect(engine.deps?.getApiKey(provider, "claude-sonnet-4-6")).resolves.toBe(
       "token-from-auth-store",
     );
   });


### PR DESCRIPTION
## Summary
Fixes #30.

This restores compatibility with OpenClaw builds that do not yet expose `api.runtime.modelAuth` to plugins.

Changes:
- use `runtime.modelAuth` when available
- fall back to legacy auth resolution (`auth-profiles.json` / env / provider config) when it is not
- log a clearer compatibility warning that points to `openclaw/openclaw#41090`
- add regressions for registration without `runtime.modelAuth` and auth-store fallback

## Why
`lossless-claw` 0.2.7 currently hard-fails during plugin registration on OpenClaw `2026.3.8` / `2026.3.8-beta.1` because those releases were cut before `openclaw/openclaw#41090` merged.

That leaves the context engine unregistered and later produces:
- `Context engine "lossless-claw" is not registered. Available engines: legacy`

## Validation
- `node node_modules/vitest/vitest.mjs run test/plugin-config-registration.test.ts test/index-complete-options.test.ts`
- Verified on the target server that the patched plugin now loads under OpenClaw `2026.3.8` and falls back cleanly when `runtime.modelAuth` is absent.
