### PR TITLE
feat: output timestamps in local timezone instead of UTC

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -86,7 +86,7 @@ function estimateTokens(content: string): number {
 }
 
 /** Format a timestamp as `YYYY-MM-DD HH:mm TZ` for prompt source text. */
-function formatTimestamp(value: Date, timezone: string = "UTC"): string {
+export function formatTimestamp(value: Date, timezone: string = "UTC"): string {
   try {
     const fmt = new Intl.DateTimeFormat("en-CA", {
       timeZone: timezone,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -563,6 +563,12 @@ export class LcmContextEngine implements ContextEngine {
   };
 
   private config: LcmConfig;
+
+  /** Get the configured timezone, falling back to system timezone. */
+  get timezone(): string {
+    return this.config.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
   private conversationStore: ConversationStore;
   private summaryStore: SummaryStore;
   private assembler: ContextAssembler;

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -8,6 +8,7 @@ import type { LcmDependencies } from "../types.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
+import { formatTimestamp } from "../compaction.js";
 
 const LcmDescribeSchema = Type.Object({
   id: Type.String({
@@ -40,8 +41,12 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
   return Math.max(1, Math.trunc(value));
 }
 
-function formatIso(value: Date | null | undefined): string {
-  return value instanceof Date ? value.toISOString() : "-";
+function formatIso(value: Date | null | undefined, timezone?: string): string {
+  if (!(value instanceof Date)) return "-";
+  if (timezone) {
+    return formatTimestamp(value, timezone);
+  }
+  return value.toISOString();
 }
 
 export function createLcmDescribeTool(input: {
@@ -61,6 +66,7 @@ export function createLcmDescribeTool(input: {
     parameters: LcmDescribeSchema,
     async execute(_toolCallId, params) {
       const retrieval = input.lcm.getRetrieval();
+      const timezone = input.lcm.timezone;
       const p = params as Record<string, unknown>;
       const id = (p.id as string).trim();
       const conversationScope = await resolveLcmConversationScope({
@@ -152,7 +158,7 @@ export function createLcmDescribeTool(input: {
         lines.push(
           `meta conv=${s.conversationId} kind=${s.kind} depth=${s.depth} tok=${s.tokenCount} ` +
             `descTok=${s.descendantTokenCount} srcTok=${s.sourceMessageTokenCount} ` +
-            `desc=${s.descendantCount} range=${formatIso(s.earliestAt)}..${formatIso(s.latestAt)} ` +
+            `desc=${s.descendantCount} range=${formatIso(s.earliestAt, timezone)}..${formatIso(s.latestAt, timezone)} ` +
             `budgetCap=${resolvedTokenCap}`,
         );
         if (s.parentIds.length > 0) {
@@ -167,7 +173,7 @@ export function createLcmDescribeTool(input: {
             `d${node.depthFromRoot} ${node.summaryId} k=${node.kind} tok=${node.tokenCount} ` +
               `descTok=${node.descendantTokenCount} srcTok=${node.sourceMessageTokenCount} ` +
               `desc=${node.descendantCount} child=${node.childCount} ` +
-              `range=${formatIso(node.earliestAt)}..${formatIso(node.latestAt)} ` +
+              `range=${formatIso(node.earliestAt, timezone)}..${formatIso(node.latestAt, timezone)} ` +
               `cost[s=${node.costs.summariesOnly},m=${node.costs.withMessages}] ` +
               `budget[s=${node.budgetFit.summariesOnly ? "in" : "over"},` +
               `m=${node.budgetFit.withMessages ? "in" : "over"}]`,
@@ -205,7 +211,7 @@ export function createLcmDescribeTool(input: {
         if (f.byteSize != null) {
           lines.push(`**Size:** ${f.byteSize.toLocaleString()} bytes`);
         }
-        lines.push(`**Created:** ${f.createdAt.toISOString()}`);
+        lines.push(`**Created:** ${formatIso(f.createdAt, timezone)}`);
         if (f.explorationSummary) {
           lines.push("");
           lines.push("## Exploration Summary");

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -4,6 +4,7 @@ import type { LcmDependencies } from "../types.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { parseIsoTimestampParam, resolveLcmConversationScope } from "./lcm-conversation-scope.js";
+import { formatTimestamp } from "../compaction.js";
 
 const MAX_RESULT_CHARS = 40_000; // ~10k tokens
 
@@ -83,6 +84,7 @@ export function createLcmGrepTool(input: {
     parameters: LcmGrepSchema,
     async execute(_toolCallId, params) {
       const retrieval = input.lcm.getRetrieval();
+      const timezone = input.lcm.timezone;
 
       const p = params as Record<string, unknown>;
       const pattern = (p.pattern as string).trim();
@@ -139,8 +141,8 @@ export function createLcmGrepTool(input: {
       }
       if (since || before) {
         lines.push(
-          `**Time filter:** ${since ? `since ${since.toISOString()}` : "since -∞"} | ${
-            before ? `before ${before.toISOString()}` : "before +∞"
+          `**Time filter:** ${since ? `since ${formatTimestamp(since, timezone)}` : "since -∞"} | ${
+            before ? `before ${formatTimestamp(before, timezone)}` : "before +∞"
           }`,
         );
       }
@@ -154,7 +156,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const msg of result.messages) {
           const snippet = truncateSnippet(msg.snippet);
-          const line = `- [msg#${msg.messageId}] (${msg.role}, ${msg.createdAt.toISOString()}): ${snippet}`;
+          const line = `- [msg#${msg.messageId}] (${msg.role}, ${formatTimestamp(msg.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;
@@ -170,7 +172,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const sum of result.summaries) {
           const snippet = truncateSnippet(sum.snippet);
-          const line = `- [${sum.summaryId}] (${sum.kind}, ${sum.createdAt.toISOString()}): ${snippet}`;
+          const line = `- [${sum.summaryId}] (${sum.kind}, ${formatTimestamp(sum.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -145,8 +145,12 @@ describe("LCM tools session scoping", () => {
     expect((result.details as { expansionCount?: number }).expansionCount).toBe(1);
   });
 
-  it("lcm_grep forwards since/before and includes ISO timestamps in text output", async () => {
+  it("lcm_grep forwards since/before and includes local timestamps in text output", async () => {
     const createdAt = new Date("2026-01-03T00:00:00.000Z");
+    // Import formatTimestamp to generate expected output
+    const { formatTimestamp } = await import("../src/compaction.js");
+    const timezone = "UTC"; // Test environment uses UTC
+    const expectedTimestamp = formatTimestamp(createdAt, timezone);
     const retrieval = {
       grep: vi.fn(async () => ({
         messages: [
@@ -184,7 +188,7 @@ describe("LCM tools session scoping", () => {
         before: expect.any(Date),
       }),
     );
-    expect((result.content[0] as { text: string }).text).toContain(createdAt.toISOString());
+    expect((result.content[0] as { text: string }).text).toContain(expectedTimestamp);
   });
 
   it("lcm_describe blocks cross-conversation lookup unless allConversations=true", async () => {


### PR DESCRIPTION

## Why

LCM tools (`lcm_grep`, `lcm_describe`) output timestamps in UTC ISO format, which causes confusion for agents and humans:
1. Agents need to mentally convert to local time during reasoning
2. Inconsistent with other OpenClaw outputs (cron, message timestamps)
3. Debugging becomes harder when timestamps do not match logs

## What Changed

| File | Change |
|------|--------|
| `src/compaction.ts` | Export `formatTimestamp` function |
| `src/engine.ts` | Add `LcmContextEngine.timezone` getter |
| `src/tools/lcm-grep-tool.ts` | Use local timezone for timestamp output |
| `src/tools/lcm-describe-tool.ts` | Use local timezone for timestamp output |
| `test/lcm-tools.test.ts` | Update test to match new format |

## Before/After

**Before:**
```
range=2026-03-09T22:42:10.000Z..2026-03-09T22:42:10.000Z
```

**After:**
```
range=2026-03-10 06:42 GMT+8..2026-03-10 06:42 GMT+8
```

Timezone source: `config.timezone` (configured) or system default.
