### PR TITLE
feat(tui): support setup-token (OAuth) for Anthropic API calls

### DIFF
--- a/tui/repair.go
+++ b/tui/repair.go
@@ -949,7 +949,11 @@ func (c *anthropicClient) summarizeAnthropic(ctx context.Context, model, prompt 
 		return "", fmt.Errorf("build Anthropic request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.apiKey)
+	if isOAuthToken(c.apiKey) {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	} else {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
 	req.Header.Set("anthropic-version", anthropicVersion)
 
 	resp, err := c.http.Do(req)
@@ -1267,6 +1271,20 @@ func resolveProviderAPIKey(paths appDataPaths, provider string) (string, error) 
 		}
 	}
 
+	// Check CLAUDE_CODE_OAUTH_TOKEN env var (setup-token / OAuth support).
+	if normalizedProvider == "anthropic" {
+		if oauthToken := strings.TrimSpace(os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")); oauthToken != "" {
+			return oauthToken, nil
+		}
+	}
+
+	// Check ~/.openclaw/secrets.json for setup-token fallback.
+	if normalizedProvider == "anthropic" {
+		if key, err := readSetupTokenFromSecrets(paths.openclawDir); err == nil && key != "" {
+			return key, nil
+		}
+	}
+
 	mode, err := readProviderProfileMode(paths.openclawConfig, normalizedProvider)
 	if err != nil {
 		return "", err
@@ -1301,6 +1319,29 @@ func resolveProviderAPIKey(paths appDataPaths, provider string) (string, error) 
 		normalizedProvider,
 		strings.Join(envCandidates, ", "),
 	)
+}
+
+// readSetupTokenFromSecrets reads an Anthropic setup-token from ~/.openclaw/secrets.json.
+func readSetupTokenFromSecrets(openclawDir string) (string, error) {
+	secretsPath := filepath.Join(openclawDir, "secrets.json")
+	data, err := os.ReadFile(secretsPath)
+	if err != nil {
+		return "", err
+	}
+	var secrets map[string]string
+	if err := json.Unmarshal(data, &secrets); err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(secrets["anthropic-setup-token"])
+	if token != "" && looksLikeAPIKey(token) {
+		return token, nil
+	}
+	return "", nil
+}
+
+// isOAuthToken returns true if the token uses the OAuth setup-token prefix.
+func isOAuthToken(token string) bool {
+	return strings.HasPrefix(token, "sk-ant-oat")
 }
 
 func providerAPIEnvCandidates(provider string) []string {


### PR DESCRIPTION
## Summary

Add OAuth setup-token support to lcm-tui's Anthropic API integration.

Closes #41

### Part 1: Token resolution
- `resolveProviderAPIKey` now checks `CLAUDE_CODE_OAUTH_TOKEN` env var and `~/.openclaw/secrets.json` (`anthropic-setup-token` key) before the provider mode check
- Token priority: `ANTHROPIC_API_KEY` env > `CLAUDE_CODE_OAUTH_TOKEN` env > `secrets.json` setup-token > openclaw.json provider config

### Part 2: Header selection
- `summarizeAnthropic` detects token prefix to choose the correct HTTP auth header:
  - `sk-ant-oat` prefix → `Authorization: Bearer` header
  - `sk-ant-api` or other → `x-api-key` header (existing behaviour)

Both token types work transparently with no config change needed. Existing API key users are unaffected.