### PR TITLE
fix: CJK-aware token estimation in estimateTokens

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -37,7 +37,17 @@ export interface AssembleContextResult {
 
 /** Simple token estimate: ~4 chars per token, same as VoltCode's Token.estimate */
 function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  let count = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0)!;
+    // CJK Unified Ideographs + Extension A: ~1.5 tokens per char
+    if ((code >= 0x4E00 && code <= 0x9FFF) || (code >= 0x3400 && code <= 0x4DBF)) {
+      count += 1.5;
+    } else {
+      count += 0.25;
+    }
+  }
+  return Math.ceil(count);
 }
 
 type SummaryPromptSignal = Pick<SummaryRecord, "kind" | "depth" | "descendantCount">;

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -82,7 +82,17 @@ type CondensedPhaseCandidate = {
 
 /** Estimate token count from character length (~4 chars per token). */
 function estimateTokens(content: string): number {
-  return Math.ceil(content.length / 4);
+  let count = 0;
+  for (const ch of content) {
+    const code = ch.codePointAt(0)!;
+    // CJK Unified Ideographs + Extension A: ~1.5 tokens per char
+    if ((code >= 0x4E00 && code <= 0x9FFF) || (code >= 0x3400 && code <= 0x4DBF)) {
+      count += 1.5;
+    } else {
+      count += 0.25;
+    }
+  }
+  return Math.ceil(count);
 }
 
 /** Format a timestamp as `YYYY-MM-DD HH:mm TZ` for prompt source text. */


### PR DESCRIPTION
## Problem

The current `estimateTokens` function uses `Math.ceil(text.length / 4)`, which assumes ~4 characters per token. This is accurate for English/ASCII but **severely underestimates CJK (Chinese/Japanese/Korean) content by ~3x**.

### Root cause

In JavaScript, `string.length` returns UTF-16 code units where each CJK character = 1 unit. However, LLM tokenizers (Claude, GPT, etc.) encode CJK characters at **~1.5 tokens per character**, not 0.25.

### Production impact

In a Chinese-heavy OpenClaw session:
- LCM estimated context at **59k tokens**
- Actual API usage was **174k tokens** (3x underestimate)
- Compaction triggered far too late → session hit the 200k hard limit and was force-reset

Verified with real data — a message with 40% CJK + 53% ASCII (28,949 chars):
| Method | Tokens |
|--------|--------|
| Old (`length/4`) | 7,238 |
| New (CJK-aware) | 22,180 |
| Ratio | **3.1x** |

## Fix

Apply per-character weighting in both `assembler.ts` and `compaction.ts`:
- CJK Unified Ideographs (U+4E00–U+9FFF) + Extension A (U+3400–U+4DBF): **1.5 tokens/char**
- All other characters: **0.25 tokens/char** (unchanged)

Zero dependencies added. Backwards compatible — only affects estimation accuracy.