### PR TITLE
fix: auth+safety hardening (#70 #72 #76)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "*",

--- a/src/expansion-auth.ts
+++ b/src/expansion-auth.ts
@@ -195,6 +195,14 @@ export class ExpansionAuthManager {
       }
     }
 
+    // 6. Depth must not exceed grant maxDepth
+    if (request.depth > grant.maxDepth) {
+      return {
+        valid: false,
+        reason: `Requested depth ${request.depth} exceeds grant maximum ${grant.maxDepth}`,
+      };
+    }
+
     return { valid: true };
   }
 

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { randomUUID } from "node:crypto";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
 import { buildLikeSearchPlan, createFallbackSnippet } from "./full-text-fallback.js";
+import { UnsafeRegexError, validateRegexSafety } from "./regex-safety.js";
 
 export type ConversationId = number;
 export type MessageId = number;
@@ -202,6 +203,8 @@ function toMessagePartRecord(row: MessagePartRow): MessagePartRecord {
 }
 
 // ── ConversationStore ─────────────────────────────────────────────────────────
+
+const MAX_REGEX_SCAN_ROWS = 10_000;
 
 export class ConversationStore {
   private readonly fts5Available: boolean;
@@ -700,7 +703,17 @@ export class ConversationStore {
     before?: Date,
   ): MessageSearchResult[] {
     // SQLite has no native POSIX regex; fetch candidates and filter in JS
-    const re = new RegExp(pattern);
+    const validation = validateRegexSafety(pattern);
+    if (!validation.safe) {
+      throw new UnsafeRegexError(`Invalid/unsafe regex: ${validation.reason ?? "Pattern not allowed"}`);
+    }
+
+    let re: RegExp;
+    try {
+      re = new RegExp(pattern);
+    } catch {
+      throw new UnsafeRegexError("Invalid/unsafe regex: Invalid regular expression");
+    }
 
     const where: string[] = [];
     const args: Array<string | number> = [];
@@ -722,7 +735,8 @@ export class ConversationStore {
         `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
          FROM messages
          ${whereClause}
-         ORDER BY created_at DESC`,
+         ORDER BY created_at DESC
+         LIMIT ${MAX_REGEX_SCAN_ROWS}`,
       )
       .all(...args) as unknown as MessageRow[];
 

--- a/src/store/regex-safety.ts
+++ b/src/store/regex-safety.ts
@@ -1,0 +1,43 @@
+const NESTED_QUANTIFIER_RE = /\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*{]/;
+const MAX_PATTERN_LENGTH = 500;
+
+export type RegexValidationResult = {
+  safe: boolean;
+  reason?: string;
+};
+
+export class UnsafeRegexError extends Error {
+  readonly code = "UNSAFE_REGEX";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeRegexError";
+  }
+}
+
+export function validateRegexSafety(pattern: string): RegexValidationResult {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return {
+      safe: false,
+      reason: `Pattern exceeds maximum length of ${MAX_PATTERN_LENGTH}`,
+    };
+  }
+
+  if (NESTED_QUANTIFIER_RE.test(pattern)) {
+    return {
+      safe: false,
+      reason: "Pattern contains nested quantifiers (potential ReDoS)",
+    };
+  }
+
+  try {
+    new RegExp(pattern);
+  } catch {
+    return {
+      safe: false,
+      reason: "Invalid regular expression",
+    };
+  }
+
+  return { safe: true };
+}

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
 import { buildLikeSearchPlan, createFallbackSnippet } from "./full-text-fallback.js";
+import { UnsafeRegexError, validateRegexSafety } from "./regex-safety.js";
 
 export type SummaryKind = "leaf" | "condensed";
 export type ContextItemType = "message" | "summary";
@@ -238,6 +239,8 @@ function toLargeFileRecord(row: LargeFileRow): LargeFileRecord {
 }
 
 // ── SummaryStore ──────────────────────────────────────────────────────────────
+
+const MAX_REGEX_SCAN_ROWS = 10_000;
 
 export class SummaryStore {
   private readonly fts5Available: boolean;
@@ -818,7 +821,17 @@ export class SummaryStore {
     since?: Date,
     before?: Date,
   ): SummarySearchResult[] {
-    const re = new RegExp(pattern);
+    const validation = validateRegexSafety(pattern);
+    if (!validation.safe) {
+      throw new UnsafeRegexError(`Invalid/unsafe regex: ${validation.reason ?? "Pattern not allowed"}`);
+    }
+
+    let re: RegExp;
+    try {
+      re = new RegExp(pattern);
+    } catch {
+      throw new UnsafeRegexError("Invalid/unsafe regex: Invalid regular expression");
+    }
 
     const where: string[] = [];
     const args: Array<string | number> = [];
@@ -842,7 +855,8 @@ export class SummaryStore {
                 source_message_token_count, created_at
          FROM summaries
          ${whereClause}
-         ORDER BY created_at DESC`,
+         ORDER BY created_at DESC
+         LIMIT ${MAX_REGEX_SCAN_ROWS}`,
       )
       .all(...args) as unknown as SummaryRow[];
 

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -3,6 +3,7 @@ import type { LcmDependencies } from "../types.js";
 
 export type LcmConversationScope = {
   conversationId?: number;
+  conversationIds?: number[];
   allConversations: boolean;
 };
 
@@ -44,33 +45,81 @@ export async function resolveLcmConversationScope(input: {
   sessionId?: string;
   sessionKey?: string;
   deps?: Pick<LcmDependencies, "resolveSessionIdFromSessionKey">;
+  grantContext?: {
+    isSubagent: boolean;
+    allowedConversationIds?: number[];
+  };
 }): Promise<LcmConversationScope> {
   const { lcm, params } = input;
+  const allowedConversationIds = input.grantContext?.allowedConversationIds;
+  const isSubagent = input.grantContext?.isSubagent === true;
+  const hasDelegatedGrant =
+    isSubagent && Array.isArray(allowedConversationIds) && allowedConversationIds.length > 0;
+
+  let cachedSessionConversationId: number | undefined;
+  let resolvedSessionConversationId = false;
+
+  const resolveSessionConversationId = async (): Promise<number | undefined> => {
+    if (resolvedSessionConversationId) {
+      return cachedSessionConversationId;
+    }
+
+    let normalizedSessionId = input.sessionId?.trim();
+    if (!normalizedSessionId && input.sessionKey && input.deps) {
+      normalizedSessionId = await input.deps.resolveSessionIdFromSessionKey(input.sessionKey.trim());
+    }
+    if (!normalizedSessionId) {
+      resolvedSessionConversationId = true;
+      return undefined;
+    }
+
+    const conversation = await lcm.getConversationStore().getConversationBySessionId(normalizedSessionId);
+    cachedSessionConversationId = conversation?.conversationId;
+    resolvedSessionConversationId = true;
+    return cachedSessionConversationId;
+  };
+
+  const enforceConversationAccess = async (conversationId: number): Promise<void> => {
+    if (hasDelegatedGrant) {
+      if (!allowedConversationIds.includes(conversationId)) {
+        throw new Error(`Conversation ${conversationId} is not in delegated grant scope.`);
+      }
+      return;
+    }
+
+    if (isSubagent) {
+      const sessionConversationId = await resolveSessionConversationId();
+      if (sessionConversationId == null || sessionConversationId !== conversationId) {
+        throw new Error(`Conversation ${conversationId} is not available in this session.`);
+      }
+    }
+  };
 
   const explicitConversationId =
     typeof params.conversationId === "number" && Number.isFinite(params.conversationId)
       ? Math.trunc(params.conversationId)
       : undefined;
   if (explicitConversationId != null) {
+    await enforceConversationAccess(explicitConversationId);
     return { conversationId: explicitConversationId, allConversations: false };
   }
 
   if (params.allConversations === true) {
+    if (hasDelegatedGrant) {
+      return { conversationIds: [...allowedConversationIds], allConversations: false };
+    }
+    if (isSubagent) {
+      const sessionConversationId = await resolveSessionConversationId();
+      return { conversationId: sessionConversationId, allConversations: false };
+    }
     return { conversationId: undefined, allConversations: true };
   }
 
-  let normalizedSessionId = input.sessionId?.trim();
-  if (!normalizedSessionId && input.sessionKey && input.deps) {
-    normalizedSessionId = await input.deps.resolveSessionIdFromSessionKey(input.sessionKey.trim());
-  }
-  if (!normalizedSessionId) {
+  const conversationId = await resolveSessionConversationId();
+  if (conversationId == null) {
     return { conversationId: undefined, allConversations: false };
   }
 
-  const conversation = await lcm.getConversationStore().getConversationBySessionId(normalizedSessionId);
-  if (!conversation) {
-    return { conversationId: undefined, allConversations: false };
-  }
-
-  return { conversationId: conversation.conversationId, allConversations: false };
+  await enforceConversationAccess(conversationId);
+  return { conversationId, allConversations: false };
 }

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -69,14 +69,36 @@ export function createLcmDescribeTool(input: {
       const timezone = input.lcm.timezone;
       const p = params as Record<string, unknown>;
       const id = (p.id as string).trim();
-      const conversationScope = await resolveLcmConversationScope({
-        lcm: input.lcm,
-        deps: input.deps,
-        sessionId: input.sessionId,
-        sessionKey: input.sessionKey,
-        params: p,
-      });
-      if (!conversationScope.allConversations && conversationScope.conversationId == null) {
+      const sessionKey = (input.sessionKey ?? input.sessionId ?? "").trim();
+      const isSubagent = input.deps.isSubagentSessionKey(sessionKey);
+      const grantId = isSubagent ? resolveDelegatedExpansionGrantId(sessionKey) : null;
+      const grant = grantId ? getRuntimeExpansionAuthManager().getGrant(grantId) : null;
+      const grantContext = {
+        isSubagent,
+        allowedConversationIds: grant?.allowedConversationIds,
+      };
+
+      let conversationScope: Awaited<ReturnType<typeof resolveLcmConversationScope>>;
+      try {
+        conversationScope = await resolveLcmConversationScope({
+          lcm: input.lcm,
+          deps: input.deps,
+          sessionId: input.sessionId,
+          sessionKey: input.sessionKey,
+          params: p,
+          grantContext,
+        });
+      } catch (scopeError) {
+        return jsonResult({
+          error: `Not found: ${id}`,
+          hint: "Check the ID format (sum_xxx for summaries, file_xxx for files).",
+        });
+      }
+      if (
+        !conversationScope.allConversations &&
+        conversationScope.conversationId == null &&
+        (!conversationScope.conversationIds || conversationScope.conversationIds.length === 0)
+      ) {
         return jsonResult({
           error:
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
@@ -91,13 +113,23 @@ export function createLcmDescribeTool(input: {
           hint: "Check the ID format (sum_xxx for summaries, file_xxx for files).",
         });
       }
+      const itemConversationId =
+        result.type === "summary" ? result.summary?.conversationId : result.file?.conversationId;
       if (conversationScope.conversationId != null) {
-        const itemConversationId =
-          result.type === "summary" ? result.summary?.conversationId : result.file?.conversationId;
         if (itemConversationId != null && itemConversationId !== conversationScope.conversationId) {
           return jsonResult({
-            error: `Not found in conversation ${conversationScope.conversationId}: ${id}`,
-            hint: "Use allConversations=true for cross-conversation lookup.",
+            error: `Not found: ${id}`,
+            hint: "Check the ID format (sum_xxx for summaries, file_xxx for files).",
+          });
+        }
+      } else if (conversationScope.conversationIds && conversationScope.conversationIds.length > 0) {
+        if (
+          itemConversationId != null &&
+          !conversationScope.conversationIds.includes(itemConversationId)
+        ) {
+          return jsonResult({
+            error: `Not found: ${id}`,
+            hint: "Check the ID format (sum_xxx for summaries, file_xxx for files).",
           });
         }
       }

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -3,6 +3,8 @@ import crypto from "node:crypto";
 import type { LcmContextEngine } from "../engine.js";
 import {
   createDelegatedExpansionGrant,
+  getRuntimeExpansionAuthManager,
+  resolveDelegatedExpansionGrantId,
   revokeDelegatedExpansionGrantForSession,
 } from "../expansion-auth.js";
 import type { LcmDependencies } from "../types.js";
@@ -254,13 +256,37 @@ async function resolveSummaryCandidates(params: {
   explicitSummaryIds: string[];
   query?: string;
   conversationId?: number;
+  conversationIds?: number[];
+  grantContext?: {
+    isSubagent: boolean;
+    allowedConversationIds?: number[];
+  };
 }): Promise<SummaryCandidate[]> {
   const retrieval = params.lcm.getRetrieval();
   const candidates = new Map<string, SummaryCandidate>();
 
+  const allowedConversationIds = params.grantContext?.allowedConversationIds;
+  const isSubagent = params.grantContext?.isSubagent === true;
+  const enforceGrantScope =
+    isSubagent &&
+    Array.isArray(allowedConversationIds) &&
+    allowedConversationIds.length > 0;
+
+  // For grantless subagents, restrict to session's own conversation
+  const sessionConversationId = params.conversationId;
+
   for (const summaryId of params.explicitSummaryIds) {
     const described = await retrieval.describe(summaryId);
     if (!described || described.type !== "summary" || !described.summary) {
+      throw new Error(`Summary not found: ${summaryId}`);
+    }
+    const summaryConvId = described.summary.conversationId;
+    if (enforceGrantScope && !allowedConversationIds.includes(summaryConvId)) {
+      // Uniform error — don't leak existence
+      throw new Error(`Summary not found: ${summaryId}`);
+    }
+    if (isSubagent && !enforceGrantScope && sessionConversationId != null && summaryConvId !== sessionConversationId) {
+      // Grantless subagent: restrict to own conversation
       throw new Error(`Summary not found: ${summaryId}`);
     }
     candidates.set(summaryId, {
@@ -270,17 +296,36 @@ async function resolveSummaryCandidates(params: {
   }
 
   if (params.query) {
-    const grepResult = await retrieval.grep({
-      query: params.query,
-      mode: "full_text",
-      scope: "summaries",
-      conversationId: params.conversationId,
-    });
-    for (const summary of grepResult.summaries) {
-      candidates.set(summary.summaryId, {
-        summaryId: summary.summaryId,
-        conversationId: summary.conversationId,
-      });
+    const scopedConversationIds =
+      Array.isArray(params.conversationIds) && params.conversationIds.length > 0
+        ? params.conversationIds
+        : null;
+    const grepResults = scopedConversationIds
+      ? await Promise.all(
+          scopedConversationIds.map((conversationId) =>
+            retrieval.grep({
+              query: params.query as string,
+              mode: "full_text",
+              scope: "summaries",
+              conversationId,
+            }),
+          ),
+        )
+      : [
+          await retrieval.grep({
+            query: params.query,
+            mode: "full_text",
+            scope: "summaries",
+            conversationId: params.conversationId,
+          }),
+        ];
+    for (const grepResult of grepResults) {
+      for (const summary of grepResult.summaries) {
+        candidates.set(summary.summaryId, {
+          summaryId: summary.summaryId,
+          conversationId: summary.conversationId,
+        });
+      }
     }
   }
 
@@ -374,17 +419,42 @@ export function createLcmExpandQueryTool(input: {
         });
       }
 
-      const conversationScope = await resolveLcmConversationScope({
-        lcm: input.lcm,
-        deps: input.deps,
-        sessionId: input.sessionId,
-        sessionKey: input.sessionKey,
-        params: p,
-      });
+      const sessionKey = (input.sessionKey ?? input.sessionId ?? "").trim();
+      const isSubagent = input.deps.isSubagentSessionKey(sessionKey);
+      const grantId = isSubagent ? resolveDelegatedExpansionGrantId(sessionKey) : null;
+      const grant = grantId ? getRuntimeExpansionAuthManager().getGrant(grantId) : null;
+      const grantContext = {
+        isSubagent,
+        allowedConversationIds: grant?.allowedConversationIds,
+      };
+
+      let conversationScope: Awaited<ReturnType<typeof resolveLcmConversationScope>>;
+      try {
+        conversationScope = await resolveLcmConversationScope({
+          lcm: input.lcm,
+          deps: input.deps,
+          sessionId: input.sessionId,
+          sessionKey: input.sessionKey,
+          params: p,
+          grantContext,
+        });
+      } catch (scopeError) {
+        return jsonResult({
+          error: "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
+        });
+      }
       let scopedConversationId = conversationScope.conversationId;
+      if (
+        scopedConversationId == null &&
+        conversationScope.conversationIds &&
+        conversationScope.conversationIds.length === 1
+      ) {
+        scopedConversationId = conversationScope.conversationIds[0];
+      }
       if (
         !conversationScope.allConversations &&
         scopedConversationId == null &&
+        (!conversationScope.conversationIds || conversationScope.conversationIds.length === 0) &&
         callerSessionKey
       ) {
         scopedConversationId = await resolveRequesterConversationScopeId({
@@ -394,7 +464,11 @@ export function createLcmExpandQueryTool(input: {
         });
       }
 
-      if (!conversationScope.allConversations && scopedConversationId == null) {
+      if (
+        !conversationScope.allConversations &&
+        scopedConversationId == null &&
+        (!conversationScope.conversationIds || conversationScope.conversationIds.length === 0)
+      ) {
         return jsonResult({
           error:
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
@@ -410,6 +484,8 @@ export function createLcmExpandQueryTool(input: {
           explicitSummaryIds,
           query: query || undefined,
           conversationId: scopedConversationId,
+          conversationIds: conversationScope.conversationIds,
+          grantContext,
         });
 
         if (candidates.length === 0) {

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -1,5 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import type { LcmContextEngine } from "../engine.js";
+import {
+  getRuntimeExpansionAuthManager,
+  resolveDelegatedExpansionGrantId,
+} from "../expansion-auth.js";
 import type { LcmDependencies } from "../types.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
@@ -106,29 +110,93 @@ export function createLcmGrepTool(input: {
           error: "`since` must be earlier than `before`.",
         });
       }
-      const conversationScope = await resolveLcmConversationScope({
-        lcm: input.lcm,
-        deps: input.deps,
-        sessionId: input.sessionId,
-        sessionKey: input.sessionKey,
-        params: p,
-      });
-      if (!conversationScope.allConversations && conversationScope.conversationId == null) {
+      const sessionKey = (input.sessionKey ?? input.sessionId ?? "").trim();
+      const isSubagent = input.deps.isSubagentSessionKey(sessionKey);
+      const grantId = isSubagent ? resolveDelegatedExpansionGrantId(sessionKey) : null;
+      const grant = grantId ? getRuntimeExpansionAuthManager().getGrant(grantId) : null;
+      const grantContext = {
+        isSubagent,
+        allowedConversationIds: grant?.allowedConversationIds,
+      };
+
+      let conversationScope: Awaited<ReturnType<typeof resolveLcmConversationScope>>;
+      try {
+        conversationScope = await resolveLcmConversationScope({
+          lcm: input.lcm,
+          deps: input.deps,
+          sessionId: input.sessionId,
+          sessionKey: input.sessionKey,
+          params: p,
+          grantContext,
+        });
+      } catch (scopeError) {
+        return jsonResult({
+          error: "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
+        });
+      }
+      if (
+        !conversationScope.allConversations &&
+        conversationScope.conversationId == null &&
+        (!conversationScope.conversationIds || conversationScope.conversationIds.length === 0)
+      ) {
         return jsonResult({
           error:
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
         });
       }
 
-      const result = await retrieval.grep({
-        query: pattern,
-        mode,
-        scope,
-        conversationId: conversationScope.conversationId,
-        limit,
-        since,
-        before,
-      });
+      const scopedConversationIds =
+        Array.isArray(conversationScope.conversationIds) && conversationScope.conversationIds.length > 0
+          ? conversationScope.conversationIds
+          : null;
+
+      let result: { messages: any[]; summaries: any[]; totalMatches: number };
+      try {
+        result = scopedConversationIds
+          ? {
+              messages: [],
+              summaries: [],
+              totalMatches: 0,
+            }
+          : await retrieval.grep({
+              query: pattern,
+              mode,
+              scope,
+              conversationId: conversationScope.conversationId,
+              limit,
+              since,
+              before,
+            });
+
+        if (scopedConversationIds) {
+          for (const scopedConversationId of scopedConversationIds) {
+            const scopedResult = await retrieval.grep({
+              query: pattern,
+              mode,
+              scope,
+              conversationId: scopedConversationId,
+              limit,
+              since,
+              before,
+            });
+            result.messages.push(...scopedResult.messages);
+            result.summaries.push(...scopedResult.summaries);
+          }
+          result.messages.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+          result.summaries.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+          if (result.messages.length > limit) {
+            result.messages = result.messages.slice(0, limit);
+          }
+          if (result.summaries.length > limit) {
+            result.summaries = result.summaries.slice(0, limit);
+          }
+          result.totalMatches = result.messages.length + result.summaries.length;
+        }
+      } catch (grepError) {
+        return jsonResult({
+          error: grepError instanceof Error ? grepError.message : "Search failed.",
+        });
+      }
 
       const lines: string[] = [];
       lines.push("## LCM Grep Results");
@@ -138,6 +206,8 @@ export function createLcmGrepTool(input: {
         lines.push("**Conversation scope:** all conversations");
       } else if (conversationScope.conversationId != null) {
         lines.push(`**Conversation scope:** ${conversationScope.conversationId}`);
+      } else if (conversationScope.conversationIds && conversationScope.conversationIds.length > 0) {
+        lines.push(`**Conversation scope:** ${conversationScope.conversationIds.join(", ")}`);
       }
       if (since || before) {
         lines.push(

--- a/test/expansion-auth.test.ts
+++ b/test/expansion-auth.test.ts
@@ -307,15 +307,15 @@ describe("ExpansionAuthManager", () => {
       expect(result.valid).toBe(true);
     });
 
-    it("does not enforce maxDepth against grant limits", () => {
+    it("rejects request exceeding maxDepth", () => {
       const result = manager.validateExpansion(grantId, {
         conversationId: 1,
         summaryIds: ["sum_a"],
         depth: 5,
         tokenCap: 1000,
       });
-      expect(result.valid).toBe(true);
-      expect(result.reason).toBeUndefined();
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("exceeds grant maximum");
     });
 
     it("does not enforce tokenCap against grant limits", () => {

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -4,6 +4,7 @@ import {
   resetDelegatedExpansionGrantsForTests,
 } from "../src/expansion-auth.js";
 import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
+import { createLcmExpandQueryTool } from "../src/tools/lcm-expand-query-tool.js";
 import { createLcmExpandTool } from "../src/tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
 import type { LcmDependencies } from "../src/types.js";
@@ -241,7 +242,7 @@ describe("LCM tools session scoping", () => {
       sessionId: "session-1",
     });
     const scoped = await tool.execute("call-3", { id: "sum_foreign" });
-    expect((scoped.details as { error?: string }).error).toContain("Not found in conversation 42");
+    expect((scoped.details as { error?: string }).error).toContain("Not found: sum_foreign");
 
     const cross = await tool.execute("call-4", {
       id: "sum_foreign",
@@ -249,5 +250,138 @@ describe("LCM tools session scoping", () => {
     });
     expect((cross.content[0] as { text: string }).text).toContain("meta conv=99");
     expect((cross.content[0] as { text: string }).text).toContain("manifest");
+  });
+
+  it("lcm_grep scopes delegated allConversations to allowed grant conversations", async () => {
+    const retrieval = {
+      grep: vi.fn(async (input: { conversationId?: number }) => ({
+        messages: [],
+        summaries: [
+          {
+            summaryId: `sum_${input.conversationId}`,
+            conversationId: input.conversationId ?? 0,
+            kind: "leaf",
+            snippet: "match",
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            rank: 0,
+          },
+        ],
+        totalMatches: 1,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const delegatedSessionKey = "agent:main:subagent:scope-test";
+    createDelegatedExpansionGrant({
+      delegatedSessionKey,
+      issuerSessionId: "main",
+      allowedConversationIds: [7, 8],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: delegatedSessionKey,
+      sessionKey: delegatedSessionKey,
+    });
+    const result = await tool.execute("call-5", {
+      pattern: "match",
+      allConversations: true,
+      scope: "summaries",
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledTimes(2);
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 7 }),
+    );
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 8 }),
+    );
+    expect((result.content[0] as { text: string }).text).toContain("**Conversation scope:** 7, 8");
+  });
+
+  it("lcm_describe rejects delegated access outside allowed conversation scope", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const delegatedSessionKey = "agent:main:subagent:describe-scope-test";
+    createDelegatedExpansionGrant({
+      delegatedSessionKey,
+      issuerSessionId: "main",
+      allowedConversationIds: [42],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: delegatedSessionKey,
+      sessionKey: delegatedSessionKey,
+    });
+
+    const scoped = await tool.execute("call-6", {
+      id: "sum_any",
+      conversationId: 99,
+    });
+
+    expect((scoped.details as { error?: string }).error).toContain(
+      "Not found: sum_any",
+    );
+    expect(retrieval.describe).not.toHaveBeenCalled();
+  });
+
+  it("lcm_expand_query rejects explicit summaryIds outside scoped conversation", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "sum_foreign",
+        type: "summary",
+        summary: {
+          conversationId: 99,
+          kind: "leaf",
+          content: "foreign content",
+          depth: 0,
+          tokenCount: 10,
+          descendantCount: 0,
+          descendantTokenCount: 0,
+          sourceMessageTokenCount: 10,
+          fileIds: [],
+          parentIds: [],
+          childIds: [],
+          messageIds: [],
+          earliestAt: new Date("2026-01-01T00:00:00.000Z"),
+          latestAt: new Date("2026-01-01T00:00:00.000Z"),
+          subtree: [],
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    // Use a main session (not subagent) with explicit conversationId=42
+    // The summary lives in conversation 99, so it should be rejected
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+      sessionKey: "session-1",
+      requesterSessionKey: "session-1",
+    });
+
+    const result = await tool.execute("call-7", {
+      summaryIds: ["sum_foreign"],
+      prompt: "test",
+      conversationId: 42,
+    });
+
+    // Summary is in conversation 99 but scope is 42 — should be rejected
+    expect((result.details as { error?: string }).error).toContain(
+      "outside conversation 42",
+    );
   });
 });

--- a/test/regex-safety.test.ts
+++ b/test/regex-safety.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { validateRegexSafety } from "../src/store/regex-safety.js";
+
+describe("validateRegexSafety", () => {
+  it("accepts simple regex patterns", () => {
+    const result = validateRegexSafety("foo.*bar");
+    expect(result.safe).toBe(true);
+  });
+
+  it("rejects nested quantifiers", () => {
+    expect(validateRegexSafety("(a+)+").safe).toBe(false);
+    expect(validateRegexSafety("(a*)*b").safe).toBe(false);
+  });
+
+  it("rejects oversized patterns", () => {
+    const pattern = "a".repeat(501);
+    const result = validateRegexSafety(pattern);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain("maximum length");
+  });
+
+  it("rejects invalid patterns", () => {
+    const result = validateRegexSafety("[invalid");
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain("Invalid regular expression");
+  });
+});


### PR DESCRIPTION
## Summary

Three security fixes from adversarial code review: cross-session data leakage (Critical), grant depth enforcement (High), and ReDoS mitigation (Medium).

### #70 (Critical) — Cross-session data leakage via lcm_grep/describe/expand_query

Sub-agents could bypass conversation scope by passing `allConversations=true` or arbitrary `conversationId` to tools that didn't consult the grant system.

**Fix:** `resolveLcmConversationScope()` now accepts optional grant context. When a sub-agent has a delegated grant, scope is restricted to `allowedConversationIds`. Sub-agents without grants are restricted to their own conversation. Uniform "Not found" errors prevent cross-conversation existence leaks.

**Files:** lcm-conversation-scope.ts, lcm-grep-tool.ts, lcm-describe-tool.ts, lcm-expand-query-tool.ts

### #72 (High) — Grant maxDepth not enforced

`validateExpansion()` checked grant existence and scope but never compared request depth against `grant.maxDepth`.

**Fix:** Added depth check after existing scope checks. Token cap enforcement intentionally left as clamp (existing `wrapWithAuth()` behavior is correct).

**File:** expansion-auth.ts

### #76 (Medium) — ReDoS in regex grep

Both store `searchRegex()` methods compiled user-provided patterns via `new RegExp()` with no validation.

**Fix:** New `regex-safety.ts` with nested quantifier detection, pattern length cap, and compile validation. Typed `UnsafeRegexError` surfaces to tool layer. SQL candidate queries capped at 10K rows. Note: this is a bounded mitigation, not a complete ReDoS fix.

**Files:** regex-safety.ts (new), conversation-store.ts, summary-store.ts

## Test Results

60 tests pass (4 new in regex-safety, 3 new in lcm-tools, 1 updated in expansion-auth).

## Changes

12 files changed, 536 insertions(+), 69 deletions(-)
