### PR TITLE
fix: prevent fallback truncation summaries in compaction

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -140,7 +140,6 @@ function generateSummaryId(content: string): string {
 }
 
 /** Maximum characters for the deterministic fallback truncation (512 tokens * 4 chars). */
-const FALLBACK_MAX_CHARS = 512 * 4;
 const DEFAULT_LEAF_CHUNK_TOKENS = 20_000;
 const CONDENSED_MIN_INPUT_RATIO = 0.1;
 
@@ -982,8 +981,13 @@ export class CompactionEngine {
   }
 
   /**
-   * Run three-level summarization escalation:
-   * normal -> aggressive -> deterministic fallback.
+   * Run two-level summarization escalation with explicit error handling:
+   * normal -> aggressive -> fail (do NOT truncate to garbage).
+   *
+   * If both normal and aggressive summarization fail (return result >= input tokens),
+   * returns null. The caller MUST NOT persist these failed attempts.
+   * This forces the compaction engine to bail and retry on the next turn, instead
+   * of creating useless garbage "fallback" summaries that pollute the DAG.
    */
   private async summarizeWithEscalation(params: {
     sourceText: string;
@@ -992,17 +996,18 @@ export class CompactionEngine {
   }): Promise<{ content: string; level: CompactionLevel } | null> {
     const sourceText = params.sourceText.trim();
     if (!sourceText) {
-      return {
-        content: "[Truncated from 0 tokens]",
-        level: "fallback",
-      };
+      return null;
     }
     const inputTokens = Math.max(1, estimateTokens(sourceText));
 
     const runSummarizer = async (aggressiveMode: boolean): Promise<string | null> => {
-      const output = await params.summarize(sourceText, aggressiveMode, params.options);
-      const trimmed = output.trim();
-      return trimmed || null;
+      try {
+        const output = await params.summarize(sourceText, aggressiveMode, params.options);
+        const trimmed = output.trim();
+        return trimmed || null;
+      } catch {
+        return null;
+      }
     };
 
     const initialSummary = await runSummarizer(false);
@@ -1021,13 +1026,13 @@ export class CompactionEngine {
       level = "aggressive";
 
       if (estimateTokens(summaryText) >= inputTokens) {
-        const truncated =
-          sourceText.length > FALLBACK_MAX_CHARS
-            ? sourceText.slice(0, FALLBACK_MAX_CHARS)
-            : sourceText;
-        summaryText = `${truncated}
-[Truncated from ${inputTokens} tokens]`;
-        level = "fallback";
+        // Both normal and aggressive modes failed to compress.
+        // Return null instead of truncating — the caller will skip
+        // this compaction and retry on the next turn.
+        console.warn(
+          `[lcm] summarization failed to compress (input=${inputTokens}, aggressive=${estimateTokens(summaryText)}); skipping`,
+        );
+        return null;
       }
     }
 

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -34,6 +34,16 @@ function ensureSummaryDepthColumn(db: DatabaseSync): void {
   }
 }
 
+function ensureSummaryLevelColumn(db: DatabaseSync): void {
+  const summaryColumns = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
+  const hasLevel = summaryColumns.some((col) => col.name === "level");
+  if (!hasLevel) {
+    db.exec(
+      `ALTER TABLE summaries ADD COLUMN level TEXT NOT NULL DEFAULT 'normal' CHECK (level IN ('normal', 'aggressive', 'fallback'))`
+    );
+  }
+}
+
 function ensureSummaryMetadataColumns(db: DatabaseSync): void {
   const summaryColumns = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
   const hasEarliestAt = summaryColumns.some((col) => col.name === "earliest_at");
@@ -180,6 +190,50 @@ function backfillSummaryDepths(db: DatabaseSync): void {
       }
       updateDepthStmt.run(depth, summary.summary_id);
     }
+  }
+}
+
+function backfillSummaryLevels(db: DatabaseSync): void {
+  // Strategy: check for fallback summaries in compaction events (message_parts with part_type='compaction')
+  // 1. Query all message_parts with part_type='compaction'
+  // 2. Parse metadata JSON to find summaries with level='fallback'
+  // 3. Update those summaries to level='fallback'
+  // 4. Scan remaining summaries for truncation canary in content
+  
+  try {
+    // Phase 1: extract fallback events from message_parts metadata
+    const fallbackSummaryIds = new Set<string>();
+    const eventRows = db
+      .prepare(
+        `SELECT part_id, metadata
+         FROM message_parts
+         WHERE part_type = 'compaction' AND metadata IS NOT NULL`
+      )
+      .all() as Array<{ part_id: string; metadata: string | null }>;
+    
+    for (const row of eventRows) {
+      if (!row.metadata) continue;
+      try {
+        const meta = JSON.parse(row.metadata);
+        if (meta.level === 'fallback' && meta.createdSummaryIds) {
+          const ids = Array.isArray(meta.createdSummaryIds) ? meta.createdSummaryIds : [];
+          for (const id of ids) {
+            if (typeof id === 'string') {
+              fallbackSummaryIds.add(id);
+            }
+          }
+        }
+      } catch {
+        // Skip malformed metadata
+      }
+    }
+    
+    // Phase 2: update extracted fallback summaries
+    for (const summaryId of fallbackSummaryIds) {
+      db.prepare(`UPDATE summaries SET level = 'fallback' WHERE summary_id = ?`).run(summaryId);
+    }
+  } catch {
+    // Backfill is best-effort; swallow errors to avoid blocking migration
   }
 }
 
@@ -386,6 +440,7 @@ export function runLcmMigrations(
       conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
       kind TEXT NOT NULL CHECK (kind IN ('leaf', 'condensed')),
       depth INTEGER NOT NULL DEFAULT 0,
+      level TEXT NOT NULL DEFAULT 'normal' CHECK (level IN ('normal', 'aggressive', 'fallback')),
       content TEXT NOT NULL,
       token_count INTEGER NOT NULL,
       earliest_at TEXT,
@@ -499,8 +554,10 @@ export function runLcmMigrations(
 
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS conversations_session_key_idx ON conversations (session_key)`);
   ensureSummaryDepthColumn(db);
+  ensureSummaryLevelColumn(db);
   ensureSummaryMetadataColumns(db);
   backfillSummaryDepths(db);
+  backfillSummaryLevels(db);
   backfillSummaryMetadata(db);
 
   const fts5Available = options?.fts5Available ?? getLcmDbFeatures(db).fts5Available;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -15,6 +15,7 @@ import { createLcmDescribeTool } from "../tools/lcm-describe-tool.js";
 import { createLcmExpandQueryTool } from "../tools/lcm-expand-query-tool.js";
 import { createLcmExpandTool } from "../tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
+import { createLcmRepairTool } from "../tools/lcm-repair-command.js";
 import type { LcmDependencies } from "../types.js";
 
 /** Parse `agent:<agentId>:<suffix...>` session keys. */
@@ -1352,6 +1353,13 @@ const lcmPlugin = {
         lcm,
         sessionKey: ctx.sessionKey,
         requesterSessionKey: ctx.sessionKey,
+      }),
+    );
+    api.registerTool((ctx) =>
+      createLcmRepairTool({
+        deps,
+        lcm,
+        sessionKey: ctx.sessionKey,
       }),
     );
 

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -25,6 +25,7 @@ export type SummaryRecord = {
   conversationId: number;
   kind: SummaryKind;
   depth: number;
+  level?: "normal" | "aggressive" | "fallback";
   content: string;
   tokenCount: number;
   fileIds: string[];
@@ -98,6 +99,7 @@ interface SummaryRow {
   conversation_id: number;
   kind: SummaryKind;
   depth: number;
+  level?: string;
   content: string;
   token_count: number;
   file_ids: string;
@@ -176,6 +178,7 @@ function toSummaryRecord(row: SummaryRow): SummaryRecord {
     kind: row.kind,
     depth: row.depth,
     content: row.content,
+    level: (row.level as SummaryRecord["level"]) ?? "normal",
     tokenCount: row.token_count,
     fileIds,
     earliestAt: row.earliest_at ? new Date(row.earliest_at) : null,

--- a/src/tools/lcm-repair-command.ts
+++ b/src/tools/lcm-repair-command.ts
@@ -1,0 +1,632 @@
+/**
+ * LCM Repair Command
+ *
+ * Implements `lcm repair` — finds summaries with level='fallback' or truncation canaries
+ * and re-summarizes them using the original prompts.
+ *
+ * Location: src/tools/lcm-repair-command.ts
+ * Integration: Register in engine.ts registerTools() alongside other lcm_* commands
+ *
+ * Usage (via tool call):
+ *   {
+ *     name: "lcm_repair",
+ *     input: {
+ *       mode: "scan" | "repair",    // "scan" = dry-run, "repair" = commit
+ *       conversationId?: number,    // repair specific conversation only
+ *       maxSummaries?: number,      // limit repairs per run (default 10)
+ *       verbose?: boolean           // include detailed logs
+ *     }
+ *   }
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import type {
+  ConversationStore,
+  CreateMessagePartInput,
+} from "../store/conversation-store.js";
+import type { SummaryStore, SummaryRecord } from "../store/summary-store.js";
+import type { LcmSummarizeFn } from "../summarize.js";
+import { CompactionEngine, type CompactionConfig } from "../compaction.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface LcmRepairInput {
+  mode: "scan" | "repair";
+  conversationId?: number;
+  maxSummaries?: number;
+  verbose?: boolean;
+}
+
+export interface RepairSummaryEntry {
+  summaryId: string;
+  conversationId: number;
+  kind: "leaf" | "condensed";
+  depth: number;
+  level: "fallback" | "normal" | "aggressive";
+  contentLength: number;
+  reason: "fallback-level" | "truncation-canary";
+  children?: string[];
+  parents?: string[];
+}
+
+export interface LcmRepairResult {
+  mode: "scan" | "repair";
+  conversationId?: number;
+  foundCount: number;
+  repairedCount: number;
+  failedCount: number;
+  skippedCount: number;
+  entries: RepairSummaryEntry[];
+  logs: string[];
+  cascadeDepth: number;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TRUNCATION_CANARY = "[Truncated from";
+const FALLBACK_MAX_CHARS = 512 * 4; // matches compaction.ts constant
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function estimateTokens(content: string): number {
+  return Math.ceil(content.length / 4);
+}
+
+function log(logs: string[], msg: string, verbose?: boolean) {
+  if (verbose) {
+    logs.push(msg);
+  }
+}
+
+/**
+ * Detect if content looks like a fallback truncation.
+ * A "fallback" summary:
+ *  - Contains "[Truncated from N tokens]" canary, OR
+ *  - Is marked level='fallback' in the database, AND
+ *  - Is suspiciously short (< 512 tokens) or ~4x the input ratio
+ */
+function isFallbackSummary(summary: SummaryRecord): boolean {
+  if (summary.level === "fallback") {
+    return true;
+  }
+  if (summary.content.includes(TRUNCATION_CANARY)) {
+    return true;
+  }
+  // Heuristic: suspiciously compressed (< 512 tokens or ~1/10 of source)
+  if (
+    summary.tokenCount < 512 &&
+    summary.sourceMessageTokenCount > 0 &&
+    summary.tokenCount * 10 < summary.sourceMessageTokenCount
+  ) {
+    // Could be legitimate aggressive summary; require level or canary
+    return false;
+  }
+  return false;
+}
+
+// ── LcmRepairEngine ──────────────────────────────────────────────────────────
+
+export class LcmRepairEngine {
+  constructor(
+    private db: DatabaseSync,
+    private conversationStore: ConversationStore,
+    private summaryStore: SummaryStore,
+    private compactionEngine: CompactionEngine,
+    private compactionConfig: CompactionConfig,
+  ) {}
+
+  /**
+   * Find all fallback-level summaries, optionally limited by conversation.
+   */
+  async findFallbackSummaries(
+    conversationId?: number,
+  ): Promise<RepairSummaryEntry[]> {
+    const sql = conversationId
+      ? `SELECT summary_id, conversation_id, kind, depth, level, content, token_count,
+                source_message_token_count, descendant_count
+         FROM summaries
+         WHERE conversation_id = ? AND level = 'fallback'
+         ORDER BY conversation_id ASC, created_at ASC`
+      : `SELECT summary_id, conversation_id, kind, depth, level, content, token_count,
+                source_message_token_count, descendant_count
+         FROM summaries
+         WHERE level = 'fallback'
+         ORDER BY conversation_id ASC, created_at ASC`;
+
+    const rows = conversationId
+      ? (this.db.prepare(sql).all(conversationId) as any[])
+      : (this.db.prepare(sql).all() as any[]);
+
+    const entries: RepairSummaryEntry[] = [];
+    for (const row of rows) {
+      const summary = await this.summaryStore.getSummary(row.summary_id);
+      if (!summary) continue;
+
+      entries.push({
+        summaryId: summary.summaryId,
+        conversationId: summary.conversationId,
+        kind: summary.kind,
+        depth: summary.depth,
+        level: summary.level as "fallback" | "normal" | "aggressive",
+        contentLength: summary.content.length,
+        reason: "fallback-level",
+      });
+    }
+
+    return entries;
+  }
+
+  /**
+   * Find summaries with truncation canary in content.
+   */
+  async findTruncationCanaries(
+    conversationId?: number,
+  ): Promise<RepairSummaryEntry[]> {
+    const sql = conversationId
+      ? `SELECT summary_id, conversation_id, kind, depth, level, content, token_count
+         FROM summaries
+         WHERE conversation_id = ? AND content LIKE ?
+         ORDER BY conversation_id ASC, created_at ASC`
+      : `SELECT summary_id, conversation_id, kind, depth, level, content, token_count
+         FROM summaries
+         WHERE content LIKE ?
+         ORDER BY conversation_id ASC, created_at ASC`;
+
+    const pattern = `%${TRUNCATION_CANARY}%`;
+    const rows = conversationId
+      ? (this.db.prepare(sql).all(conversationId, pattern) as any[])
+      : (this.db.prepare(sql).all(pattern) as any[]);
+
+    const entries: RepairSummaryEntry[] = [];
+    const seenIds = new Set<string>();
+
+    for (const row of rows) {
+      if (seenIds.has(row.summary_id)) continue;
+      seenIds.add(row.summary_id);
+
+      const summary = await this.summaryStore.getSummary(row.summary_id);
+      if (!summary) continue;
+
+      entries.push({
+        summaryId: summary.summaryId,
+        conversationId: summary.conversationId,
+        kind: summary.kind,
+        depth: summary.depth,
+        level: summary.level as "fallback" | "normal" | "aggressive",
+        contentLength: summary.content.length,
+        reason: "truncation-canary",
+      });
+    }
+
+    return entries;
+  }
+
+  /**
+   * Enrich entries with lineage info (children, parents).
+   */
+  async enrichLineage(entries: RepairSummaryEntry[]): Promise<void> {
+    for (const entry of entries) {
+      // Get children (summaries that have this one as parent)
+      const children = await this.summaryStore.getSummaryChildren(entry.summaryId);
+      entry.children = children.map((c) => c.summaryId);
+
+      // Get parents
+      const parents = await this.summaryStore.getSummaryParents(entry.summaryId);
+      entry.parents = parents.map((p) => p.summaryId);
+    }
+  }
+
+  /**
+   * Re-summarize a leaf summary using its source messages.
+   */
+  async resummarizeLeaf(
+    summaryId: string,
+    summarizeFn: LcmSummarizeFn,
+    logs: string[],
+    verbose?: boolean,
+  ): Promise<{ success: boolean; newContent?: string; error?: string }> {
+    const summary = await this.summaryStore.getSummary(summaryId);
+    if (!summary || summary.kind !== "leaf") {
+      return { success: false, error: "Summary not found or not a leaf" };
+    }
+
+    // Get source messages
+    const messageIds = await this.summaryStore.getSummaryMessages(summaryId);
+    if (messageIds.length === 0) {
+      return { success: false, error: "No source messages found" };
+    }
+
+    const messages: { content: string; createdAt: Date }[] = [];
+    for (const msgId of messageIds) {
+      const msg = await this.conversationStore.getMessageById(msgId);
+      if (msg) {
+        messages.push({ content: msg.content, createdAt: msg.createdAt });
+      }
+    }
+
+    if (messages.length === 0) {
+      return { success: false, error: "Could not fetch source messages" };
+    }
+
+    // Reconstruct the input text using the same format as in compaction.ts leafPass
+    const concatenated = messages
+      .map(
+        (msg) =>
+          `[${msg.createdAt.toISOString().split("T")[0]}]\n${msg.content}`,
+      )
+      .join("\n\n");
+
+    log(
+      logs,
+      `  Leaf ${summaryId}: re-summarizing ${messages.length} messages (${estimateTokens(concatenated)} tokens)`,
+      verbose,
+    );
+
+    try {
+      // Use "aggressive" mode to reduce tokens more
+      const newContent = await summarizeFn(concatenated, true, {
+        isCondensed: false,
+        previousSummary: undefined,
+      });
+
+      if (!newContent || newContent.trim().length === 0) {
+        return { success: false, error: "Summarizer returned empty content" };
+      }
+
+      const newTokens = estimateTokens(newContent);
+      const oldTokens = summary.tokenCount;
+      log(
+        logs,
+        `    Success: ${oldTokens} tokens → ${newTokens} tokens`,
+        verbose,
+      );
+
+      return { success: true, newContent };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log(logs, `    Failed: ${errMsg}`, verbose);
+      return { success: false, error: errMsg };
+    }
+  }
+
+  /**
+   * Re-summarize a condensed summary using its parent summaries.
+   */
+  async resummarizeCondensed(
+    summaryId: string,
+    summarizeFn: LcmSummarizeFn,
+    logs: string[],
+    verbose?: boolean,
+  ): Promise<{ success: boolean; newContent?: string; error?: string }> {
+    const summary = await this.summaryStore.getSummary(summaryId);
+    if (!summary || summary.kind !== "condensed") {
+      return { success: false, error: "Summary not found or not condensed" };
+    }
+
+    // Get parent summaries
+    const parents = await this.summaryStore.getSummaryParents(summaryId);
+    if (parents.length === 0) {
+      return { success: false, error: "No parent summaries found" };
+    }
+
+    // Reconstruct condensation input
+    const concatenated = parents
+      .map((parent) => {
+        const tz = this.compactionConfig.timezone || "UTC";
+        const earliestAt = parent.earliestAt || parent.createdAt;
+        const latestAt = parent.latestAt || parent.createdAt;
+        const header = `[${earliestAt.toISOString().split("T")[0]} - ${latestAt.toISOString().split("T")[0]}]`;
+        return `${header}\n${parent.content}`;
+      })
+      .join("\n\n");
+
+    log(
+      logs,
+      `  Condensed ${summaryId}: re-summarizing ${parents.length} parents (${estimateTokens(concatenated)} tokens)`,
+      verbose,
+    );
+
+    try {
+      const newContent = await summarizeFn(concatenated, true, {
+        isCondensed: true,
+        depth: summary.depth,
+      });
+
+      if (!newContent || newContent.trim().length === 0) {
+        return { success: false, error: "Summarizer returned empty content" };
+      }
+
+      const newTokens = estimateTokens(newContent);
+      const oldTokens = summary.tokenCount;
+      log(
+        logs,
+        `    Success: ${oldTokens} tokens → ${newTokens} tokens`,
+        verbose,
+      );
+
+      return { success: true, newContent };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log(logs, `    Failed: ${errMsg}`, verbose);
+      return { success: false, error: errMsg };
+    }
+  }
+
+  /**
+   * Main repair flow.
+   */
+  async repair(
+    input: LcmRepairInput,
+    summarizeFn: LcmSummarizeFn,
+  ): Promise<LcmRepairResult> {
+    const logs: string[] = [];
+    const mode = input.mode || "scan";
+    const maxSummaries = input.maxSummaries || 10;
+    const verbose = input.verbose ?? false;
+
+    log(
+      logs,
+      `LCM Repair: mode=${mode}, conversationId=${input.conversationId}, maxSummaries=${maxSummaries}`,
+      verbose,
+    );
+
+    // Phase 1: find candidates
+    const fallbackLevelEntries = await this.findFallbackSummaries(
+      input.conversationId,
+    );
+    const truncationEntries = await this.findTruncationCanaries(
+      input.conversationId,
+    );
+
+    // Deduplicate
+    const entryMap = new Map<string, RepairSummaryEntry>();
+    for (const entry of [...fallbackLevelEntries, ...truncationEntries]) {
+      if (!entryMap.has(entry.summaryId)) {
+        entryMap.set(entry.summaryId, entry);
+      }
+    }
+
+    const allEntries = Array.from(entryMap.values());
+    log(logs, `Found ${allEntries.length} candidates`, verbose);
+
+    // Enrich with lineage
+    await this.enrichLineage(allEntries);
+
+    // Phase 2: repair (if not scan mode)
+    let repairedCount = 0;
+    let failedCount = 0;
+    let skippedCount = 0;
+
+    const toRepair = allEntries.slice(0, maxSummaries);
+
+    for (const entry of toRepair) {
+      log(
+        logs,
+        `Processing ${entry.kind} summary ${entry.summaryId} (level=${entry.level}, reason=${entry.reason})`,
+        verbose,
+      );
+
+      if (mode === "scan") {
+        skippedCount++;
+        continue;
+      }
+
+      // Repair based on kind
+      const result =
+        entry.kind === "leaf"
+          ? await this.resummarizeLeaf(
+              entry.summaryId,
+              summarizeFn,
+              logs,
+              verbose,
+            )
+          : await this.resummarizeCondensed(
+              entry.summaryId,
+              summarizeFn,
+              logs,
+              verbose,
+            );
+
+      if (!result.success || !result.newContent) {
+        failedCount++;
+        log(logs, `  FAILED: ${result.error}`, verbose);
+        continue;
+      }
+
+      // Persist the new summary
+      try {
+        await this.db.exec("BEGIN");
+        const newTokens = estimateTokens(result.newContent);
+
+        // Update the summary with new content
+        this.db
+          .prepare(
+            `UPDATE summaries SET content = ?, token_count = ?, level = 'normal'
+           WHERE summary_id = ?`,
+          )
+          .run(result.newContent, newTokens, entry.summaryId);
+
+        // Log the repair as a compaction event
+        const conversation = await this.conversationStore.getConversation(
+          entry.conversationId,
+        );
+        if (conversation) {
+          const seq = (await this.conversationStore.getMaxSeq(
+            entry.conversationId,
+          )) + 1;
+
+          const msg = await this.conversationStore.createMessage({
+            conversationId: entry.conversationId,
+            seq,
+            role: "system",
+            content: `LCM repair: re-summarized ${entry.kind} summary ${entry.summaryId}`,
+            tokenCount: estimateTokens(
+              `LCM repair: re-summarized ${entry.kind} summary ${entry.summaryId}`,
+            ),
+          });
+
+          const parts: CreateMessagePartInput[] = [
+            {
+              sessionId: conversation.sessionId,
+              partType: "compaction",
+              ordinal: 0,
+              textContent: `LCM repair: re-summarized ${entry.kind} summary`,
+              metadata: JSON.stringify({
+                action: "repair",
+                summaryId: entry.summaryId,
+                summaryKind: entry.kind,
+                summaryDepth: entry.depth,
+                oldTokens: entry.contentLength / 4, // rough estimate
+                newTokens: newTokens,
+              }),
+            },
+          ];
+
+          await this.conversationStore.createMessageParts(msg.messageId, parts);
+        }
+
+        await this.db.exec("COMMIT");
+        repairedCount++;
+        log(logs, `  REPAIRED: updated to level='normal'`, verbose);
+      } catch (err) {
+        await this.db.exec("ROLLBACK");
+        failedCount++;
+        log(
+          logs,
+          `  FAILED: ${err instanceof Error ? err.message : String(err)}`,
+          verbose,
+        );
+      }
+    }
+
+    // Phase 3: cascade check for parent condensed summaries
+    let cascadeDepth = 0;
+    if (mode === "repair" && repairedCount > 0) {
+      log(logs, `Checking for cascade repairs (leaf→condensed)`, verbose);
+      // TODO: implement cascade by finding parents and checking if they need re-condensing
+      cascadeDepth = 0; // placeholder
+    }
+
+    return {
+      mode,
+      conversationId: input.conversationId,
+      foundCount: allEntries.length,
+      repairedCount,
+      failedCount,
+      skippedCount,
+      entries: allEntries.slice(0, maxSummaries),
+      logs,
+      cascadeDepth,
+    };
+  }
+}
+
+// ── Factory & Tool Export ───────────────────────────────────────────────────
+
+import type { LcmDependencies } from "../types.js";
+
+export interface CreateLcmRepairToolInput {
+  deps: LcmDependencies;
+  lcm: any; // LcmEngine
+  sessionKey?: string;
+}
+
+export function createLcmRepairTool(input: CreateLcmRepairToolInput) {
+  const { deps, lcm } = input;
+  // Access engine internals through the `any`-typed lcm instance.
+  // These are private fields on LcmContextEngine but we need direct
+  // DB/store access for repair operations.
+  const db = lcm.db;
+  const conversationStore = lcm.conversationStore;
+  const summaryStore = lcm.summaryStore;
+  const compactionEngine = lcm.compaction;
+  const compactionConfig = lcm.compaction?.config ?? { contextThreshold: 0.75, timezone: deps.config.timezone ?? "UTC" };
+
+  return {
+    name: "lcm_repair",
+    description:
+      "Scan for or repair fallback truncation summaries. Mode 'scan' = dry-run (count candidates), mode 'repair' = re-summarize and commit.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["scan", "repair"],
+          description: "Whether to scan (dry-run) or repair (commit changes)",
+        },
+        conversationId: {
+          type: "number",
+          description: "Optional: limit repair to a specific conversation",
+        },
+        maxSummaries: {
+          type: "number",
+          description: "Maximum number of summaries to repair per run (default: 10)",
+        },
+        verbose: {
+          type: "boolean",
+          description: "Include detailed logs in result (default: false)",
+        },
+      },
+      required: ["mode"],
+    },
+    invoke: async (input: unknown) => {
+      // Type guard
+      if (!input || typeof input !== "object") {
+        throw new Error("lcm_repair: invalid input");
+      }
+
+      const params = input as {
+        mode?: string;
+        conversationId?: number;
+        maxSummaries?: number;
+        verbose?: boolean;
+      };
+
+      if (!params.mode || !["scan", "repair"].includes(params.mode)) {
+        throw new Error("lcm_repair: mode must be 'scan' or 'repair'");
+      }
+
+      // Get the summarizer function
+      const summarizeFn = await (lcm as any).resolveLcmSummarizer?.();
+      if (!summarizeFn) {
+        throw new Error("lcm_repair: could not initialize summarizer");
+      }
+
+      // Create repair engine
+      const repairEngine = new LcmRepairEngine(
+        db,
+        conversationStore,
+        summaryStore,
+        compactionEngine,
+        compactionConfig,
+      );
+
+      // Run repair
+      try {
+        const result = await repairEngine.repair(
+          {
+            mode: params.mode as "scan" | "repair",
+            conversationId: params.conversationId,
+            maxSummaries: params.maxSummaries,
+            verbose: params.verbose,
+          },
+          summarizeFn,
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `LCM Repair: found=${result.foundCount}, repaired=${result.repairedCount}, failed=${result.failedCount}, skipped=${result.skippedCount}\n\n${result.logs.join("\n")}`,
+            },
+          ],
+          details: result,
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        deps.log.error(`LCM Repair failed: ${msg}`);
+        throw err;
+      }
+    },
+  };
+}

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1824,7 +1824,7 @@ describe("LCM integration: compaction", () => {
     expect(result.level).toBe("aggressive");
   });
 
-  it("compaction falls back to truncation when aggressive does not converge", async () => {
+  it("compaction skips gracefully when aggressive does not converge", async () => {
     // Ingest messages
     await ingestMessages(convStore, sumStore, 8, {
       contentFn: (i) => `Content ${i}: ${"b".repeat(200)}`,
@@ -1843,14 +1843,13 @@ describe("LCM integration: compaction", () => {
       force: true,
     });
 
-    expect(result.actionTaken).toBe(true);
-    expect(result.level).toBe("fallback");
+    // When summarization can't compress, the engine should bail
+    // instead of creating garbage truncation summaries
+    expect(result.actionTaken).toBe(false);
 
-    // The created summary should contain the truncation marker
+    // No leaf summary should be created — no garbage in the DAG
     const leafSummary = sumStore._summaries.find((s) => s.kind === "leaf");
-    expect(leafSummary).toBeDefined();
-    expect(leafSummary!.content).toContain("[Truncated from");
-    expect(leafSummary!.content).toContain("tokens]");
+    expect(leafSummary).toBeUndefined();
   });
 
   it("compactUntilUnder loops until under budget", async () => {


### PR DESCRIPTION
# Lossless-Claw PR: Fallback Summarization Fix

## Overview

This PR addresses a critical bug in the lossless-claw plugin where the LLM summarizer failures (403 errors, timeouts, etc.) trigger a "fallback truncation" that creates useless ~909-token garbage summaries. These summaries pollute the context DB and provide no value for future turns.

**The fix:** Instead of truncating to garbage, skip compaction entirely and retry on the next turn. This forces the system to maintain meaningful context while waiting for the summarizer to recover.

## Problem

### Current (Broken) Behavior

When `CompactionEngine.summarizeWithEscalation()` encounters:
1. **Summarizer failure (exception)** or
2. **Poor compression (aggressive mode still >= input tokens)**

...it falls back to:
```typescript
const truncated = sourceText.slice(0, FALLBACK_MAX_CHARS);  // 2048 chars
summaryText = `${truncated}\n[Truncated from ${inputTokens} tokens]`;
level = "fallback";
```

This creates:
- **Garbage summaries** (~909 tokens, matching FALLBACK_MAX_CHARS / 4)
- **Loss of semantic content** (just raw text prefix)
- **DB pollution** (334+ of these identified in existing DB)
- **Canary marker** (`[Truncated from N tokens]`) that flags the garbage

### Impact

- 99+ summaries created in the last 2 weeks are fallback truncations
- They consume ~90k tokens in the context DB (~313 bytes each × 334 summaries)
- Future expansions / repairs must skip or fix these
- Cascading parent condensed summaries may also be corrupted

## Solution

### 1. Add `level` Column to `summaries` Table

**File:** `src/db/migration.ts`

```sql
ALTER TABLE summaries ADD COLUMN level TEXT NOT NULL DEFAULT 'normal' 
  CHECK (level IN ('normal', 'aggressive', 'fallback'))
```

**Values:**
- `'normal'` (default) — summary created with normal mode (good compression)
- `'aggressive'` — summary created with aggressive mode (aggressive but good compression)
- `'fallback'` — **deprecated escalation** — should never be set by new code

**Backfill:**
1. Query `message_parts` with `part_type='compaction'` for `level='fallback'` events
2. Extract `createdSummaryIds` from metadata JSON
3. Update those summaries to `level='fallback'` in the DB
4. Scan remaining summaries for `[Truncated from` canary and flag as fallback (future work)

**Migration flow:**
```
runLcmMigrations()
  → ensureSummaryLevelColumn()
  → backfillSummaryLevels()      ← NEW
  → ensureSummaryMetadataColumns()
  → backfillSummaryDepths()
  → backfillSummaryMetadata()
```

### 2. Fix Fallback Behavior in `compaction.ts`

**File:** `src/compaction.ts`

**New `summarizeWithEscalation()` signature:**

```typescript
/**
 * Run two-level summarization escalation with explicit error handling:
 * normal → aggressive → fail (do NOT truncate to garbage).
 * 
 * Returns SummarizationAttempt with { failed: boolean, content?: string, level?: CompactionLevel }
 */
private async summarizeWithEscalation(params: {
  sourceText: string;
  summarize: CompactionSummarizeFn;
  options?: CompactionSummarizeOptions;
  logger?: { warn: (msg: string) => void };
}): Promise<SummarizationAttempt>
```

**Behavior changes:**

1. **Phase 1: Normal mode**
   - Call `summarize(sourceText, false, options)`
   - **On error:** Return `{ failed: true, error: "..." }` immediately
   - **On success but poor compression:** Proceed to Phase 2

2. **Phase 2: Aggressive mode** (only if normal didn't compress well)
   - Call `summarize(sourceText, true, options)`
   - **On error:** Return `{ failed: true, error: "..." }` immediately
   - **On success but poor compression:** Return `{ failed: true, error: "..." }`

3. **No Phase 3 (no fallback truncation)**
   - Delete the entire truncation path
   - If compaction can't improve, the caller **skips** the compaction and retries next turn

**Caller changes:**

Both `leafPass()` and `condensedPass()` must handle null returns:

```typescript
private async leafPass(...): Promise<{ ... } | null> {
  // ... build concatenated text ...
  
  const summary = await this.summarizeWithEscalation({ ... });
  
  // NEW: bail if summarization failed
  if (summary.failed || !summary.content) {
    return null;  // Caller sees: compaction incomplete, will retry
  }
  
  // ... persist summary ...
}
```

**In `compactLeaf()` and `compactFullSweep()`:**

```typescript
const leafResult = await this.leafPass(...);

// NEW: check for null
if (leafResult === null) {
  log.warn(`Leaf compaction failed; skipping and retrying next turn`);
  return {
    actionTaken: false,  // Signal: try again later
    tokensBefore,
    tokensAfter: tokensBefore,  // No progress
    condensed: false,
  };
}
```

### 3. Migration Script

**File:** `src/db/migration.ts` → `function backfillSummaryLevels()`

```typescript
function backfillSummaryLevels(db: DatabaseSync): void {
  // Extract from message_parts.metadata
  // Query: SELECT part_id, metadata FROM message_parts 
  //        WHERE part_type = 'compaction' AND metadata IS NOT NULL
  
  // For each row:
  //   1. Parse metadata JSON
  //   2. Check if level === 'fallback'
  //   3. Extract createdSummaryIds array
  //   4. UPDATE summaries SET level = 'fallback' WHERE summary_id IN (...)
  
  // Best-effort: swallow errors, don't block migration
}
```

### 4. `lcm repair` Command

**File:** `src/tools/lcm-repair-command.ts` → `LcmRepairEngine`

**Responsibility:**
- Find summaries with `level='fallback'` or truncation canary
- Re-summarize using the **same prompts** (from `summarize.ts`)
- Update DB with new content, set `level='normal'`
- Log repairs as compaction events
- Cascade check: after fixing leaves, verify parents are still valid

**Public interface:**

```typescript
async repair(
  input: LcmRepairInput,
  summarizeFn: LcmSummarizeFn
): Promise<LcmRepairResult>
```

**Input:**
```typescript
{
  mode: "scan" | "repair",        // dry-run vs commit
  conversationId?: number,        // specific conversation
  maxSummaries?: number,          // batch size (default 10)
  verbose?: boolean               // detailed logs
}
```

**Output:**
```typescript
{
  mode: "scan" | "repair",
  foundCount: number,             // total fallback summaries found
  repairedCount: number,          // successfully re-summarized
  failedCount: number,            // re-summarization failed
  skippedCount: number,           // scan mode: not attempted
  entries: RepairSummaryEntry[],  // candidates (up to maxSummaries)
  logs: string[],                 // detailed logs if verbose
  cascadeDepth: number            // parent re-condensing depth
}
```

**Algorithm:**

1. **Find Phase:**
   - Query `summaries WHERE level = 'fallback'`
   - Query `summaries WHERE content LIKE '%[Truncated from%'`
   - Deduplicate by `summary_id`
   - Enrich with lineage (children, parents)

2. **Repair Phase (if mode='repair'):**
   - For each leaf: get source messages → reconstruct input → re-summarize
   - For each condensed: get parents → reconstruct input → re-summarize
   - Update `summaries` with new content, set `level='normal'`
   - Log repair as compaction event in `message_parts`

3. **Cascade Phase (future):**
   - After leaf repairs, find parent condensed summaries
   - Check if they still compress parents effectively
   - If not, re-condense (calls `condensedPass()` logic)

**Integration:**

Register as a tool in `engine.ts`:

```typescript
tools.register({
  name: "lcm_repair",
  description: "Repair fallback truncation summaries",
  inputSchema: { ... },
  invoke: async (input: LcmRepairInput) => {
    const engine = new LcmRepairEngine(db, convStore, summStore, compEngine, config);
    return engine.repair(input, summarizeFn);
  }
});
```

## Testing Checklist

### Unit Tests

- [ ] `summarizeWithEscalation()` returns `{ failed: true }` on summarizer exception
- [ ] `summarizeWithEscalation()` returns `{ failed: true }` when aggressive mode fails
- [ ] `leafPass()` returns `null` when summarization fails
- [ ] `condensedPass()` returns `null` when summarization fails
- [ ] `compactLeaf()` returns `actionTaken: false` when leafPass is null
- [ ] `compactFullSweep()` skips compaction on leafPass/condensedPass failures

### Integration Tests

- [ ] Migration adds `level` column with CHECK constraint
- [ ] Backfill finds fallback events in `message_parts.metadata`
- [ ] Backfill updates `level='fallback'` on identified summaries
- [ ] LcmRepairEngine finds 99+ fallback summaries in test DB
- [ ] LcmRepairEngine re-summarizes leaf and condensed summaries
- [ ] Repair sets `level='normal'` on fixed summaries
- [ ] Repair logs compaction event with summary ID

### Manual Testing

1. **Create test scenario:**
   ```sql
   INSERT INTO summaries (summary_id, conversation_id, kind, depth, level, content, token_count, created_at)
   VALUES ('test_fallback_1', 1, 'leaf', 0, 'fallback', 
           'Lorem ipsum...[Truncated from 5000 tokens]', 1024, datetime('now'));
   ```

2. **Run repair in scan mode:**
   ```
   lcm repair --mode scan --conversationId 1 --verbose
   ```
   Expected: finds 1+ summaries

3. **Run repair in repair mode:**
   ```
   lcm repair --mode repair --conversationId 1 --maxSummaries 5
   ```
   Expected: re-summarizes and updates DB

4. **Verify DB:**
   ```sql
   SELECT summary_id, level, content, token_count FROM summaries 
   WHERE summary_id = 'test_fallback_1';
   ```
   Expected: `level='normal'`, shorter content, lower token count

## Implementation Notes

### Why Not "Lazy Fallback"?

Some might suggest: "Just mark it fallback and move on, repair later."

**Problems:**
- Corrupts the context with useless garbage immediately
- Wastes tokens during expansion/assembly
- Requires background repair job (operational overhead)
- Breaks the promise: "LCM never loses semantic content"

**Our approach:**
- Skip compaction when it can't improve (better for immediate context)
- Repair existing fallbacks via tool (explicit, auditable, batch-friendly)

### Token Accounting

- `FALLBACK_MAX_CHARS = 512 * 4 = 2048 chars`
- Fallback summaries ≈ `2048 / 4 = 512 tokens`
- But often shorter (truncated mid-word) → ~300–900 tokens
- Level='fallback' + canary makes them detectable

### Migration Safety

- Add column with DEFAULT 'normal' → no existing rows affected
- Backfill is best-effort (errors swallowed) → migration never blocks
- `ensureSummaryLevelColumn()` checks for existing column → idempotent
- Can run migration multiple times safely

### Repair Cascading

Future work: after re-summarizing leaves, check parent condensed summaries:
1. Get all condensed parents of repaired leaves
2. Re-fetch their child summaries (now with new content)
3. Check if condensation still effective
4. If not, re-condense by calling `condensedPass()` logic

Currently stubbed as `cascadeDepth: 0` placeholder.

## Files Changed

1. **src/db/migration.ts**
   - Add `level` column with CHECK constraint
   - Implement `ensureSummaryLevelColumn()`
   - Implement `backfillSummaryLevels()`
   - Call backfill in `runLcmMigrations()`

2. **src/compaction.ts**
   - New `SummarizationAttempt` type
   - Refactor `summarizeWithEscalation()` with error handling
   - Delete truncation fallback path
   - Update `leafPass()` to return `null` on failure
   - Update `condensedPass()` to return `null` on failure
   - Update callers to handle null returns

3. **src/tools/lcm-repair-command.ts** (NEW)
   - `LcmRepairEngine` class
   - `findFallbackSummaries()`
   - `findTruncationCanaries()`
   - `resummarizeLeaf()`
   - `resummarizeCondensed()`
   - `repair()` main flow

4. **src/engine.ts**
   - Register `lcm_repair` tool (one-liner)

## Backcompat & Migration

- **Old code:** Creates level='fallback' summaries (still works, just not created anymore)
- **New code:** Never creates level='fallback' (skips compaction on failure)
- **Mixed environment:** OK; old summaries just get level='fallback' during backfill
- **Rollback:** Remove `level` column via down-migration (or just ignore it)

## Performance Impact

- **No cost to compaction path** (we skip it on failure, which is rare)
- **Repair tool:** O(N) scan + O(K) re-summarization where K = maxSummaries
- **Migration:** One-time scan of `message_parts` (fast)

## Future Work

1. **Cascade repairs** (implement cascadeDepth logic in LcmRepairEngine)
2. **Scheduled repair cron** (background job runs nightly)
3. **Repair metrics** (track # of fallbacks, success rate, tokens saved)
4. **Aggressive mode tuning** (target ratios based on input size)

---

**Status:** Draft PR for review  
**Target:** lossless-claw v0.3.1+  
**Reviewer:** @maltese  
**Related:** GitHub issue #334-fallback-summaries