### PR TITLE
ci: add test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## What
Adds a dedicated GitHub Actions CI workflow that installs dependencies and runs the test suite on pushes and pull requests.

## Why
The repository already runs tests during publish, but it did not have a standard CI check for everyday branch and PR work. This adds earlier feedback so regressions show up before release-time workflows.

## Changes
- Add dedicated CI workflow
- Run on push and pull requests
- Use Node 22 with npm cache
- Install dependencies with npm ci
- Execute npm test in CI

## Testing
- npm test
- Expected outcome: 21 test files and 272 tests pass locally, and GitHub Actions runs the same command