### PR TITLE
fix: use pluginSummaryModel/lcmSummaryModel in resolveModel()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1123,7 +1123,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
       }
     },
     resolveModel: (modelRef, providerHint) => {
-      const raw = (modelRef?.trim() || envSnapshot.openclawDefaultModel).trim();
+      const raw = (envSnapshot.pluginSummaryModel || envSnapshot.lcmSummaryModel || modelRef?.trim() || envSnapshot.openclawDefaultModel).trim();
       if (!raw) {
         throw new Error("No model configured for LCM summarization.");
       }
@@ -1136,7 +1136,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
         }
       }
 
-      const provider = (providerHint?.trim() || envSnapshot.openclawProvider || "openai").trim();
+      const provider = (envSnapshot.pluginSummaryProvider || envSnapshot.lcmSummaryProvider || providerHint?.trim() || envSnapshot.openclawProvider || "openai").trim();
       return { provider, model: raw };
     },
     getApiKey: async (provider, model, options) => {


### PR DESCRIPTION
## Summary

- `resolveModel()` now checks `pluginSummaryModel` (from plugin config `summaryModel`) and `lcmSummaryModel` (from env `LCM_SUMMARY_MODEL`) before falling back to the session model (`modelRef`)
- Same priority fix applied to provider resolution (`pluginSummaryProvider` / `lcmSummaryProvider`)
- Backward compatible: when neither is configured, behavior is unchanged

## Problem

`summaryModel` is read from plugin config into `envSnapshot.pluginSummaryModel` (index.ts L844-848), but `resolveModel()` (L1125) never references it. Since `modelRef` (the session model) is always non-empty, the configured `summaryModel` has zero effect — all compaction calls go to the session model (e.g. Opus), burning rate limits.

## Changes

Priority chain in `resolveModel()`:

```
Before: modelRef → openclawDefaultModel
After:  pluginSummaryModel → lcmSummaryModel → modelRef → openclawDefaultModel
```

Same for provider:

```
Before: providerHint → openclawProvider → "openai"
After:  pluginSummaryProvider → lcmSummaryProvider → providerHint → openclawProvider → "openai"
```

## Testing

- [x] All 285 existing tests pass
- [x] No new dependencies

Fixes #113