### PR TITLE
fix: remove hardcoded recall tool hints

### DIFF
--- a/.changeset/short-wolves-hear.md
+++ b/.changeset/short-wolves-hear.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove hardcoded non-LCM recall tool names from the dynamic summary prompt so
+agents rely on whatever memory tooling is actually available in the host
+session.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -65,7 +65,7 @@ function buildSystemPromptAddition(summarySignals: SummaryPromptSignal[]): strin
     "",
     "Summaries above are compressed context — maps to details, not the details themselves.",
     "",
-    "**Recall priority:** LCM tools first, then qmd (for Granola/Limitless/pre-LCM data), then memory_search as last resort.",
+    "**Recall priority:** Use LCM tools first for compacted conversation history. If LCM does not cover the needed data, prefer any available memory/recall tool before falling back to raw text search.",
     "",
     "**Tool escalation:**",
     "1. `lcm_grep` — search by regex or full-text across messages and summaries",

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -990,7 +990,10 @@ describe("LcmContextEngine.assemble canonical path", () => {
     // Core recall section
     expect(promptAddition).toContain("## LCM Recall");
     expect(promptAddition).toContain("maps to details, not the details themselves");
-    expect(promptAddition).toContain("**Recall priority:** LCM tools first");
+    expect(promptAddition).toContain("Use LCM tools first for compacted conversation history");
+    expect(promptAddition).toContain("prefer any available memory/recall tool");
+    expect(promptAddition).not.toContain("qmd");
+    expect(promptAddition).not.toContain("memory_search as last resort");
     // Tool escalation
     expect(promptAddition).toContain("1. `lcm_grep`");
     expect(promptAddition).toContain("2. `lcm_describe`");


### PR DESCRIPTION
Closes #115

## What
This PR removes hardcoded non-LCM recall tool guidance from the dynamic summary prompt so lossless-claw only instructs agents about recall behavior it actually owns.

## Why
Issue #115 surfaced that local-development-specific guidance for `qmd` leaked into the prompt and incorrectly pushed agents away from `memory_search` in hosts where `qmd` is unavailable.

## Changes
- Remove hardcoded `qmd` recall guidance
- Replace tool ordering with generic fallback wording
- Add regression assertions for prompt text
- Add patch changeset for release notes

## Testing
- `npm test -- --run test/engine.test.ts`
- `npm test`
- Expected outcome: all tests pass, and assembled recall guidance no longer mentions `qmd` or `memory_search as last resort`
