### PR TITLE
fix: repair malformed changeset frontmatter

### DIFF
--- a/.changeset/great-rabbits-smile.md
+++ b/.changeset/great-rabbits-smile.md
@@ -1,3 +1,4 @@
+---
 "@martian-engineering/lossless-claw": patch
 ---
 


### PR DESCRIPTION
## What
This PR repairs a malformed Changesets file so the Version Packages workflow can parse pending release metadata again.

## Why
The GitHub Actions `changesets/action@v1` job was failing because `.changeset/great-rabbits-smile.md` was missing its opening frontmatter fence, which caused the release step to abort before versioning.

## Changes
- Add missing opening frontmatter fence
- Restore Changesets parser compatibility
- Keep scope limited to one file

## Testing
- `npx changeset status`
- Expected outcome: reports a patch bump for `@martian-engineering/lossless-claw` without parse errors