### PR TITLE
fix: skip media-only messages from summarization pipeline

### DIFF
--- a/.changeset/skip-media-only-messages.md
+++ b/.changeset/skip-media-only-messages.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip media-only messages from the summarization pipeline. Messages whose text content (after stripping `MEDIA:/` file path references) is below 50 characters are excluded from summarizer input, avoiding wasted API calls on content that cannot be meaningfully compressed.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -144,6 +144,20 @@ const FALLBACK_MAX_CHARS = 512 * 4;
 const DEFAULT_LEAF_CHUNK_TOKENS = 20_000;
 const CONDENSED_MIN_INPUT_RATIO = 0.1;
 
+/**
+ * Minimum text length (after stripping file/media references) for a message
+ * to be worth sending to the summarizer.  Messages below this threshold are
+ * typically media-only (an image attachment with no accompanying text).
+ */
+const MEDIA_ONLY_MIN_TEXT_LENGTH = 50;
+
+const MEDIA_PATH_RE = /MEDIA:\/\S+/g;
+
+function isMediaOnlyContent(content: string): boolean {
+  const stripped = content.replace(MEDIA_PATH_RE, "").trim();
+  return stripped.length < MEDIA_ONLY_MIN_TEXT_LENGTH;
+}
+
 function dedupeOrderedIds(ids: Iterable<string>): string[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
@@ -1063,7 +1077,21 @@ export class CompactionEngine {
       }
     }
 
-    const concatenated = messageContents
+    // Skip media-only messages that cannot be meaningfully summarized.
+    const summarizable = messageContents.filter(
+      (message) => !isMediaOnlyContent(message.content),
+    );
+
+    // If every message in this chunk is media-only, skip the entire leaf pass
+    // rather than sending an empty string to the summarizer.
+    if (summarizable.length === 0) {
+      console.warn(
+        `[lcm] skipping leaf chunk: all ${messageContents.length} messages are media-only; conversationId=${conversationId}`,
+      );
+      return null;
+    }
+
+    const concatenated = summarizable
       .map((message) => `[${formatTimestamp(message.createdAt, this.config.timezone)}]\n${message.content}`)
       .join("\n\n");
     const fileIds = dedupeOrderedIds(


### PR DESCRIPTION
## Summary

Messages containing only media attachments (e.g., an image with no accompanying text) produce near-empty source text (~28 tokens of `MEDIA:/...` file path metadata) that cannot be meaningfully compressed by the summarizer. These messages waste an API call every compaction cycle and can produce garbage summaries.

- Add `isMediaOnlyContent()` helper that strips `MEDIA:/` file path references and checks if remaining text is below 50 characters
- Filter media-only messages before building the concatenated text for summarization in `leafPass()`
- If an entire chunk is media-only, skip the leaf pass entirely (return `null`) with a warning log
- File ID extraction and source message linking still use the full `messageContents` array — no metadata is lost

### Observed instance (from issue #124)

`sum_66d17b5e39bd7460` (34 tokens): a media-only message (`MEDIA:/...png` + timestamp) with only 84 chars of `text_content` hit the fallback path and produced a garbage summary.

## Test plan

- [ ] Send image-only messages, verify they are skipped during compaction
- [ ] Send image + text messages, verify they are still summarized normally
- [ ] Verify file IDs from media-only messages are still preserved in summary metadata
- [ ] Check logs for `skipping leaf chunk: all N messages are media-only` when applicable

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)