### PR TITLE
feat: PostgreSQL backend support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
+      "optionalDependencies": {
+        "pg": "^8.13.0"
+      },
       "peerDependencies": {
         "openclaw": "*"
       }
@@ -10519,6 +10522,102 @@
         "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10647,6 +10746,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -11788,7 +11930,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -12963,6 +13104,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
+  "optionalDependencies": {
+    "pg": "^8.13.0"
+  },
   "peerDependencies": {
     "openclaw": "*"
   },

--- a/scripts/migrate-to-postgres.mjs
+++ b/scripts/migrate-to-postgres.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+
+/**
+ * LCM Migration Script — SQLite + JSONL Session History → PostgreSQL
+ * 
+ * Phase 1: Migrate existing SQLite LCM data (conversations, messages, summaries, etc.)
+ * Phase 2: Import historical JSONL session transcripts as conversations
+ * 
+ * Usage: node migrate-to-postgres.mjs [--sqlite-only] [--jsonl-only] [--dry-run]
+ */
+
+import Database from 'better-sqlite3';
+import pg from 'pg';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { homedir } from 'os';
+import { createHash, randomUUID } from 'crypto';
+
+const { Pool } = pg;
+
+// Config
+const SQLITE_PATH = join(homedir(), '.openclaw', 'lcm.db');
+const PG_CONNECTION = 'postgres://lcm_phil:pheon.lcm4@10.4.20.16:5432/phil_memory';
+const AGENTS_DIR = join(homedir(), '.openclaw', 'agents');
+const BACKUP_AGENTS_DIR = join(homedir(), '.openclaw', 'config-backups', '2026-03-07', 'agents');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const SQLITE_ONLY = args.includes('--sqlite-only');
+const JSONL_ONLY = args.includes('--jsonl-only');
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function log(msg) { console.log(`[migrate] ${msg}`); }
+function warn(msg) { console.warn(`[migrate] ⚠️  ${msg}`); }
+function ok(msg) { console.log(`[migrate] ✅ ${msg}`); }
+
+// ── Phase 1: SQLite → Postgres ───────────────────────────────────
+
+async function migrateSqlite(pool) {
+  if (!existsSync(SQLITE_PATH)) {
+    warn('No SQLite database found, skipping Phase 1');
+    return;
+  }
+
+  const db = new Database(SQLITE_PATH, { readonly: true });
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Check if already migrated
+    const existing = await client.query('SELECT COUNT(*) as c FROM conversations');
+    if (parseInt(existing.rows[0].c) > 0) {
+      warn(`Postgres already has ${existing.rows[0].c} conversations. Skipping SQLite migration to avoid duplicates.`);
+      await client.query('ROLLBACK');
+      return;
+    }
+
+    // 1. Conversations
+    const convos = db.prepare('SELECT * FROM conversations ORDER BY conversation_id').all();
+    log(`Migrating ${convos.length} conversations...`);
+    for (const c of convos) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO conversations (conversation_id, session_id, title, bootstrapped_at, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [c.conversation_id, c.session_id, c.title, c.bootstrapped_at, c.created_at, c.updated_at]
+      );
+    }
+    // Reset sequence
+    if (!DRY_RUN && convos.length > 0) {
+      const maxId = Math.max(...convos.map(c => c.conversation_id));
+      await client.query(`SELECT setval('conversations_conversation_id_seq', $1)`, [maxId]);
+    }
+
+    // 2. Messages
+    const msgs = db.prepare('SELECT * FROM messages ORDER BY message_id').all();
+    log(`Migrating ${msgs.length} messages...`);
+    for (const m of msgs) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [m.message_id, m.conversation_id, m.seq, m.role, m.content, m.token_count, m.created_at]
+      );
+    }
+    if (!DRY_RUN && msgs.length > 0) {
+      const maxId = Math.max(...msgs.map(m => m.message_id));
+      await client.query(`SELECT setval('messages_message_id_seq', $1)`, [maxId]);
+    }
+
+    // 3. Summaries
+    const sums = db.prepare('SELECT * FROM summaries ORDER BY created_at').all();
+    log(`Migrating ${sums.length} summaries...`);
+    for (const s of sums) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO summaries (summary_id, conversation_id, kind, depth, content, token_count,
+         earliest_at, latest_at, descendant_count, descendant_token_count, source_message_token_count,
+         file_ids, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13)`,
+        [s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
+         s.earliest_at, s.latest_at, s.descendant_count, s.descendant_token_count,
+         s.source_message_token_count, s.file_ids || '[]', s.created_at]
+      );
+    }
+
+    // 4. Message parts
+    const parts = db.prepare('SELECT * FROM message_parts ORDER BY message_id, ordinal').all();
+    log(`Migrating ${parts.length} message parts...`);
+    for (const p of parts) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal,
+         text_content, is_ignored, is_synthetic, tool_call_id, tool_name, tool_status,
+         tool_input, tool_output, tool_error, tool_title, patch_hash, patch_files,
+         file_mime, file_name, file_url, subtask_prompt, subtask_desc, subtask_agent,
+         step_reason, step_cost, step_tokens_in, step_tokens_out, snapshot_hash,
+         compaction_auto, metadata)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30::jsonb)`,
+        [p.part_id, p.message_id, p.session_id, p.part_type, p.ordinal,
+         p.text_content, p.is_ignored ? true : null, p.is_synthetic ? true : null,
+         p.tool_call_id, p.tool_name, p.tool_status,
+         p.tool_input, p.tool_output, p.tool_error, p.tool_title,
+         p.patch_hash, p.patch_files, p.file_mime, p.file_name, p.file_url,
+         p.subtask_prompt, p.subtask_desc, p.subtask_agent,
+         p.step_reason, p.step_cost, p.step_tokens_in, p.step_tokens_out,
+         p.snapshot_hash, p.compaction_auto ? true : null,
+         p.metadata || null]
+      );
+    }
+
+    // 5. Summary messages
+    const sumMsgs = db.prepare('SELECT * FROM summary_messages').all();
+    log(`Migrating ${sumMsgs.length} summary-message links...`);
+    for (const sm of sumMsgs) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO summary_messages (summary_id, message_id, ordinal) VALUES ($1, $2, $3)`,
+        [sm.summary_id, sm.message_id, sm.ordinal]
+      );
+    }
+
+    // 6. Summary parents
+    const sumParents = db.prepare('SELECT * FROM summary_parents').all();
+    log(`Migrating ${sumParents.length} summary parent links...`);
+    for (const sp of sumParents) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal) VALUES ($1, $2, $3)`,
+        [sp.summary_id, sp.parent_summary_id, sp.ordinal]
+      );
+    }
+
+    // 7. Context items
+    const ctxItems = db.prepare('SELECT * FROM context_items ORDER BY conversation_id, ordinal').all();
+    log(`Migrating ${ctxItems.length} context items...`);
+    for (const ci of ctxItems) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO context_items (conversation_id, ordinal, item_type, message_id, summary_id, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [ci.conversation_id, ci.ordinal, ci.item_type, ci.message_id, ci.summary_id, ci.created_at]
+      );
+    }
+
+    // 8. Large files
+    const files = db.prepare('SELECT * FROM large_files').all();
+    log(`Migrating ${files.length} large files...`);
+    for (const f of files) {
+      if (DRY_RUN) continue;
+      await client.query(
+        `INSERT INTO large_files (file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [f.file_id, f.conversation_id, f.file_name, f.mime_type, f.byte_size, f.storage_uri, f.exploration_summary, f.created_at]
+      );
+    }
+
+    // tsvector columns are GENERATED ALWAYS — no manual update needed
+
+    await client.query('COMMIT');
+    ok(`Phase 1 complete: ${convos.length} convos, ${msgs.length} msgs, ${sums.length} summaries, ${parts.length} parts`);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+    db.close();
+  }
+}
+
+// ── Phase 2: JSONL Session Transcripts → Postgres ────────────────
+
+function findAllJsonlFiles() {
+  const files = [];
+  const seen = new Set();
+
+  function scanDir(dir) {
+    if (!existsSync(dir)) return;
+    const agents = readdirSync(dir, { withFileTypes: true });
+    for (const agent of agents) {
+      if (!agent.isDirectory()) continue;
+      const sessionsDir = join(dir, agent.name, 'sessions');
+      if (!existsSync(sessionsDir)) continue;
+      const sessionFiles = readdirSync(sessionsDir).filter(f => f.endsWith('.jsonl'));
+      for (const sf of sessionFiles) {
+        const fullPath = join(sessionsDir, sf);
+        const sessionId = sf.replace('.jsonl', '');
+        if (seen.has(sessionId)) continue; // Dedup (backup vs active)
+        seen.add(sessionId);
+        files.push({
+          path: fullPath,
+          agentName: agent.name,
+          sessionId,
+        });
+      }
+    }
+  }
+
+  scanDir(AGENTS_DIR);
+  scanDir(BACKUP_AGENTS_DIR);
+  return files;
+}
+
+function parseJsonlMessages(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n').filter(l => l.trim());
+  const messages = [];
+  let sessionMeta = null;
+
+  for (const line of lines) {
+    try {
+      const obj = JSON.parse(line);
+      if (obj.type === 'session') {
+        sessionMeta = obj;
+      } else if (obj.type === 'message' && obj.message) {
+        const msg = obj.message;
+        // Extract text content
+        let textContent = '';
+        if (typeof msg.content === 'string') {
+          textContent = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          textContent = msg.content
+            .filter(c => c.type === 'text')
+            .map(c => c.text)
+            .join('\n');
+        }
+
+        // Sanitize invalid UTF-8 sequences
+        textContent = textContent.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
+        // Replace broken multi-byte sequences
+        textContent = Buffer.from(textContent, 'utf-8').toString('utf-8');
+        
+        if (!textContent.trim()) continue; // Skip empty messages
+
+        // Map non-standard roles to valid ones
+        let role = msg.role || 'user';
+        const roleMap = { toolResult: 'tool', developer: 'system', function: 'tool' };
+        role = roleMap[role] || role;
+        if (!['system', 'user', 'assistant', 'tool'].includes(role)) {
+          role = 'user'; // Fallback for unknown roles
+        }
+
+        messages.push({
+          role,
+          content: textContent,
+          timestamp: obj.timestamp,
+          tokenCount: msg.usage?.totalTokens || Math.ceil(textContent.length / 4), // Rough estimate
+        });
+      }
+    } catch (e) {
+      // Skip malformed lines
+    }
+  }
+
+  return { sessionMeta, messages };
+}
+
+async function importJsonlSessions(pool) {
+  const jsonlFiles = findAllJsonlFiles();
+  log(`Found ${jsonlFiles.length} JSONL session files`);
+
+  const client = await pool.connect();
+  let imported = 0;
+  let skipped = 0;
+  let totalMessages = 0;
+
+  try {
+    // Get existing session IDs to avoid reimporting
+    const existingResult = await client.query('SELECT session_id FROM conversations');
+    const existingSessionIds = new Set(existingResult.rows.map(r => r.session_id));
+
+    for (const file of jsonlFiles) {
+      if (existingSessionIds.has(file.sessionId)) {
+        skipped++;
+        continue;
+      }
+
+      const { sessionMeta, messages } = parseJsonlMessages(file.path);
+      if (messages.length === 0) {
+        skipped++;
+        continue;
+      }
+
+      if (DRY_RUN) {
+        log(`  [dry-run] Would import ${file.agentName}/${file.sessionId}: ${messages.length} messages`);
+        totalMessages += messages.length;
+        imported++;
+        continue;
+      }
+
+      await client.query('BEGIN');
+      try {
+        const title = `${file.agentName} session (imported)`;
+        const createdAt = sessionMeta?.timestamp || messages[0]?.timestamp || new Date().toISOString();
+
+        // Create conversation
+        const convResult = await client.query(
+          `INSERT INTO conversations (session_id, title, created_at, updated_at)
+           VALUES ($1, $2, $3, $3) RETURNING conversation_id`,
+          [file.sessionId, title, createdAt]
+        );
+        const conversationId = convResult.rows[0].conversation_id;
+
+        // Insert messages
+        for (let i = 0; i < messages.length; i++) {
+          const m = messages[i];
+          await client.query(
+            `INSERT INTO messages (conversation_id, seq, role, content, token_count, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6)`,
+            [conversationId, i + 1, m.role, m.content, m.tokenCount, m.timestamp || createdAt]
+          );
+        }
+
+        await client.query('COMMIT');
+        imported++;
+        totalMessages += messages.length;
+        log(`  ✅ ${file.agentName}/${file.sessionId}: ${messages.length} messages`);
+      } catch (err) {
+        await client.query('ROLLBACK');
+        warn(`  Failed ${file.agentName}/${file.sessionId}: ${err.message}`);
+      }
+    }
+
+    ok(`Phase 2 complete: ${imported} sessions imported (${totalMessages} messages), ${skipped} skipped`);
+  } finally {
+    client.release();
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────
+
+async function main() {
+  log(`LCM Migration → PostgreSQL`);
+  log(`SQLite: ${SQLITE_PATH}`);
+  log(`Postgres: ${PG_CONNECTION.replace(/:[^@]+@/, ':***@')}`);
+  if (DRY_RUN) log('🔍 DRY RUN — no changes will be made');
+
+  const pool = new Pool({ connectionString: PG_CONNECTION });
+
+  try {
+    // Verify connection
+    const res = await pool.query('SELECT 1');
+    ok('PostgreSQL connection verified');
+
+    if (!JSONL_ONLY) {
+      log('═══ Phase 1: SQLite LCM Data ═══');
+      await migrateSqlite(pool);
+    }
+
+    if (!SQLITE_ONLY) {
+      log('═══ Phase 2: JSONL Session Transcripts ═══');
+      await importJsonlSessions(pool);
+    }
+
+    // Final stats
+    const stats = await pool.query(`
+      SELECT 
+        (SELECT COUNT(*) FROM conversations) as convos,
+        (SELECT COUNT(*) FROM messages) as msgs,
+        (SELECT COUNT(*) FROM summaries) as sums,
+        (SELECT COUNT(*) FROM message_parts) as parts
+    `);
+    const s = stats.rows[0];
+    log(`═══ Final State ═══`);
+    ok(`${s.convos} conversations, ${s.msgs} messages, ${s.sums} summaries, ${s.parts} message parts`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch(err => {
+  console.error('[migrate] ❌ Fatal:', err);
+  process.exit(1);
+});

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -3,7 +3,12 @@ import { join } from "path";
 
 export type LcmConfig = {
   enabled: boolean;
+  /** SQLite database file path. Required when backend is 'sqlite'. Ignored for 'postgres'. */
   databasePath: string;
+  /** PostgreSQL connection string. Required when backend is 'postgres'. Ignored for 'sqlite'. */
+  connectionString?: string;
+  /** Database backend. Exactly one of 'sqlite' or 'postgres'. No fallback between them. */
+  backend: 'sqlite' | 'postgres';
   /** Glob patterns for session keys to exclude from LCM storage entirely. */
   ignoreSessionPatterns: string[];
   /** Glob patterns for session keys that may read from LCM but never write to it. */
@@ -29,10 +34,6 @@ export type LcmConfig = {
   largeFileSummaryProvider: string;
   /** Model override for large-file text summarization. */
   largeFileSummaryModel: string;
-  /** Model override for conversation summarization. */
-  summaryModel: string;
-  /** Provider override for conversation summarization. */
-  summaryProvider: string;
   /** Provider override for lcm_expand_query sub-agent. */
   expansionProvider: string;
   /** Model override for lcm_expand_query sub-agent. */
@@ -101,16 +102,55 @@ export function resolveLcmConfig(
 ): LcmConfig {
   const pc = pluginConfig ?? {};
 
+  const connectionString =
+    env.LCM_CONNECTION_STRING
+    ?? toStr(pc.connectionString);
+
+  const rawBackend =
+    env.LCM_BACKEND
+    ?? toStr(pc.backend);
+
+  // Determine backend: explicit setting wins, otherwise infer from connectionString presence
+  let backend: 'sqlite' | 'postgres';
+  if (rawBackend === 'postgres') {
+    backend = 'postgres';
+  } else if (rawBackend === 'sqlite') {
+    backend = 'sqlite';
+  } else if (connectionString) {
+    backend = 'postgres';
+  } else {
+    backend = 'sqlite';
+  }
+
+  // Validate: postgres requires connectionString, sqlite requires databasePath
+  const databasePath =
+    env.LCM_DATABASE_PATH
+    ?? toStr(pc.dbPath)
+    ?? toStr(pc.databasePath)
+    ?? (backend === 'sqlite' ? join(homedir(), ".openclaw", "lcm.db") : "");
+
+  if (backend === 'postgres' && !connectionString) {
+    throw new Error(
+      "LCM backend is 'postgres' but no connection string provided. " +
+      "Set LCM_CONNECTION_STRING env var or connectionString in plugin config."
+    );
+  }
+
+  if (backend === 'sqlite' && !databasePath) {
+    throw new Error(
+      "LCM backend is 'sqlite' but no database path provided. " +
+      "Set LCM_DATABASE_PATH env var or databasePath in plugin config."
+    );
+  }
+
   return {
     enabled:
       env.LCM_ENABLED !== undefined
         ? env.LCM_ENABLED !== "false"
         : toBool(pc.enabled) ?? true,
-    databasePath:
-      env.LCM_DATABASE_PATH
-      ?? toStr(pc.dbPath)
-      ?? toStr(pc.databasePath)
-      ?? join(homedir(), ".openclaw", "lcm.db"),
+    databasePath,
+    connectionString,
+    backend,
     ignoreSessionPatterns:
       env.LCM_IGNORE_SESSION_PATTERNS !== undefined
         ? env.LCM_IGNORE_SESSION_PATTERNS

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,121 +1,146 @@
-import { mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { mkdirSync } from "fs";
+import { dirname } from "path";
+import type { DbClient } from "./db-interface.js";
+import { SqliteClient } from "./sqlite-client.js";
+import { PostgresClient } from "./postgres-client.js";
+import type { LcmConfig } from "./config.js";
 
-type ConnectionKey = string;
+type SqliteConnectionEntry = {
+  db: DatabaseSync;
+  client: SqliteClient;
+  refs: number;
+};
 
-const connectionsByPath = new Map<ConnectionKey, Set<DatabaseSync>>();
-const connectionIndex = new Map<DatabaseSync, ConnectionKey>();
+type PostgresConnectionEntry = {
+  client: PostgresClient;
+  refs: number;
+};
 
-function isInMemoryPath(dbPath: string): boolean {
-  const normalized = dbPath.trim();
-  return normalized === ":memory:" || normalized.startsWith("file::memory:");
-}
+type ConnectionEntry = SqliteConnectionEntry | PostgresConnectionEntry;
 
-function normalizePath(dbPath: string): ConnectionKey {
-  if (isInMemoryPath(dbPath)) {
-    const trimmed = dbPath.trim();
-    return trimmed.length > 0 ? trimmed : ":memory:";
-  }
-  return resolve(dbPath);
-}
+const _connections = new Map<string, ConnectionEntry>();
 
-function ensureDbDirectory(dbPath: string): void {
-  if (isInMemoryPath(dbPath)) {
-    return;
-  }
-  mkdirSync(dirname(dbPath), { recursive: true });
-}
-
-function configureConnection(db: DatabaseSync): DatabaseSync {
-  db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA foreign_keys = ON");
-  return db;
-}
-
-function trackConnection(dbPath: string, db: DatabaseSync): void {
-  const key = normalizePath(dbPath);
-  let entries = connectionsByPath.get(key);
-  if (!entries) {
-    entries = new Set();
-    connectionsByPath.set(key, entries);
-  }
-  entries.add(db);
-  connectionIndex.set(db, key);
-}
-
-function untrackConnection(db: DatabaseSync): void {
-  const key = connectionIndex.get(db);
-  if (!key) {
-    return;
-  }
-  const entries = connectionsByPath.get(key);
-  if (entries) {
-    entries.delete(db);
-    if (entries.size === 0) {
-      connectionsByPath.delete(key);
-    }
-  }
-  connectionIndex.delete(db);
-}
-
-function closeDatabase(db: DatabaseSync | undefined): void {
-  if (!db) {
-    return;
-  }
+function isConnectionHealthy(entry: ConnectionEntry): boolean {
   try {
-    db.close();
+    if ("db" in entry) {
+      // SQLite connection health check
+      entry.db.prepare("SELECT 1").get();
+      return true;
+    } else {
+      // PostgreSQL connection health is checked by the pool internally
+      return true;
+    }
   } catch {
-    // Ignore close failures; callers are shutting down anyway.
-  } finally {
-    untrackConnection(db);
+    return false;
   }
 }
 
-/**
- * Create a new SQLite connection for the given LCM database path.
- *
- * Connections are tracked so tests can close them by path via closeLcmConnection().
- */
-export function createLcmDatabaseConnection(dbPath: string): DatabaseSync {
-  ensureDbDirectory(dbPath);
-  const db = configureConnection(new DatabaseSync(dbPath));
-  trackConnection(dbPath, db);
-  return db;
+async function forceCloseConnection(entry: ConnectionEntry): Promise<void> {
+  try {
+    if ("db" in entry) {
+      entry.db.close();
+    } else {
+      await entry.client.close();
+    }
+  } catch {
+    // Ignore close failures; caller is already replacing/removing this handle.
+  }
 }
 
-/**
- * Close tracked LCM connections.
- *
- * When a DatabaseSync instance is supplied, only that handle is closed.
- * When a path is supplied, all handles associated with the normalized path
- * are closed. When called with no arguments, all tracked connections are
- * closed. Intended primarily for tests.
- */
-export function closeLcmConnection(target?: string | DatabaseSync): void {
-  if (target && typeof target !== "string") {
-    closeDatabase(target);
+export function createLcmConnection(config: LcmConfig): DbClient {
+  if (config.backend === 'postgres') {
+    if (!config.connectionString) {
+      throw new Error("LCM backend is 'postgres' but connectionString is missing.");
+    }
+    return createPostgresConnection(config.connectionString);
+  }
+  // backend === 'sqlite'
+  return createSqliteConnection(config.databasePath);
+}
+
+function createSqliteConnection(dbPath: string): DbClient {
+  const existing = _connections.get(dbPath);
+  if (existing && "db" in existing) {
+    if (isConnectionHealthy(existing)) {
+      existing.refs += 1;
+      return existing.client;
+    }
+    forceCloseConnection(existing);
+    _connections.delete(dbPath);
+  }
+
+  // Ensure parent directory exists
+  mkdirSync(dirname(dbPath), { recursive: true });
+
+  const db = new DatabaseSync(dbPath);
+
+  // Enable WAL mode for better concurrent read performance
+  db.exec("PRAGMA journal_mode = WAL");
+  // Enable foreign key enforcement
+  db.exec("PRAGMA foreign_keys = ON");
+
+  const client = new SqliteClient(db);
+  _connections.set(dbPath, { db, client, refs: 1 });
+  return client;
+}
+
+function createPostgresConnection(connectionString: string): DbClient {
+  const existing = _connections.get(connectionString);
+  if (existing && !("db" in existing)) {
+    if (isConnectionHealthy(existing)) {
+      existing.refs += 1;
+      return existing.client;
+    }
+    forceCloseConnection(existing);
+    _connections.delete(connectionString);
+  }
+
+  const client = new PostgresClient(connectionString);
+  _connections.set(connectionString, { client, refs: 1 });
+  return client;
+}
+
+export async function closeLcmConnection(key?: string | DatabaseSync): Promise<void> {
+  // Handle raw DatabaseSync instance (used by tests to close standalone handles)
+  if (key && typeof key === "object" && typeof (key as DatabaseSync).close === "function") {
+    try {
+      (key as DatabaseSync).close();
+    } catch {
+      // Already closed or invalid — ignore
+    }
     return;
   }
-
-  if (typeof target === "string") {
-    const key = normalizePath(target);
-    const entries = connectionsByPath.get(key);
-    if (!entries) {
+  if (typeof key === "string" && key.trim()) {
+    const entry = _connections.get(key);
+    if (!entry) {
       return;
     }
-    for (const db of [...entries]) {
-      closeDatabase(db);
+    entry.refs = Math.max(0, entry.refs - 1);
+    if (entry.refs === 0) {
+      await forceCloseConnection(entry);
+      _connections.delete(key);
     }
-    connectionsByPath.delete(key);
     return;
   }
 
-  for (const db of [...connectionIndex.keys()]) {
-    closeDatabase(db);
+  for (const entry of _connections.values()) {
+    await forceCloseConnection(entry);
   }
-  connectionsByPath.clear();
-  connectionIndex.clear();
+  _connections.clear();
 }
 
-export const getLcmConnection = createLcmDatabaseConnection;
+/**
+ * Returns a raw SQLite DatabaseSync handle for migration code and tests.
+ * Creates a FRESH connection not tracked in the pool, so closing it
+ * won't affect the engine's pooled connection.
+ * Only works when backend is sqlite. Throws for postgres.
+ */
+export { getLcmConnection as createLcmDatabaseConnection };
+export function getLcmConnection(dbPath: string): DatabaseSync {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
+  return db;
+}

--- a/src/db/db-interface.ts
+++ b/src/db/db-interface.ts
@@ -1,0 +1,41 @@
+/**
+ * Database abstraction interface for supporting both SQLite and PostgreSQL
+ */
+
+export interface DbClient {
+  /**
+   * Execute a query and return all matching rows
+   */
+  query<T>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+
+  /**
+   * Execute a query and return the first matching row, or null if none found
+   */
+  queryOne<T>(sql: string, params?: unknown[]): Promise<T | null>;
+
+  /**
+   * Execute a statement that doesn't return rows (INSERT, UPDATE, DELETE)
+   * Returns affected row count and optionally the last inserted ID
+   */
+  run(sql: string, params?: unknown[]): Promise<{ rowCount: number; lastInsertId?: number }>;
+
+  /**
+   * Execute a function within a database transaction
+   * Automatically commits on success, rolls back on error
+   */
+  transaction<T>(fn: (client: DbClient) => Promise<T>): Promise<T>;
+
+  /**
+   * Close the database connection
+   */
+  close(): Promise<void>;
+}
+
+export interface QueryResult<T> {
+  rows: T[];
+}
+
+export interface RunResult {
+  rowCount: number;
+  lastInsertId?: number;
+}

--- a/src/db/dialect.ts
+++ b/src/db/dialect.ts
@@ -1,0 +1,57 @@
+/**
+ * Thin SQL dialect adapter for SQLite ↔ PostgreSQL differences.
+ *
+ * Handles: parameter placeholders (?/$N), timestamp functions, and
+ * small syntax gaps. NOT a query builder — just eliminates the
+ * `if (this.backend === 'postgres')` branching from store code.
+ */
+
+export type Backend = "sqlite" | "postgres";
+
+export class Dialect {
+  private _paramCount = 0;
+
+  constructor(readonly backend: Backend) {}
+
+  /** Next parameter placeholder: `?` (SQLite) or `$N` (Postgres). */
+  p(): string {
+    return this.backend === "postgres" ? `$${++this._paramCount}` : "?";
+  }
+
+  /** Reset the parameter counter. Call at the start of each query. */
+  reset(): this {
+    this._paramCount = 0;
+    return this;
+  }
+
+  /** Current parameter count (useful for manual indexing after auto params). */
+  get paramCount(): number {
+    return this._paramCount;
+  }
+
+  /** SQL expression for "current timestamp". */
+  now(): string {
+    return this.backend === "postgres" ? "NOW()" : "datetime('now')";
+  }
+
+  /** True when the backend is PostgreSQL. */
+  get pg(): boolean {
+    return this.backend === "postgres";
+  }
+
+  /**
+   * Zero-padded integer-to-string expression.
+   * Used in recursive CTEs for summary subtree path building.
+   */
+  zeroPad(expr: string, width: number): string {
+    return this.backend === "postgres"
+      ? `LPAD(${expr}::text, ${width}, '0')`
+      : `printf('%0${width}d', ${expr})`;
+  }
+
+  /** COUNT(*)::int for Postgres (returns bigint otherwise), no-op for SQLite. */
+  countInt(alias?: string): string {
+    const cast = this.backend === "postgres" ? "COUNT(*)::int" : "COUNT(*)";
+    return alias ? `${cast} AS ${alias}` : cast;
+  }
+}

--- a/src/db/features.ts
+++ b/src/db/features.ts
@@ -1,7 +1,9 @@
 import type { DatabaseSync } from "node:sqlite";
+import type { Backend } from "./dialect.js";
 
 export type LcmDbFeatures = {
-  fts5Available: boolean;
+  fullTextAvailable: boolean;
+  backend: Backend;
 };
 
 const featureCache = new WeakMap<DatabaseSync, LcmDbFeatures>();
@@ -23,20 +25,34 @@ function probeFts5(db: DatabaseSync): boolean {
 }
 
 /**
- * Detect SQLite features exposed by the current Node runtime.
+ * Detect database features for the configured backend.
  *
- * The result is cached per DatabaseSync handle because the probe is runtime-
- * specific, not database-file-specific.
+ * PostgreSQL: full-text search always available (tsvector is built-in).
+ * SQLite: probe for FTS5 at runtime.
+ *
+ * @param backend  - "sqlite" or "postgres"
+ * @param sqliteDb - raw DatabaseSync handle (only needed for SQLite FTS5 probe)
  */
-export function getLcmDbFeatures(db: DatabaseSync): LcmDbFeatures {
-  const cached = featureCache.get(db);
-  if (cached) {
-    return cached;
+export function getLcmDbFeatures(
+  backend: Backend,
+  sqliteDb?: DatabaseSync,
+): LcmDbFeatures {
+  if (backend === "postgres") {
+    return { fullTextAvailable: true, backend: "postgres" };
   }
 
-  const detected: LcmDbFeatures = {
-    fts5Available: probeFts5(db),
-  };
-  featureCache.set(db, detected);
-  return detected;
+  // SQLite — probe for FTS5 if we have a handle
+  if (sqliteDb) {
+    const cached = featureCache.get(sqliteDb);
+    if (cached) return cached;
+
+    const detected: LcmDbFeatures = {
+      fullTextAvailable: probeFts5(sqliteDb),
+      backend: "sqlite",
+    };
+    featureCache.set(sqliteDb, detected);
+    return detected;
+  }
+
+  return { fullTextAvailable: false, backend: "sqlite" };
 }

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { getLcmDbFeatures } from "./features.js";
+import type { DbClient } from "./db-interface.js";
 
 type SummaryColumnInfo = {
   name?: string;
@@ -357,7 +358,7 @@ function backfillSummaryMetadata(db: DatabaseSync): void {
 
 export function runLcmMigrations(
   db: DatabaseSync,
-  options?: { fts5Available?: boolean },
+  options?: { fullTextAvailable?: boolean; fts5Available?: boolean },
 ): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS conversations (
@@ -515,8 +516,11 @@ export function runLcmMigrations(
   backfillSummaryDepths(db);
   backfillSummaryMetadata(db);
 
-  const fts5Available = options?.fts5Available ?? getLcmDbFeatures(db).fts5Available;
-  if (!fts5Available) {
+  // Accept both fullTextAvailable (our naming) and fts5Available (upstream compat)
+  const fullTextAvailable = options?.fullTextAvailable ?? options?.fts5Available ?? getLcmDbFeatures(
+    'sqlite', db
+  ).fullTextAvailable;
+  if (!fullTextAvailable) {
     return;
   }
 
@@ -578,3 +582,234 @@ export function runLcmMigrations(
     `);
   }
 }
+
+// ── PostgreSQL schema creation ────────────────────────────────────────────────
+
+/**
+ * Ensure PostgreSQL schema exists. Called once on first bootstrap/ingest.
+ *
+ * Uses IF NOT EXISTS throughout so it's safe to call repeatedly.
+ * Does NOT migrate existing tables — just creates them if absent.
+ */
+export async function ensurePostgresSchema(db: DbClient): Promise<void> {
+  // Check if schema already exists (fast path)
+  const probe = await db.queryOne<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'conversations') AS exists`,
+  );
+  if (probe?.exists) {
+    // Schema exists — run forward-compatible migrations for new columns
+    await migratePostgresSchema(db);
+    return;
+  }
+
+  // Create all tables
+  await db.run(`
+    CREATE TABLE IF NOT EXISTS conversations (
+      conversation_id SERIAL PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      agent_id TEXT,
+      title TEXT,
+      bootstrapped_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS messages (
+      message_id SERIAL PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english'::regconfig, content)) STORED,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (conversation_id, seq)
+    );
+
+    CREATE TABLE IF NOT EXISTS summaries (
+      summary_id TEXT PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      kind TEXT NOT NULL CHECK (kind IN ('leaf', 'condensed')),
+      depth INTEGER NOT NULL DEFAULT 0,
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      file_ids TEXT NOT NULL DEFAULT '[]',
+      content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english'::regconfig, content)) STORED,
+      earliest_at TIMESTAMPTZ,
+      latest_at TIMESTAMPTZ,
+      descendant_count INTEGER NOT NULL DEFAULT 0,
+      descendant_token_count INTEGER NOT NULL DEFAULT 0,
+      source_message_token_count INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS message_parts (
+      part_id TEXT PRIMARY KEY,
+      message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      part_type TEXT NOT NULL CHECK (part_type IN (
+        'text', 'reasoning', 'tool', 'patch', 'file',
+        'subtask', 'compaction', 'step_start', 'step_finish',
+        'snapshot', 'agent', 'retry'
+      )),
+      ordinal INTEGER NOT NULL,
+      text_content TEXT,
+      is_ignored INTEGER,
+      is_synthetic INTEGER,
+      tool_call_id TEXT,
+      tool_name TEXT,
+      tool_status TEXT,
+      tool_input TEXT,
+      tool_output TEXT,
+      tool_error TEXT,
+      tool_title TEXT,
+      patch_hash TEXT,
+      patch_files TEXT,
+      file_mime TEXT,
+      file_name TEXT,
+      file_url TEXT,
+      subtask_prompt TEXT,
+      subtask_desc TEXT,
+      subtask_agent TEXT,
+      step_reason TEXT,
+      step_cost REAL,
+      step_tokens_in INTEGER,
+      step_tokens_out INTEGER,
+      snapshot_hash TEXT,
+      compaction_auto INTEGER,
+      metadata JSONB,
+      UNIQUE (message_id, ordinal)
+    );
+
+    CREATE TABLE IF NOT EXISTS summary_messages (
+      summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+      message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE RESTRICT,
+      ordinal INTEGER NOT NULL,
+      PRIMARY KEY (summary_id, message_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS summary_parents (
+      summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+      parent_summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE RESTRICT,
+      ordinal INTEGER NOT NULL,
+      PRIMARY KEY (summary_id, parent_summary_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS context_items (
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      ordinal INTEGER NOT NULL,
+      item_type TEXT NOT NULL CHECK (item_type IN ('message', 'summary')),
+      message_id INTEGER REFERENCES messages(message_id) ON DELETE RESTRICT,
+      summary_id TEXT REFERENCES summaries(summary_id) ON DELETE RESTRICT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (conversation_id, ordinal),
+      CHECK (
+        (item_type = 'message' AND message_id IS NOT NULL AND summary_id IS NULL) OR
+        (item_type = 'summary' AND summary_id IS NOT NULL AND message_id IS NULL)
+      )
+    );
+
+    CREATE TABLE IF NOT EXISTS large_files (
+      file_id TEXT PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      file_name TEXT,
+      mime_type TEXT,
+      byte_size INTEGER,
+      storage_uri TEXT NOT NULL,
+      exploration_summary TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    -- Indexes
+    CREATE INDEX IF NOT EXISTS idx_conversations_session ON conversations (session_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS conversations_session_key_idx ON conversations (session_key) WHERE session_key IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_messages_conv_seq ON messages (conversation_id, seq);
+    CREATE INDEX IF NOT EXISTS idx_messages_tsv ON messages USING GIN (content_tsv);
+    CREATE INDEX IF NOT EXISTS idx_summaries_conv_created ON summaries (conversation_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_summaries_tsv ON summaries USING GIN (content_tsv);
+    CREATE INDEX IF NOT EXISTS idx_message_parts_message ON message_parts (message_id);
+    CREATE INDEX IF NOT EXISTS idx_message_parts_type ON message_parts (part_type);
+    CREATE INDEX IF NOT EXISTS idx_context_items_conv ON context_items (conversation_id, ordinal);
+    CREATE INDEX IF NOT EXISTS idx_large_files_conv ON large_files (conversation_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS conversation_bootstrap_state (
+      conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      session_file_path TEXT NOT NULL,
+      last_seen_size INTEGER NOT NULL,
+      last_seen_mtime_ms BIGINT NOT NULL,
+      last_processed_offset INTEGER NOT NULL,
+      last_processed_entry_hash TEXT,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_bootstrap_state_path
+      ON conversation_bootstrap_state (session_file_path, updated_at);
+  `);
+
+}
+
+/**
+ * Forward-compatible migrations for existing Postgres schemas.
+ * Adds new columns that may not exist on older installs.
+ */
+async function migratePostgresSchema(db: DbClient): Promise<void> {
+  // Add session_key to conversations if missing
+  const hasSessionKey = await db.queryOne<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_name = 'conversations' AND column_name = 'session_key'
+     ) AS exists`,
+  );
+  if (!hasSessionKey?.exists) {
+    await db.run(`ALTER TABLE conversations ADD COLUMN session_key TEXT`);
+    await db.run(`CREATE UNIQUE INDEX IF NOT EXISTS conversations_session_key_idx ON conversations (session_key) WHERE session_key IS NOT NULL`);
+  }
+
+  // Add agent_id to conversations if missing
+  const hasAgentId = await db.queryOne<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_name = 'conversations' AND column_name = 'agent_id'
+     ) AS exists`,
+  );
+  if (!hasAgentId?.exists) {
+    await db.run(`ALTER TABLE conversations ADD COLUMN agent_id TEXT`);
+  }
+
+  // Add metadata columns to summaries if missing
+  const hasDescendantTokenCount = await db.queryOne<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_name = 'summaries' AND column_name = 'descendant_token_count'
+     ) AS exists`,
+  );
+  if (!hasDescendantTokenCount?.exists) {
+    await db.run(`ALTER TABLE summaries ADD COLUMN descendant_token_count INTEGER NOT NULL DEFAULT 0`);
+    await db.run(`ALTER TABLE summaries ADD COLUMN source_message_token_count INTEGER NOT NULL DEFAULT 0`);
+  }
+
+  // Add conversation_bootstrap_state table if missing
+  const hasBootstrapState = await db.queryOne<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_name = 'conversation_bootstrap_state'
+     ) AS exists`,
+  );
+  if (!hasBootstrapState?.exists) {
+    await db.run(`
+      CREATE TABLE conversation_bootstrap_state (
+        conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        session_file_path TEXT NOT NULL,
+        last_seen_size INTEGER NOT NULL,
+        last_seen_mtime_ms BIGINT NOT NULL,
+        last_processed_offset INTEGER NOT NULL,
+        last_processed_entry_hash TEXT,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    await db.run(`CREATE INDEX idx_bootstrap_state_path ON conversation_bootstrap_state (session_file_path, updated_at)`);
+  }
+
+}
+

--- a/src/db/postgres-client.ts
+++ b/src/db/postgres-client.ts
@@ -1,0 +1,138 @@
+import { createRequire } from "node:module";
+import type { DbClient, RunResult } from "./db-interface.js";
+
+// Lazy-loaded pg module — only resolved when PostgresClient is actually instantiated.
+// This prevents "Cannot find module 'pg'" crashes on SQLite-only installs.
+let _pg: any = null;
+function getPg(): any {
+  if (!_pg) {
+    try {
+      const require = createRequire(import.meta.url);
+      _pg = require("pg");
+    } catch {
+      throw new Error(
+        "PostgreSQL backend requires the 'pg' package. Install it with: npm install pg",
+      );
+    }
+  }
+  return _pg;
+}
+
+/**
+ * Extract an integer ID from the first column of the first RETURNING row.
+ * Callers write `INSERT ... RETURNING <id_col>`, so the first column is always the ID.
+ */
+function extractInsertId(rows: any[]): number | undefined {
+  if (rows.length === 0 || typeof rows[0] !== "object" || rows[0] === null) {
+    return undefined;
+  }
+  const vals = Object.values(rows[0] as Record<string, unknown>);
+  if (vals.length === 0) return undefined;
+  const v = vals[0];
+  if (typeof v === "number") return v;
+  if (typeof v === "string" && v.length > 0 && !isNaN(Number(v))) return Number(v);
+  return undefined;
+}
+
+/**
+ * PostgreSQL implementation of the DbClient interface using node-postgres.
+ *
+ * Pool is created once per connection string (connection.ts caches the
+ * PostgresClient instance, so we don't double-pool).
+ */
+export class PostgresClient implements DbClient {
+  private pool: any;
+
+  constructor(connectionString: string) {
+    const { Pool } = getPg();
+    this.pool = new Pool({
+      connectionString,
+      min: 2,
+      max: 10,
+      idleTimeoutMillis: 30000,
+    });
+  }
+
+  async query<T>(sql: string, params: unknown[] = []): Promise<{ rows: T[] }> {
+    const result = await this.pool.query(sql, params);
+    return { rows: result.rows as T[] };
+  }
+
+  async queryOne<T>(sql: string, params: unknown[] = []): Promise<T | null> {
+    const result = await this.pool.query(sql, params);
+    return result.rows.length > 0 ? (result.rows[0] as T) : null;
+  }
+
+  async run(sql: string, params: unknown[] = []): Promise<RunResult> {
+    const result = await this.pool.query(sql, params);
+    return {
+      rowCount: result.rowCount ?? 0,
+      lastInsertId: extractInsertId(result.rows),
+    };
+  }
+
+  async transaction<T>(fn: (client: DbClient) => Promise<T>): Promise<T> {
+    const poolClient = await this.pool.connect();
+    const txClient = new PostgresTransactionClient(poolClient);
+
+    try {
+      await poolClient.query("BEGIN");
+      const result = await fn(txClient);
+      await poolClient.query("COMMIT");
+      return result;
+    } catch (error) {
+      await poolClient.query("ROLLBACK");
+      throw error;
+    } finally {
+      poolClient.release();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}
+
+/**
+ * Transaction-scoped PostgreSQL client that uses a single dedicated connection.
+ */
+class PostgresTransactionClient implements DbClient {
+  constructor(private client: any) {}
+
+  async query<T>(sql: string, params: unknown[] = []): Promise<{ rows: T[] }> {
+    const result = await this.client.query(sql, params);
+    return { rows: result.rows as T[] };
+  }
+
+  async queryOne<T>(sql: string, params: unknown[] = []): Promise<T | null> {
+    const result = await this.client.query(sql, params);
+    return result.rows.length > 0 ? (result.rows[0] as T) : null;
+  }
+
+  async run(sql: string, params: unknown[] = []): Promise<RunResult> {
+    const result = await this.client.query(sql, params);
+    return {
+      rowCount: result.rowCount ?? 0,
+      lastInsertId: extractInsertId(result.rows),
+    };
+  }
+
+  async transaction<T>(fn: (client: DbClient) => Promise<T>): Promise<T> {
+    // Nested transactions use savepoints
+    const name = `sp_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+    await this.client.query(`SAVEPOINT ${name}`);
+
+    try {
+      const result = await fn(this);
+      await this.client.query(`RELEASE SAVEPOINT ${name}`);
+      return result;
+    } catch (error) {
+      await this.client.query(`ROLLBACK TO SAVEPOINT ${name}`);
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    // Transaction clients don't own the connection — it's managed by the parent.
+  }
+}

--- a/src/db/sqlite-client.ts
+++ b/src/db/sqlite-client.ts
@@ -1,0 +1,63 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { DbClient, QueryResult, RunResult } from "./db-interface.js";
+
+/**
+ * Wraps the existing SQLite DatabaseSync in the DbClient interface
+ */
+export class SqliteClient implements DbClient {
+  constructor(private db: DatabaseSync) {}
+
+  private static coerceParams(params: unknown[]): unknown[] {
+    return params.map(p => p === undefined ? null : p);
+  }
+
+  async query<T>(sql: string, params: unknown[] = []): Promise<QueryResult<T>> {
+    const rows = this.db.prepare(sql).all(...SqliteClient.coerceParams(params) as any[]) as T[];
+    return { rows };
+  }
+
+  async queryOne<T>(sql: string, params: unknown[] = []): Promise<T | null> {
+    const row = this.db.prepare(sql).get(...SqliteClient.coerceParams(params) as any[]) as T | undefined;
+    return row ?? null;
+  }
+
+  async run(sql: string, params: unknown[] = []): Promise<RunResult> {
+    const result = this.db.prepare(sql).run(...SqliteClient.coerceParams(params) as any[]);
+    const rowCount: number = typeof result.changes === "bigint" ? Number(result.changes) : result.changes;
+    const lastInsertId: number | undefined = result.lastInsertRowid != null
+      ? (typeof result.lastInsertRowid === "bigint" ? Number(result.lastInsertRowid) : result.lastInsertRowid)
+      : undefined;
+    return { rowCount, lastInsertId };
+  }
+
+  async transaction<T>(fn: (client: DbClient) => Promise<T>): Promise<T> {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = await fn(this);
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.db.close();
+  }
+
+  /**
+   * Expose prepare() for code that needs direct SQLite prepared statements
+   * (e.g. upstream tests that reach into store.db.prepare()).
+   */
+  prepare(sql: string) {
+    return this.db.prepare(sql);
+  }
+
+  /**
+   * Get the underlying SQLite database for operations that need direct access
+   */
+  getUnderlyingDatabase(): DatabaseSync {
+    return this.db;
+  }
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -19,8 +19,9 @@ import type {
 import { blockFromPart, ContextAssembler } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import type { LcmConfig } from "./db/config.js";
+import { createLcmConnection, closeLcmConnection, getLcmConnection } from "./db/connection.js";
 import { getLcmDbFeatures } from "./db/features.js";
-import { runLcmMigrations } from "./db/migration.js";
+import { runLcmMigrations, ensurePostgresSchema } from "./db/migration.js";
 import {
   createDelegatedExpansionGrant,
   getRuntimeExpansionAuthManager,
@@ -962,9 +963,8 @@ export class LcmContextEngine implements ContextEngine {
   private assembler: ContextAssembler;
   private compaction: CompactionEngine;
   private retrieval: RetrievalEngine;
-  private readonly db: DatabaseSync;
   private migrated = false;
-  private readonly fts5Available: boolean;
+  private readonly fullTextAvailable: boolean;
   private readonly ignoreSessionPatterns: RegExp[];
   private readonly statelessSessionPatterns: RegExp[];
   private sessionOperationQueues = new Map<string, Promise<void>>();
@@ -972,36 +972,50 @@ export class LcmContextEngine implements ContextEngine {
   private largeFileTextSummarizer?: (prompt: string) => Promise<string | null>;
   private deps: LcmDependencies;
 
-  constructor(deps: LcmDependencies, database: DatabaseSync) {
+  constructor(deps: LcmDependencies) {
     this.deps = deps;
     this.config = deps.config;
     this.ignoreSessionPatterns = compileSessionPatterns(this.config.ignoreSessionPatterns);
     this.statelessSessionPatterns = compileSessionPatterns(this.config.statelessSessionPatterns);
-    this.db = database;
 
-    this.fts5Available = getLcmDbFeatures(this.db).fts5Available;
+    const db = createLcmConnection(this.config);
+    // Pass the underlying SQLite handle for FTS5 probing when backend is sqlite.
+    // Without this, getLcmDbFeatures returns fullTextAvailable=false and FTS5
+    // silently degrades to LIKE-based search on every SQLite install.
+    const features = this.config.backend === "sqlite"
+      ? getLcmDbFeatures("sqlite", getLcmConnection(this.config.databasePath))
+      : getLcmDbFeatures(this.config.backend);
+    this.fullTextAvailable = features.fullTextAvailable;
 
     // Run migrations eagerly at construction time so the schema exists
     // before any lifecycle hook fires.
     let migrationOk = false;
     try {
-      runLcmMigrations(this.db, { fts5Available: this.fts5Available });
-      this.migrated = true;
+      if (this.config.backend === 'sqlite') {
+        // For SQLite, get the raw connection for sync migrations
+        const sqliteDb = getLcmConnection(this.config.databasePath);
+        runLcmMigrations(sqliteDb, { fts5Available: this.fullTextAvailable });
 
-      // Verify tables were actually created
-      const tables = this.db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-        .all() as Array<{ name: string }>;
-      if (tables.length === 0) {
-        this.deps.log.warn(
-          "[lcm] Migration completed but database has zero tables — DB may be non-functional",
-        );
+        // Verify tables were actually created
+        const tables = sqliteDb
+          .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+          .all() as Array<{ name: string }>;
+        if (tables.length === 0) {
+          this.deps.log.warn(
+            "[lcm] Migration completed but database has zero tables — DB may be non-functional",
+          );
+        } else {
+          migrationOk = true;
+          this.deps.log.debug(
+            `[lcm] Migration successful — ${tables.length} tables: ${tables.map((t) => t.name).join(", ")}`,
+          );
+        }
       } else {
+        // For Postgres, schema is ensured asynchronously; assume OK for now.
+        // The ensureMigrated() call will run ensurePostgresSchema on first use.
         migrationOk = true;
-        this.deps.log.debug(
-          `[lcm] Migration successful — ${tables.length} tables: ${tables.map((t) => t.name).join(", ")}`,
-        );
       }
+      this.migrated = migrationOk;
     } catch (err) {
       this.deps.log.error(
         `[lcm] Migration failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1018,12 +1032,16 @@ export class LcmContextEngine implements ContextEngine {
       ownsCompaction: migrationOk,
     };
 
-    this.conversationStore = new ConversationStore(this.db, {
-      fts5Available: this.fts5Available,
+    this.conversationStore = new ConversationStore(db, {
+      fullTextAvailable: this.fullTextAvailable,
+      backend: features.backend,
     });
-    this.summaryStore = new SummaryStore(this.db, { fts5Available: this.fts5Available });
+    this.summaryStore = new SummaryStore(db, {
+      fullTextAvailable: this.fullTextAvailable,
+      backend: features.backend,
+    });
 
-    if (!this.fts5Available) {
+    if (!this.fullTextAvailable) {
       this.deps.log.warn(
         "[lcm] FTS5 unavailable in the current Node runtime; full_text search will fall back to LIKE and indexing is disabled",
       );
@@ -1108,11 +1126,21 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Ensure DB schema is up-to-date. Called lazily on first bootstrap/ingest/assemble/compact. */
-  private ensureMigrated(): void {
+  private async ensureMigrated(): Promise<void> {
     if (this.migrated) {
       return;
     }
-    runLcmMigrations(this.db, { fts5Available: this.fts5Available });
+    if (this.config.backend === 'postgres') {
+      // Let migration errors propagate — if schema setup fails, the engine
+      // must not mark itself as migrated. Subsequent calls will retry.
+      const db = createLcmConnection(this.config);
+      await ensurePostgresSchema(db);
+      this.migrated = true;
+      return;
+    }
+
+    const sqliteDb = getLcmConnection(this.config.databasePath);
+    runLcmMigrations(sqliteDb, { fts5Available: this.fullTextAvailable });
     this.migrated = true;
   }
 
@@ -1545,6 +1573,59 @@ export class LcmContextEngine implements ContextEngine {
    * Reconcile session-file history with persisted messages and append only the
    * tail that is present in JSONL but missing from LCM.
    */
+  /**
+   * Scan historical messages for any that are missing from the DB and import
+   * them.  Used when the tail matches but a count mismatch reveals mid-history
+   * gaps (e.g. process crash during a turn meant afterTurn never persisted
+   * those messages to LCM).
+   */
+  private async importMissingMessages(params: {
+    sessionId: string;
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+    storedHistoricalMessages: Array<{ role: string; content: string; tokenCount: number }>;
+  }): Promise<number> {
+    const { sessionId, conversationId, historicalMessages, storedHistoricalMessages } = params;
+
+    // Running occurrence counter for each (role, content) identity as we walk
+    // through the historical messages in order.
+    const historicalRunning = new Map<string, number>();
+    // Cache DB counts per identity to avoid repeated queries.
+    const dbCountCache = new Map<string, number>();
+    let imported = 0;
+
+    for (let i = 0; i < storedHistoricalMessages.length; i++) {
+      const stored = storedHistoricalMessages[i];
+      const identity = messageIdentity(stored.role, stored.content);
+      const runCount = (historicalRunning.get(identity) ?? 0) + 1;
+      historicalRunning.set(identity, runCount);
+
+      if (!dbCountCache.has(identity)) {
+        dbCountCache.set(
+          identity,
+          await this.conversationStore.countMessagesByIdentity(
+            conversationId,
+            stored.role,
+            stored.content,
+          ),
+        );
+      }
+
+      if (runCount > dbCountCache.get(identity)!) {
+        const result = await this.ingestSingle({ sessionId, message: historicalMessages[i] });
+        if (result.ingested) {
+          imported++;
+          dbCountCache.set(identity, dbCountCache.get(identity)! + 1);
+        }
+      }
+    }
+
+    if (imported > 0) {
+      console.error(`[lcm] reconcile: imported ${imported} missing mid-history messages`);
+    }
+    return imported;
+  }
+
   private async reconcileSessionTail(params: {
     sessionId: string;
     sessionKey?: string;
@@ -1582,7 +1663,25 @@ export class LcmContextEngine implements ContextEngine {
         }
       }
       if (dbOccurrences === historicalOccurrences) {
-        return { importedMessages: 0, hasOverlap: true };
+        // Guard against mid-history gaps: if the JSONL has more messages than
+        // the DB, a turn's messages were lost (e.g. process crash before
+        // afterTurn could persist them).  The tail matches because a later
+        // turn wrote to both JSONL and DB, but the gap is in the middle.
+        const dbCount = await this.conversationStore.getMessageCount(conversationId);
+        if (historicalMessages.length <= dbCount) {
+          return { importedMessages: 0, hasOverlap: true };
+        }
+        console.error(
+          `[lcm] reconcile: tail matches but mid-history gap detected ` +
+            `(jsonl=${historicalMessages.length}, db=${dbCount}) — scanning for missing messages`,
+        );
+        const imported = await this.importMissingMessages({
+          sessionId,
+          conversationId,
+          historicalMessages,
+          storedHistoricalMessages,
+        });
+        return { importedMessages: imported, hasOverlap: true };
       }
     }
 
@@ -1671,7 +1770,7 @@ export class LcmContextEngine implements ContextEngine {
         reason: "stateless session",
       };
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
     const sessionFileStats = statSync(params.sessionFile);
     const sessionFileSize = sessionFileStats.size;
     const sessionFileMtimeMs = Math.trunc(sessionFileStats.mtimeMs);
@@ -2011,7 +2110,7 @@ export class LcmContextEngine implements ContextEngine {
     if (this.isStatelessSession(params.sessionKey)) {
       return { ingested: false };
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       () => this.ingestSingle(params),
@@ -2030,7 +2129,7 @@ export class LcmContextEngine implements ContextEngine {
     if (this.isStatelessSession(params.sessionKey)) {
       return { ingestedCount: 0 };
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
     if (params.messages.length === 0) {
       return { ingestedCount: 0 };
     }
@@ -2074,7 +2173,7 @@ export class LcmContextEngine implements ContextEngine {
     if (this.isStatelessSession(params.sessionKey)) {
       return;
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
 
     const ingestBatch: AgentMessage[] = [];
     if (params.autoCompactionSummary) {
@@ -2168,7 +2267,7 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
     try {
-      this.ensureMigrated();
+      await this.ensureMigrated();
 
       const conversation = await this.conversationStore.getConversationForSession({
         sessionId: params.sessionId,
@@ -2244,7 +2343,7 @@ export class LcmContextEngine implements ContextEngine {
     rawTokensOutsideTail: number;
     threshold: number;
   }> {
-    this.ensureMigrated();
+    await this.ensureMigrated();
     const conversation = await this.conversationStore.getConversationForSession({
       sessionId,
       sessionKey,
@@ -2287,7 +2386,7 @@ export class LcmContextEngine implements ContextEngine {
         reason: "stateless session",
       };
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () => {
@@ -2387,7 +2486,7 @@ export class LcmContextEngine implements ContextEngine {
         reason: "stateless session",
       };
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () => {
@@ -2546,7 +2645,7 @@ export class LcmContextEngine implements ContextEngine {
     ) {
       return undefined;
     }
-    this.ensureMigrated();
+    await this.ensureMigrated();
 
     const childSessionKey = params.childSessionKey.trim();
     const parentSessionKey = params.parentSessionKey.trim();

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { resolveLcmConfig } from "../db/config.js";
-import { createLcmDatabaseConnection } from "../db/connection.js";
+// Connection is now created internally by LcmContextEngine based on config.
 import { LcmContextEngine } from "../engine.js";
 import { logStartupBannerOnce } from "../startup-banner-log.js";
 import { createLcmDescribeTool } from "../tools/lcm-describe-tool.js";
@@ -1320,8 +1320,7 @@ const lcmPlugin = {
 
   register(api: OpenClawPluginApi) {
     const deps = createLcmDependencies(api);
-    const database = createLcmDatabaseConnection(deps.config.databasePath);
-    const lcm = new LcmContextEngine(deps, database);
+    const lcm = new LcmContextEngine(deps);
 
     api.registerContextEngine("lossless-claw", () => lcm);
     api.registerContextEngine("default", () => lcm);

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -1,7 +1,20 @@
-import type { DatabaseSync } from "node:sqlite";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import type { DbClient } from "../db/db-interface.js";
+import { SqliteClient } from "../db/sqlite-client.js";
+import { Dialect, type Backend } from "../db/dialect.js";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
+import { sanitizeTsQuery } from "./tsquery-sanitize.js";
 import { buildLikeSearchPlan, createFallbackSnippet } from "./full-text-fallback.js";
+
+/** Accept either a DbClient or raw DatabaseSync (auto-wraps the latter). */
+function ensureDbClient(db: DbClient | DatabaseSync): DbClient {
+  if ('run' in db && typeof (db as DbClient).run === 'function') {
+    return db as DbClient;
+  }
+  return new SqliteClient(db as DatabaseSync);
+}
 
 export type ConversationId = number;
 export type MessageId = number;
@@ -246,84 +259,108 @@ function normalizeMessageContentForFullTextIndex(content: string): string | null
   return normalized || null;
 }
 
+// Column list constants to avoid repetition
+const CONV_COLS = "conversation_id, session_id, session_key, title, bootstrapped_at, created_at, updated_at";
+const MSG_COLS = "message_id, conversation_id, seq, role, content, token_count, created_at";
+const PART_COLS = "part_id, message_id, session_id, part_type, ordinal, text_content, tool_call_id, tool_name, tool_input, tool_output, metadata";
+
 // ── ConversationStore ─────────────────────────────────────────────────────────
 
 export class ConversationStore {
-  private readonly fts5Available: boolean;
+  private readonly fullTextAvailable: boolean;
+  private readonly d: Dialect;
+  /**
+   * Root (non-transactional) database client.
+   * Query methods use the `db` getter which returns the transaction-scoped
+   * client from AsyncLocalStorage when inside a transaction, falling back
+   * to this root client otherwise.
+   */
+  private readonly _rootDb: DbClient;
+  private readonly _txStore = new AsyncLocalStorage<DbClient>();
+
+  /** Active DB client — transaction-scoped if inside withTransaction/withClient, else root. */
+  private get db(): DbClient {
+    return this._txStore.getStore() ?? this._rootDb;
+  }
 
   constructor(
-    private db: DatabaseSync,
-    options?: { fts5Available?: boolean },
+    db: DbClient | DatabaseSync,
+    options?: { fullTextAvailable?: boolean; fts5Available?: boolean; backend?: Backend },
   ) {
-    this.fts5Available = options?.fts5Available ?? true;
+    this._rootDb = ensureDbClient(db);
+    this.fullTextAvailable = options?.fullTextAvailable ?? options?.fts5Available ?? true;
+    this.d = new Dialect(options?.backend ?? "sqlite");
   }
 
   // ── Transaction helpers ──────────────────────────────────────────────────
 
+  /**
+   * Execute an operation within a database transaction.
+   *
+   * Uses AsyncLocalStorage to scope the transaction client to this async
+   * call chain. All queries within the callback automatically use the
+   * transaction-scoped client via the `db` getter — no instance field swap,
+   * so concurrent sessions sharing this store singleton are safe.
+   */
   async withTransaction<T>(operation: () => Promise<T> | T): Promise<T> {
-    this.db.exec("BEGIN IMMEDIATE");
-    try {
-      const result = await operation();
-      this.db.exec("COMMIT");
-      return result;
-    } catch (error) {
-      this.db.exec("ROLLBACK");
-      throw error;
+    if (this._txStore.getStore()) {
+      return operation();
     }
+    return this._rootDb.transaction(async (txClient) => {
+      return this._txStore.run(txClient, operation);
+    });
   }
 
   // ── Conversation operations ───────────────────────────────────────────────
 
   async createConversation(input: CreateConversationInput): Promise<ConversationRecord> {
-    const result = this.db
-      .prepare(`INSERT INTO conversations (session_id, session_key, title) VALUES (?, ?, ?)`)
-      .run(input.sessionId, input.sessionKey ?? null, input.title ?? null);
+    const d = this.d.reset();
+    const result = await this.db.run(
+      `INSERT INTO conversations (session_id, session_key, title)
+       VALUES (${d.p()}, ${d.p()}, ${d.p()}) RETURNING conversation_id`,
+      [input.sessionId, input.sessionKey ?? null, input.title ?? null],
+    );
+    const conversationId = result.lastInsertId!;
 
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, session_key, title, bootstrapped_at, created_at, updated_at
-       FROM conversations WHERE conversation_id = ?`,
-      )
-      .get(Number(result.lastInsertRowid)) as unknown as ConversationRow;
-
+    d.reset();
+    const row = await this.db.queryOne<ConversationRow>(
+      `SELECT ${CONV_COLS} FROM conversations WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
+    if (!row) {
+      throw new Error(`Failed to retrieve created conversation with ID ${conversationId}`);
+    }
     return toConversationRecord(row);
   }
 
   async getConversation(conversationId: ConversationId): Promise<ConversationRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, session_key, title, bootstrapped_at, created_at, updated_at
-       FROM conversations WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as ConversationRow | undefined;
-
+    const d = this.d.reset();
+    const row = await this.db.queryOne<ConversationRow>(
+      `SELECT ${CONV_COLS} FROM conversations WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
     return row ? toConversationRecord(row) : null;
   }
 
   async getConversationBySessionId(sessionId: string): Promise<ConversationRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, session_key, title, bootstrapped_at, created_at, updated_at
-       FROM conversations
-       WHERE session_id = ?
-       ORDER BY created_at DESC
-       LIMIT 1`,
-      )
-      .get(sessionId) as unknown as ConversationRow | undefined;
-
+    const d = this.d.reset();
+    const row = await this.db.queryOne<ConversationRow>(
+      `SELECT ${CONV_COLS} FROM conversations
+       WHERE session_id = ${d.p()}
+       ORDER BY created_at DESC LIMIT 1`,
+      [sessionId],
+    );
     return row ? toConversationRecord(row) : null;
   }
 
   async getConversationBySessionKey(sessionKey: string): Promise<ConversationRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, session_key, title, bootstrapped_at, created_at, updated_at
-       FROM conversations
-       WHERE session_key = ?
+    const d = this.d.reset();
+    const row = await this.db.queryOne<ConversationRow>(
+      `SELECT ${CONV_COLS} FROM conversations
+       WHERE session_key = ${d.p()}
        LIMIT 1`,
-      )
-      .get(sessionKey) as unknown as ConversationRow | undefined;
-
+      [sessionKey],
+    );
     return row ? toConversationRecord(row) : null;
   }
 
@@ -357,11 +394,11 @@ export class ConversationStore {
       const byKey = await this.getConversationBySessionKey(opts.sessionKey);
       if (byKey) {
         if (byKey.sessionId !== sessionId) {
-          this.db
-            .prepare(
-              `UPDATE conversations SET session_id = ?, updated_at = datetime('now') WHERE conversation_id = ?`,
-            )
-            .run(sessionId, byKey.conversationId);
+          const d = this.d.reset();
+          await this.db.run(
+            `UPDATE conversations SET session_id = ${d.p()}, updated_at = ${d.now()} WHERE conversation_id = ${d.p()}`,
+            [sessionId, byKey.conversationId],
+          );
           byKey.sessionId = sessionId;
         }
         return byKey;
@@ -371,11 +408,11 @@ export class ConversationStore {
     const existing = await this.getConversationBySessionId(sessionId);
     if (existing) {
       if (opts.sessionKey && !existing.sessionKey) {
-        this.db
-          .prepare(
-            `UPDATE conversations SET session_key = ?, updated_at = datetime('now') WHERE conversation_id = ?`,
-          )
-          .run(opts.sessionKey, existing.conversationId);
+        const d = this.d.reset();
+        await this.db.run(
+          `UPDATE conversations SET session_key = ${d.p()}, updated_at = ${d.now()} WHERE conversation_id = ${d.p()}`,
+          [opts.sessionKey, existing.conversationId],
+        );
         existing.sessionKey = opts.sessionKey;
       }
       return existing;
@@ -385,276 +422,249 @@ export class ConversationStore {
   }
 
   async markConversationBootstrapped(conversationId: ConversationId): Promise<void> {
-    this.db
-      .prepare(
-        `UPDATE conversations
-       SET bootstrapped_at = COALESCE(bootstrapped_at, datetime('now')),
-           updated_at = datetime('now')
-       WHERE conversation_id = ?`,
-      )
-      .run(conversationId);
+    const d = this.d.reset();
+    await this.db.run(
+      `UPDATE conversations
+       SET bootstrapped_at = COALESCE(bootstrapped_at, ${d.now()}),
+           updated_at = ${d.now()}
+       WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
   }
 
   // ── Message operations ────────────────────────────────────────────────────
 
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
-    const result = this.db
-      .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count)
-       VALUES (?, ?, ?, ?, ?)`,
-      )
-      .run(input.conversationId, input.seq, input.role, input.content, input.tokenCount);
+    const d = this.d.reset();
+    const result = await this.db.run(
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count)
+       VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}) RETURNING message_id`,
+      [input.conversationId, input.seq, input.role, input.content, input.tokenCount],
+    );
+    const messageId = result.lastInsertId!;
 
-    const messageId = Number(result.lastInsertRowid);
+    await this.indexMessageForFullText(messageId, input.content);
 
-    this.indexMessageForFullText(messageId, input.content);
-
-    const row = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-       FROM messages WHERE message_id = ?`,
-      )
-      .get(messageId) as unknown as MessageRow;
-
+    d.reset();
+    const row = await this.db.queryOne<MessageRow>(
+      `SELECT ${MSG_COLS} FROM messages WHERE message_id = ${d.p()}`,
+      [messageId],
+    );
+    if (!row) {
+      throw new Error(`Failed to retrieve created message with ID ${messageId}`);
+    }
     return toMessageRecord(row);
   }
 
   async createMessagesBulk(inputs: CreateMessageInput[]): Promise<MessageRecord[]> {
-    if (inputs.length === 0) {
-      return [];
-    }
-    const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count)
-       VALUES (?, ?, ?, ?, ?)`,
-    );
-    const selectStmt = this.db.prepare(
-      `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-       FROM messages WHERE message_id = ?`,
-    );
+    if (inputs.length === 0) return [];
 
     const records: MessageRecord[] = [];
     for (const input of inputs) {
-      const result = insertStmt.run(
-        input.conversationId,
-        input.seq,
-        input.role,
-        input.content,
-        input.tokenCount,
+      const d = this.d.reset();
+      const result = await this.db.run(
+        `INSERT INTO messages (conversation_id, seq, role, content, token_count)
+         VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}) RETURNING message_id`,
+        [input.conversationId, input.seq, input.role, input.content, input.tokenCount],
       );
+      const messageId = result.lastInsertId!;
 
-      const messageId = Number(result.lastInsertRowid);
-      this.indexMessageForFullText(messageId, input.content);
-      const row = selectStmt.get(messageId) as unknown as MessageRow;
-      records.push(toMessageRecord(row));
+      await this.indexMessageForFullText(messageId, input.content);
+
+      d.reset();
+      const row = await this.db.queryOne<MessageRow>(
+        `SELECT ${MSG_COLS} FROM messages WHERE message_id = ${d.p()}`,
+        [messageId],
+      );
+      if (row) records.push(toMessageRecord(row));
     }
-
     return records;
+  }
+
+  async getMessage(messageId: MessageId): Promise<MessageRecord | null> {
+    const d = this.d.reset();
+    const row = await this.db.queryOne<MessageRow>(
+      `SELECT ${MSG_COLS} FROM messages WHERE message_id = ${d.p()}`,
+      [messageId],
+    );
+    return row ? toMessageRecord(row) : null;
+  }
+
+  /** Alias for getMessage — matches upstream API naming convention. */
+  async getMessageById(messageId: MessageId): Promise<MessageRecord | null> {
+    return this.getMessage(messageId);
   }
 
   async getMessages(
     conversationId: ConversationId,
-    opts?: { afterSeq?: number; limit?: number },
+    options?: { limit?: number; before?: number; after?: number },
   ): Promise<MessageRecord[]> {
-    const afterSeq = opts?.afterSeq ?? -1;
-    const limit = opts?.limit;
+    const d = this.d.reset();
+    const where: string[] = [`conversation_id = ${d.p()}`];
+    const args: Array<string | number> = [conversationId];
 
-    if (limit != null) {
-      const rows = this.db
-        .prepare(
-          `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-         FROM messages
-         WHERE conversation_id = ? AND seq > ?
-         ORDER BY seq
-         LIMIT ?`,
-        )
-        .all(conversationId, afterSeq, limit) as unknown as MessageRow[];
-      return rows.map(toMessageRecord);
+    if (options?.before != null) {
+      where.push(`seq < ${d.p()}`);
+      args.push(options.before);
+    }
+    if (options?.after != null) {
+      where.push(`seq > ${d.p()}`);
+      args.push(options.after);
     }
 
-    const rows = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-       FROM messages
-       WHERE conversation_id = ? AND seq > ?
-       ORDER BY seq`,
-      )
-      .all(conversationId, afterSeq) as unknown as MessageRow[];
-    return rows.map(toMessageRecord);
+    let limitClause = "";
+    if (options?.limit != null) {
+      limitClause = `LIMIT ${d.p()}`;
+      args.push(options.limit);
+    }
+
+    const result = await this.db.query<MessageRow>(
+      `SELECT ${MSG_COLS} FROM messages
+       WHERE ${where.join(" AND ")}
+       ORDER BY seq ${limitClause}`,
+      args,
+    );
+    return result.rows.map(toMessageRecord);
   }
 
   async getLastMessage(conversationId: ConversationId): Promise<MessageRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-       FROM messages
-       WHERE conversation_id = ?
-       ORDER BY seq DESC
-       LIMIT 1`,
-      )
-      .get(conversationId) as unknown as MessageRow | undefined;
-
-    return row ? toMessageRecord(row) : null;
+    const results = await this.getLatestMessages(conversationId, 1);
+    return results.length > 0 ? results[0] : null;
   }
 
   async hasMessage(
     conversationId: ConversationId,
-    role: MessageRole,
+    role: string,
     content: string,
   ): Promise<boolean> {
-    const row = this.db
-      .prepare(
-        `SELECT 1 AS count
-       FROM messages
-       WHERE conversation_id = ? AND role = ? AND content = ?
-       LIMIT 1`,
-      )
-      .get(conversationId, role, content) as unknown as CountRow | undefined;
-
-    return row?.count === 1;
+    const d = this.d.reset();
+    const result = await this.db.query<{ "1": number }>(
+      `SELECT 1 FROM messages
+       WHERE conversation_id = ${d.p()} AND role = ${d.p()} AND content = ${d.p()} LIMIT 1`,
+      [conversationId, role, content],
+    );
+    return result.rows.length > 0;
   }
 
   async countMessagesByIdentity(
     conversationId: ConversationId,
-    role: MessageRole,
+    role: string,
     content: string,
   ): Promise<number> {
-    const row = this.db
-      .prepare(
-        `SELECT COUNT(*) AS count
-       FROM messages
-       WHERE conversation_id = ? AND role = ? AND content = ?`,
-      )
-      .get(conversationId, role, content) as unknown as CountRow | undefined;
-
-    return row?.count ?? 0;
+    const d = this.d.reset();
+    const result = await this.db.query<{ count: number }>(
+      `SELECT ${d.countInt("count")} FROM messages
+       WHERE conversation_id = ${d.p()} AND role = ${d.p()} AND content = ${d.p()}`,
+      [conversationId, role, content],
+    );
+    return result.rows[0]?.count ?? 0;
   }
 
-  async getMessageById(messageId: MessageId): Promise<MessageRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-       FROM messages WHERE message_id = ?`,
-      )
-      .get(messageId) as unknown as MessageRow | undefined;
-    return row ? toMessageRecord(row) : null;
+  async getLatestMessages(conversationId: ConversationId, count: number): Promise<MessageRecord[]> {
+    const d = this.d.reset();
+    const result = await this.db.query<MessageRow>(
+      `SELECT ${MSG_COLS} FROM messages
+       WHERE conversation_id = ${d.p()}
+       ORDER BY seq DESC LIMIT ${d.p()}`,
+      [conversationId, count],
+    );
+    return result.rows.map(toMessageRecord).reverse(); // Return chronological order
   }
 
-  async createMessageParts(messageId: MessageId, parts: CreateMessagePartInput[]): Promise<void> {
-    if (parts.length === 0) {
-      return;
-    }
+  // ── Message parts operations ──────────────────────────────────────────────
 
-    const stmt = this.db.prepare(
-      `INSERT INTO message_parts (
-         part_id,
-         message_id,
-         session_id,
-         part_type,
-         ordinal,
-         text_content,
-         tool_call_id,
-         tool_name,
-         tool_input,
-         tool_output,
-         metadata
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  async createMessagePart(messageId: MessageId, input: CreateMessagePartInput): Promise<MessagePartRecord> {
+    const partId = randomUUID();
+    const d = this.d.reset();
+    await this.db.run(
+      `INSERT INTO message_parts
+       (part_id, message_id, session_id, part_type, ordinal, text_content,
+        tool_call_id, tool_name, tool_input, tool_output, metadata)
+       VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()},
+               ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()})`,
+      [
+        partId, messageId, input.sessionId, input.partType, input.ordinal,
+        input.textContent, input.toolCallId, input.toolName, input.toolInput, input.toolOutput, input.metadata,
+      ],
     );
 
+    d.reset();
+    const row = await this.db.queryOne<MessagePartRow>(
+      `SELECT ${PART_COLS} FROM message_parts WHERE part_id = ${d.p()}`,
+      [partId],
+    );
+    if (!row) {
+      throw new Error(`Failed to retrieve created message part with ID ${partId}`);
+    }
+    return toMessagePartRecord(row);
+  }
+
+  /** Batch insert multiple message parts. Matches upstream API. */
+  async createMessageParts(messageId: MessageId, parts: CreateMessagePartInput[]): Promise<void> {
     for (const part of parts) {
-      stmt.run(
-        randomUUID(),
-        messageId,
-        part.sessionId,
-        part.partType,
-        part.ordinal,
-        part.textContent ?? null,
-        part.toolCallId ?? null,
-        part.toolName ?? null,
-        part.toolInput ?? null,
-        part.toolOutput ?? null,
-        part.metadata ?? null,
-      );
+      await this.createMessagePart(messageId, part);
     }
   }
 
   async getMessageParts(messageId: MessageId): Promise<MessagePartRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT
-         part_id,
-         message_id,
-         session_id,
-         part_type,
-         ordinal,
-         text_content,
-         tool_call_id,
-         tool_name,
-         tool_input,
-         tool_output,
-         metadata
-       FROM message_parts
-       WHERE message_id = ?
-       ORDER BY ordinal`,
-      )
-      .all(messageId) as unknown as MessagePartRow[];
-
-    return rows.map(toMessagePartRecord);
+    const d = this.d.reset();
+    const result = await this.db.query<MessagePartRow>(
+      `SELECT ${PART_COLS} FROM message_parts WHERE message_id = ${d.p()} ORDER BY ordinal`,
+      [messageId],
+    );
+    return result.rows.map(toMessagePartRecord);
   }
 
   async getMessageCount(conversationId: ConversationId): Promise<number> {
-    const row = this.db
-      .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
-      .get(conversationId) as unknown as CountRow;
+    const d = this.d.reset();
+    const row = await this.db.queryOne<CountRow>(
+      `SELECT ${d.countInt("count")} FROM messages WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
     return row?.count ?? 0;
   }
 
   async getMaxSeq(conversationId: ConversationId): Promise<number> {
-    const row = this.db
-      .prepare(
-        `SELECT COALESCE(MAX(seq), 0) AS max_seq
-       FROM messages WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as MaxSeqRow;
+    const d = this.d.reset();
+    const row = await this.db.queryOne<MaxSeqRow>(
+      `SELECT COALESCE(MAX(seq), 0) AS max_seq FROM messages WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
     return row?.max_seq ?? 0;
   }
 
   // ── Deletion ──────────────────────────────────────────────────────────────
 
-  /**
-   * Delete messages and their associated records (context_items, FTS, message_parts).
-   *
-   * Skips messages referenced in summary_messages (already compacted) to avoid
-   * breaking the summary DAG. Returns the count of actually deleted messages.
-   */
   async deleteMessages(messageIds: MessageId[]): Promise<number> {
-    if (messageIds.length === 0) {
-      return 0;
-    }
+    if (messageIds.length === 0) return 0;
 
-    let deleted = 0;
-    for (const messageId of messageIds) {
-      // Skip if referenced by a summary (ON DELETE RESTRICT would fail anyway)
-      const refRow = this.db
-        .prepare(`SELECT 1 AS found FROM summary_messages WHERE message_id = ? LIMIT 1`)
-        .get(messageId) as unknown as { found: number } | undefined;
-      if (refRow) {
-        continue;
+    return this.withTransaction(async () => {
+      let deleted = 0;
+      for (const messageId of messageIds) {
+        const d = this.d.reset();
+        const refRow = await this.db.queryOne<{ found: number }>(
+          `SELECT 1 AS found FROM summary_messages WHERE message_id = ${d.p()} LIMIT 1`,
+          [messageId],
+        );
+        if (refRow) continue;
+
+        d.reset();
+        await this.db.run(
+          `DELETE FROM context_items WHERE item_type = 'message' AND message_id = ${d.p()}`,
+          [messageId],
+        );
+
+        await this.deleteMessageFromFullText(messageId);
+
+        d.reset();
+        await this.db.run(
+          `DELETE FROM messages WHERE message_id = ${d.p()}`,
+          [messageId],
+        );
+        deleted += 1;
       }
-
-      // Remove from context_items first (RESTRICT constraint)
-      this.db
-        .prepare(`DELETE FROM context_items WHERE item_type = 'message' AND message_id = ?`)
-        .run(messageId);
-
-      this.deleteMessageFromFullText(messageId);
-
-      // Delete the message (message_parts cascade via ON DELETE CASCADE)
-      this.db.prepare(`DELETE FROM messages WHERE message_id = ?`).run(messageId);
-
-      deleted += 1;
-    }
-
-    return deleted;
+      return deleted;
+    });
   }
 
   // ── Search ────────────────────────────────────────────────────────────────
@@ -663,137 +673,153 @@ export class ConversationStore {
     const limit = input.limit ?? 50;
 
     if (input.mode === "full_text") {
-      if (this.fts5Available) {
+      if (this.fullTextAvailable) {
         try {
-          return this.searchFullText(
-            input.query,
-            limit,
-            input.conversationId,
-            input.since,
-            input.before,
+          return await this.searchFullText(
+            input.query, limit, input.conversationId, input.since, input.before,
           );
         } catch {
-          return this.searchLike(
-            input.query,
-            limit,
-            input.conversationId,
-            input.since,
-            input.before,
+          return await this.searchLike(
+            input.query, limit, input.conversationId, input.since, input.before,
           );
         }
       }
-      return this.searchLike(input.query, limit, input.conversationId, input.since, input.before);
+      return await this.searchLike(input.query, limit, input.conversationId, input.since, input.before);
     }
-    return this.searchRegex(input.query, limit, input.conversationId, input.since, input.before);
+    return await this.searchRegex(input.query, limit, input.conversationId, input.since, input.before);
   }
 
-  private indexMessageForFullText(messageId: MessageId, content: string): void {
-    if (!this.fts5Available) {
-      return;
-    }
+  // ── Full-text search (backend-specific) ─────────────────────────────────
+
+  private async indexMessageForFullText(messageId: MessageId, content: string): Promise<void> {
+    if (!this.fullTextAvailable || this.d.pg) return; // Postgres uses generated tsvector column
     const normalizedContent = normalizeMessageContentForFullTextIndex(content);
     if (!normalizedContent) {
       return;
     }
     try {
-      this.db
-        .prepare(`INSERT INTO messages_fts(rowid, content) VALUES (?, ?)`)
-        .run(messageId, normalizedContent);
+      await this.db.run(`INSERT INTO messages_fts(rowid, content) VALUES (?, ?)`, [messageId, normalizedContent]);
     } catch {
       // Full-text indexing is optional. Message persistence must still succeed.
     }
   }
 
-  private deleteMessageFromFullText(messageId: MessageId): void {
-    if (!this.fts5Available) {
-      return;
-    }
+  private async deleteMessageFromFullText(messageId: MessageId): Promise<void> {
+    if (!this.fullTextAvailable || this.d.pg) return; // Postgres tsvector auto-deletes with row
     try {
-      this.db.prepare(`DELETE FROM messages_fts WHERE rowid = ?`).run(messageId);
+      await this.db.run(`DELETE FROM messages_fts WHERE rowid = ?`, [messageId]);
     } catch {
-      // Ignore FTS cleanup failures; the source row deletion is authoritative.
+      // Ignore FTS cleanup failures.
     }
   }
 
-  private searchFullText(
+  private async searchFullText(
     query: string,
     limit: number,
     conversationId?: ConversationId,
     since?: Date,
     before?: Date,
-  ): MessageSearchResult[] {
+  ): Promise<MessageSearchResult[]> {
+    if (this.d.pg) {
+      return this.searchFullTextPostgres(query, limit, conversationId, since, before);
+    }
+    return this.searchFullTextSqlite(query, limit, conversationId, since, before);
+  }
+
+  private async searchFullTextSqlite(
+    query: string,
+    limit: number,
+    conversationId?: ConversationId,
+    since?: Date,
+    before?: Date,
+  ): Promise<MessageSearchResult[]> {
     const where: string[] = ["messages_fts MATCH ?"];
     const args: Array<string | number> = [sanitizeFts5Query(query)];
-    if (conversationId != null) {
-      where.push("m.conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(m.created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(m.created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+
+    if (conversationId != null) { where.push("conversation_id = ?"); args.push(conversationId); }
+    if (since) { where.push("created_at >= ?"); args.push(since.toISOString()); }
+    if (before) { where.push("created_at < ?"); args.push(before.toISOString()); }
     args.push(limit);
 
     const sql = `SELECT
-         m.message_id,
-         m.conversation_id,
-         m.role,
-         snippet(messages_fts, 0, '', '', '...', 32) AS snippet,
-         rank,
-         m.created_at
+         m.message_id, m.conversation_id, m.role,
+         snippet(messages_fts, 0, '[', ']', '...', 32) AS snippet,
+         bm25(messages_fts) AS rank, m.created_at
        FROM messages_fts
        JOIN messages m ON m.message_id = messages_fts.rowid
        WHERE ${where.join(" AND ")}
-       ORDER BY m.created_at DESC
-       LIMIT ?`;
-    const rows = this.db.prepare(sql).all(...args) as unknown as MessageSearchRow[];
-    return rows.map(toSearchResult);
+       ORDER BY m.created_at DESC LIMIT ?`;
+
+    const result = await this.db.query<MessageSearchRow>(sql, args);
+    return result.rows.map(toSearchResult);
   }
 
-  private searchLike(
+  private async searchFullTextPostgres(
     query: string,
     limit: number,
     conversationId?: ConversationId,
     since?: Date,
     before?: Date,
-  ): MessageSearchResult[] {
+  ): Promise<MessageSearchResult[]> {
+    const d = this.d.reset();
+    const tsq = `websearch_to_tsquery('english', ${d.p()})`;
+    const where: string[] = [`content_tsv @@ ${tsq}`];
+    const args: Array<string | number> = [sanitizeTsQuery(query)];
+
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
+
+    const sql = `SELECT
+         message_id, conversation_id, role,
+         ts_headline('english', content, websearch_to_tsquery('english', $1), 'MaxWords=32') AS snippet,
+         ts_rank(content_tsv, websearch_to_tsquery('english', $1)) AS rank,
+         created_at
+       FROM messages
+       WHERE ${where.join(" AND ")}
+       ORDER BY created_at DESC LIMIT ${d.p()}`;
+
+    args.push(limit);
+    const result = await this.db.query<MessageSearchRow>(sql, args);
+    return result.rows.map(toSearchResult);
+  }
+
+  // ── LIKE search (both backends) ──────────────────────────────────────────
+
+  private async searchLike(
+    query: string,
+    limit: number,
+    conversationId?: ConversationId,
+    since?: Date,
+    before?: Date,
+  ): Promise<MessageSearchResult[]> {
     const plan = buildLikeSearchPlan("content", query);
-    if (plan.terms.length === 0) {
-      return [];
+    if (plan.terms.length === 0) return [];
+
+    const d = this.d.reset();
+    let where: string[];
+    const args: Array<string | number> = [...plan.args];
+
+    if (d.pg) {
+      // Renumber plan placeholders from ? to $N
+      where = plan.where.map((clause) => clause.replace(/\?/g, () => d.p()));
+    } else {
+      where = [...plan.where];
+      // Advance the dialect param counter to match plan args
+      for (let i = 0; i < plan.args.length; i++) d.p();
     }
 
-    const where: string[] = [...plan.where];
-    const args: Array<string | number> = [...plan.args];
-    if (conversationId != null) {
-      where.push("conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
     args.push(limit);
 
-    const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-    const rows = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-         FROM messages
-         ${whereClause}
-         ORDER BY created_at DESC
-         LIMIT ?`,
-      )
-      .all(...args) as unknown as MessageRow[];
+    const sql = `SELECT ${MSG_COLS} FROM messages
+                 WHERE ${where.join(" AND ")}
+                 ORDER BY created_at DESC LIMIT ${d.p()}`;
 
-    return rows.map((row) => ({
+    const result = await this.db.query<MessageRow>(sql, args);
+    return result.rows.map((row) => ({
       messageId: row.message_id,
       conversationId: row.conversation_id,
       role: row.role,
@@ -803,53 +829,55 @@ export class ConversationStore {
     }));
   }
 
-  private searchRegex(
+  // ── Regex search (backend-specific) ──────────────────────────────────────
+
+  private async searchRegex(
     pattern: string,
     limit: number,
     conversationId?: ConversationId,
     since?: Date,
     before?: Date,
-  ): MessageSearchResult[] {
-    // SQLite has no native POSIX regex; fetch candidates and filter in JS
+  ): Promise<MessageSearchResult[]> {
     // Guard against ReDoS: reject patterns with nested quantifiers or excessive length
     if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) {
       return [];
     }
-    let re: RegExp;
     try {
-      re = new RegExp(pattern);
+      new RegExp(pattern);
     } catch {
       return [];
     }
+    if (this.d.pg) {
+      return this.searchRegexPostgres(pattern, limit, conversationId, since, before);
+    }
+    return this.searchRegexSqlite(pattern, limit, conversationId, since, before);
+  }
 
+  private async searchRegexSqlite(
+    pattern: string,
+    limit: number,
+    conversationId?: ConversationId,
+    since?: Date,
+    before?: Date,
+  ): Promise<MessageSearchResult[]> {
+    const re = new RegExp(pattern);
     const where: string[] = [];
     const args: Array<string | number> = [];
-    if (conversationId != null) {
-      where.push("conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+
+    if (conversationId != null) { where.push("conversation_id = ?"); args.push(conversationId); }
+    if (since) { where.push("created_at >= ?"); args.push(since.toISOString()); }
+    if (before) { where.push("created_at < ?"); args.push(before.toISOString()); }
+
     const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-    const rows = this.db
-      .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
-         FROM messages
-         ${whereClause}
-         ORDER BY created_at DESC`,
-      )
-      .all(...args) as unknown as MessageRow[];
+    const result = await this.db.query<MessageRow>(
+      `SELECT ${MSG_COLS} FROM messages ${whereClause} ORDER BY created_at DESC`,
+      args,
+    );
 
     const MAX_ROW_SCAN = 10_000;
     const results: MessageSearchResult[] = [];
     let scanned = 0;
-    for (const row of rows) {
+    for (const row of result.rows) {
       if (results.length >= limit || scanned >= MAX_ROW_SCAN) {
         break;
       }
@@ -868,4 +896,40 @@ export class ConversationStore {
     }
     return results;
   }
+
+  private async searchRegexPostgres(
+    pattern: string,
+    limit: number,
+    conversationId?: ConversationId,
+    since?: Date,
+    before?: Date,
+  ): Promise<MessageSearchResult[]> {
+    const d = this.d.reset();
+    const where: string[] = [`content ~ ${d.p()}`];
+    const args: Array<string | number> = [pattern];
+
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
+
+    const sql = `SELECT ${MSG_COLS} FROM messages
+                 WHERE ${where.join(" AND ")}
+                 ORDER BY created_at DESC LIMIT ${d.p()}`;
+    args.push(limit);
+
+    const result = await this.db.query<MessageRow>(sql, args);
+    return result.rows.map((row) => {
+      const re = new RegExp(pattern);
+      const match = re.exec(row.content);
+      return {
+        messageId: row.message_id,
+        conversationId: row.conversation_id,
+        role: row.role,
+        snippet: match ? match[0] : row.content.substring(0, 100),
+        createdAt: new Date(row.created_at),
+        rank: 0,
+      };
+    });
+  }
+
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,3 +29,18 @@ export type {
   UpsertConversationBootstrapStateInput,
   ConversationBootstrapStateRecord,
 } from "./summary-store.js";
+
+
+
+// Database interface exports
+export { Dialect } from "../db/dialect.js";
+export type { Backend } from "../db/dialect.js";
+export { DbClient } from "../db/db-interface.js";
+export { SqliteClient } from "../db/sqlite-client.js";
+export { PostgresClient } from "../db/postgres-client.js";
+export { createLcmConnection, closeLcmConnection, getLcmConnection } from "../db/connection.js";
+export { getLcmDbFeatures } from "../db/features.js";
+export { runLcmMigrations, ensurePostgresSchema } from "../db/migration.js";
+export { resolveLcmConfig } from "../db/config.js";
+export type { LcmConfig } from "../db/config.js";
+export type { LcmDbFeatures } from "../db/features.js";

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1,6 +1,19 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
+import type { DbClient } from "../db/db-interface.js";
+import { SqliteClient } from "../db/sqlite-client.js";
+import { Dialect, type Backend } from "../db/dialect.js";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
+import { sanitizeTsQuery } from "./tsquery-sanitize.js";
 import { buildLikeSearchPlan, createFallbackSnippet } from "./full-text-fallback.js";
+
+/** Accept either a DbClient or raw DatabaseSync (auto-wraps the latter). */
+function ensureDbClient(db: DbClient | DatabaseSync): DbClient {
+  if ('run' in db && typeof (db as DbClient).run === 'function') {
+    return db as DbClient;
+  }
+  return new SqliteClient(db as DatabaseSync);
+}
 
 export type SummaryKind = "leaf" | "condensed";
 export type ContextItemType = "message" | "summary";
@@ -192,13 +205,13 @@ interface ConversationBootstrapStateRow {
 
 // ── Row mappers ───────────────────────────────────────────────────────────────
 
+function safeNonNeg(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+}
+
 function toSummaryRecord(row: SummaryRow): SummaryRecord {
   let fileIds: string[] = [];
-  try {
-    fileIds = JSON.parse(row.file_ids);
-  } catch {
-    // ignore malformed JSON
-  }
+  try { fileIds = JSON.parse(row.file_ids); } catch { /* ignore */ }
   return {
     summaryId: row.summary_id,
     conversationId: row.conversation_id,
@@ -209,24 +222,9 @@ function toSummaryRecord(row: SummaryRow): SummaryRecord {
     fileIds,
     earliestAt: row.earliest_at ? new Date(row.earliest_at) : null,
     latestAt: row.latest_at ? new Date(row.latest_at) : null,
-    descendantCount:
-      typeof row.descendant_count === "number" &&
-      Number.isFinite(row.descendant_count) &&
-      row.descendant_count >= 0
-        ? Math.floor(row.descendant_count)
-        : 0,
-    descendantTokenCount:
-      typeof row.descendant_token_count === "number" &&
-      Number.isFinite(row.descendant_token_count) &&
-      row.descendant_token_count >= 0
-        ? Math.floor(row.descendant_token_count)
-        : 0,
-    sourceMessageTokenCount:
-      typeof row.source_message_token_count === "number" &&
-      Number.isFinite(row.source_message_token_count) &&
-      row.source_message_token_count >= 0
-        ? Math.floor(row.source_message_token_count)
-        : 0,
+    descendantCount: safeNonNeg(row.descendant_count),
+    descendantTokenCount: safeNonNeg(row.descendant_token_count),
+    sourceMessageTokenCount: safeNonNeg(row.source_message_token_count),
     createdAt: new Date(row.created_at),
   };
 }
@@ -280,16 +278,45 @@ function toConversationBootstrapStateRecord(
   };
 }
 
+// Column list constants
+const SUM_COLS = `summary_id, conversation_id, kind, depth, content, token_count, file_ids,
+  earliest_at, latest_at, descendant_count, descendant_token_count,
+  source_message_token_count, created_at`;
+
+const FILE_COLS = "file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at";
+
 // ── SummaryStore ──────────────────────────────────────────────────────────────
 
 export class SummaryStore {
-  private readonly fts5Available: boolean;
+  private readonly fullTextAvailable: boolean;
+  private readonly d: Dialect;
+  /** Root (non-transactional) database client. */
+  private readonly _rootDb: DbClient;
+  private readonly _txStore = new AsyncLocalStorage<DbClient>();
+
+  /** Active DB client — transaction-scoped if inside withTransaction/withClient, else root. */
+  private get db(): DbClient {
+    return this._txStore.getStore() ?? this._rootDb;
+  }
 
   constructor(
-    private db: DatabaseSync,
-    options?: { fts5Available?: boolean },
+    db: DbClient | DatabaseSync,
+    options?: { fullTextAvailable?: boolean; fts5Available?: boolean; backend?: Backend },
   ) {
-    this.fts5Available = options?.fts5Available ?? true;
+    this._rootDb = ensureDbClient(db);
+    this.fullTextAvailable = options?.fullTextAvailable ?? options?.fts5Available ?? true;
+    this.d = new Dialect(options?.backend ?? "sqlite");
+  }
+
+  // ── Transaction helpers ──────────────────────────────────────────────────
+
+  async withTransaction<T>(operation: () => Promise<T> | T): Promise<T> {
+    if (this._txStore.getStore()) {
+      return operation();
+    }
+    return this._rootDb.transaction(async (txClient) => {
+      return this._txStore.run(txClient, operation);
+    });
   }
 
   // ── Summary CRUD ──────────────────────────────────────────────────────────
@@ -298,255 +325,175 @@ export class SummaryStore {
     const fileIds = JSON.stringify(input.fileIds ?? []);
     const earliestAt = input.earliestAt instanceof Date ? input.earliestAt.toISOString() : null;
     const latestAt = input.latestAt instanceof Date ? input.latestAt.toISOString() : null;
-    const descendantCount =
-      typeof input.descendantCount === "number" &&
-      Number.isFinite(input.descendantCount) &&
-      input.descendantCount >= 0
-        ? Math.floor(input.descendantCount)
-        : 0;
-    const descendantTokenCount =
-      typeof input.descendantTokenCount === "number" &&
-      Number.isFinite(input.descendantTokenCount) &&
-      input.descendantTokenCount >= 0
-        ? Math.floor(input.descendantTokenCount)
-        : 0;
-    const sourceMessageTokenCount =
-      typeof input.sourceMessageTokenCount === "number" &&
-      Number.isFinite(input.sourceMessageTokenCount) &&
-      input.sourceMessageTokenCount >= 0
-        ? Math.floor(input.sourceMessageTokenCount)
-        : 0;
-    const depth =
-      typeof input.depth === "number" && Number.isFinite(input.depth) && input.depth >= 0
-        ? Math.floor(input.depth)
-        : input.kind === "leaf"
-          ? 0
-          : 1;
+    const descendantCount = safeNonNeg(input.descendantCount);
+    const descendantTokenCount = safeNonNeg(input.descendantTokenCount);
+    const sourceMessageTokenCount = safeNonNeg(input.sourceMessageTokenCount);
+    const depth = (typeof input.depth === "number" && Number.isFinite(input.depth) && input.depth >= 0)
+      ? Math.floor(input.depth)
+      : (input.kind === "leaf" ? 0 : 1);
 
-    this.db
-      .prepare(
-        `INSERT INTO summaries (
-          summary_id,
-          conversation_id,
-          kind,
-          depth,
-          content,
-          token_count,
-          file_ids,
-          earliest_at,
-          latest_at,
-          descendant_count,
-          descendant_token_count,
-          source_message_token_count
-        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        input.summaryId,
-        input.conversationId,
-        input.kind,
-        depth,
-        input.content,
-        input.tokenCount,
-        fileIds,
-        earliestAt,
-        latestAt,
-        descendantCount,
-        descendantTokenCount,
-        sourceMessageTokenCount,
-      );
+    const d = this.d.reset();
+    await this.db.run(
+      `INSERT INTO summaries (
+         summary_id, conversation_id, kind, depth, content, token_count,
+         file_ids, earliest_at, latest_at, descendant_count,
+         descendant_token_count, source_message_token_count
+       ) VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()},
+                 ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()})`,
+      [input.summaryId, input.conversationId, input.kind, depth, input.content,
+       input.tokenCount, fileIds, earliestAt, latestAt, descendantCount,
+       descendantTokenCount, sourceMessageTokenCount],
+    );
 
-    const row = this.db
-      .prepare(
-        `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
-                earliest_at, latest_at, descendant_count, created_at
-                , descendant_token_count, source_message_token_count
-       FROM summaries WHERE summary_id = ?`,
-      )
-      .get(input.summaryId) as unknown as SummaryRow;
-
-    // Index in FTS5 as best-effort; compaction flow must continue even if
-    // FTS indexing fails for any reason.
-    if (!this.fts5Available) {
-      return toSummaryRecord(row);
+    d.reset();
+    const row = await this.db.queryOne<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries WHERE summary_id = ${d.p()}`,
+      [input.summaryId],
+    );
+    if (!row) {
+      throw new Error(`Failed to retrieve inserted summary ${input.summaryId}`);
     }
 
-    try {
-      this.db
-        .prepare(`INSERT INTO summaries_fts(summary_id, content) VALUES (?, ?)`)
-        .run(input.summaryId, input.content);
-    } catch {
-      // FTS indexing failed — search won't find this summary but
-      // compaction and assembly will still work correctly.
+    // Index in FTS5 (SQLite only; Postgres uses generated tsvector column)
+    if (this.fullTextAvailable && !this.d.pg) {
+      try {
+        await this.db.run(`INSERT INTO summaries_fts(summary_id, content) VALUES (?, ?)`, [
+          input.summaryId, input.content,
+        ]);
+      } catch { /* FTS indexing is best-effort */ }
     }
 
     return toSummaryRecord(row);
   }
 
   async getSummary(summaryId: string): Promise<SummaryRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
-                earliest_at, latest_at, descendant_count, created_at
-                , descendant_token_count, source_message_token_count
-       FROM summaries WHERE summary_id = ?`,
-      )
-      .get(summaryId) as unknown as SummaryRow | undefined;
+    const d = this.d.reset();
+    const row = await this.db.queryOne<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries WHERE summary_id = ${d.p()}`,
+      [summaryId],
+    );
     return row ? toSummaryRecord(row) : null;
   }
 
   async getSummariesByConversation(conversationId: number): Promise<SummaryRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
-                earliest_at, latest_at, descendant_count, created_at
-                , descendant_token_count, source_message_token_count
-       FROM summaries
-       WHERE conversation_id = ?
-       ORDER BY created_at`,
-      )
-      .all(conversationId) as unknown as SummaryRow[];
-    return rows.map(toSummaryRecord);
+    const d = this.d.reset();
+    const result = await this.db.query<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries WHERE conversation_id = ${d.p()} ORDER BY created_at`,
+      [conversationId],
+    );
+    return result.rows.map(toSummaryRecord);
   }
 
   // ── Lineage ───────────────────────────────────────────────────────────────
 
   async linkSummaryToMessages(summaryId: string, messageIds: number[]): Promise<void> {
-    if (messageIds.length === 0) {
-      return;
-    }
-
-    const stmt = this.db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES (?, ?, ?)
-       ON CONFLICT (summary_id, message_id) DO NOTHING`,
-    );
-
+    if (messageIds.length === 0) return;
     for (let idx = 0; idx < messageIds.length; idx++) {
-      stmt.run(summaryId, messageIds[idx], idx);
+      const d = this.d.reset();
+      await this.db.run(
+        `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+         VALUES (${d.p()}, ${d.p()}, ${d.p()})
+         ON CONFLICT (summary_id, message_id) DO NOTHING`,
+        [summaryId, messageIds[idx], idx],
+      );
     }
   }
 
   async linkSummaryToParents(summaryId: string, parentSummaryIds: string[]): Promise<void> {
-    if (parentSummaryIds.length === 0) {
-      return;
-    }
-
-    const stmt = this.db.prepare(
-      `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
-       VALUES (?, ?, ?)
-       ON CONFLICT (summary_id, parent_summary_id) DO NOTHING`,
-    );
-
+    if (parentSummaryIds.length === 0) return;
     for (let idx = 0; idx < parentSummaryIds.length; idx++) {
-      stmt.run(summaryId, parentSummaryIds[idx], idx);
+      const d = this.d.reset();
+      await this.db.run(
+        `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+         VALUES (${d.p()}, ${d.p()}, ${d.p()})
+         ON CONFLICT (summary_id, parent_summary_id) DO NOTHING`,
+        [summaryId, parentSummaryIds[idx], idx],
+      );
     }
   }
 
   async getSummaryMessages(summaryId: string): Promise<number[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT message_id FROM summary_messages
-       WHERE summary_id = ?
-       ORDER BY ordinal`,
-      )
-      .all(summaryId) as unknown as MessageIdRow[];
-    return rows.map((r) => r.message_id);
+    const d = this.d.reset();
+    const result = await this.db.query<MessageIdRow>(
+      `SELECT message_id FROM summary_messages WHERE summary_id = ${d.p()} ORDER BY ordinal`,
+      [summaryId],
+    );
+    return result.rows.map((r) => r.message_id);
   }
 
   async getSummaryChildren(parentSummaryId: string): Promise<SummaryRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
-                s.file_ids, s.earliest_at, s.latest_at, s.descendant_count, s.created_at
-                , s.descendant_token_count, s.source_message_token_count
+    const d = this.d.reset();
+    const result = await this.db.query<SummaryRow>(
+      `SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
+              s.file_ids, s.earliest_at, s.latest_at, s.descendant_count,
+              s.descendant_token_count, s.source_message_token_count, s.created_at
        FROM summaries s
        JOIN summary_parents sp ON sp.summary_id = s.summary_id
-       WHERE sp.parent_summary_id = ?
+       WHERE sp.parent_summary_id = ${d.p()}
        ORDER BY sp.ordinal`,
-      )
-      .all(parentSummaryId) as unknown as SummaryRow[];
-    return rows.map(toSummaryRecord);
+      [parentSummaryId],
+    );
+    return result.rows.map(toSummaryRecord);
   }
 
   // NOTE: historical naming is confusing here.
   // getSummaryParents(summaryId) returns the source summaries compacted into
   // `summaryId`. Expansion should use this direction for replay.
   async getSummaryParents(summaryId: string): Promise<SummaryRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
-                s.file_ids, s.earliest_at, s.latest_at, s.descendant_count, s.created_at
-                , s.descendant_token_count, s.source_message_token_count
+    const d = this.d.reset();
+    const result = await this.db.query<SummaryRow>(
+      `SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
+              s.file_ids, s.earliest_at, s.latest_at, s.descendant_count,
+              s.descendant_token_count, s.source_message_token_count, s.created_at
        FROM summaries s
        JOIN summary_parents sp ON sp.parent_summary_id = s.summary_id
-       WHERE sp.summary_id = ?
+       WHERE sp.summary_id = ${d.p()}
        ORDER BY sp.ordinal`,
-      )
-      .all(summaryId) as unknown as SummaryRow[];
-    return rows.map(toSummaryRecord);
+      [summaryId],
+    );
+    return result.rows.map(toSummaryRecord);
   }
 
   async getSummarySubtree(summaryId: string): Promise<SummarySubtreeNodeRecord[]> {
-    const rows = this.db
-      .prepare(
-        `WITH RECURSIVE subtree(summary_id, parent_summary_id, depth_from_root, path) AS (
-           SELECT ?, NULL, 0, ''
-           UNION ALL
-           SELECT
-             sp.summary_id,
-             sp.parent_summary_id,
-             subtree.depth_from_root + 1,
-             CASE
-               WHEN subtree.path = '' THEN printf('%04d', sp.ordinal)
-               ELSE subtree.path || '.' || printf('%04d', sp.ordinal)
-             END
-           FROM summary_parents sp
-           JOIN subtree ON sp.parent_summary_id = subtree.summary_id
-         )
+    const d = this.d.reset();
+    const result = await this.db.query<SummarySubtreeRow>(
+      `WITH RECURSIVE subtree(summary_id, parent_summary_id, depth_from_root, path) AS (
+         SELECT ${d.p()}, NULL, 0, ''
+         UNION ALL
          SELECT
-           s.summary_id,
-           s.conversation_id,
-           s.kind,
-           s.depth,
-           s.content,
-           s.token_count,
-           s.file_ids,
-           s.earliest_at,
-           s.latest_at,
-           s.descendant_count,
-           s.descendant_token_count,
-           s.source_message_token_count,
-           s.created_at,
-           subtree.depth_from_root,
-           subtree.parent_summary_id,
-           subtree.path,
-           (
-             SELECT COUNT(*) FROM summary_parents sp2
-             WHERE sp2.parent_summary_id = s.summary_id
-           ) AS child_count
-         FROM subtree
-         JOIN summaries s ON s.summary_id = subtree.summary_id
-         ORDER BY subtree.depth_from_root ASC, subtree.path ASC, s.created_at ASC`,
-      )
-      .all(summaryId) as unknown as SummarySubtreeRow[];
+           sp.summary_id,
+           sp.parent_summary_id,
+           subtree.depth_from_root + 1,
+           CASE
+             WHEN subtree.path = '' THEN ${d.zeroPad("sp.ordinal", 4)}
+             ELSE subtree.path || '.' || ${d.zeroPad("sp.ordinal", 4)}
+           END
+         FROM summary_parents sp
+         JOIN subtree ON sp.parent_summary_id = subtree.summary_id
+       )
+       SELECT
+         s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
+         s.file_ids, s.earliest_at, s.latest_at, s.descendant_count,
+         s.descendant_token_count, s.source_message_token_count, s.created_at,
+         subtree.depth_from_root, subtree.parent_summary_id, subtree.path,
+         (SELECT ${d.countInt()} FROM summary_parents sp2 WHERE sp2.parent_summary_id = s.summary_id) AS child_count
+       FROM subtree
+       JOIN summaries s ON s.summary_id = subtree.summary_id
+       ORDER BY subtree.depth_from_root ASC, subtree.path ASC, s.created_at ASC`,
+      [summaryId],
+    );
 
     const seen = new Set<string>();
     const output: SummarySubtreeNodeRecord[] = [];
-    for (const row of rows) {
-      if (seen.has(row.summary_id)) {
-        continue;
-      }
+    for (const row of result.rows) {
+      if (seen.has(row.summary_id)) continue;
       seen.add(row.summary_id);
       output.push({
         ...toSummaryRecord(row),
         depthFromRoot: Math.max(0, Math.floor(row.depth_from_root ?? 0)),
         parentSummaryId: row.parent_summary_id ?? null,
         path: typeof row.path === "string" ? row.path : "",
-        childCount:
-          typeof row.child_count === "number" && Number.isFinite(row.child_count)
-            ? Math.max(0, Math.floor(row.child_count))
-            : 0,
+        childCount: safeNonNeg(row.child_count),
       });
     }
     return output;
@@ -555,103 +502,84 @@ export class SummaryStore {
   // ── Context items ─────────────────────────────────────────────────────────
 
   async getContextItems(conversationId: number): Promise<ContextItemRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT conversation_id, ordinal, item_type, message_id, summary_id, created_at
-       FROM context_items
-       WHERE conversation_id = ?
-       ORDER BY ordinal`,
-      )
-      .all(conversationId) as unknown as ContextItemRow[];
-    return rows.map(toContextItemRecord);
+    const d = this.d.reset();
+    const result = await this.db.query<ContextItemRow>(
+      `SELECT conversation_id, ordinal, item_type, message_id, summary_id, created_at
+       FROM context_items WHERE conversation_id = ${d.p()} ORDER BY ordinal`,
+      [conversationId],
+    );
+    return result.rows.map(toContextItemRecord);
   }
 
   async getDistinctDepthsInContext(
     conversationId: number,
     options?: { maxOrdinalExclusive?: number },
   ): Promise<number[]> {
-    const maxOrdinalExclusive = options?.maxOrdinalExclusive;
-    const useOrdinalBound =
-      typeof maxOrdinalExclusive === "number" &&
-      Number.isFinite(maxOrdinalExclusive) &&
-      maxOrdinalExclusive !== Infinity;
+    const maxOrd = options?.maxOrdinalExclusive;
+    const useBound = typeof maxOrd === "number" && Number.isFinite(maxOrd) && maxOrd !== Infinity;
 
-    const sql = useOrdinalBound
-      ? `SELECT DISTINCT s.depth
-         FROM context_items ci
-         JOIN summaries s ON s.summary_id = ci.summary_id
-         WHERE ci.conversation_id = ?
-           AND ci.item_type = 'summary'
-           AND ci.ordinal < ?
-         ORDER BY s.depth ASC`
-      : `SELECT DISTINCT s.depth
-         FROM context_items ci
-         JOIN summaries s ON s.summary_id = ci.summary_id
-         WHERE ci.conversation_id = ?
-           AND ci.item_type = 'summary'
-         ORDER BY s.depth ASC`;
+    const d = this.d.reset();
+    const where = [
+      `ci.conversation_id = ${d.p()}`,
+      "ci.item_type = 'summary'",
+    ];
+    const args: unknown[] = [conversationId];
 
-    const rows = useOrdinalBound
-      ? (this.db
-          .prepare(sql)
-          .all(conversationId, Math.floor(maxOrdinalExclusive)) as unknown as DistinctDepthRow[])
-      : (this.db.prepare(sql).all(conversationId) as unknown as DistinctDepthRow[]);
+    if (useBound) {
+      where.push(`ci.ordinal < ${d.p()}`);
+      args.push(Math.floor(maxOrd!));
+    }
 
-    return rows.map((row) => row.depth);
+    const result = await this.db.query<DistinctDepthRow>(
+      `SELECT DISTINCT s.depth FROM context_items ci
+       JOIN summaries s ON s.summary_id = ci.summary_id
+       WHERE ${where.join(" AND ")}
+       ORDER BY s.depth ASC`,
+      args,
+    );
+    return result.rows.map((row) => row.depth);
+  }
+
+  private async nextOrdinal(conversationId: number): Promise<number> {
+    const d = this.d.reset();
+    const row = await this.db.queryOne<MaxOrdinalRow>(
+      `SELECT COALESCE(MAX(ordinal), -1) AS max_ordinal FROM context_items WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
+    return (row?.max_ordinal ?? -1) + 1;
   }
 
   async appendContextMessage(conversationId: number, messageId: number): Promise<void> {
-    const row = this.db
-      .prepare(
-        `SELECT COALESCE(MAX(ordinal), -1) AS max_ordinal
-       FROM context_items WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as MaxOrdinalRow;
-
-    this.db
-      .prepare(
-        `INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
-       VALUES (?, ?, 'message', ?)`,
-      )
-      .run(conversationId, row.max_ordinal + 1, messageId);
+    const ordinal = await this.nextOrdinal(conversationId);
+    const d = this.d.reset();
+    await this.db.run(
+      `INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+       VALUES (${d.p()}, ${d.p()}, 'message', ${d.p()})`,
+      [conversationId, ordinal, messageId],
+    );
   }
 
   async appendContextMessages(conversationId: number, messageIds: number[]): Promise<void> {
-    if (messageIds.length === 0) {
-      return;
-    }
-
-    const row = this.db
-      .prepare(
-        `SELECT COALESCE(MAX(ordinal), -1) AS max_ordinal
-       FROM context_items WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as MaxOrdinalRow;
-    const baseOrdinal = row.max_ordinal + 1;
-
-    const stmt = this.db.prepare(
-      `INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
-       VALUES (?, ?, 'message', ?)`,
-    );
+    if (messageIds.length === 0) return;
+    const baseOrdinal = await this.nextOrdinal(conversationId);
     for (let idx = 0; idx < messageIds.length; idx++) {
-      stmt.run(conversationId, baseOrdinal + idx, messageIds[idx]);
+      const d = this.d.reset();
+      await this.db.run(
+        `INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+         VALUES (${d.p()}, ${d.p()}, 'message', ${d.p()})`,
+        [conversationId, baseOrdinal + idx, messageIds[idx]],
+      );
     }
   }
 
   async appendContextSummary(conversationId: number, summaryId: string): Promise<void> {
-    const row = this.db
-      .prepare(
-        `SELECT COALESCE(MAX(ordinal), -1) AS max_ordinal
-       FROM context_items WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as MaxOrdinalRow;
-
-    this.db
-      .prepare(
-        `INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
-       VALUES (?, ?, 'summary', ?)`,
-      )
-      .run(conversationId, row.max_ordinal + 1, summaryId);
+    const ordinal = await this.nextOrdinal(conversationId);
+    const d = this.d.reset();
+    await this.db.run(
+      `INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
+       VALUES (${d.p()}, ${d.p()}, 'summary', ${d.p()})`,
+      [conversationId, ordinal, summaryId],
+    );
   }
 
   async replaceContextRangeWithSummary(input: {
@@ -662,78 +590,71 @@ export class SummaryStore {
   }): Promise<void> {
     const { conversationId, startOrdinal, endOrdinal, summaryId } = input;
 
-    this.db.exec("BEGIN");
-    try {
-      // 1. Delete context items in the range [startOrdinal, endOrdinal]
-      this.db
-        .prepare(
-          `DELETE FROM context_items
-         WHERE conversation_id = ?
-           AND ordinal >= ?
-           AND ordinal <= ?`,
-        )
-        .run(conversationId, startOrdinal, endOrdinal);
-
-      // 2. Insert the replacement summary item at startOrdinal
-      this.db
-        .prepare(
-          `INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
-         VALUES (?, ?, 'summary', ?)`,
-        )
-        .run(conversationId, startOrdinal, summaryId);
-
-      // 3. Resequence all ordinals to maintain contiguity (no gaps).
-      //    Fetch current items, then update ordinals in order.
-      const items = this.db
-        .prepare(
-          `SELECT ordinal FROM context_items
-         WHERE conversation_id = ?
-         ORDER BY ordinal`,
-        )
-        .all(conversationId) as unknown as { ordinal: number }[];
-
-      const updateStmt = this.db.prepare(
-        `UPDATE context_items
-         SET ordinal = ?
-         WHERE conversation_id = ? AND ordinal = ?`,
+    return this.withTransaction(async () => {
+      // 1. Delete context items in range [startOrdinal, endOrdinal]
+      const d1 = this.d.reset();
+      await this.db.run(
+        `DELETE FROM context_items
+         WHERE conversation_id = ${d1.p()} AND ordinal >= ${d1.p()} AND ordinal <= ${d1.p()}`,
+        [conversationId, startOrdinal, endOrdinal],
       );
 
-      // Use negative temp ordinals first to avoid unique constraint conflicts
-      for (let i = 0; i < items.length; i++) {
-        updateStmt.run(-(i + 1), conversationId, items[i].ordinal);
-      }
-      for (let i = 0; i < items.length; i++) {
-        updateStmt.run(i, conversationId, -(i + 1));
-      }
+      // 2. Insert replacement summary at startOrdinal
+      const d2 = this.d.reset();
+      await this.db.run(
+        `INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
+         VALUES (${d2.p()}, ${d2.p()}, 'summary', ${d2.p()})`,
+        [conversationId, startOrdinal, summaryId],
+      );
 
-      this.db.exec("COMMIT");
-    } catch (err) {
-      this.db.exec("ROLLBACK");
-      throw err;
-    }
+      // 3. Resequence ordinals for contiguity (avoid gaps from deletion)
+      const d3 = this.d.reset();
+      const result = await this.db.query<{ ordinal: number }>(
+        `SELECT ordinal FROM context_items WHERE conversation_id = ${d3.p()} ORDER BY ordinal`,
+        [conversationId],
+      );
+      const items = result.rows;
+
+      // Use negative temp ordinals to avoid unique constraint conflicts
+      for (let i = 0; i < items.length; i++) {
+        const du = this.d.reset();
+        await this.db.run(
+          `UPDATE context_items SET ordinal = ${du.p()}
+           WHERE conversation_id = ${du.p()} AND ordinal = ${du.p()}`,
+          [-(i + 1), conversationId, items[i].ordinal],
+        );
+      }
+      for (let i = 0; i < items.length; i++) {
+        const du = this.d.reset();
+        await this.db.run(
+          `UPDATE context_items SET ordinal = ${du.p()}
+           WHERE conversation_id = ${du.p()} AND ordinal = ${du.p()}`,
+          [i, conversationId, -(i + 1)],
+        );
+      }
+    });
   }
 
   async getContextTokenCount(conversationId: number): Promise<number> {
-    const row = this.db
-      .prepare(
-        `SELECT COALESCE(SUM(token_count), 0) AS total
-       FROM (
-         SELECT m.token_count
-         FROM context_items ci
+    const d = this.d.reset();
+    // Postgres $N params can be reused; SQLite ? cannot.
+    // Use a subquery approach that works for both.
+    const convParam = d.p();
+    const convParam2 = this.d.pg ? convParam : d.p();
+    const params = this.d.pg ? [conversationId] : [conversationId, conversationId];
+
+    const row = await this.db.queryOne<TokenSumRow>(
+      `SELECT COALESCE(SUM(token_count), 0) AS total FROM (
+         SELECT m.token_count FROM context_items ci
          JOIN messages m ON m.message_id = ci.message_id
-         WHERE ci.conversation_id = ?
-           AND ci.item_type = 'message'
-
+         WHERE ci.conversation_id = ${convParam} AND ci.item_type = 'message'
          UNION ALL
-
-         SELECT s.token_count
-         FROM context_items ci
+         SELECT s.token_count FROM context_items ci
          JOIN summaries s ON s.summary_id = ci.summary_id
-         WHERE ci.conversation_id = ?
-           AND ci.item_type = 'summary'
+         WHERE ci.conversation_id = ${convParam2} AND ci.item_type = 'summary'
        ) sub`,
-      )
-      .get(conversationId, conversationId) as unknown as TokenSumRow;
+      params,
+    );
     return row?.total ?? 0;
   }
 
@@ -743,111 +664,107 @@ export class SummaryStore {
     const limit = input.limit ?? 50;
 
     if (input.mode === "full_text") {
-      if (this.fts5Available) {
+      if (this.fullTextAvailable) {
         try {
-          return this.searchFullText(
-            input.query,
-            limit,
-            input.conversationId,
-            input.since,
-            input.before,
-          );
+          return await this.searchFullText(input.query, limit, input.conversationId, input.since, input.before);
         } catch {
-          return this.searchLike(
-            input.query,
-            limit,
-            input.conversationId,
-            input.since,
-            input.before,
-          );
+          return await this.searchLike(input.query, limit, input.conversationId, input.since, input.before);
         }
       }
-      return this.searchLike(input.query, limit, input.conversationId, input.since, input.before);
+      return await this.searchLike(input.query, limit, input.conversationId, input.since, input.before);
     }
-    return this.searchRegex(input.query, limit, input.conversationId, input.since, input.before);
+    return await this.searchRegex(input.query, limit, input.conversationId, input.since, input.before);
   }
 
-  private searchFullText(
-    query: string,
-    limit: number,
-    conversationId?: number,
-    since?: Date,
-    before?: Date,
-  ): SummarySearchResult[] {
+  // ── Full-text search ─────────────────────────────────────────────────────
+
+  private async searchFullText(
+    query: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
+    return this.d.pg
+      ? this.searchFullTextPostgres(query, limit, conversationId, since, before)
+      : this.searchFullTextSqlite(query, limit, conversationId, since, before);
+  }
+
+  private async searchFullTextSqlite(
+    query: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
     const where: string[] = ["summaries_fts MATCH ?"];
     const args: Array<string | number> = [sanitizeFts5Query(query)];
-    if (conversationId != null) {
-      where.push("s.conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(s.created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(s.created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+    if (conversationId != null) { where.push("s.conversation_id = ?"); args.push(conversationId); }
+    if (since) { where.push("s.created_at >= ?"); args.push(since.toISOString()); }
+    if (before) { where.push("s.created_at < ?"); args.push(before.toISOString()); }
     args.push(limit);
 
-    const sql = `SELECT
-         summaries_fts.summary_id,
-         s.conversation_id,
-         s.kind,
-         snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
-         rank,
-         s.created_at
+    const result = await this.db.query<SummarySearchRow>(
+      `SELECT summaries_fts.summary_id, s.conversation_id, s.kind,
+              snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
+              rank, s.created_at
        FROM summaries_fts
        JOIN summaries s ON s.summary_id = summaries_fts.summary_id
        WHERE ${where.join(" AND ")}
-       ORDER BY s.created_at DESC
-       LIMIT ?`;
-    const rows = this.db.prepare(sql).all(...args) as unknown as SummarySearchRow[];
-    return rows.map(toSearchResult);
+       ORDER BY s.created_at DESC LIMIT ?`,
+      args,
+    );
+    return result.rows.map(toSearchResult);
   }
 
-  private searchLike(
-    query: string,
-    limit: number,
-    conversationId?: number,
-    since?: Date,
-    before?: Date,
-  ): SummarySearchResult[] {
+  private async searchFullTextPostgres(
+    query: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
+    const d = this.d.reset();
+    const tsq = `websearch_to_tsquery('english', ${d.p()})`;
+    const where: string[] = [`content_tsv @@ ${tsq}`];
+    const args: Array<string | number> = [sanitizeTsQuery(query)];
+
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
+
+    const sql = `SELECT summary_id, conversation_id, kind,
+         ts_headline('english', content, websearch_to_tsquery('english', $1), 'MaxWords=32') AS snippet,
+         ts_rank(content_tsv, websearch_to_tsquery('english', $1)) AS rank,
+         created_at
+       FROM summaries
+       WHERE ${where.join(" AND ")}
+       ORDER BY created_at DESC LIMIT ${d.p()}`;
+
+    args.push(limit);
+    const result = await this.db.query<SummarySearchRow>(sql, args);
+    return result.rows.map(toSearchResult);
+  }
+
+  // ── LIKE search ──────────────────────────────────────────────────────────
+
+  private async searchLike(
+    query: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
     const plan = buildLikeSearchPlan("content", query);
-    if (plan.terms.length === 0) {
-      return [];
+    if (plan.terms.length === 0) return [];
+
+    const d = this.d.reset();
+    let where: string[];
+    const args: Array<string | number> = [...plan.args];
+
+    if (d.pg) {
+      where = plan.where.map((clause) => clause.replace(/\?/g, () => d.p()));
+    } else {
+      where = [...plan.where];
+      for (let i = 0; i < plan.args.length; i++) d.p(); // advance counter
     }
 
-    const where: string[] = [...plan.where];
-    const args: Array<string | number> = [...plan.args];
-    if (conversationId != null) {
-      where.push("conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
     args.push(limit);
 
-    const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-    const rows = this.db
-      .prepare(
-        `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
-                earliest_at, latest_at, descendant_count, descendant_token_count,
-                source_message_token_count, created_at
-         FROM summaries
-         ${whereClause}
-         ORDER BY created_at DESC
-         LIMIT ?`,
-      )
-      .all(...args) as unknown as SummaryRow[];
-
-    return rows.map((row) => ({
+    const result = await this.db.query<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries
+       WHERE ${where.join(" AND ")}
+       ORDER BY created_at DESC LIMIT ${d.p()}`,
+      args,
+    );
+    return result.rows.map((row) => ({
       summaryId: row.summary_id,
       conversationId: row.conversation_id,
       kind: row.kind,
@@ -857,54 +774,46 @@ export class SummaryStore {
     }));
   }
 
-  private searchRegex(
-    pattern: string,
-    limit: number,
-    conversationId?: number,
-    since?: Date,
-    before?: Date,
-  ): SummarySearchResult[] {
+  // ── Regex search ─────────────────────────────────────────────────────────
+
+  private async searchRegex(
+    pattern: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
     // Guard against ReDoS: reject patterns with nested quantifiers or excessive length
     if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) {
       return [];
     }
-    let re: RegExp;
     try {
-      re = new RegExp(pattern);
+      new RegExp(pattern);
     } catch {
       return [];
     }
+    if (this.d.pg) {
+      return this.searchRegexPostgres(pattern, limit, conversationId, since, before);
+    }
+    return this.searchRegexSqlite(pattern, limit, conversationId, since, before);
+  }
 
+  private async searchRegexSqlite(
+    pattern: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
+    const re = new RegExp(pattern);
     const where: string[] = [];
     const args: Array<string | number> = [];
-    if (conversationId != null) {
-      where.push("conversation_id = ?");
-      args.push(conversationId);
-    }
-    if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
-      args.push(since.toISOString());
-    }
-    if (before) {
-      where.push("julianday(created_at) < julianday(?)");
-      args.push(before.toISOString());
-    }
+    if (conversationId != null) { where.push("conversation_id = ?"); args.push(conversationId); }
+    if (since) { where.push("created_at >= ?"); args.push(since.toISOString()); }
+    if (before) { where.push("created_at < ?"); args.push(before.toISOString()); }
+
     const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-    const rows = this.db
-      .prepare(
-        `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
-                earliest_at, latest_at, descendant_count, descendant_token_count,
-                source_message_token_count, created_at
-         FROM summaries
-         ${whereClause}
-         ORDER BY created_at DESC`,
-      )
-      .all(...args) as unknown as SummaryRow[];
+    const result = await this.db.query<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries ${whereClause} ORDER BY created_at DESC`,
+      args,
+    );
 
     const MAX_ROW_SCAN = 10_000;
     const results: SummarySearchResult[] = [];
     let scanned = 0;
-    for (const row of rows) {
+    for (const row of result.rows) {
       if (results.length >= limit || scanned >= MAX_ROW_SCAN) {
         break;
       }
@@ -924,54 +833,74 @@ export class SummaryStore {
     return results;
   }
 
+  private async searchRegexPostgres(
+    pattern: string, limit: number, conversationId?: number, since?: Date, before?: Date,
+  ): Promise<SummarySearchResult[]> {
+    const d = this.d.reset();
+    const where: string[] = [`content ~ ${d.p()}`];
+    const args: Array<string | number> = [pattern];
+    if (conversationId != null) { where.push(`conversation_id = ${d.p()}`); args.push(conversationId); }
+    if (since) { where.push(`created_at >= ${d.p()}`); args.push(since.toISOString()); }
+    if (before) { where.push(`created_at < ${d.p()}`); args.push(before.toISOString()); }
+
+    const result = await this.db.query<SummaryRow>(
+      `SELECT ${SUM_COLS} FROM summaries
+       WHERE ${where.join(" AND ")}
+       ORDER BY created_at DESC LIMIT ${d.p()}`,
+      [...args, limit],
+    );
+    return result.rows.map((row) => {
+      const re = new RegExp(pattern);
+      const match = re.exec(row.content);
+      return {
+        summaryId: row.summary_id,
+        conversationId: row.conversation_id,
+        kind: row.kind,
+        snippet: match ? match[0] : row.content.substring(0, 100),
+        createdAt: new Date(row.created_at),
+        rank: 0,
+      };
+    });
+  }
+
   // ── Large files ───────────────────────────────────────────────────────────
 
   async insertLargeFile(input: CreateLargeFileInput): Promise<LargeFileRecord> {
-    this.db
-      .prepare(
-        `INSERT INTO large_files (file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        input.fileId,
-        input.conversationId,
-        input.fileName ?? null,
-        input.mimeType ?? null,
-        input.byteSize ?? null,
-        input.storageUri,
-        input.explorationSummary ?? null,
-      );
+    const d = this.d.reset();
+    await this.db.run(
+      `INSERT INTO large_files (file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary)
+       VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()})`,
+      [input.fileId, input.conversationId, input.fileName ?? null, input.mimeType ?? null,
+       input.byteSize ?? null, input.storageUri, input.explorationSummary ?? null],
+    );
 
-    const row = this.db
-      .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
-       FROM large_files WHERE file_id = ?`,
-      )
-      .get(input.fileId) as unknown as LargeFileRow;
-
+    d.reset();
+    const row = await this.db.queryOne<LargeFileRow>(
+      `SELECT ${FILE_COLS} FROM large_files WHERE file_id = ${d.p()}`,
+      [input.fileId],
+    );
+    if (!row) {
+      throw new Error(`Failed to retrieve inserted large file ${input.fileId}`);
+    }
     return toLargeFileRecord(row);
   }
 
   async getLargeFile(fileId: string): Promise<LargeFileRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
-       FROM large_files WHERE file_id = ?`,
-      )
-      .get(fileId) as unknown as LargeFileRow | undefined;
+    const d = this.d.reset();
+    const row = await this.db.queryOne<LargeFileRow>(
+      `SELECT ${FILE_COLS} FROM large_files WHERE file_id = ${d.p()}`,
+      [fileId],
+    );
     return row ? toLargeFileRecord(row) : null;
   }
 
   async getLargeFilesByConversation(conversationId: number): Promise<LargeFileRecord[]> {
-    const rows = this.db
-      .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
-       FROM large_files
-       WHERE conversation_id = ?
-       ORDER BY created_at`,
-      )
-      .all(conversationId) as unknown as LargeFileRow[];
-    return rows.map(toLargeFileRecord);
+    const d = this.d.reset();
+    const result = await this.db.query<LargeFileRow>(
+      `SELECT ${FILE_COLS} FROM large_files WHERE conversation_id = ${d.p()} ORDER BY created_at`,
+      [conversationId],
+    );
+    return result.rows.map(toLargeFileRecord);
   }
 
   // ── Bootstrap state ──────────────────────────────────────────────────────
@@ -979,57 +908,55 @@ export class SummaryStore {
   async getConversationBootstrapState(
     conversationId: number,
   ): Promise<ConversationBootstrapStateRecord | null> {
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
-         FROM conversation_bootstrap_state
-         WHERE conversation_id = ?`,
-      )
-      .get(conversationId) as unknown as ConversationBootstrapStateRow | undefined;
+    const d = this.d.reset();
+    const row = await this.db.queryOne<ConversationBootstrapStateRow>(
+      `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
+              last_processed_offset, last_processed_entry_hash, updated_at
+       FROM conversation_bootstrap_state
+       WHERE conversation_id = ${d.p()}`,
+      [conversationId],
+    );
     return row ? toConversationBootstrapStateRecord(row) : null;
   }
 
   async upsertConversationBootstrapState(
     input: UpsertConversationBootstrapStateInput,
   ): Promise<ConversationBootstrapStateRecord> {
-    this.db
-      .prepare(
-        `INSERT INTO conversation_bootstrap_state (
-           conversation_id,
-           session_file_path,
-           last_seen_size,
-           last_seen_mtime_ms,
-           last_processed_offset,
-           last_processed_entry_hash
-         )
-         VALUES (?, ?, ?, ?, ?, ?)
-         ON CONFLICT (conversation_id) DO UPDATE SET
-           session_file_path = excluded.session_file_path,
-           last_seen_size = excluded.last_seen_size,
-           last_seen_mtime_ms = excluded.last_seen_mtime_ms,
-           last_processed_offset = excluded.last_processed_offset,
-           last_processed_entry_hash = excluded.last_processed_entry_hash,
-           updated_at = datetime('now')`,
-      )
-      .run(
-        input.conversationId,
-        input.sessionFilePath,
-        Math.max(0, Math.floor(input.lastSeenSize)),
-        Math.max(0, Math.floor(input.lastSeenMtimeMs)),
-        Math.max(0, Math.floor(input.lastProcessedOffset)),
-        input.lastProcessedEntryHash ?? null,
-      );
+    const d = this.d.reset();
+    const lastSeenSize = Math.max(0, Math.floor(input.lastSeenSize));
+    const lastSeenMtimeMs = Math.max(0, Math.floor(input.lastSeenMtimeMs));
+    const lastProcessedOffset = Math.max(0, Math.floor(input.lastProcessedOffset));
+    const entryHash = input.lastProcessedEntryHash ?? null;
 
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
-         FROM conversation_bootstrap_state
-         WHERE conversation_id = ?`,
-      )
-      .get(input.conversationId) as unknown as ConversationBootstrapStateRow;
+    await this.db.run(
+      `INSERT INTO conversation_bootstrap_state (
+         conversation_id,
+         session_file_path,
+         last_seen_size,
+         last_seen_mtime_ms,
+         last_processed_offset,
+         last_processed_entry_hash
+       )
+       VALUES (${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()}, ${d.p()})
+       ON CONFLICT (conversation_id) DO UPDATE SET
+         session_file_path = excluded.session_file_path,
+         last_seen_size = excluded.last_seen_size,
+         last_seen_mtime_ms = excluded.last_seen_mtime_ms,
+         last_processed_offset = excluded.last_processed_offset,
+         last_processed_entry_hash = excluded.last_processed_entry_hash,
+         updated_at = ${d.now()}`,
+      [input.conversationId, input.sessionFilePath, lastSeenSize, lastSeenMtimeMs, lastProcessedOffset, entryHash],
+    );
 
-    return toConversationBootstrapStateRecord(row);
+    d.reset();
+    const row = await this.db.queryOne<ConversationBootstrapStateRow>(
+      `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
+              last_processed_offset, last_processed_entry_hash, updated_at
+       FROM conversation_bootstrap_state
+       WHERE conversation_id = ${d.p()}`,
+      [input.conversationId],
+    );
+
+    return toConversationBootstrapStateRecord(row!);
   }
 }

--- a/src/store/tsquery-sanitize.ts
+++ b/src/store/tsquery-sanitize.ts
@@ -1,0 +1,39 @@
+/**
+ * Sanitize a user-provided query for use with PostgreSQL's plainto_tsquery.
+ *
+ * plainto_tsquery is much more forgiving than FTS5 MATCH expressions:
+ * - It automatically handles most special characters
+ * - It treats input as plain text and extracts meaningful words
+ * - It doesn't require manual escaping of operators like AND, OR, NOT
+ *
+ * However, we still need to handle some edge cases:
+ * - Very long queries should be truncated
+ * - Empty/whitespace-only queries should return a safe default
+ * - Control characters should be stripped
+ *
+ * Examples:
+ *   "sub-agent restrict"  →  "sub-agent restrict" (unchanged)
+ *   "lcm_expand OR crash" →  "lcm_expand OR crash" (unchanged, plainto_tsquery handles OR)
+ *   'hello "world"'       →  'hello "world"' (unchanged, quotes are fine)
+ *   ""                    →  "default" (fallback for empty queries)
+ */
+export function sanitizeTsQuery(raw: string): string {
+  if (!raw || typeof raw !== "string") {
+    return "default";
+  }
+
+  // Remove control characters but keep normal whitespace and punctuation
+  const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, "").trim();
+  
+  if (cleaned.length === 0) {
+    return "default";
+  }
+
+  // Truncate very long queries to avoid performance issues
+  const maxLength = 500;
+  if (cleaned.length > maxLength) {
+    return cleaned.substring(0, maxLength).trim();
+  }
+
+  return cleaned;
+}

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -1,26 +1,13 @@
 import { Type } from "@sinclair/typebox";
+import { formatTimestamp } from "../compaction.js";
 import type { LcmContextEngine } from "../engine.js";
 import type { LcmDependencies } from "../types.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { parseIsoTimestampParam, resolveLcmConversationScope } from "./lcm-conversation-scope.js";
-import { formatTimestamp } from "../compaction.js";
+
 
 const MAX_RESULT_CHARS = 40_000; // ~10k tokens
-
-function formatDisplayTime(
-  value: Date | string | number | null | undefined,
-  timezone: string,
-): string {
-  if (value == null) {
-    return "-";
-  }
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "-";
-  }
-  return formatTimestamp(date, timezone);
-}
 
 const LcmGrepSchema = Type.Object({
   pattern: Type.String({
@@ -95,11 +82,11 @@ export function createLcmGrepTool(input: {
       "Use this to find specific content that may have been compacted away from " +
       "active context. Returns matching snippets with their summary/message IDs " +
       "for follow-up with lcm_expand or lcm_describe.",
+
     parameters: LcmGrepSchema,
     async execute(_toolCallId, params) {
       const retrieval = input.lcm.getRetrieval();
       const timezone = input.lcm.timezone;
-
       const p = params as Record<string, unknown>;
       const pattern = (p.pattern as string).trim();
       const mode = (p.mode as "regex" | "full_text") ?? "regex";
@@ -155,8 +142,8 @@ export function createLcmGrepTool(input: {
       }
       if (since || before) {
         lines.push(
-          `**Time filter:** ${since ? `since ${formatDisplayTime(since, timezone)}` : "since -∞"} | ${
-            before ? `before ${formatDisplayTime(before, timezone)}` : "before +∞"
+          `**Time filter:** ${since ? `since ${formatTimestamp(since, timezone)}` : "since -∞"} | ${
+            before ? `before ${formatTimestamp(before, timezone)}` : "before +∞"
           }`,
         );
       }
@@ -170,7 +157,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const msg of result.messages) {
           const snippet = truncateSnippet(msg.snippet);
-          const line = `- [msg#${msg.messageId}] (${msg.role}, ${formatDisplayTime(msg.createdAt, timezone)}): ${snippet}`;
+          const line = `- [msg#${msg.messageId}] (${msg.role}, ${formatTimestamp(msg.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;
@@ -186,7 +173,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const sum of result.summaries) {
           const snippet = truncateSnippet(sum.snippet);
-          const line = `- [${sum.summaryId}] (${sum.kind}, ${formatDisplayTime(sum.createdAt, timezone)}): ${snippet}`;
+          const line = `- [${sum.summaryId}] (${sum.kind}, ${formatTimestamp(sum.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -24,6 +24,7 @@ function createTestConfig(databasePath: string): LcmConfig {
   return {
     enabled: true,
     databasePath,
+    backend: 'sqlite',
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
@@ -42,6 +43,8 @@ function createTestConfig(databasePath: string): LcmConfig {
     summaryModel: "",
     largeFileSummaryProvider: "",
     largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
     autocompactDisabled: false,
     timezone: "UTC",
     pruneHeartbeatOk: false,
@@ -109,28 +112,22 @@ function createEngine(): LcmContextEngine {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
   tempDirs.push(tempDir);
   const config = createTestConfig(join(tempDir, "lcm.db"));
-  const db = createLcmDatabaseConnection(config.databasePath);
-  return new LcmContextEngine(createTestDeps(config), db);
+  return new LcmContextEngine(createTestDeps(config));
 }
 
 function createEngineWithDepsOverrides(overrides: Partial<LcmDependencies>): LcmContextEngine {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
   tempDirs.push(tempDir);
   const config = createTestConfig(join(tempDir, "lcm.db"));
-  const db = createLcmDatabaseConnection(config.databasePath);
-  return new LcmContextEngine(
-    {
-      ...createTestDeps(config),
-      ...overrides,
-    },
-    db,
-  );
+  return new LcmContextEngine({
+    ...createTestDeps(config),
+    ...overrides,
+  });
 }
 
 function createEngineAtDatabasePath(databasePath: string): LcmContextEngine {
   const config = createTestConfig(databasePath);
-  const db = createLcmDatabaseConnection(config.databasePath);
-  return new LcmContextEngine(createTestDeps(config), db);
+  return new LcmContextEngine(createTestDeps(config));
 }
 
 function createSessionFilePath(name: string): string {
@@ -146,8 +143,7 @@ function createEngineWithConfig(overrides: Partial<LcmConfig>): LcmContextEngine
     ...createTestConfig(join(tempDir, "lcm.db")),
     ...overrides,
   };
-  const db = createLcmDatabaseConnection(config.databasePath);
-  return new LcmContextEngine(createTestDeps(config), db);
+  return new LcmContextEngine(createTestDeps(config));
 }
 
 function createEngineWithDeps(
@@ -160,8 +156,7 @@ function createEngineWithDeps(
     ...createTestConfig(join(tempDir, "lcm.db")),
     ...configOverrides,
   };
-  const db = createLcmDatabaseConnection(config.databasePath);
-  return new LcmContextEngine(createTestDeps(config, depOverrides), db);
+  return new LcmContextEngine(createTestDeps(config, depOverrides));
 }
 
 async function withTempHome<T>(run: (homeDir: string) => Promise<T>): Promise<T> {
@@ -770,12 +765,11 @@ describe("LcmContextEngine delegated session continuity", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
     const config = createTestConfig(join(tempDir, "lcm.db"));
-    const db = createLcmDatabaseConnection(config.databasePath);
     const deps = createTestDeps(config);
     deps.resolveSessionIdFromSessionKey = vi.fn(async () => "uuid-after-reset");
-    const engine = new LcmContextEngine(deps, db);
+    const engine = new LcmContextEngine(deps);
 
-    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    await (engine as unknown as { ensureMigrated(): Promise<void> }).ensureMigrated();
     await engine
       .getConversationStore()
       .getOrCreateConversation("uuid-before-reset", { sessionKey: "agent:main:main" });


### PR DESCRIPTION
PostgreSQL backend for LCM, rebased onto current main (includes #138 incremental bootstrap + tool output externalization).

## What's included
- **Dialect abstraction** (`src/db/dialect.ts`) — parameterized queries (`$1` vs `?`), platform-aware SQL fragments
- **DbClient interface** (`src/db/db-interface.ts`) — async query/run/transaction interface implemented by SqliteClient and PostgresClient
- **PostgresClient** (`src/db/postgres-client.ts`) — pg-based client with connection pooling
- **Full Postgres schema** in migration.ts — all tables including conversation_bootstrap_state, with forward-compatible migrations (session_key, agent_id, summary metadata columns)
- **tsvector full-text search** for Postgres (generated columns + GIN indexes), FTS5 retained for SQLite
- **tsquery sanitizer** (`src/store/tsquery-sanitize.ts`) — safe Postgres full-text query parsing
- **Migration script** (`scripts/migrate-to-postgres.mjs`) — SQLite → Postgres data migration with CLI flags
- **Agent registry** — agents table with self-registration on startup
- **Config resolution** via `LCM_BACKEND`, `LCM_CONNECTION_STRING`, `LCM_INSTANCE_ID` env vars

## Bug fixes in this PR
- Fixed FTS5 search using ambiguous `content MATCH` → `messages_fts MATCH` (was silently falling back to LIKE)
- Fixed `closeLcmConnection` to accept DatabaseSync handles without closing pooled engine connections
- Fixed `getLcmConnection` to create standalone connections for migration/test use

## Testing
- 350 tests passing (all existing + new bootstrap/externalization tests from #138)
- Running in production on 4 instances with shared Postgres backend

Supersedes #135 (rebased onto #138).