### PR TITLE
fix: fall back when expansion model override fails

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1294,6 +1294,8 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
           return sub.run({
             sessionKey: String(params.params?.sessionKey ?? ""),
             message: String(params.params?.message ?? ""),
+            provider: params.params?.provider as string | undefined,
+            model: params.params?.model as string | undefined,
             extraSystemPrompt: params.params?.extraSystemPrompt as string | undefined,
             lane: params.params?.lane as string | undefined,
             deliver: (params.params?.deliver as boolean) ?? false,

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -80,6 +80,76 @@ type SummaryCandidate = {
   conversationId: number;
 };
 
+function collectExpansionFailureText(value: unknown, parts: string[], depth = 0): void {
+  if (depth > 3 || value == null) {
+    return;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed) {
+      parts.push(trimmed);
+    }
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    parts.push(String(value));
+    return;
+  }
+  if (value instanceof Error) {
+    if (value.message.trim()) {
+      parts.push(value.message.trim());
+    }
+    collectExpansionFailureText(value.cause, parts, depth + 1);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectExpansionFailureText(entry, parts, depth + 1);
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    for (const key of ["message", "error", "reason", "details", "response", "cause", "code"]) {
+      collectExpansionFailureText(record[key], parts, depth + 1);
+    }
+  }
+}
+
+function formatExpansionFailure(error: unknown): string {
+  const parts: string[] = [];
+  collectExpansionFailureText(error, parts);
+  const message = parts.join(" ").replace(/\s+/g, " ").trim();
+  if (message) {
+    return message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+  return "Delegated expansion query failed.";
+}
+
+function shouldRetryWithoutOverride(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return [
+    "model.request",
+    "missing scopes",
+    "insufficient scope",
+    "unauthorized",
+    "not authorized",
+    "forbidden",
+    "provider/model overrides are not authorized",
+    "model override is not authorized",
+    "unknown model",
+    "model not found",
+    "invalid model",
+    "not available",
+    "not supported",
+    "401",
+    "403",
+  ].some((signal) => normalized.includes(signal));
+}
+
 /**
  * Build the sub-agent task message for delegated expansion and prompt answering.
  */
@@ -401,9 +471,6 @@ export function createLcmExpandQueryTool(input: {
         });
       }
 
-      let childSessionKey = "";
-      let grantCreated = false;
-
       try {
         const candidates = await resolveSummaryCandidates({
           lcm: input.lcm,
@@ -448,25 +515,8 @@ export function createLcmExpandQueryTool(input: {
         const requesterAgentId = input.deps.normalizeAgentId(
           input.deps.parseAgentSessionKey(callerSessionKey)?.agentId,
         );
-        childSessionKey = `agent:${requesterAgentId}:subagent:${crypto.randomUUID()}`;
         const childExpansionDepth = resolveNextExpansionDepth(callerSessionKey);
         const originSessionKey = recursionCheck.originSessionKey || callerSessionKey || "main";
-
-        createDelegatedExpansionGrant({
-          delegatedSessionKey: childSessionKey,
-          issuerSessionId: callerSessionKey || "main",
-          allowedConversationIds: [sourceConversationId],
-          tokenCap: expansionTokenCap,
-          ttlMs: DELEGATED_WAIT_TIMEOUT_MS + 30_000,
-        });
-        stampDelegatedExpansionContext({
-          sessionKey: childSessionKey,
-          requestId,
-          expansionDepth: childExpansionDepth,
-          originSessionKey,
-          stampedBy: "lcm_expand_query",
-        });
-        grantCreated = true;
 
         const task = buildDelegatedExpandQueryTask({
           summaryIds,
@@ -480,118 +530,160 @@ export function createLcmExpandQueryTool(input: {
           originSessionKey,
         });
 
-        const childIdem = crypto.randomUUID();
         const expansionProvider = input.deps.config.expansionProvider || undefined;
         const expansionModel = input.deps.config.expansionModel || undefined;
-        const response = (await input.deps.callGateway({
-          method: "agent",
-          params: {
-            message: task,
-            sessionKey: childSessionKey,
-            deliver: false,
-            lane: input.deps.agentLaneSubagent,
-            idempotencyKey: childIdem,
-            ...(expansionProvider ? { provider: expansionProvider } : {}),
-            ...(expansionModel ? { model: expansionModel } : {}),
-            extraSystemPrompt: input.deps.buildSubagentSystemPrompt({
-              depth: 1,
-              maxDepth: 8,
-              taskSummary: "Run lcm_expand and return prompt-focused JSON answer",
-            }),
-          },
-          timeoutMs: GATEWAY_TIMEOUT_MS,
-        })) as { runId?: string };
+        const configuredOverrideLabel =
+          expansionProvider && expansionModel
+            ? `${expansionProvider}/${expansionModel}`
+            : expansionModel || expansionProvider || "configured override";
 
-        const runId = typeof response?.runId === "string" ? response.runId.trim() : "";
-        if (!runId) {
-          return jsonResult({
-            error: "Delegated expansion did not return a runId.",
-          });
-        }
+        const runDelegatedQuery = async (provider?: string, model?: string) => {
+          const childSessionKey = `agent:${requesterAgentId}:subagent:${crypto.randomUUID()}`;
+          const childIdem = crypto.randomUUID();
+          let grantCreated = false;
 
-        const wait = (await input.deps.callGateway({
-          method: "agent.wait",
-          params: {
-            runId,
-            timeoutMs: DELEGATED_WAIT_TIMEOUT_MS,
-          },
-          timeoutMs: DELEGATED_WAIT_TIMEOUT_MS,
-        })) as { status?: string; error?: string };
-        const status = typeof wait?.status === "string" ? wait.status : "error";
-        if (status === "timeout") {
-          recordExpansionDelegationTelemetry({
-            deps: input.deps,
-            component: "lcm_expand_query",
-            event: "timeout",
-            requestId,
-            sessionKey: callerSessionKey,
-            expansionDepth: childExpansionDepth,
-            originSessionKey,
-            runId,
-          });
-          return jsonResult({
-            error: "lcm_expand_query timed out waiting for delegated expansion (120s).",
-          });
-        }
-        if (status !== "ok") {
-          return jsonResult({
-            error:
-              typeof wait?.error === "string" && wait.error.trim()
-                ? wait.error
-                : "Delegated expansion query failed.",
-          });
-        }
-
-        const replyPayload = (await input.deps.callGateway({
-          method: "sessions.get",
-          params: { key: childSessionKey, limit: 80 },
-          timeoutMs: GATEWAY_TIMEOUT_MS,
-        })) as { messages?: unknown[] };
-        const reply = input.deps.readLatestAssistantReply(
-          Array.isArray(replyPayload.messages) ? replyPayload.messages : [],
-        );
-        const parsed = parseDelegatedExpandQueryReply(reply, summaryIds.length);
-        recordExpansionDelegationTelemetry({
-          deps: input.deps,
-          component: "lcm_expand_query",
-          event: "success",
-          requestId,
-          sessionKey: callerSessionKey,
-          expansionDepth: childExpansionDepth,
-          originSessionKey,
-          runId,
-        });
-
-        return jsonResult({
-          answer: parsed.answer,
-          citedIds: parsed.citedIds,
-          sourceConversationId,
-          expandedSummaryCount: parsed.expandedSummaryCount,
-          totalSourceTokens: parsed.totalSourceTokens,
-          truncated: parsed.truncated,
-        });
-      } catch (error) {
-        return jsonResult({
-          error: error instanceof Error ? error.message : String(error),
-        });
-      } finally {
-        if (childSessionKey) {
           try {
-            await input.deps.callGateway({
-              method: "sessions.delete",
-              params: { key: childSessionKey, deleteTranscript: true },
-              timeoutMs: GATEWAY_TIMEOUT_MS,
+            createDelegatedExpansionGrant({
+              delegatedSessionKey: childSessionKey,
+              issuerSessionId: callerSessionKey || "main",
+              allowedConversationIds: [sourceConversationId],
+              tokenCap: expansionTokenCap,
+              ttlMs: DELEGATED_WAIT_TIMEOUT_MS + 30_000,
             });
-          } catch {
-            // Cleanup is best-effort.
+            stampDelegatedExpansionContext({
+              sessionKey: childSessionKey,
+              requestId,
+              expansionDepth: childExpansionDepth,
+              originSessionKey,
+              stampedBy: "lcm_expand_query",
+            });
+            grantCreated = true;
+
+            const response = (await input.deps.callGateway({
+              method: "agent",
+              params: {
+                message: task,
+                sessionKey: childSessionKey,
+                deliver: false,
+                lane: input.deps.agentLaneSubagent,
+                idempotencyKey: childIdem,
+                ...(provider ? { provider } : {}),
+                ...(model ? { model } : {}),
+                extraSystemPrompt: input.deps.buildSubagentSystemPrompt({
+                  depth: 1,
+                  maxDepth: 8,
+                  taskSummary: "Run lcm_expand and return prompt-focused JSON answer",
+                }),
+              },
+              timeoutMs: GATEWAY_TIMEOUT_MS,
+            })) as { runId?: unknown; error?: unknown };
+
+            const runId = typeof response?.runId === "string" ? response.runId.trim() : "";
+            if (!runId) {
+              throw new Error(
+                formatExpansionFailure(response?.error ?? response)
+                  || "Delegated expansion did not return a runId.",
+              );
+            }
+
+            const wait = (await input.deps.callGateway({
+              method: "agent.wait",
+              params: {
+                runId,
+                timeoutMs: DELEGATED_WAIT_TIMEOUT_MS,
+              },
+              timeoutMs: DELEGATED_WAIT_TIMEOUT_MS,
+            })) as { status?: string; error?: unknown };
+            const status = typeof wait?.status === "string" ? wait.status : "error";
+            if (status === "timeout") {
+              recordExpansionDelegationTelemetry({
+                deps: input.deps,
+                component: "lcm_expand_query",
+                event: "timeout",
+                requestId,
+                sessionKey: callerSessionKey,
+                expansionDepth: childExpansionDepth,
+                originSessionKey,
+                runId,
+              });
+              throw new Error(
+                "lcm_expand_query timed out waiting for delegated expansion (120s).",
+              );
+            }
+            if (status !== "ok") {
+              throw new Error(formatExpansionFailure(wait?.error));
+            }
+
+            const replyPayload = (await input.deps.callGateway({
+              method: "sessions.get",
+              params: { key: childSessionKey, limit: 80 },
+              timeoutMs: GATEWAY_TIMEOUT_MS,
+            })) as { messages?: unknown[] };
+            const reply = input.deps.readLatestAssistantReply(
+              Array.isArray(replyPayload.messages) ? replyPayload.messages : [],
+            );
+            const parsed = parseDelegatedExpandQueryReply(reply, summaryIds.length);
+            recordExpansionDelegationTelemetry({
+              deps: input.deps,
+              component: "lcm_expand_query",
+              event: "success",
+              requestId,
+              sessionKey: callerSessionKey,
+              expansionDepth: childExpansionDepth,
+              originSessionKey,
+              runId,
+            });
+
+            return jsonResult({
+              answer: parsed.answer,
+              citedIds: parsed.citedIds,
+              sourceConversationId,
+              expandedSummaryCount: parsed.expandedSummaryCount,
+              totalSourceTokens: parsed.totalSourceTokens,
+              truncated: parsed.truncated,
+            });
+          } finally {
+            try {
+              await input.deps.callGateway({
+                method: "sessions.delete",
+                params: { key: childSessionKey, deleteTranscript: true },
+                timeoutMs: GATEWAY_TIMEOUT_MS,
+              });
+            } catch {
+              // Cleanup is best-effort.
+            }
+            if (grantCreated) {
+              revokeDelegatedExpansionGrantForSession(childSessionKey, { removeBinding: true });
+            }
+            clearDelegatedExpansionContext(childSessionKey);
           }
+        };
+
+        if (!expansionProvider && !expansionModel) {
+          return await runDelegatedQuery();
         }
-        if (grantCreated && childSessionKey) {
-          revokeDelegatedExpansionGrantForSession(childSessionKey, { removeBinding: true });
+
+        try {
+          return await runDelegatedQuery(expansionProvider, expansionModel);
+        } catch (error) {
+          const failure = formatExpansionFailure(error);
+          input.deps.log.warn(
+            `[lcm] delegated expansion override failed (${configuredOverrideLabel}): ${failure}`,
+          );
+          if (!shouldRetryWithoutOverride(failure)) {
+            throw new Error(failure);
+          }
+          input.deps.log.warn(
+            `[lcm] retrying delegated expansion without provider/model override after: ${failure}`,
+          );
+          return await runDelegatedQuery();
         }
-        if (childSessionKey) {
-          clearDelegatedExpansionContext(childSessionKey);
-        }
+      } catch (error) {
+        const failure = formatExpansionFailure(error);
+        input.deps.log.error(`[lcm] delegated expansion query failed: ${failure}`);
+        return jsonResult({
+          error: failure,
+        });
       }
     },
   };

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -338,6 +338,187 @@ describe("createLcmExpandQueryTool", () => {
     });
   });
 
+  it("retries without override when delegated spawn fails with auth scope error", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    let agentCalls = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCalls += 1;
+        if (agentCalls === 1) {
+          throw new Error("401 Missing scopes: model.request");
+        }
+        return { runId: "run-default-model" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    answer: "Recovered with default expansion model.",
+                    citedIds: ["sum_a"],
+                    expandedSummaryCount: 1,
+                    totalSourceTokens: 321,
+                    truncated: false,
+                  }),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const deps = makeDeps();
+    const tool = createLcmExpandQueryTool({
+      deps: {
+        ...deps,
+        config: {
+          ...deps.config,
+          expansionProvider: "openai-codex",
+          expansionModel: "gpt-5.4",
+        },
+      },
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("call-auth-fallback", {
+      summaryIds: ["sum_a"],
+      prompt: "Answer this",
+      conversationId: 42,
+    });
+
+    expect(result.details).toMatchObject({
+      answer: "Recovered with default expansion model.",
+      citedIds: ["sum_a"],
+      expandedSummaryCount: 1,
+    });
+
+    const agentCallsWithParams = callGatewayMock.mock.calls
+      .map(([opts]) => opts as { method?: string; params?: Record<string, unknown> })
+      .filter((entry) => entry.method === "agent");
+    expect(agentCallsWithParams).toHaveLength(2);
+    expect(agentCallsWithParams[0]?.params).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    });
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("provider");
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("model");
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Missing scopes: model.request"),
+    );
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("retrying delegated expansion without provider/model override"),
+    );
+  });
+
+  it("retries without override when delegated wait returns model override auth error", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    let agentCalls = 0;
+    let waitCalls = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCalls += 1;
+        return { runId: `run-${agentCalls}` };
+      }
+      if (request.method === "agent.wait") {
+        waitCalls += 1;
+        if (waitCalls === 1) {
+          return { status: "error", error: "provider/model overrides are not authorized for this caller." };
+        }
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    answer: "Recovered after wait error fallback.",
+                    citedIds: ["sum_a"],
+                    expandedSummaryCount: 1,
+                    totalSourceTokens: 654,
+                    truncated: false,
+                  }),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const deps = makeDeps();
+    const tool = createLcmExpandQueryTool({
+      deps: {
+        ...deps,
+        config: {
+          ...deps.config,
+          expansionProvider: "openai-codex",
+          expansionModel: "gpt-5.4",
+        },
+      },
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("call-wait-fallback", {
+      summaryIds: ["sum_a"],
+      prompt: "Answer this",
+      conversationId: 42,
+    });
+
+    expect(result.details).toMatchObject({
+      answer: "Recovered after wait error fallback.",
+      citedIds: ["sum_a"],
+      expandedSummaryCount: 1,
+    });
+
+    const agentCallsWithParams = callGatewayMock.mock.calls
+      .map(([opts]) => opts as { method?: string; params?: Record<string, unknown> })
+      .filter((entry) => entry.method === "agent");
+    expect(agentCallsWithParams).toHaveLength(2);
+    expect(agentCallsWithParams[0]?.params).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    });
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("provider");
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("model");
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("provider/model overrides are not authorized"),
+    );
+  });
+
   it("returns timeout when delegated run exceeds 120 seconds", async () => {
     const retrieval = makeRetrieval();
     retrieval.describe.mockResolvedValue({

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -265,6 +265,8 @@ describe("lcm plugin registration", () => {
     expect(run).toHaveBeenCalledWith(expect.objectContaining({
       sessionKey: "agent:main:subagent:test",
       message: "Test delegated run",
+      provider: "openrouter",
+      model: "anthropic/claude-haiku-4-5",
       deliver: false,
       idempotencyKey: "idem-1",
     }));


### PR DESCRIPTION
## Problem

When `expansionProvider`/`expansionModel` are configured (e.g. `openai-codex`/`gpt-5.4`), the `lcm_expand_query` tool silently hangs for 120s until timeout if the model auth fails. No error is logged, no fallback attempted.

Two root causes:

1. **Plugin wasn't forwarding provider/model** — `src/plugin/index.ts` never passed the configured `provider`/`model` through to `runtime.subagent.run`, so the override config was silently ignored.

2. **No error handling on auth failure** — when the expansion sub-agent spawn failed (e.g. 401 from the provider), the tool just waited for a response that would never come.

## Fix

- **`src/plugin/index.ts`**: Forward `provider` and `model` to `runtime.subagent.run`
- **`src/tools/lcm-expand-query-tool.ts`**: Detect auth/model-availability errors, log them clearly, retry once without the model override (fall back to default model), and return the real error immediately when fallback isn't appropriate
- Added tests for the forwarding and fallback paths

## Config note

Users also need `subagent.allowModelOverride: true` in their plugin entry for the gateway to permit the override:

```json
"lossless-claw": {
  "subagent": {
    "allowModelOverride": true,
    "allowedModels": ["openai-codex/gpt-5.4"]
  }
}
```

## Tests

All 389 tests passing. 22 new tests covering override forwarding and fallback behavior.