### PR TITLE
fix: add models.providers.*.apiKey fallback to getApiKey()

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1374,7 +1374,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
 
       const piAiModuleId = "@mariozechner/pi-ai";
       const mod = (await import(piAiModuleId)) as PiAiModule;
-      return resolveApiKeyFromAuthProfiles({
+      const profileKey = await resolveApiKeyFromAuthProfiles({
         provider,
         authProfileId: options?.profileId,
         agentDir: api.resolvePath("."),
@@ -1382,6 +1382,36 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
         piAiModule: mod,
         envSnapshot,
       });
+      if (profileKey) {
+        return profileKey;
+      }
+
+      // Fallback: read apiKey from models.providers config (e.g. proxy providers
+      // like MiniMax that store keys under models.providers.<provider>.apiKey).
+      // Without this, getApiKey() fails for providers whose keys are only in
+      // openclaw.json config but not in process.env or keychain.
+      const runtimeCfg = (() => {
+        try {
+          return api.runtime?.config?.loadConfig?.() ?? api.config;
+        } catch {
+          return api.config;
+        }
+      })();
+      if (isRecord(runtimeCfg)) {
+        const providers = (runtimeCfg as { models?: { providers?: Record<string, unknown> } })
+          .models?.providers;
+        if (providers) {
+          const providerCfg = findProviderConfigValue(providers, provider);
+          if (isRecord(providerCfg) && typeof providerCfg.apiKey === "string") {
+            const cfgKey = providerCfg.apiKey.trim();
+            if (cfgKey) {
+              return cfgKey;
+            }
+          }
+        }
+      }
+
+      return undefined;
     },
     requireApiKey: async (provider, model, options) => {
       const key = await (async () => {
@@ -1410,7 +1440,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
 
         const piAiModuleId = "@mariozechner/pi-ai";
         const mod = (await import(piAiModuleId)) as PiAiModule;
-        return resolveApiKeyFromAuthProfiles({
+        const profileKey = await resolveApiKeyFromAuthProfiles({
           provider,
           authProfileId: options?.profileId,
           agentDir: api.resolvePath("."),
@@ -1418,6 +1448,33 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
           piAiModule: mod,
           envSnapshot,
         });
+        if (profileKey) {
+          return profileKey;
+        }
+
+        // Fallback: read apiKey from models.providers config (same as getApiKey)
+        const runtimeCfg = (() => {
+          try {
+            return api.runtime?.config?.loadConfig?.() ?? api.config;
+          } catch {
+            return api.config;
+          }
+        })();
+        if (isRecord(runtimeCfg)) {
+          const providers = (runtimeCfg as { models?: { providers?: Record<string, unknown> } })
+            .models?.providers;
+          if (providers) {
+            const providerCfg = findProviderConfigValue(providers, provider);
+            if (isRecord(providerCfg) && typeof providerCfg.apiKey === "string") {
+              const cfgKey = providerCfg.apiKey.trim();
+              if (cfgKey) {
+                return cfgKey;
+              }
+            }
+          }
+        }
+
+        return undefined;
       })();
       if (!key) {
         throw new Error(`Missing API key for provider '${provider}' (model '${model}').`);


### PR DESCRIPTION
## Summary

Relates to #177 — LCM summarizer cannot resolve provider credentials when API key is configured via `models.providers.*.apiKey` rather than environment variables or auth profiles.

## Problem

`getApiKey()` and `requireApiKey()` walk a fallback chain:

1. `modelAuth.getApiKeyForModel()`
2. `resolveApiKey(provider, readEnv)` → env vars → `authProfiles`

But they **never** read `models.providers.<provider>.apiKey` from the config. The main model's `complete()` function (line ~1217) has this fallback, but the LCM summarizer's `getApiKey()` does not.

## Impact

When a provider's API key is **only** configured in `models.providers.*.apiKey` (common for non-built-in providers like MiniMax), the main model works fine but LCM compaction fails with 401.

Adding the env var to launchd plist doesn't fully help because `getApiKey()` may use a startup-time snapshot of `process.env`.

## Fix

Add a 6th fallback layer to `getApiKey()` and `requireApiKey()` that reads `models.providers.<provider>.apiKey` from the config, matching the `complete()` function's behavior.

## Verified On

| Machine | Config | Result |
|---------|--------|--------|
| Scott#2 | MiniMax key only in `models.providers.minimax.apiKey` | Before: 401 on every compaction. After: clean |
| Scott#4 | Same config | 200+ summaries, zero auth errors |

> **Note**: v0.5.1 may already partially address this via `findProviderConfigValue`. This PR ensures full parity between `getApiKey()` and `complete()` fallback chains.