### PR TITLE
fix: add missing pruneHeartbeatOk config option

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -111,6 +111,9 @@
       },
       "expansionProvider": {
         "type": "string"
+      },
+      "pruneHeartbeatOk": {
+        "type": "boolean"
       }
     }
   }


### PR DESCRIPTION
Add missing pruneHeartbeatOk config option to the plugin schema.

This config option is needed for the LCM plugin to properly handle heartbeat OK pruning behavior.