### PR TITLE
fix: detect session file rotation in bootstrap — compaction never triggers

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1722,11 +1722,59 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
           });
           const conversationId = conversation.conversationId;
-          const existingCount = await this.conversationStore.getMessageCount(conversationId);
-          const bootstrapState =
+          let existingCount = await this.conversationStore.getMessageCount(conversationId);
+          let bootstrapState =
             existingCount > 0
               ? await this.summaryStore.getConversationBootstrapState(conversationId)
               : null;
+
+          // Session file rotation detection: OpenClaw may create a new session
+          // file (new UUID.jsonl) on /reset or natural rotation without notifying
+          // LCM. If the file path changed, the conversation data in the DB belongs
+          // to the old file — reset it and re-bootstrap from the new file.
+          if (
+            bootstrapState &&
+            bootstrapState.sessionFilePath !== params.sessionFile
+          ) {
+            console.error(
+              `[lcm] bootstrap: session file rotated for session ${params.sessionId}: ` +
+                `"${bootstrapState.sessionFilePath}" → "${params.sessionFile}" — resetting conversation ${conversationId}`,
+            );
+            // Purge all data for this conversation and start fresh.
+            // Tables are ordered to respect FK constraints; message_parts
+            // cascade-deletes via ON DELETE CASCADE on messages.
+            this.db
+              .prepare(`DELETE FROM context_items WHERE conversation_id = ?`)
+              .run(conversationId);
+            this.db
+              .prepare(`DELETE FROM summary_messages WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`)
+              .run(conversationId);
+            this.db
+              .prepare(`DELETE FROM summary_parents WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?) OR parent_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`)
+              .run(conversationId, conversationId);
+            this.db
+              .prepare(`DELETE FROM summaries WHERE conversation_id = ?`)
+              .run(conversationId);
+            this.db
+              .prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`)
+              .run(conversationId);
+            this.db
+              .prepare(`DELETE FROM large_files WHERE conversation_id = ?`)
+              .run(conversationId);
+            // messages_fts is a contentless FTS5 table — must be cleaned explicitly.
+            this.db
+              .prepare(`DELETE FROM messages_fts WHERE rowid IN (SELECT message_id FROM messages WHERE conversation_id = ?)`)
+              .run(conversationId);
+            const msgCount = this.db
+              .prepare(`DELETE FROM messages WHERE conversation_id = ?`)
+              .run(conversationId).changes;
+            console.error(
+              `[lcm] bootstrap: purged ${msgCount} messages and all summaries for conversation ${conversationId}`,
+            );
+            // Reset local state so the code below treats this as a fresh conversation.
+            bootstrapState = null;
+            existingCount = 0;
+          }
 
           // If the transcript file is byte-for-byte unchanged from the last
           // successful bootstrap checkpoint, skip reopening and reparsing it.


### PR DESCRIPTION
## Bug: Session file rotation breaks bootstrap — compaction never triggers, context overflows

### Environment

- lossless-claw: 0.5.2
- OpenClaw: latest (gateway daemon mode)
- Platform: macOS (darwin arm64), Node.js v25.x

### Description

When OpenClaw rotates a session file (creates a new UUID.jsonl on `/reset` or natural rotation), LCM's `bootstrap()` method fails to detect and handle the change. The new session file's messages are never ingested into the LCM database, compaction never triggers, and the main session's context grows unbounded until it hits the context limit.

### Root Cause

In `src/engine.ts`, the `bootstrap()` method tracks sessions by **absolute file path** in the `conversation_bootstrap_state` table. When a session file rotates:

1. **Line 1735** — `bootstrapState.sessionFilePath === params.sessionFile` is `false` (new path ≠ old path), so the "file unchanged" fast path is skipped. ✅ Correct so far.

2. **Line 1752** — Same path comparison in the incremental append path. Also skipped. ✅ Correct.

3. **Line 1844** — Falls through to `reconcileSessionTail()`. This reads the new file's messages and tries to find a "anchor" message that exists in both the new file and the DB. Since the new file is from a post-reset session, **no messages overlap** with the old DB data → `anchorIndex = -1` → returns `{ importedMessages: 0, hasOverlap: false }`.

4. **Line 1908** — Only updates `bootstrapState` when `reconcile.hasOverlap === true`. Since it's `false`, the old file path remains in the DB.

5. **Line 1910** — `conversation.bootstrappedAt` is `true` from the prior session → returns `"already bootstrapped"`.

**Result**: A dead loop. Every subsequent bootstrap call sees the same stale path, takes the same reconcile path, finds no overlap, and never ingests new messages. Compaction depends on DB token counts which never grow → compaction never triggers.

### Evidence from production

- `compaction_events` table: **0 rows** (never compacted)
- `conversations` table: session tracked wrong `.jsonl` file (815KB, stale)
- LCM produced 200 summaries on wrong/deleted files
- Two agents hit context overflow with `compactionAttempts: 0/1`

### Reproduction Steps

1. Start an agent session that uses LCM as its context engine
2. Verify LCM is working (bootstrap succeeds, summaries are created)
3. Execute `/reset` or trigger session file rotation in OpenClaw
4. Send messages in the new session
5. Observe: new messages never appear in LCM DB
6. Observe: compaction never triggers
7. Eventually: context overflow

### Proposed Fix

Add session file rotation detection in `bootstrap()`, right after fetching `bootstrapState` and before the path-comparison guards. When a path change is detected, purge all conversation data and re-bootstrap as a fresh conversation.

```typescript
// After getting bootstrapState, before the "file unchanged" check:

if (
  bootstrapState &&
  bootstrapState.sessionFilePath !== params.sessionFile
) {
  console.error(
    `[lcm] bootstrap: session file rotated for session ${params.sessionId}: ` +
      `"${bootstrapState.sessionFilePath}" → "${params.sessionFile}" — resetting conversation ${conversationId}`,
  );
  // Purge all data for this conversation
  this.db.prepare(`DELETE FROM context_items WHERE conversation_id = ?`).run(conversationId);
  this.db.prepare(`DELETE FROM summary_messages WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`).run(conversationId);
  this.db.prepare(`DELETE FROM summary_parents WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?) OR parent_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`).run(conversationId, conversationId);
  this.db.prepare(`DELETE FROM summaries WHERE conversation_id = ?`).run(conversationId);
  this.db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(conversationId);
  this.db.prepare(`DELETE FROM large_files WHERE conversation_id = ?`).run(conversationId);
  this.db.prepare(`DELETE FROM messages_fts WHERE rowid IN (SELECT message_id FROM messages WHERE conversation_id = ?)`).run(conversationId);
  const msgCount = this.db.prepare(`DELETE FROM messages WHERE conversation_id = ?`).run(conversationId).changes;
  console.error(`[lcm] bootstrap: purged ${msgCount} messages and all summaries for conversation ${conversationId}`);
  // Reset local state — existingCount must also be 0 for first-import path
  bootstrapState = null;
  existingCount = 0;
}
```

Also requires changing `const existingCount` → `let existingCount` and `const bootstrapState` → `let bootstrapState`.

### Trade-offs

- **Old summaries are lost** on rotation. This is acceptable because the conversation was reset — old summaries refer to a conversation that no longer exists.
- **Alternative approaches** (archiving old data, creating new conversation records) are more complex and provide little value since the old session is gone.

### Secondary Issue (unrelated)

`ZAI_API_KEY` was found empty (length=0) in the LCM auth cascade, which would cause summarization to fail auth even if bootstrap worked. This is a configuration issue, not a code bug.
