### PR TITLE
Docs: clarify plugins.allow requirements during lossless-claw setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ openclaw plugins install --link /path/to/lossless-claw
 
 The install command records the plugin, enables it, and applies compatible slot selection (including `contextEngine` when applicable).
 
+> **Note:** If your OpenClaw config uses `plugins.allow`, make sure both `lossless-claw` and any active plugins you rely on remain allowlisted. In some setups, narrowing the allowlist can prevent plugin-backed integrations from loading, even if `lossless-claw` itself is installed correctly. Restart the gateway after plugin config changes.
+
 ### Configure OpenClaw
 
 In most cases, no manual JSON edits are needed after `openclaw plugins install`.


### PR DESCRIPTION
## Summary

Adds a small Quick Start note explaining that OpenClaw setups using `plugins.allow` should keep both `lossless-claw` and any active plugins they rely on allowlisted.

## Why this change

When installing `lossless-claw`, it is easy to focus on enabling the plugin and setting the `contextEngine` slot while overlooking existing plugin allowlist constraints.

In practice, some OpenClaw integrations that users think of as “channels” (for example Discord or Telegram setups) are also plugin-backed. If a user narrows `plugins.allow` and only adds `lossless-claw`, they can accidentally stop those active integrations from loading.

That makes the setup failure mode confusing: `lossless-claw` may appear to be the cause, when the real issue is that the allowlist no longer includes the other active plugins the setup depends on.

This is a documentation/usability improvement for that integration gotcha, not a code bug in `lossless-claw` itself.

## What changed

Added a short Quick Start note that explains:
- `lossless-claw` should remain allowlisted when `plugins.allow` is used
- other active plugins the user relies on should also remain allowlisted
- narrowing the allowlist can prevent plugin-backed integrations from loading in some setups
- the gateway should be restarted after plugin config changes

## Validation

- docs-only change
- placed near install/config flow
- local tests passed successfully
- wording kept reasonably careful to avoid overclaiming exact behavior across every integration/setup/version
