### PR TITLE
feat: add pinnedFiles config for workspace files injected outside compaction DAG

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -107,6 +107,10 @@
     "pinnedFiles": {
       "label": "Pinned Files",
       "help": "Workspace files always present in context (never compacted). Paths relative to agent workspace."
+    },
+    "pinnedFilesPerAgent": {
+      "label": "Per-Agent Pinned Files",
+      "help": "Agent-specific pinned files keyed by agent ID. Merged with global pinnedFiles."
     }
   },
   "configSchema": {
@@ -234,6 +238,14 @@
         "type": "array",
         "items": { "type": "string" },
         "description": "Workspace-relative file paths injected into every context assembly, outside the compaction DAG. These files are never summarized."
+      },
+      "pinnedFilesPerAgent": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "description": "Per-agent pinned file paths, keyed by agent ID. Merged with global pinnedFiles at resolution time."
       }
     }
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -103,6 +103,10 @@
     "pruneHeartbeatOk": {
       "label": "Prune HEARTBEAT_OK",
       "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
+    },
+    "pinnedFiles": {
+      "label": "Pinned Files",
+      "help": "Workspace files always present in context (never compacted). Paths relative to agent workspace."
     }
   },
   "configSchema": {
@@ -225,6 +229,11 @@
       "databasePath": {
         "description": "Path to LCM SQLite database (alias for dbPath)",
         "type": "string"
+      },
+      "pinnedFiles": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Workspace-relative file paths injected into every context assembly, outside the compaction DAG. These files are never summarized."
       }
     }
   }

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -20,6 +20,13 @@ const TOOL_CALL_TYPES = new Set([
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
+export interface PinnedFileEntry {
+  /** Workspace-relative path */
+  path: string;
+  /** File content read from disk */
+  content: string;
+}
+
 export interface AssembleContextInput {
   conversationId: number;
   tokenBudget: number;
@@ -27,6 +34,8 @@ export interface AssembleContextInput {
   freshTailCount?: number;
   /** Optional user query for relevance-based eviction scoring (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
   prompt?: string;
+  /** Files to inject at the start of context, outside the compaction DAG */
+  pinnedFiles?: PinnedFileEntry[];
 }
 
 export interface AssembleContextResult {
@@ -899,14 +908,27 @@ export class ContextAssembler {
   async assemble(input: AssembleContextInput): Promise<AssembleContextResult> {
     const { conversationId, tokenBudget } = input;
     const freshTailCount = input.freshTailCount ?? 8;
+    const pinnedFiles = input.pinnedFiles ?? [];
+
+    // Step 0: Build pinned file messages and subtract from budget
+    const pinnedMessages: AgentMessage[] = [];
+    let pinnedTokens = 0;
+    for (const pf of pinnedFiles) {
+      const safePath = pf.path.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      const text = `<pinned_file path="${safePath}">\n${pf.content}\n</pinned_file>`;
+      const tokens = estimateTokens(text);
+      pinnedMessages.push({ role: "user", content: text } as AgentMessage);
+      pinnedTokens += tokens;
+    }
+    const effectiveBudget = Math.max(0, tokenBudget - pinnedTokens);
 
     // Step 1: Get all context items ordered by ordinal
     const contextItems = await this.summaryStore.getContextItems(conversationId);
 
     if (contextItems.length === 0) {
       return {
-        messages: [],
-        estimatedTokens: 0,
+        messages: pinnedMessages,
+        estimatedTokens: pinnedTokens,
         stats: { rawMessageCount: 0, summaryCount: 0, totalContextItems: 0 },
       };
     }
@@ -955,7 +977,7 @@ export class ContextAssembler {
     // Fill remaining budget from evictable items, oldest first.
     // If the fresh tail alone exceeds the budget we still include it
     // (we never drop fresh items), but we skip all evictable items.
-    const remainingBudget = Math.max(0, tokenBudget - tailTokens);
+    const remainingBudget = Math.max(0, effectiveBudget - tailTokens);
     const selected: ResolvedItem[] = [];
     let evictableTokens = 0;
 
@@ -1017,11 +1039,11 @@ export class ContextAssembler {
     // Append fresh tail after the evictable prefix
     selected.push(...freshTail);
 
-    const estimatedTokens = evictableTokens + tailTokens;
+    const estimatedTokens = pinnedTokens + evictableTokens + tailTokens;
 
     // Normalize assistant string content to array blocks (some providers return
     // content as a plain string; Anthropic expects content block arrays).
-    const rawMessages = filterNonFreshAssistantToolCalls(selected, freshTailOrdinals);
+    const rawMessages = [...pinnedMessages, ...filterNonFreshAssistantToolCalls(selected, freshTailOrdinals)];
     for (let i = 0; i < rawMessages.length; i++) {
       const msg = rawMessages[i];
       if (msg?.role === "assistant" && typeof msg.content === "string") {

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -32,10 +32,6 @@ export type LcmConfig = {
   largeFileSummaryProvider: string;
   /** Model override for large-file text summarization. */
   largeFileSummaryModel: string;
-  /** Model override for conversation summarization. */
-  summaryModel: string;
-  /** Provider override for conversation summarization. */
-  summaryProvider: string;
   /** Provider override for lcm_expand_query sub-agent. */
   expansionProvider: string;
   /** Model override for lcm_expand_query sub-agent. */
@@ -52,6 +48,8 @@ export type LcmConfig = {
   summaryMaxOverageFactor: number;
   /** Custom instructions injected into all summarization prompts. */
   customInstructions: string;
+  /** Workspace-relative file paths injected into every context assembly, outside the compaction DAG. */
+  pinnedFiles: string[];
   /** Consecutive auth failures before the compaction circuit breaker trips (default 5). */
   circuitBreakerThreshold: number;
   /** Cooldown in milliseconds before the circuit breaker auto-resets (default 30 min). */
@@ -232,6 +230,7 @@ export function resolveLcmConfig(
         ?? toNumber(pc.summaryMaxOverageFactor) ?? 3,
     customInstructions:
       env.LCM_CUSTOM_INSTRUCTIONS?.trim() ?? toStr(pc.customInstructions) ?? "",
+    pinnedFiles: toStrArray(pc.pinnedFiles) ?? [],
     circuitBreakerThreshold:
       parseFiniteInt(env.LCM_CIRCUIT_BREAKER_THRESHOLD)
         ?? toNumber(pc.circuitBreakerThreshold) ?? 5,

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -50,6 +50,8 @@ export type LcmConfig = {
   customInstructions: string;
   /** Workspace-relative file paths injected into every context assembly, outside the compaction DAG. */
   pinnedFiles: string[];
+  /** Per-agent pinned file overrides, keyed by agent ID. Merged with global pinnedFiles at resolution time. */
+  pinnedFilesPerAgent: Record<string, string[]>;
   /** Consecutive auth failures before the compaction circuit breaker trips (default 5). */
   circuitBreakerThreshold: number;
   /** Cooldown in milliseconds before the circuit breaker auto-resets (default 30 min). */
@@ -96,6 +98,17 @@ function toStr(value: unknown): string | undefined {
     return trimmed.length > 0 ? trimmed : undefined;
   }
   return undefined;
+}
+
+/** Coerce a plugin config value into a Record<string, string[]> where each value is a string array. */
+function toStrArrayRecord(value: unknown): Record<string, string[]> | undefined {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: Record<string, string[]> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    const arr = toStrArray(val);
+    if (arr) result[key] = arr;
+  }
+  return Object.keys(result).length > 0 ? result : {};
 }
 
 /** Coerce a plugin config value into a trimmed string array when possible. */
@@ -231,6 +244,7 @@ export function resolveLcmConfig(
     customInstructions:
       env.LCM_CUSTOM_INSTRUCTIONS?.trim() ?? toStr(pc.customInstructions) ?? "",
     pinnedFiles: toStrArray(pc.pinnedFiles) ?? [],
+    pinnedFilesPerAgent: toStrArrayRecord(pc.pinnedFilesPerAgent) ?? {},
     circuitBreakerThreshold:
       parseFiniteInt(env.LCM_CIRCUIT_BREAKER_THRESHOLD)
         ?? toNumber(pc.circuitBreakerThreshold) ?? 5,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2742,9 +2742,6 @@ export class LcmContextEngine implements ContextEngine {
    * Missing, unreadable, oversized, or path-traversal files are silently skipped.
    */
   private async resolvePinnedFiles(sessionKey?: string): Promise<PinnedFileEntry[]> {
-    const paths = this.config.pinnedFiles;
-    if (paths.length === 0) return [];
-
     // Extract agent ID from session key (e.g. "agent:brunelleschi:telegram:...")
     const parsed = sessionKey ? (() => {
       const trimmed = sessionKey.trim();
@@ -2752,6 +2749,12 @@ export class LcmContextEngine implements ContextEngine {
       const parts = trimmed.split(":");
       return parts.length >= 2 ? parts[1]?.trim() : null;
     })() : undefined;
+
+    const agentId = parsed ?? "main";
+    const globalPaths = this.config.pinnedFiles;
+    const agentPaths = this.config.pinnedFilesPerAgent[agentId] ?? [];
+    const paths = [...new Set([...globalPaths, ...agentPaths])];
+    if (paths.length === 0) return [];
 
     const workspaceDir = this.deps.resolveWorkspaceDir?.(parsed ?? undefined);
     if (!workspaceDir) return [];

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,8 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { closeSync, createReadStream, openSync, readSync, statSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { createInterface } from "node:readline";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
@@ -24,6 +24,7 @@ import {
   pickToolCallId,
   pickToolIsError,
   pickToolName,
+  type PinnedFileEntry,
 } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import type { LcmConfig } from "./db/config.js";
@@ -2697,11 +2698,15 @@ export class LcmContextEngine implements ContextEngine {
           : 128_000,
       );
 
+      // Resolve pinned files from disk for this agent's workspace
+      const pinnedFiles = await this.resolvePinnedFiles(params.sessionKey);
+
       const assembled = await this.assembler.assemble({
         conversationId: conversation.conversationId,
         tokenBudget,
         freshTailCount: this.config.freshTailCount,
         prompt: params.prompt,
+        pinnedFiles,
       });
 
       // If assembly produced no messages for a non-empty live session,
@@ -2727,6 +2732,51 @@ export class LcmContextEngine implements ContextEngine {
         estimatedTokens: 0,
       };
     }
+  }
+
+  /** Maximum bytes per pinned file (100 KB). Files exceeding this are skipped. */
+  private static readonly PINNED_FILE_MAX_BYTES = 100_000;
+
+  /**
+   * Read configured pinned files from disk.
+   * Missing, unreadable, oversized, or path-traversal files are silently skipped.
+   */
+  private async resolvePinnedFiles(sessionKey?: string): Promise<PinnedFileEntry[]> {
+    const paths = this.config.pinnedFiles;
+    if (paths.length === 0) return [];
+
+    // Extract agent ID from session key (e.g. "agent:brunelleschi:telegram:...")
+    const parsed = sessionKey ? (() => {
+      const trimmed = sessionKey.trim();
+      if (!trimmed.startsWith("agent:")) return null;
+      const parts = trimmed.split(":");
+      return parts.length >= 2 ? parts[1]?.trim() : null;
+    })() : undefined;
+
+    const workspaceDir = this.deps.resolveWorkspaceDir?.(parsed ?? undefined);
+    if (!workspaceDir) return [];
+
+    const resolvedRoot = resolve(workspaceDir);
+    const results: PinnedFileEntry[] = [];
+    for (const relativePath of paths) {
+      try {
+        const absolutePath = resolve(workspaceDir, relativePath);
+        // Path traversal guard: resolved path must stay within workspace
+        if (!absolutePath.startsWith(resolvedRoot + "/") && absolutePath !== resolvedRoot) {
+          continue;
+        }
+        // Size guard: check before reading to avoid OOM on huge files
+        const fileStat = await stat(absolutePath);
+        if (!fileStat.isFile() || fileStat.size > LcmContextEngine.PINNED_FILE_MAX_BYTES) {
+          continue;
+        }
+        const content = await readFile(absolutePath, "utf-8");
+        results.push({ path: relativePath, content });
+      } catch {
+        // Silently skip missing or unreadable files
+      }
+    }
+    return results;
   }
 
   /** Evaluate whether incremental leaf compaction should run for a session. */

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1499,6 +1499,47 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
     buildSubagentSystemPrompt,
     readLatestAssistantReply,
     resolveAgentDir: () => api.resolvePath("."),
+    resolveWorkspaceDir: (agentId?: string) => {
+      try {
+        const cfg = api.runtime.config.loadConfig() as Record<string, unknown>;
+        const agents = cfg.agents as Record<string, unknown> | undefined;
+        const id = normalizeAgentId(agentId);
+
+        const expandTilde = (p: string): string =>
+          p.startsWith("~/") || p === "~"
+            ? (process.env.HOME ?? "") + p.slice(1)
+            : p;
+
+        // agents.list is an array of { id, workspace, ... } entries
+        const agentList = agents?.list as Array<Record<string, unknown>> | undefined;
+        if (Array.isArray(agentList)) {
+          const entry = agentList.find(
+            (a) => normalizeAgentId(a.id as string | undefined) === id,
+          );
+          const ws = entry?.workspace as string | undefined;
+          if (typeof ws === "string" && ws.trim()) {
+            return expandTilde(ws);
+          }
+        }
+
+        // Check default workspace for the default agent
+        const defaultAgentId = normalizeAgentId(
+          (cfg.defaultAgent as string | undefined) ?? (agents?.default as string | undefined),
+        );
+        if (id === defaultAgentId) {
+          const defaultWs = (agents?.defaults as Record<string, unknown>)?.workspace as string | undefined;
+          if (typeof defaultWs === "string" && defaultWs.trim()) {
+            return expandTilde(defaultWs);
+          }
+        }
+
+        // Fallback: OpenClaw convention — ~/.openclaw/workspace-{agentId}
+        const home = process.env.HOME ?? "";
+        return join(home, ".openclaw", `workspace-${id}`);
+      } catch {
+        return undefined;
+      }
+    },
     resolveSessionIdFromSessionKey: async (sessionKey) => {
       const key = sessionKey.trim();
       if (!key) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,9 @@ export interface LcmDependencies {
   /** Resolve the OpenClaw agent directory */
   resolveAgentDir: () => string;
 
+  /** Resolve an agent's workspace directory (for workspace-relative file paths) */
+  resolveWorkspaceDir?: (agentId?: string) => string | undefined;
+
   /** Resolve runtime session id from an agent session key */
   resolveSessionIdFromSessionKey: (sessionKey: string) => Promise<string | undefined>;
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -47,6 +47,10 @@ function createTestConfig(databasePath: string): LcmConfig {
     pruneHeartbeatOk: false,
     summaryMaxOverageFactor: 3,
     customInstructions: "",
+    expansionProvider: "",
+    expansionModel: "",
+    pinnedFiles: [],
+    pinnedFilesPerAgent: {},
     circuitBreakerThreshold: 5,
     circuitBreakerCooldownMs: 1_800_000,
   };

--- a/test/pinned-files.test.ts
+++ b/test/pinned-files.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from "vitest";
+import { ContextAssembler, type PinnedFileEntry } from "../src/assembler.js";
+import type { ConversationStore } from "../src/store/conversation-store.js";
+import type { SummaryStore, ContextItemRecord } from "../src/store/summary-store.js";
+import { resolveLcmConfig } from "../src/db/config.js";
+
+// ── Minimal store stubs ──────────────────────────────────────────────────────
+
+function stubConversationStore(overrides?: Partial<ConversationStore>): ConversationStore {
+  return {
+    getMessageById: vi.fn().mockResolvedValue(null),
+    getMessageParts: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as ConversationStore;
+}
+
+function stubSummaryStore(contextItems: ContextItemRecord[] = []): SummaryStore {
+  return {
+    getContextItems: vi.fn().mockResolvedValue(contextItems),
+    getSummary: vi.fn().mockResolvedValue(null),
+    getSummaryParents: vi.fn().mockResolvedValue([]),
+  } as unknown as SummaryStore;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("pinnedFiles", () => {
+  it("pinned files appear in assembled context as user messages", async () => {
+    const pinnedFiles: PinnedFileEntry[] = [
+      { path: "FLEET.md", content: "# Fleet Protocol\nFollow these rules." },
+      { path: "BOUNDARIES.md", content: "# Boundaries\nStay within scope." },
+    ];
+
+    const assembler = new ContextAssembler(
+      stubConversationStore(),
+      stubSummaryStore([]),
+    );
+
+    const result = await assembler.assemble({
+      conversationId: 1,
+      tokenBudget: 100_000,
+      pinnedFiles,
+    });
+
+    // Pinned files should be the only messages (no context items in DB)
+    expect(result.messages).toHaveLength(2);
+
+    const msg0 = result.messages[0] as { role: string; content: string };
+    expect(msg0.role).toBe("user");
+    expect(msg0.content).toContain('<pinned_file path="FLEET.md">');
+    expect(msg0.content).toContain("# Fleet Protocol");
+    expect(msg0.content).toContain("</pinned_file>");
+
+    const msg1 = result.messages[1] as { role: string; content: string };
+    expect(msg1.role).toBe("user");
+    expect(msg1.content).toContain('<pinned_file path="BOUNDARIES.md">');
+    expect(msg1.content).toContain("# Boundaries");
+  });
+
+  it("pinned files are not subject to eviction", async () => {
+    const pinnedFiles: PinnedFileEntry[] = [
+      { path: "FLEET.md", content: "A".repeat(400) }, // ~100 tokens
+    ];
+
+    // Create context items that fill most of the budget
+    const items: ContextItemRecord[] = [
+      { ordinal: 1, itemType: "message", messageId: 1, summaryId: null, conversationId: 1 },
+      { ordinal: 2, itemType: "message", messageId: 2, summaryId: null, conversationId: 1 },
+    ];
+
+    const assembler = new ContextAssembler(
+      stubConversationStore({
+        getMessageById: vi.fn().mockImplementation(async (id: number) => ({
+          messageId: id,
+          role: "user" as const,
+          content: "B".repeat(200), // ~50 tokens each
+          conversationId: 1,
+          createdAt: new Date(),
+        })),
+        getMessageParts: vi.fn().mockResolvedValue([]),
+      }),
+      stubSummaryStore(items),
+    );
+
+    // Budget is tight: pinned file (100t) + 2 messages (50t each) = 200t
+    // With a budget of 200, everything should fit
+    const result = await assembler.assemble({
+      conversationId: 1,
+      tokenBudget: 200,
+      pinnedFiles,
+      freshTailCount: 1, // protect only the last message
+    });
+
+    // Pinned file should always be present
+    const pinnedMsg = result.messages[0] as { role: string; content: string };
+    expect(pinnedMsg.content).toContain('<pinned_file path="FLEET.md">');
+
+    // With very tight budget (only enough for pinned + fresh tail),
+    // the evictable message should be dropped
+    const tightResult = await assembler.assemble({
+      conversationId: 1,
+      tokenBudget: 160, // pinned (100t) + 1 fresh tail msg (50t) = 150t, evictable doesn't fit
+      pinnedFiles,
+      freshTailCount: 1,
+    });
+
+    // Pinned file is still present
+    const tightPinned = tightResult.messages[0] as { role: string; content: string };
+    expect(tightPinned.content).toContain('<pinned_file path="FLEET.md">');
+
+    // Only fresh tail message remains (evictable one was dropped)
+    // messages = [pinned, fresh_tail_msg]
+    expect(tightResult.messages).toHaveLength(2);
+  });
+
+  it("missing pinned files are handled gracefully (empty array)", async () => {
+    const assembler = new ContextAssembler(
+      stubConversationStore(),
+      stubSummaryStore([]),
+    );
+
+    // No pinned files provided
+    const result = await assembler.assemble({
+      conversationId: 1,
+      tokenBudget: 100_000,
+      pinnedFiles: [],
+    });
+
+    expect(result.messages).toHaveLength(0);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("token budget accounts for pinned file sizes", async () => {
+    const content = "X".repeat(4000); // ~1000 tokens
+    const pinnedFiles: PinnedFileEntry[] = [
+      { path: "big.md", content },
+    ];
+
+    const assembler = new ContextAssembler(
+      stubConversationStore(),
+      stubSummaryStore([]),
+    );
+
+    const result = await assembler.assemble({
+      conversationId: 1,
+      tokenBudget: 100_000,
+      pinnedFiles,
+    });
+
+    // Token estimate should include the pinned file
+    expect(result.estimatedTokens).toBeGreaterThan(900);
+    expect(result.estimatedTokens).toBeLessThan(1100);
+  });
+});
+
+describe("pinnedFiles config", () => {
+  it("resolves pinnedFiles from plugin config", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFiles: ["FLEET.md", "FLEET-BOUNDARIES.md"],
+    });
+    expect(config.pinnedFiles).toEqual(["FLEET.md", "FLEET-BOUNDARIES.md"]);
+  });
+
+  it("defaults pinnedFiles to empty array", () => {
+    const config = resolveLcmConfig({}, {});
+    expect(config.pinnedFiles).toEqual([]);
+  });
+
+  it("handles comma-separated string for pinnedFiles", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFiles: "FLEET.md, BOUNDARIES.md",
+    });
+    expect(config.pinnedFiles).toEqual(["FLEET.md", "BOUNDARIES.md"]);
+  });
+});

--- a/test/pinned-files.test.ts
+++ b/test/pinned-files.test.ts
@@ -173,3 +173,59 @@ describe("pinnedFiles config", () => {
     expect(config.pinnedFiles).toEqual(["FLEET.md", "BOUNDARIES.md"]);
   });
 });
+
+describe("pinnedFilesPerAgent config", () => {
+  it("resolves per-agent pinned files from plugin config", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFilesPerAgent: {
+        athena: ["system/subject-guides.md", "system/standing-rules.md"],
+      },
+    });
+    expect(config.pinnedFilesPerAgent).toEqual({
+      athena: ["system/subject-guides.md", "system/standing-rules.md"],
+    });
+  });
+
+  it("defaults pinnedFilesPerAgent to empty object", () => {
+    const config = resolveLcmConfig({}, {});
+    expect(config.pinnedFilesPerAgent).toEqual({});
+  });
+
+  it("ignores non-object pinnedFilesPerAgent values", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFilesPerAgent: "not-an-object",
+    });
+    expect(config.pinnedFilesPerAgent).toEqual({});
+  });
+
+  it("ignores array pinnedFilesPerAgent values", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFilesPerAgent: ["a", "b"],
+    });
+    expect(config.pinnedFilesPerAgent).toEqual({});
+  });
+
+  it("handles multiple agents", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFilesPerAgent: {
+        athena: ["a.md"],
+        brunelleschi: ["b.md", "c.md"],
+      },
+    });
+    expect(config.pinnedFilesPerAgent).toEqual({
+      athena: ["a.md"],
+      brunelleschi: ["b.md", "c.md"],
+    });
+  });
+
+  it("filters out non-string entries within per-agent arrays", () => {
+    const config = resolveLcmConfig({}, {
+      pinnedFilesPerAgent: {
+        athena: ["valid.md", 123, null, "also-valid.md"],
+      },
+    });
+    expect(config.pinnedFilesPerAgent).toEqual({
+      athena: ["valid.md", "also-valid.md"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `pinnedFiles` config option that injects workspace-relative files into every context assembly **outside the compaction DAG**. These files are always current (read from disk each turn), never summarized, and never evicted.

## Motivation

Long-running sessions lose procedural context as LCM compacts earlier turns into summaries. Critical files like fleet-wide rules or safety boundaries get compressed into vague references, causing behavioral drift. Agents need a way to keep certain workspace files permanently in context.

## How it works

1. **Config**: `"pinnedFiles": ["FLEET.md", "BOUNDARIES.md"]` in `openclaw.plugin.json`
2. **Engine**: `resolvePinnedFiles()` reads files from the agent's workspace directory on each `assemble()` call
3. **Assembler**: Files are prepended as synthetic user messages wrapped in `<pinned_file path="...">` tags, with token budget deducted before eviction runs
4. **Workspace resolution**: Reads `agents.list` from OpenClaw config to find the correct workspace path per agent, with `~/.openclaw/workspace-{agentId}` fallback

## Security

- **Path traversal guard**: `resolve()` + `startsWith()` ensures paths stay within workspace
- **XML attribute escaping**: `&`, `"`, `<`, `>` escaped in path attributes
- **Tilde expansion**: Only leading `~/` or bare `~` (no mid-string replacement)
- **Size cap**: `stat()` check before `readFile()`, 100KB per-file limit, oversized files silently skipped
- **Missing files**: Silently skipped (no errors for absent or unreadable files)

## Changes

- `src/db/config.ts`: `pinnedFiles: string[]` field + `toStrArray` parsing
- `src/types.ts`: `resolveWorkspaceDir()` on `LcmDependencies` interface
- `src/assembler.ts`: `PinnedFileEntry` type, Step 0 prepend + budget deduction
- `src/engine.ts`: `resolvePinnedFiles()` with disk I/O, path validation, size guard
- `src/plugin/index.ts`: `resolveWorkspaceDir()` implementation reading OpenClaw agent config
- `openclaw.plugin.json`: Schema + UI hints for `pinnedFiles`
- `test/pinned-files.test.ts`: 7 new tests (injection, eviction immunity, budget, config parsing)

All 403 tests passing.