### PR TITLE
fix: update default compaction settings

### DIFF
--- a/.changeset/default-compaction-defaults.md
+++ b/.changeset/default-compaction-defaults.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Raise the default protected fresh tail to 64 messages and make incremental compaction run one condensed pass by default.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
       "lossless-claw": {
         "enabled": true,
         "config": {
-          "freshTailCount": 32,
+          "freshTailCount": 64,
           "contextThreshold": 0.75,
-          "incrementalMaxDepth": -1,
+          "incrementalMaxDepth": 1,
           "ignoreSessionPatterns": [
             "agent:*:cron:**"
           ],
@@ -121,11 +121,11 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_STATELESS_SESSION_PATTERNS` | `""` | Comma-separated glob patterns for session keys that may read from LCM but never write to it |
 | `LCM_SKIP_STATELESS_SESSIONS` | `true` | Enable stateless-session write skipping for matching session keys |
 | `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of context window that triggers compaction (0.0–1.0) |
-| `LCM_FRESH_TAIL_COUNT` | `32` | Number of recent messages protected from compaction |
+| `LCM_FRESH_TAIL_COUNT` | `64` | Number of recent messages protected from compaction |
 | `LCM_LEAF_MIN_FANOUT` | `8` | Minimum raw messages per leaf summary |
 | `LCM_CONDENSED_MIN_FANOUT` | `4` | Minimum summaries per condensed node |
 | `LCM_CONDENSED_MIN_FANOUT_HARD` | `2` | Relaxed fanout for forced compaction sweeps |
-| `LCM_INCREMENTAL_MAX_DEPTH` | `0` | How deep incremental compaction goes (0 = leaf only, -1 = unlimited) |
+| `LCM_INCREMENTAL_MAX_DEPTH` | `1` | How deep incremental compaction goes (0 = leaf only, 1 = one condensed pass, -1 = unlimited) |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Max source tokens per leaf compaction chunk |
 | `LCM_LEAF_TARGET_TOKENS` | `1200` | Target token count for leaf summaries |
 | `LCM_CONDENSED_TARGET_TOKENS` | `2000` | Target token count for condensed summaries |
@@ -198,13 +198,13 @@ If `summaryModel` already includes a provider prefix such as `anthropic/claude-s
 ### Recommended starting configuration
 
 ```
-LCM_FRESH_TAIL_COUNT=32
-LCM_INCREMENTAL_MAX_DEPTH=-1
+LCM_FRESH_TAIL_COUNT=64
+LCM_INCREMENTAL_MAX_DEPTH=1
 LCM_CONTEXT_THRESHOLD=0.75
 ```
 
-- **freshTailCount=32** protects the last 32 messages from compaction, giving the model enough recent context for continuity.
-- **incrementalMaxDepth=-1** enables unlimited automatic condensation after each compaction pass — the DAG cascades as deep as needed. Set to `0` (default) for leaf-only, or a positive integer for a specific depth cap.
+- **freshTailCount=64** protects the last 64 messages from compaction, giving the model more recent context for continuity.
+- **incrementalMaxDepth=1** runs one condensed pass after each leaf compaction by default. Set to `0` for leaf-only behavior, a larger positive integer for a deeper cap, or `-1` for unlimited cascading.
 - **contextThreshold=0.75** triggers compaction when context reaches 75% of the model's window, leaving headroom for the model's response.
 
 ### Session exclusion patterns

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -38,7 +38,7 @@ export interface CompactionConfig {
   condensedMinFanout: number;
   /** Relaxed minimum fanout for hard-trigger sweeps. */
   condensedMinFanoutHard: number;
-  /** Incremental depth passes to run after each leaf compaction (default 0). */
+  /** Incremental depth passes to run after each leaf compaction (default 1). */
   incrementalMaxDepth: number;
   /** Max source tokens to compact per leaf/condensed chunk (default 20000) */
   leafChunkTokens?: number;

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -140,7 +140,7 @@ export function resolveLcmConfig(
         ?? toNumber(pc.contextThreshold) ?? 0.75,
     freshTailCount:
       (env.LCM_FRESH_TAIL_COUNT !== undefined ? parseInt(env.LCM_FRESH_TAIL_COUNT, 10) : undefined)
-        ?? toNumber(pc.freshTailCount) ?? 32,
+        ?? toNumber(pc.freshTailCount) ?? 64,
     leafMinFanout:
       (env.LCM_LEAF_MIN_FANOUT !== undefined ? parseInt(env.LCM_LEAF_MIN_FANOUT, 10) : undefined)
         ?? toNumber(pc.leafMinFanout) ?? 8,
@@ -152,7 +152,7 @@ export function resolveLcmConfig(
         ?? toNumber(pc.condensedMinFanoutHard) ?? 2,
     incrementalMaxDepth:
       (env.LCM_INCREMENTAL_MAX_DEPTH !== undefined ? parseInt(env.LCM_INCREMENTAL_MAX_DEPTH, 10) : undefined)
-        ?? toNumber(pc.incrementalMaxDepth) ?? 0,
+        ?? toNumber(pc.incrementalMaxDepth) ?? 1,
     leafChunkTokens:
       (env.LCM_LEAF_CHUNK_TOKENS !== undefined ? parseInt(env.LCM_LEAF_CHUNK_TOKENS, 10) : undefined)
         ?? toNumber(pc.leafChunkTokens) ?? 20000,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,8 +10,8 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
     expect(config.contextThreshold).toBe(0.75);
-    expect(config.freshTailCount).toBe(32);
-    expect(config.incrementalMaxDepth).toBe(0);
+    expect(config.freshTailCount).toBe(64);
+    expect(config.incrementalMaxDepth).toBe(1);
     expect(config.leafMinFanout).toBe(8);
     expect(config.condensedMinFanout).toBe(4);
     expect(config.condensedMinFanoutHard).toBe(2);
@@ -133,7 +133,7 @@ describe("resolveLcmConfig", () => {
       enabled: "maybe",
     });
     expect(config.contextThreshold).toBe(0.75); // falls through to default
-    expect(config.freshTailCount).toBe(32); // falls through to default
+    expect(config.freshTailCount).toBe(64); // falls through to default
     expect(config.enabled).toBe(true); // falls through to default
   });
 


### PR DESCRIPTION
## What
Adjust the out-of-the-box LCM compaction defaults to preserve more recent raw context and run a single incremental condensed pass after each leaf compaction. This also updates the README and adds a changeset so the release notes match the new behavior.

## Why
The previous defaults were conservative for recent-context retention and did not perform any incremental condensed pass unless users opted in. Moving to a larger fresh tail and a single incremental condensation pass gives new installs a better default balance between continuity and background compaction without switching all the way to unlimited cascading.

## Changes
- Raise default `freshTailCount` to 64
- Raise default `incrementalMaxDepth` to 1
- Update config tests for new defaults
- Refresh README examples and defaults table
- Add changeset for release notes

## Testing
- `npx vitest run test/config.test.ts`
- `npx vitest run test/lcm-integration.test.ts -t "compactLeaf performs one depth-zero condensation pass when incrementalMaxDepth is one"`
- Expected: both commands pass