### PR TITLE
fix: harden compaction summary fallback

### DIFF
--- a/.changeset/compaction-fallback-banner.md
+++ b/.changeset/compaction-fallback-banner.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Make compaction summarization fall back to the next resolved model when the preferred model times out or returns repeated empty provider errors, and make the startup banner reflect the same compaction model precedence used at runtime.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -228,6 +228,30 @@ function readDefaultModelFromConfig(config: unknown): string {
   return typeof primary === "string" ? primary.trim() : "";
 }
 
+/** Read OpenClaw's configured compaction model from the validated runtime config. */
+function readCompactionModelFromConfig(config: unknown): string {
+  if (!config || typeof config !== "object") {
+    return "";
+  }
+
+  const compaction = (config as {
+    agents?: {
+      defaults?: {
+        compaction?: {
+          model?: unknown;
+        };
+      };
+    };
+  }).agents?.defaults?.compaction;
+  const model = compaction?.model;
+  if (typeof model === "string") {
+    return model.trim();
+  }
+
+  const primary = (model as { primary?: unknown } | undefined)?.primary;
+  return typeof primary === "string" ? primary.trim() : "";
+}
+
 /** Format a provider/model pair for logs. */
 function formatProviderModel(params: { provider: string; model: string }): string {
   return `${params.provider}/${params.model}`;
@@ -236,11 +260,28 @@ function formatProviderModel(params: { provider: string; model: string }): strin
 /** Build a startup log showing which compaction model LCM will use. */
 function buildCompactionModelLog(params: {
   config: LcmConfig;
-  defaultModelRef: string;
+  openClawConfig: unknown;
   defaultProvider: string;
 }): string {
-  const usingOverride = Boolean(params.config.summaryModel || params.config.summaryProvider);
-  const raw = (params.config.summaryModel || params.defaultModelRef).trim();
+  const envSummaryModel = process.env.LCM_SUMMARY_MODEL?.trim() ?? "";
+  const envSummaryProvider = process.env.LCM_SUMMARY_PROVIDER?.trim() ?? "";
+  const pluginSummaryModel = params.config.summaryModel.trim();
+  const pluginSummaryProvider = params.config.summaryProvider.trim();
+  const compactionModelRef = readCompactionModelFromConfig(params.openClawConfig);
+  const defaultModelRef = readDefaultModelFromConfig(params.openClawConfig);
+  const selected =
+    envSummaryModel
+      ? { raw: envSummaryModel, source: "override" as const }
+      : pluginSummaryModel
+        ? { raw: pluginSummaryModel, source: "override" as const }
+        : compactionModelRef
+          ? { raw: compactionModelRef, source: "override" as const }
+          : defaultModelRef
+            ? { raw: defaultModelRef, source: "default" as const }
+            : undefined;
+  const usingOverride =
+    selected?.source === "override" || Boolean(envSummaryProvider || pluginSummaryProvider);
+  const raw = selected?.raw.trim() ?? "";
   if (!raw) {
     return "[lcm] Compaction summarization model: (unconfigured)";
   }
@@ -256,7 +297,12 @@ function buildCompactionModelLog(params: {
     }
   }
 
-  const provider = (params.config.summaryProvider || params.defaultProvider || "openai").trim();
+  const provider = (
+    envSummaryProvider ||
+    pluginSummaryProvider ||
+    params.defaultProvider ||
+    "openai"
+  ).trim();
   return `[lcm] Compaction summarization model: ${formatProviderModel({
     provider,
     model: raw,
@@ -1519,7 +1565,7 @@ const lcmPlugin = {
       log: (message) => api.logger.info(message),
       message: buildCompactionModelLog({
         config: deps.config,
-        defaultModelRef: readDefaultModelFromConfig(api.config),
+        openClawConfig: api.config,
         defaultProvider: process.env.OPENCLAW_PROVIDER?.trim() ?? "",
       }),
     });

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1112,6 +1112,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       const candidate = resolvedCandidates[index]!;
       const provider = candidate.provider;
       const model = candidate.model;
+      const nextCandidate = index < resolvedCandidates.length - 1 ? resolvedCandidates[index + 1]! : undefined;
       const authProfileId = candidate.useLegacyAuthProfile ? legacyAuthProfileId : undefined;
       const providerApi = resolveProviderApiFromLegacyConfig(params.legacyParams.config, provider);
       const lookupOptions = {
@@ -1226,8 +1227,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       } catch (err) {
         if (err instanceof LcmProviderAuthError) {
           lastAuthError = err;
-          if (index < resolvedCandidates.length - 1) {
-            const nextCandidate = resolvedCandidates[index + 1]!;
+          if (nextCandidate) {
             console.warn(
               `[lcm] summarizer auth fallback: retrying with ${nextCandidate.provider}/${nextCandidate.model} after ${provider}/${model} failed auth.`,
             );
@@ -1240,6 +1240,12 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         console.warn(
           `[lcm] summarizer ${isTimeout ? "timed out" : "failed"}; provider=${provider}; model=${model}; timeout=${SUMMARIZER_TIMEOUT_MS}ms; error=${errMsg}`,
         );
+        if (nextCandidate) {
+          console.warn(
+            `[lcm] summarizer candidate fallback: retrying with ${nextCandidate.provider}/${nextCandidate.model} after ${provider}/${model} ${isTimeout ? "timed out" : "failed"}.`,
+          );
+          continue;
+        }
         if (err instanceof SummarizerTimeoutError) {
           console.error(
             `[lcm] summarizer timed out; provider=${provider}; model=${model}; source=fallback`,
@@ -1322,14 +1328,19 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             if (retryDiag) {
               retryParts.push(retryDiag);
             }
+            if (nextCandidate) {
+              console.warn(
+                `${retryParts.join("; ")}; retrying with ${nextCandidate.provider}/${nextCandidate.model}`,
+              );
+              continue;
+            }
             console.error(`${retryParts.join("; ")}; falling back to truncation`);
             summary = initialSummary;
           }
         } catch (retryErr) {
           if (retryErr instanceof LcmProviderAuthError) {
             lastAuthError = retryErr;
-            if (index < resolvedCandidates.length - 1) {
-              const nextCandidate = resolvedCandidates[index + 1]!;
+            if (nextCandidate) {
               console.warn(
                 `[lcm] summarizer auth fallback: retrying with ${nextCandidate.provider}/${nextCandidate.model} after ${provider}/${model} failed auth.`,
               );
@@ -1340,6 +1351,12 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           // Retry is best-effort; log and proceed to deterministic fallback.
           const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
           const isRetryTimeout = retryErrMsg.includes("summarizer timeout");
+          if (nextCandidate) {
+            console.warn(
+              `[lcm] retry ${isRetryTimeout ? "timed out" : "failed"}; provider=${provider}; model=${model}; timeout=${SUMMARIZER_TIMEOUT_MS}ms; error=${retryErrMsg}; retrying with ${nextCandidate.provider}/${nextCandidate.model}`,
+            );
+            continue;
+          }
           console.warn(
             `[lcm] retry ${isRetryTimeout ? "timed out" : "failed"}; provider=${provider}; model=${model}; timeout=${SUMMARIZER_TIMEOUT_MS}ms; error=${retryErrMsg}; falling back to truncation`,
           );

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -96,6 +96,32 @@ function defaultModelConfig(model: string): Record<string, unknown> {
   };
 }
 
+function compactionAndDefaultModelConfig(params: {
+  compactionModel?: string;
+  defaultModel?: string;
+}): Record<string, unknown> {
+  return {
+    agents: {
+      defaults: {
+        ...(params.defaultModel
+          ? {
+              model: {
+                primary: params.defaultModel,
+              },
+            }
+          : {}),
+        ...(params.compactionModel
+          ? {
+              compaction: {
+                model: params.compactionModel,
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
 describe("lcm plugin registration", () => {
   const dbPaths = new Set<string>();
   const tempDirs = new Set<string>();
@@ -356,6 +382,40 @@ describe("lcm plugin registration", () => {
 
     expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Compaction summarization model: openai-resp/gpt-5.4 (override)",
+    );
+  });
+
+  it("logs the OpenClaw compaction model at startup when no plugin override is set", () => {
+    const { api, infoLog } = buildApi({
+      enabled: true,
+    });
+    api.config = compactionAndDefaultModelConfig({
+      compactionModel: "anthropic/claude-opus-4-6",
+      defaultModel: "openai-codex/gpt-5.4",
+    }) as OpenClawPluginApi["config"];
+
+    lcmPlugin.register(api);
+
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Compaction summarization model: anthropic/claude-opus-4-6 (override)",
+    );
+  });
+
+  it("prefers env summary overrides over the OpenClaw compaction model in the startup banner", () => {
+    vi.stubEnv("LCM_SUMMARY_PROVIDER", "openai-codex");
+    vi.stubEnv("LCM_SUMMARY_MODEL", "gpt-5.4");
+    const { api, infoLog } = buildApi({
+      enabled: true,
+    });
+    api.config = compactionAndDefaultModelConfig({
+      compactionModel: "anthropic/claude-opus-4-6",
+      defaultModel: "openai-codex/gpt-5.3-codex",
+    }) as OpenClawPluginApi["config"];
+
+    lcmPlugin.register(api);
+
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Compaction summarization model: openai-codex/gpt-5.4 (override)",
     );
   });
 

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -906,6 +906,91 @@ describe("createLcmSummarizeFromLegacyParams", () => {
       }
     });
 
+    it("falls back to the next resolved model when retry also returns an empty overloaded response", async () => {
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const deps = makeDeps({
+          resolveModel: vi.fn((modelRef?: string, providerHint?: string) => {
+            if (modelRef === "anthropic/claude-opus-4-6") {
+              return { provider: "anthropic", model: "claude-opus-4-6" };
+            }
+            if (modelRef === "gpt-5.4") {
+              return { provider: providerHint ?? "openai-codex", model: "gpt-5.4" };
+            }
+            throw new Error(`unexpected modelRef: ${String(modelRef)}`);
+          }),
+          complete: vi
+            .fn()
+            .mockResolvedValueOnce({
+              content: [],
+              errorMessage: JSON.stringify({
+                type: "error",
+                error: { type: "api_error", message: "Internal server error" },
+              }),
+            })
+            .mockResolvedValueOnce({
+              content: [],
+              errorMessage: JSON.stringify({
+                type: "error",
+                error: { type: "overloaded_error", message: "Overloaded" },
+              }),
+            })
+            .mockResolvedValueOnce({
+              content: [{ type: "text", text: "Recovered summary from fallback candidate." }],
+            }),
+        });
+
+        const summarize = await createSummarizeFn({
+          deps,
+          legacyParams: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            config: {
+              agents: {
+                defaults: {
+                  compaction: {
+                    model: "anthropic/claude-opus-4-6",
+                  },
+                  model: {
+                    primary: "openai-codex/gpt-5.4",
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const summary = await summarize!("A".repeat(8_000), false);
+
+        expect(summary).toBe("Recovered summary from fallback candidate.");
+        expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(3);
+        expect(vi.mocked(deps.complete).mock.calls[0]?.[0]).toMatchObject({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        });
+        expect(vi.mocked(deps.complete).mock.calls[1]?.[0]).toMatchObject({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          reasoning: "low",
+        });
+        expect(vi.mocked(deps.complete).mock.calls[2]?.[0]).toMatchObject({
+          provider: "openai-codex",
+          model: "gpt-5.4",
+        });
+
+        const warningText = consoleWarn.mock.calls.flatMap((call) => call.map(String)).join(" ");
+        expect(warningText).toContain("retrying with openai-codex/gpt-5.4");
+        expect(warningText).toContain("retry also returned empty summary");
+
+        const errorText = consoleError.mock.calls.flatMap((call) => call.map(String)).join(" ");
+        expect(errorText).not.toContain("falling back to truncation");
+      } finally {
+        consoleWarn.mockRestore();
+        consoleError.mockRestore();
+      }
+    });
+
     it("retries the same model with direct credentials before falling back to another provider", async () => {
       const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {


### PR DESCRIPTION
## What
This PR makes lossless-claw fall through to the next resolved compaction summary model when the preferred model times out or returns repeated empty provider error responses, and it updates the startup banner to reflect the same compaction-model precedence used at runtime.

## Why
OpenClaw PR #56710 exposed that compaction override selection was working, but lossless-claw still truncated summaries when the preferred summarizer overloaded instead of trying the next configured candidate. The startup banner also remained misleading because it ignored `agents.defaults.compaction.model`.

## Changes
- Fall back to the next resolved summary candidate on non-auth summarize failures
- Keep auth-only fallback behavior unchanged
- Make startup banner honor compaction-model precedence
- Add regression tests for overload fallback and banner precedence
- Add a patch changeset for the bugfix

## Testing
- `pnpm test -- test/plugin-config-registration.test.ts test/summarize.test.ts`
- Expected: targeted summarize and startup-banner coverage passes, including the Anthropic overload to `gpt-5.4` fallback path
