### PR TITLE
Enhance documentation specifically for conflicts w/ OpenClaw agents' …

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -175,6 +175,27 @@ When summaries in context have an "Expand for details about:" footer
 listing something you need, use `lcm_expand_query` to get the full detail.
 ```
 
+OpenClaw agents commonly have two complementary recall systems. LCM handles conversation history; memory_search handles curated workspace files. Both should be available and both should be used for different questions.
+
+For openclaw specifically use these instructions instead of the above prompt to avoid conflicting information from system prompt and LCM tools suggestion:
+
+Add to AGENTS.md (or equivalent startup file):
+
+```markdown
+## Memory & Context
+
+Two separate recall systems — use both as appropriate:
+
+**1. `memory_search` (workspace files)** — Searches MEMORY.md + memory/*.md via local embeddings. Use for: prior decisions, protocols, system setup, long-term knowledge. This is curated, edited knowledge — "what's our protocol for X?"
+
+**2. LCM tools (conversation history)** — Searches compacted conversation transcripts in the LCM database. Use for: recalling what happened in past sessions, finding specific discussions, recovering details from summaries. Nothing is lost — raw messages persist in the DB.
+- `lcm_grep` — Search all conversations by keyword/regex
+- `lcm_describe` — Inspect a specific summary (cheap, no sub-agent)
+- `lcm_expand_query` — Deep recall with sub-agent expansion
+
+When summaries in context have an "Expand for details about:" footer listing something you need, use `lcm_expand_query` to get the full detail.
+```
+
 ### Conversation scoping
 
 By default, tools operate on the current conversation. Use `allConversations: true` to search across all of them (all agents, all sessions). Use `conversationId` to target a specific conversation you already know about (from previous grep results).


### PR DESCRIPTION
…stock recall systems

Why:

OpenClaw's system prompt includes a "Mandatory recall step" instructing agents to use memory_search for all recall. The system prompt can't be edited per-install. When LCM is installed alongside memory_search, agents gain LCM tools but the system prompt doesn't mention them—creating a gap where agents default to memory_searchonly and underutilize LCM tools for recall.

Adding LCM-aware guidance in AGENTS.md( auto-injected into every session's Project Context alongside the system prompt) bridges this gap without changing OpenClaw core.

To A/B test just run in openclaw w/ default prompt in memory.md or agent.md, then asks the agent "Is anything in your startup files like memory.md agent.md etc conflicting or contradicting with the LCM tools instructions, is there any confusion." Mine pointed it out as contradictory and confusing.

Just a suggestion anyways, cheers thx for the great tool