### PR TITLE
feat: Token budget aware fresh tail

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -25,6 +25,8 @@ export interface AssembleContextInput {
   tokenBudget: number;
   /** Number of most recent raw turns to always include (default: 8) */
   freshTailCount?: number;
+  /** Context threshold as fraction of budget, used for token-budget tail. */
+  contextThreshold?: number;
   /** Optional user query for relevance-based eviction scoring (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
   prompt?: string;
 }
@@ -936,9 +938,31 @@ export class ContextAssembler {
     const systemPromptAddition = buildSystemPromptAddition(summarySignals);
 
     // Step 3: Split into evictable prefix and protected fresh tail
-    const tailStart = Math.max(0, resolved.length - freshTailCount);
-    const baseFreshTail = resolved.slice(tailStart);
-    const initialEvictable = resolved.slice(0, tailStart);
+    let baseFreshTail: ResolvedItem[];
+    let initialEvictable: ResolvedItem[];
+
+    if (input.contextThreshold && input.contextThreshold > 0) {
+      const tailBudget = Math.floor(input.contextThreshold * tokenBudget);
+      let tokensUsed = 0;
+      let totalCount = 0;
+      let splitIdx = resolved.length;
+
+      for (let i = resolved.length - 1; i >= 0; i--) {
+        if (freshTailCount > 0 && totalCount >= freshTailCount) break;
+        const item = resolved[i]!;
+        if (tokensUsed + item.tokens > tailBudget) break;
+        tokensUsed += item.tokens;
+        splitIdx = i;
+        totalCount++;
+      }
+
+      baseFreshTail = resolved.slice(splitIdx);
+      initialEvictable = resolved.slice(0, splitIdx);
+    } else {
+      const tailStart = Math.max(0, resolved.length - freshTailCount);
+      baseFreshTail = resolved.slice(tailStart);
+      initialEvictable = resolved.slice(0, tailStart);
+    }
     const freshTailOrdinals = new Set(baseFreshTail.map((item) => item.ordinal));
     const tailToolCallIds = collectAssistantToolCallIds(baseFreshTail);
     const tailPairToolResults = initialEvictable.filter((item) => {

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -438,12 +438,16 @@ export class CompactionEngine {
    * `leafChunkTokens`. This lets callers trigger a soft incremental leaf pass
    * before the full context threshold is breached.
    */
-  async evaluateLeafTrigger(conversationId: number, leafChunkTokensOverride?: number): Promise<{
+  async evaluateLeafTrigger(
+    conversationId: number,
+    leafChunkTokensOverride?: number,
+    runtimeTokenBudget?: number,
+  ): Promise<{
     shouldCompact: boolean;
     rawTokensOutsideTail: number;
     threshold: number;
   }> {
-    const rawTokensOutsideTail = await this.countRawTokensOutsideFreshTail(conversationId);
+    const rawTokensOutsideTail = await this.countRawTokensOutsideFreshTail(conversationId, runtimeTokenBudget);
     const threshold = this.resolveLeafChunkTokens(leafChunkTokensOverride);
     return {
       shouldCompact: rawTokensOutsideTail >= threshold,
@@ -498,7 +502,11 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId, input.leafChunkTokens);
+    const leafTrigger = await this.evaluateLeafTrigger(
+      conversationId,
+      input.leafChunkTokens,
+      tokenBudget,
+    );
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {
@@ -509,7 +517,11 @@ export class CompactionEngine {
       };
     }
 
-    const leafChunk = await this.selectOldestLeafChunk(conversationId, input.leafChunkTokens);
+    const leafChunk = await this.selectOldestLeafChunk(
+      conversationId,
+      input.leafChunkTokens,
+      tokenBudget,
+    );
     if (leafChunk.items.length === 0) {
       return {
         actionTaken: false,
@@ -629,7 +641,7 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    const leafTrigger = await this.evaluateLeafTrigger(conversationId, undefined, tokenBudget);
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {
@@ -663,7 +675,7 @@ export class CompactionEngine {
     // after each pass. The arithmetic is exact: tokensAfter = tokensBefore - removed + added.
     let runningTokens = tokensBefore;
     while (true) {
-      const leafChunk = await this.selectOldestLeafChunk(conversationId);
+      const leafChunk = await this.selectOldestLeafChunk(conversationId, undefined, tokenBudget);
       if (leafChunk.items.length === 0) {
         break;
       }
@@ -915,6 +927,77 @@ export class CompactionEngine {
     return rawMessageItems[tailStartIdx]?.ordinal ?? Infinity;
   }
 
+  /** Tail token budget derived from the existing contextThreshold config. */
+  private resolveTailTokenBudget(runtimeTokenBudget: number): number {
+    return Math.floor(this.config.contextThreshold * runtimeTokenBudget);
+  }
+
+  /**
+   * Build a set of protected ordinals using a unified token budget.
+   *
+   * Walks backward from the most recent message. A message is protected
+   * as long as:
+   *  - The unified token budget has room
+   *  - The position cap (freshTailCount) hasn't been reached
+   *
+   * Returns undefined when the position-based tail already fits within the
+   * token budget (no override needed) or when config makes it inapplicable.
+   */
+  private async resolveTokenBudgetProtectedOrdinal(
+    contextItems: ContextItemRecord[],
+    runtimeTokenBudget: number,
+  ): Promise<number> {
+    const positionCap = this.resolveFreshTailCount();
+    if (positionCap <= 0) {
+      return this.resolveFreshTailOrdinal(contextItems);
+    }
+
+    const tailBudget = this.resolveTailTokenBudget(runtimeTokenBudget);
+    if (tailBudget <= 0) {
+      return this.resolveFreshTailOrdinal(contextItems);
+    }
+
+    const rawMessageItems = contextItems.filter(
+      (item) => item.itemType === "message" && item.messageId != null,
+    );
+    if (rawMessageItems.length === 0) {
+      return Infinity;
+    }
+
+    // If the position-based tail fits within the token budget, fall back
+    // to stock behavior — no override needed.
+    const tailStartIdx = Math.max(0, rawMessageItems.length - positionCap);
+    let positionTailTokens = 0;
+    for (let i = tailStartIdx; i < rawMessageItems.length; i++) {
+      positionTailTokens += await this.getMessageTokenCount(rawMessageItems[i]!.messageId!);
+    }
+    if (positionTailTokens <= tailBudget) {
+      return this.resolveFreshTailOrdinal(contextItems);
+    }
+
+    // Position-based tail would exceed the token budget — walk backward
+    // and protect only what fits.
+    let tokensUsed = 0;
+    let countUsed = 0;
+    let protectedOrdinal = Infinity;
+
+    for (let i = rawMessageItems.length - 1; i >= 0; i--) {
+      if (countUsed >= positionCap) {
+        break;
+      }
+      const item = rawMessageItems[i]!;
+      const tokens = await this.getMessageTokenCount(item.messageId!);
+      if (tokensUsed + tokens > tailBudget) {
+        break;
+      }
+      tokensUsed += tokens;
+      countUsed++;
+      protectedOrdinal = item.ordinal;
+    }
+
+    return protectedOrdinal;
+  }
+
   /** Resolve message token count with a content-length fallback. */
   private async getMessageTokenCount(messageId: number): Promise<number> {
     const message = await this.conversationStore.getMessageById(messageId);
@@ -932,9 +1015,14 @@ export class CompactionEngine {
   }
 
   /** Sum raw message tokens outside the protected fresh tail. */
-  private async countRawTokensOutsideFreshTail(conversationId: number): Promise<number> {
+  private async countRawTokensOutsideFreshTail(
+    conversationId: number,
+    runtimeTokenBudget?: number,
+  ): Promise<number> {
     const contextItems = await this.getContextItemsCached(conversationId);
-    const freshTailOrdinal = this.resolveFreshTailOrdinal(contextItems);
+    const freshTailOrdinal = runtimeTokenBudget
+      ? await this.resolveTokenBudgetProtectedOrdinal(contextItems, runtimeTokenBudget)
+      : this.resolveFreshTailOrdinal(contextItems);
     let rawTokens = 0;
 
     for (const item of contextItems) {
@@ -959,9 +1047,12 @@ export class CompactionEngine {
   private async selectOldestLeafChunk(
     conversationId: number,
     leafChunkTokensOverride?: number,
+    runtimeTokenBudget?: number,
   ): Promise<LeafChunkSelection> {
     const contextItems = await this.getContextItemsCached(conversationId);
-    const freshTailOrdinal = this.resolveFreshTailOrdinal(contextItems);
+    const freshTailOrdinal = runtimeTokenBudget
+      ? await this.resolveTokenBudgetProtectedOrdinal(contextItems, runtimeTokenBudget)
+      : this.resolveFreshTailOrdinal(contextItems);
     const threshold = this.resolveLeafChunkTokens(leafChunkTokensOverride);
 
     let rawTokensOutsideTail = 0;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3427,6 +3427,7 @@ export class LcmContextEngine implements ContextEngine {
         conversationId: conversation.conversationId,
         tokenBudget,
         freshTailCount: this.config.freshTailCount,
+        contextThreshold: this.config.contextThreshold,
         prompt: params.prompt,
       });
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1448,6 +1448,7 @@ describe("LCM integration: compaction", () => {
   it("compaction keeps leaf and condensed telemetry out of canonical transcript state", async () => {
     const condensedFriendlyEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
+      contextThreshold: 0,
       leafMinFanout: 2,
       leafChunkTokens: 100,
       condensedTargetTokens: 10,
@@ -1495,6 +1496,33 @@ describe("LCM integration: compaction", () => {
 
     const contextItems = await sumStore.getContextItems(CONV_ID);
     expect(contextItems.some((item) => item.itemType === "summary")).toBe(true);
+  });
+
+  it("token-budget tail exposes more messages to leaf compaction when tail is bloated", async () => {
+    const engine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 4,
+      leafChunkTokens: 100,
+    });
+
+    await convStore.createConversation({ sessionId: "token-budget-tail-session" });
+    // 8 msgs × 50 tokens = 400. freshTailCount=4 → 200 tokens protected.
+    // tailBudget = 0.75 * 260 = 195 < 200, so token-budget tail kicks in.
+    await ingestMessages(convStore, sumStore, 8, {
+      contentFn: (i) => `Turn ${i}: ${"c".repeat(200)}`,
+      tokenCountFn: () => 50,
+    });
+
+    const summarize = vi.fn(async () => "Compacted summary.");
+    const result = await engine.compact({
+      conversationId: CONV_ID,
+      tokenBudget: 260,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(result.tokensBefore).toBeGreaterThan(result.tokensAfter);
+    expect(summarize).toHaveBeenCalled();
   });
 
   it("depth-aware condensation sets condensed depth to max parent depth plus one", async () => {
@@ -2054,7 +2082,11 @@ describe("LCM integration: compaction", () => {
   });
 
   it("compactUntilUnder loops until under budget", async () => {
-    // Ingest many messages with substantial token counts
+    const engine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      contextThreshold: 0,
+    });
+
     await ingestMessages(convStore, sumStore, 20, {
       contentFn: (i) => `Turn ${i}: ${"c".repeat(200)}`,
       tokenCountFn: (_i, content) => estimateTokens(content),
@@ -2070,7 +2102,7 @@ describe("LCM integration: compaction", () => {
     // Set a tight budget that requires multiple rounds
     // Each message is ~52 tokens; 20 messages = ~1040 tokens total.
     // Set budget to 200 tokens to force multiple compaction rounds.
-    const result = await compactionEngine.compactUntilUnder({
+    const result = await engine.compactUntilUnder({
       conversationId: CONV_ID,
       tokenBudget: 200,
       summarize,
@@ -2079,6 +2111,31 @@ describe("LCM integration: compaction", () => {
     // Multiple rounds should have been needed
     expect(result.rounds).toBeGreaterThan(1);
     // Final tokens should be at or under budget (or we ran out of rounds)
+    if (result.success) {
+      expect(result.finalTokens).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it("compactUntilUnder converges faster with token-budget tail", async () => {
+    await ingestMessages(convStore, sumStore, 20, {
+      contentFn: (i) => `Turn ${i}: ${"c".repeat(200)}`,
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    let callCount = 0;
+    const summarize = vi.fn(async (text: string, _aggressive?: boolean) => {
+      callCount++;
+      return `Round ${callCount} summary of ${text.length} chars.`;
+    });
+
+    const result = await compactionEngine.compactUntilUnder({
+      conversationId: CONV_ID,
+      tokenBudget: 200,
+      summarize,
+    });
+
+    expect(result.rounds).toBeGreaterThanOrEqual(1);
+    expect(summarize).toHaveBeenCalled();
     if (result.success) {
       expect(result.finalTokens).toBeLessThanOrEqual(200);
     }


### PR DESCRIPTION
This basically just adds a way for us to force compact older messages when we actually reach the configured compaction threshold, instead of the blunt "keep last 64 messages no matter what" behaviour that could lead to overflows when using models with lower context lengths. Now we TRY to keep the last 64 (or whatever you configure) messages, but if they really don't fit, we gotta compact.

`freshTailCount` protects the last N messages from compaction regardless of size. With the default of 64, a handful of large tool results in the tail can exceed the context window and there's no way to compact them out, even when context is about to overflow. 

This is common in agentic workflows where tool results vary wildly in size. One message might be 50 tokens and the next one might be 30k. 

This adds a token-count cap to the fresh tail using the existing `contextThreshold` config. Walks backward from the newest message, accumulating tokens. Once the budget (`contextThreshold * contextWindow`) is hit, older messages lose protection and become compactable regardless of how many you try to protect with `freshTailCount`