### PR TITLE
fix: prevent empty assistant content from crashing provider APIs

### DIFF
--- a/.changeset/fix-empty-assistant-content.md
+++ b/.changeset/fix-empty-assistant-content.md
@@ -1,0 +1,22 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix crash when assistant message has empty content
+
+`contentFromParts()` returned an empty array `[]` when both message parts
+and fallback content were empty for assistant messages. Providers like
+Anthropic reject messages with zero ContentBlock entries, causing:
+
+> The content field in the Message object at messages.0 is empty.
+
+This can happen when:
+- A stored assistant message has no parts and empty content text
+- Tool-call-only assistant turns lose all blocks after orphan filtering
+
+Two fixes applied:
+1. `contentFromParts()` now always returns at least one text block for
+   assistant messages instead of an empty array.
+2. `assemble()` filters out any assistant messages that still end up with
+   empty content arrays as a safety net (e.g. after
+   `filterNonFreshAssistantToolCalls` removes all tool-call blocks).

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -475,7 +475,9 @@ function contentFromParts(
 ): unknown {
   if (parts.length === 0) {
     if (role === "assistant") {
-      return fallbackContent ? [{ type: "text", text: fallbackContent }] : [];
+      // Never return an empty content array — providers like Anthropic
+      // reject messages where content has zero ContentBlock entries.
+      return [{ type: "text", text: fallbackContent || "" }];
     }
     if (role === "toolResult") {
       return [{ type: "text", text: fallbackContent }];
@@ -949,8 +951,24 @@ export class ContextAssembler {
       }
     }
 
+    // Drop assistant messages with completely empty content arrays.
+    // This can happen when all tool-call blocks were filtered out by
+    // filterNonFreshAssistantToolCalls or when the original message
+    // was stored without any parts or text.  Providers like Anthropic
+    // reject such messages with "content field is empty".
+    const nonEmptyMessages = rawMessages.filter((msg) => {
+      if (
+        msg?.role === "assistant" &&
+        Array.isArray(msg.content) &&
+        (msg.content as unknown[]).length === 0
+      ) {
+        return false;
+      }
+      return true;
+    });
+
     return {
-      messages: sanitizeToolUseResultPairing(rawMessages) as AgentMessage[],
+      messages: sanitizeToolUseResultPairing(nonEmptyMessages) as AgentMessage[],
       estimatedTokens,
       systemPromptAddition,
       stats: {


### PR DESCRIPTION
## Problem

When LCM assembles context from the SQLite database, assistant messages can end up with an empty `content` array (`[]`). This causes provider APIs like Anthropic Claude to reject the request with:

> The content field in the Message object at messages.0 is empty. Add a ContentBlock object to the content field and try again.

### Root Cause

In `src/assembler.ts`, `contentFromParts()` returns `[]` when:
1. The message has no stored parts (`parts.length === 0`)  
2. The fallback content is an empty string (`""` is falsy)

```typescript
// Before (bug):
return fallbackContent ? [{ type: "text", text: fallbackContent }] : [];
```

This can happen when:
- A stored assistant message has no message_parts rows and empty content text
- Tool-call-only assistant turns are stored without text content
- Session reset/compaction leaves orphaned empty assistant records

Additionally, `filterNonFreshAssistantToolCalls()` can strip all tool-call blocks from a non-fresh assistant message, leaving `content: []`, but the empty-check only skips messages where the *filtering itself* produced an empty array — messages that started empty pass through.

## Fix

Two defensive layers:

1. **`contentFromParts()`**: Always return at least one text block for assistant messages instead of an empty array:
   ```typescript
   return [{ type: "text", text: fallbackContent || "" }];
   ```

2. **`assemble()` safety net**: Filter out any assistant messages that still have empty content arrays before returning, catching edge cases from tool-call orphan filtering:
   ```typescript
   const nonEmptyMessages = rawMessages.filter((msg) => {
     if (msg?.role === "assistant" && Array.isArray(msg.content) && msg.content.length === 0) {
       return false;
     }
     return true;
   });
   ```

## Testing

- Verified the fix handles the exact error scenario from production logs
- Both Anthropic and OpenAI APIs require non-empty content arrays for assistant messages
- The changeset is included for version bumping