### PR TITLE
fix: add databasePath alias to plugin schema

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -210,6 +210,10 @@
       },
       "pruneHeartbeatOk": {
         "type": "boolean"
+      },
+      "databasePath": {
+        "description": "Path to LCM SQLite database (alias for dbPath)",
+        "type": "string"
       }
     }
   }


### PR DESCRIPTION
## What
This PR adds `databasePath` to `openclaw.plugin.json` so the manifest schema accepts the runtime-supported alias for `dbPath`.

## Why
Lossless-claw's runtime config loader accepts both `dbPath` and `databasePath`, but OpenClaw validates plugin config against `openclaw.plugin.json` with `additionalProperties: false`. Without this alias in the schema, a valid runtime config key can still be rejected before startup.

## Changes
- Add `databasePath` to plugin manifest schema

## Testing
- Parsed `openclaw.plugin.json` after the schema update
- Expected outcome: manifest remains valid JSON and OpenClaw accepts `databasePath` as a config alias
