### PR TITLE
fix: handle session_end lifecycle rollover

### DIFF
--- a/.changeset/session-end-lifecycle.md
+++ b/.changeset/session-end-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use OpenClaw's enriched `session_end` hook to preserve clean LCM conversation boundaries across automatic session rollover, compaction session replacement, and session deletion.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Lossless-claw distinguishes OpenClaw's two session-reset commands:
 - `2`: keep d2+ summaries; recommended default
 - `3+`: keep only deeper, more abstract summaries
 
-Lossless-claw currently applies these storage semantics through the `before_reset` hook only. User-facing confirmation text after `/new` or `/reset` must be emitted by OpenClaw's command handlers.
+Lossless-claw applies `/new` pruning through `before_reset` and uses `session_end` to catch transcript rollovers such as `/reset`, idle or daily session rotation, compaction session replacement, and deletions. User-facing confirmation text after `/new` or `/reset` must still be emitted by OpenClaw's command handlers.
 
 Use `ignoreSessionPatterns` or `LCM_IGNORE_SESSION_PATTERNS` to keep low-value sessions completely out of LCM. Matching sessions do not create conversations, do not store messages, and do not participate in compaction or delegated expansion grants.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,7 @@ Lossless-claw treats the two OpenClaw reset commands differently:
 - `/reset` archives the active conversation row and creates a fresh active row for the same stable `sessionKey`.
 
 This preserves lossless history while still giving users a real clean-slate command.
-OpenClaw's command handlers still own the user-facing post-command disclosure text; lossless-claw applies only the underlying storage transition through `before_reset`.
+Lossless-claw applies `/new` through `before_reset`, then uses `session_end` to catch the broader rollover cases OpenClaw can emit: `/reset`, idle or daily session rotation, compaction-driven session replacement, and deletions. OpenClaw's command handlers still own the user-facing post-command disclosure text.
 
 Use `ignoreSessionPatterns` or `LCM_IGNORE_SESSION_PATTERNS` to keep low-value sessions completely out of LCM. Matching sessions do not create conversations, do not store messages, and do not participate in compaction or delegated expansion grants.
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -48,6 +48,7 @@ import { compileSessionPatterns, matchesSessionPattern } from "./session-pattern
 import { logStartupBannerOnce } from "./startup-banner-log.js";
 import {
   ConversationStore,
+  type ConversationRecord,
   type CreateMessagePartInput,
   type MessagePartRecord,
   type MessagePartType,
@@ -3219,6 +3220,69 @@ export class LcmContextEngine implements ContextEngine {
     // The shared connection is managed for the lifetime of the plugin process.
   }
 
+  /** Detect the empty replacement row created during a prior lifecycle rollover. */
+  private async isFreshLifecycleConversation(conversation: ConversationRecord): Promise<boolean> {
+    const currentMessageCount = await this.conversationStore.getMessageCount(conversation.conversationId);
+    if (currentMessageCount !== 0) {
+      return false;
+    }
+    const currentContextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+    return currentContextItems.length === 0 && !conversation.bootstrappedAt;
+  }
+
+  /**
+   * Archive the current active conversation and optionally create the replacement
+   * row that bootstrap should attach to for the next session transcript.
+   */
+  private async applySessionReplacement(params: {
+    reason: string;
+    sessionId?: string;
+    sessionKey?: string;
+    nextSessionId?: string;
+    nextSessionKey?: string;
+    createReplacement: boolean;
+    createReplacementWhenMissing?: boolean;
+  }): Promise<void> {
+    const current = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    if (!current && !params.createReplacementWhenMissing) {
+      return;
+    }
+
+    if (current?.active) {
+      if (params.createReplacement && await this.isFreshLifecycleConversation(current)) {
+        this.deps.log.info(
+          `[lcm] ${params.reason} lifecycle no-op for already fresh conversation ${current.conversationId}`,
+        );
+        return;
+      }
+      await this.conversationStore.archiveConversation(current.conversationId);
+    }
+
+    if (!params.createReplacement) {
+      this.deps.log.info(
+        `[lcm] ${params.reason} lifecycle archived conversation ${current?.conversationId ?? "(none)"}`,
+      );
+      return;
+    }
+
+    const nextSessionId = params.nextSessionId?.trim() || params.sessionId?.trim() || current?.sessionId;
+    if (!nextSessionId) {
+      this.deps.log.warn(`[lcm] ${params.reason} lifecycle skipped: no session identity available`);
+      return;
+    }
+    const nextSessionKey = params.nextSessionKey?.trim() || params.sessionKey?.trim() || current?.sessionKey;
+    const freshConversation = await this.conversationStore.createConversation({
+      sessionId: nextSessionId,
+      sessionKey: nextSessionKey,
+    });
+    this.deps.log.info(
+      `[lcm] ${params.reason} lifecycle archived prior conversation and created ${freshConversation.conversationId}`,
+    );
+  }
+
   /** Apply LCM lifecycle semantics for OpenClaw's /new and /reset commands. */
   async handleBeforeReset(params: {
     reason?: string;
@@ -3261,44 +3325,50 @@ export class LcmContextEngine implements ContextEngine {
             );
             return;
           }
-
-          const current = await this.conversationStore.getConversationForSession({
+          await this.applySessionReplacement({
+            reason: "/reset",
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
+            createReplacement: true,
+            createReplacementWhenMissing: true,
           });
-          if (current?.active) {
-            const currentMessageCount = await this.conversationStore.getMessageCount(
-              current.conversationId,
-            );
-            const currentContextItems = await this.summaryStore.getContextItems(
-              current.conversationId,
-            );
-            if (
-              currentMessageCount === 0
-              && currentContextItems.length === 0
-              && !current.bootstrappedAt
-            ) {
-              this.deps.log.info(
-                `[lcm] /reset no-op for already fresh conversation ${current.conversationId}`,
-              );
-              return;
-            }
-            await this.conversationStore.archiveConversation(current.conversationId);
-          }
+        }),
+    );
+  }
 
-          const nextSessionId = params.sessionId?.trim() || current?.sessionId;
-          if (!nextSessionId) {
-            this.deps.log.warn("[lcm] /reset skipped: no session identity available");
-            return;
-          }
+  /** Apply generic lifecycle semantics for session rollover and deletion hooks. */
+  async handleSessionEnd(params: {
+    reason?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    nextSessionId?: string;
+    nextSessionKey?: string;
+  }): Promise<void> {
+    const reason = params.reason?.trim();
+    if (!reason || reason === "new" || reason === "unknown") {
+      return;
+    }
+    if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      return;
+    }
+    if (this.isStatelessSession(params.sessionKey ?? params.nextSessionKey)) {
+      return;
+    }
 
-          const freshConversation = await this.conversationStore.createConversation({
-            sessionId: nextSessionId,
-            sessionKey: params.sessionKey?.trim(),
+    const createReplacement = reason !== "deleted";
+    this.ensureMigrated();
+    await this.withSessionQueue(
+      this.resolveSessionQueueKey(params.nextSessionId ?? params.sessionId, params.sessionKey ?? params.nextSessionKey),
+      async () =>
+        this.conversationStore.withTransaction(async () => {
+          await this.applySessionReplacement({
+            reason: `session_end:${reason}`,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey ?? params.nextSessionKey,
+            nextSessionId: params.nextSessionId,
+            nextSessionKey: params.nextSessionKey,
+            createReplacement,
           });
-          this.deps.log.info(
-            `[lcm] /reset archived prior conversation and created ${freshConversation.conversationId}`,
-          );
         }),
     );
   }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -66,6 +66,14 @@ type RuntimeModelAuthResult = {
   apiKey?: string;
 };
 
+type SessionEndLifecycleEvent = {
+  sessionId?: string;
+  sessionKey?: string;
+  reason?: string;
+  nextSessionId?: string;
+  nextSessionKey?: string;
+};
+
 type RuntimeModelAuthModel = {
   id: string;
   provider: string;
@@ -1568,6 +1576,16 @@ const lcmPlugin = {
     api.on("before_prompt_build", () => ({
       prependSystemContext: LOSSLESS_RECALL_POLICY_PROMPT,
     }));
+    api.on("session_end", async (event) => {
+      const lifecycleEvent = event as SessionEndLifecycleEvent;
+      await lcm.handleSessionEnd({
+        reason: lifecycleEvent.reason,
+        sessionId: lifecycleEvent.sessionId,
+        sessionKey: lifecycleEvent.sessionKey,
+        nextSessionId: lifecycleEvent.nextSessionId,
+        nextSessionKey: lifecycleEvent.nextSessionKey,
+      });
+    });
     api.registerContextEngine("lossless-claw", () => lcm);
     api.registerContextEngine("default", () => lcm);
     api.registerTool((ctx) =>

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1012,6 +1012,135 @@ describe("LcmContextEngine before_reset lifecycle", () => {
   });
 });
 
+describe("LcmContextEngine session_end lifecycle", () => {
+  it("ignores session_end new so /new stays a prune-in-place flow", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+    await store.createMessage({
+      conversationId: original.conversationId,
+      seq: 1,
+      role: "user",
+      content: "seed",
+      tokenCount: 5,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "new",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+      nextSessionId: "uuid-2",
+    });
+
+    const active = await store.getConversationBySessionKey("agent:main:main");
+    expect(active?.conversationId).toBe(original.conversationId);
+    expect(active?.active).toBe(true);
+  });
+
+  it("archives the prior active conversation and creates a fresh active row on idle rollover", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+    await store.createMessage({
+      conversationId: original.conversationId,
+      seq: 1,
+      role: "user",
+      content: "seed",
+      tokenCount: 5,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "idle",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+      nextSessionId: "uuid-2",
+    });
+
+    const active = await store.getConversationBySessionKey("agent:main:main");
+    const archived = await store.getConversation(original.conversationId);
+
+    expect(active).not.toBeNull();
+    expect(active?.conversationId).not.toBe(original.conversationId);
+    expect(active?.sessionId).toBe("uuid-2");
+    expect(active?.active).toBe(true);
+    expect(archived?.active).toBe(false);
+    expect(archived?.archivedAt).not.toBeNull();
+  });
+
+  it("archives the active conversation without replacement on deleted session_end", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+    await store.createMessage({
+      conversationId: original.conversationId,
+      seq: 1,
+      role: "user",
+      content: "seed",
+      tokenCount: 5,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "deleted",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+    });
+
+    const active = await store.getConversationBySessionKey("agent:main:main");
+    const archived = await store.getConversation(original.conversationId);
+
+    expect(active).toBeNull();
+    expect(archived?.active).toBe(false);
+    expect(archived?.archivedAt).not.toBeNull();
+  });
+
+  it("treats session_end reset after before_reset as a no-op on the fresh replacement row", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+    await store.createMessage({
+      conversationId: original.conversationId,
+      seq: 1,
+      role: "user",
+      content: "seed",
+      tokenCount: 5,
+    });
+
+    await engine.handleBeforeReset({
+      reason: "reset",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+    });
+    const firstFresh = await store.getConversationBySessionKey("agent:main:main");
+
+    await engine.handleSessionEnd({
+      reason: "reset",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+      nextSessionId: "uuid-2",
+    });
+    const secondFresh = await store.getConversationBySessionKey("agent:main:main");
+
+    expect(firstFresh?.conversationId).not.toBe(original.conversationId);
+    expect(secondFresh?.conversationId).toBe(firstFresh?.conversationId);
+  });
+});
+
 describe("LcmContextEngine delegated session continuity", () => {
   it("prepares subagent spawn from an existing conversation found by sessionKey", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -197,6 +197,7 @@ describe("lcm plugin registration", () => {
       "[lcm] Compaction summarization model: (unconfigured)",
     );
     expect(api.on).toHaveBeenCalledWith("before_reset", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("session_end", expect.any(Function));
   });
 
   it("inherits OpenClaw's default model for summarization when no LCM model override is set", { timeout: 20000 }, () => {


### PR DESCRIPTION
## What
Teach lossless-claw to consume OpenClaw's enriched `session_end` lifecycle hook so LCM keeps clean conversation boundaries across automatic rollover, compaction-driven session replacement, and session deletion, while preserving the existing `/new` prune semantics.

## Why
OpenClaw PR #59715 makes `session_end` the stable generic hook for old-session teardown. Without consuming it, lossless-claw still only reacts to manual `before_reset`, which leaves automatic daily/idle rollover and compaction session replacement reusing the old active conversation.

## Changes
- Register `session_end` lifecycle hook
- Add generic rollover/delete engine handling
- Keep `/new` prune-only semantics intact
- Guard duplicate `/reset` rotation
- Add lifecycle docs and changeset
- Cover new lifecycle flows with tests

## Testing
- `npm test -- test/engine.test.ts test/plugin-config-registration.test.ts`
- Expected: both test files pass, including the new `session_end` rollover and delete lifecycle coverage
