### PR TITLE
fix: filter empty-content assistant messages before API call

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -949,8 +949,19 @@ export class ContextAssembler {
       }
     }
 
+    // Filter out assistant messages with empty content — these can occur when
+    // tool-use-only turns are stored with content="" and zero message_parts,
+    // or when filterNonFreshAssistantToolCalls strips all tool_use blocks.
+    // Anthropic (and other providers) reject empty content arrays/strings.
+    const cleaned = rawMessages.filter(
+      (m) =>
+        !(
+          m?.role === "assistant" &&
+          (Array.isArray(m.content) ? m.content.length === 0 : !m.content)
+        ),
+    );
     return {
-      messages: sanitizeToolUseResultPairing(rawMessages) as AgentMessage[],
+      messages: sanitizeToolUseResultPairing(cleaned) as AgentMessage[],
       estimatedTokens,
       systemPromptAddition,
       stats: {


### PR DESCRIPTION
## Problem

Anthropic API rejects messages with empty content:

```
The content field in the Message object at messages.0 is empty.
Add a ContentBlock object to the content field and try again.
```

This occurs when:
1. Tool-use-only assistant turns are stored with `content=''` and zero `message_parts` in the database
2. `filterNonFreshAssistantToolCalls()` strips all tool_use blocks from a non-fresh assistant message, leaving `content: []`

## Root Cause

`assembler.ts assemble()` passes `rawMessages` directly to `sanitizeToolUseResultPairing()` and then to the API without validating that assistant messages have non-empty content.

While `filterNonFreshAssistantToolCalls()` does skip messages where `content.length === 0` after filtering, this only covers the array case. Messages with falsy string content (`''`) bypass this check via the `!Array.isArray()` branch and are passed through unchanged.

## Fix

Add an explicit filter in `assemble()` before the return statement that removes assistant messages with empty content (either `[]` or falsy string). Only targets assistant role — user messages are left untouched.

```typescript
const cleaned = rawMessages.filter(
  (m) =>
    !(
      m?.role === 'assistant' &&
      (Array.isArray(m.content) ? m.content.length === 0 : !m.content)
    ),
);
```

## Testing

Verified on production instance with 5,246+ affected messages across 12 conversations. Filter correctly removes empty assistant messages while preserving all valid messages. All agents recovered immediately after deploying this fix.