### PR TITLE
fix: sync plugin config schema

### DIFF
--- a/.changeset/plugin-config-schema-sync.md
+++ b/.changeset/plugin-config-schema-sync.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Sync the published plugin manifest schema with the runtime-supported plugin config surface so documented config keys are accepted by OpenClaw. This also removes the undocumented `autocompactDisabled` setting from the advertised config surface because it was parsed but not wired to runtime behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,9 @@
 ## Release Notes Source Of Truth
 
 - Follow [RELEASING.md](./RELEASING.md) for the repo's full Changesets and publish workflow.
+
+## Config Schema Sync
+
+- Whenever you add, rename, or remove a plugin config option in the runtime config loader or docs, update [`openclaw.plugin.json`](./openclaw.plugin.json) in the same change.
+- Keep the manifest `configSchema` and `uiHints` aligned with every supported `plugins.entries.lossless-claw.config` field so OpenClaw accepts documented config keys.
+- Add or update a regression test when changing config options so schema drift is caught before release.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_EXPANSION_MODEL` | *(from OpenClaw)* | Model override for `lcm_expand_query` sub-agent (e.g. `anthropic/claude-haiku-4-5`) |
 | `LCM_EXPANSION_PROVIDER` | *(from OpenClaw)* | Provider override for `lcm_expand_query` sub-agent |
 | `LCM_DELEGATION_TIMEOUT_MS` | `120000` | Max time to wait for delegated `lcm_expand_query` sub-agent completion |
-| `LCM_AUTOCOMPACT_DISABLED` | `false` | Disable automatic compaction after turns |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 
 ### Expansion model override requirements

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -21,6 +21,18 @@
       "label": "New Session Retain Depth",
       "help": "Context retained after /new (-1 keeps all context, 2 keeps d2+)"
     },
+    "leafTargetTokens": {
+      "label": "Leaf Target Tokens",
+      "help": "Target token count for leaf summaries"
+    },
+    "condensedTargetTokens": {
+      "label": "Condensed Target Tokens",
+      "help": "Target token count for condensed summaries"
+    },
+    "maxExpandTokens": {
+      "label": "Max Expand Tokens",
+      "help": "Token cap for lcm_expand_query expansion calls"
+    },
     "dbPath": {
       "label": "Database Path",
       "help": "Path to LCM SQLite database (default: ~/.openclaw/lcm.db)"
@@ -45,6 +57,14 @@
       "label": "Summary Provider",
       "help": "Provider override used only when summaryModel is a bare model name (e.g., 'openai-resp')"
     },
+    "largeFileSummaryModel": {
+      "label": "Large File Summary Model",
+      "help": "Model override for large-file summarization"
+    },
+    "largeFileSummaryProvider": {
+      "label": "Large File Summary Provider",
+      "help": "Provider override for large-file summarization"
+    },
     "expansionModel": {
       "label": "Expansion Model",
       "help": "Model override for lcm_expand_query sub-agent (e.g., 'anthropic/claude-haiku-4-5')"
@@ -68,6 +88,14 @@
     "customInstructions": {
       "label": "Custom Instructions",
       "help": "Natural language instructions injected into all summarization prompts (e.g., formatting rules, tone control)"
+    },
+    "timezone": {
+      "label": "Timezone",
+      "help": "IANA timezone used for summary timestamps"
+    },
+    "pruneHeartbeatOk": {
+      "label": "Prune HEARTBEAT_OK",
+      "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
     }
   },
   "configSchema": {
@@ -97,6 +125,18 @@
       "newSessionRetainDepth": {
         "type": "integer",
         "minimum": -1
+      },
+      "leafTargetTokens": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "condensedTargetTokens": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "maxExpandTokens": {
+        "type": "integer",
+        "minimum": 1
       },
       "leafMinFanout": {
         "type": "integer",
@@ -138,6 +178,12 @@
       "summaryProvider": {
         "type": "string"
       },
+      "largeFileSummaryModel": {
+        "type": "string"
+      },
+      "largeFileSummaryProvider": {
+        "type": "string"
+      },
       "expansionModel": {
         "type": "string"
       },
@@ -158,6 +204,12 @@
       },
       "customInstructions": {
         "type": "string"
+      },
+      "timezone": {
+        "type": "string"
+      },
+      "pruneHeartbeatOk": {
+        "type": "boolean"
       }
     }
   }

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -40,7 +40,6 @@ export type LcmConfig = {
   expansionModel: string;
   /** Max time to wait for delegated lcm_expand_query sub-agent completion. */
   delegationTimeoutMs: number;
-  autocompactDisabled: boolean;
   /** IANA timezone for timestamps in summaries (from TZ env or system default) */
   timezone: string;
   /** When true, retroactively delete HEARTBEAT_OK turn cycles from LCM storage. */
@@ -199,10 +198,6 @@ export function resolveLcmConfig(
     expansionModel:
       env.LCM_EXPANSION_MODEL?.trim() ?? toStr(pc.expansionModel) ?? "",
     delegationTimeoutMs: envDelegationTimeoutMs ?? toNumber(pc.delegationTimeoutMs) ?? 120000,
-    autocompactDisabled:
-      env.LCM_AUTOCOMPACT_DISABLED !== undefined
-        ? env.LCM_AUTOCOMPACT_DISABLED === "true"
-        : toBool(pc.autocompactDisabled) ?? false,
     timezone: env.TZ ?? toStr(pc.timezone) ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
     pruneHeartbeatOk:
       env.LCM_PRUNE_HEARTBEAT_OK !== undefined

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,7 +20,6 @@ describe("resolveLcmConfig", () => {
     expect(config.leafTargetTokens).toBe(2400);
     expect(config.summaryProvider).toBe("");
     expect(config.summaryModel).toBe("");
-    expect(config.autocompactDisabled).toBe(false);
     expect(config.pruneHeartbeatOk).toBe(false);
   });
 
@@ -36,7 +35,6 @@ describe("resolveLcmConfig", () => {
       skipStatelessSessions: false,
       leafMinFanout: 4,
       condensedMinFanout: 2,
-      autocompactDisabled: true,
       pruneHeartbeatOk: true,
       enabled: false,
     });
@@ -54,7 +52,6 @@ describe("resolveLcmConfig", () => {
     expect(config.incrementalMaxDepth).toBe(-1);
     expect(config.leafMinFanout).toBe(4);
     expect(config.condensedMinFanout).toBe(2);
-    expect(config.autocompactDisabled).toBe(true);
     expect(config.pruneHeartbeatOk).toBe(true);
   });
 
@@ -65,7 +62,6 @@ describe("resolveLcmConfig", () => {
       LCM_NEW_SESSION_RETAIN_DEPTH: "5",
       LCM_INCREMENTAL_MAX_DEPTH: "3",
       LCM_ENABLED: "false",
-      LCM_AUTOCOMPACT_DISABLED: "true",
       LCM_IGNORE_SESSION_PATTERNS: "agent:*:cron:*, agent:main:subagent:**",
       LCM_STATELESS_SESSION_PATTERNS: "agent:*:ephemeral:**, agent:main:preview:*",
       LCM_SKIP_STATELESS_SESSIONS: "false",
@@ -78,7 +74,6 @@ describe("resolveLcmConfig", () => {
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
       enabled: true,
-      autocompactDisabled: false,
     };
     const config = resolveLcmConfig(env, pluginConfig);
     expect(config.enabled).toBe(false); // env wins
@@ -95,7 +90,6 @@ describe("resolveLcmConfig", () => {
     expect(config.freshTailCount).toBe(64); // env wins
     expect(config.newSessionRetainDepth).toBe(5); // env wins
     expect(config.incrementalMaxDepth).toBe(3); // env wins
-    expect(config.autocompactDisabled).toBe(true); // env wins
   });
 
   it("plugin config fills gaps when env vars are absent", () => {
@@ -327,6 +321,28 @@ describe("resolveLcmConfig", () => {
       type: "integer",
       minimum: 1,
     });
+  });
+
+  it("ships a manifest with plugin-config schema entries for runtime token controls", () => {
+    expect(manifest.configSchema.properties.leafTargetTokens).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(manifest.configSchema.properties.condensedTargetTokens).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(manifest.configSchema.properties.maxExpandTokens).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+  });
+
+  it("ships a manifest with schema entries for runtime-only toggles and model overrides", () => {
+    expect(manifest.configSchema.properties.largeFileSummaryModel).toEqual({ type: "string" });
+    expect(manifest.configSchema.properties.largeFileSummaryProvider).toEqual({ type: "string" });
+    expect(manifest.configSchema.properties.timezone).toEqual({ type: "string" });
+    expect(manifest.configSchema.properties.pruneHeartbeatOk).toEqual({ type: "boolean" });
   });
 
   it("defaults summaryMaxOverageFactor to 3 and maxAssemblyTokenBudget to undefined", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -43,7 +43,6 @@ function createTestConfig(databasePath: string): LcmConfig {
     summaryModel: "",
     largeFileSummaryProvider: "",
     largeFileSummaryModel: "",
-    autocompactDisabled: false,
     timezone: "UTC",
     pruneHeartbeatOk: false,
     summaryMaxOverageFactor: 3,

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -25,7 +25,6 @@ const BASE_CONFIG: LcmConfig = {
   summaryModel: "",
   largeFileSummaryProvider: "",
   largeFileSummaryModel: "",
-  autocompactDisabled: false,
   timezone: "UTC",
   pruneHeartbeatOk: false,
   summaryMaxOverageFactor: 3,

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -83,7 +83,6 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       expansionProvider: "",
       expansionModel: "",
       delegationTimeoutMs: 120000,
-      autocompactDisabled: false,
       timezone: "UTC",
       pruneHeartbeatOk: false,
       summaryMaxOverageFactor: 3,

--- a/test/lcm-expand-tool.test.ts
+++ b/test/lcm-expand-tool.test.ts
@@ -49,7 +49,6 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       summaryModel: "",
       largeFileSummaryProvider: "",
       largeFileSummaryModel: "",
-      autocompactDisabled: false,
       timezone: "UTC",
       pruneHeartbeatOk: false,
       summaryMaxOverageFactor: 3,

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -48,7 +48,6 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       summaryModel: "",
       largeFileSummaryProvider: "",
       largeFileSummaryModel: "",
-      autocompactDisabled: false,
       timezone: "UTC",
       pruneHeartbeatOk: false,
       summaryMaxOverageFactor: 3,

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -45,7 +45,6 @@ function createTestConfig(databasePath: string): LcmConfig {
     summaryModel: "",
     largeFileSummaryProvider: "",
     largeFileSummaryModel: "",
-    autocompactDisabled: false,
     timezone: "UTC",
     pruneHeartbeatOk: false,
     summaryMaxOverageFactor: 3,

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -37,7 +37,6 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       summaryModel: "",
       largeFileSummaryProvider: "",
       largeFileSummaryModel: "",
-      autocompactDisabled: false,
       timezone: "UTC",
       pruneHeartbeatOk: false,
       summaryMaxOverageFactor: 3,


### PR DESCRIPTION
## What
This PR syncs `openclaw.plugin.json` with the runtime-supported plugin config surface so valid lossless-claw settings are accepted by OpenClaw instead of failing schema validation. It also removes the dead `autocompactDisabled` option from the advertised config surface and adds release metadata plus regression coverage to keep the manifest from drifting again.

## Why
Issue #247 reported that the published docs and runtime supported config keys that the published plugin manifest rejected as additional properties, which could prevent the gateway from starting. The manifest is the schema OpenClaw enforces, so it needs to stay aligned with the actual config loader and documented settings.

## Changes
- Add missing manifest schema entries
- Add missing manifest UI hints
- Remove dead `autocompactDisabled` option
- Add config-schema regression coverage
- Add maintainer changeset for release
- Add repo guidance for schema sync

| File | Change |
|------|--------|
| `openclaw.plugin.json` | Added missing schema and uiHints entries for supported config keys |
| `src/db/config.ts` | Removed dead `autocompactDisabled` parsing from runtime config |
| `README.md` | Removed unsupported `LCM_AUTOCOMPACT_DISABLED` documentation |
| `test/config.test.ts` | Added manifest schema coverage and removed dead option expectations |
| `test/engine.test.ts` | Removed dead config fixture field |
| `test/expansion.test.ts` | Removed dead config fixture field |
| `test/lcm-expand-query-tool.test.ts` | Removed dead config fixture field |
| `test/lcm-expand-tool.test.ts` | Removed dead config fixture field |
| `test/lcm-tools.test.ts` | Removed dead config fixture field |
| `test/session-operation-queues.test.ts` | Removed dead config fixture field |
| `test/summarize.test.ts` | Removed dead config fixture field |
| `AGENTS.md` | Added rule to keep manifest and runtime config in sync |
| `.changeset/plugin-config-schema-sync.md` | Added patch release note for the next publish |

## Testing
- `npx vitest run test/config.test.ts test/engine.test.ts test/expansion.test.ts test/lcm-expand-query-tool.test.ts test/lcm-expand-tool.test.ts test/lcm-tools.test.ts test/session-operation-queues.test.ts test/summarize.test.ts`
- Expected outcome: all listed Vitest suites pass

Fixes #247
