### PR TITLE
fix: cap first bootstrap parent import

### DIFF
--- a/.changeset/bootstrap-context-budget.md
+++ b/.changeset/bootstrap-context-budget.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Limit first-time fork bootstrap imports so new conversations only inherit the newest slice of raw parent history instead of loading the entire parent transcript into lossless memory.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -17,6 +17,10 @@
       "label": "Leaf Chunk Tokens",
       "help": "Maximum source tokens per leaf compaction chunk before summarization"
     },
+    "bootstrapMaxTokens": {
+      "label": "Bootstrap Max Tokens",
+      "help": "Maximum raw parent-history tokens imported into a brand-new conversation bootstrap; oldest turns are dropped first"
+    },
     "newSessionRetainDepth": {
       "label": "New Session Retain Depth",
       "help": "Context retained after /new (-1 keeps all context, 2 keeps d2+)"
@@ -119,6 +123,10 @@
         "minimum": 1
       },
       "leafChunkTokens": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "bootstrapMaxTokens": {
         "type": "integer",
         "minimum": 1
       },

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -18,6 +18,8 @@ export type LcmConfig = {
   condensedMinFanoutHard: number;
   incrementalMaxDepth: number;
   leafChunkTokens: number;
+  /** Maximum raw parent-history tokens imported during first-time bootstrap. */
+  bootstrapMaxTokens?: number;
   leafTargetTokens: number;
   condensedTargetTokens: number;
   maxExpandTokens: number;
@@ -112,6 +114,13 @@ export function resolveLcmConfig(
   pluginConfig?: Record<string, unknown>,
 ): LcmConfig {
   const pc = pluginConfig ?? {};
+  const resolvedLeafChunkTokens =
+    (env.LCM_LEAF_CHUNK_TOKENS !== undefined ? parseInt(env.LCM_LEAF_CHUNK_TOKENS, 10) : undefined)
+      ?? toNumber(pc.leafChunkTokens) ?? 20000;
+  const resolvedBootstrapMaxTokens =
+    (env.LCM_BOOTSTRAP_MAX_TOKENS !== undefined ? parseInt(env.LCM_BOOTSTRAP_MAX_TOKENS, 10) : undefined)
+      ?? toNumber(pc.bootstrapMaxTokens)
+      ?? Math.max(6000, Math.floor(resolvedLeafChunkTokens * 0.3));
   const envDelegationTimeoutMs =
     env.LCM_DELEGATION_TIMEOUT_MS !== undefined
       ? toNumber(env.LCM_DELEGATION_TIMEOUT_MS)
@@ -168,9 +177,8 @@ export function resolveLcmConfig(
     incrementalMaxDepth:
       (env.LCM_INCREMENTAL_MAX_DEPTH !== undefined ? parseInt(env.LCM_INCREMENTAL_MAX_DEPTH, 10) : undefined)
         ?? toNumber(pc.incrementalMaxDepth) ?? 1,
-    leafChunkTokens:
-      (env.LCM_LEAF_CHUNK_TOKENS !== undefined ? parseInt(env.LCM_LEAF_CHUNK_TOKENS, 10) : undefined)
-        ?? toNumber(pc.leafChunkTokens) ?? 20000,
+    leafChunkTokens: resolvedLeafChunkTokens,
+    bootstrapMaxTokens: resolvedBootstrapMaxTokens,
     leafTargetTokens:
       (env.LCM_LEAF_TARGET_TOKENS !== undefined ? parseInt(env.LCM_LEAF_TARGET_TOKENS, 10) : undefined)
         ?? toNumber(pc.leafTargetTokens) ?? 2400,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -830,6 +830,63 @@ async function readLeafPathMessages(sessionFile: string): Promise<AgentMessage[]
   }
 }
 
+/**
+ * Resolve the first-time bootstrap token budget.
+ *
+ * When unset, bootstrap keeps a modest suffix of the parent session rather than
+ * inheriting the full raw history into a brand-new conversation.
+ */
+function resolveBootstrapMaxTokens(config: Pick<LcmConfig, "bootstrapMaxTokens" | "leafChunkTokens">): number {
+  if (
+    typeof config.bootstrapMaxTokens === "number" &&
+    Number.isFinite(config.bootstrapMaxTokens) &&
+    config.bootstrapMaxTokens > 0
+  ) {
+    return Math.floor(config.bootstrapMaxTokens);
+  }
+
+  const leafChunkTokens =
+    typeof config.leafChunkTokens === "number" &&
+    Number.isFinite(config.leafChunkTokens) &&
+    config.leafChunkTokens > 0
+      ? Math.floor(config.leafChunkTokens)
+      : 20_000;
+  return Math.max(6000, Math.floor(leafChunkTokens * 0.3));
+}
+
+/**
+ * Keep only the newest bootstrap messages that fit within the token budget.
+ *
+ * The newest message is always preserved so a fork never starts empty when the
+ * parent transcript has any recoverable content at all.
+ */
+function trimBootstrapMessagesToBudget(messages: AgentMessage[], maxTokens: number): AgentMessage[] {
+  if (messages.length === 0) {
+    return [];
+  }
+
+  const safeMaxTokens = Number.isFinite(maxTokens) ? Math.floor(maxTokens) : 0;
+  if (safeMaxTokens <= 0) {
+    return [messages[messages.length - 1]!];
+  }
+
+  const kept: AgentMessage[] = [];
+  let totalTokens = 0;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!;
+    const tokenCount = toStoredMessage(message).tokenCount;
+    if (kept.length > 0 && totalTokens + tokenCount > safeMaxTokens) {
+      break;
+    }
+    kept.push(message);
+    totalTokens += tokenCount;
+  }
+
+  kept.reverse();
+  return kept;
+}
+
 function readFileSegment(sessionFile: string, offset: number): string | null {
   let fd: number | null = null;
   try {
@@ -1908,7 +1965,12 @@ export class LcmContextEngine implements ContextEngine {
           // First-time import path: no LCM rows yet, so seed directly from the
           // active leaf context snapshot.
           if (existingCount === 0) {
-            if (historicalMessages.length === 0) {
+            const bootstrapMessages = trimBootstrapMessagesToBudget(
+              historicalMessages,
+              resolveBootstrapMaxTokens(this.config),
+            );
+
+            if (bootstrapMessages.length === 0) {
               await this.conversationStore.markConversationBootstrapped(conversationId);
               await persistBootstrapState(conversationId, historicalMessages);
               return {
@@ -1919,7 +1981,7 @@ export class LcmContextEngine implements ContextEngine {
             }
 
             const nextSeq = (await this.conversationStore.getMaxSeq(conversationId)) + 1;
-            const bulkInput = historicalMessages.map((message, index) => {
+            const bulkInput = bootstrapMessages.map((message, index) => {
               const stored = toStoredMessage(message);
               return {
                 conversationId,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -345,11 +345,38 @@ describe("resolveLcmConfig", () => {
     expect(manifest.configSchema.properties.pruneHeartbeatOk).toEqual({ type: "boolean" });
   });
 
+  it("ships a manifest with bootstrapMaxTokens in schema", () => {
+    expect(manifest.configSchema.properties.bootstrapMaxTokens).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+  });
   it("defaults summaryMaxOverageFactor to 3 and maxAssemblyTokenBudget to undefined", () => {
     const config = resolveLcmConfig({}, {});
+    expect(config.bootstrapMaxTokens).toBe(6000);
     expect(config.delegationTimeoutMs).toBe(120000);
     expect(config.summaryMaxOverageFactor).toBe(3);
     expect(config.maxAssemblyTokenBudget).toBeUndefined();
+  });
+
+  it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {
+    expect(resolveLcmConfig({}, {
+      leafChunkTokens: 80_000,
+    }).bootstrapMaxTokens).toBe(24_000);
+
+    expect(resolveLcmConfig({}, {
+      leafChunkTokens: 80_000,
+      bootstrapMaxTokens: 12_345,
+    }).bootstrapMaxTokens).toBe(12_345);
+  });
+
+  it("env vars override bootstrapMaxTokens", () => {
+    const config = resolveLcmConfig({
+      LCM_BOOTSTRAP_MAX_TOKENS: "4321",
+    } as NodeJS.ProcessEnv, {
+      bootstrapMaxTokens: 12_345,
+    });
+    expect(config.bootstrapMaxTokens).toBe(4321);
   });
 
   it("reads summaryMaxOverageFactor and maxAssemblyTokenBudget from plugin config", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1939,6 +1939,33 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(singleSpy).not.toHaveBeenCalled();
   });
 
+  it("limits first-time bootstrap imports to the newest messages within bootstrapMaxTokens", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-token-cap");
+    const sm = SessionManager.open(sessionFile);
+    for (let index = 0; index < 5; index += 1) {
+      sm.appendMessage({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `turn ${index} ${"x".repeat(396)}` }],
+      } as AgentMessage);
+    }
+
+    const engine = createEngineWithConfig({ bootstrapMaxTokens: 250 });
+    const sessionId = "bootstrap-token-cap";
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      `turn 3 ${"x".repeat(396)}`,
+      `turn 4 ${"x".repeat(396)}`,
+    ]);
+  });
+
   it("streams JSONL replay and skips malformed lines while keeping later messages", async () => {
     const sessionFile = createSessionFilePath("streaming-jsonl");
     const lines: string[] = [];


### PR DESCRIPTION
## What
This PR caps the amount of raw parent history imported during first-time LCM bootstrap. When a new conversation is seeded from a large parent session, lossless-claw now keeps only the newest messages that fit within a bootstrap token budget instead of importing the full raw parent transcript.

## Why
Issue #249 was caused by first-time bootstrap bulk-importing all recoverable parent messages into a brand-new conversation. On large unsummarized parent sessions, that could immediately bloat the child conversation and blow the model context before compaction had a chance to help.

## Changes
- Add `bootstrapMaxTokens` config support
- Derive sensible default from `leafChunkTokens`
- Trim bootstrap imports to newest budgeted messages
- Expose schema in `openclaw.plugin.json`
- Add config and engine regression coverage
- Add patch changeset for release notes

## Testing
- `pnpm vitest run --exclude '.worktrees/**' test/config.test.ts test/engine.test.ts`
- Expected: `2 passed`, including the bootstrap token-cap regression in `test/engine.test.ts`
