### PR TITLE
fix: harden afterTurn dedup guard against false-positive drops

### DIFF
--- a/.changeset/green-lions-bake.md
+++ b/.changeset/green-lions-bake.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix the hardened `afterTurn()` replay dedup path so it ingests the intended post-turn batch, and add coverage for restart replay when an auto-compaction summary is present.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2091,11 +2091,6 @@ export class LcmContextEngine implements ContextEngine {
    * Remove messages from the batch that already exist in the DB for this session.
    * Conservative replay detection: only strip a prefix when the incoming
    * batch begins with the entire stored transcript for the session.
-   */
-  /**
-   * Remove messages from the batch that already exist in the DB for this session.
-   * Conservative replay detection: only strip a prefix when the incoming
-   * batch begins with the entire stored transcript for the session.
    *
    * Fixes two issues from #246:
    * 1. Replaced hasMessage() fast-path with aligned-tail check — the old
@@ -2330,7 +2325,7 @@ export class LcmContextEngine implements ContextEngine {
       await this.ingestBatch({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
-        messages: dedupedBatch,
+        messages: ingestBatch,
         isHeartbeat: params.isHeartbeat === true,
       });
     } catch (err) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3132,6 +3132,49 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ]);
   });
 
+  it("afterTurn deduplicates replayed history before prepending auto-compaction summary", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-replay";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-replay-seed"),
+      messages: [
+        makeMessage({ role: "user", content: "old question" }),
+        makeMessage({ role: "assistant", content: "old answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-replay"),
+      messages: [
+        makeMessage({ role: "system", content: "system prompt" }),
+        makeMessage({ role: "user", content: "old question" }),
+        makeMessage({ role: "assistant", content: "old answer" }),
+        makeMessage({ role: "user", content: "new question" }),
+        makeMessage({ role: "assistant", content: "new answer" }),
+      ],
+      prePromptMessageCount: 1,
+      autoCompactionSummary: "[summary] compacted older history",
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old question",
+      "old answer",
+      "[summary] compacted older history",
+      "new question",
+      "new answer",
+    ]);
+  });
+
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-proactive-compact";


### PR DESCRIPTION
## Problem

The dedup guard merged in #246 has two issues that can cause data loss in production:

### 1. `hasMessage()` fast-path drops legitimate repeated messages

The current fast-path checks if `batch[0]` exists **anywhere** in the conversation DB. This false-positives when a user legitimately sends the same message content again:

```
DB: ["hello", "first reply"]
New turn: ["hello", "first reply", "hello", "second reply"]
prePromptMessageCount: 2
```

After slicing: `newMessages = ["hello", "second reply"]`

The current code sees `"hello"` exists in DB → enters the replay path → compares only 2 stored messages against the first 2 batch items → drops the legitimate new messages.

### 2. Dedup runs on ingestBatch (includes autoCompactionSummary)

The dedup currently runs on the full `ingestBatch` which includes the synthetic `autoCompactionSummary` at index 0. This means the summary content participates in replay detection, which can interfere when summary text happens to match historical message content.

## Fix

1. **Replace `hasMessage()` with aligned-tail boundary check:** Instead of checking if `batch[0]` exists anywhere, verify that the DB's last message matches the message at the exact replay boundary position (`batch[storedMessageCount - 1]`). This is O(1) and only triggers on actual replay geometry.

2. **Dedup newMessages before prepending autoCompactionSummary:** Slice first, dedup second, then prepend the synthetic summary. This keeps the summary out of replay detection entirely.

Both changes are conservative — any mismatch falls through to the full ordered-prefix proof, and mismatches always preserve the batch unchanged (no data loss on false negatives).

## Evidence

We hit this in production when a 120K-message conversation whale formed from restart-replay duplication. The forensic analysis showed restart-aligned replay bursts accounting for 62.4% of rows. After fixing this locally, we also identified that the `autoCompactionSummary` ordering issue could mask legitimate replays in the other direction.

## Testing

- Syntax check passes (`node --experimental-strip-types --check src/engine.ts`)
- Adversarial review by two independent agents (Opus + GPT-5.4) validated the approach
- Local deployment running with this fix applied