### PR TITLE
fix: restore missing changeset frontmatter fence

### DIFF
--- a/.changeset/fair-emus-move.md
+++ b/.changeset/fair-emus-move.md
@@ -1,3 +1,4 @@
+---
 "@martian-engineering/lossless-claw": patch
 ---
 


### PR DESCRIPTION
## What
Repair the malformed changeset file on `main` so the Changesets action can parse pending release notes again.

## Why
The `Version Packages` workflow failed on push `f07400009be2f181f3fe382dbab5985793873540` because `.changeset/fair-emus-move.md` was missing its opening frontmatter fence. That blocks release PR updates until the file is corrected.

## Changes
- Add the missing opening `---` fence
- Leave changeset summary and bump unchanged

## Testing
- `npm exec changeset status -- --output=/tmp/changeset-status.json`
- Expected: command exits successfully and changesets parse cleanly