### PR TITLE
fix: route timeout-recovery budget compaction through compactUntilUnder

### DIFF
--- a/.changeset/metal-poets-think.md
+++ b/.changeset/metal-poets-think.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix forced timeout-recovery compaction so live budget overflows use the capped `compactUntilUnder()` path instead of no-oping through a stored-context full sweep.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3020,8 +3020,9 @@ export class LcmContextEngine implements ContextEngine {
           };
         }
 
-        const useSweep =
-          manualCompactionRequested || forceCompaction || params.compactionTarget === "threshold";
+        // Forced budget recovery should use the capped convergence loop so live
+        // overflow counts can drive recovery even when persisted context is already small.
+        const useSweep = manualCompactionRequested || params.compactionTarget === "threshold";
         if (useSweep) {
           const sweepResult = await this.compaction.compactFullSweep({
             conversationId,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4416,6 +4416,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         tokensAfter: 280,
         condensed: false,
       });
+    const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder");
 
     await engine.ingest({
       sessionId: "threshold-target-session",
@@ -4441,6 +4442,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         hardTrigger: false,
       }),
     );
+    expect(compactUntilUnderSpy).not.toHaveBeenCalled();
   });
 
   it("passes currentTokenCount through to compaction evaluation and loop", async () => {
@@ -4536,7 +4538,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.reason).toBe("already under target");
   });
 
-  it("reports live overflow when a forced sweep cannot compact stored context", async () => {
+  it("routes forced budget recovery through compactUntilUnder for the issue #268 overflow shape", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
       compaction: {
@@ -4546,20 +4548,21 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
           observed?: number,
         ) => Promise<unknown>;
         compactFullSweep: (input: unknown) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
       };
     };
 
-    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
       shouldCompact: true,
       reason: "threshold",
       currentTokens: 277_403,
       threshold: 150_000,
     });
-    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
-      actionTaken: false,
-      tokensBefore: 17_561,
-      tokensAfter: 17_561,
-      condensed: false,
+    const compactFullSweepSpy = vi.spyOn(privateEngine.compaction, "compactFullSweep");
+    const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder").mockResolvedValue({
+      success: true,
+      rounds: 2,
+      finalTokens: 199_500,
     });
 
     await engine.ingest({
@@ -4576,15 +4579,26 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       compactionTarget: "budget",
     });
 
-    expect(result.ok).toBe(false);
-    expect(result.compacted).toBe(false);
-    expect(result.reason).toBe("live context still exceeds target");
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
     expect(result.result?.tokensBefore).toBe(277_403);
-    expect(result.result?.tokensAfter).toBe(17_561);
+    expect(result.result?.tokensAfter).toBe(199_500);
     expect(result.result?.details).toEqual(
       expect.objectContaining({
-        rounds: 0,
+        rounds: 2,
         targetTokens: 200_000,
+      }),
+    );
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 277_403);
+    expect(compactFullSweepSpy).not.toHaveBeenCalled();
+    expect(compactUntilUnderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 200_000,
+        targetTokens: 200_000,
+        currentTokens: 277_403,
+        summarize: expect.any(Function),
       }),
     );
   });


### PR DESCRIPTION
## What
This PR fixes the Phase 1 regression behind issue #268 by routing forced timeout-recovery budget compaction through the capped `compactUntilUnder()` flow instead of the one-pass `compactFullSweep()` path.

## Why
Forced recovery can be triggered by live context overflow even when persisted summary-store tokens are already small. Sending that path through `compactFullSweep()` lets the recovery no-op on stored tokens and miss the live overflow signal, which is the incident shape captured in issue #268.

## Changes
- Route forced budget recovery to `compactUntilUnder()`
- Preserve threshold-triggered full sweeps
- Preserve manual full-sweep compaction behavior
- Add issue #268 regression coverage
- Add patch changeset for release notes

## Testing
- `npx vitest run test/engine.test.ts -t "LcmContextEngine.compact token budget plumbing"`
- `npx vitest run test/engine.test.ts`
- Expect the compaction routing tests and full engine suite to pass
