### PR TITLE
fix: update bootstrap checkpoint after maintain() to prevent replay floods

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { closeSync, createReadStream, openSync, readSync, statSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -1916,6 +1916,20 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const missingTail = historicalMessages.slice(anchorIndex + 1);
+
+    // Defense-in-depth: cap reconcile imports at 20% of existing DB message
+    // count to prevent catastrophic duplicate floods if the anchor lands at
+    // the wrong position (e.g. due to many identical messages).
+    const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
+    if (existingDbCount > 0 && missingTail.length > Math.max(existingDbCount * 0.2, 50)) {
+      console.error(
+        `[lcm] reconcileSessionTail: aborting — would import ${missingTail.length} messages ` +
+          `into conversation ${conversationId} with ${existingDbCount} existing messages ` +
+          `(exceeds 20% cap). This likely indicates a stale bootstrap checkpoint.`,
+      );
+      return { importedMessages: 0, hasOverlap: true };
+    }
+
     let importedMessages = 0;
     for (const message of missingTail) {
       const result = await this.ingestSingle({ sessionId, sessionKey: params.sessionKey, message });
@@ -2041,11 +2055,14 @@ export class LcmContextEngine implements ContextEngine {
                 }
 
                 let importedMessages = 0;
-                for (const message of appended.messages) {
+                for (let i = 0; i < appended.messages.length; i++) {
+                  const message = appended.messages[i];
+                  const entryId = appended.annotated[i]?.entryId;
                   const ingestResult = await this.ingestSingle({
                     sessionId: params.sessionId,
                     sessionKey: params.sessionKey,
                     message,
+                    jsonlEntryId: entryId,
                   });
                   if (ingestResult.ingested) {
                     importedMessages += 1;
@@ -2405,9 +2422,37 @@ export class LcmContextEngine implements ContextEngine {
           };
         }
 
-        return params.runtimeContext.rewriteTranscriptEntries({
+        const rewriteResult = await params.runtimeContext.rewriteTranscriptEntries({
           replacements,
         });
+
+        // After a successful JSONL rewrite, update the bootstrap checkpoint so
+        // the next bootstrap() sees the new file state and doesn't fall through
+        // to the fragile reconcileSessionTail() anchor-matching path.
+        if (rewriteResult.changed && conversation) {
+          try {
+            const newStats = await stat(params.sessionFile);
+            const newSize = newStats.size;
+            const newMtimeMs = Math.trunc(newStats.mtimeMs);
+            const lastEntryRaw = readLastJsonlEntryBeforeOffset(params.sessionFile, newSize);
+            const lastEntryMessage = readBootstrapMessageFromJsonLine(lastEntryRaw);
+            const lastEntryHash = lastEntryMessage
+              ? createBootstrapEntryHash(toStoredMessage(lastEntryMessage))
+              : null;
+            await this.summaryStore.upsertConversationBootstrapState({
+              conversationId: conversation.conversationId,
+              sessionFilePath: params.sessionFile,
+              lastSeenSize: newSize,
+              lastSeenMtimeMs: newMtimeMs,
+              lastProcessedOffset: newSize,
+              lastProcessedEntryHash: lastEntryHash,
+            });
+          } catch (err) {
+            console.error("[lcm] maintain: failed to update bootstrap checkpoint after rewrite:", err);
+          }
+        }
+
+        return rewriteResult;
       },
     );
   }


### PR DESCRIPTION
## Root cause of #268, #271, #276

This is the root fix for the recurring bootstrap replay flood that causes doom loops (#268), exponential message accumulation (#271), and session lockouts (#276).

### The bug

`maintain()` calls `rewriteTranscriptEntries()` after every successful turn. This rewrites the JSONL via branch-and-reappend — changing file size, mtime, and entry IDs. But `conversation_bootstrap_state` was **only updated during `bootstrap()`**, never after maintenance rewrites.

On the next gateway restart:
1. Fast path 1 fails (size/mtime mismatch from stale checkpoint)
2. Fast path 2 fails (entry at stored offset is now a different entry, or a non-message type like `openclaw.cache-ttl` — `readLastJsonlEntryBeforeOffset` returns `null`, hash comparison fails)
3. Falls through to `reconcileSessionTail()` — content-based anchor matching using occurrence counting on `(role, content)` identity

On conversations with repeated identical messages (empty assistant turns, duplicate tool outputs, `NO_REPLY` patterns), the occurrence-count anchor lands thousands of entries too early, re-importing everything after the false anchor as duplicates.

### Evidence from production

Our conv 1 (17K messages) experienced **19 flood events across 453 gateway restarts** since LCM activation on March 29. Every flood maps 1:1 to a restart where the JSONL had been rewritten by `maintain()` since the last checkpoint update. The final flood (April 5) imported 5,733 duplicates in one second, inflating context to 1.7M tokens and triggering a 50-minute compaction doom loop that cascaded into a fleet-wide outage.

The doom loop (#268) is a consequence, not the cause. `compactFullSweep` runs correctly — the problem is that it's asked to compact 1.7M tokens that shouldn't exist. Fix the replay flood and the doom loop doesn't trigger.

### Fix

Two changes:

1. **Checkpoint update after maintain()** (primary fix): When `rewriteTranscriptEntries()` returns `changed: true`, stat the session file and call `upsertConversationBootstrapState()` with fresh size/mtime/offset/hash. Next restart hits the fast path. Wrapped in try/catch so a checkpoint failure doesn't break the rewrite.

2. **Import cap in reconcileSessionTail()** (defense-in-depth): If the reconcile would import more than `max(existingDbCount * 0.2, 50)` messages, abort with a warning log. First bootstrap (`existingDbCount === 0`) is exempt. This caps damage if reconcile fires for any reason we haven't anticipated.

### Testing

All 533 tests pass (546 minus 13 pinnedFiles tests on separate branch).

### Related issues

- #268 — compactFullSweep doom loop (consequence of flood inflating context)
- #271 — reconcileSessionTail exponential accumulation with identical messages (this is the mechanism)
- #276 — bootstrap checkpoint stale after maintain() (this PR)
- #263 — afterTurn dedup fix (fixed a different code path; bootstrap path was unfixed)