### PR TITLE
fix: cap compactFullSweep Phase 1 leaf passes to prevent doom loop

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -27,6 +27,8 @@ export interface CompactionResult {
   level?: CompactionLevel;
   /** Whether compaction was blocked by a provider auth failure */
   authFailure?: boolean;
+  /** Whether the sweep was capped by maxLeafPasses before completing all leaf work */
+  cappedByPassLimit?: boolean;
 }
 
 export interface CompactionConfig {
@@ -50,6 +52,8 @@ export interface CompactionConfig {
   condensedTargetTokens: number;
   /** Maximum compaction rounds (default 10) */
   maxRounds: number;
+  /** Maximum Phase 1 leaf passes per full sweep (default 25). */
+  maxLeafPasses?: number;
   /** IANA timezone for timestamps in summaries (default: UTC) */
   timezone?: string;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
@@ -585,13 +589,21 @@ export class CompactionEngine {
     let previousSummaryContent: string | undefined;
     let previousTokens = tokensBefore;
     let hadAuthFailure = false;
+    let cappedByPassLimit = false;
 
     // Phase 1: leaf passes over oldest raw chunks outside the protected tail.
+    const maxLeafPasses = this.config.maxLeafPasses ?? 25;
+    let leafPassCount = 0;
     while (true) {
+      if (leafPassCount >= maxLeafPasses) {
+        cappedByPassLimit = true;
+        break;
+      }
       const leafChunk = await this.selectOldestLeafChunk(conversationId);
       if (leafChunk.items.length === 0) {
         break;
       }
+      leafPassCount++;
 
       const passTokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
       const leafResult = await this.leafPass(
@@ -687,6 +699,7 @@ export class CompactionEngine {
       condensed,
       level,
       ...(hadAuthFailure ? { authFailure: true } : {}),
+      ...(cappedByPassLimit ? { cappedByPassLimit: true } : {}),
     };
   }
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -52,6 +52,9 @@ export type LcmConfig = {
   summaryMaxOverageFactor: number;
   /** Custom instructions injected into all summarization prompts. */
   customInstructions: string;
+  /** Maximum number of Phase 1 leaf passes per compactFullSweep invocation (default 25).
+   *  When exhausted the sweep returns partial progress instead of blocking indefinitely. */
+  maxLeafPasses: number;
   /** Consecutive auth failures before the compaction circuit breaker trips (default 5). */
   circuitBreakerThreshold: number;
   /** Cooldown in milliseconds before the circuit breaker auto-resets (default 30 min). */
@@ -232,6 +235,9 @@ export function resolveLcmConfig(
         ?? toNumber(pc.summaryMaxOverageFactor) ?? 3,
     customInstructions:
       env.LCM_CUSTOM_INSTRUCTIONS?.trim() ?? toStr(pc.customInstructions) ?? "",
+    maxLeafPasses:
+      parseFiniteInt(env.LCM_MAX_LEAF_PASSES)
+        ?? toNumber(pc.maxLeafPasses) ?? 25,
     circuitBreakerThreshold:
       parseFiniteInt(env.LCM_CIRCUIT_BREAKER_THRESHOLD)
         ?? toNumber(pc.circuitBreakerThreshold) ?? 5,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1235,6 +1235,7 @@ export class LcmContextEngine implements ContextEngine {
       leafTargetTokens: this.config.leafTargetTokens,
       condensedTargetTokens: this.config.condensedTargetTokens,
       maxRounds: 10,
+      maxLeafPasses: this.config.maxLeafPasses,
       timezone: this.config.timezone,
       summaryMaxOverageFactor: this.config.summaryMaxOverageFactor,
     };
@@ -1311,7 +1312,7 @@ export class LcmContextEngine implements ContextEngine {
     if (state.failures >= this.config.circuitBreakerThreshold) {
       state.openSince = Date.now();
       console.error(
-        `[lcm] compaction circuit breaker OPEN: ${state.failures} consecutive auth failures for ${key}. Compaction halted. Will auto-retry after ${Math.round(this.config.circuitBreakerCooldownMs / 60000)}m or gateway restart.`,
+        `[lcm] compaction circuit breaker OPEN: ${state.failures} consecutive failures for ${key}. Compaction halted. Will auto-retry after ${Math.round(this.config.circuitBreakerCooldownMs / 60000)}m or gateway restart.`,
       );
     }
   }
@@ -2864,14 +2865,22 @@ export class LcmContextEngine implements ContextEngine {
           };
         }
 
-        const leafResult = await this.compaction.compactLeaf({
-          conversationId: conversation.conversationId,
-          tokenBudget,
-          summarize,
-          force: params.force,
-          previousSummaryContent: params.previousSummaryContent,
-          summaryModel,
-        });
+        let leafResult: Awaited<ReturnType<typeof this.compaction.compactLeaf>>;
+        try {
+          leafResult = await this.compaction.compactLeaf({
+            conversationId: conversation.conversationId,
+            tokenBudget,
+            summarize,
+            force: params.force,
+            previousSummaryContent: params.previousSummaryContent,
+            summaryModel,
+          });
+        } catch (err) {
+          if (breakerKey) {
+            this.recordCompactionAuthFailure(breakerKey);
+          }
+          throw err;
+        }
 
         if (leafResult.authFailure && breakerKey) {
           this.recordCompactionAuthFailure(breakerKey);
@@ -3023,20 +3032,35 @@ export class LcmContextEngine implements ContextEngine {
         const useSweep =
           manualCompactionRequested || forceCompaction || params.compactionTarget === "threshold";
         if (useSweep) {
-          const sweepResult = await this.compaction.compactFullSweep({
-            conversationId,
-            tokenBudget,
-            summarize,
-            force: forceCompaction,
-            hardTrigger: false,
-            summaryModel,
-          });
+          let sweepResult: Awaited<ReturnType<typeof this.compaction.compactFullSweep>>;
+          try {
+            sweepResult = await this.compaction.compactFullSweep({
+              conversationId,
+              tokenBudget,
+              summarize,
+              force: forceCompaction,
+              hardTrigger: false,
+              summaryModel,
+            });
+          } catch (err) {
+            // Treat unexpected errors (timeouts, network failures, gateway
+            // restarts) as circuit-breaker–worthy failures so that repeated
+            // crashes don't keep re-triggering the same expensive sweep.
+            if (breakerKey) {
+              this.recordCompactionAuthFailure(breakerKey);
+            }
+            throw err;
+          }
 
           if (sweepResult.authFailure && breakerKey) {
             this.recordCompactionAuthFailure(breakerKey);
           } else if (sweepResult.actionTaken && breakerKey) {
             this.recordCompactionSuccess(breakerKey);
           }
+
+          const cappedReason = sweepResult.cappedByPassLimit
+            ? "compacted (capped by pass limit)"
+            : undefined;
 
           return {
             ok: !sweepResult.authFailure && (sweepResult.actionTaken || !liveContextStillExceedsTarget),
@@ -3045,13 +3069,14 @@ export class LcmContextEngine implements ContextEngine {
               ? (sweepResult.actionTaken
                   ? "provider auth failure after partial compaction"
                   : "provider auth failure")
-              : sweepResult.actionTaken
-                ? "compacted"
-                : manualCompactionRequested
-                  ? "nothing to compact"
-                  : liveContextStillExceedsTarget
-                    ? "live context still exceeds target"
-                    : "already under target",
+              : cappedReason
+                ?? (sweepResult.actionTaken
+                  ? "compacted"
+                  : manualCompactionRequested
+                    ? "nothing to compact"
+                    : liveContextStillExceedsTarget
+                      ? "live context still exceeds target"
+                      : "already under target"),
             result: {
               tokensBefore: decision.currentTokens,
               tokensAfter: sweepResult.tokensAfter,
@@ -3070,14 +3095,22 @@ export class LcmContextEngine implements ContextEngine {
             ? decision.threshold
             : tokenBudget;
 
-        const compactResult = await this.compaction.compactUntilUnder({
-          conversationId,
-          tokenBudget,
-          targetTokens: convergenceTargetTokens,
-          ...(observedTokens !== undefined ? { currentTokens: observedTokens } : {}),
-          summarize,
-          summaryModel,
-        });
+        let compactResult: Awaited<ReturnType<typeof this.compaction.compactUntilUnder>>;
+        try {
+          compactResult = await this.compaction.compactUntilUnder({
+            conversationId,
+            tokenBudget,
+            targetTokens: convergenceTargetTokens,
+            ...(observedTokens !== undefined ? { currentTokens: observedTokens } : {}),
+            summarize,
+            summaryModel,
+          });
+        } catch (err) {
+          if (breakerKey) {
+            this.recordCompactionAuthFailure(breakerKey);
+          }
+          throw err;
+        }
 
         if (compactResult.authFailure && breakerKey) {
           this.recordCompactionAuthFailure(breakerKey);


### PR DESCRIPTION
Fixes #268

## Problem

`compactFullSweep()` Phase 1 runs an unbounded `while(true)` loop over leaf summaries. On large conversations (10K+ messages, 700+ leaf summaries), this runs 70-200+ passes, locking the session for 50+ minutes.

## Fix

1. **maxLeafPasses config** (default 25): Caps Phase 1 passes. When hit, returns partial progress with `cappedByPassLimit: true` so callers don't retry immediately.

2. **Circuit breaker extension**: Counts any thrown error (timeouts, network failures, crashes) against the breaker — not just auth failures. Prevents repeated expensive sweeps after transient failures.

## Testing

All 533 tests pass (546 minus 13 pinnedFiles tests on separate branch).

## Environment

- OpenClaw 3.28, lossless-claw 0.6.1
- macOS 26.3.1, M2, 24GB