### PR TITLE
feat: default lcm_grep to search all conversations

### DIFF
--- a/.changeset/grep-all-conversations-default.md
+++ b/.changeset/grep-all-conversations-default.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Default lcm_grep to search all conversations when neither conversationId nor allConversations is explicitly provided

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -50,7 +50,7 @@ const LcmGrepSchema = Type.Object({
   allConversations: Type.Optional(
     Type.Boolean({
       description:
-        "Set true to explicitly search across all conversations. Ignored when conversationId is provided.",
+        "Search across all conversations. Defaults to true when conversationId is not provided. Set false to restrict to the current session conversation.",
     }),
   ),
   since: Type.Optional(
@@ -91,9 +91,9 @@ export function createLcmGrepTool(input: {
     label: "LCM Grep",
     description:
       "Search compacted conversation history using regex or full-text search. " +
-      "Searches across messages and/or summaries stored by LCM. " +
-      "Use this to find specific content that may have been compacted away from " +
-      "active context. Returns matching snippets with their summary/message IDs " +
+      "By default searches across ALL conversations. " +
+      "Use conversationId to restrict to a specific conversation, or allConversations=false " +
+      "to restrict to the current session. Returns matching snippets with their summary/message IDs " +
       "for follow-up with lcm_expand or lcm_describe.",
     parameters: LcmGrepSchema,
     async execute(_toolCallId, params) {
@@ -120,12 +120,19 @@ export function createLcmGrepTool(input: {
           error: "`since` must be earlier than `before`.",
         });
       }
+      // Default to searching all conversations when neither conversationId
+      // nor allConversations is explicitly provided.
+      const effectiveParams =
+        p.conversationId === undefined && p.allConversations === undefined
+          ? { ...p, allConversations: true }
+          : p;
+
       const conversationScope = await resolveLcmConversationScope({
         lcm: input.lcm,
         deps: input.deps,
         sessionId: input.sessionId,
         sessionKey: input.sessionKey,
-        params: p,
+        params: effectiveParams,
       });
       if (!conversationScope.allConversations && conversationScope.conversationId == null) {
         return jsonResult({

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -201,21 +201,51 @@ describe("LCM tools session scoping", () => {
       before: "2026-01-04T00:00:00.000Z",
     });
 
+    // lcm_grep defaults to allConversations when no conversationId is provided
     expect(retrieval.grep).toHaveBeenCalledWith(
       expect.objectContaining({
-        conversationId: 42,
+        conversationId: undefined,
         since: expect.any(Date),
         before: expect.any(Date),
       }),
     );
     const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("all conversations");
     expect(text).toContain(formatTimestamp(createdAt, timezone));
     expect(text).toContain(formatTimestamp(new Date("2026-01-01T00:00:00.000Z"), timezone));
     expect(text).toContain(formatTimestamp(new Date("2026-01-04T00:00:00.000Z"), timezone));
     expect(text).toContain("deployment timeline");
   });
 
-  it("lcm_grep resolves conversation scope via sessionKey continuity before sessionId lookup", async () => {
+  it("lcm_grep scopes to current session when allConversations is explicitly false", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    await tool.execute("call-scope", {
+      pattern: "test",
+      allConversations: false,
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 42,
+      }),
+    );
+  });
+
+  it("lcm_grep resolves conversation scope via sessionKey continuity when allConversations is explicitly false", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({
         messages: [],
@@ -233,13 +263,41 @@ describe("LCM tools session scoping", () => {
       lcm: buildLcmEngine({ retrieval, conversationIdBySessionKey: 42 }) as never,
       sessionKey: "agent:main:main",
     });
-    await tool.execute("call-2b", { pattern: "deployment" });
+    await tool.execute("call-2b", { pattern: "deployment", allConversations: false });
 
     expect(retrieval.grep).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: 42,
       }),
     );
+  });
+
+  it("lcm_grep defaults to all conversations when no scope params provided", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-default", { pattern: "test" });
+
+    // Should search all conversations, not scope to conversation 42
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: undefined,
+      }),
+    );
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("all conversations");
   });
 
   it("lcm_describe blocks cross-conversation lookup unless allConversations=true", async () => {


### PR DESCRIPTION
## Summary

Changes lcm_grep's default scope from current-session-only to all conversations. The allConversations parameter was added post-v0.5.0 but defaults to false, which means agents in multi-session setups (DM, gateway, cron) can't recall content from other sessions without explicitly passing allConversations: true.

## Changes

- src/tools/lcm-grep-tool.ts: When neither conversationId nor allConversations is explicitly provided, default to searching all conversations
- Updated tool description to reflect the new default
- Updated affected tests
- Added changeset for minor version bump

## Testing

vitest tests pass (6/6).

Fixes #170

This contribution was developed with AI assistance (Claude Code).