### PR TITLE
[fix] fix startup summary model banner resolution

### DIFF
--- a/.changeset/late-cups-rhyme.md
+++ b/.changeset/late-cups-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix startup-time summary model resolution when OpenClaw populates plugin config before the top-level runtime config surface.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -394,16 +394,16 @@ function resolveRegistrationConfig(api: OpenClawPluginApi): {
   openClawConfig: unknown;
   pluginConfig?: Record<string, unknown>;
 } {
+  const openClawConfig = loadEffectiveOpenClawConfig(api);
   const apiPluginConfig =
     api.pluginConfig && typeof api.pluginConfig === "object" && !Array.isArray(api.pluginConfig)
       ? api.pluginConfig
       : undefined;
 
   if (apiPluginConfig && Object.keys(apiPluginConfig).length > 0) {
-    return { openClawConfig: api.config, pluginConfig: apiPluginConfig };
+    return { openClawConfig, pluginConfig: apiPluginConfig };
   }
 
-  const openClawConfig = loadEffectiveOpenClawConfig(api);
   return {
     openClawConfig,
     pluginConfig: readPluginConfigFromOpenClawConfig(openClawConfig, api.id),

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -344,6 +344,72 @@ function readDefaultModelFromConfig(config: unknown): string {
   return typeof primary === "string" ? primary.trim() : "";
 }
 
+/** Load the best available validated OpenClaw config during plugin registration. */
+function loadEffectiveOpenClawConfig(api: OpenClawPluginApi): unknown {
+  try {
+    const runtimeConfig = api.runtime.config.loadConfig();
+    if (runtimeConfig !== undefined) {
+      if (isRecord(runtimeConfig) && Object.keys(runtimeConfig).length > 0) {
+        return runtimeConfig;
+      }
+      if (!isRecord(api.config) || Object.keys(api.config).length === 0) {
+        return runtimeConfig;
+      }
+    }
+  } catch {
+    // Older runtimes or early startup can leave loadConfig unavailable.
+  }
+  return api.config;
+}
+
+/** Read this plugin's config from the validated OpenClaw runtime config. */
+function readPluginConfigFromOpenClawConfig(
+  openClawConfig: unknown,
+  pluginId: string,
+): Record<string, unknown> | undefined {
+  if (!isRecord(openClawConfig)) {
+    return undefined;
+  }
+
+  const plugins = openClawConfig.plugins;
+  if (!isRecord(plugins)) {
+    return undefined;
+  }
+
+  const entries = plugins.entries;
+  if (!isRecord(entries)) {
+    return undefined;
+  }
+
+  const entry = entries[pluginId];
+  if (!isRecord(entry) || !isRecord(entry.config)) {
+    return undefined;
+  }
+
+  return entry.config;
+}
+
+/** Resolve the config surfaces that should drive registration-time behavior. */
+function resolveRegistrationConfig(api: OpenClawPluginApi): {
+  openClawConfig: unknown;
+  pluginConfig?: Record<string, unknown>;
+} {
+  const apiPluginConfig =
+    api.pluginConfig && typeof api.pluginConfig === "object" && !Array.isArray(api.pluginConfig)
+      ? api.pluginConfig
+      : undefined;
+
+  if (apiPluginConfig && Object.keys(apiPluginConfig).length > 0) {
+    return { openClawConfig: api.config, pluginConfig: apiPluginConfig };
+  }
+
+  const openClawConfig = loadEffectiveOpenClawConfig(api);
+  return {
+    openClawConfig,
+    pluginConfig: readPluginConfigFromOpenClawConfig(openClawConfig, api.id),
+  };
+}
+
 /** Read OpenClaw's configured compaction model from the validated runtime config. */
 function readCompactionModelFromConfig(config: unknown): string {
   if (!config || typeof config !== "object") {
@@ -1278,12 +1344,15 @@ function readLatestAssistantReply(messages: unknown[]): string | undefined {
 }
 
 /** Construct LCM dependencies from plugin API/runtime surfaces. */
-function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
+function createLcmDependencies(
+  api: OpenClawPluginApi,
+  registrationConfig = resolveRegistrationConfig(api),
+): LcmDependencies {
   const envSnapshot = snapshotPluginEnv();
-  envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(api.config);
+  envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(registrationConfig.openClawConfig);
   const modelAuth = getRuntimeModelAuth(api);
   const readEnv: ReadEnvFn = (key) => process.env[key];
-  const pluginConfig = resolvePluginConfig(api);
+  const pluginConfig = registrationConfig.pluginConfig;
   const log = createLcmLogger(api);
   const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
 
@@ -1943,7 +2012,8 @@ const lcmPlugin = {
   },
 
   register(api: OpenClawPluginApi) {
-    const deps = createLcmDependencies(api);
+    const registrationConfig = resolveRegistrationConfig(api);
+    const deps = createLcmDependencies(api, registrationConfig);
     const dbPath = deps.config.databasePath;
     const normalizedDbPath = normalizePath(dbPath);
 
@@ -2132,7 +2202,7 @@ const lcmPlugin = {
       log: (message) => deps.log.info(message),
       message: buildCompactionModelLog({
         config: deps.config,
-        openClawConfig: api.config,
+        openClawConfig: registrationConfig.openClawConfig,
         defaultProvider: process.env.OPENCLAW_PROVIDER?.trim() ?? "",
       }),
     });

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -157,7 +157,7 @@ describe("createLcmDependencies.complete provider config resolution", () => {
       model: "unit-model",
     });
 
-    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(loadConfig).toHaveBeenCalled();
     expect(piAiMock.completeSimple).toHaveBeenCalledTimes(1);
     expect(piAiMock.completeSimple).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -552,6 +552,41 @@ describe("lcm plugin registration", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("uses runtime OpenClaw defaults when api.pluginConfig is ready before api.config", () => {
+    const { api, getFactory } = buildApi(
+      {
+        enabled: true,
+      },
+      {
+        runtimeConfig: compactionAndDefaultModelConfig({
+          defaultModel: "anthropic/claude-sonnet-4-6",
+        }),
+      },
+    );
+    api.config = {} as OpenClawPluginApi["config"];
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    lcmPlugin.register(api);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[lcm] Compaction summarization model: anthropic/claude-sonnet-4-6 (default)",
+    );
+
+    const factory = getFactory();
+    expect(factory).toBeTypeOf("function");
+
+    const engine = factory!() as { deps?: { resolveModel: (modelRef?: string, providerHint?: string) => unknown } };
+    const resolved = engine.deps?.resolveModel(undefined, undefined) as
+      | { provider: string; model: string }
+      | undefined;
+
+    expect(resolved).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
   it("logs the OpenClaw compaction model at startup when no plugin override is set", () => {
     const { api, infoLog } = buildApi({
       enabled: true,

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -14,7 +14,11 @@ type HookHandler = (event: unknown, context: unknown) => unknown;
 
 function buildApi(
   pluginConfig: unknown,
-  options?: { includeModelAuth?: boolean; agentDir?: string },
+  options?: {
+    includeModelAuth?: boolean;
+    agentDir?: string;
+    runtimeConfig?: Record<string, unknown>;
+  },
 ): {
   api: OpenClawPluginApi;
   getFactory: () => RegisteredEngineFactory;
@@ -58,7 +62,7 @@ function buildApi(
             },
           }),
       config: {
-        loadConfig: vi.fn(() => ({})),
+        loadConfig: vi.fn(() => options?.runtimeConfig ?? {}),
       },
       logging: {
         getChildLogger: vi.fn(() => ({
@@ -517,6 +521,35 @@ describe("lcm plugin registration", () => {
       "[lcm] Compaction summarization model: openai-resp/gpt-5.4 (override)",
     );
     expect(sessionInfoLog).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runtime plugin config for the startup banner when register runs before api.pluginConfig is populated", () => {
+    const { api } = buildApi(
+      {},
+      {
+        runtimeConfig: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+                config: {
+                  summaryModel: "openai-codex/gpt-5.4",
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+    api.config = {} as OpenClawPluginApi["config"];
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    lcmPlugin.register(api);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[lcm] Compaction summarization model: openai-codex/gpt-5.4 (override)",
+    );
+    consoleErrorSpy.mockRestore();
   });
 
   it("logs the OpenClaw compaction model at startup when no plugin override is set", () => {

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -524,7 +524,7 @@ describe("lcm plugin registration", () => {
   });
 
   it("falls back to runtime plugin config for the startup banner when register runs before api.pluginConfig is populated", () => {
-    const { api } = buildApi(
+    const { api, infoLog } = buildApi(
       {},
       {
         runtimeConfig: {
@@ -542,18 +542,16 @@ describe("lcm plugin registration", () => {
       },
     );
     api.config = {} as OpenClawPluginApi["config"];
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     lcmPlugin.register(api);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Compaction summarization model: openai-codex/gpt-5.4 (override)",
     );
-    consoleErrorSpy.mockRestore();
   });
 
   it("uses runtime OpenClaw defaults when api.pluginConfig is ready before api.config", () => {
-    const { api, getFactory } = buildApi(
+    const { api, getFactory, infoLog } = buildApi(
       {
         enabled: true,
       },
@@ -564,11 +562,10 @@ describe("lcm plugin registration", () => {
       },
     );
     api.config = {} as OpenClawPluginApi["config"];
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     lcmPlugin.register(api);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Compaction summarization model: anthropic/claude-sonnet-4-6 (default)",
     );
 
@@ -584,7 +581,6 @@ describe("lcm plugin registration", () => {
       provider: "anthropic",
       model: "claude-sonnet-4-6",
     });
-    consoleErrorSpy.mockRestore();
   });
 
   it("logs the OpenClaw compaction model at startup when no plugin override is set", () => {


### PR DESCRIPTION
## Summary

Fix the misleading startup banner that reports the compaction summarization model as `(unconfigured)` when `lossless-claw` registers before `api.pluginConfig` is populated.

Fixes #304.

## What changed

- resolve registration-time config from the validated runtime config only when the early plugin config surface is empty
- read `plugins.entries.lossless-claw.config` from that validated config for startup-time dependency resolution
- feed the same effective OpenClaw config into the startup banner path
- add a regression test covering the early-startup case where runtime config is available before `api.pluginConfig`

## Root cause

The startup banner path depended on `api.config` and `api.pluginConfig` during `register()`, but OpenClaw can invoke plugin registration before those surfaces are fully populated. Later runtime compaction used the correct config path, so compaction worked while the banner incorrectly logged `(unconfigured)`.

## Impact

Startup logs now reflect the effective summary model consistently with runtime compaction behavior, without changing the actual summarizer resolution path.

## Validation

- `npm test -- --run test/plugin-config-registration.test.ts`
- `npm test -- --run test/plugin-config-registration.test.ts test/index-complete-provider-config.test.ts`
- `npm test`
