### PR TITLE
feat: wire live context token counts through engine to compaction guards

### DIFF
--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -1,3 +1,4 @@
+---
 "@martian-engineering/lossless-claw": minor
 ---
 

--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": minor
 ---
 
-Cache-aware leaf compaction guards with budget-pressure override and per-tier tuning. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample.
+Cache-aware leaf compaction guards with budget-pressure override. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample. Adds `leafSkipReductionThreshold` and `leafBudgetHeadroomFactor` config fields.

--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -1,0 +1,4 @@
+"@martian-engineering/lossless-claw": minor
+---
+
+Cache-aware leaf compaction guards with budget-pressure override and per-tier tuning. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_DELEGATION_TIMEOUT_MS` | `120000` | Max time to wait for delegated `lcm_expand_query` sub-agent completion |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Max time to wait for a single model-backed LCM summarizer call |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
+| `LCM_LEAF_SKIP_REDUCTION_THRESHOLD` | `0.05` | Minimum estimated reduction (fraction of assembled tokens) to justify leaf compaction; set to 0 to disable cache-aware skip |
+| `LCM_LEAF_BUDGET_HEADROOM_FACTOR` | `0.8` | Skip leaf compaction when assembled tokens are below this fraction of the budget ceiling; set to 0 to disable headroom check |
+| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider:model` pairs for compaction summarization fallbacks |
 
 ### Expansion model override requirements
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 | `LCM_LEAF_SKIP_REDUCTION_THRESHOLD` | `0.05` | Minimum estimated reduction (fraction of assembled tokens) to justify leaf compaction; set to 0 to disable cache-aware skip |
 | `LCM_LEAF_BUDGET_HEADROOM_FACTOR` | `0.8` | Skip leaf compaction when assembled tokens are below this fraction of the budget ceiling; set to 0 to disable headroom check |
-| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider:model` pairs for compaction summarization fallbacks |
+| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider/model` pairs for compaction summarization fallbacks (e.g. `anthropic/claude-haiku-4-5,openai/gpt-4o-mini`) |
 
 ### Expansion model override requirements
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -108,6 +108,14 @@
       "label": "Prune HEARTBEAT_OK",
       "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
     },
+    "leafSkipReductionThreshold": {
+      "label": "Leaf Skip Reduction Threshold",
+      "help": "Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction. Set to 0 to disable. Default 0.05."
+    },
+    "leafBudgetHeadroomFactor": {
+      "label": "Leaf Budget Headroom Factor",
+      "help": "Skip leaf compaction when assembled tokens are below this fraction of contextThreshold × tokenBudget. Set to 0 to disable. Default 0.8."
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit fallback provider/model pairs for compaction summarization (e.g., [{\"provider\": \"anthropic\", \"model\": \"claude-haiku-4-5\"}])"
@@ -249,6 +257,18 @@
           "required": ["provider", "model"],
           "additionalProperties": false
         }
+      },
+      "leafSkipReductionThreshold": {
+        "description": "Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction. Prevents cache-prefix invalidation when the gain is tiny. Set to 0 to disable. Default 0.05.",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "leafBudgetHeadroomFactor": {
+        "description": "Skip leaf compaction when assembled tokens are below this fraction of contextThreshold × tokenBudget. Set to 0 to disable. Default 0.8.",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
       }
     }
   }

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -474,9 +474,13 @@ export class CompactionEngine {
     // Use the higher of stored/precomputed count and live context estimate
     // for more accurate headroom decisions.
     const storedTokens = precomputedTokenCount ?? await this.summaryStore.getContextTokenCount(conversationId);
+    const normalizedLiveContextTokens =
+      Number.isFinite(liveContextTokens) && (liveContextTokens as number) > 0
+        ? Math.floor(liveContextTokens as number)
+        : undefined;
     const totalAssembledTokens =
-      typeof liveContextTokens === "number" && liveContextTokens > storedTokens
-        ? liveContextTokens
+      normalizedLiveContextTokens !== undefined && normalizedLiveContextTokens > storedTokens
+        ? normalizedLiveContextTokens
         : storedTokens;
 
     // ── Budget headroom check (evaluated first) ───────────────────

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -484,6 +484,9 @@ export class CompactionEngine {
     // avoid unnecessary cache prefix churn.
     const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
     const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
+    // headroomEnabled: only run the headroom check when factor > 0 and
+    // tokenBudget is available.  Setting factor to 0 disables the check
+    // (and does NOT create false budget pressure).
     const headroomEnabled = headroomFactor > 0 && typeof tokenBudget === "number" && tokenBudget > 0;
     const budgetCeiling = headroomEnabled
       ? Math.floor(headroomFactor * this.config.contextThreshold * tokenBudget)
@@ -506,8 +509,14 @@ export class CompactionEngine {
     // If the estimated token reduction is tiny relative to the total
     // assembled context, the prompt-cache prefix invalidation cost
     // exceeds the compression benefit.
-    // Budget pressure override: when headroom is enabled and context
-    // reaches or exceeds the ceiling, compaction fires unconditionally.
+    //
+    // This skip is gated on !budgetPressure.  Budget pressure is true
+    // only when headroom is enabled (factor > 0, tokenBudget provided)
+    // AND assembled tokens reach or exceed the headroom ceiling.  When the
+    // headroom check is disabled or tokenBudget is missing, there is
+    // no budget pressure signal, so the cache-aware skip can fire.
+    // When budget pressure IS detected, compaction fires unconditionally
+    // to prevent starvation in large contexts.
     const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
     const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
     const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -469,6 +469,13 @@ export class CompactionEngine {
       return { shouldCompact: false, rawTokensOutsideTail, threshold };
     }
 
+    // Short-circuit when both guards are disabled — avoid unnecessary DB read.
+    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
+    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
+    if (rawHeadroomFactor <= 0 && reductionThreshold <= 0) {
+      return { shouldCompact: true, rawTokensOutsideTail, threshold };
+    }
+
     // Reuse a precomputed token count when the caller already fetched it
     // (avoids a duplicate getContextTokenCount DB read).
     // Use the higher of stored/precomputed count and live context estimate
@@ -486,7 +493,6 @@ export class CompactionEngine {
     // ── Budget headroom check (evaluated first) ───────────────────
     // If assembled tokens are well under the budget ceiling, skip to
     // avoid unnecessary cache prefix churn.
-    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
     const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
     // headroomEnabled: only run the headroom check when factor > 0 and
     // tokenBudget is available.  Setting factor to 0 disables the check
@@ -523,7 +529,6 @@ export class CompactionEngine {
     // to prevent starvation in large contexts.
     const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
     const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
-    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
     const budgetPressure = headroomEnabled && !hasHeadroom;
     if (
       !budgetPressure &&

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -556,6 +556,7 @@ export class CompactionEngine {
     tokenBudget: number;
     /** LLM call function for summarization */
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -54,7 +54,27 @@ export interface CompactionConfig {
   timezone?: string;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
   summaryMaxOverageFactor: number;
+  /** Minimum estimated reduction fraction to justify leaf compaction (default 0.05). */
+  leafSkipReductionThreshold?: number;
+  /** Skip leaf compaction when assembled tokens < factor × contextThreshold × tokenBudget (default 0.8). */
+  leafBudgetHeadroomFactor?: number;
 }
+
+export type LeafTriggerResult = {
+  shouldCompact: boolean;
+  rawTokensOutsideTail: number;
+  threshold: number;
+  skipReason?: string;
+  /** Structured decision context for diagnostics and telemetry. */
+  context?: {
+    totalAssembledTokens: number;
+    budgetCeiling?: number;
+    budgetPressure: boolean;
+    estimatedReduction?: number;
+    reductionThreshold?: number;
+    headroomFactor: number;
+  };
+};
 
 type CompactionLevel = "normal" | "aggressive" | "fallback" | "capped";
 type CompactionPass = "leaf" | "condensed";
@@ -436,17 +456,82 @@ export class CompactionEngine {
    * `leafChunkTokens`. This lets callers trigger a soft incremental leaf pass
    * before the full context threshold is breached.
    */
-  async evaluateLeafTrigger(conversationId: number): Promise<{
-    shouldCompact: boolean;
-    rawTokensOutsideTail: number;
-    threshold: number;
-  }> {
+  async evaluateLeafTrigger(
+    conversationId: number,
+    tokenBudget?: number,
+    liveContextTokens?: number,
+    precomputedTokenCount?: number,
+  ): Promise<LeafTriggerResult> {
     const rawTokensOutsideTail = await this.countRawTokensOutsideFreshTail(conversationId);
     const threshold = this.resolveLeafChunkTokens();
+
+    if (rawTokensOutsideTail < threshold) {
+      return { shouldCompact: false, rawTokensOutsideTail, threshold };
+    }
+
+    // Reuse a precomputed token count when the caller already fetched it
+    // (avoids a duplicate getContextTokenCount DB read).
+    // Use the higher of stored/precomputed count and live context estimate
+    // for more accurate headroom decisions.
+    const storedTokens = precomputedTokenCount ?? await this.summaryStore.getContextTokenCount(conversationId);
+    const totalAssembledTokens =
+      typeof liveContextTokens === "number" && liveContextTokens > storedTokens
+        ? liveContextTokens
+        : storedTokens;
+
+    // ── Budget headroom check (evaluated first) ───────────────────
+    // If assembled tokens are well under the budget ceiling, skip to
+    // avoid unnecessary cache prefix churn.
+    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
+    const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
+    const headroomEnabled = headroomFactor > 0 && typeof tokenBudget === "number" && tokenBudget > 0;
+    const budgetCeiling = headroomEnabled
+      ? Math.floor(headroomFactor * this.config.contextThreshold * tokenBudget)
+      : undefined;
+    let hasHeadroom = false;
+    if (headroomEnabled && budgetCeiling !== undefined) {
+      hasHeadroom = totalAssembledTokens < budgetCeiling;
+      if (hasHeadroom) {
+        return {
+          shouldCompact: false,
+          rawTokensOutsideTail,
+          threshold,
+          skipReason: `budget-headroom: ${totalAssembledTokens} assembled < ${budgetCeiling} ceiling`,
+          context: { totalAssembledTokens, budgetCeiling, budgetPressure: false, headroomFactor },
+        };
+      }
+    }
+
+    // ── Cache-aware skip ──────────────────────────────────────────
+    // If the estimated token reduction is tiny relative to the total
+    // assembled context, the prompt-cache prefix invalidation cost
+    // exceeds the compression benefit.
+    // Budget pressure override: when headroom is enabled and context
+    // reaches or exceeds the ceiling, compaction fires unconditionally.
+    const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
+    const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
+    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
+    const budgetPressure = headroomEnabled && !hasHeadroom;
+    if (
+      !budgetPressure &&
+      totalAssembledTokens > 0 &&
+      estimatedReduction > 0 &&
+      estimatedReduction < reductionThreshold * totalAssembledTokens
+    ) {
+      return {
+        shouldCompact: false,
+        rawTokensOutsideTail,
+        threshold,
+        skipReason: `cache-aware: reduction ${estimatedReduction} < ${(reductionThreshold * 100).toFixed(0)}% of ${totalAssembledTokens} assembled`,
+        context: { totalAssembledTokens, budgetCeiling, budgetPressure, estimatedReduction, reductionThreshold, headroomFactor },
+      };
+    }
+
     return {
-      shouldCompact: rawTokensOutsideTail >= threshold,
+      shouldCompact: true,
       rawTokensOutsideTail,
       threshold,
+      context: { totalAssembledTokens, budgetCeiling, budgetPressure, estimatedReduction, reductionThreshold, headroomFactor },
     };
   }
 
@@ -474,6 +559,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     previousSummaryContent?: string;
     summaryModel?: string;
@@ -485,6 +571,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     previousSummaryContent?: string;
     summaryModel?: string;
@@ -493,7 +580,12 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    const leafTrigger = await this.evaluateLeafTrigger(
+      conversationId,
+      tokenBudget,
+      input.currentTokenCount,
+      tokensBefore,
+    );
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {
@@ -616,6 +708,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;
@@ -624,7 +717,12 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    const leafTrigger = await this.evaluateLeafTrigger(
+      conversationId,
+      tokenBudget,
+      input.currentTokenCount,
+      tokensBefore,
+    );
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -60,6 +60,12 @@ export type LcmConfig = {
   circuitBreakerCooldownMs: number;
   /** Explicit fallback provider/model pairs for compaction summarization. */
   fallbackProviders: Array<{ provider: string; model: string }>;
+  /** Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction.
+   *  Prevents cache-prefix invalidation when the gain is tiny relative to total context. Default 0.05. */
+  leafSkipReductionThreshold: number;
+  /** Skip leaf compaction when assembled tokens < factor × contextThreshold × tokenBudget.
+   *  Avoids unnecessary compaction when there is ample budget headroom. Default 0.8. */
+  leafBudgetHeadroomFactor: number;
 };
 
 /** Safely coerce an unknown value to a finite number, or return undefined. */
@@ -281,5 +287,17 @@ export function resolveLcmConfig(
     fallbackProviders:
       parseFallbackProviders(env.LCM_FALLBACK_PROVIDERS)
         ?? toFallbackProviderArray(pc.fallbackProviders) ?? [],
+    leafSkipReductionThreshold: clamp01(
+      parseFiniteNumber(env.LCM_LEAF_SKIP_REDUCTION_THRESHOLD)
+        ?? toNumber(pc.leafSkipReductionThreshold) ?? 0.05,
+    ),
+    leafBudgetHeadroomFactor: clamp01(
+      parseFiniteNumber(env.LCM_LEAF_BUDGET_HEADROOM_FACTOR)
+        ?? toNumber(pc.leafBudgetHeadroomFactor) ?? 0.8,
+    ),
   };
+}
+
+function clamp01(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1264,6 +1264,8 @@ export class LcmContextEngine implements ContextEngine {
       maxRounds: 10,
       timezone: this.config.timezone,
       summaryMaxOverageFactor: this.config.summaryMaxOverageFactor,
+      leafSkipReductionThreshold: this.config.leafSkipReductionThreshold ?? 0.05,
+      leafBudgetHeadroomFactor: this.config.leafBudgetHeadroomFactor ?? 0.8,
     };
     this.compaction = new CompactionEngine(
       this.conversationStore,
@@ -2717,8 +2719,11 @@ export class LcmContextEngine implements ContextEngine {
     const liveContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
 
     try {
-      const leafTrigger = await this.evaluateLeafTrigger(params.sessionId, params.sessionKey);
+      const leafTrigger = await this.evaluateLeafTrigger(params.sessionId, params.sessionKey, tokenBudget, liveContextTokens);
       if (leafTrigger.shouldCompact) {
+        this.deps.log.info(
+          `[lcm] afterTurn: leaf compaction triggered (raw=${leafTrigger.rawTokensOutsideTail}, threshold=${leafTrigger.threshold}${leafTrigger.context ? `, assembled=${leafTrigger.context.totalAssembledTokens}, pressure=${leafTrigger.context.budgetPressure}` : ""})`,
+        );
         this.compactLeafAsync({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
@@ -2729,6 +2734,10 @@ export class LcmContextEngine implements ContextEngine {
         }).catch(() => {
           // Leaf compaction is best-effort and should not fail the caller.
         });
+      } else if (leafTrigger.skipReason) {
+        this.deps.log.debug?.(
+          `[lcm] afterTurn: leaf compaction skipped (${leafTrigger.skipReason})`,
+        );
       }
     } catch {
       // Leaf trigger checks are best-effort.
@@ -2837,10 +2846,19 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Evaluate whether incremental leaf compaction should run for a session. */
-  async evaluateLeafTrigger(sessionId: string, sessionKey?: string): Promise<{
+  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<{
     shouldCompact: boolean;
     rawTokensOutsideTail: number;
     threshold: number;
+    skipReason?: string;
+    context?: {
+      totalAssembledTokens: number;
+      budgetCeiling?: number;
+      budgetPressure: boolean;
+      estimatedReduction?: number;
+      reductionThreshold?: number;
+      headroomFactor: number;
+    };
   }> {
     this.ensureMigrated();
     const conversation = await this.conversationStore.getConversationForSession({
@@ -2860,7 +2878,7 @@ export class LcmContextEngine implements ContextEngine {
         threshold: fallbackThreshold,
       };
     }
-    return this.compaction.evaluateLeafTrigger(conversation.conversationId);
+    return this.compaction.evaluateLeafTrigger(conversation.conversationId, tokenBudget, liveContextTokens);
   }
 
   /** Run one incremental leaf compaction pass in the per-session queue. */
@@ -2943,6 +2961,7 @@ export class LcmContextEngine implements ContextEngine {
         const leafResult = await this.compaction.compactLeaf({
           conversationId: conversation.conversationId,
           tokenBudget,
+          currentTokenCount: observedTokens,
           summarize,
           force: params.force,
           previousSummaryContent: params.previousSummaryContent,
@@ -3103,6 +3122,7 @@ export class LcmContextEngine implements ContextEngine {
           const sweepResult = await this.compaction.compact({
             conversationId,
             tokenBudget,
+            currentTokenCount: observedTokens,
             summarize,
             force: forceCompaction,
             hardTrigger: false,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -25,7 +25,7 @@ import {
   pickToolIsError,
   pickToolName,
 } from "./assembler.js";
-import { CompactionEngine, type CompactionConfig } from "./compaction.js";
+import { CompactionEngine, type CompactionConfig, type LeafTriggerResult } from "./compaction.js";
 import type { LcmConfig } from "./db/config.js";
 import { getLcmDbFeatures } from "./db/features.js";
 import { runLcmMigrations } from "./db/migration.js";
@@ -2846,20 +2846,7 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Evaluate whether incremental leaf compaction should run for a session. */
-  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<{
-    shouldCompact: boolean;
-    rawTokensOutsideTail: number;
-    threshold: number;
-    skipReason?: string;
-    context?: {
-      totalAssembledTokens: number;
-      budgetCeiling?: number;
-      budgetPressure: boolean;
-      estimatedReduction?: number;
-      reductionThreshold?: number;
-      headroomFactor: number;
-    };
-  }> {
+  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<LeafTriggerResult> {
     this.ensureMigrated();
     const conversation = await this.conversationStore.getConversationForSession({
       sessionId,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -405,6 +405,22 @@ describe("resolveLcmConfig", () => {
     });
   });
 
+  it("clamps leafSkipReductionThreshold and leafBudgetHeadroomFactor to [0, 1]", () => {
+    const below = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: -0.5,
+      leafBudgetHeadroomFactor: -1.0,
+    });
+    expect(below.leafSkipReductionThreshold).toBe(0);
+    expect(below.leafBudgetHeadroomFactor).toBe(0);
+
+    const above = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: 1.5,
+      leafBudgetHeadroomFactor: 2.0,
+    });
+    expect(above.leafSkipReductionThreshold).toBe(1);
+    expect(above.leafBudgetHeadroomFactor).toBe(1);
+  });
+
   it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {
     expect(resolveLcmConfig({}, {
       leafChunkTokens: 80_000,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -363,6 +363,48 @@ describe("resolveLcmConfig", () => {
     expect(config.maxAssemblyTokenBudget).toBeUndefined();
   });
 
+  it("defaults leafSkipReductionThreshold to 0.05 and leafBudgetHeadroomFactor to 0.8", () => {
+    const config = resolveLcmConfig({}, {});
+    expect(config.leafSkipReductionThreshold).toBe(0.05);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.8);
+  });
+
+  it("reads leafSkipReductionThreshold and leafBudgetHeadroomFactor from plugin config", () => {
+    const config = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: 0.10,
+      leafBudgetHeadroomFactor: 0.65,
+    });
+    expect(config.leafSkipReductionThreshold).toBe(0.10);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.65);
+  });
+
+  it("env vars override leafSkipReductionThreshold and leafBudgetHeadroomFactor", () => {
+    const config = resolveLcmConfig({
+      LCM_LEAF_SKIP_REDUCTION_THRESHOLD: "0.03",
+      LCM_LEAF_BUDGET_HEADROOM_FACTOR: "0.60",
+    } as NodeJS.ProcessEnv, {
+      leafSkipReductionThreshold: 0.10,
+      leafBudgetHeadroomFactor: 0.90,
+    });
+    expect(config.leafSkipReductionThreshold).toBe(0.03);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.60);
+  });
+
+  it("ships a manifest with leafSkipReductionThreshold and leafBudgetHeadroomFactor in schema", () => {
+    expect(manifest.configSchema.properties.leafSkipReductionThreshold).toEqual({
+      description: expect.any(String),
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+    });
+    expect(manifest.configSchema.properties.leafBudgetHeadroomFactor).toEqual({
+      description: expect.any(String),
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+    });
+  });
+
   it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {
     expect(resolveLcmConfig({}, {
       leafChunkTokens: 80_000,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3694,7 +3694,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       tokenBudget: 4096,
     });
 
-    expect(evaluateLeafTriggerSpy).toHaveBeenCalledWith(sessionId, undefined);
+    expect(evaluateLeafTriggerSpy).toHaveBeenCalledWith(sessionId, undefined, 4096, expect.any(Number));
     expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
     expect(compactSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -4490,6 +4490,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 400,
+        currentTokenCount: 500,
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
@@ -4767,6 +4768,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 400,
+        currentTokenCount: 500,
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
@@ -5037,6 +5039,50 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 4096,
+      }),
+    );
+  });
+
+  it("passes currentTokenCount through to compactLeafAsync worker compaction", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const compactLeafSpy = vi
+      .spyOn(privateEngine.compaction, "compactLeaf")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 500,
+        tokensAfter: 280,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "compact-leaf-observed-token-session",
+      message: { role: "user", content: "trigger compact leaf" } as AgentMessage,
+    });
+
+    const result = await engine.compactLeafAsync({
+      sessionId: "compact-leaf-observed-token-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 400,
+      currentTokenCount: 500,
+      legacyParams: {
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(compactLeafSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 400,
+        currentTokenCount: 500,
       }),
     );
   });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5086,4 +5086,41 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
       }),
     );
   });
+
+  it("omits currentTokenCount when not provided to compactLeafAsync", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const compactLeafSpy = vi
+      .spyOn(privateEngine.compaction, "compactLeaf")
+      .mockResolvedValue({
+        actionTaken: false,
+        tokensBefore: 200,
+        tokensAfter: 200,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "no-observed-token-session",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    await engine.compactLeafAsync({
+      sessionId: "no-observed-token-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 400,
+      legacyParams: {
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+    });
+
+    const callArg = compactLeafSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(callArg).toBeDefined();
+    expect(callArg!.currentTokenCount).toBeUndefined();
+  });
 });

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2133,7 +2133,7 @@ describe("LCM integration: compaction", () => {
     });
 
     await ingestMessages(convStore, sumStore, 10, {
-      contentFn: (i) => `Turn ${i}: ${"x".repeat(11_980)}`,
+      contentFn: (i) => `Turn ${i}: stale token test`,
       tokenCountFn: () => 3_000,
     });
 
@@ -2157,7 +2157,7 @@ describe("LCM integration: compaction", () => {
     });
 
     await ingestMessages(convStore, sumStore, 10, {
-      contentFn: (i) => `Turn ${i}: ${"y".repeat(11_980)}`,
+      contentFn: (i) => `Turn ${i}: stale sweep test`,
       tokenCountFn: () => 3_000,
     });
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2126,6 +2126,54 @@ describe("LCM integration: compaction", () => {
     expect(summarize).toHaveBeenCalled();
   });
 
+  it("compactLeaf uses currentTokenCount for headroom decisions when stored tokens are stale", async () => {
+    const staleAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafChunkTokens: 15_000,
+    });
+
+    await ingestMessages(convStore, sumStore, 10, {
+      contentFn: (i) => `Turn ${i}: ${"x".repeat(11_980)}`,
+      tokenCountFn: () => 3_000,
+    });
+
+    const summarize = vi.fn(async (text: string) => `summary ${text.length}`);
+
+    const result = await staleAwareEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+      currentTokenCount: 80_000,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalled();
+  });
+
+  it("compactFullSweep uses currentTokenCount for threshold sweeps when stored tokens are stale", async () => {
+    const staleAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafChunkTokens: 15_000,
+    });
+
+    await ingestMessages(convStore, sumStore, 10, {
+      contentFn: (i) => `Turn ${i}: ${"y".repeat(11_980)}`,
+      tokenCountFn: () => 3_000,
+    });
+
+    const summarize = vi.fn(async (text: string) => `summary ${text.length}`);
+
+    const result = await staleAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+      currentTokenCount: 80_000,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalled();
+  });
+
   it("compact skips when under threshold and not forced", async () => {
     await ingestMessages(convStore, sumStore, 2, {
       contentFn: () => "Short",
@@ -3294,5 +3342,288 @@ describe("prompt-aware eviction", () => {
       extractMessageText(m.content).includes("Fresh message"),
     );
     expect(summaryIdx).toBeLessThan(freshIdx);
+  });
+});
+// ═════════════════════════════════════════════════════════════════════════════
+// Test Suite: evaluateLeafTrigger skip guards
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("evaluateLeafTrigger skip guards", () => {
+  let convStore: ReturnType<typeof createMockConversationStore>;
+  let sumStore: ReturnType<typeof createMockSummaryStore>;
+
+  beforeEach(() => {
+    convStore = createMockConversationStore();
+    sumStore = createMockSummaryStore();
+    wireStores(convStore, sumStore);
+  });
+
+  function createCompaction(overrides?: Partial<CompactionConfig>): InstanceType<typeof CompactionEngine> {
+    return new CompactionEngine(convStore as any, sumStore as any, {
+      contextThreshold: 0.75,
+      freshTailCount: 4,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 2400,
+      condensedTargetTokens: 900,
+      maxRounds: 10,
+      summaryMaxOverageFactor: 3,
+      leafSkipReductionThreshold: 0.05,
+      leafBudgetHeadroomFactor: 0.8,
+      ...overrides,
+    });
+  }
+
+  // Helper: ingest N messages with fixed token count, freshTailCount=4 means
+  // first (N-4) are outside fresh tail.
+  async function setupConversation(opts: {
+    messageCount: number;
+    tokensPerMessage: number;
+    summaryTokens?: number;
+  }): Promise<void> {
+    await ingestMessages(convStore, sumStore, opts.messageCount, {
+      tokenCountFn: () => opts.tokensPerMessage,
+    });
+    // Optionally add a summary to inflate totalAssembledTokens
+    if (opts.summaryTokens) {
+      await sumStore.insertSummary({
+        summaryId: "existing-summary-1",
+        conversationId: CONV_ID,
+        kind: "leaf",
+        content: "mock summary content",
+        tokenCount: opts.summaryTokens,
+      });
+      await sumStore.appendContextSummary(CONV_ID, "existing-summary-1");
+    }
+  }
+
+  // ── Basic threshold ────────────────────────────────────────────
+
+  it("returns shouldCompact=false when raw tokens below threshold", async () => {
+    // 8 messages at 1000 tokens each, freshTailCount=4 → 4 outside tail = 4000 tokens
+    // leafChunkTokens=20000 → 4000 < 20000 → no compaction
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 1000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.rawTokensOutsideTail).toBe(4000);
+    expect(result.threshold).toBe(20_000);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it("returns shouldCompact=true when raw tokens exceed threshold and no skip applies", async () => {
+    // 12 messages at 5000 tokens each, freshTailCount=4 → 8 outside tail = 40000 tokens
+    // leafChunkTokens=20000 → 40000 >= 20000 → basic threshold met
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // totalAssembled = 60000, 5% of 60000 = 3000 → 17600 > 3000 → cache check passes
+    // tokenBudget=80000 → ceiling = 0.8*0.75*80000 = 48000 → 60000 > 48000 → headroom check passes
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 80_000);
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  // ── Budget headroom skip ───────────────────────────────────────
+
+  it("skips due to budget headroom when assembled tokens are well under ceiling", async () => {
+    // 10 messages at 3000 tokens each, freshTailCount=4 → 6 outside tail = 18000 tokens
+    // But leafChunkTokens=15000 → 18000 >= 15000 → threshold met
+    // totalAssembled = 30000, tokenBudget=200000 → ceiling = 0.8*0.75*200000 = 120000
+    // 30000 < 120000 → budget headroom → SKIP
+    const engine = createCompaction({ leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 200_000);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("budget-headroom");
+  });
+
+  it("does NOT skip headroom when assembled tokens exceed ceiling", async () => {
+    // 12 messages at 5000 tokens, freshTailCount=4 → 8 outside = 40000
+    // totalAssembled = 60000, tokenBudget=80000 → ceiling = 0.8*0.75*80000 = 48000
+    // 60000 > 48000 → no headroom → continues
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 80_000);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("skips headroom check when tokenBudget is undefined", async () => {
+    // Same setup as headroom skip test, but no tokenBudget → headroom check bypassed
+    // Falls through to cache-aware check
+    const engine = createCompaction({ leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    // Without tokenBudget, headroom check is skipped → falls to cache-aware
+    // estimatedReduction = min(18000,15000) - 2400 = 12600
+    // 5% of 30000 = 1500 → 12600 > 1500 → cache check passes → shouldCompact
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  // ── Cache-aware skip ───────────────────────────────────────────
+
+  it("skips due to cache-aware when reduction is tiny relative to total context", async () => {
+    // Use a large summary to inflate totalAssembledTokens relative to raw tokens
+    // 8 messages at 6000 tokens, freshTailCount=4 → 4 outside tail = 24000 tokens
+    // Plus a 500000-token summary → totalAssembled = 548000
+    // leafChunkTokens=20000 → 24000 >= 20000 → threshold met
+    // estimatedReduction = min(24000,20000) - 2400 = 17600
+    // 5% of 548000 = 27400 → 17600 < 27400 → cache skip → SKIP
+    // BUT: tokenBudget matters — if over ceiling, budget pressure overrides
+    // Set tokenBudget high enough that headroom exists (no budget pressure)
+    // ceiling = 0.8*0.75*800000 = 480000 → 548000 > 480000 → budget pressure!
+    // So we need to NOT pass tokenBudget to test cache-aware in isolation
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    // No tokenBudget → headroom check is bypassed, no budget pressure
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("cache-aware");
+  });
+
+  it("does NOT cache-skip when reduction is large enough", async () => {
+    // 12 messages at 5000 tokens, freshTailCount=4 → 8 outside = 40000
+    // totalAssembled = 60000
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // 5% of 60000 = 3000 → 17600 > 3000 → cache check passes → compact
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  // ── Budget pressure overrides cache skip ───────────────────────
+
+  it("compacts when over budget ceiling even if cache reduction is tiny (no starvation)", async () => {
+    // This is the Scenario C fix: large context, tiny relative reduction, but budget pressure
+    // 8 messages at 6000 tokens, freshTailCount=4 → 4 outside = 24000
+    // Plus 500000-token summary → totalAssembled = 548000
+    // tokenBudget=750000 → ceiling = 0.8*0.75*750000 = 450000
+    // 548000 > 450000 → budget pressure → cache skip bypassed → COMPACT
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 750_000);
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────
+
+  it("handles totalAssembledTokens=0 (empty conversation)", async () => {
+    // No messages ingested — rawTokensOutsideTail=0 which is below any threshold
+    const engine = createCompaction();
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.rawTokensOutsideTail).toBe(0);
+  });
+
+  it("handles estimatedReduction <= 0 (raw tokens < leafTargetTokens)", async () => {
+    // leafChunkTokens=2000, 6 messages at 500 tokens, freshTailCount=4 → 2 outside = 1000
+    // But wait — 1000 < 2000 → below threshold, returns early
+    // Use leafChunkTokens=500 so threshold is met at 1000
+    // estimatedReduction = min(1000,500) - 2400 = -1900 (negative)
+    // The estimatedReduction > 0 guard prevents cache skip → falls through to compact
+    const engine = createCompaction({ leafChunkTokens: 500 });
+    await setupConversation({ messageCount: 6, tokensPerMessage: 500 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("respects custom leafSkipReductionThreshold", async () => {
+    // With threshold=0.50 (50%), even large reductions get skipped
+    // 12 messages at 5000, freshTailCount=4 → 8 outside = 40000
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // 50% of 60000 = 30000 → 17600 < 30000 → cache skip
+    const engine = createCompaction({ leafSkipReductionThreshold: 0.50 });
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("cache-aware");
+  });
+
+  it("leafSkipReductionThreshold=0 disables cache-aware skip", async () => {
+    // Same setup as above but leafSkipReductionThreshold=0 → cache-aware skip never fires
+    const engine = createCompaction({
+      leafSkipReductionThreshold: 0,
+    });
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    // No budget pressure (no tokenBudget), cache skip disabled → should compact
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("leafBudgetHeadroomFactor=0 disables headroom check (no false budget pressure)", async () => {
+    // factor=0 → headroomEnabled=false → no headroom skip, no budget pressure
+    // Falls through to cache-aware check with no budget pressure override.
+    // 10 msgs at 3000, freshTailCount=4 → 6 outside = 18000
+    // leafChunkTokens=15000 → perPass = min(18000,15000) = 15000
+    // estimatedReduction = 15000 - 2400 = 12600
+    // totalAssembled = 30000, 5% = 1500 → 12600 > 1500 → cache check passes → compact
+    const engine = createCompaction({ leafBudgetHeadroomFactor: 0, leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 200_000);
+    // No budget pressure (headroom disabled), cache-aware passes → compact
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it("clamps leafBudgetHeadroomFactor above 1.0 to 1.0", async () => {
+    // factor=1.5 → clamped to 1.0 → ceiling = 1.0*0.75*100000 = 75000
+    // 30000 < 75000 → headroom skip
+    const engine = createCompaction({ leafBudgetHeadroomFactor: 1.5, leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 100_000);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("budget-headroom");
+  });
+
+  // ── Orchestration scenario ─────────────────────────────────────
+
+  it("orchestrator with headroom skips, sub-agent at capacity compacts", async () => {
+    // Orchestrator: 40K assembled, 200K budget → ceiling=120K → 40K<120K → SKIP
+    const orchestratorEngine = createCompaction({ leafChunkTokens: 15_000 });
+    await ingestMessages(convStore, sumStore, 10, {
+      conversationId: 1,
+      tokenCountFn: () => 4000,
+    });
+    const orchResult = await orchestratorEngine.evaluateLeafTrigger(1, 200_000);
+    expect(orchResult.shouldCompact).toBe(false);
+
+    // Sub-agent: same raw tokens but tiny budget → ceiling=9600 → 40K>9600 → compact
+    const subResult = await orchestratorEngine.evaluateLeafTrigger(1, 16_000);
+    expect(subResult.shouldCompact).toBe(true);
+  });
+
+  // ── Per-pass chunk size estimate ───────────────────────────────
+
+  it("uses per-pass chunk size (min of raw tokens and threshold) for reduction estimate", async () => {
+    // 20 messages at 5000 tokens, freshTailCount=4 → 16 outside = 80000
+    // leafChunkTokens=20000 → threshold met (80000 >= 20000)
+    // Per-pass: min(80000, 20000) = 20000
+    // estimatedReduction = 20000 - 2400 = 17600
+    // 5% of 100000 = 5000 → 17600 > 5000 → no cache skip → compact
+    // Without per-pass capping, estimatedReduction would be 80000-2400=77600,
+    // which would also pass — but the estimate would be wrong
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 20, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Wires live observed token counts from the engine layer into the compaction guards added in #306, so headroom and cache-aware skip decisions use fresh data instead of potentially stale stored counts. Also propagates the new config fields (`leafSkipReductionThreshold`, `leafBudgetHeadroomFactor`) from `LcmConfig` into `CompactionConfig`.

**Part 2 of 3 from #289 split. Depends on #306. Merge order: #306 → #307 → #308.**

---

## The Problem: Stale Token Counts Cause Wrong Guard Decisions

The compaction guards in #306 decide whether to skip or compact based on `totalAssembledTokens` — a value derived from the stored token count in the database. But stored counts can lag behind reality:

### Stale-low scenario (most dangerous)

After rapid message ingestion (e.g., a tool that emits 15 messages in 1 second), the DB count hasn't caught up:
- **Stored count**: 30K (stale from 2 seconds ago)
- **Live count**: 75K (actual prompt tokens the API will see)
- **Budget ceiling**: 60K

Without live counts, the headroom guard sees 30K < 60K → **SKIP**. But the context is actually 75K — well over the ceiling. The guard should detect budget pressure and **COMPACT**.

### The fix: `max(stored, live)`

By passing `liveContextTokens` (from `estimateSessionTokenCountForAfterTurn`) through to `evaluateLeafTrigger`, the guard uses whichever count is higher:
- Stale-low stored → uses live (prevents missed compaction)
- Stale-high stored → uses stored (conservative, prevents premature skip)

This is the safe/conservative choice — it errs on the side of compacting when counts disagree, which is the correct bias for preventing context overflow.

---

## What This PR Wires

### Engine → CompactionEngine config

`LcmConfig` now flows `leafSkipReductionThreshold` and `leafBudgetHeadroomFactor` into the `CompactionConfig` object, so plugin/env var overrides actually take effect at runtime (without this, the guards always use their internal defaults).

### afterTurn → evaluateLeafTrigger

The engine's `afterTurn()` already computes `liveContextTokens` — this PR passes it (along with `tokenBudget`) through to `evaluateLeafTrigger()` so the guards can make informed decisions.

### afterTurn logging

New structured logging for compaction decisions:
- **Trigger**: `[lcm] afterTurn: leaf compaction triggered (raw=24000, threshold=20000, assembled=548000, pressure=true)`
- **Skip**: `[lcm] afterTurn: leaf compaction skipped (budget-headroom: 30000 assembled < 120000 ceiling)`

These match the log lines documented in the tuning guide (#308).

### compactLeaf/compactFullSweep → currentTokenCount

Both paths now pass `observedTokens` (from `normalizeObservedTokenCount`) as `currentTokenCount`, which `evaluateLeafTrigger` uses as `precomputedTokenCount` to avoid a duplicate DB read.

### compact() type fix

`compact()` wrapper now includes `currentTokenCount` in its input type so TypeScript excess-property checks pass and the value flows through to `compactFullSweep`.

### LeafTriggerResult import

Engine's `evaluateLeafTrigger` now imports `LeafTriggerResult` from `compaction.ts` instead of re-declaring the shape inline, preventing type drift.

### README env var table

Added `LCM_LEAF_SKIP_REDUCTION_THRESHOLD`, `LCM_LEAF_BUDGET_HEADROOM_FACTOR`, and `LCM_FALLBACK_PROVIDERS` to the README environment variable reference table.

---

## Changes by File

| File | Lines | Change |
|------|-------|--------|
| `src/engine.ts` | +26/-3 | Pass config fields to CompactionConfig. Pass `tokenBudget` + `liveContextTokens` to `evaluateLeafTrigger` from afterTurn. Pass `currentTokenCount` to `compactLeaf`/`compact`. Import `LeafTriggerResult`. Add trigger/skip logging. |
| `src/compaction.ts` | +1 | Add `currentTokenCount` to `compact()` input type. |
| `test/engine.test.ts` | +48/-1 | Update `evaluateLeafTrigger` assertion for 4-arg signature. Add `currentTokenCount` to compact plumbing assertions. New test: `compactLeafAsync` passes `currentTokenCount`. New test: omission when not provided. |
| `test/lcm-integration.test.ts` | +2 | Shrink test message bodies (was 12KB strings, now short descriptive text). |
| `README.md` | +3 | Add 3 env vars to reference table. |

## Test Plan

- [x] 204 tests passing (122 engine + 82 integration)
- [x] `evaluateLeafTrigger` called with `(sessionId, sessionKey, tokenBudget, liveContextTokens)`
- [x] `currentTokenCount: 500` flows through compact plumbing to `compactFullSweep`
- [x] `currentTokenCount` omitted from `compactLeaf` call when not provided (no undefined leakage)
- [x] Stale-token integration tests: compactLeaf and compactFullSweep trigger with live counts