### PR TITLE
feat: compaction efficiency tracker in /lossless command

### DIFF
--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -1,3 +1,4 @@
+---
 "@martian-engineering/lossless-claw": minor
 ---
 

--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": minor
 ---
 
-Cache-aware leaf compaction guards with budget-pressure override and per-tier tuning. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample.
+Cache-aware leaf compaction guards with budget-pressure override. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample. Adds `leafSkipReductionThreshold` and `leafBudgetHeadroomFactor` config fields.

--- a/.changeset/cache-aware-compaction-guards.md
+++ b/.changeset/cache-aware-compaction-guards.md
@@ -1,0 +1,4 @@
+"@martian-engineering/lossless-claw": minor
+---
+
+Cache-aware leaf compaction guards with budget-pressure override and per-tier tuning. Prevents unnecessary prompt-cache invalidation by skipping compaction when token reduction is negligible or budget headroom is ample.

--- a/.changeset/compaction-efficiency-tracker.md
+++ b/.changeset/compaction-efficiency-tracker.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Compaction efficiency tracker: persists compaction events to SQLite, adds cost/savings estimation to `/lossless status`, and introduces `/lossless efficiency` subcommand with per-model breakdown and actionable recommendations.

--- a/.changeset/track-actual-compaction-model.md
+++ b/.changeset/track-actual-compaction-model.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Track the actual provider/model used for compaction instead of the configured model. When fallback providers activate, the efficiency tracker now records which model actually produced the summary, making per-model cost breakdowns accurate.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_DELEGATION_TIMEOUT_MS` | `120000` | Max time to wait for delegated `lcm_expand_query` sub-agent completion |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Max time to wait for a single model-backed LCM summarizer call |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
+| `LCM_LEAF_SKIP_REDUCTION_THRESHOLD` | `0.05` | Minimum estimated reduction (fraction of assembled tokens) to justify leaf compaction; set to 0 to disable cache-aware skip |
+| `LCM_LEAF_BUDGET_HEADROOM_FACTOR` | `0.8` | Skip leaf compaction when assembled tokens are below this fraction of the budget ceiling; set to 0 to disable headroom check |
+| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider:model` pairs for compaction summarization fallbacks |
 
 ### Expansion model override requirements
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 | `LCM_LEAF_SKIP_REDUCTION_THRESHOLD` | `0.05` | Minimum estimated reduction (fraction of assembled tokens) to justify leaf compaction; set to 0 to disable cache-aware skip |
 | `LCM_LEAF_BUDGET_HEADROOM_FACTOR` | `0.8` | Skip leaf compaction when assembled tokens are below this fraction of the budget ceiling; set to 0 to disable headroom check |
-| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider:model` pairs for compaction summarization fallbacks |
+| `LCM_FALLBACK_PROVIDERS` | `""` | Comma-separated `provider/model` pairs for compaction summarization fallbacks (e.g. `anthropic/claude-haiku-4-5,openai/gpt-4o-mini`) |
 
 ### Expansion model override requirements
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -108,6 +108,14 @@
       "label": "Prune HEARTBEAT_OK",
       "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
     },
+    "leafSkipReductionThreshold": {
+      "label": "Leaf Skip Reduction Threshold",
+      "help": "Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction. Set to 0 to disable. Default 0.05."
+    },
+    "leafBudgetHeadroomFactor": {
+      "label": "Leaf Budget Headroom Factor",
+      "help": "Skip leaf compaction when assembled tokens are below this fraction of contextThreshold × tokenBudget. Set to 0 to disable. Default 0.8."
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit fallback provider/model pairs for compaction summarization (e.g., [{\"provider\": \"anthropic\", \"model\": \"claude-haiku-4-5\"}])"
@@ -249,6 +257,18 @@
           "required": ["provider", "model"],
           "additionalProperties": false
         }
+      },
+      "leafSkipReductionThreshold": {
+        "description": "Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction. Prevents cache-prefix invalidation when the gain is tiny. Set to 0 to disable. Default 0.05.",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "leafBudgetHeadroomFactor": {
+        "description": "Skip leaf compaction when assembled tokens are below this fraction of contextThreshold × tokenBudget. Set to 0 to disable. Default 0.8.",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.3.0",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.3.0",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "*",

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -99,6 +99,8 @@ type PassResult = {
   modelInputTokensEst: number;
   /** Estimated tokens produced by the compaction model. */
   modelOutputTokensEst: number;
+  /** The provider/model that actually produced this summary (may differ from configured after fallback). */
+  modelUsed?: string;
 };
 type LeafChunkSelection = {
   items: ContextItemRecord[];
@@ -657,7 +659,7 @@ export class CompactionEngine {
       tokensBefore,
       tokensAfterLeaf,
       tokensAfterFinal: tokensAfterLeaf,
-      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst },
+      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst, modelUsed: leafResult.modelUsed },
       condenseResult: null,
       compactionModel: input.summaryModel,
     });
@@ -804,7 +806,7 @@ export class CompactionEngine {
         tokensBefore: passTokensBefore,
         tokensAfterLeaf: passTokensAfter,
         tokensAfterFinal: passTokensAfter,
-        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst },
+        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst, modelUsed: leafResult.modelUsed },
         condenseResult: null,
         compactionModel: input.summaryModel,
       });
@@ -1401,7 +1403,7 @@ export class CompactionEngine {
     options?: CompactionSummarizeOptions;
     /** Target token count for this summary kind (leaf or condensed). Used for hard-cap enforcement. */
     targetTokens: number;
-  }): Promise<{ content: string; level: CompactionLevel } | null> {
+  }): Promise<{ content: string; level: CompactionLevel; modelUsed?: string } | null> {
     const sourceText = params.sourceText.trim();
     if (!sourceText) {
       return {
@@ -1423,17 +1425,24 @@ export class CompactionEngine {
     };
     const authFailure = Symbol("authFailure");
 
+    let resolvedModelUsed: string | undefined;
+
     const runSummarizer = async (
       aggressiveMode: boolean,
     ): Promise<string | null | typeof authFailure> => {
-      let output: string;
+      let rawOutput: string | { text: string; modelUsed?: string };
       try {
-        output = await params.summarize(sourceText, aggressiveMode, params.options);
+        rawOutput = await params.summarize(sourceText, aggressiveMode, params.options);
       } catch (err) {
         if (err instanceof LcmProviderAuthError) {
           return authFailure;
         }
         throw err;
+      }
+      // Handle union return: string or { text, modelUsed }
+      const output = typeof rawOutput === "string" ? rawOutput : rawOutput.text;
+      if (typeof rawOutput === "object" && rawOutput.modelUsed) {
+        resolvedModelUsed = rawOutput.modelUsed;
       }
       const trimmed = output.trim();
       return trimmed || null;
@@ -1482,7 +1491,7 @@ export class CompactionEngine {
       level = "capped";
     }
 
-    return { content: summaryText, level };
+    return { content: summaryText, level, modelUsed: resolvedModelUsed };
   }
 
   // ── Private: Media Annotation ────────────────────────────────────────────
@@ -1538,7 +1547,7 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn,
     previousSummaryContent?: string,
     summaryModel?: string,
-  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number; modelInputTokensEst: number; modelOutputTokensEst: number } | null> {
+  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number; modelInputTokensEst: number; modelOutputTokensEst: number; modelUsed?: string } | null> {
     // Fetch full message content for each context item
     const messageContents: { messageId: number; content: string; createdAt: Date; tokenCount: number }[] =
       [];
@@ -1648,6 +1657,7 @@ export class CompactionEngine {
         + estimateTokens(previousSummaryContent ?? "")
         + 500, // prompt wrapper overhead (instructions, XML tags)
       modelOutputTokensEst: tokenCount,
+      modelUsed: summary.modelUsed,
     };
   }
 
@@ -1801,6 +1811,7 @@ export class CompactionEngine {
         + estimateTokens(previousSummaryContent ?? "")
         + 500, // prompt wrapper overhead
       modelOutputTokensEst: tokenCount,
+      modelUsed: condensed.modelUsed,
     };
   }
 
@@ -1810,8 +1821,8 @@ export class CompactionEngine {
     tokensBefore: number;
     tokensAfterLeaf: number;
     tokensAfterFinal: number;
-    leafResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number } | null;
-    condenseResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number } | null;
+    leafResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number; modelUsed?: string } | null;
+    condenseResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number; modelUsed?: string } | null;
     compactionModel?: string;
   }): Promise<void> {
     const {
@@ -1847,7 +1858,7 @@ export class CompactionEngine {
         tokensAfter: tokensAfterLeaf,
         inputTokensEst: leafResult.inputTokensEst ?? 0,
         outputTokensEst: leafResult.outputTokensEst ?? 0,
-        compactionModel: input.compactionModel,
+        compactionModel: leafResult.modelUsed ?? input.compactionModel,
         createdSummaryId: leafResult.summaryId,
         createdSummaryIds,
         condensedPassOccurred,
@@ -1864,7 +1875,7 @@ export class CompactionEngine {
         tokensAfter: tokensAfterFinal,
         inputTokensEst: condenseResult.inputTokensEst ?? 0,
         outputTokensEst: condenseResult.outputTokensEst ?? 0,
-        compactionModel: input.compactionModel,
+        compactionModel: condenseResult.modelUsed ?? input.compactionModel,
         createdSummaryId: condenseResult.summaryId,
         createdSummaryIds,
         condensedPassOccurred,

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1644,7 +1644,9 @@ export class CompactionEngine {
       content: summary.content,
       removedTokens,
       addedTokens: tokenCount,
-      modelInputTokensEst: estimateTokens(concatenated),
+      modelInputTokensEst: estimateTokens(concatenated)
+        + estimateTokens(previousSummaryContent ?? "")
+        + 500, // prompt wrapper overhead (instructions, XML tags)
       modelOutputTokensEst: tokenCount,
     };
   }
@@ -1795,7 +1797,9 @@ export class CompactionEngine {
       level: condensed.level,
       removedTokens,
       addedTokens: tokenCount,
-      modelInputTokensEst: estimateTokens(concatenated),
+      modelInputTokensEst: estimateTokens(concatenated)
+        + estimateTokens(previousSummaryContent ?? "")
+        + 500, // prompt wrapper overhead
       modelOutputTokensEst: tokenCount,
     };
   }

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -474,9 +474,13 @@ export class CompactionEngine {
     // Use the higher of stored/precomputed count and live context estimate
     // for more accurate headroom decisions.
     const storedTokens = precomputedTokenCount ?? await this.summaryStore.getContextTokenCount(conversationId);
+    const normalizedLiveContextTokens =
+      Number.isFinite(liveContextTokens) && (liveContextTokens as number) > 0
+        ? Math.floor(liveContextTokens as number)
+        : undefined;
     const totalAssembledTokens =
-      typeof liveContextTokens === "number" && liveContextTokens > storedTokens
-        ? liveContextTokens
+      normalizedLiveContextTokens !== undefined && normalizedLiveContextTokens > storedTokens
+        ? normalizedLiveContextTokens
         : storedTokens;
 
     // ── Budget headroom check (evaluated first) ───────────────────

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -484,6 +484,9 @@ export class CompactionEngine {
     // avoid unnecessary cache prefix churn.
     const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
     const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
+    // headroomEnabled: only run the headroom check when factor > 0 and
+    // tokenBudget is available.  Setting factor to 0 disables the check
+    // (and does NOT create false budget pressure).
     const headroomEnabled = headroomFactor > 0 && typeof tokenBudget === "number" && tokenBudget > 0;
     const budgetCeiling = headroomEnabled
       ? Math.floor(headroomFactor * this.config.contextThreshold * tokenBudget)
@@ -506,8 +509,14 @@ export class CompactionEngine {
     // If the estimated token reduction is tiny relative to the total
     // assembled context, the prompt-cache prefix invalidation cost
     // exceeds the compression benefit.
-    // Budget pressure override: when headroom is enabled and context
-    // reaches or exceeds the ceiling, compaction fires unconditionally.
+    //
+    // This skip is gated on !budgetPressure.  Budget pressure is true
+    // only when headroom is enabled (factor > 0, tokenBudget provided)
+    // AND assembled tokens reach or exceed the headroom ceiling.  When the
+    // headroom check is disabled or tokenBudget is missing, there is
+    // no budget pressure signal, so the cache-aware skip can fire.
+    // When budget pressure IS detected, compaction fires unconditionally
+    // to prevent starvation in large contexts.
     const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
     const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
     const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -653,8 +653,9 @@ export class CompactionEngine {
       tokensBefore,
       tokensAfterLeaf,
       tokensAfterFinal: tokensAfterLeaf,
-      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level },
+      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.removedTokens, outputTokensEst: leafResult.addedTokens },
       condenseResult: null,
+      compactionModel: input.summaryModel,
     });
 
     let tokensAfter = tokensAfterLeaf;
@@ -691,7 +692,8 @@ export class CompactionEngine {
           tokensAfterLeaf: passTokensBefore,
           tokensAfterFinal: passTokensAfter,
           leafResult: null,
-          condenseResult,
+          condenseResult: { ...condenseResult, inputTokensEst: condenseResult.removedTokens, outputTokensEst: condenseResult.addedTokens },
+          compactionModel: input.summaryModel,
         });
 
         tokensAfter = passTokensAfter;
@@ -798,8 +800,9 @@ export class CompactionEngine {
         tokensBefore: passTokensBefore,
         tokensAfterLeaf: passTokensAfter,
         tokensAfterFinal: passTokensAfter,
-        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level },
+        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.removedTokens, outputTokensEst: leafResult.addedTokens },
         condenseResult: null,
+        compactionModel: input.summaryModel,
       });
 
       actionTaken = true;
@@ -847,7 +850,8 @@ export class CompactionEngine {
         tokensAfterLeaf: passTokensBefore,
         tokensAfterFinal: passTokensAfter,
         leafResult: null,
-        condenseResult,
+        condenseResult: { ...condenseResult, inputTokensEst: condenseResult.removedTokens, outputTokensEst: condenseResult.addedTokens },
+        compactionModel: input.summaryModel,
       });
 
       actionTaken = true;
@@ -1783,8 +1787,9 @@ export class CompactionEngine {
     tokensBefore: number;
     tokensAfterLeaf: number;
     tokensAfterFinal: number;
-    leafResult: { summaryId: string; level: CompactionLevel } | null;
-    condenseResult: { summaryId: string; level: CompactionLevel } | null;
+    leafResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number } | null;
+    condenseResult: { summaryId: string; level: CompactionLevel; inputTokensEst?: number; outputTokensEst?: number } | null;
+    compactionModel?: string;
   }): Promise<void> {
     const {
       conversationId,
@@ -1817,6 +1822,9 @@ export class CompactionEngine {
         level: leafResult.level,
         tokensBefore,
         tokensAfter: tokensAfterLeaf,
+        inputTokensEst: leafResult.inputTokensEst ?? 0,
+        outputTokensEst: leafResult.outputTokensEst ?? 0,
+        compactionModel: input.compactionModel,
         createdSummaryId: leafResult.summaryId,
         createdSummaryIds,
         condensedPassOccurred,
@@ -1831,6 +1839,9 @@ export class CompactionEngine {
         level: condenseResult.level,
         tokensBefore: tokensAfterLeaf,
         tokensAfter: tokensAfterFinal,
+        inputTokensEst: condenseResult.inputTokensEst ?? 0,
+        outputTokensEst: condenseResult.outputTokensEst ?? 0,
+        compactionModel: input.compactionModel,
         createdSummaryId: condenseResult.summaryId,
         createdSummaryIds,
         condensedPassOccurred,
@@ -1838,7 +1849,7 @@ export class CompactionEngine {
     }
   }
 
-  /** Log one compaction event without appending a synthetic chat message. */
+  /** Log and persist one compaction event. */
   private async persistCompactionEvent(input: {
     conversationId: number;
     sessionId: string;
@@ -1846,6 +1857,9 @@ export class CompactionEngine {
     level: CompactionLevel;
     tokensBefore: number;
     tokensAfter: number;
+    inputTokensEst: number;
+    outputTokensEst: number;
+    compactionModel?: string;
     createdSummaryId: string;
     createdSummaryIds: string[];
     condensedPassOccurred: boolean;
@@ -1854,5 +1868,18 @@ export class CompactionEngine {
     console.info(
       `[lcm] ${content} conversation=${input.conversationId} summary=${input.createdSummaryId}`,
     );
+
+    if (typeof this.summaryStore.insertCompactionEvent === "function") {
+      this.summaryStore.insertCompactionEvent({
+        conversationId: input.conversationId,
+        pass: input.pass,
+        level: input.level,
+        tokensBefore: input.tokensBefore,
+        tokensAfter: input.tokensAfter,
+        inputTokensEst: input.inputTokensEst,
+        outputTokensEst: input.outputTokensEst,
+        compactionModel: input.compactionModel,
+      });
+    }
   }
 }

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -95,6 +95,10 @@ type PassResult = {
   removedTokens: number;
   /** Token count of the newly created summary. */
   addedTokens: number;
+  /** Estimated tokens sent to the compaction model. */
+  modelInputTokensEst: number;
+  /** Estimated tokens produced by the compaction model. */
+  modelOutputTokensEst: number;
 };
 type LeafChunkSelection = {
   items: ContextItemRecord[];
@@ -653,7 +657,7 @@ export class CompactionEngine {
       tokensBefore,
       tokensAfterLeaf,
       tokensAfterFinal: tokensAfterLeaf,
-      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.removedTokens, outputTokensEst: leafResult.addedTokens },
+      leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst },
       condenseResult: null,
       compactionModel: input.summaryModel,
     });
@@ -692,7 +696,7 @@ export class CompactionEngine {
           tokensAfterLeaf: passTokensBefore,
           tokensAfterFinal: passTokensAfter,
           leafResult: null,
-          condenseResult: { ...condenseResult, inputTokensEst: condenseResult.removedTokens, outputTokensEst: condenseResult.addedTokens },
+          condenseResult: { ...condenseResult, inputTokensEst: condenseResult.modelInputTokensEst, outputTokensEst: condenseResult.modelOutputTokensEst },
           compactionModel: input.summaryModel,
         });
 
@@ -800,7 +804,7 @@ export class CompactionEngine {
         tokensBefore: passTokensBefore,
         tokensAfterLeaf: passTokensAfter,
         tokensAfterFinal: passTokensAfter,
-        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.removedTokens, outputTokensEst: leafResult.addedTokens },
+        leafResult: { summaryId: leafResult.summaryId, level: leafResult.level, inputTokensEst: leafResult.modelInputTokensEst, outputTokensEst: leafResult.modelOutputTokensEst },
         condenseResult: null,
         compactionModel: input.summaryModel,
       });
@@ -850,7 +854,7 @@ export class CompactionEngine {
         tokensAfterLeaf: passTokensBefore,
         tokensAfterFinal: passTokensAfter,
         leafResult: null,
-        condenseResult: { ...condenseResult, inputTokensEst: condenseResult.removedTokens, outputTokensEst: condenseResult.addedTokens },
+        condenseResult: { ...condenseResult, inputTokensEst: condenseResult.modelInputTokensEst, outputTokensEst: condenseResult.modelOutputTokensEst },
         compactionModel: input.summaryModel,
       });
 
@@ -1534,7 +1538,7 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn,
     previousSummaryContent?: string,
     summaryModel?: string,
-  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number } | null> {
+  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number; modelInputTokensEst: number; modelOutputTokensEst: number } | null> {
     // Fetch full message content for each context item
     const messageContents: { messageId: number; content: string; createdAt: Date; tokenCount: number }[] =
       [];
@@ -1634,7 +1638,15 @@ export class CompactionEngine {
     });
     this.invalidateContextCache(conversationId);
 
-    return { summaryId, level: summary.level, content: summary.content, removedTokens, addedTokens: tokenCount };
+    return {
+      summaryId,
+      level: summary.level,
+      content: summary.content,
+      removedTokens,
+      addedTokens: tokenCount,
+      modelInputTokensEst: estimateTokens(concatenated),
+      modelOutputTokensEst: tokenCount,
+    };
   }
 
   // ── Private: Condensed Pass ──────────────────────────────────────────────
@@ -1778,7 +1790,14 @@ export class CompactionEngine {
       (sum, s) => sum + Math.max(0, Math.floor(s.tokenCount)),
       0,
     );
-    return { summaryId, level: condensed.level, removedTokens, addedTokens: tokenCount };
+    return {
+      summaryId,
+      level: condensed.level,
+      removedTokens,
+      addedTokens: tokenCount,
+      modelInputTokensEst: estimateTokens(concatenated),
+      modelOutputTokensEst: tokenCount,
+    };
   }
 
   /** Emit compaction telemetry without mutating canonical conversation history. */

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -469,6 +469,13 @@ export class CompactionEngine {
       return { shouldCompact: false, rawTokensOutsideTail, threshold };
     }
 
+    // Short-circuit when both guards are disabled — avoid unnecessary DB read.
+    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
+    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
+    if (rawHeadroomFactor <= 0 && reductionThreshold <= 0) {
+      return { shouldCompact: true, rawTokensOutsideTail, threshold };
+    }
+
     // Reuse a precomputed token count when the caller already fetched it
     // (avoids a duplicate getContextTokenCount DB read).
     // Use the higher of stored/precomputed count and live context estimate
@@ -486,7 +493,6 @@ export class CompactionEngine {
     // ── Budget headroom check (evaluated first) ───────────────────
     // If assembled tokens are well under the budget ceiling, skip to
     // avoid unnecessary cache prefix churn.
-    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
     const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
     // headroomEnabled: only run the headroom check when factor > 0 and
     // tokenBudget is available.  Setting factor to 0 disables the check
@@ -523,7 +529,6 @@ export class CompactionEngine {
     // to prevent starvation in large contexts.
     const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
     const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
-    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
     const budgetPressure = headroomEnabled && !hasHeadroom;
     if (
       !budgetPressure &&

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -556,6 +556,7 @@ export class CompactionEngine {
     tokenBudget: number;
     /** LLM call function for summarization */
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -54,7 +54,27 @@ export interface CompactionConfig {
   timezone?: string;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
   summaryMaxOverageFactor: number;
+  /** Minimum estimated reduction fraction to justify leaf compaction (default 0.05). */
+  leafSkipReductionThreshold?: number;
+  /** Skip leaf compaction when assembled tokens < factor × contextThreshold × tokenBudget (default 0.8). */
+  leafBudgetHeadroomFactor?: number;
 }
+
+export type LeafTriggerResult = {
+  shouldCompact: boolean;
+  rawTokensOutsideTail: number;
+  threshold: number;
+  skipReason?: string;
+  /** Structured decision context for diagnostics and telemetry. */
+  context?: {
+    totalAssembledTokens: number;
+    budgetCeiling?: number;
+    budgetPressure: boolean;
+    estimatedReduction?: number;
+    reductionThreshold?: number;
+    headroomFactor: number;
+  };
+};
 
 type CompactionLevel = "normal" | "aggressive" | "fallback" | "capped";
 type CompactionPass = "leaf" | "condensed";
@@ -436,17 +456,82 @@ export class CompactionEngine {
    * `leafChunkTokens`. This lets callers trigger a soft incremental leaf pass
    * before the full context threshold is breached.
    */
-  async evaluateLeafTrigger(conversationId: number): Promise<{
-    shouldCompact: boolean;
-    rawTokensOutsideTail: number;
-    threshold: number;
-  }> {
+  async evaluateLeafTrigger(
+    conversationId: number,
+    tokenBudget?: number,
+    liveContextTokens?: number,
+    precomputedTokenCount?: number,
+  ): Promise<LeafTriggerResult> {
     const rawTokensOutsideTail = await this.countRawTokensOutsideFreshTail(conversationId);
     const threshold = this.resolveLeafChunkTokens();
+
+    if (rawTokensOutsideTail < threshold) {
+      return { shouldCompact: false, rawTokensOutsideTail, threshold };
+    }
+
+    // Reuse a precomputed token count when the caller already fetched it
+    // (avoids a duplicate getContextTokenCount DB read).
+    // Use the higher of stored/precomputed count and live context estimate
+    // for more accurate headroom decisions.
+    const storedTokens = precomputedTokenCount ?? await this.summaryStore.getContextTokenCount(conversationId);
+    const totalAssembledTokens =
+      typeof liveContextTokens === "number" && liveContextTokens > storedTokens
+        ? liveContextTokens
+        : storedTokens;
+
+    // ── Budget headroom check (evaluated first) ───────────────────
+    // If assembled tokens are well under the budget ceiling, skip to
+    // avoid unnecessary cache prefix churn.
+    const rawHeadroomFactor = this.config.leafBudgetHeadroomFactor ?? 0.8;
+    const headroomFactor = Math.min(Math.max(rawHeadroomFactor, 0), 1.0);
+    const headroomEnabled = headroomFactor > 0 && typeof tokenBudget === "number" && tokenBudget > 0;
+    const budgetCeiling = headroomEnabled
+      ? Math.floor(headroomFactor * this.config.contextThreshold * tokenBudget)
+      : undefined;
+    let hasHeadroom = false;
+    if (headroomEnabled && budgetCeiling !== undefined) {
+      hasHeadroom = totalAssembledTokens < budgetCeiling;
+      if (hasHeadroom) {
+        return {
+          shouldCompact: false,
+          rawTokensOutsideTail,
+          threshold,
+          skipReason: `budget-headroom: ${totalAssembledTokens} assembled < ${budgetCeiling} ceiling`,
+          context: { totalAssembledTokens, budgetCeiling, budgetPressure: false, headroomFactor },
+        };
+      }
+    }
+
+    // ── Cache-aware skip ──────────────────────────────────────────
+    // If the estimated token reduction is tiny relative to the total
+    // assembled context, the prompt-cache prefix invalidation cost
+    // exceeds the compression benefit.
+    // Budget pressure override: when headroom is enabled and context
+    // reaches or exceeds the ceiling, compaction fires unconditionally.
+    const perPassRawTokens = Math.min(rawTokensOutsideTail, threshold);
+    const estimatedReduction = perPassRawTokens - this.config.leafTargetTokens;
+    const reductionThreshold = Math.min(Math.max(this.config.leafSkipReductionThreshold ?? 0.05, 0), 1.0);
+    const budgetPressure = headroomEnabled && !hasHeadroom;
+    if (
+      !budgetPressure &&
+      totalAssembledTokens > 0 &&
+      estimatedReduction > 0 &&
+      estimatedReduction < reductionThreshold * totalAssembledTokens
+    ) {
+      return {
+        shouldCompact: false,
+        rawTokensOutsideTail,
+        threshold,
+        skipReason: `cache-aware: reduction ${estimatedReduction} < ${(reductionThreshold * 100).toFixed(0)}% of ${totalAssembledTokens} assembled`,
+        context: { totalAssembledTokens, budgetCeiling, budgetPressure, estimatedReduction, reductionThreshold, headroomFactor },
+      };
+    }
+
     return {
-      shouldCompact: rawTokensOutsideTail >= threshold,
+      shouldCompact: true,
       rawTokensOutsideTail,
       threshold,
+      context: { totalAssembledTokens, budgetCeiling, budgetPressure, estimatedReduction, reductionThreshold, headroomFactor },
     };
   }
 
@@ -474,6 +559,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     previousSummaryContent?: string;
     summaryModel?: string;
@@ -485,6 +571,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     previousSummaryContent?: string;
     summaryModel?: string;
@@ -493,7 +580,12 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    const leafTrigger = await this.evaluateLeafTrigger(
+      conversationId,
+      tokenBudget,
+      input.currentTokenCount,
+      tokensBefore,
+    );
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {
@@ -616,6 +708,7 @@ export class CompactionEngine {
     conversationId: number;
     tokenBudget: number;
     summarize: CompactionSummarizeFn;
+    currentTokenCount?: number;
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;
@@ -624,7 +717,12 @@ export class CompactionEngine {
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
-    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    const leafTrigger = await this.evaluateLeafTrigger(
+      conversationId,
+      tokenBudget,
+      input.currentTokenCount,
+      tokensBefore,
+    );
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -60,6 +60,12 @@ export type LcmConfig = {
   circuitBreakerCooldownMs: number;
   /** Explicit fallback provider/model pairs for compaction summarization. */
   fallbackProviders: Array<{ provider: string; model: string }>;
+  /** Minimum estimated reduction (fraction of total assembled tokens) to justify leaf compaction.
+   *  Prevents cache-prefix invalidation when the gain is tiny relative to total context. Default 0.05. */
+  leafSkipReductionThreshold: number;
+  /** Skip leaf compaction when assembled tokens < factor × contextThreshold × tokenBudget.
+   *  Avoids unnecessary compaction when there is ample budget headroom. Default 0.8. */
+  leafBudgetHeadroomFactor: number;
 };
 
 /** Safely coerce an unknown value to a finite number, or return undefined. */
@@ -281,5 +287,17 @@ export function resolveLcmConfig(
     fallbackProviders:
       parseFallbackProviders(env.LCM_FALLBACK_PROVIDERS)
         ?? toFallbackProviderArray(pc.fallbackProviders) ?? [],
+    leafSkipReductionThreshold: clamp01(
+      parseFiniteNumber(env.LCM_LEAF_SKIP_REDUCTION_THRESHOLD)
+        ?? toNumber(pc.leafSkipReductionThreshold) ?? 0.05,
+    ),
+    leafBudgetHeadroomFactor: clamp01(
+      parseFiniteNumber(env.LCM_LEAF_BUDGET_HEADROOM_FACTOR)
+        ?? toNumber(pc.leafBudgetHeadroomFactor) ?? 0.8,
+    ),
   };
+}
+
+function clamp01(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
 }

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -560,7 +560,7 @@ export function runLcmMigrations(
     );
 
     -- Indexes
-    CREATE INDEX IF NOT EXISTS compaction_events_conv_idx ON compaction_events (conversation_id);
+    CREATE INDEX IF NOT EXISTS compaction_events_conv_idx ON compaction_events (conversation_id, created_at);
     CREATE INDEX IF NOT EXISTS messages_conv_seq_idx ON messages (conversation_id, seq);
     CREATE INDEX IF NOT EXISTS summaries_conv_created_idx ON summaries (conversation_id, created_at);
     CREATE INDEX IF NOT EXISTS summary_messages_message_idx ON summary_messages (message_id);

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -546,7 +546,21 @@ export function runLcmMigrations(
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS compaction_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      pass TEXT NOT NULL CHECK (pass IN ('leaf', 'condensed')),
+      level TEXT NOT NULL,
+      tokens_before INTEGER NOT NULL,
+      tokens_after INTEGER NOT NULL,
+      input_tokens_est INTEGER NOT NULL DEFAULT 0,
+      output_tokens_est INTEGER NOT NULL DEFAULT 0,
+      compaction_model TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     -- Indexes
+    CREATE INDEX IF NOT EXISTS compaction_events_conv_idx ON compaction_events (conversation_id);
     CREATE INDEX IF NOT EXISTS messages_conv_seq_idx ON messages (conversation_id, seq);
     CREATE INDEX IF NOT EXISTS summaries_conv_created_idx ON summaries (conversation_id, created_at);
     CREATE INDEX IF NOT EXISTS summary_messages_message_idx ON summary_messages (message_id);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1264,6 +1264,8 @@ export class LcmContextEngine implements ContextEngine {
       maxRounds: 10,
       timezone: this.config.timezone,
       summaryMaxOverageFactor: this.config.summaryMaxOverageFactor,
+      leafSkipReductionThreshold: this.config.leafSkipReductionThreshold ?? 0.05,
+      leafBudgetHeadroomFactor: this.config.leafBudgetHeadroomFactor ?? 0.8,
     };
     this.compaction = new CompactionEngine(
       this.conversationStore,
@@ -2717,8 +2719,11 @@ export class LcmContextEngine implements ContextEngine {
     const liveContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
 
     try {
-      const leafTrigger = await this.evaluateLeafTrigger(params.sessionId, params.sessionKey);
+      const leafTrigger = await this.evaluateLeafTrigger(params.sessionId, params.sessionKey, tokenBudget, liveContextTokens);
       if (leafTrigger.shouldCompact) {
+        this.deps.log.info(
+          `[lcm] afterTurn: leaf compaction triggered (raw=${leafTrigger.rawTokensOutsideTail}, threshold=${leafTrigger.threshold}${leafTrigger.context ? `, assembled=${leafTrigger.context.totalAssembledTokens}, pressure=${leafTrigger.context.budgetPressure}` : ""})`,
+        );
         this.compactLeafAsync({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
@@ -2729,6 +2734,10 @@ export class LcmContextEngine implements ContextEngine {
         }).catch(() => {
           // Leaf compaction is best-effort and should not fail the caller.
         });
+      } else if (leafTrigger.skipReason) {
+        this.deps.log.debug?.(
+          `[lcm] afterTurn: leaf compaction skipped (${leafTrigger.skipReason})`,
+        );
       }
     } catch {
       // Leaf trigger checks are best-effort.
@@ -2837,10 +2846,19 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Evaluate whether incremental leaf compaction should run for a session. */
-  async evaluateLeafTrigger(sessionId: string, sessionKey?: string): Promise<{
+  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<{
     shouldCompact: boolean;
     rawTokensOutsideTail: number;
     threshold: number;
+    skipReason?: string;
+    context?: {
+      totalAssembledTokens: number;
+      budgetCeiling?: number;
+      budgetPressure: boolean;
+      estimatedReduction?: number;
+      reductionThreshold?: number;
+      headroomFactor: number;
+    };
   }> {
     this.ensureMigrated();
     const conversation = await this.conversationStore.getConversationForSession({
@@ -2860,7 +2878,7 @@ export class LcmContextEngine implements ContextEngine {
         threshold: fallbackThreshold,
       };
     }
-    return this.compaction.evaluateLeafTrigger(conversation.conversationId);
+    return this.compaction.evaluateLeafTrigger(conversation.conversationId, tokenBudget, liveContextTokens);
   }
 
   /** Run one incremental leaf compaction pass in the per-session queue. */
@@ -2943,6 +2961,7 @@ export class LcmContextEngine implements ContextEngine {
         const leafResult = await this.compaction.compactLeaf({
           conversationId: conversation.conversationId,
           tokenBudget,
+          currentTokenCount: observedTokens,
           summarize,
           force: params.force,
           previousSummaryContent: params.previousSummaryContent,
@@ -3103,6 +3122,7 @@ export class LcmContextEngine implements ContextEngine {
           const sweepResult = await this.compaction.compact({
             conversationId,
             tokenBudget,
+            currentTokenCount: observedTokens,
             summarize,
             force: forceCompaction,
             hardTrigger: false,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -25,7 +25,7 @@ import {
   pickToolIsError,
   pickToolName,
 } from "./assembler.js";
-import { CompactionEngine, type CompactionConfig } from "./compaction.js";
+import { CompactionEngine, type CompactionConfig, type LeafTriggerResult } from "./compaction.js";
 import type { LcmConfig } from "./db/config.js";
 import { getLcmDbFeatures } from "./db/features.js";
 import { runLcmMigrations } from "./db/migration.js";
@@ -2846,20 +2846,7 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Evaluate whether incremental leaf compaction should run for a session. */
-  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<{
-    shouldCompact: boolean;
-    rawTokensOutsideTail: number;
-    threshold: number;
-    skipReason?: string;
-    context?: {
-      totalAssembledTokens: number;
-      budgetCeiling?: number;
-      budgetPressure: boolean;
-      estimatedReduction?: number;
-      reductionThreshold?: number;
-      headroomFactor: number;
-    };
-  }> {
+  async evaluateLeafTrigger(sessionId: string, sessionKey?: string, tokenBudget?: number, liveContextTokens?: number): Promise<LeafTriggerResult> {
     this.ensureMigrated();
     const conversation = await this.conversationStore.getConversationForSession({
       sessionId,

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -478,24 +478,29 @@ function getCompactionHealthStats(db: DatabaseSync, conversationId: number): {
       .prepare(
         `SELECT created_at, pass FROM compaction_events
          WHERE conversation_id = ?
-         ORDER BY created_at DESC LIMIT 1`,
+         ORDER BY created_at DESC, event_id DESC LIMIT 1`,
       )
       .get(conversationId) as { created_at: string; pass: string } | undefined;
 
-    const counts = db
+    const lastHour = db
       .prepare(
-        `SELECT
-           SUM(CASE WHEN created_at > datetime('now', '-1 hour') THEN 1 ELSE 0 END) AS last_hour,
-           SUM(CASE WHEN created_at > datetime('now', '-24 hours') THEN 1 ELSE 0 END) AS last_24h
-         FROM compaction_events WHERE conversation_id = ?`,
+        `SELECT COUNT(*) AS cnt FROM compaction_events
+         WHERE conversation_id = ? AND created_at > datetime('now', '-1 hour')`,
       )
-      .get(conversationId) as { last_hour: number; last_24h: number } | undefined;
+      .get(conversationId) as { cnt: number } | undefined;
+
+    const last24h = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt FROM compaction_events
+         WHERE conversation_id = ? AND created_at > datetime('now', '-24 hours')`,
+      )
+      .get(conversationId) as { cnt: number } | undefined;
 
     return {
       lastCompactionAt: last?.created_at ?? null,
       lastCompactionPass: last?.pass ?? null,
-      passesLastHour: counts?.last_hour ?? 0,
-      passesLast24h: counts?.last_24h ?? 0,
+      passesLastHour: lastHour?.cnt ?? 0,
+      passesLast24h: last24h?.cnt ?? 0,
     };
   } catch {
     return { lastCompactionAt: null, lastCompactionPass: null, passesLastHour: 0, passesLast24h: 0 };
@@ -779,15 +784,25 @@ async function buildEfficiencyText(params: {
   db: DatabaseSync;
 }): Promise<string> {
   const current = await resolveCurrentConversation({ ctx: params.ctx, db: params.db });
-  const convId = current.kind === "resolved" ? current.stats.conversationId : undefined;
-  const stats = getCompactionEfficiencyStats(params.db, convId);
+  if (current.kind === "unavailable") {
+    return [
+      ...buildHeaderLines(),
+      "",
+      buildSection("\u26A1 Compaction efficiency", [
+        buildStatLine("status", "Current conversation unavailable."),
+        buildStatLine("reason", current.reason),
+      ]),
+    ].join("\n");
+  }
+
+  const stats = getCompactionEfficiencyStats(params.db, current.stats.conversationId);
 
   if (stats.totalPasses === 0) {
     return [
       ...buildHeaderLines(),
       "",
       buildSection("\u26A1 Compaction efficiency", [
-        buildStatLine("status", "No compaction events recorded yet."),
+        buildStatLine("status", "No compaction events recorded for this conversation."),
         buildStatLine("tip", "Run a session with 10+ turns to generate compaction data."),
       ]),
     ].join("\n");

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -671,7 +671,12 @@ async function buildStatusText(params: {
       const savings = estimateSavings(effStats.totalTokensSaved);
       const net = savings - compactionCost;
       const effPct = savings > 0 ? Math.round((net / savings) * 100) : 0;
-      const topModel = effStats.modelBreakdown[0]?.model ?? "unknown";
+      // Pick the model with highest total cost as the top model (cost driver),
+      // not just the one with most passes.
+      const costRanked = effStats.modelBreakdown
+        .map((m) => ({ ...m, cost: estimateModelCost(m.model, m.inputTokens, m.outputTokens).totalCost }))
+        .sort((a, b) => b.cost - a.cost);
+      const topModel = costRanked[0]?.model ?? "unknown";
       const modelLabel = effStats.modelBreakdown.length > 1
         ? `${topModel} +${effStats.modelBreakdown.length - 1} more`
         : topModel;

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -452,7 +452,7 @@ function formatTimeAgo(isoDate: string | null): string {
   // Normalize to ISO 8601: replace space with T, append Z only if no timezone.
   const trimmed = isoDate.trim();
   const normalized = trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T");
-  const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(normalized);
+  const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(normalized);
   const then = new Date(hasTimezone ? normalized : normalized + "Z");
   if (Number.isNaN(then.getTime())) return "unknown";
   const now = Date.now();

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -678,9 +678,9 @@ async function buildStatusText(params: {
 
       // Memory quality metrics
       const totalSummaries = current.stats.summaryCount;
-      const doctorIssues = conversationDoctor.total;
+      const lossyIssues = conversationDoctor.truncated + conversationDoctor.fallback;
       const losslessPct = totalSummaries > 0
-        ? Math.round(((totalSummaries - doctorIssues) / totalSummaries) * 100)
+        ? Math.round(((totalSummaries - lossyIssues) / totalSummaries) * 100)
         : 100;
       const compressionRatio = current.stats.compressedTokenCount > 0
         ? current.stats.contextTokenCount / current.stats.compressedTokenCount
@@ -700,7 +700,7 @@ async function buildStatusText(params: {
           buildStatLine("estimated savings", `~${formatCurrency(savings)}`),
           buildStatLine("net efficiency", `${net >= 0 ? "+" : ""}${formatCurrency(net)} (${effPct}% efficient)`),
           buildStatLine("summary quality", totalSummaries > 0
-            ? `${losslessPct}% lossless (${doctorIssues > 0 ? `${doctorIssues} fallback/truncated` : "all clean"} of ${totalSummaries})`
+            ? `${losslessPct}% lossless (${lossyIssues > 0 ? `${lossyIssues} fallback/truncated` : "all clean"} of ${totalSummaries})`
             : "no summaries yet"),
           buildStatLine("compression health", compressionHealth),
           buildStatLine("recommendation", net >= 0 ? `\u2713 ${recommendation}` : `\u26A0 ${recommendation}`),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -448,7 +448,10 @@ function buildHelpText(error?: string): string {
 
 function formatTimeAgo(isoDate: string | null): string {
   if (!isoDate) return "unknown";
-  const then = new Date(isoDate + "Z"); // SQLite datetime() is UTC
+  // SQLite datetime() returns "YYYY-MM-DD HH:MM:SS" (space-separated, UTC).
+  // Normalize to ISO 8601 by replacing space with T before appending Z.
+  const normalized = isoDate.includes("T") ? isoDate : isoDate.replace(" ", "T");
+  const then = new Date(normalized.endsWith("Z") ? normalized : normalized + "Z");
   const now = Date.now();
   const diffMs = now - then.getTime();
   if (diffMs < 0) return "just now";
@@ -610,9 +613,6 @@ async function buildStatusText(params: {
     );
 
     // Fresh tail
-    const unsummarizedCount = Math.max(0, current.stats.messageCount - (current.stats.summaryCount > 0
-      ? current.stats.messageCount - freshTailConfig
-      : 0));
     const freshTailHealthy = current.stats.messageCount <= freshTailConfig || current.stats.summaryCount > 0;
     healthLines.push(
       buildStatLine(
@@ -726,7 +726,7 @@ function getCompactionEfficiencyStats(db: DatabaseSync, conversationId?: number)
            COUNT(*) AS total_passes,
            SUM(CASE WHEN pass = 'leaf' THEN 1 ELSE 0 END) AS leaf_passes,
            SUM(CASE WHEN pass = 'condensed' THEN 1 ELSE 0 END) AS condensed_passes,
-           SUM(tokens_before - tokens_after) AS total_tokens_saved
+           SUM(CASE WHEN tokens_before > tokens_after THEN tokens_before - tokens_after ELSE 0 END) AS total_tokens_saved
          FROM compaction_events ${whereClause}`,
       )
       .get(...params) as {
@@ -827,11 +827,15 @@ async function buildEfficiencyText(params: {
   const recommendations: string[] = [];
   for (const m of stats.modelBreakdown) {
     const lower = m.model.toLowerCase();
+    const avgCost = m.passes > 0
+      ? estimateModelCost(m.model, m.inputTokens / m.passes, m.outputTokens / m.passes).totalCost
+      : 0;
+    const avgLabel = formatCurrency(avgCost);
     if (lower.includes("opus")) {
-      recommendations.push(`\u26A0 Using ${m.model} (~$0.16/call). Fix: set "summaryModel": "claude-haiku-4-5" or export LCM_SUMMARY_MODEL=claude-haiku-4-5`);
+      recommendations.push(`\u26A0 Using ${m.model} (~${avgLabel}/call). Fix: set "summaryModel": "claude-haiku-4-5" or export LCM_SUMMARY_MODEL=claude-haiku-4-5`);
     }
     if (lower.includes("sonnet") && stats.totalPasses > 5) {
-      recommendations.push(`\uD83D\uDCA1 Using ${m.model}. Haiku is 3x cheaper: set "summaryModel": "claude-haiku-4-5"`);
+      recommendations.push(`\uD83D\uDCA1 Using ${m.model} (~${avgLabel}/call). Haiku is 3x cheaper: set "summaryModel": "claude-haiku-4-5"`);
     }
   }
   if (net < 0) {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -447,11 +447,14 @@ function buildHelpText(error?: string): string {
 }
 
 function formatTimeAgo(isoDate: string | null): string {
-  if (!isoDate) return "unknown";
+  if (!isoDate?.trim()) return "unknown";
   // SQLite datetime() returns "YYYY-MM-DD HH:MM:SS" (space-separated, UTC).
-  // Normalize to ISO 8601 by replacing space with T before appending Z.
-  const normalized = isoDate.includes("T") ? isoDate : isoDate.replace(" ", "T");
-  const then = new Date(normalized.endsWith("Z") ? normalized : normalized + "Z");
+  // Normalize to ISO 8601: replace space with T, append Z only if no timezone.
+  const trimmed = isoDate.trim();
+  const normalized = trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T");
+  const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(normalized);
+  const then = new Date(hasTimezone ? normalized : normalized + "Z");
+  if (Number.isNaN(then.getTime())) return "unknown";
   const now = Date.now();
   const diffMs = now - then.getTime();
   if (diffMs < 0) return "just now";
@@ -475,7 +478,7 @@ function getCompactionHealthStats(db: DatabaseSync, conversationId: number): {
       .prepare(
         `SELECT created_at, pass FROM compaction_events
          WHERE conversation_id = ?
-         ORDER BY event_id DESC LIMIT 1`,
+         ORDER BY created_at DESC LIMIT 1`,
       )
       .get(conversationId) as { created_at: string; pass: string } | undefined;
 

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -11,6 +11,7 @@ import {
   getDoctorSummaryStats,
   type DoctorSummaryStats,
 } from "./lcm-doctor-shared.js";
+import { estimateModelCost, estimateSavings, formatCurrency } from "./pricing.js";
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
@@ -52,6 +53,7 @@ type CurrentConversationResolution =
 type ParsedLcmCommand =
   | { kind: "status" }
   | { kind: "doctor"; apply: boolean }
+  | { kind: "efficiency" }
   | { kind: "help"; error?: string };
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -161,12 +163,16 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
         kind: "help",
         error: "`/lcm doctor` accepts no arguments, or `apply` for the scoped repair path.",
       };
+    case "efficiency":
+      return rest.length === 0
+        ? { kind: "efficiency" }
+        : { kind: "help", error: "`/lcm efficiency` does not accept extra arguments." };
     case "help":
       return { kind: "help" };
     default:
       return {
         kind: "help",
-        error: `Unknown subcommand \`${head}\`. Supported: status, doctor, doctor apply.`,
+        error: `Unknown subcommand \`${head}\`. Supported: status, doctor, doctor apply, efficiency.`,
       };
   }
 }
@@ -424,6 +430,7 @@ function buildHelpText(error?: string): string {
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} status`), "Show plugin, Global, and current-conversation status."),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor apply`), "Repair broken summaries in the current conversation."),
+      buildStatLine(formatCommand(`${VISIBLE_COMMAND} efficiency`), "Detailed compaction cost/savings analysis with recommendations."),
     ]),
     "",
     buildSection("🧭 Notes", [
@@ -517,6 +524,178 @@ async function buildStatusText(params: {
       ]),
     );
   }
+
+  // Efficiency section (only when compaction events exist for current conversation)
+  if (current.kind === "resolved") {
+    const effStats = getCompactionEfficiencyStats(params.db, current.stats.conversationId);
+    if (effStats.totalPasses > 0) {
+      const compactionCost = effStats.modelBreakdown.reduce((sum, m) => {
+        return sum + estimateModelCost(m.model, m.inputTokens, m.outputTokens).totalCost;
+      }, 0);
+      const savings = estimateSavings(effStats.totalTokensSaved);
+      const net = savings - compactionCost;
+      const effPct = savings > 0 ? Math.round((net / savings) * 100) : 0;
+      const modelLabel = effStats.modelBreakdown[0]?.model ?? "unknown";
+      const recommendation = net >= 0
+        ? "Compaction is saving money"
+        : modelLabel.includes("opus")
+          ? "Switch summaryModel to haiku \u2014 Opus costs 40x more"
+          : "Compaction cost exceeds savings \u2014 check summaryModel";
+
+      lines.push(
+        "",
+        buildSection("\u26A1 Compaction efficiency", [
+          buildStatLine("passes", `${formatNumber(effStats.totalPasses)} (${formatNumber(effStats.leafPasses)} leaf, ${formatNumber(effStats.condensedPasses)} condensed)`),
+          buildStatLine("tokens saved", formatNumber(effStats.totalTokensSaved)),
+          buildStatLine("compaction cost", `~${formatCurrency(compactionCost)} (${effStats.totalPasses} calls \u00D7 ${modelLabel})`),
+          buildStatLine("estimated savings", `~${formatCurrency(savings)}`),
+          buildStatLine("net efficiency", `${net >= 0 ? "+" : ""}${formatCurrency(net)} (${effPct}% efficient)`),
+          buildStatLine("recommendation", net >= 0 ? `\u2713 ${recommendation}` : `\u26A0 ${recommendation}`),
+        ]),
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function getCompactionEfficiencyStats(db: DatabaseSync, conversationId?: number): {
+  totalPasses: number;
+  leafPasses: number;
+  condensedPasses: number;
+  totalTokensSaved: number;
+  modelBreakdown: Array<{ model: string; passes: number; inputTokens: number; outputTokens: number }>;
+} {
+  try {
+    const whereClause = conversationId !== undefined ? "WHERE conversation_id = ?" : "";
+    const params = conversationId !== undefined ? [conversationId] : [];
+
+    const agg = db
+      .prepare(
+        `SELECT
+           COUNT(*) AS total_passes,
+           SUM(CASE WHEN pass = 'leaf' THEN 1 ELSE 0 END) AS leaf_passes,
+           SUM(CASE WHEN pass = 'condensed' THEN 1 ELSE 0 END) AS condensed_passes,
+           SUM(tokens_before - tokens_after) AS total_tokens_saved
+         FROM compaction_events ${whereClause}`,
+      )
+      .get(...params) as {
+      total_passes: number;
+      leaf_passes: number;
+      condensed_passes: number;
+      total_tokens_saved: number;
+    };
+
+    const modelRows = db
+      .prepare(
+        `SELECT
+           COALESCE(compaction_model, 'unknown') AS model,
+           COUNT(*) AS passes,
+           SUM(input_tokens_est) AS input_tokens,
+           SUM(output_tokens_est) AS output_tokens
+         FROM compaction_events ${whereClause}
+         GROUP BY COALESCE(compaction_model, 'unknown')
+         ORDER BY passes DESC`,
+      )
+      .all(...params) as Array<{
+      model: string;
+      passes: number;
+      input_tokens: number;
+      output_tokens: number;
+    }>;
+
+    return {
+      totalPasses: agg.total_passes ?? 0,
+      leafPasses: agg.leaf_passes ?? 0,
+      condensedPasses: agg.condensed_passes ?? 0,
+      totalTokensSaved: agg.total_tokens_saved ?? 0,
+      modelBreakdown: modelRows.map((r) => ({
+        model: r.model,
+        passes: r.passes,
+        inputTokens: r.input_tokens,
+        outputTokens: r.output_tokens,
+      })),
+    };
+  } catch {
+    return { totalPasses: 0, leafPasses: 0, condensedPasses: 0, totalTokensSaved: 0, modelBreakdown: [] };
+  }
+}
+
+async function buildEfficiencyText(params: {
+  ctx: PluginCommandContext;
+  db: DatabaseSync;
+}): Promise<string> {
+  const current = await resolveCurrentConversation({ ctx: params.ctx, db: params.db });
+  const convId = current.kind === "resolved" ? current.stats.conversationId : undefined;
+  const stats = getCompactionEfficiencyStats(params.db, convId);
+
+  if (stats.totalPasses === 0) {
+    return [
+      ...buildHeaderLines(),
+      "",
+      buildSection("\u26A1 Compaction efficiency", [
+        buildStatLine("status", "No compaction events recorded yet."),
+        buildStatLine("tip", "Run a session with 10+ turns to generate compaction data."),
+      ]),
+    ].join("\n");
+  }
+
+  const lines = [...buildHeaderLines(), ""];
+
+  // Summary
+  const totalCompactionCost = stats.modelBreakdown.reduce((sum, m) => {
+    return sum + estimateModelCost(m.model, m.inputTokens, m.outputTokens).totalCost;
+  }, 0);
+  const savings = estimateSavings(stats.totalTokensSaved);
+  const net = savings - totalCompactionCost;
+  const effPct = savings > 0 ? Math.round((net / savings) * 100) : 0;
+
+  lines.push(
+    buildSection("\u26A1 Summary", [
+      buildStatLine("total passes", `${formatNumber(stats.totalPasses)} (${formatNumber(stats.leafPasses)} leaf, ${formatNumber(stats.condensedPasses)} condensed)`),
+      buildStatLine("tokens saved", formatNumber(stats.totalTokensSaved)),
+      buildStatLine("compaction cost", `~${formatCurrency(totalCompactionCost)}`),
+      buildStatLine("estimated savings", `~${formatCurrency(savings)}`),
+      buildStatLine("net", `${net >= 0 ? "+" : ""}${formatCurrency(net)} (${effPct}% efficient)`),
+    ]),
+    "",
+  );
+
+  // Per-model breakdown
+  if (stats.modelBreakdown.length > 0) {
+    const modelLines: string[] = [];
+    for (const m of stats.modelBreakdown) {
+      const cost = estimateModelCost(m.model, m.inputTokens, m.outputTokens);
+      modelLines.push(
+        buildStatLine(m.model, `${m.passes} passes, ~${formatCurrency(cost.totalCost)}${!cost.matched ? " (unknown model \u2014 using estimate)" : ""}`),
+      );
+    }
+    lines.push(buildSection("\uD83D\uDCCA By model", modelLines), "");
+  }
+
+  // Recommendations
+  const recommendations: string[] = [];
+  for (const m of stats.modelBreakdown) {
+    if (m.model.includes("opus")) {
+      recommendations.push(`\u26A0 Using ${m.model} for compaction costs ~$0.16/call. Switch to haiku (~$0.03) or gpt-4o-mini (~$0.004).`);
+    }
+    if (m.model.includes("sonnet") && stats.totalPasses > 5) {
+      recommendations.push(`\uD83D\uDCA1 Using ${m.model}. Consider haiku for 3x cost reduction with similar quality.`);
+    }
+  }
+  if (net < 0) {
+    recommendations.push("\u26A0 Compaction is costing more than it saves. Check your summaryModel setting.");
+  }
+  if (stats.totalTokensSaved > 0 && stats.totalTokensSaved / stats.totalPasses < 2000) {
+    recommendations.push("\uD83D\uDCA1 Average tokens saved per pass is low (<2K). Consider raising leafSkipReductionThreshold.");
+  }
+  if (recommendations.length > 0) {
+    lines.push(buildSection("\uD83D\uDCA1 Recommendations", recommendations));
+  } else {
+    lines.push(buildSection("\u2713 Status", ["Compaction is working efficiently. No action needed."]));
+  }
+
+  lines.push("", "_Costs are estimates based on published API pricing (Apr 2026). Actual costs depend on your provider agreement._");
 
   return lines.join("\n");
 }
@@ -742,6 +921,8 @@ export function createLcmCommand(params: {
                 }),
               }
             : { text: await buildDoctorText({ ctx, db: await getDb() }) };
+        case "efficiency":
+          return { text: await buildEfficiencyText({ ctx, db: await getDb() }) };
         case "help":
           return { text: buildHelpText(parsed.error) };
       }

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -545,14 +545,13 @@ async function buildStatusText(params: {
     "",
   ];
 
+  const conversationDoctor = current.kind === "resolved"
+    ? doctor.byConversation.get(current.stats.conversationId) ?? {
+        total: 0, old: 0, truncated: 0, fallback: 0,
+      }
+    : { total: 0, old: 0, truncated: 0, fallback: 0 };
+
   if (current.kind === "resolved") {
-    const conversationDoctor =
-      doctor.byConversation.get(current.stats.conversationId) ?? {
-        total: 0,
-        old: 0,
-        truncated: 0,
-        fallback: 0,
-      };
     lines.push(
       buildSection("📍 Current conversation", [
         buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
@@ -692,8 +691,11 @@ async function buildStatusText(params: {
       const losslessPct = totalSummaries > 0
         ? Math.round(((totalSummaries - lossyIssues) / totalSummaries) * 100)
         : 100;
-      const compressionRatio = current.stats.compressedTokenCount > 0
-        ? current.stats.contextTokenCount / current.stats.compressedTokenCount
+      // compressedTokenCount = original source tokens that were compressed into summaries.
+      // contextTokenCount = tokens currently in the assembled context.
+      // Ratio = source / context → higher means more compression.
+      const compressionRatio = current.stats.contextTokenCount > 0
+        ? current.stats.compressedTokenCount / current.stats.contextTokenCount
         : 0;
       const compressionHealth = compressionRatio === 0 ? "no compression yet"
         : compressionRatio < 2 ? "conservative \u2014 summaries are barely compressing"

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -535,12 +535,30 @@ async function buildStatusText(params: {
       const savings = estimateSavings(effStats.totalTokensSaved);
       const net = savings - compactionCost;
       const effPct = savings > 0 ? Math.round((net / savings) * 100) : 0;
-      const modelLabel = effStats.modelBreakdown[0]?.model ?? "unknown";
+      const topModel = effStats.modelBreakdown[0]?.model ?? "unknown";
+      const modelLabel = effStats.modelBreakdown.length > 1
+        ? `${topModel} +${effStats.modelBreakdown.length - 1} more`
+        : topModel;
       const recommendation = net >= 0
         ? "Compaction is saving money"
-        : modelLabel.includes("opus")
-          ? "Switch summaryModel to haiku \u2014 Opus costs 40x more"
+        : topModel.toLowerCase().includes("opus")
+          ? "Switch summaryModel to haiku \u2014 Opus is ~5x more expensive"
           : "Compaction cost exceeds savings \u2014 check summaryModel";
+
+      // Memory quality metrics
+      const totalSummaries = current.stats.summaryCount;
+      const doctorIssues = conversationDoctor.total;
+      const losslessPct = totalSummaries > 0
+        ? Math.round(((totalSummaries - doctorIssues) / totalSummaries) * 100)
+        : 100;
+      const compressionRatio = current.stats.compressedTokenCount > 0
+        ? current.stats.contextTokenCount / current.stats.compressedTokenCount
+        : 0;
+      const compressionHealth = compressionRatio === 0 ? "no compression yet"
+        : compressionRatio < 2 ? "conservative \u2014 summaries are barely compressing"
+        : compressionRatio <= 8 ? "healthy"
+        : compressionRatio <= 15 ? "aggressive \u2014 detail may be hard to retrieve"
+        : "very aggressive \u2014 check fallback rate";
 
       lines.push(
         "",
@@ -550,6 +568,10 @@ async function buildStatusText(params: {
           buildStatLine("compaction cost", `~${formatCurrency(compactionCost)} (${effStats.totalPasses} calls \u00D7 ${modelLabel})`),
           buildStatLine("estimated savings", `~${formatCurrency(savings)}`),
           buildStatLine("net efficiency", `${net >= 0 ? "+" : ""}${formatCurrency(net)} (${effPct}% efficient)`),
+          buildStatLine("summary quality", totalSummaries > 0
+            ? `${losslessPct}% lossless (${doctorIssues > 0 ? `${doctorIssues} fallback/truncated` : "all clean"} of ${totalSummaries})`
+            : "no summaries yet"),
+          buildStatLine("compression health", compressionHealth),
           buildStatLine("recommendation", net >= 0 ? `\u2713 ${recommendation}` : `\u26A0 ${recommendation}`),
         ]),
       );
@@ -676,10 +698,11 @@ async function buildEfficiencyText(params: {
   // Recommendations
   const recommendations: string[] = [];
   for (const m of stats.modelBreakdown) {
-    if (m.model.includes("opus")) {
+    const lower = m.model.toLowerCase();
+    if (lower.includes("opus")) {
       recommendations.push(`\u26A0 Using ${m.model} for compaction costs ~$0.16/call. Switch to haiku (~$0.03) or gpt-4o-mini (~$0.004).`);
     }
-    if (m.model.includes("sonnet") && stats.totalPasses > 5) {
+    if (lower.includes("sonnet") && stats.totalPasses > 5) {
       recommendations.push(`\uD83D\uDCA1 Using ${m.model}. Consider haiku for 3x cost reduction with similar quality.`);
     }
   }

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -29,6 +29,7 @@ type LcmConversationStatusStats = {
   conversationId: number;
   sessionId: string;
   sessionKey: string | null;
+  createdAt: string | null;
   messageCount: number;
   summaryCount: number;
   storedSummaryTokens: number;
@@ -220,6 +221,7 @@ function getConversationStatusStats(
          c.conversation_id,
          c.session_id,
          c.session_key,
+         c.created_at,
          COALESCE((SELECT COUNT(*) FROM messages WHERE conversation_id = c.conversation_id), 0) AS message_count,
          COALESCE((SELECT COUNT(*) FROM summaries WHERE conversation_id = c.conversation_id), 0) AS summary_count,
          COALESCE((SELECT SUM(token_count) FROM summaries WHERE conversation_id = c.conversation_id), 0) AS stored_summary_tokens,
@@ -257,6 +259,7 @@ function getConversationStatusStats(
         conversation_id: number;
         session_id: string;
         session_key: string | null;
+        created_at: string | null;
         message_count: number;
         summary_count: number;
         stored_summary_tokens: number;
@@ -276,6 +279,7 @@ function getConversationStatusStats(
     conversationId: row.conversation_id,
     sessionId: row.session_id,
     sessionKey: row.session_key,
+    createdAt: row.created_at,
     messageCount: row.message_count,
     summaryCount: row.summary_count,
     storedSummaryTokens: row.stored_summary_tokens,
@@ -442,6 +446,56 @@ function buildHelpText(error?: string): string {
   return lines.join("\n");
 }
 
+function formatTimeAgo(isoDate: string | null): string {
+  if (!isoDate) return "unknown";
+  const then = new Date(isoDate + "Z"); // SQLite datetime() is UTC
+  const now = Date.now();
+  const diffMs = now - then.getTime();
+  if (diffMs < 0) return "just now";
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h ago`;
+}
+
+function getCompactionHealthStats(db: DatabaseSync, conversationId: number): {
+  lastCompactionAt: string | null;
+  lastCompactionPass: string | null;
+  passesLastHour: number;
+  passesLast24h: number;
+} {
+  try {
+    const last = db
+      .prepare(
+        `SELECT created_at, pass FROM compaction_events
+         WHERE conversation_id = ?
+         ORDER BY event_id DESC LIMIT 1`,
+      )
+      .get(conversationId) as { created_at: string; pass: string } | undefined;
+
+    const counts = db
+      .prepare(
+        `SELECT
+           SUM(CASE WHEN created_at > datetime('now', '-1 hour') THEN 1 ELSE 0 END) AS last_hour,
+           SUM(CASE WHEN created_at > datetime('now', '-24 hours') THEN 1 ELSE 0 END) AS last_24h
+         FROM compaction_events WHERE conversation_id = ?`,
+      )
+      .get(conversationId) as { last_hour: number; last_24h: number } | undefined;
+
+    return {
+      lastCompactionAt: last?.created_at ?? null,
+      lastCompactionPass: last?.pass ?? null,
+      passesLastHour: counts?.last_hour ?? 0,
+      passesLast24h: counts?.last_24h ?? 0,
+    };
+  } catch {
+    return { lastCompactionAt: null, lastCompactionPass: null, passesLastHour: 0, passesLast24h: 0 };
+  }
+}
+
 async function buildStatusText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
@@ -525,6 +579,80 @@ async function buildStatusText(params: {
     );
   }
 
+  // Health section (only when current conversation is available)
+  if (current.kind === "resolved") {
+    const health = getCompactionHealthStats(params.db, current.stats.conversationId);
+    const freshTailConfig = params.config.freshTailCount ?? 64;
+    const summaryModel = params.config.summaryModel;
+    const summaryProvider = params.config.summaryProvider;
+
+    const healthLines: string[] = [];
+
+    // Conversation age
+    healthLines.push(
+      buildStatLine("conversation age", formatTimeAgo(current.stats.createdAt)),
+    );
+
+    // Last compaction
+    const lastLabel = health.lastCompactionAt
+      ? `${formatTimeAgo(health.lastCompactionAt)} (${health.lastCompactionPass})`
+      : "never";
+    const lastIndicator = health.lastCompactionAt
+      ? "\u2713"
+      : current.stats.messageCount > freshTailConfig * 2
+        ? "\u26A0 \u2014 compaction may be stalled"
+        : "";
+    healthLines.push(buildStatLine("last compaction", `${lastLabel} ${lastIndicator}`.trim()));
+
+    // Compaction activity
+    healthLines.push(
+      buildStatLine("compaction activity", `${health.passesLastHour} in last 1h, ${health.passesLast24h} in last 24h`),
+    );
+
+    // Fresh tail
+    const unsummarizedCount = Math.max(0, current.stats.messageCount - (current.stats.summaryCount > 0
+      ? current.stats.messageCount - freshTailConfig
+      : 0));
+    const freshTailHealthy = current.stats.messageCount <= freshTailConfig || current.stats.summaryCount > 0;
+    healthLines.push(
+      buildStatLine(
+        "fresh tail",
+        `${formatNumber(Math.min(current.stats.messageCount, freshTailConfig))} of ${formatNumber(current.stats.messageCount)} msgs protected${freshTailHealthy ? " \u2713" : " \u26A0"}`,
+      ),
+    );
+
+    // Summary model
+    const modelDisplay = summaryModel
+      ? `${summaryProvider ? `${summaryProvider}/` : ""}${summaryModel}`
+      : null;
+    if (modelDisplay) {
+      const isExpensive = modelDisplay.toLowerCase().includes("opus");
+      healthLines.push(
+        buildStatLine("summary model", `${modelDisplay}${isExpensive ? " \u26A0 \u2014 expensive for compaction" : " \u2713"}`),
+      );
+    } else {
+      healthLines.push(
+        buildStatLine("summary model", "(default \u2014 may use expensive model) \u26A0"),
+      );
+    }
+
+    // Doctor issues (only when problems exist — clean state already shown above)
+    if (conversationDoctor.total > 0) {
+      healthLines.push(
+        buildStatLine("doctor issues", `${conversationDoctor.total} \u2014 run ${formatCommand(`${VISIBLE_COMMAND} doctor apply`)} to repair \u26A0`),
+      );
+    }
+
+    // Key config
+    const threshold = Math.round((params.config.contextThreshold ?? 0.75) * 100);
+    const leafChunk = Math.round((params.config.leafChunkTokens ?? 20000) / 1000);
+    healthLines.push(
+      buildStatLine("config", `threshold=${threshold}%, freshTail=${freshTailConfig}, leafChunk=${leafChunk}k`),
+    );
+
+    lines.push("", buildSection("\uD83C\uDFE5 Health", healthLines));
+  }
+
   // Efficiency section (only when compaction events exist for current conversation)
   if (current.kind === "resolved") {
     const effStats = getCompactionEfficiencyStats(params.db, current.stats.conversationId);
@@ -542,8 +670,8 @@ async function buildStatusText(params: {
       const recommendation = net >= 0
         ? "Compaction is saving money"
         : topModel.toLowerCase().includes("opus")
-          ? "Switch summaryModel to haiku \u2014 Opus is ~5x more expensive"
-          : "Compaction cost exceeds savings \u2014 check summaryModel";
+          ? 'Set "summaryModel": "claude-haiku-4-5" or export LCM_SUMMARY_MODEL=claude-haiku-4-5'
+          : 'Compaction cost exceeds savings \u2014 set "summaryModel" to a cheaper model';
 
       // Memory quality metrics
       const totalSummaries = current.stats.summaryCount;
@@ -700,17 +828,17 @@ async function buildEfficiencyText(params: {
   for (const m of stats.modelBreakdown) {
     const lower = m.model.toLowerCase();
     if (lower.includes("opus")) {
-      recommendations.push(`\u26A0 Using ${m.model} for compaction costs ~$0.16/call. Switch to haiku (~$0.03) or gpt-4o-mini (~$0.004).`);
+      recommendations.push(`\u26A0 Using ${m.model} (~$0.16/call). Fix: set "summaryModel": "claude-haiku-4-5" or export LCM_SUMMARY_MODEL=claude-haiku-4-5`);
     }
     if (lower.includes("sonnet") && stats.totalPasses > 5) {
-      recommendations.push(`\uD83D\uDCA1 Using ${m.model}. Consider haiku for 3x cost reduction with similar quality.`);
+      recommendations.push(`\uD83D\uDCA1 Using ${m.model}. Haiku is 3x cheaper: set "summaryModel": "claude-haiku-4-5"`);
     }
   }
   if (net < 0) {
-    recommendations.push("\u26A0 Compaction is costing more than it saves. Check your summaryModel setting.");
+    recommendations.push('\u26A0 Compaction is costing more than it saves. Set "summaryModel" to a cheaper model.');
   }
   if (stats.totalTokensSaved > 0 && stats.totalTokensSaved / stats.totalPasses < 2000) {
-    recommendations.push("\uD83D\uDCA1 Average tokens saved per pass is low (<2K). Consider raising leafSkipReductionThreshold.");
+    recommendations.push('\uD83D\uDCA1 Average tokens saved per pass is low (<2K). Raise: export LCM_LEAF_SKIP_REDUCTION_THRESHOLD=0.10');
   }
   if (recommendations.length > 0) {
     lines.push(buildSection("\uD83D\uDCA1 Recommendations", recommendations));

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -3,7 +3,7 @@ import { withDatabaseTransaction } from "../transaction-mutex.js";
 import { formatTimestamp } from "../compaction.js";
 import type { LcmConfig } from "../db/config.js";
 import type { LcmSummarizeFn } from "../summarize.js";
-import { createLcmSummarizeFromLegacyParams } from "../summarize.js";
+import { createLcmSummarizeFromLegacyParams, extractSummaryText } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import { detectDoctorMarker, loadDoctorTargets, type DoctorTargetRecord } from "./lcm-doctor-shared.js";
 
@@ -101,11 +101,12 @@ export async function applyScopedDoctorRepair(params: {
         overrides,
       });
 
-      const rewritten = (await summarize(sourceText, false, {
+      const rewrittenRaw = await summarize(sourceText, false, {
         previousSummary,
         isCondensed: isCondensedTarget(target),
         ...(isCondensedTarget(target) ? { depth: target.depth } : {}),
-      })).trim();
+      });
+      const rewritten = extractSummaryText(rewrittenRaw).trim();
       if (!rewritten) {
         skipped.push({
           summaryId: target.summaryId,

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -65,5 +65,6 @@ export function estimateSavings(
 
 export function formatCurrency(amount: number): string {
   if (Math.abs(amount) < 0.005) return "$0.00";
+  if (amount < 0) return `-$${Math.abs(amount).toFixed(2)}`;
   return `$${amount.toFixed(2)}`;
 }

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -22,7 +22,7 @@ const MODEL_PRICING: Array<[prefix: string, pricing: ModelPricing]> = [
   ["gemini-2.5-flash", { input: 0.30, output: 2.50 }],
   ["gemini-2.5-pro", { input: 1.25, output: 10.00 }],
   // Others
-  ["mistral-small", { input: 0.20, output: 0.60 }],
+  ["mistral-small", { input: 0.20, output: 0.60 }], // matches mistral-small-4 via prefix
   ["deepseek-v3", { input: 0.28, output: 0.42 }],
 ];
 

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -7,20 +7,22 @@
 type ModelPricing = { input: number; output: number };
 
 const MODEL_PRICING: Array<[prefix: string, pricing: ModelPricing]> = [
-  // Anthropic
+  // Anthropic (Opus 4.5/4.6 = $5/$25, Sonnet 4.x = $3/$15, Haiku 4.5 = $1/$5)
   ["claude-opus-4", { input: 5.00, output: 25.00 }],
   ["claude-sonnet-4", { input: 3.00, output: 15.00 }],
   ["claude-haiku-4", { input: 1.00, output: 5.00 }],
+  ["claude-haiku-3", { input: 0.25, output: 1.25 }],
   // OpenAI
+  ["gpt-4.1-nano", { input: 0.10, output: 0.40 }],
   ["gpt-4o-mini", { input: 0.15, output: 0.60 }],
-  ["gpt-4.1-mini", { input: 0.40, output: 1.60 }],
+  ["gpt-4.1-mini", { input: 0.20, output: 0.80 }],
   ["gpt-4o", { input: 2.50, output: 10.00 }],
   ["gpt-5.4-mini", { input: 0.75, output: 4.50 }],
   // Google
   ["gemini-2.5-flash", { input: 0.30, output: 2.50 }],
   ["gemini-2.5-pro", { input: 1.25, output: 10.00 }],
   // Others
-  ["mistral-small", { input: 0.15, output: 0.60 }],
+  ["mistral-small", { input: 0.20, output: 0.60 }],
   ["deepseek-v3", { input: 0.28, output: 0.42 }],
 ];
 

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -1,0 +1,69 @@
+/**
+ * Static model pricing table for compaction cost estimation.
+ * Rates are USD per million tokens ($/MTok) as of April 2026.
+ * These are estimates for reporting — not for billing.
+ */
+
+type ModelPricing = { input: number; output: number };
+
+const MODEL_PRICING: Array<[prefix: string, pricing: ModelPricing]> = [
+  // Anthropic
+  ["claude-opus-4", { input: 5.00, output: 25.00 }],
+  ["claude-sonnet-4", { input: 3.00, output: 15.00 }],
+  ["claude-haiku-4", { input: 1.00, output: 5.00 }],
+  // OpenAI
+  ["gpt-4o-mini", { input: 0.15, output: 0.60 }],
+  ["gpt-4.1-mini", { input: 0.40, output: 1.60 }],
+  ["gpt-4o", { input: 2.50, output: 10.00 }],
+  ["gpt-5.4-mini", { input: 0.75, output: 4.50 }],
+  // Google
+  ["gemini-2.5-flash", { input: 0.30, output: 2.50 }],
+  ["gemini-2.5-pro", { input: 1.25, output: 10.00 }],
+  // Others
+  ["mistral-small", { input: 0.15, output: 0.60 }],
+  ["deepseek-v3", { input: 0.28, output: 0.42 }],
+];
+
+/** Default rate when model is unknown — Sonnet-class as a conservative middle estimate. */
+const UNKNOWN_MODEL_PRICING: ModelPricing = { input: 3.00, output: 15.00 };
+
+/** Default main-model input price ($/MTok) for savings estimation. Sonnet-class. */
+export const DEFAULT_MAIN_MODEL_INPUT_PRICE = 3.00;
+
+/** Conservative estimate of how many future turns benefit from each token saved. */
+export const BENEFIT_TURNS = 5;
+
+function findPricing(model: string | undefined): { pricing: ModelPricing; matched: boolean } {
+  if (!model) return { pricing: UNKNOWN_MODEL_PRICING, matched: false };
+  const lower = model.toLowerCase();
+  for (const [prefix, pricing] of MODEL_PRICING) {
+    if (lower.startsWith(prefix) || lower.includes(prefix)) {
+      return { pricing, matched: true };
+    }
+  }
+  return { pricing: UNKNOWN_MODEL_PRICING, matched: false };
+}
+
+export function estimateModelCost(
+  model: string | undefined,
+  inputTokens: number,
+  outputTokens: number,
+): { inputCost: number; outputCost: number; totalCost: number; matched: boolean } {
+  const { pricing, matched } = findPricing(model);
+  const inputCost = (inputTokens / 1_000_000) * pricing.input;
+  const outputCost = (outputTokens / 1_000_000) * pricing.output;
+  return { inputCost, outputCost, totalCost: inputCost + outputCost, matched };
+}
+
+export function estimateSavings(
+  tokensSaved: number,
+  mainModelInputPrice: number = DEFAULT_MAIN_MODEL_INPUT_PRICE,
+  benefitTurns: number = BENEFIT_TURNS,
+): number {
+  return (tokensSaved / 1_000_000) * mainModelInputPrice * benefitTurns;
+}
+
+export function formatCurrency(amount: number): string {
+  if (Math.abs(amount) < 0.005) return "$0.00";
+  return `$${amount.toFixed(2)}`;
+}

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1516,4 +1516,39 @@ export class SummaryStore {
 
     return toConversationBootstrapStateRecord(row);
   }
+
+  // ── Compaction events ──────────────────────────────────────────
+
+  insertCompactionEvent(event: {
+    conversationId: number;
+    pass: "leaf" | "condensed";
+    level: string;
+    tokensBefore: number;
+    tokensAfter: number;
+    inputTokensEst: number;
+    outputTokensEst: number;
+    compactionModel?: string;
+  }): void {
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO compaction_events
+           (conversation_id, pass, level, tokens_before, tokens_after,
+            input_tokens_est, output_tokens_est, compaction_model)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          event.conversationId,
+          event.pass,
+          event.level,
+          event.tokensBefore,
+          event.tokensAfter,
+          event.inputTokensEst,
+          event.outputTokensEst,
+          event.compactionModel ?? null,
+        );
+    } catch {
+      // Best-effort — don't fail compaction if event recording fails
+    }
+  }
 }

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -6,11 +6,17 @@ export type LcmSummarizeOptions = {
   depth?: number;
 };
 
+export type LcmSummarizeResult = {
+  text: string;
+  /** The provider/model that actually produced this summary (may differ from configured model after fallback). */
+  modelUsed?: string;
+};
+
 export type LcmSummarizeFn = (
   text: string,
   aggressive?: boolean,
   options?: LcmSummarizeOptions,
-) => Promise<string>;
+) => Promise<string | LcmSummarizeResult>;
 
 export type LcmSummarizerLegacyParams = {
   provider?: unknown;
@@ -1156,7 +1162,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
     text: string,
     aggressive?: boolean,
     options?: LcmSummarizeOptions,
-  ): Promise<string> => {
+  ): Promise<string | LcmSummarizeResult> => {
     if (!text.trim()) {
       return "";
     }
@@ -1484,7 +1490,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         );
       }
 
-      return summary;
+      return { text: summary, modelUsed: `${provider}/${model}` };
     }
 
     console.error(

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -12,6 +12,11 @@ export type LcmSummarizeResult = {
   modelUsed?: string;
 };
 
+/** Extract the summary text from a summarizer result (handles both string and object returns). */
+export function extractSummaryText(result: string | LcmSummarizeResult): string {
+  return typeof result === "string" ? result : result.text;
+}
+
 export type LcmSummarizeFn = (
   text: string,
   aggressive?: boolean,

--- a/test/compaction-efficiency.test.ts
+++ b/test/compaction-efficiency.test.ts
@@ -71,6 +71,15 @@ describe("formatCurrency", () => {
   it("formats near-zero as $0.00", () => {
     expect(formatCurrency(0.001)).toBe("$0.00");
   });
+
+  it("formats negative amounts with sign before dollar", () => {
+    expect(formatCurrency(-4.35)).toBe("-$4.35");
+    expect(formatCurrency(-0.12)).toBe("-$0.12");
+  });
+
+  it("formats near-zero negative as $0.00", () => {
+    expect(formatCurrency(-0.001)).toBe("$0.00");
+  });
 });
 
 describe("efficiency scoring", () => {

--- a/test/compaction-efficiency.test.ts
+++ b/test/compaction-efficiency.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { estimateModelCost, estimateSavings, formatCurrency } from "../src/plugin/pricing.js";
+
+describe("estimateModelCost", () => {
+  it("matches known model by exact prefix", () => {
+    const result = estimateModelCost("claude-haiku-4-5", 20_000, 2_400);
+    expect(result.matched).toBe(true);
+    expect(result.inputCost).toBeCloseTo(0.02, 4);
+    expect(result.outputCost).toBeCloseTo(0.012, 4);
+    expect(result.totalCost).toBeCloseTo(0.032, 4);
+  });
+
+  it("matches dated model variant via prefix", () => {
+    const result = estimateModelCost("claude-opus-4-6-20260301", 20_000, 2_400);
+    expect(result.matched).toBe(true);
+    expect(result.inputCost).toBeCloseTo(0.10, 4);
+  });
+
+  it("matches gpt-4o-mini", () => {
+    const result = estimateModelCost("gpt-4o-mini", 20_000, 2_400);
+    expect(result.matched).toBe(true);
+    expect(result.inputCost).toBeCloseTo(0.003, 4);
+  });
+
+  it("returns matched=false for unknown models with Sonnet-class default", () => {
+    const result = estimateModelCost("my-custom-model-v3", 20_000, 2_400);
+    expect(result.matched).toBe(false);
+    expect(result.inputCost).toBeCloseTo(0.06, 4);
+  });
+
+  it("handles undefined model", () => {
+    const result = estimateModelCost(undefined, 20_000, 2_400);
+    expect(result.matched).toBe(false);
+  });
+
+  it("handles zero tokens", () => {
+    const result = estimateModelCost("claude-haiku-4-5", 0, 0);
+    expect(result.totalCost).toBe(0);
+  });
+});
+
+describe("estimateSavings", () => {
+  it("estimates savings with default parameters", () => {
+    const savings = estimateSavings(48_200);
+    expect(savings).toBeCloseTo(0.723, 2);
+  });
+
+  it("uses custom main model price", () => {
+    const savings = estimateSavings(48_200, 5.00);
+    expect(savings).toBeCloseTo(1.205, 2);
+  });
+
+  it("returns 0 for zero tokens saved", () => {
+    expect(estimateSavings(0)).toBe(0);
+  });
+});
+
+describe("formatCurrency", () => {
+  it("formats positive amounts", () => {
+    expect(formatCurrency(1.07)).toBe("$1.07");
+  });
+
+  it("formats small amounts", () => {
+    expect(formatCurrency(0.032)).toBe("$0.03");
+  });
+
+  it("formats zero as $0.00", () => {
+    expect(formatCurrency(0)).toBe("$0.00");
+  });
+
+  it("formats near-zero as $0.00", () => {
+    expect(formatCurrency(0.001)).toBe("$0.00");
+  });
+});
+
+describe("efficiency scoring", () => {
+  it("positive efficiency: haiku compaction saving money", () => {
+    const compactionCost = estimateModelCost("claude-haiku-4-5", 20_000 * 12, 2_400 * 12).totalCost;
+    const savings = estimateSavings(48_200);
+    const net = savings - compactionCost;
+    expect(net).toBeGreaterThan(0);
+    expect(compactionCost).toBeCloseTo(0.384, 2);
+    expect(savings).toBeCloseTo(0.723, 2);
+  });
+
+  it("negative efficiency: opus compaction losing money", () => {
+    const compactionCost = estimateModelCost("claude-opus-4-6", 20_000 * 28, 2_400 * 28).totalCost;
+    const savings = estimateSavings(8_400);
+    const net = savings - compactionCost;
+    expect(net).toBeLessThan(0);
+    expect(compactionCost).toBeGreaterThan(4);
+    expect(savings).toBeLessThan(0.5);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -405,6 +405,22 @@ describe("resolveLcmConfig", () => {
     });
   });
 
+  it("clamps leafSkipReductionThreshold and leafBudgetHeadroomFactor to [0, 1]", () => {
+    const below = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: -0.5,
+      leafBudgetHeadroomFactor: -1.0,
+    });
+    expect(below.leafSkipReductionThreshold).toBe(0);
+    expect(below.leafBudgetHeadroomFactor).toBe(0);
+
+    const above = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: 1.5,
+      leafBudgetHeadroomFactor: 2.0,
+    });
+    expect(above.leafSkipReductionThreshold).toBe(1);
+    expect(above.leafBudgetHeadroomFactor).toBe(1);
+  });
+
   it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {
     expect(resolveLcmConfig({}, {
       leafChunkTokens: 80_000,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -363,6 +363,48 @@ describe("resolveLcmConfig", () => {
     expect(config.maxAssemblyTokenBudget).toBeUndefined();
   });
 
+  it("defaults leafSkipReductionThreshold to 0.05 and leafBudgetHeadroomFactor to 0.8", () => {
+    const config = resolveLcmConfig({}, {});
+    expect(config.leafSkipReductionThreshold).toBe(0.05);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.8);
+  });
+
+  it("reads leafSkipReductionThreshold and leafBudgetHeadroomFactor from plugin config", () => {
+    const config = resolveLcmConfig({}, {
+      leafSkipReductionThreshold: 0.10,
+      leafBudgetHeadroomFactor: 0.65,
+    });
+    expect(config.leafSkipReductionThreshold).toBe(0.10);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.65);
+  });
+
+  it("env vars override leafSkipReductionThreshold and leafBudgetHeadroomFactor", () => {
+    const config = resolveLcmConfig({
+      LCM_LEAF_SKIP_REDUCTION_THRESHOLD: "0.03",
+      LCM_LEAF_BUDGET_HEADROOM_FACTOR: "0.60",
+    } as NodeJS.ProcessEnv, {
+      leafSkipReductionThreshold: 0.10,
+      leafBudgetHeadroomFactor: 0.90,
+    });
+    expect(config.leafSkipReductionThreshold).toBe(0.03);
+    expect(config.leafBudgetHeadroomFactor).toBe(0.60);
+  });
+
+  it("ships a manifest with leafSkipReductionThreshold and leafBudgetHeadroomFactor in schema", () => {
+    expect(manifest.configSchema.properties.leafSkipReductionThreshold).toEqual({
+      description: expect.any(String),
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+    });
+    expect(manifest.configSchema.properties.leafBudgetHeadroomFactor).toEqual({
+      description: expect.any(String),
+      type: "number",
+      minimum: 0,
+      maximum: 1,
+    });
+  });
+
   it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {
     expect(resolveLcmConfig({}, {
       leafChunkTokens: 80_000,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3694,7 +3694,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       tokenBudget: 4096,
     });
 
-    expect(evaluateLeafTriggerSpy).toHaveBeenCalledWith(sessionId, undefined);
+    expect(evaluateLeafTriggerSpy).toHaveBeenCalledWith(sessionId, undefined, 4096, expect.any(Number));
     expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
     expect(compactSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -4490,6 +4490,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 400,
+        currentTokenCount: 500,
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
@@ -4767,6 +4768,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 400,
+        currentTokenCount: 500,
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
@@ -5037,6 +5039,50 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 4096,
+      }),
+    );
+  });
+
+  it("passes currentTokenCount through to compactLeafAsync worker compaction", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const compactLeafSpy = vi
+      .spyOn(privateEngine.compaction, "compactLeaf")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 500,
+        tokensAfter: 280,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "compact-leaf-observed-token-session",
+      message: { role: "user", content: "trigger compact leaf" } as AgentMessage,
+    });
+
+    const result = await engine.compactLeafAsync({
+      sessionId: "compact-leaf-observed-token-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 400,
+      currentTokenCount: 500,
+      legacyParams: {
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(compactLeafSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 400,
+        currentTokenCount: 500,
       }),
     );
   });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5086,4 +5086,41 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
       }),
     );
   });
+
+  it("omits currentTokenCount when not provided to compactLeafAsync", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const compactLeafSpy = vi
+      .spyOn(privateEngine.compaction, "compactLeaf")
+      .mockResolvedValue({
+        actionTaken: false,
+        tokensBefore: 200,
+        tokensAfter: 200,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "no-observed-token-session",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    await engine.compactLeafAsync({
+      sessionId: "no-observed-token-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 400,
+      legacyParams: {
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      },
+    });
+
+    const callArg = compactLeafSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(callArg).toBeDefined();
+    expect(callArg!.currentTokenCount).toBeUndefined();
+  });
 });

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2133,7 +2133,7 @@ describe("LCM integration: compaction", () => {
     });
 
     await ingestMessages(convStore, sumStore, 10, {
-      contentFn: (i) => `Turn ${i}: ${"x".repeat(11_980)}`,
+      contentFn: (i) => `Turn ${i}: stale token test`,
       tokenCountFn: () => 3_000,
     });
 
@@ -2157,7 +2157,7 @@ describe("LCM integration: compaction", () => {
     });
 
     await ingestMessages(convStore, sumStore, 10, {
-      contentFn: (i) => `Turn ${i}: ${"y".repeat(11_980)}`,
+      contentFn: (i) => `Turn ${i}: stale sweep test`,
       tokenCountFn: () => 3_000,
     });
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2126,6 +2126,54 @@ describe("LCM integration: compaction", () => {
     expect(summarize).toHaveBeenCalled();
   });
 
+  it("compactLeaf uses currentTokenCount for headroom decisions when stored tokens are stale", async () => {
+    const staleAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafChunkTokens: 15_000,
+    });
+
+    await ingestMessages(convStore, sumStore, 10, {
+      contentFn: (i) => `Turn ${i}: ${"x".repeat(11_980)}`,
+      tokenCountFn: () => 3_000,
+    });
+
+    const summarize = vi.fn(async (text: string) => `summary ${text.length}`);
+
+    const result = await staleAwareEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+      currentTokenCount: 80_000,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalled();
+  });
+
+  it("compactFullSweep uses currentTokenCount for threshold sweeps when stored tokens are stale", async () => {
+    const staleAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafChunkTokens: 15_000,
+    });
+
+    await ingestMessages(convStore, sumStore, 10, {
+      contentFn: (i) => `Turn ${i}: ${"y".repeat(11_980)}`,
+      tokenCountFn: () => 3_000,
+    });
+
+    const summarize = vi.fn(async (text: string) => `summary ${text.length}`);
+
+    const result = await staleAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+      currentTokenCount: 80_000,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalled();
+  });
+
   it("compact skips when under threshold and not forced", async () => {
     await ingestMessages(convStore, sumStore, 2, {
       contentFn: () => "Short",
@@ -3294,5 +3342,288 @@ describe("prompt-aware eviction", () => {
       extractMessageText(m.content).includes("Fresh message"),
     );
     expect(summaryIdx).toBeLessThan(freshIdx);
+  });
+});
+// ═════════════════════════════════════════════════════════════════════════════
+// Test Suite: evaluateLeafTrigger skip guards
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("evaluateLeafTrigger skip guards", () => {
+  let convStore: ReturnType<typeof createMockConversationStore>;
+  let sumStore: ReturnType<typeof createMockSummaryStore>;
+
+  beforeEach(() => {
+    convStore = createMockConversationStore();
+    sumStore = createMockSummaryStore();
+    wireStores(convStore, sumStore);
+  });
+
+  function createCompaction(overrides?: Partial<CompactionConfig>): InstanceType<typeof CompactionEngine> {
+    return new CompactionEngine(convStore as any, sumStore as any, {
+      contextThreshold: 0.75,
+      freshTailCount: 4,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 2400,
+      condensedTargetTokens: 900,
+      maxRounds: 10,
+      summaryMaxOverageFactor: 3,
+      leafSkipReductionThreshold: 0.05,
+      leafBudgetHeadroomFactor: 0.8,
+      ...overrides,
+    });
+  }
+
+  // Helper: ingest N messages with fixed token count, freshTailCount=4 means
+  // first (N-4) are outside fresh tail.
+  async function setupConversation(opts: {
+    messageCount: number;
+    tokensPerMessage: number;
+    summaryTokens?: number;
+  }): Promise<void> {
+    await ingestMessages(convStore, sumStore, opts.messageCount, {
+      tokenCountFn: () => opts.tokensPerMessage,
+    });
+    // Optionally add a summary to inflate totalAssembledTokens
+    if (opts.summaryTokens) {
+      await sumStore.insertSummary({
+        summaryId: "existing-summary-1",
+        conversationId: CONV_ID,
+        kind: "leaf",
+        content: "mock summary content",
+        tokenCount: opts.summaryTokens,
+      });
+      await sumStore.appendContextSummary(CONV_ID, "existing-summary-1");
+    }
+  }
+
+  // ── Basic threshold ────────────────────────────────────────────
+
+  it("returns shouldCompact=false when raw tokens below threshold", async () => {
+    // 8 messages at 1000 tokens each, freshTailCount=4 → 4 outside tail = 4000 tokens
+    // leafChunkTokens=20000 → 4000 < 20000 → no compaction
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 1000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.rawTokensOutsideTail).toBe(4000);
+    expect(result.threshold).toBe(20_000);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it("returns shouldCompact=true when raw tokens exceed threshold and no skip applies", async () => {
+    // 12 messages at 5000 tokens each, freshTailCount=4 → 8 outside tail = 40000 tokens
+    // leafChunkTokens=20000 → 40000 >= 20000 → basic threshold met
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // totalAssembled = 60000, 5% of 60000 = 3000 → 17600 > 3000 → cache check passes
+    // tokenBudget=80000 → ceiling = 0.8*0.75*80000 = 48000 → 60000 > 48000 → headroom check passes
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 80_000);
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  // ── Budget headroom skip ───────────────────────────────────────
+
+  it("skips due to budget headroom when assembled tokens are well under ceiling", async () => {
+    // 10 messages at 3000 tokens each, freshTailCount=4 → 6 outside tail = 18000 tokens
+    // But leafChunkTokens=15000 → 18000 >= 15000 → threshold met
+    // totalAssembled = 30000, tokenBudget=200000 → ceiling = 0.8*0.75*200000 = 120000
+    // 30000 < 120000 → budget headroom → SKIP
+    const engine = createCompaction({ leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 200_000);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("budget-headroom");
+  });
+
+  it("does NOT skip headroom when assembled tokens exceed ceiling", async () => {
+    // 12 messages at 5000 tokens, freshTailCount=4 → 8 outside = 40000
+    // totalAssembled = 60000, tokenBudget=80000 → ceiling = 0.8*0.75*80000 = 48000
+    // 60000 > 48000 → no headroom → continues
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 80_000);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("skips headroom check when tokenBudget is undefined", async () => {
+    // Same setup as headroom skip test, but no tokenBudget → headroom check bypassed
+    // Falls through to cache-aware check
+    const engine = createCompaction({ leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    // Without tokenBudget, headroom check is skipped → falls to cache-aware
+    // estimatedReduction = min(18000,15000) - 2400 = 12600
+    // 5% of 30000 = 1500 → 12600 > 1500 → cache check passes → shouldCompact
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  // ── Cache-aware skip ───────────────────────────────────────────
+
+  it("skips due to cache-aware when reduction is tiny relative to total context", async () => {
+    // Use a large summary to inflate totalAssembledTokens relative to raw tokens
+    // 8 messages at 6000 tokens, freshTailCount=4 → 4 outside tail = 24000 tokens
+    // Plus a 500000-token summary → totalAssembled = 548000
+    // leafChunkTokens=20000 → 24000 >= 20000 → threshold met
+    // estimatedReduction = min(24000,20000) - 2400 = 17600
+    // 5% of 548000 = 27400 → 17600 < 27400 → cache skip → SKIP
+    // BUT: tokenBudget matters — if over ceiling, budget pressure overrides
+    // Set tokenBudget high enough that headroom exists (no budget pressure)
+    // ceiling = 0.8*0.75*800000 = 480000 → 548000 > 480000 → budget pressure!
+    // So we need to NOT pass tokenBudget to test cache-aware in isolation
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    // No tokenBudget → headroom check is bypassed, no budget pressure
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("cache-aware");
+  });
+
+  it("does NOT cache-skip when reduction is large enough", async () => {
+    // 12 messages at 5000 tokens, freshTailCount=4 → 8 outside = 40000
+    // totalAssembled = 60000
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // 5% of 60000 = 3000 → 17600 > 3000 → cache check passes → compact
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  // ── Budget pressure overrides cache skip ───────────────────────
+
+  it("compacts when over budget ceiling even if cache reduction is tiny (no starvation)", async () => {
+    // This is the Scenario C fix: large context, tiny relative reduction, but budget pressure
+    // 8 messages at 6000 tokens, freshTailCount=4 → 4 outside = 24000
+    // Plus 500000-token summary → totalAssembled = 548000
+    // tokenBudget=750000 → ceiling = 0.8*0.75*750000 = 450000
+    // 548000 > 450000 → budget pressure → cache skip bypassed → COMPACT
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 750_000);
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────
+
+  it("handles totalAssembledTokens=0 (empty conversation)", async () => {
+    // No messages ingested — rawTokensOutsideTail=0 which is below any threshold
+    const engine = createCompaction();
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.rawTokensOutsideTail).toBe(0);
+  });
+
+  it("handles estimatedReduction <= 0 (raw tokens < leafTargetTokens)", async () => {
+    // leafChunkTokens=2000, 6 messages at 500 tokens, freshTailCount=4 → 2 outside = 1000
+    // But wait — 1000 < 2000 → below threshold, returns early
+    // Use leafChunkTokens=500 so threshold is met at 1000
+    // estimatedReduction = min(1000,500) - 2400 = -1900 (negative)
+    // The estimatedReduction > 0 guard prevents cache skip → falls through to compact
+    const engine = createCompaction({ leafChunkTokens: 500 });
+    await setupConversation({ messageCount: 6, tokensPerMessage: 500 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("respects custom leafSkipReductionThreshold", async () => {
+    // With threshold=0.50 (50%), even large reductions get skipped
+    // 12 messages at 5000, freshTailCount=4 → 8 outside = 40000
+    // estimatedReduction = min(40000,20000) - 2400 = 17600
+    // 50% of 60000 = 30000 → 17600 < 30000 → cache skip
+    const engine = createCompaction({ leafSkipReductionThreshold: 0.50 });
+    await setupConversation({ messageCount: 12, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("cache-aware");
+  });
+
+  it("leafSkipReductionThreshold=0 disables cache-aware skip", async () => {
+    // Same setup as above but leafSkipReductionThreshold=0 → cache-aware skip never fires
+    const engine = createCompaction({
+      leafSkipReductionThreshold: 0,
+    });
+    await setupConversation({ messageCount: 8, tokensPerMessage: 6000, summaryTokens: 500_000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    // No budget pressure (no tokenBudget), cache skip disabled → should compact
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("leafBudgetHeadroomFactor=0 disables headroom check (no false budget pressure)", async () => {
+    // factor=0 → headroomEnabled=false → no headroom skip, no budget pressure
+    // Falls through to cache-aware check with no budget pressure override.
+    // 10 msgs at 3000, freshTailCount=4 → 6 outside = 18000
+    // leafChunkTokens=15000 → perPass = min(18000,15000) = 15000
+    // estimatedReduction = 15000 - 2400 = 12600
+    // totalAssembled = 30000, 5% = 1500 → 12600 > 1500 → cache check passes → compact
+    const engine = createCompaction({ leafBudgetHeadroomFactor: 0, leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 200_000);
+    // No budget pressure (headroom disabled), cache-aware passes → compact
+    expect(result.shouldCompact).toBe(true);
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it("clamps leafBudgetHeadroomFactor above 1.0 to 1.0", async () => {
+    // factor=1.5 → clamped to 1.0 → ceiling = 1.0*0.75*100000 = 75000
+    // 30000 < 75000 → headroom skip
+    const engine = createCompaction({ leafBudgetHeadroomFactor: 1.5, leafChunkTokens: 15_000 });
+    await setupConversation({ messageCount: 10, tokensPerMessage: 3000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID, 100_000);
+    expect(result.shouldCompact).toBe(false);
+    expect(result.skipReason).toContain("budget-headroom");
+  });
+
+  // ── Orchestration scenario ─────────────────────────────────────
+
+  it("orchestrator with headroom skips, sub-agent at capacity compacts", async () => {
+    // Orchestrator: 40K assembled, 200K budget → ceiling=120K → 40K<120K → SKIP
+    const orchestratorEngine = createCompaction({ leafChunkTokens: 15_000 });
+    await ingestMessages(convStore, sumStore, 10, {
+      conversationId: 1,
+      tokenCountFn: () => 4000,
+    });
+    const orchResult = await orchestratorEngine.evaluateLeafTrigger(1, 200_000);
+    expect(orchResult.shouldCompact).toBe(false);
+
+    // Sub-agent: same raw tokens but tiny budget → ceiling=9600 → 40K>9600 → compact
+    const subResult = await orchestratorEngine.evaluateLeafTrigger(1, 16_000);
+    expect(subResult.shouldCompact).toBe(true);
+  });
+
+  // ── Per-pass chunk size estimate ───────────────────────────────
+
+  it("uses per-pass chunk size (min of raw tokens and threshold) for reduction estimate", async () => {
+    // 20 messages at 5000 tokens, freshTailCount=4 → 16 outside = 80000
+    // leafChunkTokens=20000 → threshold met (80000 >= 20000)
+    // Per-pass: min(80000, 20000) = 20000
+    // estimatedReduction = 20000 - 2400 = 17600
+    // 5% of 100000 = 5000 → 17600 > 5000 → no cache skip → compact
+    // Without per-pass capping, estimatedReduction would be 80000-2400=77600,
+    // which would also pass — but the estimate would be wrong
+    const engine = createCompaction();
+    await setupConversation({ messageCount: 20, tokensPerMessage: 5000 });
+
+    const result = await engine.evaluateLeafTrigger(CONV_ID);
+    expect(result.shouldCompact).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds persistent compaction event tracking, cost estimation, and efficiency reporting to the `/lossless` command. Users can now see whether LCM compaction is saving or wasting money.

**Closes #309. Depends on #306 and #307. Merge order: #306 → #307 → this PR.**

---

## Problem

Users have zero visibility into compaction economics. Real user experience:

> "My usage is blowing up and I don't know why."

Investigation revealed: LCM was compacting every turn using **Opus** ($0.16/call), invalidating the prompt cache ($0.68/miss on 150K cached prefix), and producing junk summaries from 1000-token tool calls. The cost of compaction exceeded the savings from token reduction — **LCM was actively losing money** — and there was no way to know.

### What users couldn't see before

- How many compaction passes ran per session
- What model was being used for summarization (and its cost)
- Whether the tokens saved justified the compaction cost
- Whether they should switch to a cheaper compaction model

### What they can see now

**In `/lossless status`** — a new efficiency section (only shown when events exist):

```
⚡ Compaction efficiency
  passes             12 (10 leaf, 2 condensed)
  tokens saved       48,200
  compaction cost     ~$0.38 (12 calls × claude-haiku-4-5)
  estimated savings   ~$0.72
  net efficiency      +$0.34 (47% efficient)
  recommendation      ✓ Compaction is saving money
```

Or the warning case:
```
⚡ Compaction efficiency
  passes             28 (25 leaf, 3 condensed)
  tokens saved       8,400
  compaction cost     ~$4.48 (28 calls × claude-opus-4-6)
  estimated savings   ~$0.13
  net efficiency      -$4.35 (LOSING money)
  recommendation      ⚠ Switch summaryModel to haiku — Opus costs 40x more
```

**In `/lossless efficiency`** — detailed breakdown:

```
⚡ Summary
  total passes        28 (25 leaf, 3 condensed)
  tokens saved        8,400
  compaction cost     ~$4.48
  estimated savings   ~$0.13
  net                 -$4.35 (-3346% efficient)

📊 By model
  claude-opus-4-6     28 passes, ~$4.48

💡 Recommendations
  ⚠ Using claude-opus-4-6 for compaction costs ~$0.16/call. Switch to haiku (~$0.03) or gpt-4o-mini (~$0.004).
  ⚠ Compaction is costing more than it saves. Check your summaryModel setting.
  💡 Average tokens saved per pass is low (<2K). Consider raising leafSkipReductionThreshold.
```

---

## Implementation

### 1. Persistent event tracking

New `compaction_events` SQLite table records each compaction pass:
- `tokens_before`, `tokens_after` — context token counts
- `input_tokens_est`, `output_tokens_est` — estimated tokens consumed by compaction model
- `compaction_model` — which model was used
- `pass` (leaf/condensed), `level` (normal/aggressive/fallback/capped)

Recording is best-effort — if the table doesn't exist (older DB), compaction still works. The `typeof` check on `insertCompactionEvent` handles mock stores in tests.

### 2. Static pricing table

`src/plugin/pricing.ts` — 11 models with fuzzy prefix matching:
- `"claude-haiku-4-5-20251001"` matches `"claude-haiku-4"` → $1.00/$5.00 per MTok
- Unknown models get Sonnet-class defaults ($3.00/$15.00) with a `matched: false` flag

### 3. Efficiency scoring formula

```
savings_estimate = tokens_saved × $3/MTok × 5 turns
compaction_cost  = Σ(input_tokens × model_input_price + output_tokens × model_output_price)
net_efficiency   = savings_estimate - compaction_cost
```

Conservative assumptions: Sonnet-class main model ($3/MTok), 5-turn benefit horizon per token saved.

### 4. Actionable recommendations

Rules-based engine checks for:
- Using Opus/Sonnet for compaction → suggests cheaper alternatives
- Net negative efficiency → warns compaction is losing money
- Low average tokens saved per pass → suggests raising `leafSkipReductionThreshold`

---

## Changes by File

| File | Lines | Change |
|------|-------|--------|
| `src/db/migration.ts` | +14 | `compaction_events` table + index |
| `src/plugin/pricing.ts` | +69 | **NEW** — static model pricing, cost estimation, savings formula |
| `src/compaction.ts` | +41/-10 | Thread `inputTokensEst`/`outputTokensEst`/`compactionModel` through persist calls. Best-effort DB insert in `persistCompactionEvent()`. |
| `src/store/summary-store.ts` | +35 | `insertCompactionEvent()` with try/catch for backward compat |
| `src/plugin/lcm-command.ts` | +183 | Efficiency section in status, `getCompactionEfficiencyStats()` query helper, `buildEfficiencyText()` subcommand, help text update |
| `test/compaction-efficiency.test.ts` | +94 | **NEW** — 15 tests: model matching, cost estimation, savings formula, currency formatting, positive/negative efficiency scenarios |
| `.changeset/` | +5 | Patch bump |

## Test Plan

- [x] 258 tests passing (122 engine + 82 integration + 39 config + 15 efficiency)
- [x] Pricing: exact prefix match, dated variant match, unknown model fallback, undefined model, zero tokens
- [x] Savings: default params, custom main model price, zero tokens
- [x] Efficiency: Haiku compaction = positive (47% efficient), Opus compaction = negative (losing $4+)
- [x] Best-effort recording: mock stores without `insertCompactionEvent` don't crash
- [x] Backward compat: older DBs without `compaction_events` table handled gracefully