### PR TITLE
fix: fall back to root plugin config

### DIFF
--- a/.changeset/tall-geckos-compete.md
+++ b/.changeset/tall-geckos-compete.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fall back to `plugins.entries["lossless-claw"].config` when older or otherwise incompatible OpenClaw runtimes do not provide a usable `api.pluginConfig`.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -172,6 +172,27 @@ function snapshotPluginEnv(env: NodeJS.ProcessEnv = process.env): PluginEnvSnaps
   };
 }
 
+/** Coerce a plugin-config-like value into a plain object when possible. */
+function toPluginConfig(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Resolve plugin config from direct runtime injection or the root OpenClaw config fallback. */
+function resolvePluginConfig(api: OpenClawPluginApi): Record<string, unknown> | undefined {
+  const directPluginConfig = toPluginConfig(api.pluginConfig);
+  if (directPluginConfig) {
+    return directPluginConfig;
+  }
+
+  const rootConfig = toPluginConfig(api.config);
+  const plugins = toPluginConfig(rootConfig?.plugins);
+  const entries = toPluginConfig(plugins?.entries);
+  const pluginEntry = toPluginConfig(entries?.["lossless-claw"]);
+  return toPluginConfig(pluginEntry?.config);
+}
+
 function truncateErrorMessage(message: string, maxChars = 240): string {
   return message.length <= maxChars ? message : `${message.slice(0, maxChars)}...`;
 }
@@ -1107,10 +1128,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
   envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(api.config);
   const modelAuth = getRuntimeModelAuth(api);
   const readEnv: ReadEnvFn = (key) => process.env[key];
-  const pluginConfig =
-    api.pluginConfig && typeof api.pluginConfig === "object" && !Array.isArray(api.pluginConfig)
-      ? api.pluginConfig
-      : undefined;
+  const pluginConfig = resolvePluginConfig(api);
   const config = resolveLcmConfig(process.env, pluginConfig);
 
   // Read model overrides from plugin config

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -182,7 +182,7 @@ function toPluginConfig(value: unknown): Record<string, unknown> | undefined {
 /** Resolve plugin config from direct runtime injection or the root OpenClaw config fallback. */
 function resolvePluginConfig(api: OpenClawPluginApi): Record<string, unknown> | undefined {
   const directPluginConfig = toPluginConfig(api.pluginConfig);
-  if (directPluginConfig) {
+  if (directPluginConfig && Object.keys(directPluginConfig).length > 0) {
     return directPluginConfig;
   }
 

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -13,7 +13,7 @@ type RegisteredEngineFactory = (() => unknown) | undefined;
 type HookHandler = (event: unknown, context: unknown) => unknown;
 
 function buildApi(
-  pluginConfig: Record<string, unknown>,
+  pluginConfig: unknown,
   options?: { includeModelAuth?: boolean; agentDir?: string },
 ): {
   api: OpenClawPluginApi;
@@ -217,6 +217,46 @@ describe("lcm plugin registration", () => {
     expect(api.on).toHaveBeenCalledWith("before_reset", expect.any(Function));
     expect(api.on).toHaveBeenCalledWith("session_end", expect.any(Function));
   });
+
+  it.each([
+    ["missing", undefined],
+    ["invalid", ["not-a-plugin-config"]],
+  ])(
+    "falls back to root plugin config when api.pluginConfig is %s",
+    (_label, pluginConfig) => {
+      const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+      dbPaths.add(dbPath);
+
+      const { api, getFactory } = buildApi(pluginConfig);
+      api.config = {
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              config: {
+                enabled: true,
+                contextThreshold: 0.42,
+                freshTailCount: 9,
+                dbPath,
+              },
+            },
+          },
+        },
+      } as OpenClawPluginApi["config"];
+
+      lcmPlugin.register(api);
+
+      const factory = getFactory();
+      expect(factory).toBeTypeOf("function");
+
+      const engine = factory!() as { config: Record<string, unknown> };
+      expect(engine.config).toMatchObject({
+        enabled: true,
+        contextThreshold: 0.42,
+        freshTailCount: 9,
+        databasePath: dbPath,
+      });
+    },
+  );
 
   it("inherits OpenClaw's default model for summarization when no LCM model override is set", { timeout: 20000 }, () => {
     const { api, getFactory } = buildApi({

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -221,6 +221,7 @@ describe("lcm plugin registration", () => {
   it.each([
     ["missing", undefined],
     ["invalid", ["not-a-plugin-config"]],
+    ["empty", {}],
   ])(
     "falls back to root plugin config when api.pluginConfig is %s",
     (_label, pluginConfig) => {


### PR DESCRIPTION
## What
This PR hardens lossless-claw's runtime config loading during plugin registration so the plugin still reads its settings from the root OpenClaw config when `api.pluginConfig` is missing or unusable.

## Why
Some OpenClaw runtimes do not provide a usable `api.pluginConfig` to plugin registration, which caused lossless-claw to ignore configured settings even though the same values were still present under `plugins.entries["lossless-claw"].config`.

## Changes
- Add root-config fallback for plugin registration
- Cover missing direct plugin config path
- Cover invalid direct plugin config path
- Add patch changeset for runtime fix

## Testing
- `npx vitest run test/plugin-config-registration.test.ts`
- Expect `23` tests to pass, including the new root-config fallback cases

Closed #325 
