### PR TITLE
doctor (stack 2/4): add backup-first cleaner apply

### DIFF
--- a/.changeset/sly-poems-nail.md
+++ b/.changeset/sly-poems-nail.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add `/lossless doctor clean apply` for backup-first cleanup of approved high-confidence junk conversations, while preserving archived-only handling for NULL-key subagent rows and surfacing integrity-check warnings after apply.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 
 - `/lcm` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
 - `/lcm doctor` scans for broken or truncated summaries
-- `/lcm doctor cleaners` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
+- `/lcm doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
 - `/lossless` is an alias for `/lcm` on supported native command surfaces
 
 These are plugin slash/native commands, not root shell CLI subcommands. Supported examples:
 
 - `/lcm`
 - `/lcm doctor`
-- `/lcm doctor cleaners`
+- `/lcm doctor clean`
 - `/lossless`
 
 Not currently supported as root CLI commands:

--- a/skills/lossless-claw/SKILL.md
+++ b/skills/lossless-claw/SKILL.md
@@ -12,7 +12,7 @@ Start here:
 1. Confirm whether the user needs configuration help, diagnostics, recall-tool guidance, or session-lifecycle guidance.
 2. If they need a quick health check, tell them to run `/lossless` (`/lcm` is the shorter alias).
 3. If they suspect summary corruption or truncation, use `/lossless doctor`.
-4. If they want high-confidence junk/session cleanup guidance, use `/lossless doctor cleaners` before recommending any deletes.
+4. If they want high-confidence junk/session cleanup guidance, use `/lossless doctor clean` before recommending any deletes.
 5. If they ask how `/new` or `/reset` interacts with LCM, read the session-lifecycle reference before answering.
 6. Load the relevant reference file instead of improvising details from memory.
 

--- a/skills/lossless-claw/references/architecture.md
+++ b/skills/lossless-claw/references/architecture.md
@@ -51,7 +51,7 @@ It looks for known summary-health markers that indicate:
 
 This gives users one place to answer the question “is my summary graph healthy?” without introducing a broader mutation surface.
 
-## What `/lcm doctor cleaners` tells you
+## What `/lcm doctor clean` tells you
 
 The cleaners flow is also diagnostic first.
 

--- a/skills/lossless-claw/references/diagnostics.md
+++ b/skills/lossless-claw/references/diagnostics.md
@@ -29,7 +29,7 @@ What it should help confirm:
 - whether truncation markers exist
 - which conversations are affected most
 
-### `/lossless doctor cleaners`
+### `/lossless doctor clean`
 
 Use this when the user wants read-only diagnostics for high-confidence junk patterns before any cleanup.
 

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -8,24 +8,34 @@ const SQLITE_BUSY_TIMEOUT_MS = 5_000;
 const connectionsByPath = new Map<ConnectionKey, Set<DatabaseSync>>();
 const connectionIndex = new Map<DatabaseSync, ConnectionKey>();
 
-function isInMemoryPath(dbPath: string): boolean {
+export function isInMemoryPath(dbPath: string): boolean {
   const normalized = dbPath.trim();
   return normalized === ":memory:" || normalized.startsWith("file::memory:");
 }
 
+export function getFileBackedDatabasePath(dbPath: string): string | null {
+  const trimmed = dbPath.trim();
+  if (!trimmed || isInMemoryPath(trimmed)) {
+    return null;
+  }
+  return resolve(trimmed);
+}
+
 export function normalizePath(dbPath: string): ConnectionKey {
-  if (isInMemoryPath(dbPath)) {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(dbPath);
+  if (!fileBackedDatabasePath) {
     const trimmed = dbPath.trim();
     return trimmed.length > 0 ? trimmed : ":memory:";
   }
-  return resolve(dbPath);
+  return fileBackedDatabasePath;
 }
 
 function ensureDbDirectory(dbPath: string): void {
-  if (isInMemoryPath(dbPath)) {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(dbPath);
+  if (!fileBackedDatabasePath) {
     return;
   }
-  mkdirSync(dirname(dbPath), { recursive: true });
+  mkdirSync(dirname(fileBackedDatabasePath), { recursive: true });
 }
 
 function configureConnection(db: DatabaseSync): DatabaseSync {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -6,7 +6,13 @@ import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
-import { scanDoctorCleaners } from "./lcm-doctor-cleaners.js";
+import {
+  applyDoctorCleaners,
+  getDoctorCleanerApplyUnavailableReason,
+  getDoctorCleanerFilterIds,
+  scanDoctorCleaners,
+  type DoctorCleanerId,
+} from "./lcm-doctor-cleaners.js";
 import {
   detectDoctorMarker,
   getDoctorSummaryStats,
@@ -53,8 +59,10 @@ type CurrentConversationResolution =
 type ParsedLcmCommand =
   | { kind: "status" }
   | { kind: "doctor"; apply: boolean }
-  | { kind: "doctor_cleaners" }
+  | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
   | { kind: "help"; error?: string };
+
+const DOCTOR_CLEANER_IDS = new Set<DoctorCleanerId>(getDoctorCleanerFilterIds());
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -140,6 +148,32 @@ function splitArgs(rawArgs: string | undefined): string[] {
     .filter(Boolean);
 }
 
+function parseDoctorCleanerApplyArgs(tokens: string[]):
+  | { ok: true; filterId?: DoctorCleanerId; vacuum: boolean }
+  | { ok: false; error: string } {
+  let filterId: DoctorCleanerId | undefined;
+  let vacuum = false;
+
+  for (const token of tokens) {
+    const normalized = token.toLowerCase();
+    if (normalized === "vacuum") {
+      vacuum = true;
+      continue;
+    }
+    if (DOCTOR_CLEANER_IDS.has(normalized as DoctorCleanerId) && !filterId) {
+      filterId = normalized as DoctorCleanerId;
+      continue;
+    }
+    return {
+      ok: false,
+      error:
+        `\`${VISIBLE_COMMAND} doctor clean apply\` accepts at most one filter id (\`${getDoctorCleanerFilterIds().join("`, `")}\`) plus optional \`vacuum\`.`,
+    };
+  }
+
+  return { ok: true, filterId, vacuum };
+}
+
 function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
   const tokens = splitArgs(rawArgs);
   if (tokens.length === 0) {
@@ -156,8 +190,19 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       if (rest.length === 0) {
         return { kind: "doctor", apply: false };
       }
-      if (rest.length === 1 && rest[0]?.toLowerCase() === "cleaners") {
-        return { kind: "doctor_cleaners" };
+      if (rest.length === 1 && rest[0]?.toLowerCase() === "clean") {
+        return { kind: "doctor_cleaners", apply: false, vacuum: false };
+      }
+      if (rest[0]?.toLowerCase() === "clean" && rest[1]?.toLowerCase() === "apply") {
+        const parsedApply = parseDoctorCleanerApplyArgs(rest.slice(2));
+        return parsedApply.ok
+          ? {
+              kind: "doctor_cleaners",
+              apply: true,
+              filterId: parsedApply.filterId,
+              vacuum: parsedApply.vacuum,
+            }
+          : { kind: "help", error: parsedApply.error };
       }
       if (rest.length === 1 && rest[0]?.toLowerCase() === "apply") {
         return { kind: "doctor", apply: true };
@@ -165,14 +210,14 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`cleaners\` for global high-confidence junk diagnostics, or \`apply\` for the scoped repair path.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply\` for the scoped summary repair path.`,
       };
     case "help":
       return { kind: "help" };
     default:
       return {
         kind: "help",
-        error: `Unknown subcommand \`${head}\`. Supported: status, doctor, doctor cleaners, doctor apply.`,
+        error: `Unknown subcommand \`${head}\`. Supported: status, doctor, doctor clean, doctor apply, help.`,
       };
   }
 }
@@ -430,8 +475,12 @@ function buildHelpText(error?: string): string {
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} status`), "Show plugin, Global, and current-conversation status."),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
-        formatCommand(`${VISIBLE_COMMAND} doctor cleaners`),
+        formatCommand(`${VISIBLE_COMMAND} doctor clean`),
         "Report global high-confidence junk candidates without deleting anything.",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor clean apply`),
+        "Delete approved high-confidence cleaner matches after creating a DB backup.",
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor apply`), "Repair broken summaries in the current conversation."),
     ]),
@@ -612,7 +661,7 @@ async function buildDoctorCleanersText(params: {
   const lines = [
     ...buildHeaderLines(),
     "",
-    "🩺 Lossless Claw Doctor Cleaners",
+    "🩺 Lossless Claw Doctor Clean",
     "",
     buildSection("🌐 Global scan", [
       buildStatLine("filters", formatNumber(scan.filters.length)),
@@ -655,7 +704,142 @@ async function buildDoctorCleanersText(params: {
   lines.push(
     "",
     buildSection("🛠️ Next step", [
-      "Cleaner apply is intentionally not included in this build; review these diagnostics before any destructive workflow is added.",
+      `Review the examples, then run ${formatCommand(`${VISIBLE_COMMAND} doctor clean apply`)} to delete approved matches after Lossless Claw creates a backup.`,
+    ]),
+  );
+
+  return lines.join("\n");
+}
+
+function runQuickCheck(db: DatabaseSync): string {
+  const rows = db.prepare(`PRAGMA quick_check`).all() as Array<{ quick_check?: string }>;
+  const results = rows
+    .map((row) => row.quick_check)
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  if (results.length === 0) {
+    return "unknown";
+  }
+
+  if (results.length === 1 && results[0] === "ok") {
+    return "ok";
+  }
+
+  return results.join("; ");
+}
+
+function isPassingQuickCheck(result: string): boolean {
+  return result === "ok";
+}
+
+async function buildDoctorCleanersApplyText(params: {
+  db: DatabaseSync;
+  config: LcmConfig;
+  filterId?: DoctorCleanerId;
+  vacuum: boolean;
+}): Promise<string> {
+  const filterIds = params.filterId ? [params.filterId] : undefined;
+  const unavailableReason = getDoctorCleanerApplyUnavailableReason(params.config.databasePath);
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🩺 Lossless Claw Doctor Clean Apply",
+    "",
+    buildSection("🌐 Cleaner scope", [
+      buildStatLine(
+        "filters",
+        filterIds && filterIds.length > 0
+          ? filterIds.map((filter) => formatCommand(filter)).join(", ")
+          : "all approved cleaner filters",
+      ),
+      buildStatLine("vacuum requested", formatBoolean(params.vacuum)),
+    ]),
+    "",
+  ];
+  if (unavailableReason) {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", unavailableReason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const before = scanDoctorCleaners(params.db, filterIds);
+  lines.splice(
+    lines.length - 1,
+    0,
+    buildSection("📊 Current matches", [
+      buildStatLine("matched conversations before apply", formatNumber(before.totalDistinctConversations)),
+      buildStatLine("matched messages before apply", formatNumber(before.totalDistinctMessages)),
+    ]),
+    "",
+  );
+
+  if (before.totalDistinctConversations === 0) {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "completed"),
+        buildStatLine("backup path", "skipped (no matches)"),
+        buildStatLine("deleted conversations", "0"),
+        buildStatLine("deleted messages", "0"),
+        buildStatLine("vacuumed", "no"),
+        buildStatLine("quick_check", "not run (no writes)"),
+        buildStatLine("result", "clean; no deletes ran"),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  let result: ReturnType<typeof applyDoctorCleaners>;
+  try {
+    result = applyDoctorCleaners(params.db, {
+      databasePath: params.config.databasePath,
+      filterIds,
+      vacuum: params.vacuum,
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "failed"),
+        buildStatLine(
+          "reason",
+          error instanceof Error ? error.message : "unknown cleaner apply failure",
+        ),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  if (result.kind === "unavailable") {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", result.reason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const quickCheck = runQuickCheck(params.db);
+  const quickCheckPassed = isPassingQuickCheck(quickCheck);
+  lines.push(
+    buildSection("🛠️ Apply", [
+      buildStatLine("status", quickCheckPassed ? "completed" : "warning"),
+      buildStatLine("backup path", result.backupPath),
+      buildStatLine("deleted conversations", formatNumber(result.deletedConversations)),
+      buildStatLine("deleted messages", formatNumber(result.deletedMessages)),
+      buildStatLine("vacuumed", formatBoolean(result.vacuumed)),
+      buildStatLine("quick_check", quickCheck),
+      buildStatLine(
+        "result",
+        quickCheckPassed
+          ? result.deletedConversations > 0
+            ? `removed ${formatNumber(result.deletedConversations)} conversation(s)`
+            : "clean; no deletes ran"
+          : "writes committed, but SQLite integrity verification reported problems; inspect the database or restore from the backup before continuing",
+      ),
     ]),
   );
 
@@ -804,7 +988,8 @@ export function createLcmCommand(params: {
     nativeProgressMessages: {
       telegram: "Lossless Claw is working...",
     },
-    description: "Show Lossless Claw health, scan broken summaries, and repair scoped doctor issues.",
+    description:
+      "Show Lossless Claw health, scan broken summaries, inspect high-confidence junk candidates, and run scoped doctor actions.",
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);
@@ -824,7 +1009,16 @@ export function createLcmCommand(params: {
               }
             : { text: await buildDoctorText({ ctx, db: await getDb() }) };
         case "doctor_cleaners":
-          return { text: await buildDoctorCleanersText({ db: await getDb() }) };
+          return parsed.apply
+            ? {
+                text: await buildDoctorCleanersApplyText({
+                  db: await getDb(),
+                  config: params.config,
+                  filterId: parsed.filterId,
+                  vacuum: parsed.vacuum,
+                }),
+              }
+            : { text: await buildDoctorCleanersText({ db: await getDb() }) };
         case "help":
           return { text: buildHelpText(parsed.error) };
       }

--- a/src/plugin/lcm-doctor-cleaners.ts
+++ b/src/plugin/lcm-doctor-cleaners.ts
@@ -1,4 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
+import { basename, dirname, join } from "node:path";
+import { getFileBackedDatabasePath } from "../db/connection.js";
 
 export type DoctorCleanerId =
   | "archived_subagents"
@@ -26,6 +28,20 @@ export type DoctorCleanerScan = {
   totalDistinctConversations: number;
   totalDistinctMessages: number;
 };
+
+export type DoctorCleanerApplyResult =
+  | {
+      kind: "applied";
+      filterIds: DoctorCleanerId[];
+      deletedConversations: number;
+      deletedMessages: number;
+      vacuumed: boolean;
+      backupPath: string;
+    }
+  | {
+      kind: "unavailable";
+      reason: string;
+    };
 
 type CleanerDefinition = {
   id: DoctorCleanerId;
@@ -71,13 +87,17 @@ const CLEANER_DEFINITIONS: CleanerDefinition[] = [
     id: "null_subagent_context",
     label: "NULL-key subagent context",
     description:
-      "Conversations with NULL session_key whose first stored message begins with [Subagent Context].",
-    candidatePredicateSql: "(c.session_key IS NULL)",
+      "Archived conversations with NULL session_key whose first stored message begins with [Subagent Context].",
+    candidatePredicateSql: "(c.session_key IS NULL AND c.active = 0 AND c.archived_at IS NOT NULL)",
     predicateSql:
-      "(c.session_key IS NULL AND message_stats.first_message_preview LIKE '[Subagent Context]%')",
+      "(c.session_key IS NULL AND c.active = 0 AND c.archived_at IS NOT NULL AND message_stats.first_message_preview LIKE '[Subagent Context]%')",
     needsFirstMessage: true,
   },
 ];
+
+const DOCTOR_CLEANER_IDS = CLEANER_DEFINITIONS.map(
+  (definition) => definition.id,
+) as DoctorCleanerId[];
 
 function getCleanerDefinitions(filterIds?: DoctorCleanerId[]): CleanerDefinition[] {
   if (!filterIds || filterIds.length === 0) {
@@ -236,6 +256,10 @@ export function getDoctorCleanerFilters(): Array<Pick<DoctorCleanerFilterStat, "
   }));
 }
 
+export function getDoctorCleanerFilterIds(): DoctorCleanerId[] {
+  return [...DOCTOR_CLEANER_IDS];
+}
+
 export function scanDoctorCleaners(
   db: DatabaseSync,
   filterIds?: DoctorCleanerId[],
@@ -353,4 +377,279 @@ export function scanDoctorCleaners(
   } finally {
     dropTempCleanerScanTables(db);
   }
+}
+
+function hasTable(db: DatabaseSync, tableName: string): boolean {
+  const row = db
+    .prepare(`SELECT 1 AS found FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1`)
+    .get(tableName) as { found?: number } | undefined;
+  return row?.found === 1;
+}
+
+function dropTempCleanerTables(db: DatabaseSync): void {
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_first_messages`);
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_message_ids`);
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_summary_ids`);
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_conversation_ids`);
+}
+
+function stageTempCleanerFirstMessages(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TEMP TABLE doctor_cleaner_first_messages (
+      conversation_id INTEGER PRIMARY KEY,
+      first_message_preview TEXT
+    )
+  `);
+  db.exec(`
+    WITH ranked_messages AS (
+      SELECT
+        m.conversation_id,
+        substr(m.content, 1, ${SCAN_FIRST_MESSAGE_PREVIEW_LIMIT}) AS content,
+        ROW_NUMBER() OVER (
+          PARTITION BY m.conversation_id
+          ORDER BY m.seq ASC, m.created_at ASC, m.message_id ASC
+        ) AS row_num
+      FROM messages m
+    )
+    INSERT INTO temp.doctor_cleaner_first_messages (
+      conversation_id,
+      first_message_preview
+    )
+    SELECT
+      conversation_id,
+      MAX(CASE WHEN row_num = 1 THEN content END) AS first_message_preview
+    FROM ranked_messages
+    GROUP BY conversation_id
+  `);
+}
+
+function stageCleanerConversationIds(
+  db: DatabaseSync,
+  definitions: CleanerDefinition[],
+): void {
+  dropTempCleanerTables(db);
+  db.exec(`CREATE TEMP TABLE doctor_cleaner_conversation_ids (conversation_id INTEGER PRIMARY KEY)`);
+  db.exec(`CREATE TEMP TABLE doctor_cleaner_summary_ids (summary_id TEXT PRIMARY KEY)`);
+  db.exec(`CREATE TEMP TABLE doctor_cleaner_message_ids (message_id INTEGER PRIMARY KEY)`);
+
+  if (definitions.length === 0) {
+    return;
+  }
+
+  const needsFirstMessage = definitions.some((definition) => definition.needsFirstMessage);
+  if (needsFirstMessage) {
+    stageTempCleanerFirstMessages(db);
+  }
+  const matchedConversationsSql = buildMatchedConversationsSql({
+    definitions,
+    includeFilterId: false,
+    messageStatsTableName: needsFirstMessage
+      ? "temp.doctor_cleaner_first_messages"
+      : undefined,
+  });
+  db.exec(`
+    INSERT INTO temp.doctor_cleaner_conversation_ids (conversation_id)
+    SELECT DISTINCT conversation_id
+    FROM (
+      ${matchedConversationsSql}
+    )
+  `);
+
+  db.exec(`
+    INSERT INTO temp.doctor_cleaner_summary_ids (summary_id)
+    SELECT s.summary_id
+    FROM summaries s
+    JOIN temp.doctor_cleaner_conversation_ids ids
+      ON ids.conversation_id = s.conversation_id
+  `);
+
+  db.exec(`
+    INSERT INTO temp.doctor_cleaner_message_ids (message_id)
+    SELECT m.message_id
+    FROM messages m
+    JOIN temp.doctor_cleaner_conversation_ids ids
+      ON ids.conversation_id = m.conversation_id
+  `);
+}
+
+function readTempCleanerDeleteCounts(db: DatabaseSync): {
+  conversationCount: number;
+  messageCount: number;
+} {
+  const row = db
+    .prepare(
+      `SELECT
+         COALESCE((SELECT COUNT(*) FROM temp.doctor_cleaner_conversation_ids), 0) AS conversation_count,
+         COALESCE((SELECT COUNT(*) FROM temp.doctor_cleaner_message_ids), 0) AS message_count`,
+    )
+    .get() as CleanerCountRow | undefined;
+  return {
+    conversationCount: row?.conversation_count ?? 0,
+    messageCount: row?.message_count ?? 0,
+  };
+}
+
+function deleteTempCleanerCandidates(db: DatabaseSync): number {
+  const hasMessagesFts = hasTable(db, "messages_fts");
+  const hasSummariesFts = hasTable(db, "summaries_fts");
+  const hasSummariesFtsCjk = hasTable(db, "summaries_fts_cjk");
+
+  db.prepare(
+    `DELETE FROM summary_messages
+     WHERE summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+  ).run();
+  db.prepare(
+    `DELETE FROM summary_messages
+     WHERE message_id IN (SELECT message_id FROM temp.doctor_cleaner_message_ids)`,
+  ).run();
+
+  db.prepare(
+    `DELETE FROM summary_parents
+     WHERE summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+  ).run();
+  db.prepare(
+    `DELETE FROM summary_parents
+     WHERE parent_summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+  ).run();
+
+  db.prepare(
+    `DELETE FROM context_items
+     WHERE message_id IN (SELECT message_id FROM temp.doctor_cleaner_message_ids)`,
+  ).run();
+  db.prepare(
+    `DELETE FROM context_items
+     WHERE summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+  ).run();
+  db.prepare(
+    `DELETE FROM context_items
+     WHERE conversation_id IN (SELECT conversation_id FROM temp.doctor_cleaner_conversation_ids)`,
+  ).run();
+
+  if (hasMessagesFts) {
+    db.prepare(
+      `DELETE FROM messages_fts
+       WHERE rowid IN (SELECT message_id FROM temp.doctor_cleaner_message_ids)`,
+    ).run();
+  }
+  if (hasSummariesFts) {
+    db.prepare(
+      `DELETE FROM summaries_fts
+       WHERE summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+    ).run();
+  }
+  if (hasSummariesFtsCjk) {
+    db.prepare(
+      `DELETE FROM summaries_fts_cjk
+       WHERE summary_id IN (SELECT summary_id FROM temp.doctor_cleaner_summary_ids)`,
+    ).run();
+  }
+
+  return Number(
+    db
+      .prepare(
+        `DELETE FROM conversations
+         WHERE conversation_id IN (SELECT conversation_id FROM temp.doctor_cleaner_conversation_ids)`,
+      )
+      .run().changes ?? 0,
+  );
+}
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function getDoctorCleanerApplyUnavailableReason(databasePath: string): string | null {
+  return getFileBackedDatabasePath(databasePath)
+    ? null
+    : "Cleaner apply requires a file-backed SQLite database so Lossless Claw can create a backup first.";
+}
+
+function buildCleanerBackupPath(databasePath: string): string | null {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(databasePath);
+  if (!fileBackedDatabasePath) {
+    return null;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return join(
+    dirname(fileBackedDatabasePath),
+    `${basename(fileBackedDatabasePath)}.doctor-cleaners-${timestamp}-${suffix}.bak`,
+  );
+}
+
+export function applyDoctorCleaners(
+  db: DatabaseSync,
+  options: {
+    databasePath: string;
+    filterIds?: DoctorCleanerId[];
+    vacuum?: boolean;
+  },
+): DoctorCleanerApplyResult {
+  const definitions = getCleanerDefinitions(options.filterIds);
+  if (definitions.length === 0) {
+    return {
+      kind: "unavailable",
+      reason: "No valid doctor cleaner filters were selected.",
+    };
+  }
+
+  const unavailableReason = getDoctorCleanerApplyUnavailableReason(options.databasePath);
+  if (unavailableReason) {
+    return {
+      kind: "unavailable",
+      reason: unavailableReason,
+    };
+  }
+  const backupPath = buildCleanerBackupPath(options.databasePath);
+  if (!backupPath) {
+    return {
+      kind: "unavailable",
+      reason:
+        getDoctorCleanerApplyUnavailableReason(options.databasePath)
+        ?? "Cleaner apply could not determine a backup path.",
+    };
+  }
+
+  db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
+
+  let deletedConversations = 0;
+  let deletedMessages = 0;
+  let vacuumed = false;
+  let transactionActive = false;
+
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    transactionActive = true;
+    stageCleanerConversationIds(db, definitions);
+    const counts = readTempCleanerDeleteCounts(db);
+    deletedMessages = counts.messageCount;
+    if (counts.conversationCount > 0) {
+      deletedConversations = deleteTempCleanerCandidates(db);
+    }
+    db.exec("COMMIT");
+    transactionActive = false;
+  } catch (error) {
+    if (transactionActive) {
+      db.exec("ROLLBACK");
+    }
+    throw error;
+  } finally {
+    dropTempCleanerTables(db);
+  }
+
+  if (options.vacuum && deletedConversations > 0) {
+    db.exec("VACUUM");
+    db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    vacuumed = true;
+  }
+
+  return {
+    kind: "applied",
+    filterIds: definitions.map((definition) => definition.id),
+    deletedConversations,
+    deletedMessages,
+    vacuumed,
+    backupPath,
+  };
 }

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -27,7 +27,7 @@ function createCommandFixture(options?: { summarize?: LcmSummarizeFn; deps?: Lcm
     summarize: options?.summarize,
     deps: options?.deps,
   });
-  return { tempDir, dbPath, command, conversationStore, summaryStore };
+  return { tempDir, dbPath, db, command, conversationStore, summaryStore };
 }
 
 function createCommandContext(
@@ -492,9 +492,31 @@ describe("lcm command", () => {
       },
     ]);
 
-    const result = await fixture.command.handler(createCommandContext("doctor cleaners"));
+    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId);
 
-    expect(result.text).toContain("🩺 Lossless Claw Doctor Cleaners");
+    const liveNullSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-live-null-subagent",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: liveNullSubagent.conversationId,
+        seq: 0,
+        role: "user",
+        content: "[Subagent Context] Live child session still in progress.",
+        tokenCount: 8,
+      },
+      {
+        conversationId: liveNullSubagent.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "Still active and should not be treated as junk.",
+        tokenCount: 10,
+      },
+    ]);
+
+    const result = await fixture.command.handler(createCommandContext("doctor clean"));
+
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Clean");
     expect(result.text).toContain("mode: read-only diagnostics");
     expect(result.text).toContain("matched conversations: 3");
     expect(result.text).toContain("matched messages: 4");
@@ -504,12 +526,13 @@ describe("lcm command", () => {
     expect(result.text).toContain("agent:main:subagent:worker-1");
     expect(result.text).toContain("agent:main:cron:nightly");
     expect(result.text).toContain("\"[Subagent Context] Inspect the repo and summarize the issue.\"");
-    expect(result.text).toContain("Cleaner apply is intentionally not included in this build");
+    expect(result.text).toContain("run `/lossless doctor clean apply`");
+    expect(result.text).not.toContain("\"[Subagent Context] Live child session still in progress.\"");
     expect(result.text).not.toContain("doctor-cleaner-normal");
     expect(result.text).not.toContain("ordinary conversation");
   });
 
-  it("reports a clean doctor cleaners scan when no high-confidence candidates exist", async () => {
+  it("reports a clean doctor clean scan when no high-confidence candidates exist", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
@@ -528,13 +551,259 @@ describe("lcm command", () => {
       },
     ]);
 
-    const result = await fixture.command.handler(createCommandContext("doctor cleaners"));
+    const result = await fixture.command.handler(createCommandContext("doctor clean"));
 
-    expect(result.text).toContain("🩺 Lossless Claw Doctor Cleaners");
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Clean");
     expect(result.text).toContain("matched conversations: 0");
     expect(result.text).toContain("matched messages: 0");
     expect(result.text).toContain("No high-confidence cleaner candidates detected.");
     expect(result.text).not.toContain("🧹 Archived subagents");
+  });
+
+  it("applies all doctor clean filters with backup-first deletion and preserves unrelated conversations", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const archivedSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-apply-archived-subagent",
+      sessionKey: "agent:main:subagent:apply-worker",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: archivedSubagent.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "archived worker output",
+        tokenCount: 5,
+      },
+    ]);
+    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId);
+
+    const cronConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-apply-cron",
+      sessionKey: "agent:main:cron:apply-nightly",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: cronConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "cron cleanup run",
+        tokenCount: 4,
+      },
+    ]);
+
+    const nullSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-apply-null",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: nullSubagent.conversationId,
+        seq: 1,
+        role: "user",
+        content: "[Subagent Context] Collect evidence and respond.",
+        tokenCount: 8,
+      },
+      {
+        conversationId: nullSubagent.conversationId,
+        seq: 2,
+        role: "assistant",
+        content: "Subagent result",
+        tokenCount: 4,
+      },
+    ]);
+    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId);
+
+    const liveNullSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-apply-live-null",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: liveNullSubagent.conversationId,
+        seq: 0,
+        role: "user",
+        content: "[Subagent Context] Live child session still in progress.",
+        tokenCount: 8,
+      },
+      {
+        conversationId: liveNullSubagent.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "Still active and should not be treated as junk.",
+        tokenCount: 10,
+      },
+    ]);
+
+    const normalConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-apply-normal",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: normalConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "keep this conversation",
+        tokenCount: 4,
+      },
+    ]);
+
+    const result = await fixture.command.handler(createCommandContext("doctor clean apply"));
+
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+    const quickCheck = fixture.db.prepare(`PRAGMA quick_check`).get() as { quick_check?: string } | undefined;
+    const remainingNormal = await fixture.conversationStore.getConversation(normalConversation.conversationId);
+    const removedArchived = await fixture.conversationStore.getConversation(archivedSubagent.conversationId);
+    const removedCron = await fixture.conversationStore.getConversation(cronConversation.conversationId);
+    const removedNull = await fixture.conversationStore.getConversation(nullSubagent.conversationId);
+    const remainingLiveNull = await fixture.conversationStore.getConversation(liveNullSubagent.conversationId);
+
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Clean Apply");
+    expect(result.text).toContain("matched conversations before apply: 3");
+    expect(result.text).toContain("deleted conversations: 3");
+    expect(result.text).toContain("deleted messages: 4");
+    expect(result.text).toContain("vacuumed: no");
+    expect(result.text).toContain("quick_check: ok");
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
+    expect(quickCheck?.quick_check).toBe("ok");
+    expect(remainingNormal?.conversationId).toBe(normalConversation.conversationId);
+    expect(remainingLiveNull?.conversationId).toBe(liveNullSubagent.conversationId);
+    expect(removedArchived).toBeNull();
+    expect(removedCron).toBeNull();
+    expect(removedNull).toBeNull();
+  });
+
+  it("applies a single doctor clean filter without deleting other candidate classes", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const archivedSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-single-archived",
+      sessionKey: "agent:main:subagent:single-worker",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: archivedSubagent.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "archived single worker output",
+        tokenCount: 5,
+      },
+    ]);
+    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId);
+
+    const cronConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-single-cron",
+      sessionKey: "agent:main:cron:single-nightly",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: cronConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "cron single run",
+        tokenCount: 4,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor clean apply cron_sessions"),
+    );
+
+    const remainingArchived = await fixture.conversationStore.getConversation(archivedSubagent.conversationId);
+    const removedCron = await fixture.conversationStore.getConversation(cronConversation.conversationId);
+
+    expect(result.text).toContain("filters: `cron_sessions`");
+    expect(result.text).toContain("matched conversations before apply: 1");
+    expect(result.text).toContain("deleted conversations: 1");
+    expect(remainingArchived?.conversationId).toBe(archivedSubagent.conversationId);
+    expect(removedCron).toBeNull();
+  });
+
+  it("vacuums after doctor clean apply when requested", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const cronConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-vacuum-cron",
+      sessionKey: "agent:main:cron:vacuum-nightly",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: cronConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "cron vacuum run",
+        tokenCount: 4,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor clean apply cron_sessions vacuum"),
+    );
+    const walCheckpoint = fixture.db
+      .prepare(`PRAGMA wal_checkpoint`)
+      .get() as { busy?: number; log?: number; checkpointed?: number } | undefined;
+
+    expect(result.text).toContain("filters: `cron_sessions`");
+    expect(result.text).toContain("vacuum requested: yes");
+    expect(result.text).toContain("deleted conversations: 1");
+    expect(result.text).toContain("vacuumed: yes");
+    expect(walCheckpoint?.busy).toBe(0);
+  });
+
+  it("warns when doctor clean apply quick_check reports integrity issues", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const cronConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-cleaner-warning-cron",
+      sessionKey: "agent:main:cron:warning-nightly",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: cronConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "cron warning run",
+        tokenCount: 4,
+      },
+    ]);
+
+    const config = resolveLcmConfig({}, { dbPath: fixture.dbPath });
+    const dbWithQuickCheckWarning = new Proxy(fixture.db, {
+      get(target, prop, receiver) {
+        if (prop === "prepare") {
+          return (sql: string) => {
+            if (sql === "PRAGMA quick_check") {
+              return {
+                all: () => [{ quick_check: "row 1 missing from index example_idx" }],
+              };
+            }
+            return target.prepare(sql);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as unknown as typeof fixture.db;
+    const command = createLcmCommand({
+      db: dbWithQuickCheckWarning,
+      config,
+    });
+
+    const result = await command.handler(
+      createCommandContext("doctor clean apply cron_sessions"),
+    );
+
+    expect(result.text).toContain("status: warning");
+    expect(result.text).toContain("quick_check: row 1 missing from index example_idx");
+    expect(result.text).toContain("writes committed, but SQLite integrity verification reported problems");
   });
 
   it("keeps doctor apply as a clean scoped no-op when no issues exist", async () => {


### PR DESCRIPTION
## Stack context
This is stack PR 2/4 for #335 and builds directly on #336.

Until #336 merges, GitHub will show the diagnostics commit in this diff as well.

## Summary
Adds `doctor cleaners apply`, a backup-first cleanup workflow that deletes only approved high-confidence matches.

## Why this exists
Diagnostics are necessary, but they are not enough when a database is already carrying clearly non-core rows that operators want to remove safely.

This PR turns the read-only cleaner report into an explicit operational workflow with three safeguards:
- backup first
- transactional deletion
- post-delete integrity verification

## What this PR changes
- extends `lcm-doctor-cleaners.ts` with apply support for approved filters
- creates a backup with `VACUUM INTO` before any delete runs
- stages conversation/message/summary ids in temp tables before deletion
- removes related rows across FK/FTS-linked tables in a controlled order
- adds `/lossless doctor cleaners apply [filter-id] [vacuum]`
- reports backup path, delete counts, optional vacuum status, and `PRAGMA quick_check`

## How it works
```mermaid
flowchart TD
  A[doctor cleaners apply] --> B[Create SQLite backup]
  B --> C[Stage matched conversation ids]
  C --> D[Stage dependent summary/message ids]
  D --> E[Delete FTS and relational dependents]
  E --> F[Delete conversations]
  F --> G[Commit and drop temp tables]
  G --> H[Optional VACUUM + quick_check]
```

## Scenarios this enables
### 1. Remove obvious orphaned subagent debris
A maintainer can clean `null_subagent_context` candidates after reviewing the read-only report.

### 2. Remove obviously non-core background lanes
Archived subagent segments and cron lanes can be cleaned without manually crafting SQL.

### 3. Repeatable support operations
Instead of bespoke one-off DB surgery, operators get a documented, backup-first workflow with integrity checks.

## Design decisions and trade-offs
- File-backed DBs only.
  Apply is intentionally unavailable for in-memory databases because the safety model depends on creating a backup first.
- Explicit apply, never implicit cleanup.
  The command surface forces an intentional operator action after diagnostics.
- Temp-table staging over inline deletes.
  That makes the delete set inspectable and keeps downstream deletes consistent across related tables.
- Optional `vacuum` only.
  Some operators want cleanup now and file compaction later, so physical reclamation is opt-in.

## Validation
- `pnpm exec vitest run test/lcm-command.test.ts`
