### PR TITLE
fix: CJK-aware token estimation (6× correction for Chinese/Japanese/Korean)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -124,9 +124,27 @@ const DYNAMIC_ACTIVITY_HIGH_DOWNSHIFT_FACTOR = 0.75;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Rough token estimate: ~4 chars per token. */
+/** CJK-aware token estimate. ASCII ~4 chars/token, CJK ~1.5 chars/token, emoji ~0.5 chars/token. */
 function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  let tokens = 0;
+  for (const char of text) {
+    const cp = char.codePointAt(0) ?? 0;
+    if (
+      (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+      (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Extension A
+      (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility
+      (cp >= 0x3040 && cp <= 0x30ff) || // Hiragana + Katakana
+      (cp >= 0xac00 && cp <= 0xd7af) || // Hangul
+      (cp >= 0xff00 && cp <= 0xffef)    // Fullwidth forms
+    ) {
+      tokens += 1.5; // CJK: ~1.5 tokens per char
+    } else if (cp > 0xffff) {
+      tokens += 2; // Emoji / supplementary plane
+    } else {
+      tokens += 0.25; // ASCII / Latin: ~4 chars per token
+    }
+  }
+  return Math.ceil(tokens);
 }
 
 function toJson(value: unknown): string {


### PR DESCRIPTION
## Problem

`estimateTokens()` uses `text.length / 4` to estimate token counts. In JavaScript, `String.length` counts **UTF-16 code units**, not Unicode code points. This causes two categories of severe underestimation:

### CJK text (6× underestimate)

Chinese/Japanese/Korean characters are typically tokenized at ~1.5 tokens per character by modern LLM tokenizers (GPT-4, Claude, etc.), but `length / 4` treats them as ~0.5 tokens per character because each CJK character is one UTF-16 unit → ÷4 = 0.25.

| Text | Old (`length/4`) | New (CJK-aware) | Actual ~tokens |
|------|-------------------|------------------|----------------|
| `Hello world` | 3 | 3 | ~3 |
| `你好世界` | **1** | **6** | ~6 |
| `🔥🎉💯` | **2** | **6** | ~6-12 |
| `mixed 你好 world 🔥` | **5** | **9** | ~9-14 |

### Emoji / Supplementary Plane

Emoji are UTF-16 surrogate pairs (`🔥.length === 2`), so `length / 4 = 0.5`, rounded up to 1 token each. Real tokenization is typically 2-4 tokens per emoji.

## Impact

When LCM underestimates token counts for CJK-heavy conversations:
- Compaction triggers **too late** — context grows far beyond the configured threshold before compaction kicks in
- Assembly budgets are calculated incorrectly — `maxAssemblyTokenBudget` and `leafChunkTokens` thresholds are effectively 6× too lenient for Chinese text
- Root cause of a **context explosion incident**: CJK content was estimated at 1/6th its actual size, allowing 388K+ tokens of garbage context to accumulate before compaction triggered

## Fix

Replace the single `length / 4` heuristic with a code-point-aware estimator that applies different ratios per character class:

- **ASCII / Latin**: 0.25 tokens/char (same as before, ~4 chars per token)
- **CJK Ideographs, Hiragana, Katakana, Hangul, Fullwidth forms**: 1.5 tokens/char (~1.5 tokens per character)
- **Supplementary plane (emoji, etc.)**: 2 tokens/char

The iteration uses `for (const char of text)` which correctly iterates by Unicode code point (not UTF-16 unit), fixing the surrogate pair issue as well.

## Performance

The new implementation iterates character-by-character (O(n)) instead of a single division (O(1)), but this is negligible in practice:
- Compaction bottleneck is the LLM call (seconds), not token estimation (microseconds)
- Even with thousands of calls per compaction pass, total overhead is <1ms
- A fast-path for pure-ASCII text could be added but is unnecessary

## Testing

Verified locally with the following test cases:
```
Hello world          -> old: 3   new: 3
你好世界              -> old: 1   new: 6
🔥🎉💯               -> old: 2   new: 6
mixed 你好 world 🔥  -> old: 5   new: 9
```

Closes #47, Closes #250, Closes #256, Closes #266