### PR TITLE
fix: prevent overflow recovery from bailing when observed tokens unavailable

### DIFF
--- a/.changeset/pr-351-overflow-recovery.md
+++ b/.changeset/pr-351-overflow-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Ensure forced overflow recovery still runs compaction when live observed token counts are unavailable.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4020,11 +4020,21 @@ export class LcmContextEngine implements ContextEngine {
             ? decision.threshold
             : tokenBudget;
 
+        // When forced (overflow recovery) and the caller did not supply an
+        // observed token count, assume we are at least at the token budget so
+        // compactUntilUnder does not bail with "already under target" while the
+        // live context is actually overflowing.
+        const effectiveCurrentTokens =
+          observedTokens !== undefined
+            ? observedTokens
+            : forceCompaction
+              ? tokenBudget
+              : undefined;
         const compactResult = await this.compaction.compactUntilUnder({
           conversationId,
           tokenBudget,
           targetTokens: convergenceTargetTokens,
-          ...(observedTokens !== undefined ? { currentTokens: observedTokens } : {}),
+          ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
           summarize,
           summaryModel,
         });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6064,6 +6064,64 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       }),
     );
   });
+
+  it("uses tokenBudget as currentTokens for forced recovery when observed tokens are unavailable", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 150_000,
+      threshold: 120_000,
+    });
+    const compactFullSweepSpy = vi.spyOn(privateEngine.compaction, "compactFullSweep");
+    const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder").mockResolvedValue({
+      success: true,
+      rounds: 1,
+      finalTokens: 118_000,
+    });
+
+    await engine.ingest({
+      sessionId: "forced-sweep-unknown-observed-tokens",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "forced-sweep-unknown-observed-tokens",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 120_000,
+      force: true,
+      compactionTarget: "budget",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(result.result?.tokensBefore).toBe(150_000);
+    expect(result.result?.tokensAfter).toBe(118_000);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 120_000);
+    expect(compactFullSweepSpy).not.toHaveBeenCalled();
+    expect(compactUntilUnderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 120_000,
+        targetTokens: 120_000,
+        currentTokens: 120_000,
+        summarize: expect.any(Function),
+      }),
+    );
+  });
 });
 
 describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {


### PR DESCRIPTION
## Summary

- When the preemptive context overflow guard fires during the tool loop, the error message doesn't include an observed token count, so `observedTokens` is `undefined` in the overflow recovery path
- `compactUntilUnder()` then uses only the stored token count (which is low because `afterTurn` hasn't ingested the current turn yet) and bails with "already under target" — even though the live context is actually overflowing
- This causes the session to be nuked and restarted instead of being compacted

## Fix

When `force=true` (overflow recovery) and `observedTokens` is `undefined`, pass `tokenBudget` as `currentTokens` to `compactUntilUnder()`. This ensures the convergence loop knows we're at least at the budget and proceeds with compaction.

The fix is 6 lines in `compact()` in `engine.ts`.

## Reproduction

1. Use a small-context model like `gemini-2.5-flash-lite` (150K context window)
2. Accumulate messages in a session until the preemptive context guard fires
3. Observe: `auto-compaction failed for google/gemini-2.5-flash-lite: already under target` followed by session restart
4. After fix: `auto-compaction succeeded for google/gemini-2.5-flash-lite; retrying prompt`

## Test plan

- [x] Verified fix in production — compaction now runs 3 leaf passes (108745 → 87472 tokens) and prompt retry succeeds
- [ ] Unit test for `compactUntilUnder` with `force=true` and no `currentTokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)