### PR TITLE
feat: inline image detection and tool result string format fix

### DIFF
--- a/.changeset/wise-bears-doubt.md
+++ b/.changeset/wise-bears-doubt.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Externalize inline base64 images before large tool-result text compaction, and add `largeFilesDir` / `LCM_LARGE_FILES_DIR` so externalized payload storage can be configured explicitly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,7 @@ Files embedded in user messages (typically via `<file>` blocks from tool output)
 1. Parse file blocks from message content.
 2. For each block exceeding `largeFileTokenThreshold` (default 25k tokens):
    - Generate a unique file ID (`file_` prefix)
-   - Store the content to `~/.openclaw/lcm-files/<conversation_id>/<file_id>.<ext>`
+   - Store the content to `largeFilesDir/<conversation_id>/<file_id>.<ext>` (default `~/.openclaw/lcm-files/...`)
    - Generate a ~200 token exploration summary (structural analysis, key sections, etc.)
    - Insert a `large_files` record with metadata
    - Replace the file block in the message with a compact reference

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `enabled` | `boolean` | `true` | `LCM_ENABLED` | Enables or disables lossless-claw without uninstalling it. |
 | `databasePath` | `string` | `${OPENCLAW_STATE_DIR}/lcm.db` | `LCM_DATABASE_PATH` | Preferred path for the SQLite database. |
 | `dbPath` | `string` | alias of `databasePath` | `LCM_DATABASE_PATH` | Legacy alias for `databasePath`. Prefer `databasePath` in new config. |
-| `largeFilesDir` | `string` | `${OPENCLAW_STATE_DIR}/lcm-files` | `LCM_LARGE_FILES_DIR` | Directory where large-file text payloads are persisted. Automatically follows the active state directory. |
+| `largeFilesDir` | `string` | `${OPENCLAW_STATE_DIR}/lcm-files` | `LCM_LARGE_FILES_DIR` | Directory where externalized large files and inline images are persisted. Automatically follows the active state directory. |
 | `ignoreSessionPatterns` | `string[]` | `[]` | `LCM_IGNORE_SESSION_PATTERNS` | Session-key glob patterns that skip LCM entirely. |
 | `statelessSessionPatterns` | `string[]` | `[]` | `LCM_STATELESS_SESSION_PATTERNS` | Session-key glob patterns that may read from LCM but never write to it. |
 | `skipStatelessSessions` | `boolean` | `true` | `LCM_SKIP_STATELESS_SESSIONS` | Enforces `statelessSessionPatterns` when enabled. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -73,6 +73,10 @@
       "label": "Large Files Directory",
       "help": "Directory for persisting large-file text payloads (default: <stateDir>/lcm-files). Uses OPENCLAW_STATE_DIR when set."
     },
+    "largeFilesDir": {
+      "label": "Large Files Directory",
+      "help": "Directory for externalized large files and inline-image payloads (default: ~/.openclaw/lcm-files)"
+    },
     "ignoreSessionPatterns": {
       "label": "Ignored Sessions",
       "help": "Glob patterns for session keys to exclude from LCM storage"
@@ -247,6 +251,9 @@
         "minimum": 2
       },
       "dbPath": {
+        "type": "string"
+      },
+      "largeFilesDir": {
         "type": "string"
       },
       "ignoreSessionPatterns": {

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -187,7 +187,6 @@ Why it matters:
 
 - defaults to `${OPENCLAW_STATE_DIR}/lcm-files`; on multi-profile hosts each profile stores files in its own state directory automatically
 - override with `LCM_LARGE_FILES_DIR` or set `largeFilesDir` in plugin config when you want an explicit path
-
 ### `largeFileThresholdTokens`
 
 Threshold for externalizing oversized tool/file payloads out of the main transcript into large-file storage.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2165,6 +2165,176 @@ export class LcmContextEngine implements ContextEngine {
     }
   }
 
+  // ── Image detection & externalization ──────────────────────────────────────
+
+  private static readonly BASE64_IMAGE_MAGIC: ReadonlyArray<{
+    prefix: string;
+    extension: string;
+    mimeType: string;
+  }> = [
+    { prefix: "/9j/", extension: "jpg", mimeType: "image/jpeg" },
+    { prefix: "iVBOR", extension: "png", mimeType: "image/png" },
+    { prefix: "R0lGOD", extension: "gif", mimeType: "image/gif" },
+    { prefix: "UklGR", extension: "webp", mimeType: "image/webp" },
+    { prefix: "PHN2Zy", extension: "svg", mimeType: "image/svg+xml" },
+  ];
+
+  private static detectBase64ImageType(
+    base64Data: string,
+  ): { extension: string; mimeType: string } | null {
+    for (const sig of LcmContextEngine.BASE64_IMAGE_MAGIC) {
+      if (base64Data.startsWith(sig.prefix)) {
+        return { extension: sig.extension, mimeType: sig.mimeType };
+      }
+    }
+    return null;
+  }
+
+  private async storeImageFileContent(params: {
+    conversationId: number;
+    fileId: string;
+    extension: string;
+    base64Data: string;
+  }): Promise<string> {
+    const dir = join(this.config.largeFilesDir, String(params.conversationId));
+    await mkdir(dir, { recursive: true });
+    const normalized = params.extension.replace(/[^a-z0-9]/gi, "").toLowerCase() || "bin";
+    const filePath = join(dir, `${params.fileId}.${normalized}`);
+    const buffer = Buffer.from(params.base64Data, "base64");
+    await writeFile(filePath, buffer);
+    return filePath;
+  }
+
+  private async externalizeImage(params: {
+    conversationId: number;
+    base64Data: string;
+    fileName?: string;
+    extension: string;
+    mimeType: string;
+    label: string;
+  }): Promise<{ fileId: string; byteSize: number; summary: string; reference: string }> {
+    const fileId = `file_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const byteSize = Buffer.from(params.base64Data, "base64").byteLength;
+    const storageUri = await this.storeImageFileContent({
+      conversationId: params.conversationId,
+      fileId,
+      extension: params.extension,
+      base64Data: params.base64Data,
+    });
+    const fileName = params.fileName ?? `image.${params.extension}`;
+    const summary = `Image file (${params.extension.toUpperCase()}, ${byteSize.toLocaleString("en-US")} bytes)${params.fileName ? ` — ${params.fileName}` : ""}`;
+
+    await this.summaryStore.insertLargeFile({
+      fileId,
+      conversationId: params.conversationId,
+      fileName,
+      mimeType: params.mimeType,
+      byteSize,
+      storageUri,
+      explorationSummary: summary,
+    });
+
+    const reference = `[${params.label}: ${fileName} (${params.mimeType}, ${byteSize.toLocaleString("en-US")} bytes) | LCM file: ${fileId}]`;
+    return { fileId, byteSize, summary, reference };
+  }
+
+  private async interceptInlineImages(params: {
+    conversationId: number;
+    content: string;
+    role: string;
+  }): Promise<{ rewrittenContent: string; fileIds: string[] } | null> {
+    const mediaResult = await this.interceptUserMediaBase64(params);
+    if (mediaResult) {
+      return mediaResult;
+    }
+    return this.interceptPureBase64Image(params);
+  }
+
+  private async interceptUserMediaBase64(params: {
+    conversationId: number;
+    content: string;
+  }): Promise<{ rewrittenContent: string; fileIds: string[] } | null> {
+    const prefix = "[media attached:";
+    if (!params.content.startsWith(prefix)) {
+      return null;
+    }
+
+    const base64LineRe = /\n([A-Za-z0-9+/]{20,}={0,2})\n/m;
+    const base64Match = base64LineRe.exec(params.content);
+    if (!base64Match) {
+      return null;
+    }
+
+    const headerEnd = base64Match.index + 1;
+    const header = params.content.slice(0, headerEnd).trim();
+    const base64Data = params.content.slice(headerEnd);
+
+    if (estimateTokens(base64Data) < 100) {
+      return null;
+    }
+
+    const detected = LcmContextEngine.detectBase64ImageType(base64Data);
+    if (!detected) {
+      return null;
+    }
+
+    const pathMatch = header.match(/\[media attached:\s*([^\s(]+)/);
+    const fileName = pathMatch ? pathMatch[1] : `user-image.${detected.extension}`;
+
+    const externalized = await this.externalizeImage({
+      conversationId: params.conversationId,
+      base64Data,
+      fileName,
+      extension: detected.extension,
+      mimeType: detected.mimeType,
+      label: "User image",
+    });
+
+    return {
+      rewrittenContent: `${header}\n\n${externalized.reference}`,
+      fileIds: [externalized.fileId],
+    };
+  }
+
+  private async interceptPureBase64Image(params: {
+    conversationId: number;
+    content: string;
+    role: string;
+  }): Promise<{ rewrittenContent: string; fileIds: string[] } | null> {
+    const trimmed = params.content.trim();
+    if (estimateTokens(trimmed) < 100) {
+      return null;
+    }
+
+    const detected = LcmContextEngine.detectBase64ImageType(trimmed);
+    if (!detected) {
+      return null;
+    }
+
+    const b64Chars = trimmed.replace(/[^A-Za-z0-9+/=\s]/g, "");
+    if (b64Chars.length / trimmed.length < 0.8) {
+      return null;
+    }
+
+    const label = params.role === "tool" ? "Tool image" :
+                  params.role === "assistant" ? "Assistant image" : "Image";
+    const fileName = `${params.role}-image.${detected.extension}`;
+
+    const externalized = await this.externalizeImage({
+      conversationId: params.conversationId,
+      base64Data: trimmed,
+      fileName,
+      extension: detected.extension,
+      mimeType: detected.mimeType,
+      label,
+    });
+
+    return {
+      rewrittenContent: externalized.reference,
+      fileIds: [externalized.fileId],
+    };
+  }
+
   /** Persist intercepted large-file text payloads to the configured lcm-files directory. */
   private async storeLargeFileContent(params: {
     conversationId: number;
@@ -2297,6 +2467,18 @@ export class LcmContextEngine implements ContextEngine {
     ) {
       return null;
     }
+
+    // Convert string content to array format for unified processing.
+    if (typeof params.message.content === "string") {
+      params = {
+        ...params,
+        message: {
+          ...params.message,
+          content: [{ type: "text", text: params.message.content }],
+        } as AgentMessage,
+      };
+    }
+
     if (!Array.isArray(params.message.content)) {
       return null;
     }
@@ -3223,6 +3405,24 @@ export class LcmContextEngine implements ContextEngine {
     const conversationId = conversation.conversationId;
 
     let messageForParts = message;
+
+    // Externalize inline base64 images for ALL roles.
+    const imageIntercepted = await this.interceptInlineImages({
+      conversationId,
+      content: stored.content,
+      role: stored.role,
+    });
+    if (imageIntercepted) {
+      stored.content = imageIntercepted.rewrittenContent;
+      stored.tokenCount = estimateTokens(stored.content);
+      if ("content" in message) {
+        messageForParts = {
+          ...message,
+          content: stored.content,
+        } as AgentMessage;
+      }
+    }
+
     if (stored.role === "user") {
       const intercepted = await this.interceptLargeFiles({
         conversationId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2190,13 +2190,24 @@ export class LcmContextEngine implements ContextEngine {
     return null;
   }
 
+  private static isExternalizedImageReference(value: string): boolean {
+    return /^\[(?:User|Tool|Assistant|Image) image: .*LCM file: file_[a-f0-9]{16}\]$/.test(
+      value.trim(),
+    );
+  }
+
+  /** Resolve the configured externalized-payload directory for one conversation. */
+  private largeFilesDirForConversation(conversationId: number): string {
+    return join(this.config.largeFilesDir, String(conversationId));
+  }
+
   private async storeImageFileContent(params: {
     conversationId: number;
     fileId: string;
     extension: string;
     base64Data: string;
   }): Promise<string> {
-    const dir = join(this.config.largeFilesDir, String(params.conversationId));
+    const dir = this.largeFilesDirForConversation(params.conversationId);
     await mkdir(dir, { recursive: true });
     const normalized = params.extension.replace(/[^a-z0-9]/gi, "").toLowerCase() || "bin";
     const filePath = join(dir, `${params.fileId}.${normalized}`);
@@ -2335,6 +2346,160 @@ export class LcmContextEngine implements ContextEngine {
     };
   }
 
+  /**
+   * Walk tool-result payload blocks and replace pure inline image strings with
+   * compact references before generic text-output externalization runs.
+   */
+  private async rewriteToolInlineImageValue(params: {
+    conversationId: number;
+    value: unknown;
+  }): Promise<{ rewrittenValue: unknown; fileIds: string[]; changed: boolean }> {
+    if (typeof params.value === "string") {
+      const intercepted = await this.interceptPureBase64Image({
+        conversationId: params.conversationId,
+        content: params.value,
+        role: "tool",
+      });
+      if (!intercepted) {
+        return { rewrittenValue: params.value, fileIds: [], changed: false };
+      }
+      return {
+        rewrittenValue: intercepted.rewrittenContent,
+        fileIds: intercepted.fileIds,
+        changed: true,
+      };
+    }
+
+    if (Array.isArray(params.value)) {
+      const rewrittenValues: unknown[] = [];
+      const fileIds: string[] = [];
+      let changed = false;
+
+      for (const entry of params.value) {
+        const rewritten = await this.rewriteToolInlineImageValue({
+          conversationId: params.conversationId,
+          value: entry,
+        });
+        rewrittenValues.push(rewritten.rewrittenValue);
+        fileIds.push(...rewritten.fileIds);
+        changed ||= rewritten.changed;
+      }
+
+      return changed
+        ? { rewrittenValue: rewrittenValues, fileIds, changed: true }
+        : { rewrittenValue: params.value, fileIds: [], changed: false };
+    }
+
+    if (!params.value || typeof params.value !== "object") {
+      return { rewrittenValue: params.value, fileIds: [], changed: false };
+    }
+
+    const record = params.value as Record<string, unknown>;
+    if (record.type === "text" && typeof record.text === "string") {
+      const intercepted = await this.interceptPureBase64Image({
+        conversationId: params.conversationId,
+        content: record.text,
+        role: "tool",
+      });
+      if (!intercepted) {
+        return { rewrittenValue: params.value, fileIds: [], changed: false };
+      }
+      return {
+        rewrittenValue: {
+          ...record,
+          text: intercepted.rewrittenContent,
+        },
+        fileIds: intercepted.fileIds,
+        changed: true,
+      };
+    }
+
+    const nestedKeys = ["output", "content", "result"] as const;
+    const rewrittenRecord: Record<string, unknown> = { ...record };
+    const fileIds: string[] = [];
+    let changed = false;
+
+    for (const key of nestedKeys) {
+      if (!(key in record)) {
+        continue;
+      }
+      const rewritten = await this.rewriteToolInlineImageValue({
+        conversationId: params.conversationId,
+        value: record[key],
+      });
+      if (!rewritten.changed) {
+        continue;
+      }
+      rewrittenRecord[key] = rewritten.rewrittenValue;
+      fileIds.push(...rewritten.fileIds);
+      changed = true;
+    }
+
+    return changed
+      ? { rewrittenValue: rewrittenRecord, fileIds, changed: true }
+      : { rewrittenValue: params.value, fileIds: [], changed: false };
+  }
+
+  private async interceptInlineImagesInToolMessage(params: {
+    conversationId: number;
+    message: AgentMessage;
+  }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
+    if (
+      (params.message.role !== "toolResult" && params.message.role !== "tool") ||
+      !("content" in params.message)
+    ) {
+      return null;
+    }
+
+    if (typeof params.message.content === "string") {
+      const intercepted = await this.interceptPureBase64Image({
+        conversationId: params.conversationId,
+        content: params.message.content,
+        role: "tool",
+      });
+      if (!intercepted) {
+        return null;
+      }
+      return {
+        rewrittenMessage: {
+          ...params.message,
+          content: intercepted.rewrittenContent,
+        } as AgentMessage,
+        fileIds: intercepted.fileIds,
+      };
+    }
+
+    if (!Array.isArray(params.message.content)) {
+      return null;
+    }
+
+    const rewrittenContent: unknown[] = [];
+    const fileIds: string[] = [];
+    let changed = false;
+
+    for (const item of params.message.content) {
+      const rewritten = await this.rewriteToolInlineImageValue({
+        conversationId: params.conversationId,
+        value: item,
+      });
+      rewrittenContent.push(rewritten.rewrittenValue);
+      fileIds.push(...rewritten.fileIds);
+      changed ||= rewritten.changed;
+    }
+
+    if (!changed) {
+      return null;
+    }
+
+    return {
+      rewrittenMessage: {
+        ...params.message,
+        content: rewrittenContent,
+      } as AgentMessage,
+      fileIds,
+    };
+  }
+
   /** Persist intercepted large-file text payloads to the configured lcm-files directory. */
   private async storeLargeFileContent(params: {
     conversationId: number;
@@ -2342,7 +2507,7 @@ export class LcmContextEngine implements ContextEngine {
     extension: string;
     content: string;
   }): Promise<string> {
-    const dir = join(this.config.largeFilesDir, String(params.conversationId));
+    const dir = this.largeFilesDirForConversation(params.conversationId);
     await mkdir(dir, { recursive: true });
 
     const normalizedExtension = params.extension.replace(/[^a-z0-9]/gi, "").toLowerCase() || "txt";
@@ -2531,6 +2696,13 @@ export class LcmContextEngine implements ContextEngine {
             ? record.content
             : record;
       const extractedText = extractStructuredText(textSource);
+      if (
+        typeof extractedText === "string" &&
+        LcmContextEngine.isExternalizedImageReference(extractedText)
+      ) {
+        rewrittenContent.push(item);
+        continue;
+      }
       if (typeof extractedText !== "string" || estimateTokens(extractedText) < threshold) {
         rewrittenContent.push(item);
         continue;
@@ -3396,7 +3568,7 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    const stored = toStoredMessage(message);
+    let stored = toStoredMessage(message);
 
     // Get or create conversation for this session
     const conversation = await this.conversationStore.getOrCreateConversation(sessionId, {
@@ -3406,20 +3578,30 @@ export class LcmContextEngine implements ContextEngine {
 
     let messageForParts = message;
 
-    // Externalize inline base64 images for ALL roles.
-    const imageIntercepted = await this.interceptInlineImages({
-      conversationId,
-      content: stored.content,
-      role: stored.role,
-    });
-    if (imageIntercepted) {
-      stored.content = imageIntercepted.rewrittenContent;
-      stored.tokenCount = estimateTokens(stored.content);
-      if ("content" in message) {
-        messageForParts = {
-          ...message,
-          content: stored.content,
-        } as AgentMessage;
+    if (stored.role === "tool") {
+      const imageIntercepted = await this.interceptInlineImagesInToolMessage({
+        conversationId,
+        message: messageForParts,
+      });
+      if (imageIntercepted) {
+        messageForParts = imageIntercepted.rewrittenMessage;
+        stored = toStoredMessage(messageForParts);
+      }
+    } else {
+      const imageIntercepted = await this.interceptInlineImages({
+        conversationId,
+        content: stored.content,
+        role: stored.role,
+      });
+      if (imageIntercepted) {
+        stored.content = imageIntercepted.rewrittenContent;
+        stored.tokenCount = estimateTokens(stored.content);
+        if ("content" in message) {
+          messageForParts = {
+            ...message,
+            content: stored.content,
+          } as AgentMessage;
+        }
       }
     }
 
@@ -3441,7 +3623,7 @@ export class LcmContextEngine implements ContextEngine {
     } else if (stored.role === "tool") {
       const intercepted = await this.interceptLargeToolResults({
         conversationId,
-        message,
+        message: messageForParts,
       });
       if (intercepted) {
         messageForParts = intercepted.rewrittenMessage;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,6 +20,8 @@ describe("resolveLcmConfig", () => {
   it("uses hardcoded defaults when no env or plugin config", () => {
     const config = resolveLcmConfig({}, {});
     expect(config.enabled).toBe(true);
+    expect(config.databasePath).toBe(join(homedir(), ".openclaw", "lcm.db"));
+    expect(config.largeFilesDir).toBe(join(homedir(), ".openclaw", "lcm-files"));
     expect(config.ignoreSessionPatterns).toEqual([]);
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
@@ -279,6 +281,21 @@ describe("resolveLcmConfig", () => {
       { databasePath: "/plugin/path/lcm.db" },
     );
     expect(config.databasePath).toBe("/env/path/lcm.db");
+  });
+
+  it("handles largeFilesDir from plugin config", () => {
+    const config = resolveLcmConfig({}, {
+      largeFilesDir: "/custom/path/lcm-files",
+    });
+    expect(config.largeFilesDir).toBe("/custom/path/lcm-files");
+  });
+
+  it("env largeFilesDir overrides plugin config", () => {
+    const config = resolveLcmConfig(
+      { LCM_LARGE_FILES_DIR: "/env/path/lcm-files" } as NodeJS.ProcessEnv,
+      { largeFilesDir: "/plugin/path/lcm-files" },
+    );
+    expect(config.largeFilesDir).toBe("/env/path/lcm-files");
   });
 
   it("accepts manifest largeFileThresholdTokens from plugin config", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1446,6 +1446,46 @@ describe("LcmContextEngine.ingest content extraction", () => {
     });
   });
 
+  it("stores externalized inline images under largeFilesDir", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBOR${"A".repeat(600)}`;
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "user",
+        content: `[media attached: screenshot.png]\n${base64Image}\n`,
+      }),
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("[User image: screenshot.png");
+    expect(messages[0].content).not.toContain(base64Image.slice(0, 32));
+
+    const fileIdMatch = messages[0].content.match(/file_[a-f0-9]{16}/);
+    expect(fileIdMatch).not.toBeNull();
+    const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+    expect(storedFile).not.toBeNull();
+    expect(storedFile!.mimeType).toBe("image/png");
+    expect(storedFile!.storageUri).toContain(
+      `${largeFilesDir}/${conversation!.conversationId}/`,
+    );
+  });
+
   it("externalizes oversized tool-result payloads into large_files", async () => {
     await withTempHome(async () => {
       const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
@@ -1650,6 +1690,163 @@ describe("LcmContextEngine.ingest content extraction", () => {
       expect(typeof block?.text).toBe("string");
       expect(String(block?.text)).toContain(fileId);
       expect(block).not.toHaveProperty("output");
+    });
+  });
+
+  it("externalizes structured tool-result image payloads before text externalization", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBOR${"A".repeat(600)}`;
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_structured_image",
+            name: "capture",
+            input: { cmd: "screenshot" },
+          },
+        ],
+      } as AgentMessage,
+    });
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_structured_image",
+        toolName: "capture",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_structured_image",
+            name: "capture",
+            content: [{ type: "text", text: base64Image }],
+          },
+        ],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const storedMessages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(storedMessages).toHaveLength(2);
+    expect(storedMessages[1].content).toBe("");
+
+    const parts = await engine.getConversationStore().getMessageParts(storedMessages[1].messageId);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].partType).toBe("tool");
+    expect(parts[0].toolOutput).toBeNull();
+    const metadata = JSON.parse(parts[0].metadata ?? "{}") as Record<string, unknown>;
+    const raw = metadata.raw as {
+      type: string;
+      content: Array<{ type: string; text: string }>;
+    };
+    const imageReference = raw.content[0]?.text ?? "";
+    expect(imageReference).toContain("[Tool image: tool-image.png");
+    expect(imageReference).not.toContain(base64Image.slice(0, 32));
+
+    const fileIdMatch = imageReference.match(/file_[a-f0-9]{16}/);
+    expect(fileIdMatch).not.toBeNull();
+    const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+    expect(storedFile).not.toBeNull();
+    expect(storedFile!.mimeType).toBe("image/png");
+    expect(storedFile!.fileName).toBe("tool-image.png");
+
+    expect(metadata.raw).toMatchObject({
+      type: "tool_result",
+      content: [{ type: "text", text: expect.stringContaining("[Tool image: tool-image.png") }],
+    });
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+    const assembledToolResult = assembled.messages[1] as {
+      role: string;
+      content?: Array<{ content?: Array<{ text?: string }> }>;
+    };
+    expect(assembledToolResult.role).toBe("toolResult");
+    expect(assembledToolResult.content?.[0]?.content?.[0]?.text).toContain("[Tool image: tool-image.png");
+  });
+
+  it("externalizes string-content tool-result images without converting them to text files", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBOR${"A".repeat(600)}`;
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_text_image",
+            name: "capture",
+            input: { cmd: "screenshot" },
+          },
+        ],
+      } as AgentMessage,
+    });
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_text_image",
+        toolName: "capture",
+        isError: false,
+        content: base64Image,
+      } as AgentMessage,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const storedMessages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(storedMessages).toHaveLength(2);
+    expect(storedMessages[1].content).toContain("[Tool image: tool-image.png");
+    expect(storedMessages[1].content).not.toContain("[LCM Tool Output:");
+
+    const fileIdMatch = storedMessages[1].content.match(/file_[a-f0-9]{16}/);
+    expect(fileIdMatch).not.toBeNull();
+    const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+    expect(storedFile).not.toBeNull();
+    expect(storedFile!.mimeType).toBe("image/png");
+    expect(storedFile!.fileName).toBe("tool-image.png");
+    expect(storedFile!.storageUri.endsWith(".png")).toBe(true);
+
+    const parts = await engine.getConversationStore().getMessageParts(storedMessages[1].messageId);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].partType).toBe("text");
+    expect(JSON.parse(parts[0].metadata ?? "{}")).toMatchObject({
+      toolCallId: "call_text_image",
+      toolName: "capture",
+      isError: false,
     });
   });
 


### PR DESCRIPTION
## Summary

- **Unified inline image detection**: Detect and externalize base64 image data (JPEG, PNG, GIF, WebP, SVG) embedded in messages of any role (user/tool/assistant). Images are saved as binary files. Handles both OpenClaw's `[media attached:]` user pattern and pure base64 payloads in any message content. Image detection is a standalone system independent of the large file text pipeline.
- **String format fix for tool results**: Normalize string-format tool result content to array format before processing, ensuring large string tool outputs are properly externalized instead of silently skipped.

## Test plan

- [ ] Verify user image attachments are externalized and saved as valid binary files
- [ ] Verify tool results containing base64 image data are externalized
- [ ] Verify string-format tool results with large outputs are properly externalized
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)