### PR TITLE
fix: make cache-aware compaction resilient to routing noise

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `cacheAwareCompaction.maxColdCacheCatchupPasses` | `integer` | `2` | `LCM_MAX_COLD_CACHE_CATCHUP_PASSES` | Maximum bounded catch-up passes allowed in one maintenance cycle when cache telemetry is cold. |
 | `cacheAwareCompaction.hotCachePressureFactor` | `number` | `4` | `LCM_HOT_CACHE_PRESSURE_FACTOR` | Multiplier applied to the hot-cache leaf trigger before raw-history pressure overrides cache preservation. |
 | `cacheAwareCompaction.hotCacheBudgetHeadroomRatio` | `number` | `0.2` | `LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO` | Minimum fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely. |
+| `cacheAwareCompaction.coldCacheObservationThreshold` | `integer` | `3` | `LCM_COLD_CACHE_OBSERVATION_THRESHOLD` | Consecutive cold observations required before non-explicit cache misses are treated as truly cold. This dampens one-off routing noise and provider failover blips. |
 
 #### `dynamicLeafChunkTokens`
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -169,6 +169,10 @@
       "label": "Hot Cache Budget Headroom",
       "help": "Fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely"
     },
+    "cacheAwareCompaction.coldCacheObservationThreshold": {
+      "label": "Cold Cache Observation Threshold",
+      "help": "Consecutive cold observations required before non-explicit cache misses are treated as truly cold"
+    },
     "dynamicLeafChunkTokens.enabled": {
       "label": "Dynamic Leaf Chunk Tokens",
       "help": "When enabled, incremental compaction uses a larger working leaf chunk in busy sessions and keeps the static floor in quieter sessions"
@@ -355,6 +359,10 @@
             "type": "number",
             "minimum": 0,
             "maximum": 0.95
+          },
+          "coldCacheObservationThreshold": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -87,6 +87,7 @@ Good defaults:
 - `maxColdCacheCatchupPasses: 2`
 - `hotCachePressureFactor: 4`
 - `hotCacheBudgetHeadroomRatio: 0.2`
+- `coldCacheObservationThreshold: 3`
 
 Operationally:
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -384,6 +384,19 @@ Default:
 
 - `0.2`
 
+#### `cacheAwareCompaction.coldCacheObservationThreshold`
+
+Consecutive cold observations required before non-explicit cache misses are treated as truly cold.
+
+Why it matters:
+
+- prevents a single OpenRouter routing miss or provider failover blip from immediately triggering cold-cache catch-up
+- explicit cache breaks still count as cold immediately
+
+Default:
+
+- `3`
+
 ### `dynamicLeafChunkTokens`
 
 #### `dynamicLeafChunkTokens.enabled`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -23,6 +23,7 @@ export type CacheAwareCompactionConfig = {
   maxColdCacheCatchupPasses: number;
   hotCachePressureFactor: number;
   hotCacheBudgetHeadroomRatio: number;
+  coldCacheObservationThreshold: number;
 };
 
 export type DynamicLeafChunkTokensConfig = {
@@ -315,6 +316,14 @@ export function resolveLcmConfigWithDiagnostics(
         ?? 0.2,
     ),
   );
+  const resolvedColdCacheObservationThreshold = Math.max(
+    1,
+    Math.floor(
+      parseFiniteNumber(env.LCM_COLD_CACHE_OBSERVATION_THRESHOLD)
+        ?? toNumber(cacheAwareCompaction?.coldCacheObservationThreshold)
+        ?? 3,
+    ),
+  );
 
   const ignoreSessionPatterns = resolvePatternArray({
     envValue: env.LCM_IGNORE_SESSION_PATTERNS,
@@ -444,6 +453,7 @@ export function resolveLcmConfigWithDiagnostics(
             ?? 2,
         hotCachePressureFactor: resolvedHotCachePressureFactor,
         hotCacheBudgetHeadroomRatio: resolvedHotCacheBudgetHeadroomRatio,
+        coldCacheObservationThreshold: resolvedColdCacheObservationThreshold,
       },
       dynamicLeafChunkTokens: {
         enabled:

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -104,6 +104,9 @@ function ensureSummaryModelColumn(db: DatabaseSync): void {
 
 function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const telemetryColumns = db.prepare(`PRAGMA table_info(conversation_compaction_telemetry)`).all() as SummaryColumnInfo[];
+  const hasConsecutiveColdObservations = telemetryColumns.some(
+    (col) => col.name === "consecutive_cold_observations",
+  );
   const hasLastLeafCompactionAt = telemetryColumns.some((col) => col.name === "last_leaf_compaction_at");
   const hasTurnsSinceLeafCompaction = telemetryColumns.some((col) => col.name === "turns_since_leaf_compaction");
   const hasTokensAccumulatedSinceLeafCompaction = telemetryColumns.some(
@@ -115,6 +118,11 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const hasProvider = telemetryColumns.some((col) => col.name === "provider");
   const hasModel = telemetryColumns.some((col) => col.name === "model");
 
+  if (!hasConsecutiveColdObservations) {
+    db.exec(
+      `ALTER TABLE conversation_compaction_telemetry ADD COLUMN consecutive_cold_observations INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
   if (!hasLastLeafCompactionAt) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_leaf_compaction_at TEXT`);
   }
@@ -801,6 +809,7 @@ export function runLcmMigrations(
       last_observed_cache_break_at TEXT,
       cache_state TEXT NOT NULL DEFAULT 'unknown'
         CHECK (cache_state IN ('hot', 'cold', 'unknown')),
+      consecutive_cold_observations INTEGER NOT NULL DEFAULT 0,
       retention TEXT,
       last_leaf_compaction_at TEXT,
       turns_since_leaf_compaction INTEGER NOT NULL DEFAULT 0,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1591,6 +1591,27 @@ export class LcmContextEngine implements ContextEngine {
     if (this.shouldApplyHotCacheHysteresis(telemetry)) {
       return "hot";
     }
+    if (
+      telemetry.lastObservedCacheBreakAt
+      && (
+        !telemetry.lastObservedCacheHitAt
+        || telemetry.lastObservedCacheBreakAt >= telemetry.lastObservedCacheHitAt
+      )
+    ) {
+      return "cold";
+    }
+    if (
+      telemetry.consecutiveColdObservations
+      >= this.config.cacheAwareCompaction.coldCacheObservationThreshold
+    ) {
+      return "cold";
+    }
+    if (telemetry.lastObservedCacheHitAt) {
+      return "hot";
+    }
+    if (telemetry.cacheState === "cold") {
+      return "unknown";
+    }
     return telemetry.cacheState;
   }
 
@@ -1862,6 +1883,17 @@ export class LcmContextEngine implements ContextEngine {
           ? now
           : existing?.lastCacheTouchAt ?? null
       );
+    const consecutiveColdObservations =
+      snapshot?.sawExplicitBreak
+        ? Math.max(
+          existing?.consecutiveColdObservations ?? 0,
+          this.config.cacheAwareCompaction.coldCacheObservationThreshold,
+        )
+        : snapshot?.cacheState === "hot"
+          ? 0
+          : snapshot?.cacheState === "cold"
+            ? (existing?.consecutiveColdObservations ?? 0) + 1
+            : existing?.consecutiveColdObservations ?? 0;
     const lastActivityBand = this.classifyDynamicLeafActivityBand({
       lastActivityBand: existing?.lastActivityBand,
       tokensAccumulatedSinceLeafCompaction,
@@ -1882,6 +1914,7 @@ export class LcmContextEngine implements ContextEngine {
           ? now
           : existing?.lastObservedCacheBreakAt ?? null,
       cacheState: snapshot?.cacheState ?? existing?.cacheState ?? "unknown",
+      consecutiveColdObservations,
       retention: snapshot?.retention ?? existing?.retention ?? null,
       lastLeafCompactionAt: existing?.lastLeafCompactionAt ?? null,
       turnsSinceLeafCompaction,
@@ -1897,7 +1930,7 @@ export class LcmContextEngine implements ContextEngine {
     );
     if (updated) {
       this.deps.log.debug(
-        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} lastApiCallAt=${updated.lastApiCallAt?.toISOString() ?? "null"} lastCacheTouchAt=${updated.lastCacheTouchAt?.toISOString() ?? "null"} provider=${updated.provider ?? "null"} model=${updated.model ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
+        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} coldObservationStreak=${updated.consecutiveColdObservations} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} lastApiCallAt=${updated.lastApiCallAt?.toISOString() ?? "null"} lastCacheTouchAt=${updated.lastCacheTouchAt?.toISOString() ?? "null"} provider=${updated.provider ?? "null"} model=${updated.model ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
       );
     }
     return updated;
@@ -1918,6 +1951,7 @@ export class LcmContextEngine implements ContextEngine {
       lastObservedCacheHitAt: existing?.lastObservedCacheHitAt ?? null,
       lastObservedCacheBreakAt: existing?.lastObservedCacheBreakAt ?? null,
       cacheState: existing?.cacheState ?? "unknown",
+      consecutiveColdObservations: existing?.consecutiveColdObservations ?? 0,
       retention: existing?.retention ?? null,
       lastLeafCompactionAt: new Date(),
       turnsSinceLeafCompaction: 0,

--- a/src/store/compaction-telemetry-store.ts
+++ b/src/store/compaction-telemetry-store.ts
@@ -12,6 +12,7 @@ export type ConversationCompactionTelemetryRecord = {
   lastObservedCacheHitAt: Date | null;
   lastObservedCacheBreakAt: Date | null;
   cacheState: CacheState;
+  consecutiveColdObservations: number;
   retention: string | null;
   lastLeafCompactionAt: Date | null;
   turnsSinceLeafCompaction: number;
@@ -31,6 +32,7 @@ export type UpsertConversationCompactionTelemetryInput = {
   lastObservedCacheHitAt?: Date | null;
   lastObservedCacheBreakAt?: Date | null;
   cacheState: CacheState;
+  consecutiveColdObservations?: number;
   retention?: string | null;
   lastLeafCompactionAt?: Date | null;
   turnsSinceLeafCompaction?: number;
@@ -49,6 +51,7 @@ type ConversationCompactionTelemetryRow = {
   last_observed_cache_hit_at: string | null;
   last_observed_cache_break_at: string | null;
   cache_state: CacheState;
+  consecutive_cold_observations: number | null;
   retention: string | null;
   last_leaf_compaction_at: string | null;
   turns_since_leaf_compaction: number | null;
@@ -71,6 +74,7 @@ function toConversationCompactionTelemetryRecord(
     lastObservedCacheHitAt: parseUtcTimestampOrNull(row.last_observed_cache_hit_at),
     lastObservedCacheBreakAt: parseUtcTimestampOrNull(row.last_observed_cache_break_at),
     cacheState: row.cache_state,
+    consecutiveColdObservations: row.consecutive_cold_observations ?? 0,
     retention: row.retention,
     lastLeafCompactionAt: parseUtcTimestampOrNull(row.last_leaf_compaction_at),
     turnsSinceLeafCompaction: row.turns_since_leaf_compaction ?? 0,
@@ -109,6 +113,7 @@ export class CompactionTelemetryStore {
            last_observed_cache_hit_at,
            last_observed_cache_break_at,
            cache_state,
+           consecutive_cold_observations,
            retention,
            last_leaf_compaction_at,
            turns_since_leaf_compaction,
@@ -139,6 +144,7 @@ export class CompactionTelemetryStore {
            last_observed_cache_hit_at,
            last_observed_cache_break_at,
            cache_state,
+           consecutive_cold_observations,
            retention,
            last_leaf_compaction_at,
            turns_since_leaf_compaction,
@@ -149,13 +155,14 @@ export class CompactionTelemetryStore {
            provider,
            model,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            last_observed_cache_read = excluded.last_observed_cache_read,
            last_observed_cache_write = excluded.last_observed_cache_write,
            last_observed_cache_hit_at = excluded.last_observed_cache_hit_at,
            last_observed_cache_break_at = excluded.last_observed_cache_break_at,
            cache_state = excluded.cache_state,
+           consecutive_cold_observations = excluded.consecutive_cold_observations,
            retention = excluded.retention,
            last_leaf_compaction_at = excluded.last_leaf_compaction_at,
            turns_since_leaf_compaction = excluded.turns_since_leaf_compaction,
@@ -174,6 +181,7 @@ export class CompactionTelemetryStore {
         input.lastObservedCacheHitAt?.toISOString() ?? null,
         input.lastObservedCacheBreakAt?.toISOString() ?? null,
         input.cacheState,
+        input.consecutiveColdObservations ?? 0,
         input.retention ?? null,
         input.lastLeafCompactionAt?.toISOString() ?? null,
         input.turnsSinceLeafCompaction ?? 0,

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -57,6 +57,7 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -46,6 +46,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -76,6 +77,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
+        coldCacheObservationThreshold: 4,
       },
       dynamicLeafChunkTokens: {
         enabled: true,
@@ -106,6 +108,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
+      coldCacheObservationThreshold: 4,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -130,6 +133,7 @@ describe("resolveLcmConfig", () => {
       LCM_MAX_COLD_CACHE_CATCHUP_PASSES: "4",
       LCM_HOT_CACHE_PRESSURE_FACTOR: "5.5",
       LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO: "0.25",
+      LCM_COLD_CACHE_OBSERVATION_THRESHOLD: "5",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED: "true",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_MAX: "60000",
       LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE: "inline",
@@ -151,6 +155,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 2,
         hotCachePressureFactor: 3,
         hotCacheBudgetHeadroomRatio: 0.1,
+        coldCacheObservationThreshold: 2,
       },
       dynamicLeafChunkTokens: {
         enabled: false,
@@ -181,6 +186,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 4,
       hotCachePressureFactor: 5.5,
       hotCacheBudgetHeadroomRatio: 0.25,
+      coldCacheObservationThreshold: 5,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -341,6 +347,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
+        coldCacheObservationThreshold: 4,
       },
     });
 
@@ -350,6 +357,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
+      coldCacheObservationThreshold: 4,
     });
   });
 
@@ -577,6 +585,10 @@ describe("resolveLcmConfig", () => {
           type: "number",
           minimum: 0,
           maximum: 0.95,
+        },
+        coldCacheObservationThreshold: {
+          type: "integer",
+          minimum: 1,
         },
       },
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -64,6 +64,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,
@@ -5536,7 +5537,241 @@ describe("LcmContextEngine fidelity and token budget", () => {
       cacheState: "cold",
       lastObservedCacheRead: 4_096,
       lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
       turnsSinceLeafCompaction: 1,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("hot");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction treats a single cold reading as non-authoritative when the session was previously hot", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-single-cold-non-authoritative";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "cold",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
+      turnsSinceLeafCompaction: 9,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("hot");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction eventually treats repeated cold readings as authoritative", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-authoritative-cold-streak";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+        maxPasses: number;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "cold",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(Date.now() - 60_000),
+      consecutiveColdObservations: 3,
+      turnsSinceLeafCompaction: 9,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.cacheState).toBe("cold");
+    expect(decision.maxPasses).toBe(2);
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=cold-cache-catchup"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction keeps hot-cache protection for unknown observations without an explicit break", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-unknown-cache-non-authoritative";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "unknown",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 0,
+      turnsSinceLeafCompaction: 9,
       tokensAccumulatedSinceLeafCompaction: 55_000,
       lastActivityBand: "low",
     });

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -43,6 +43,7 @@ const BASE_CONFIG: LcmConfig = {
     maxColdCacheCatchupPasses: 2,
     hotCachePressureFactor: 4,
     hotCacheBudgetHeadroomRatio: 0.2,
+    coldCacheObservationThreshold: 3,
   },
   dynamicLeafChunkTokens: {
     enabled: true,

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -63,6 +63,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,


### PR DESCRIPTION
## Summary

This fixes the cache-noise failure mode behind #358.

Current `main` treats a single cold observation as authoritative unless a very short hot-cache hysteresis window happens to save the session. That is too aggressive for provider failover and OpenRouter routing noise: a single `cacheRead=0` can drop a previously hot session into cold-cache catch-up and trigger destructive compaction that was not justified by real memory pressure.

This PR makes cache-aware compaction state sticky instead of single-sample authoritative.

## What changed

- add `cacheAwareCompaction.coldCacheObservationThreshold` (default `3`)
- persist a `consecutive_cold_observations` counter in compaction telemetry
- keep explicit cache breaks authoritative immediately
- keep prior hot sessions effectively hot through one-off `cold` and `unknown` blips until the cold-observation threshold is reached
- preserve existing budget-pressure behavior once a session is truly under pressure

## Why this helps

The conservative failure mode for cache-aware compaction should be “preserve context until we are confident the cache is really cold,” not “compact aggressively because one read looked cold.”

This is especially important on OpenRouter, where identical prefixes can still produce transient cold reads because requests land on different backend instances.

## Tests

- `pnpm exec vitest run test/config.test.ts test/engine.test.ts test/session-operation-queues.test.ts test/circuit-breaker.test.ts test/expansion.test.ts`

Adds focused coverage for:
- single cold reading after a prior hot streak stays non-authoritative
- repeated cold readings eventually become authoritative
- unknown/no-usage observations do not collapse hot-cache protection
- explicit breaks still force cold behavior immediately

Closes #358.