### PR TITLE
fix: move proactive threshold compaction off the reply path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `cacheAwareCompaction.maxColdCacheCatchupPasses` | `integer` | `2` | `LCM_MAX_COLD_CACHE_CATCHUP_PASSES` | Maximum bounded catch-up passes allowed in one maintenance cycle when cache telemetry is cold. |
 | `cacheAwareCompaction.hotCachePressureFactor` | `number` | `4` | `LCM_HOT_CACHE_PRESSURE_FACTOR` | Multiplier applied to the hot-cache leaf trigger before raw-history pressure overrides cache preservation. |
 | `cacheAwareCompaction.hotCacheBudgetHeadroomRatio` | `number` | `0.2` | `LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO` | Minimum fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely. |
+| `cacheAwareCompaction.coldCacheObservationThreshold` | `integer` | `3` | `LCM_COLD_CACHE_OBSERVATION_THRESHOLD` | Consecutive cold observations required before non-explicit cache misses are treated as truly cold. This dampens one-off routing noise and provider failover blips. |
 
 #### `dynamicLeafChunkTokens`
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -152,6 +152,10 @@
       "label": "Hot Cache Budget Headroom",
       "help": "Fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely"
     },
+    "cacheAwareCompaction.coldCacheObservationThreshold": {
+      "label": "Cold Cache Observation Threshold",
+      "help": "Consecutive cold observations required before non-explicit cache misses are treated as truly cold"
+    },
     "dynamicLeafChunkTokens.enabled": {
       "label": "Dynamic Leaf Chunk Tokens",
       "help": "When enabled, incremental compaction uses a larger working leaf chunk in busy sessions and keeps the static floor in quieter sessions"
@@ -319,6 +323,10 @@
             "type": "number",
             "minimum": 0,
             "maximum": 0.95
+          },
+          "coldCacheObservationThreshold": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -323,6 +323,19 @@ Default:
 
 - `0.2`
 
+#### `cacheAwareCompaction.coldCacheObservationThreshold`
+
+Consecutive cold observations required before non-explicit cache misses are treated as truly cold.
+
+Why it matters:
+
+- prevents a single OpenRouter routing miss or provider failover blip from immediately triggering cold-cache catch-up
+- explicit cache breaks still count as cold immediately
+
+Default:
+
+- `3`
+
 ### `dynamicLeafChunkTokens`
 
 #### `dynamicLeafChunkTokens.enabled`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -6,6 +6,7 @@ export type CacheAwareCompactionConfig = {
   maxColdCacheCatchupPasses: number;
   hotCachePressureFactor: number;
   hotCacheBudgetHeadroomRatio: number;
+  coldCacheObservationThreshold: number;
 };
 
 export type DynamicLeafChunkTokensConfig = {
@@ -218,6 +219,14 @@ export function resolveLcmConfig(
         ?? 0.2,
     ),
   );
+  const resolvedColdCacheObservationThreshold = Math.max(
+    1,
+    Math.floor(
+      parseFiniteNumber(env.LCM_COLD_CACHE_OBSERVATION_THRESHOLD)
+        ?? toNumber(cacheAwareCompaction?.coldCacheObservationThreshold)
+        ?? 3,
+    ),
+  );
 
   return {
     enabled:
@@ -333,6 +342,7 @@ export function resolveLcmConfig(
           ?? 2,
       hotCachePressureFactor: resolvedHotCachePressureFactor,
       hotCacheBudgetHeadroomRatio: resolvedHotCacheBudgetHeadroomRatio,
+      coldCacheObservationThreshold: resolvedColdCacheObservationThreshold,
     },
     dynamicLeafChunkTokens: {
       enabled:

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -96,6 +96,9 @@ function ensureSummaryModelColumn(db: DatabaseSync): void {
 
 function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const telemetryColumns = db.prepare(`PRAGMA table_info(conversation_compaction_telemetry)`).all() as SummaryColumnInfo[];
+  const hasConsecutiveColdObservations = telemetryColumns.some(
+    (col) => col.name === "consecutive_cold_observations",
+  );
   const hasLastLeafCompactionAt = telemetryColumns.some((col) => col.name === "last_leaf_compaction_at");
   const hasTurnsSinceLeafCompaction = telemetryColumns.some((col) => col.name === "turns_since_leaf_compaction");
   const hasTokensAccumulatedSinceLeafCompaction = telemetryColumns.some(
@@ -103,6 +106,11 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   );
   const hasLastActivityBand = telemetryColumns.some((col) => col.name === "last_activity_band");
 
+  if (!hasConsecutiveColdObservations) {
+    db.exec(
+      `ALTER TABLE conversation_compaction_telemetry ADD COLUMN consecutive_cold_observations INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
   if (!hasLastLeafCompactionAt) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_leaf_compaction_at TEXT`);
   }
@@ -701,6 +709,7 @@ export function runLcmMigrations(
       last_observed_cache_break_at TEXT,
       cache_state TEXT NOT NULL DEFAULT 'unknown'
         CHECK (cache_state IN ('hot', 'cold', 'unknown')),
+      consecutive_cold_observations INTEGER NOT NULL DEFAULT 0,
       retention TEXT,
       last_leaf_compaction_at TEXT,
       turns_since_leaf_compaction INTEGER NOT NULL DEFAULT 0,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1572,6 +1572,27 @@ export class LcmContextEngine implements ContextEngine {
     if (this.shouldApplyHotCacheHysteresis(telemetry)) {
       return "hot";
     }
+    if (
+      telemetry.lastObservedCacheBreakAt
+      && (
+        !telemetry.lastObservedCacheHitAt
+        || telemetry.lastObservedCacheBreakAt >= telemetry.lastObservedCacheHitAt
+      )
+    ) {
+      return "cold";
+    }
+    if (
+      telemetry.consecutiveColdObservations
+      >= this.config.cacheAwareCompaction.coldCacheObservationThreshold
+    ) {
+      return "cold";
+    }
+    if (telemetry.lastObservedCacheHitAt) {
+      return "hot";
+    }
+    if (telemetry.cacheState === "cold") {
+      return "unknown";
+    }
     return telemetry.cacheState;
   }
 
@@ -1774,6 +1795,17 @@ export class LcmContextEngine implements ContextEngine {
       (existing?.turnsSinceLeafCompaction ?? 0) + 1;
     const tokensAccumulatedSinceLeafCompaction =
       params.rawTokensOutsideTail ?? existing?.tokensAccumulatedSinceLeafCompaction ?? 0;
+    const consecutiveColdObservations =
+      snapshot?.sawExplicitBreak
+        ? Math.max(
+          existing?.consecutiveColdObservations ?? 0,
+          this.config.cacheAwareCompaction.coldCacheObservationThreshold,
+        )
+        : snapshot?.cacheState === "hot"
+          ? 0
+          : snapshot?.cacheState === "cold"
+            ? (existing?.consecutiveColdObservations ?? 0) + 1
+            : existing?.consecutiveColdObservations ?? 0;
     const lastActivityBand = this.classifyDynamicLeafActivityBand({
       lastActivityBand: existing?.lastActivityBand,
       tokensAccumulatedSinceLeafCompaction,
@@ -1794,6 +1826,7 @@ export class LcmContextEngine implements ContextEngine {
           ? now
           : existing?.lastObservedCacheBreakAt ?? null,
       cacheState: snapshot?.cacheState ?? existing?.cacheState ?? "unknown",
+      consecutiveColdObservations,
       retention: snapshot?.retention ?? existing?.retention ?? null,
       lastLeafCompactionAt: existing?.lastLeafCompactionAt ?? null,
       turnsSinceLeafCompaction,
@@ -1805,7 +1838,7 @@ export class LcmContextEngine implements ContextEngine {
     );
     if (updated) {
       this.deps.log.debug(
-        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
+        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} coldObservationStreak=${updated.consecutiveColdObservations} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
       );
     }
     return updated;
@@ -1826,6 +1859,7 @@ export class LcmContextEngine implements ContextEngine {
       lastObservedCacheHitAt: existing?.lastObservedCacheHitAt ?? null,
       lastObservedCacheBreakAt: existing?.lastObservedCacheBreakAt ?? null,
       cacheState: existing?.cacheState ?? "unknown",
+      consecutiveColdObservations: existing?.consecutiveColdObservations ?? 0,
       retention: existing?.retention ?? null,
       lastLeafCompactionAt: new Date(),
       turnsSinceLeafCompaction: 0,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1221,6 +1221,7 @@ export class LcmContextEngine implements ContextEngine {
     string,
     { promise: Promise<void>; refCount: number }
   >();
+  private backgroundThresholdCompactions = new Map<string, Promise<void>>();
   private largeFileTextSummarizerResolved = false;
   private largeFileTextSummarizer?: (prompt: string) => Promise<string | null>;
   private deps: LcmDependencies;
@@ -1495,6 +1496,52 @@ export class LcmContextEngine implements ContextEngine {
     const normalizedSessionKey = sessionKey?.trim();
     const normalizedSessionId = sessionId?.trim();
     return normalizedSessionKey || normalizedSessionId || "__lcm__";
+  }
+
+  /** Queue proactive threshold compaction without blocking reply delivery. */
+  private scheduleBackgroundThresholdCompaction(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    tokenBudget: number;
+    currentTokenCount?: number;
+    legacyParams?: Record<string, unknown>;
+  }): void {
+    const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
+    if (this.backgroundThresholdCompactions.has(queueKey)) {
+      this.deps.log.info(
+        `[lcm] afterTurn: threshold compaction already scheduled queueKey=${queueKey}`,
+      );
+      return;
+    }
+
+    const task = (async () => {
+      try {
+        await this.compact({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          tokenBudget: params.tokenBudget,
+          currentTokenCount: params.currentTokenCount,
+          compactionTarget: "threshold",
+          legacyParams: params.legacyParams,
+        });
+      } catch (err) {
+        this.deps.log.warn(
+          `[lcm] afterTurn: background threshold compaction failed: ${describeLogError(err)}`,
+        );
+      }
+    })();
+
+    this.backgroundThresholdCompactions.set(queueKey, task);
+    task.finally(() => {
+      const active = this.backgroundThresholdCompactions.get(queueKey);
+      if (active === task) {
+        this.backgroundThresholdCompactions.delete(queueKey);
+      }
+    }).catch(() => {
+      // The task handles its own errors; this only silences finally-chain noise.
+    });
   }
 
   /** Normalize optional live token estimates supplied by runtime callers. */
@@ -3529,19 +3576,14 @@ export class LcmContextEngine implements ContextEngine {
       // Leaf trigger checks are best-effort.
     }
 
-    try {
-      await this.compact({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        tokenBudget,
-        currentTokenCount: liveContextTokens,
-        compactionTarget: "threshold",
-        legacyParams,
-      });
-    } catch {
-      // Proactive compaction is best-effort in the post-turn lifecycle.
-    }
+    this.scheduleBackgroundThresholdCompaction({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionFile: params.sessionFile,
+      tokenBudget,
+      currentTokenCount: liveContextTokens,
+      legacyParams,
+    });
 
     this.deps.log.info(
       `[lcm] afterTurn: done conversation=${conversation.conversationId} ${sessionLabel} newMessages=${newMessages.length} dedupedMessages=${dedupedNewMessages.length} ingestedMessages=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/src/store/compaction-telemetry-store.ts
+++ b/src/store/compaction-telemetry-store.ts
@@ -12,6 +12,7 @@ export type ConversationCompactionTelemetryRecord = {
   lastObservedCacheHitAt: Date | null;
   lastObservedCacheBreakAt: Date | null;
   cacheState: CacheState;
+  consecutiveColdObservations: number;
   retention: string | null;
   lastLeafCompactionAt: Date | null;
   turnsSinceLeafCompaction: number;
@@ -27,6 +28,7 @@ export type UpsertConversationCompactionTelemetryInput = {
   lastObservedCacheHitAt?: Date | null;
   lastObservedCacheBreakAt?: Date | null;
   cacheState: CacheState;
+  consecutiveColdObservations?: number;
   retention?: string | null;
   lastLeafCompactionAt?: Date | null;
   turnsSinceLeafCompaction?: number;
@@ -41,6 +43,7 @@ type ConversationCompactionTelemetryRow = {
   last_observed_cache_hit_at: string | null;
   last_observed_cache_break_at: string | null;
   cache_state: CacheState;
+  consecutive_cold_observations: number | null;
   retention: string | null;
   last_leaf_compaction_at: string | null;
   turns_since_leaf_compaction: number | null;
@@ -59,6 +62,7 @@ function toConversationCompactionTelemetryRecord(
     lastObservedCacheHitAt: parseUtcTimestampOrNull(row.last_observed_cache_hit_at),
     lastObservedCacheBreakAt: parseUtcTimestampOrNull(row.last_observed_cache_break_at),
     cacheState: row.cache_state,
+    consecutiveColdObservations: row.consecutive_cold_observations ?? 0,
     retention: row.retention,
     lastLeafCompactionAt: parseUtcTimestampOrNull(row.last_leaf_compaction_at),
     turnsSinceLeafCompaction: row.turns_since_leaf_compaction ?? 0,
@@ -93,6 +97,7 @@ export class CompactionTelemetryStore {
            last_observed_cache_hit_at,
            last_observed_cache_break_at,
            cache_state,
+           consecutive_cold_observations,
            retention,
            last_leaf_compaction_at,
            turns_since_leaf_compaction,
@@ -119,19 +124,21 @@ export class CompactionTelemetryStore {
            last_observed_cache_hit_at,
            last_observed_cache_break_at,
            cache_state,
+           consecutive_cold_observations,
            retention,
            last_leaf_compaction_at,
            turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction,
            last_activity_band,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            last_observed_cache_read = excluded.last_observed_cache_read,
            last_observed_cache_write = excluded.last_observed_cache_write,
            last_observed_cache_hit_at = excluded.last_observed_cache_hit_at,
            last_observed_cache_break_at = excluded.last_observed_cache_break_at,
            cache_state = excluded.cache_state,
+           consecutive_cold_observations = excluded.consecutive_cold_observations,
            retention = excluded.retention,
            last_leaf_compaction_at = excluded.last_leaf_compaction_at,
            turns_since_leaf_compaction = excluded.turns_since_leaf_compaction,
@@ -146,6 +153,7 @@ export class CompactionTelemetryStore {
         input.lastObservedCacheHitAt?.toISOString() ?? null,
         input.lastObservedCacheBreakAt?.toISOString() ?? null,
         input.cacheState,
+        input.consecutiveColdObservations ?? 0,
         input.retention ?? null,
         input.lastLeafCompactionAt?.toISOString() ?? null,
         input.turnsSinceLeafCompaction ?? 0,

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -55,6 +55,7 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -30,6 +30,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -56,6 +57,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
+        coldCacheObservationThreshold: 4,
       },
       dynamicLeafChunkTokens: {
         enabled: true,
@@ -82,6 +84,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
+      coldCacheObservationThreshold: 4,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -103,6 +106,7 @@ describe("resolveLcmConfig", () => {
       LCM_MAX_COLD_CACHE_CATCHUP_PASSES: "4",
       LCM_HOT_CACHE_PRESSURE_FACTOR: "5.5",
       LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO: "0.25",
+      LCM_COLD_CACHE_OBSERVATION_THRESHOLD: "5",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED: "true",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_MAX: "60000",
     } as NodeJS.ProcessEnv;
@@ -119,6 +123,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 2,
         hotCachePressureFactor: 3,
         hotCacheBudgetHeadroomRatio: 0.1,
+        coldCacheObservationThreshold: 2,
       },
       dynamicLeafChunkTokens: {
         enabled: false,
@@ -145,6 +150,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 4,
       hotCachePressureFactor: 5.5,
       hotCacheBudgetHeadroomRatio: 0.25,
+      coldCacheObservationThreshold: 5,
     });
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
@@ -260,6 +266,7 @@ describe("resolveLcmConfig", () => {
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
+        coldCacheObservationThreshold: 4,
       },
     });
 
@@ -268,6 +275,7 @@ describe("resolveLcmConfig", () => {
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
+      coldCacheObservationThreshold: 4,
     });
   });
 
@@ -478,6 +486,10 @@ describe("resolveLcmConfig", () => {
           type: "number",
           minimum: 0,
           maximum: 0.95,
+        },
+        coldCacheObservationThreshold: {
+          type: "integer",
+          minimum: 1,
         },
       },
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -59,6 +59,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,
@@ -4512,7 +4513,241 @@ describe("LcmContextEngine fidelity and token budget", () => {
       cacheState: "cold",
       lastObservedCacheRead: 4_096,
       lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
       turnsSinceLeafCompaction: 1,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("hot");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction treats a single cold reading as non-authoritative when the session was previously hot", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-single-cold-non-authoritative";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "cold",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
+      turnsSinceLeafCompaction: 9,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("hot");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction eventually treats repeated cold readings as authoritative", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-authoritative-cold-streak";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+        maxPasses: number;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "cold",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(Date.now() - 60_000),
+      consecutiveColdObservations: 3,
+      turnsSinceLeafCompaction: 9,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.cacheState).toBe("cold");
+    expect(decision.maxPasses).toBe(2);
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=cold-cache-catchup"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction keeps hot-cache protection for unknown observations without an explicit break", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-unknown-cache-non-authoritative";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "unknown",
+      lastObservedCacheRead: 8_192,
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 0,
+      turnsSinceLeafCompaction: 9,
       tokensAccumulatedSinceLeafCompaction: 55_000,
       lastActivityBand: "low",
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5177,6 +5177,104 @@ describe("LcmContextEngine fidelity and token budget", () => {
       ),
     );
   });
+
+  it("afterTurn returns before proactive threshold compaction finishes", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-threshold";
+    let resolveCompact!: (value: { ok: boolean; compacted: boolean; reason: string }) => void;
+    const compactPromise = new Promise<{ ok: boolean; compacted: boolean; reason: string }>((resolve) => {
+      resolveCompact = resolve;
+    });
+    const compactSpy = vi.spyOn(engine, "compact").mockReturnValue(compactPromise);
+
+    const afterTurnPromise = engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-threshold"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const winner = await Promise.race([
+      afterTurnPromise.then(() => "afterTurn-finished"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ]);
+
+    expect(winner).toBe("afterTurn-finished");
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+
+    resolveCompact({
+      ok: true,
+      compacted: false,
+      reason: "below threshold",
+    });
+    await compactPromise;
+  });
+
+  it("afterTurn coalesces duplicate background threshold compaction requests per session", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-threshold-coalesce";
+    let resolveCompact!: (value: { ok: boolean; compacted: boolean; reason: string }) => void;
+    const compactPromise = new Promise<{ ok: boolean; compacted: boolean; reason: string }>((resolve) => {
+      resolveCompact = resolve;
+    });
+    const compactSpy = vi.spyOn(engine, "compact").mockReturnValue(compactPromise);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-threshold-coalesce-1"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-threshold-coalesce-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: "fresh turn content" }),
+        makeMessage({ role: "user", content: "follow up" }),
+      ],
+      prePromptMessageCount: 1,
+      tokenBudget: 4096,
+    });
+
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+
+    resolveCompact({
+      ok: true,
+      compacted: false,
+      reason: "below threshold",
+    });
+    await compactPromise;
+  });
+
+  it("afterTurn ignores background threshold compaction failures", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "after-turn-background-threshold-failure";
+    vi.spyOn(engine, "compact").mockRejectedValue(new Error("background compact failed"));
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-threshold-failure"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(warnLog).toHaveBeenCalledWith(
+      "[lcm] afterTurn: background threshold compaction failed: background compact failed",
+    );
+  });
 });
 
 // ── afterTurn dedup guard ────────────────────────────────────────────────────

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -41,6 +41,7 @@ const BASE_CONFIG: LcmConfig = {
     maxColdCacheCatchupPasses: 2,
     hotCachePressureFactor: 4,
     hotCacheBudgetHeadroomRatio: 0.2,
+    coldCacheObservationThreshold: 3,
   },
   dynamicLeafChunkTokens: {
     enabled: true,

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -61,6 +61,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
     },
     dynamicLeafChunkTokens: {
       enabled: true,


### PR DESCRIPTION
## Summary

This addresses #313 by moving proactive threshold compaction out of the synchronous `afterTurn()` reply path.

Right now reply generation can already be done, but `afterTurn()` still awaits the proactive threshold sweep before it returns. On conversations where compaction is slow or frequent, that turns compaction latency into reply latency.

## What changed

- keep ingest and compaction telemetry in `afterTurn()`
- keep best-effort incremental leaf compaction behavior unchanged
- stop awaiting proactive threshold compaction inline
- schedule threshold compaction onto a tracked background slot keyed by session
- coalesce duplicate background threshold requests so repeated turns do not pile up redundant sweeps
- keep true overflow recovery synchronous and unchanged; this only changes the post-turn maintenance path

## Why this is safe

The proactive threshold sweep operates on persisted conversation state. It does not need to block reply delivery to preserve correctness. The next turn will still see whatever compaction accomplished because the actual mutation still runs through the existing per-session queue.

## Tests

- `pnpm exec vitest run test/engine.test.ts test/config.test.ts test/session-operation-queues.test.ts test/circuit-breaker.test.ts test/expansion.test.ts`

Adds focused coverage for:
- `afterTurn()` resolving before proactive threshold compaction finishes
- duplicate background threshold requests coalescing per session
- background threshold failures not surfacing to the user path
- existing force/overflow recovery behavior remaining intact

## Stack note

This branch is cut on top of #362. Until #362 merges, GitHub will show the lower branch commits here too.

Closes #313.