### PR TITLE
feat: add token-budget-aware fresh tail

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "skipStatelessSessions": true,
   "contextThreshold": 0.75,
   "freshTailCount": 64,
+  "freshTailMaxTokens": 24000,
   "newSessionRetainDepth": 2,
   "leafMinFanout": 8,
   "condensedMinFanout": 4,
@@ -119,6 +120,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | --- | --- | --- | --- | --- |
 | `contextThreshold` | `number` | `0.75` | `LCM_CONTEXT_THRESHOLD` | Fraction of the active model context window that triggers compaction. |
 | `freshTailCount` | `integer` | `64` | `LCM_FRESH_TAIL_COUNT` | Number of newest messages always kept raw. |
+| `freshTailMaxTokens` | `integer` | unset | `LCM_FRESH_TAIL_MAX_TOKENS` | Optional token cap for the protected fresh tail. The newest message is always preserved even if it exceeds the cap. |
 | `leafMinFanout` | `integer` | `8` | `LCM_LEAF_MIN_FANOUT` | Minimum number of raw messages required before a leaf pass runs. |
 | `condensedMinFanout` | `integer` | `4` | `LCM_CONDENSED_MIN_FANOUT` | Number of same-depth summaries needed before condensation is attempted. |
 | `condensedMinFanoutHard` | `integer` | `2` | `LCM_CONDENSED_MIN_FANOUT_HARD` | Hard floor for condensation grouping during maintenance and repair flows. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -20,6 +20,10 @@
       "label": "Fresh Tail Count",
       "help": "Number of recent messages protected from compaction"
     },
+    "freshTailMaxTokens": {
+      "label": "Fresh Tail Max Tokens",
+      "help": "Optional token cap for the protected fresh tail; the newest message is always preserved"
+    },
     "leafChunkTokens": {
       "label": "Leaf Chunk Tokens",
       "help": "Maximum source tokens per leaf compaction chunk before summarization"
@@ -200,6 +204,10 @@
       "freshTailCount": {
         "type": "integer",
         "minimum": 1
+      },
+      "freshTailMaxTokens": {
+        "type": "integer",
+        "minimum": 0
       },
       "leafChunkTokens": {
         "type": "integer",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -43,6 +43,20 @@ Good starting range:
 
 - `32` to `64`
 
+### `freshTailMaxTokens`
+
+Optional token cap for the protected fresh tail.
+
+Why it matters:
+
+- Prevents a few huge tool results from making the "fresh" suffix effectively uncompactable.
+- Still preserves the newest message even if that single message exceeds the cap.
+
+Good starting range:
+
+- Leave unset unless large tool outputs are forcing avoidable cost or overflow.
+- Start around `12000` to `32000` when you want a softer, size-aware fresh tail.
+
 ### `leafChunkTokens`
 
 Caps how much raw material gets summarized into one leaf summary.
@@ -199,6 +213,10 @@ Why it matters:
 See high-impact settings above.
 
 ### `freshTailCount`
+
+See high-impact settings above.
+
+### `freshTailMaxTokens`
 
 See high-impact settings above.
 

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -637,12 +637,24 @@ function collectAssistantToolCallIds(items: ResolvedItem[]): Set<string> {
   return ids;
 }
 
+function normalizeFreshTailTokenCap(freshTailMaxTokens?: number): number | undefined {
+  if (
+    typeof freshTailMaxTokens === "number" &&
+    Number.isFinite(freshTailMaxTokens) &&
+    freshTailMaxTokens >= 0
+  ) {
+    return Math.floor(freshTailMaxTokens);
+  }
+  return undefined;
+}
+
 function mergeFreshTailWithMatchingToolResults(
   freshTail: ResolvedItem[],
   matchingToolResults: ResolvedItem[],
-): ResolvedItem[] {
+  freshTailMaxTokens?: number,
+): { items: ResolvedItem[]; promotedOrdinals: Set<number> } {
   if (matchingToolResults.length === 0) {
-    return freshTail;
+    return { items: freshTail, promotedOrdinals: new Set<number>() };
   }
 
   const resultsById = new Map<string, ResolvedItem[]>();
@@ -660,7 +672,9 @@ function mergeFreshTailWithMatchingToolResults(
   }
 
   const merged: ResolvedItem[] = [];
-  const usedOrdinals = new Set<number>();
+  const promotedOrdinals = new Set<number>();
+  const tokenCap = normalizeFreshTailTokenCap(freshTailMaxTokens);
+  let mergedTokens = freshTail.reduce((sum, item) => sum + item.tokens, 0);
 
   for (const item of freshTail) {
     merged.push(item);
@@ -676,27 +690,37 @@ function mergeFreshTailWithMatchingToolResults(
         continue;
       }
       for (const match of matches) {
-        if (usedOrdinals.has(match.ordinal)) {
+        if (promotedOrdinals.has(match.ordinal)) {
+          continue;
+        }
+        if (
+          typeof tokenCap === "number" &&
+          mergedTokens + match.tokens > tokenCap
+        ) {
           continue;
         }
         merged.push(match);
-        usedOrdinals.add(match.ordinal);
+        promotedOrdinals.add(match.ordinal);
+        mergedTokens += match.tokens;
       }
     }
   }
 
-  for (const item of matchingToolResults) {
-    if (!usedOrdinals.has(item.ordinal)) {
-      merged.push(item);
+  if (typeof tokenCap !== "number") {
+    for (const item of matchingToolResults) {
+      if (!promotedOrdinals.has(item.ordinal)) {
+        merged.push(item);
+      }
     }
   }
 
-  return merged;
+  return { items: merged, promotedOrdinals };
 }
 
 function filterNonFreshAssistantToolCalls(
   items: ResolvedItem[],
   freshTailOrdinals: Set<number>,
+  preserveFreshTailToolCalls = true,
 ): AgentMessage[] {
   const availableToolResultIds = new Set<string>();
   for (const item of items) {
@@ -708,7 +732,10 @@ function filterNonFreshAssistantToolCalls(
 
   const filteredMessages: AgentMessage[] = [];
   for (const item of items) {
-    if (item.message?.role !== "assistant" || freshTailOrdinals.has(item.ordinal)) {
+    if (
+      item.message?.role !== "assistant" ||
+      (preserveFreshTailToolCalls && freshTailOrdinals.has(item.ordinal))
+    ) {
       filteredMessages.push(item.message);
       continue;
     }
@@ -1001,9 +1028,15 @@ export class ContextAssembler {
       const toolResultId = extractToolResultIdFromMessage(item.message);
       return toolResultId !== null && tailToolCallIds.has(toolResultId);
     });
-    const protectedEvictableOrdinals = new Set(tailPairToolResults.map((item) => item.ordinal));
-    const evictable = initialEvictable.filter((item) => !protectedEvictableOrdinals.has(item.ordinal));
-    const freshTail = mergeFreshTailWithMatchingToolResults(baseFreshTail, tailPairToolResults);
+    const mergedFreshTail = mergeFreshTailWithMatchingToolResults(
+      baseFreshTail,
+      tailPairToolResults,
+      input.freshTailMaxTokens,
+    );
+    const evictable = initialEvictable.filter(
+      (item) => !mergedFreshTail.promotedOrdinals.has(item.ordinal),
+    );
+    const freshTail = mergedFreshTail.items;
 
     // Step 4: Budget-aware selection
     // First, compute the token cost of the fresh tail (always included).
@@ -1081,7 +1114,11 @@ export class ContextAssembler {
 
     // Normalize assistant string content to array blocks (some providers return
     // content as a plain string; Anthropic expects content block arrays).
-    const rawMessages = filterNonFreshAssistantToolCalls(selected, freshTailOrdinals);
+    const rawMessages = filterNonFreshAssistantToolCalls(
+      selected,
+      freshTailOrdinals,
+      normalizeFreshTailTokenCap(input.freshTailMaxTokens) === undefined,
+    );
     for (let i = 0; i < rawMessages.length; i++) {
       const msg = rawMessages[i];
       if (msg?.role === "assistant" && typeof msg.content === "string") {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -26,6 +26,8 @@ export interface AssembleContextInput {
   tokenBudget: number;
   /** Number of most recent raw turns to always include (default: 8) */
   freshTailCount?: number;
+  /** Optional token cap for the protected fresh tail; newest message is always preserved. */
+  freshTailMaxTokens?: number;
   /** Optional user query for relevance-based eviction scoring (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
   prompt?: string;
 }
@@ -831,6 +833,57 @@ interface ResolvedItem {
   summarySignal?: SummaryPromptSignal;
 }
 
+function resolveFreshTailOrdinal(
+  resolved: ResolvedItem[],
+  freshTailCount: number,
+  freshTailMaxTokens?: number,
+): number {
+  if (!Number.isFinite(freshTailCount) || freshTailCount <= 0) {
+    return Infinity;
+  }
+
+  const rawMessages = resolved.filter((item) => item.isMessage);
+  if (rawMessages.length === 0) {
+    return Infinity;
+  }
+
+  const tokenCap =
+    typeof freshTailMaxTokens === "number" &&
+    Number.isFinite(freshTailMaxTokens) &&
+    freshTailMaxTokens >= 0
+      ? Math.floor(freshTailMaxTokens)
+      : undefined;
+
+  let protectedCount = 0;
+  let protectedTokens = 0;
+  let tailStartOrdinal = Infinity;
+
+  for (let idx = rawMessages.length - 1; idx >= 0; idx--) {
+    if (protectedCount >= freshTailCount) {
+      break;
+    }
+
+    const item = rawMessages[idx];
+    if (!item) {
+      continue;
+    }
+
+    const wouldExceedBudget =
+      protectedCount > 0 &&
+      typeof tokenCap === "number" &&
+      protectedTokens + item.tokens > tokenCap;
+    if (wouldExceedBudget) {
+      break;
+    }
+
+    tailStartOrdinal = item.ordinal;
+    protectedCount++;
+    protectedTokens += item.tokens;
+  }
+
+  return tailStartOrdinal;
+}
+
 // ── BM25-lite relevance scorer ────────────────────────────────────────────────
 
 /** @internal Exported for testing only. Tokenize text into lowercase alphanumeric terms. */
@@ -894,7 +947,8 @@ export class ContextAssembler {
    * 1. Fetch all context items for the conversation (ordered by ordinal).
    * 2. Resolve each item into an AgentMessage (fetching the underlying
    *    message or summary record).
-   * 3. Protect the "fresh tail" (last N items) from truncation.
+   * 3. Protect the "fresh tail" (last N raw messages, optionally token-capped)
+   *    from truncation.
    * 4. If over budget, drop oldest non-fresh items until we fit.
    * 5. Return the final ordered messages in chronological order.
    */
@@ -934,9 +988,13 @@ export class ContextAssembler {
     const systemPromptAddition = buildSystemPromptAddition(summarySignals);
 
     // Step 3: Split into evictable prefix and protected fresh tail
-    const tailStart = Math.max(0, resolved.length - freshTailCount);
-    const baseFreshTail = resolved.slice(tailStart);
-    const initialEvictable = resolved.slice(0, tailStart);
+    const freshTailOrdinal = resolveFreshTailOrdinal(
+      resolved,
+      freshTailCount,
+      input.freshTailMaxTokens,
+    );
+    const baseFreshTail = resolved.filter((item) => item.ordinal >= freshTailOrdinal);
+    const initialEvictable = resolved.filter((item) => item.ordinal < freshTailOrdinal);
     const freshTailOrdinals = new Set(baseFreshTail.map((item) => item.ordinal));
     const tailToolCallIds = collectAssistantToolCallIds(baseFreshTail);
     const tailPairToolResults = initialEvictable.filter((item) => {

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -36,6 +36,8 @@ export interface CompactionConfig {
   contextThreshold: number;
   /** Number of fresh tail turns to protect (default 8) */
   freshTailCount: number;
+  /** Optional token cap for the protected fresh tail; newest message is always preserved. */
+  freshTailMaxTokens?: number;
   /** Minimum number of depth-0 summaries needed for condensation. */
   leafMinFanout: number;
   /** Minimum number of depth>=1 summaries needed for condensation. */
@@ -890,16 +892,29 @@ export class CompactionEngine {
     return 0;
   }
 
+  /** Normalize configured fresh tail token cap to a safe non-negative integer. */
+  private resolveFreshTailMaxTokens(): number | undefined {
+    if (
+      typeof this.config.freshTailMaxTokens === "number" &&
+      Number.isFinite(this.config.freshTailMaxTokens) &&
+      this.config.freshTailMaxTokens >= 0
+    ) {
+      return Math.floor(this.config.freshTailMaxTokens);
+    }
+    return undefined;
+  }
+
   /**
    * Compute the ordinal boundary for protected fresh messages.
    *
    * Messages with ordinal >= returned value are preserved as fresh tail.
    */
-  private resolveFreshTailOrdinal(contextItems: ContextItemRecord[]): number {
+  private async resolveFreshTailOrdinal(contextItems: ContextItemRecord[]): Promise<number> {
     const freshTailCount = this.resolveFreshTailCount();
     if (freshTailCount <= 0) {
       return Infinity;
     }
+    const freshTailMaxTokens = this.resolveFreshTailMaxTokens();
 
     const rawMessageItems = contextItems.filter(
       (item) => item.itemType === "message" && item.messageId != null,
@@ -908,8 +923,35 @@ export class CompactionEngine {
       return Infinity;
     }
 
-    const tailStartIdx = Math.max(0, rawMessageItems.length - freshTailCount);
-    return rawMessageItems[tailStartIdx]?.ordinal ?? Infinity;
+    let protectedCount = 0;
+    let protectedTokens = 0;
+    let tailStartOrdinal = Infinity;
+
+    for (let idx = rawMessageItems.length - 1; idx >= 0; idx--) {
+      if (protectedCount >= freshTailCount) {
+        break;
+      }
+
+      const item = rawMessageItems[idx];
+      if (!item || item.messageId == null) {
+        continue;
+      }
+
+      const messageTokens = await this.getMessageTokenCount(item.messageId);
+      const wouldExceedBudget =
+        protectedCount > 0 &&
+        typeof freshTailMaxTokens === "number" &&
+        protectedTokens + messageTokens > freshTailMaxTokens;
+      if (wouldExceedBudget) {
+        break;
+      }
+
+      tailStartOrdinal = item.ordinal;
+      protectedCount++;
+      protectedTokens += messageTokens;
+    }
+
+    return tailStartOrdinal;
   }
 
   /** Resolve message token count with a content-length fallback. */
@@ -931,7 +973,7 @@ export class CompactionEngine {
   /** Sum raw message tokens outside the protected fresh tail. */
   private async countRawTokensOutsideFreshTail(conversationId: number): Promise<number> {
     const contextItems = await this.getContextItemsCached(conversationId);
-    const freshTailOrdinal = this.resolveFreshTailOrdinal(contextItems);
+    const freshTailOrdinal = await this.resolveFreshTailOrdinal(contextItems);
     let rawTokens = 0;
 
     for (const item of contextItems) {
@@ -958,7 +1000,7 @@ export class CompactionEngine {
     leafChunkTokensOverride?: number,
   ): Promise<LeafChunkSelection> {
     const contextItems = await this.getContextItemsCached(conversationId);
-    const freshTailOrdinal = this.resolveFreshTailOrdinal(contextItems);
+    const freshTailOrdinal = await this.resolveFreshTailOrdinal(contextItems);
     const threshold = this.resolveLeafChunkTokens(leafChunkTokensOverride);
 
     let rawTokensOutsideTail = 0;
@@ -1147,7 +1189,7 @@ export class CompactionEngine {
   }): Promise<CondensedPhaseCandidate | null> {
     const { conversationId, hardTrigger } = params;
     const contextItems = await this.getContextItemsCached(conversationId);
-    const freshTailOrdinal = this.resolveFreshTailOrdinal(contextItems);
+    const freshTailOrdinal = await this.resolveFreshTailOrdinal(contextItems);
     const minChunkTokens = this.resolveCondensedMinChunkTokens();
     const depthLevels = await this.summaryStore.getDistinctDepthsInContext(conversationId, {
       maxOrdinalExclusive: freshTailOrdinal,
@@ -1187,7 +1229,7 @@ export class CompactionEngine {
     const freshTailOrdinal =
       typeof freshTailOrdinalOverride === "number"
         ? freshTailOrdinalOverride
-        : this.resolveFreshTailOrdinal(contextItems);
+        : await this.resolveFreshTailOrdinal(contextItems);
     const chunkTokenBudget = this.resolveLeafChunkTokens();
 
     const chunk: ContextItemRecord[] = [];

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -51,6 +51,8 @@ export type LcmConfig = {
   skipStatelessSessions: boolean;
   contextThreshold: number;
   freshTailCount: number;
+  /** Optional token cap for the protected fresh tail; newest message is always preserved. */
+  freshTailMaxTokens?: number;
   newSessionRetainDepth: number;
   leafMinFanout: number;
   condensedMinFanout: number;
@@ -332,6 +334,9 @@ export function resolveLcmConfigWithDiagnostics(
       freshTailCount:
         parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
           ?? toNumber(pc.freshTailCount) ?? 64,
+      freshTailMaxTokens:
+        parseFiniteInt(env.LCM_FRESH_TAIL_MAX_TOKENS)
+          ?? toNumber(pc.freshTailMaxTokens) ?? undefined,
       newSessionRetainDepth:
         parseFiniteInt(env.LCM_NEW_SESSION_RETAIN_DEPTH)
           ?? toNumber(pc.newSessionRetainDepth) ?? 2,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1328,6 +1328,7 @@ export class LcmContextEngine implements ContextEngine {
     const compactionConfig: CompactionConfig = {
       contextThreshold: this.config.contextThreshold,
       freshTailCount: this.config.freshTailCount,
+      freshTailMaxTokens: this.config.freshTailMaxTokens,
       leafMinFanout: this.config.leafMinFanout,
       condensedMinFanout: this.config.condensedMinFanout,
       condensedMinFanoutHard: this.config.condensedMinFanoutHard,
@@ -3677,6 +3678,7 @@ export class LcmContextEngine implements ContextEngine {
         conversationId: conversation.conversationId,
         tokenBudget,
         freshTailCount: this.config.freshTailCount,
+        freshTailMaxTokens: this.config.freshTailMaxTokens,
         prompt: params.prompt,
       });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,6 +21,7 @@ describe("resolveLcmConfig", () => {
     expect(config.skipStatelessSessions).toBe(true);
     expect(config.contextThreshold).toBe(0.75);
     expect(config.freshTailCount).toBe(64);
+    expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.newSessionRetainDepth).toBe(2);
     expect(config.incrementalMaxDepth).toBe(1);
     expect(config.leafChunkTokens).toBe(20000);
@@ -48,6 +49,7 @@ describe("resolveLcmConfig", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: 0.5,
       freshTailCount: 16,
+      freshTailMaxTokens: 12000,
       leafChunkTokens: 80000,
       newSessionRetainDepth: 3,
       incrementalMaxDepth: -1,
@@ -79,6 +81,7 @@ describe("resolveLcmConfig", () => {
     expect(config.skipStatelessSessions).toBe(false);
     expect(config.contextThreshold).toBe(0.5);
     expect(config.freshTailCount).toBe(16);
+    expect(config.freshTailMaxTokens).toBe(12000);
     expect(config.newSessionRetainDepth).toBe(3);
     expect(config.leafChunkTokens).toBe(80000);
     expect(config.incrementalMaxDepth).toBe(-1);
@@ -102,6 +105,7 @@ describe("resolveLcmConfig", () => {
     const env = {
       LCM_CONTEXT_THRESHOLD: "0.9",
       LCM_FRESH_TAIL_COUNT: "64",
+      LCM_FRESH_TAIL_MAX_TOKENS: "32000",
       LCM_NEW_SESSION_RETAIN_DEPTH: "5",
       LCM_INCREMENTAL_MAX_DEPTH: "3",
       LCM_ENABLED: "false",
@@ -119,6 +123,7 @@ describe("resolveLcmConfig", () => {
     const pluginConfig = {
       contextThreshold: 0.5,
       freshTailCount: 16,
+      freshTailMaxTokens: 12000,
       incrementalMaxDepth: -1,
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
@@ -150,6 +155,7 @@ describe("resolveLcmConfig", () => {
     expect(config.transcriptGcEnabled).toBe(true);
     expect(config.contextThreshold).toBe(0.9); // env wins
     expect(config.freshTailCount).toBe(64); // env wins
+    expect(config.freshTailMaxTokens).toBe(32000); // env wins
     expect(config.newSessionRetainDepth).toBe(5); // env wins
     expect(config.incrementalMaxDepth).toBe(3); // env wins
     expect(config.cacheAwareCompaction).toEqual({
@@ -211,6 +217,7 @@ describe("resolveLcmConfig", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: "0.6",
       freshTailCount: "24",
+      freshTailMaxTokens: "4800",
       leafChunkTokens: "64000",
       newSessionRetainDepth: "6",
       ignoreSessionPatterns: "agent:*:cron:*, agent:main:subagent:**",
@@ -219,6 +226,7 @@ describe("resolveLcmConfig", () => {
     });
     expect(config.contextThreshold).toBe(0.6);
     expect(config.freshTailCount).toBe(24);
+    expect(config.freshTailMaxTokens).toBe(4800);
     expect(config.newSessionRetainDepth).toBe(6);
     expect(config.leafChunkTokens).toBe(64000);
     expect(config.ignoreSessionPatterns).toEqual([
@@ -236,11 +244,13 @@ describe("resolveLcmConfig", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: "not-a-number",
       freshTailCount: null,
+      freshTailMaxTokens: "not-a-number",
       newSessionRetainDepth: "nope",
       enabled: "maybe",
     });
     expect(config.contextThreshold).toBe(0.75); // falls through to default
     expect(config.freshTailCount).toBe(64); // falls through to default
+    expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.newSessionRetainDepth).toBe(2); // falls through to default
     expect(config.enabled).toBe(true); // falls through to default
   });

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -828,6 +828,40 @@ describe("LCM integration: ingest -> assemble", () => {
     expect(result.messages).toHaveLength(3);
   });
 
+  it("fresh tail token cap drops older oversized tail messages from assembly", async () => {
+    await ingestMessages(convStore, sumStore, 4, {
+      contentFn: (i) => `M${i} ${"z".repeat(396)}`,
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 150,
+      freshTailCount: 4,
+      freshTailMaxTokens: 110,
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(extractMessageText(result.messages[0]?.content)).toContain("M3");
+  });
+
+  it("fresh tail token cap still preserves the newest message when it alone exceeds the cap", async () => {
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => (i === 1 ? `Huge tail ${"q".repeat(796)}` : `Older ${"q".repeat(196)}`),
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 100,
+      freshTailCount: 2,
+      freshTailMaxTokens: 50,
+    });
+
+    const contents = result.messages.map((message) => extractMessageText(message.content));
+    expect(contents.some((text) => text.includes("Huge tail"))).toBe(true);
+  });
+
   it("pulls matching tool results into the protected tail when the tail contains their tool call", async () => {
     await convStore.createConversation({ sessionId: "session-tail-tool-pair" });
 
@@ -984,6 +1018,25 @@ describe("LCM integration: compaction", () => {
 
     // Total context items should be fewer than the original 10
     expect(contextItems.length).toBeLessThan(10);
+  });
+
+  it("leaf-trigger accounting respects fresh tail token caps", async () => {
+    const tokenAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 4,
+      freshTailMaxTokens: 150,
+      leafChunkTokens: 200,
+    });
+
+    await ingestMessages(convStore, sumStore, 4, {
+      contentFn: (i) => `Turn ${i}: ${"r".repeat(396)}`,
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    const trigger = await tokenAwareEngine.evaluateLeafTrigger(CONV_ID);
+
+    expect(trigger.rawTokensOutsideTail).toBeGreaterThanOrEqual(250);
+    expect(trigger.shouldCompact).toBe(true);
   });
 
   it("compactLeaf uses preceding summary context for soft leaf continuity", async () => {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -941,6 +941,98 @@ describe("LCM integration: ingest -> assemble", () => {
     expect(extractMessageText(result.messages[2].content)).toBe("tail marker");
   });
 
+  it("does not let paired tool results bypass fresh tail token caps", async () => {
+    await convStore.createConversation({ sessionId: "session-tail-tool-pair-capped" });
+
+    const hugeToolResult = `huge tool result ${"x".repeat(4096)}`;
+    const toolResultMsg = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 1,
+      role: "tool",
+      content: hugeToolResult,
+      tokenCount: estimateTokens(hugeToolResult),
+    });
+    await convStore.createMessageParts(toolResultMsg.messageId, [
+      {
+        sessionId: "session-tail-tool-pair-capped",
+        partType: "tool",
+        ordinal: 0,
+        textContent: hugeToolResult,
+        toolCallId: "call_tail_capped",
+        toolName: "read",
+        metadata: JSON.stringify({
+          originalRole: "toolResult",
+          rawType: "tool_result",
+          toolCallId: "call_tail_capped",
+          toolName: "read",
+        }),
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, toolResultMsg.messageId);
+
+    const assistantMsg = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 2,
+      role: "assistant",
+      content: "tail tool call",
+      tokenCount: estimateTokens("tail tool call"),
+    });
+    await convStore.createMessageParts(assistantMsg.messageId, [
+      {
+        sessionId: "session-tail-tool-pair-capped",
+        partType: "text",
+        ordinal: 0,
+        textContent: "tail tool call",
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          rawType: "text",
+        }),
+      },
+      {
+        sessionId: "session-tail-tool-pair-capped",
+        partType: "tool",
+        ordinal: 1,
+        toolCallId: "call_tail_capped",
+        toolName: "read",
+        toolInput: JSON.stringify({ path: "foo.txt" }),
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          rawType: "toolCall",
+          raw: {
+            type: "toolCall",
+            id: "call_tail_capped",
+            name: "read",
+            input: { path: "foo.txt" },
+          },
+        }),
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, assistantMsg.messageId);
+
+    const trailingUser = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 3,
+      role: "user",
+      content: "tail marker",
+      tokenCount: estimateTokens("tail marker"),
+    });
+    await sumStore.appendContextMessage(CONV_ID, trailingUser.messageId);
+
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 120,
+      freshTailCount: 2,
+      freshTailMaxTokens: 80,
+    });
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.some((message) => message.role === "toolResult")).toBe(false);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(extractMessageText(result.messages[0]?.content)).toContain("tail tool call");
+    expect(result.messages[1]?.role).toBe("user");
+    expect(extractMessageText(result.messages[1]?.content)).toBe("tail marker");
+  });
+
   it("degrades tool rows without toolCallId to assistant text", async () => {
     await ingestMessages(convStore, sumStore, 1, {
       roleFn: () => "tool",


### PR DESCRIPTION
## Summary

This implements the core idea from #236 as an opt-in fresh-tail token budget instead of a count-only protection rule.

Today `freshTailCount` protects the newest `N` raw messages no matter how large they are. In agentic sessions that can make a few giant tool results effectively uncompactable, which increases overflow risk and keeps more expensive raw context around than users intended.

## What changed

- add optional `freshTailMaxTokens` config and `LCM_FRESH_TAIL_MAX_TOKENS`
- keep the existing default behavior unchanged when the new setting is unset
- make both compaction and assembly use the same fresh-tail boundary rule
- bound the protected tail by message count and token budget together
- always preserve the newest message even if it alone exceeds the token cap
- document the new setting in the manifest, configuration docs, and skill reference

## Why this helps

This keeps the near-term conversational suffix intact without letting a handful of outsized tool results pin an arbitrarily large raw tail in place. Users who do not need the behavior change get the exact existing default; users seeing avoidable cost or overflow from giant tails can opt in and tune the boundary.

## Tests

- `pnpm exec vitest run test/config.test.ts test/lcm-integration.test.ts test/engine.test.ts test/plugin-config-registration.test.ts`

Adds focused coverage for:
- config parsing and precedence for `freshTailMaxTokens`
- assembly dropping older oversized tail messages once the cap is hit
- newest-message preservation even when the newest message exceeds the cap
- leaf-trigger accounting respecting the same token-capped fresh-tail boundary

## Notes

- default behavior remains count-only because `freshTailMaxTokens` is unset by default
- this supersedes the original concept in #236 with a smaller current-main implementation
