### PR TITLE
fix: reset bootstrap state on session file rotation

### DIFF
--- a/.changeset/nice-ways-hear.md
+++ b/.changeset/nice-ways-hear.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix bootstrap recovery when a session rotates to a new transcript file so stale summaries and checkpoints are cleared before re-importing the replacement session history.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1004,6 +1004,13 @@ function resolveBootstrapMaxTokens(config: Pick<LcmConfig, "bootstrapMaxTokens" 
   return Math.max(6000, Math.floor(leafChunkTokens * 0.3));
 }
 
+function hasTable(db: DatabaseSync, tableName: string): boolean {
+  const row = db
+    .prepare(`SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(tableName) as { present?: number } | undefined;
+  return row?.present === 1;
+}
+
 /**
  * Keep only the newest bootstrap messages that fit within the token budget.
  *
@@ -2610,6 +2617,62 @@ export class LcmContextEngine implements ContextEngine {
     });
   }
 
+  private purgeConversationForBootstrapRotation(conversationId: number): void {
+    this.db.prepare(`DELETE FROM context_items WHERE conversation_id = ?`).run(conversationId);
+    this.db
+      .prepare(
+        `DELETE FROM summary_messages
+         WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
+      )
+      .run(conversationId);
+    this.db
+      .prepare(
+        `DELETE FROM summary_parents
+         WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)
+            OR parent_summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
+      )
+      .run(conversationId, conversationId);
+    if (hasTable(this.db, "summaries_fts")) {
+      this.db
+        .prepare(
+          `DELETE FROM summaries_fts
+           WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
+        )
+        .run(conversationId);
+    }
+    if (hasTable(this.db, "summaries_fts_cjk")) {
+      this.db
+        .prepare(
+          `DELETE FROM summaries_fts_cjk
+           WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
+        )
+        .run(conversationId);
+    }
+    this.db.prepare(`DELETE FROM summaries WHERE conversation_id = ?`).run(conversationId);
+    this.db.prepare(`DELETE FROM large_files WHERE conversation_id = ?`).run(conversationId);
+    this.db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(conversationId);
+    this.db
+      .prepare(`DELETE FROM conversation_compaction_telemetry WHERE conversation_id = ?`)
+      .run(conversationId);
+    if (hasTable(this.db, "messages_fts")) {
+      this.db
+        .prepare(
+          `DELETE FROM messages_fts
+           WHERE rowid IN (SELECT message_id FROM messages WHERE conversation_id = ?)`,
+        )
+        .run(conversationId);
+    }
+    this.db.prepare(`DELETE FROM messages WHERE conversation_id = ?`).run(conversationId);
+    this.db
+      .prepare(
+        `UPDATE conversations
+         SET bootstrapped_at = NULL,
+             updated_at = datetime('now')
+         WHERE conversation_id = ?`,
+      )
+      .run(conversationId);
+  }
+
   async bootstrap(params: {
     sessionId: string;
     sessionFile: string;
@@ -2660,11 +2723,24 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
           });
           const conversationId = conversation.conversationId;
-          const existingCount = await this.conversationStore.getMessageCount(conversationId);
-          const bootstrapState =
+          let existingCount = await this.conversationStore.getMessageCount(conversationId);
+          let bootstrapState =
             existingCount > 0
               ? await this.summaryStore.getConversationBootstrapState(conversationId)
               : null;
+
+          if (
+            bootstrapState &&
+            bootstrapState.sessionFilePath !== params.sessionFile
+          ) {
+            this.deps.log.warn(
+              `[lcm] bootstrap: session file rotated conversation=${conversationId} ${sessionLabel} oldFile=${bootstrapState.sessionFilePath} newFile=${params.sessionFile}`,
+            );
+            this.purgeConversationForBootstrapRotation(conversationId);
+            bootstrapState = null;
+            existingCount = 0;
+            conversation.bootstrappedAt = null;
+          }
 
           // If the transcript file is byte-for-byte unchanged from the last
           // successful bootstrap checkpoint, skip reopening and reparsing it.

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2165,6 +2165,70 @@ describe("LcmContextEngine.bootstrap", () => {
     });
   });
 
+  it("purges stale conversation data and re-bootstraps when the session file rotates", async () => {
+    const firstSessionFile = createSessionFilePath("rotation-old");
+    const firstManager = SessionManager.open(firstSessionFile);
+    firstManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    firstManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-rotation";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile: firstSessionFile });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_rotation_old",
+      conversationId: conversation!.conversationId,
+      kind: "leaf",
+      content: "old summary",
+      tokenCount: 5,
+    });
+    await engine.getSummaryStore().appendContextSummary(conversation!.conversationId, "sum_rotation_old");
+
+    const rotatedSessionFile = createSessionFilePath("rotation-new");
+    const rotatedManager = SessionManager.open(rotatedSessionFile);
+    rotatedManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "new user" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "new assistant" }],
+    } as AgentMessage);
+
+    const second = await engine.bootstrap({ sessionId, sessionFile: rotatedSessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["new user", "new assistant"]);
+
+    const contextItems = await engine.getSummaryStore().getContextItems(conversation!.conversationId);
+    expect(contextItems).toHaveLength(2);
+    expect(contextItems.every((item) => item.itemType === "message")).toBe(true);
+
+    const rotatedBootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(rotatedBootstrapState?.sessionFilePath).toBe(rotatedSessionFile);
+    expect(await engine.getSummaryStore().getSummary("sum_rotation_old")).toBeNull();
+  });
+
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-tail");
     const sm = SessionManager.open(sessionFile);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2229,6 +2229,92 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(await engine.getSummaryStore().getSummary("sum_rotation_old")).toBeNull();
   });
 
+  it("purges stale conversation data when the session file rotates across a stable sessionKey", async () => {
+    const engine = createEngine();
+    const firstSessionId = "bootstrap-rotation-session-key-1";
+    const secondSessionId = "bootstrap-rotation-session-key-2";
+    const sessionKey = "agent:main:test:bootstrap-rotation";
+    const firstSessionFile = createSessionFilePath("rotation-session-key-old");
+    const firstManager = SessionManager.open(firstSessionFile);
+    firstManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old keyed user" }],
+    } as AgentMessage);
+    firstManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old keyed assistant" }],
+    } as AgentMessage);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const firstConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(firstConversation).not.toBeNull();
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_rotation_session_key_old",
+      conversationId: firstConversation!.conversationId,
+      kind: "leaf",
+      content: "old keyed summary",
+      tokenCount: 5,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(firstConversation!.conversationId, "sum_rotation_session_key_old");
+
+    const rotatedSessionFile = createSessionFilePath("rotation-session-key-new");
+    const rotatedManager = SessionManager.open(rotatedSessionFile);
+    rotatedManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "new keyed user" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "new keyed assistant" }],
+    } as AgentMessage);
+
+    const second = await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: rotatedSessionFile,
+    });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    expect(conversation!.conversationId).toBe(firstConversation!.conversationId);
+    expect(conversation!.sessionId).toBe(secondSessionId);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["new keyed user", "new keyed assistant"]);
+
+    const contextItems = await engine.getSummaryStore().getContextItems(conversation!.conversationId);
+    expect(contextItems).toHaveLength(2);
+    expect(contextItems.every((item) => item.itemType === "message")).toBe(true);
+
+    const rotatedBootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(rotatedBootstrapState?.sessionFilePath).toBe(rotatedSessionFile);
+    expect(await engine.getSummaryStore().getSummary("sum_rotation_session_key_old")).toBeNull();
+  });
+
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-tail");
     const sm = SessionManager.open(sessionFile);


### PR DESCRIPTION
## Summary

This fixes the stale-bootstrap loop described in #233.

When OpenClaw rotates a session file to a new `UUID.jsonl`, the current bootstrap path still treats the existing LCM conversation as authoritative even if its checkpoint points at the old file. With no overlap between the new file and the old DB tail, bootstrap falls through to `already bootstrapped`, new transcript data never enters LCM, and compaction never gets a chance to run.

## What changed

- detect session-file path rotation immediately after loading bootstrap state
- purge the stale conversation-scoped bootstrap data for the rotated transcript
- reset `bootstrapped_at` so the existing first-import path can seed from the new file
- clear related summaries, context items, compaction telemetry, bootstrap state, large files, and FTS rows for that conversation before re-import
- add a regression test proving that rotated sessions discard stale summaries and import the new transcript cleanly

## Why this is safe

A rotated session file is a transcript identity change. Reusing summaries and bootstrap checkpoints from the previous file is what creates the dead loop. Resetting the conversation-scoped LCM state keeps the conversation record itself but drops stale derived data so bootstrap can rebuild from the current transcript.

## Tests

- `pnpm exec vitest run test/engine.test.ts test/bootstrap-flood-regression.test.ts`

Adds focused coverage for:
- session-file rotation purging stale messages and summaries
- bootstrapping cleanly from the replacement transcript
- existing append-only/import-cap bootstrap regressions remaining green

Closes #233.
