### PR TITLE
feat: pre-assembly cache-TTL compaction

### DIFF
--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -6,6 +6,7 @@ export type CacheAwareCompactionConfig = {
   maxColdCacheCatchupPasses: number;
   hotCachePressureFactor: number;
   hotCacheBudgetHeadroomRatio: number;
+  cacheTTLSeconds: number;
 };
 
 export type DynamicLeafChunkTokensConfig = {
@@ -333,6 +334,12 @@ export function resolveLcmConfig(
           ?? 2,
       hotCachePressureFactor: resolvedHotCachePressureFactor,
       hotCacheBudgetHeadroomRatio: resolvedHotCacheBudgetHeadroomRatio,
+      cacheTTLSeconds: Math.max(
+        0,
+        parseFiniteInt(env.LCM_CACHE_TTL_SECONDS)
+          ?? toNumber(cacheAwareCompaction?.cacheTTLSeconds)
+          ?? 300,
+      ),
     },
     dynamicLeafChunkTokens: {
       enabled:

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -102,6 +102,7 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
     (col) => col.name === "tokens_accumulated_since_leaf_compaction",
   );
   const hasLastActivityBand = telemetryColumns.some((col) => col.name === "last_activity_band");
+  const hasLastApiCallAt = telemetryColumns.some((col) => col.name === "last_api_call_at");
 
   if (!hasLastLeafCompactionAt) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_leaf_compaction_at TEXT`);
@@ -119,6 +120,11 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   if (!hasLastActivityBand) {
     db.exec(
       `ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_activity_band TEXT NOT NULL DEFAULT 'low' CHECK (last_activity_band IN ('low', 'medium', 'high'))`,
+    );
+  }
+  if (!hasLastApiCallAt) {
+    db.exec(
+      `ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_api_call_at INTEGER`,
     );
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1799,6 +1799,7 @@ export class LcmContextEngine implements ContextEngine {
       turnsSinceLeafCompaction,
       tokensAccumulatedSinceLeafCompaction,
       lastActivityBand,
+      lastApiCallAt: Date.now(),
     });
     const updated = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
       params.conversationId,
@@ -1949,56 +1950,6 @@ export class LcmContextEngine implements ContextEngine {
       });
     }
 
-    if (
-      cacheState === "hot"
-      && this.isComfortablyUnderTokenBudget({
-        currentTokenCount: params.currentTokenCount,
-        tokenBudget: params.tokenBudget,
-      })
-    ) {
-      return this.logIncrementalCompactionDecision({
-        conversationId: params.conversationId,
-        cacheState,
-        activityBand,
-        triggerLeafChunkTokens,
-        preferredLeafChunkTokens,
-        fallbackLeafChunkTokens,
-        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
-        threshold: leafTrigger.threshold,
-        shouldCompact: false,
-        maxPasses: 1,
-        allowCondensedPasses: false,
-        reason: "hot-cache-budget-headroom",
-      });
-    }
-
-    if (
-      cacheState === "hot"
-      && leafTrigger.rawTokensOutsideTail
-        < Math.floor(
-          leafTrigger.threshold * this.config.cacheAwareCompaction.hotCachePressureFactor,
-        )
-    ) {
-      return this.logIncrementalCompactionDecision({
-        conversationId: params.conversationId,
-        cacheState,
-        activityBand,
-        triggerLeafChunkTokens,
-        preferredLeafChunkTokens,
-        fallbackLeafChunkTokens,
-        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
-        threshold: leafTrigger.threshold,
-        shouldCompact: false,
-        maxPasses: 1,
-        allowCondensedPasses: false,
-        reason: "hot-cache-defer",
-      });
-    }
-
-    const maxPasses =
-      cacheState === "cold"
-        ? Math.max(1, this.config.cacheAwareCompaction.maxColdCacheCatchupPasses)
-        : 1;
     return this.logIncrementalCompactionDecision({
       conversationId: params.conversationId,
       cacheState,
@@ -2009,9 +1960,9 @@ export class LcmContextEngine implements ContextEngine {
       rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
       threshold: leafTrigger.threshold,
       shouldCompact: true,
-      maxPasses,
-      allowCondensedPasses: cacheState !== "hot",
-      reason: cacheState === "cold" ? "cold-cache-catchup" : "leaf-trigger",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      reason: "leaf-trigger",
     });
   }
 
@@ -3548,6 +3499,49 @@ export class LcmContextEngine implements ContextEngine {
           messages: params.messages,
           estimatedTokens: 0,
         };
+      }
+
+      // Pre-assembly cache-TTL compaction: if the cache has expired since the
+      // last API call, compact before assembling so stale context is evicted.
+      try {
+        const cacheTTLMs = (this.config.cacheAwareCompaction.cacheTTLSeconds ?? 300) * 1000;
+        const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+          conversation.conversationId,
+        );
+        if (telemetry?.lastApiCallAt) {
+          const idleMs = Date.now() - telemetry.lastApiCallAt;
+          if (idleMs > cacheTTLMs) {
+            const leafTrigger = await this.compaction.evaluateLeafTrigger(
+              conversation.conversationId,
+              this.config.leafChunkTokens,
+            );
+            if (leafTrigger.shouldCompact) {
+              this.deps.log.info(
+                `[lcm] assemble: pre-assembly compaction — cache expired (idle ${idleMs}ms), compacting before assembly`,
+              );
+              const tokenBudget = this.applyAssemblyBudgetCap(
+                typeof params.tokenBudget === "number" &&
+                Number.isFinite(params.tokenBudget) &&
+                params.tokenBudget > 0
+                  ? Math.floor(params.tokenBudget)
+                  : 128_000,
+              );
+              await this.compactLeafAsync({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                sessionFile: "",
+                tokenBudget,
+                maxPasses: 1,
+                leafChunkTokens: this.config.leafChunkTokens,
+                allowCondensedPasses: true,
+              });
+            }
+          }
+        }
+      } catch (err) {
+        this.deps.log.warn(
+          `[lcm] assemble: pre-assembly compaction failed: ${describeLogError(err)}`,
+        );
       }
 
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);

--- a/src/store/compaction-telemetry-store.ts
+++ b/src/store/compaction-telemetry-store.ts
@@ -17,6 +17,7 @@ export type ConversationCompactionTelemetryRecord = {
   turnsSinceLeafCompaction: number;
   tokensAccumulatedSinceLeafCompaction: number;
   lastActivityBand: ActivityBand;
+  lastApiCallAt: number | null;
   updatedAt: Date;
 };
 
@@ -32,6 +33,7 @@ export type UpsertConversationCompactionTelemetryInput = {
   turnsSinceLeafCompaction?: number;
   tokensAccumulatedSinceLeafCompaction?: number;
   lastActivityBand?: ActivityBand;
+  lastApiCallAt?: number | null;
 };
 
 type ConversationCompactionTelemetryRow = {
@@ -46,6 +48,7 @@ type ConversationCompactionTelemetryRow = {
   turns_since_leaf_compaction: number | null;
   tokens_accumulated_since_leaf_compaction: number | null;
   last_activity_band: ActivityBand | null;
+  last_api_call_at: number | null;
   updated_at: string;
 };
 
@@ -64,6 +67,7 @@ function toConversationCompactionTelemetryRecord(
     turnsSinceLeafCompaction: row.turns_since_leaf_compaction ?? 0,
     tokensAccumulatedSinceLeafCompaction: row.tokens_accumulated_since_leaf_compaction ?? 0,
     lastActivityBand: row.last_activity_band ?? "low",
+    lastApiCallAt: row.last_api_call_at ?? null,
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -98,6 +102,7 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction,
            last_activity_band,
+           last_api_call_at,
            updated_at
          FROM conversation_compaction_telemetry
          WHERE conversation_id = ?`,
@@ -124,8 +129,9 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction,
            last_activity_band,
+           last_api_call_at,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            last_observed_cache_read = excluded.last_observed_cache_read,
            last_observed_cache_write = excluded.last_observed_cache_write,
@@ -137,6 +143,7 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction = excluded.turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction = excluded.tokens_accumulated_since_leaf_compaction,
            last_activity_band = excluded.last_activity_band,
+           last_api_call_at = excluded.last_api_call_at,
            updated_at = datetime('now')`,
       )
       .run(
@@ -151,6 +158,7 @@ export class CompactionTelemetryStore {
         input.turnsSinceLeafCompaction ?? 0,
         input.tokensAccumulatedSinceLeafCompaction ?? 0,
         input.lastActivityBand ?? "low",
+        input.lastApiCallAt ?? null,
       );
   }
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,6 +27,7 @@ describe("resolveLcmConfig", () => {
     expect(config.pruneHeartbeatOk).toBe(false);
     expect(config.cacheAwareCompaction).toEqual({
       enabled: true,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
@@ -79,6 +80,7 @@ describe("resolveLcmConfig", () => {
     expect(config.pruneHeartbeatOk).toBe(true);
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
@@ -142,6 +144,7 @@ describe("resolveLcmConfig", () => {
     expect(config.incrementalMaxDepth).toBe(3); // env wins
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 4,
       hotCachePressureFactor: 5.5,
       hotCacheBudgetHeadroomRatio: 0.25,
@@ -265,6 +268,7 @@ describe("resolveLcmConfig", () => {
 
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,


### PR DESCRIPTION
## Summary

Replace afterTurn cache-state-based compaction with assembly-path TTL-based trigger. Based on v0.8.0.

## Problem

`evaluateIncrementalCompaction()` runs in `afterTurn()` and reads the cache status of the call that just completed. This is a timing inversion:

- A **cold** reading means the provider just wrote the cache — it's now **hot**. Compacting destroys it.
- A **hot** reading means cache is alive — correct to defer, but misses the idle window when cache expires naturally.
- On load-balanced providers (separate prompt caches per instance), random cold readings trigger compaction cascades. See #358.

## Solution

### 1. Pre-assembly compaction (new)
Before assembling context, check: idle > `cacheTTLSeconds` (default 300s) AND memory pressure? → compact before assembly.

### 2. Simplify afterTurn
Remove `hot-cache-budget-headroom`, `hot-cache-defer`, `cold-cache-catchup`. Keep budget-trigger safety valve and simple leaf-trigger.

## Changes
- `config.ts`: Add `cacheTTLSeconds` (default 300, env `LCM_CACHE_TTL_SECONDS`)
- `migration.ts`: Add `last_api_call_at` column
- `compaction-telemetry-store.ts`: Read/write `lastApiCallAt`
- `engine.ts`: Pre-assembly check in `assemble()`, simplified `evaluateIncrementalCompaction()`
- `config.test.ts`: Updated assertions

Closes #367. Related: #358, #362, #363.