### PR TITLE
refactor: simplify evaluateIncrementalCompaction — remove cache-state branching

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1949,56 +1949,6 @@ export class LcmContextEngine implements ContextEngine {
       });
     }
 
-    if (
-      cacheState === "hot"
-      && this.isComfortablyUnderTokenBudget({
-        currentTokenCount: params.currentTokenCount,
-        tokenBudget: params.tokenBudget,
-      })
-    ) {
-      return this.logIncrementalCompactionDecision({
-        conversationId: params.conversationId,
-        cacheState,
-        activityBand,
-        triggerLeafChunkTokens,
-        preferredLeafChunkTokens,
-        fallbackLeafChunkTokens,
-        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
-        threshold: leafTrigger.threshold,
-        shouldCompact: false,
-        maxPasses: 1,
-        allowCondensedPasses: false,
-        reason: "hot-cache-budget-headroom",
-      });
-    }
-
-    if (
-      cacheState === "hot"
-      && leafTrigger.rawTokensOutsideTail
-        < Math.floor(
-          leafTrigger.threshold * this.config.cacheAwareCompaction.hotCachePressureFactor,
-        )
-    ) {
-      return this.logIncrementalCompactionDecision({
-        conversationId: params.conversationId,
-        cacheState,
-        activityBand,
-        triggerLeafChunkTokens,
-        preferredLeafChunkTokens,
-        fallbackLeafChunkTokens,
-        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
-        threshold: leafTrigger.threshold,
-        shouldCompact: false,
-        maxPasses: 1,
-        allowCondensedPasses: false,
-        reason: "hot-cache-defer",
-      });
-    }
-
-    const maxPasses =
-      cacheState === "cold"
-        ? Math.max(1, this.config.cacheAwareCompaction.maxColdCacheCatchupPasses)
-        : 1;
     return this.logIncrementalCompactionDecision({
       conversationId: params.conversationId,
       cacheState,
@@ -2009,9 +1959,9 @@ export class LcmContextEngine implements ContextEngine {
       rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
       threshold: leafTrigger.threshold,
       shouldCompact: true,
-      maxPasses,
-      allowCondensedPasses: cacheState !== "hot",
-      reason: cacheState === "cold" ? "cold-cache-catchup" : "leaf-trigger",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      reason: "leaf-trigger",
     });
   }
 


### PR DESCRIPTION
## Summary

Remove cache-state-dependent branches from `evaluateIncrementalCompaction()` in afterTurn. Based on v0.8.0.

## Problem

`evaluateIncrementalCompaction()` uses the cache status of the just-completed API call to decide compaction strategy. On load-balanced providers with separate prompt caches per backend instance, random cold readings trigger aggressive multi-pass compaction that destroys live caches. See #358 for data.

The three problematic branches:
- **hot-cache-budget-headroom**: defers compaction when cache is hot and under budget — misses the window when cache expires
- **hot-cache-defer**: defers when pressure is below hotCachePressureFactor × threshold — same issue
- **cold-cache-catchup**: triggers aggressive multi-pass compaction on cold readings — a cold reading often means the cache was just written and is now hot

## Change

Remove all three branches. After this change:
- **budget-trigger**: unchanged, safety valve, always fires
- **below-leaf-trigger**: unchanged, no compaction needed
- **leaf-trigger**: single pass, no condensed passes, no cache-state branching

1 file changed, 3 insertions, 53 deletions.

Closes #367. Related: #358, #362.