### PR TITLE
fix: avoid disabling reasoning for reasoning-capable summarizers

### DIFF
--- a/.changeset/tiny-pots-teach.md
+++ b/.changeset/tiny-pots-teach.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Avoid treating omitted LCM summarizer reasoning settings like reasoning-disabled requests for reasoning-capable models by applying a low default only when the resolved model supports reasoning.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -585,6 +585,30 @@ export function buildCompleteSimpleOptions(params: {
   return options;
 }
 
+/**
+ * Prefer an explicit reasoning setting, otherwise apply a caller-provided
+ * default only when the resolved model advertises reasoning support.
+ */
+export function resolveEffectiveReasoning(params: {
+  reasoning: string | undefined;
+  reasoningIfSupported: string | undefined;
+  modelSupportsReasoning: boolean | undefined;
+}): string | undefined {
+  if (typeof params.reasoning === "string" && params.reasoning.trim()) {
+    return params.reasoning.trim();
+  }
+
+  if (
+    params.modelSupportsReasoning === true &&
+    typeof params.reasoningIfSupported === "string" &&
+    params.reasoningIfSupported.trim()
+  ) {
+    return params.reasoningIfSupported.trim();
+  }
+
+  return undefined;
+}
+
 /** Select provider-specific config values with case-insensitive provider keys. */
 function findProviderConfigValue<T>(
   map: Record<string, T> | undefined,
@@ -1353,6 +1377,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
       maxTokens,
       temperature,
       reasoning,
+      reasoningIfSupported,
     }) => {
       try {
         const piAiModuleId = "@mariozechner/pi-ai";
@@ -1590,19 +1615,24 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
           }
         }
 
+        const effectiveReasoning = resolveEffectiveReasoning({
+          reasoning,
+          reasoningIfSupported,
+          modelSupportsReasoning: resolvedModel.reasoning,
+        });
+
         const completeOptions = buildCompleteSimpleOptions({
           api: resolvedModel.api,
           apiKey: resolvedApiKey,
           maxTokens,
           temperature,
-          reasoning,
+          reasoning: effectiveReasoning,
         });
         const requestMetadata = {
           request_provider: providerId,
           request_model: modelId,
           request_api: resolvedModel.api,
-          request_reasoning:
-            typeof reasoning === "string" && reasoning.trim() ? reasoning.trim() : "(none)",
+          request_reasoning: effectiveReasoning ?? "(none)",
           request_has_system: typeof system === "string" && system.trim().length > 0 ? "true" : "false",
           request_temperature:
             typeof completeOptions.temperature === "number"

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1223,6 +1223,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             },
           ],
           maxTokens: targetTokens,
+          reasoningIfSupported: "low",
           ...(reasoning ? { reasoning } : {}),
           ...(options?.skipModelAuth === true ? { skipModelAuth: true } : {}),
         }), summarizerTimeoutMs, label);

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type CompleteFn = (params: {
   maxTokens: number;
   temperature?: number;
   reasoning?: string;
+  reasoningIfSupported?: string;
 }) => Promise<CompletionResult>;
 
 /**

--- a/test/lcm-summarizer-reasoning.test.ts
+++ b/test/lcm-summarizer-reasoning.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEffectiveReasoning } from "../src/plugin/index.js";
+import { createLcmSummarizeFromLegacyParams } from "../src/summarize.js";
+
+function createDeps(overrides: Partial<Record<string, unknown>> = {}) {
+  const calls: Array<Record<string, unknown>> = [];
+  const deps = {
+    config: {
+      leafTargetTokens: 128,
+      condensedTargetTokens: 128,
+    },
+    complete: async (params: Record<string, unknown>) => {
+      calls.push(params);
+      return {
+        content: [{ type: "text", text: "Short summary" }],
+      };
+    },
+    callGateway: async () => ({}),
+    resolveModel: (modelRef?: string, providerHint?: string) => ({
+      provider: providerHint?.trim() || "openrouter",
+      model: modelRef?.trim() || "minimax/minimax-m2.7",
+    }),
+    getApiKey: async () => "test-key",
+    requireApiKey: async () => "test-key",
+    parseAgentSessionKey: () => null,
+    isSubagentSessionKey: () => false,
+    normalizeAgentId: (id?: string) => id ?? "main",
+    buildSubagentSystemPrompt: () => "",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => "/tmp/lcm-test",
+    resolveSessionIdFromSessionKey: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    ...overrides,
+  };
+
+  return {
+    deps,
+    calls,
+  };
+}
+
+describe("resolveEffectiveReasoning", () => {
+  it("prefers an explicit reasoning setting over the supported-model default", () => {
+    expect(
+      resolveEffectiveReasoning({
+        reasoning: "high",
+        reasoningIfSupported: "low",
+        modelSupportsReasoning: true,
+      }),
+    ).toBe("high");
+  });
+
+  it("only applies the default when the model supports reasoning", () => {
+    expect(
+      resolveEffectiveReasoning({
+        reasoning: undefined,
+        reasoningIfSupported: "low",
+        modelSupportsReasoning: true,
+      }),
+    ).toBe("low");
+
+    expect(
+      resolveEffectiveReasoning({
+        reasoning: undefined,
+        reasoningIfSupported: "low",
+        modelSupportsReasoning: false,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("createLcmSummarizeFromLegacyParams", () => {
+  it("requests a low default reasoning budget for the initial summarizer call", async () => {
+    const { deps, calls } = createDeps();
+    const summarizer = await createLcmSummarizeFromLegacyParams({
+      deps: deps as never,
+      legacyParams: {
+        provider: "openrouter",
+        model: "minimax/minimax-m2.7",
+        config: {},
+      },
+    });
+
+    expect(summarizer).toBeDefined();
+    const summary = await summarizer!.fn("Summarize this conversation.");
+
+    expect(summary).toBe("Short summary");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.reasoning).toBeUndefined();
+    expect(calls[0]?.reasoningIfSupported).toBe("low");
+  });
+
+  it("keeps the explicit low retry reasoning while preserving the same supported-model default", async () => {
+    const { deps, calls } = createDeps({
+      complete: async (params: Record<string, unknown>) => {
+        calls.push(params);
+        if (calls.length === 1) {
+          return { content: [] };
+        }
+        return { content: [{ type: "text", text: "Recovered summary" }] };
+      },
+    });
+
+    const summarizer = await createLcmSummarizeFromLegacyParams({
+      deps: deps as never,
+      legacyParams: {
+        provider: "openrouter",
+        model: "minimax/minimax-m2.7",
+        config: {},
+      },
+    });
+
+    expect(summarizer).toBeDefined();
+    const summary = await summarizer!.fn("Summarize this conversation.");
+
+    expect(summary).toBe("Recovered summary");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.reasoning).toBeUndefined();
+    expect(calls[0]?.reasoningIfSupported).toBe("low");
+    expect(calls[1]?.reasoning).toBe("low");
+    expect(calls[1]?.reasoningIfSupported).toBe("low");
+  });
+});


### PR DESCRIPTION
## Summary

Hi! This PR fixes an LCM summarizer edge case for reasoning-capable models.

If the initial summarizer request omits a reasoning setting, some provider compatibility layers can normalize that into a reasoning-disabled request. Some models do not support turning reasoning off, so the first request fails and only the retry succeeds.

I first noticed this with `openrouter/minimax/minimax-m2.7`, but the issue is more general than one specific model.

## What changed

- add a small `reasoningIfSupported` option to the completion bridge
- keep explicit `reasoning` values unchanged and give them priority
- apply the fallback only when the resolved model advertises reasoning support
- update the LCM summarizer to send `reasoningIfSupported: "low"` on the initial request
- keep the existing explicit retry behavior unchanged
- add focused tests and a patch changeset

## Why this approach

This keeps the fix narrow and model-aware.

It avoids a model-specific special case, preserves explicit caller intent, and does not force reasoning on models that do not support it.

## Testing

- `npx vitest run test/index-complete-model-auth.test.ts test/summarize.test.ts test/lcm-summarizer-reasoning.test.ts`

Thanks very much for taking a look.