### PR TITLE
[codex] Harden session-key admission and ignored rollovers

### DIFF
--- a/.changeset/pr372-session-admission.md
+++ b/.changeset/pr372-session-admission.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip `session_end` rollover when either the current or next session key is ignored or stateless, and avoid reusing archived conversations by `sessionId` alone when no `sessionKey` is available.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4315,6 +4315,13 @@ export class LcmContextEngine implements ContextEngine {
     if (this.isStatelessSession(params.sessionKey ?? params.nextSessionKey)) {
       return;
     }
+    const nextSessionKey = params.nextSessionKey?.trim() || undefined;
+    if (nextSessionKey && this.shouldIgnoreSession({ sessionKey: nextSessionKey })) {
+      return;
+    }
+    if (nextSessionKey && this.isStatelessSession(nextSessionKey)) {
+      return;
+    }
 
     const createReplacement = reason !== "deleted";
     this.ensureMigrated();

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -387,7 +387,10 @@ export class ConversationStore {
     const existing = await this.getConversationBySessionId(sessionId);
     if (existing) {
       if (!normalizedSessionKey) {
-        return existing;
+        if (existing.active) {
+          return existing;
+        }
+        return this.createConversation({ sessionId, title: opts.title });
       }
       if (existing.active && !existing.sessionKey) {
         this.db

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -891,6 +891,23 @@ describe("ConversationStore session reuse", () => {
     const refreshed = await store.getConversation(conv1.conversationId);
     expect(refreshed?.sessionId).toBe("uuid-2");
   });
+
+  it("does not reuse archived conversations by sessionId alone when sessionKey is missing", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+    await store.archiveConversation(original.conversationId);
+
+    const recycled = await store.getOrCreateConversation("uuid-1");
+
+    expect(recycled.conversationId).not.toBe(original.conversationId);
+    expect(recycled.active).toBe(true);
+    expect((await store.getConversation(original.conversationId))?.active).toBe(false);
+  });
 });
 
 describe("LcmContextEngine before_reset lifecycle", () => {
@@ -1249,6 +1266,36 @@ describe("LcmContextEngine session_end lifecycle", () => {
 
     expect(firstFresh?.conversationId).not.toBe(original.conversationId);
     expect(secondFresh?.conversationId).toBe(firstFresh?.conversationId);
+  });
+
+  it("leaves the current conversation active when the next session key is ignored", async () => {
+    const engine = createEngineWithConfig({
+      ignoreSessionPatterns: ["agent:workspace-support:**"],
+    });
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+
+    const original = await store.getOrCreateConversation("uuid-1", {
+      sessionKey: "agent:main:main",
+    });
+
+    await engine.handleSessionEnd({
+      reason: "idle",
+      sessionId: "uuid-1",
+      sessionKey: "agent:main:main",
+      nextSessionId: "uuid-2",
+      nextSessionKey: "agent:workspace-support:main",
+    });
+
+    const active = await store.getConversationBySessionKey("agent:main:main");
+    const ignored = await store.getConversationBySessionKey("agent:workspace-support:main");
+    const archived = await store.getConversation(original.conversationId);
+
+    expect(active?.conversationId).toBe(original.conversationId);
+    expect(active?.active).toBe(true);
+    expect(ignored).toBeNull();
+    expect(archived?.active).toBe(true);
+    expect(archived?.archivedAt).toBeNull();
   });
 });
 


### PR DESCRIPTION
Partial fix for #372 — follow-up tracked in #382.

## Summary
- Skip `session_end` rollover when either the current or next session key is ignored or stateless.
- Stop reusing archived conversations by `sessionId` alone when no `sessionKey` is available.

## Why
The `workspace-support` incident in #372 had two attack vectors. This PR lands the two fixes that are safe without changing the `sessionKey` contract:
- **Archived-row reuse** — `getOrCreateConversation` was returning archived conversations looked up by `sessionId`, which allowed a new turn to re-animate an already-archived row when the caller provided no `sessionKey`. It now creates a fresh conversation instead.
- **Ignored-next-key rollover** — `handleSessionEnd` only checked ignore/stateless patterns against the *current* session key. If the incoming turn was allowed but rolled over into an ignored next session, we still created a replacement conversation for the ignored session. It now also skips the rollover when `nextSessionKey` matches an ignore/stateless pattern.

## What this PR does NOT do (and why)
An earlier version of this PR added `requireWritableSessionKey()` which made every mutating engine hook (`bootstrap`, `ingest`, `ingestBatch`, `afterTurn`, `maintain`, `compact`, `compactLeafAsync`, `handleBeforeReset`, `handleSessionEnd`) fail closed with a warning when `sessionKey` was missing. That logic was dropped because:

- The engine interface (`ContextEngine` from `@openclaw/plugin-sdk`) still types `sessionKey?: string` on every method. We can't tighten it locally without breaking `implements ContextEngine`.
- OpenClaw's own runtime (`pi-embedded-runner/run/attempt.ts:338`) falls back to `sessionKey = sessionId` when a key is not provided. Even with fail-closed gating, the engine would see a non-empty "sessionKey" that happens to be a bare UUID and write anyway — the bare-UUID can't match `agent:workspace-support:**` and the ignore pattern silently bypasses.
- The tests masked both facts by wrapping every engine instance in a `withDefaultSessionKeys` helper that auto-synthesized `agent:main:<sessionId>` on every call, so the suite never exercised the undefined case and never exercised the bare-UUID case either.

The real fix is tightening the sessionKey contract in OpenClaw itself (or adding pattern-format validation to `shouldIgnoreSession` as a local defense). #382 tracks that work.

## Validation
- `npm test` — 666 tests pass (39 files)
- Diff vs `main`: `+63 / -1` across 4 files
- Files touched: `src/engine.ts`, `src/store/conversation-store.ts`, `test/engine.test.ts`, `.changeset/pr372-session-admission.md`
- New regression tests:
  - `ConversationStore session reuse > does not reuse archived conversations by sessionId alone when sessionKey is missing`
  - `LcmContextEngine session_end lifecycle > leaves the current conversation active when the next session key is ignored`