### PR TITLE
[codex] Add session pattern config diagnostics

### DIFF
--- a/.changeset/pr373-config-diagnostics.md
+++ b/.changeset/pr373-config-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add startup diagnostics that attribute resolved ignore/stateless pattern sources, and warn when env-backed pattern arrays override plugin config arrays.

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -29,6 +29,15 @@ export type DynamicLeafChunkTokensConfig = {
   max: number;
 };
 
+export type LcmConfigSource = "env" | "plugin-config" | "default";
+
+export type LcmConfigDiagnostics = {
+  ignoreSessionPatternsSource: LcmConfigSource;
+  statelessSessionPatternsSource: LcmConfigSource;
+  ignoreSessionPatternsEnvOverridesPluginConfig: boolean;
+  statelessSessionPatternsEnvOverridesPluginConfig: boolean;
+};
+
 export type LcmConfig = {
   enabled: boolean;
   databasePath: string;
@@ -193,16 +202,64 @@ function toRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-/**
- * Resolve LCM configuration with three-tier precedence:
- *   1. Environment variables (highest — backward compat)
- *   2. Plugin config object (from plugins.entries.lossless-claw.config)
- *   3. Hardcoded defaults (lowest)
- */
-export function resolveLcmConfig(
+function parseEnvStrArray(value: string | undefined): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function resolvePatternArray(params: {
+  envValue: string | undefined;
+  pluginValue: unknown;
+}): {
+  patterns: string[];
+  source: LcmConfigSource;
+  envOverridesPluginConfig: boolean;
+} {
+  const pluginPatterns = toStrArray(params.pluginValue);
+  const pluginHasPatterns = (pluginPatterns?.length ?? 0) > 0;
+  if (params.envValue !== undefined) {
+    return {
+      patterns: parseEnvStrArray(params.envValue) ?? [],
+      source: "env",
+      envOverridesPluginConfig: pluginHasPatterns,
+    };
+  }
+
+  if (pluginPatterns !== undefined) {
+    return {
+      patterns: pluginPatterns,
+      source: "plugin-config",
+      envOverridesPluginConfig: false,
+    };
+  }
+
+  return {
+    patterns: [],
+    source: "default",
+    envOverridesPluginConfig: false,
+  };
+}
+
+export function describeLcmConfigSource(source: LcmConfigSource): string {
+  switch (source) {
+    case "env":
+      return "env";
+    case "plugin-config":
+      return "plugin config";
+    case "default":
+      return "defaults";
+  }
+}
+
+export function resolveLcmConfigWithDiagnostics(
   env: NodeJS.ProcessEnv = process.env,
   pluginConfig?: Record<string, unknown>,
-): LcmConfig {
+): { config: LcmConfig; diagnostics: LcmConfigDiagnostics } {
   const pc = pluginConfig ?? {};
   const cacheAwareCompaction = toRecord(pc.cacheAwareCompaction);
   const dynamicLeafChunkTokens = toRecord(pc.dynamicLeafChunkTokens);
@@ -239,135 +296,154 @@ export function resolveLcmConfig(
     ),
   );
 
+  const ignoreSessionPatterns = resolvePatternArray({
+    envValue: env.LCM_IGNORE_SESSION_PATTERNS,
+    pluginValue: pc.ignoreSessionPatterns,
+  });
+  const statelessSessionPatterns = resolvePatternArray({
+    envValue: env.LCM_STATELESS_SESSION_PATTERNS,
+    pluginValue: pc.statelessSessionPatterns,
+  });
+
   return {
-    enabled:
-      env.LCM_ENABLED !== undefined
-        ? env.LCM_ENABLED !== "false"
-        : toBool(pc.enabled) ?? true,
-    databasePath:
-      env.LCM_DATABASE_PATH
-      ?? toStr(pc.dbPath)
-      ?? toStr(pc.databasePath)
-      ?? join(resolveOpenclawStateDir(env), "lcm.db"),
-    largeFilesDir:
-      env.LCM_LARGE_FILES_DIR?.trim()
-      ?? toStr(pc.largeFilesDir)
-      ?? join(resolveOpenclawStateDir(env), "lcm-files"),
-    ignoreSessionPatterns:
-      env.LCM_IGNORE_SESSION_PATTERNS !== undefined
-        ? env.LCM_IGNORE_SESSION_PATTERNS
-          .split(",")
-          .map((entry) => entry.trim())
-          .filter(Boolean)
-        : toStrArray(pc.ignoreSessionPatterns) ?? [],
-    statelessSessionPatterns:
-      env.LCM_STATELESS_SESSION_PATTERNS !== undefined
-        ? env.LCM_STATELESS_SESSION_PATTERNS
-          .split(",")
-          .map((entry) => entry.trim())
-          .filter(Boolean)
-        : toStrArray(pc.statelessSessionPatterns) ?? [],
-    skipStatelessSessions:
-      env.LCM_SKIP_STATELESS_SESSIONS !== undefined
-        ? env.LCM_SKIP_STATELESS_SESSIONS === "true"
-        : toBool(pc.skipStatelessSessions) ?? true,
-    contextThreshold:
-      parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
-        ?? toNumber(pc.contextThreshold) ?? 0.75,
-    freshTailCount:
-      parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
-        ?? toNumber(pc.freshTailCount) ?? 64,
-    newSessionRetainDepth:
-      parseFiniteInt(env.LCM_NEW_SESSION_RETAIN_DEPTH)
-        ?? toNumber(pc.newSessionRetainDepth) ?? 2,
-    leafMinFanout:
-      parseFiniteInt(env.LCM_LEAF_MIN_FANOUT)
-        ?? toNumber(pc.leafMinFanout) ?? 8,
-    condensedMinFanout:
-      parseFiniteInt(env.LCM_CONDENSED_MIN_FANOUT)
-        ?? toNumber(pc.condensedMinFanout) ?? 4,
-    condensedMinFanoutHard:
-      parseFiniteInt(env.LCM_CONDENSED_MIN_FANOUT_HARD)
-        ?? toNumber(pc.condensedMinFanoutHard) ?? 2,
-    incrementalMaxDepth:
-      parseFiniteInt(env.LCM_INCREMENTAL_MAX_DEPTH)
-        ?? toNumber(pc.incrementalMaxDepth) ?? 1,
-    leafChunkTokens: resolvedLeafChunkTokens,
-    bootstrapMaxTokens: resolvedBootstrapMaxTokens,
-    leafTargetTokens:
-      parseFiniteInt(env.LCM_LEAF_TARGET_TOKENS)
-        ?? toNumber(pc.leafTargetTokens) ?? 2400,
-    condensedTargetTokens:
-      parseFiniteInt(env.LCM_CONDENSED_TARGET_TOKENS)
-        ?? toNumber(pc.condensedTargetTokens) ?? 2000,
-    maxExpandTokens:
-      parseFiniteInt(env.LCM_MAX_EXPAND_TOKENS)
-        ?? toNumber(pc.maxExpandTokens) ?? 4000,
-    largeFileTokenThreshold:
-      parseFiniteInt(env.LCM_LARGE_FILE_TOKEN_THRESHOLD)
-        ?? toNumber(pc.largeFileThresholdTokens)
-        ?? toNumber(pc.largeFileTokenThreshold)
-        ?? 25000,
-    summaryProvider:
-      env.LCM_SUMMARY_PROVIDER?.trim() ?? toStr(pc.summaryProvider) ?? "",
-    summaryModel:
-      env.LCM_SUMMARY_MODEL?.trim() ?? toStr(pc.summaryModel) ?? "",
-    largeFileSummaryProvider:
-      env.LCM_LARGE_FILE_SUMMARY_PROVIDER?.trim() ?? toStr(pc.largeFileSummaryProvider) ?? "",
-    largeFileSummaryModel:
-      env.LCM_LARGE_FILE_SUMMARY_MODEL?.trim() ?? toStr(pc.largeFileSummaryModel) ?? "",
-    expansionProvider:
-      env.LCM_EXPANSION_PROVIDER?.trim() ?? toStr(pc.expansionProvider) ?? "",
-    expansionModel:
-      env.LCM_EXPANSION_MODEL?.trim() ?? toStr(pc.expansionModel) ?? "",
-    delegationTimeoutMs: envDelegationTimeoutMs ?? toNumber(pc.delegationTimeoutMs) ?? 120000,
-    summaryTimeoutMs:
-      parseFiniteInt(env.LCM_SUMMARY_TIMEOUT_MS)
-        ?? toNumber(pc.summaryTimeoutMs) ?? 60000,
-    timezone: env.TZ ?? toStr(pc.timezone) ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
-    pruneHeartbeatOk:
-      env.LCM_PRUNE_HEARTBEAT_OK !== undefined
-        ? env.LCM_PRUNE_HEARTBEAT_OK === "true"
-        : toBool(pc.pruneHeartbeatOk) ?? false,
-    transcriptGcEnabled:
-      env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
-        ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"
-        : toBool(pc.transcriptGcEnabled) ?? false,
-    maxAssemblyTokenBudget:
-      parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)
-        ?? toNumber(pc.maxAssemblyTokenBudget) ?? undefined,
-    summaryMaxOverageFactor:
-      parseFiniteNumber(env.LCM_SUMMARY_MAX_OVERAGE_FACTOR)
-        ?? toNumber(pc.summaryMaxOverageFactor) ?? 3,
-    customInstructions:
-      env.LCM_CUSTOM_INSTRUCTIONS?.trim() ?? toStr(pc.customInstructions) ?? "",
-    circuitBreakerThreshold:
-      parseFiniteInt(env.LCM_CIRCUIT_BREAKER_THRESHOLD)
-        ?? toNumber(pc.circuitBreakerThreshold) ?? 5,
-    circuitBreakerCooldownMs:
-      parseFiniteInt(env.LCM_CIRCUIT_BREAKER_COOLDOWN_MS)
-        ?? toNumber(pc.circuitBreakerCooldownMs) ?? 1_800_000,
-    fallbackProviders:
-      parseFallbackProviders(env.LCM_FALLBACK_PROVIDERS)
-        ?? toFallbackProviderArray(pc.fallbackProviders) ?? [],
-    cacheAwareCompaction: {
+    config: {
       enabled:
-        env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== undefined
-          ? env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== "false"
-          : toBool(cacheAwareCompaction?.enabled) ?? true,
-      maxColdCacheCatchupPasses:
-        parseFiniteInt(env.LCM_MAX_COLD_CACHE_CATCHUP_PASSES)
-          ?? toNumber(cacheAwareCompaction?.maxColdCacheCatchupPasses)
-          ?? 2,
-      hotCachePressureFactor: resolvedHotCachePressureFactor,
-      hotCacheBudgetHeadroomRatio: resolvedHotCacheBudgetHeadroomRatio,
+        env.LCM_ENABLED !== undefined
+          ? env.LCM_ENABLED !== "false"
+          : toBool(pc.enabled) ?? true,
+      databasePath:
+        env.LCM_DATABASE_PATH
+        ?? toStr(pc.dbPath)
+        ?? toStr(pc.databasePath)
+        ?? join(resolveOpenclawStateDir(env), "lcm.db"),
+      largeFilesDir:
+        env.LCM_LARGE_FILES_DIR?.trim()
+        ?? toStr(pc.largeFilesDir)
+        ?? join(resolveOpenclawStateDir(env), "lcm-files"),
+      ignoreSessionPatterns: ignoreSessionPatterns.patterns,
+      statelessSessionPatterns: statelessSessionPatterns.patterns,
+      skipStatelessSessions:
+        env.LCM_SKIP_STATELESS_SESSIONS !== undefined
+          ? env.LCM_SKIP_STATELESS_SESSIONS === "true"
+          : toBool(pc.skipStatelessSessions) ?? true,
+      contextThreshold:
+        parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
+          ?? toNumber(pc.contextThreshold) ?? 0.75,
+      freshTailCount:
+        parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
+          ?? toNumber(pc.freshTailCount) ?? 64,
+      newSessionRetainDepth:
+        parseFiniteInt(env.LCM_NEW_SESSION_RETAIN_DEPTH)
+          ?? toNumber(pc.newSessionRetainDepth) ?? 2,
+      leafMinFanout:
+        parseFiniteInt(env.LCM_LEAF_MIN_FANOUT)
+          ?? toNumber(pc.leafMinFanout) ?? 8,
+      condensedMinFanout:
+        parseFiniteInt(env.LCM_CONDENSED_MIN_FANOUT)
+          ?? toNumber(pc.condensedMinFanout) ?? 4,
+      condensedMinFanoutHard:
+        parseFiniteInt(env.LCM_CONDENSED_MIN_FANOUT_HARD)
+          ?? toNumber(pc.condensedMinFanoutHard) ?? 2,
+      incrementalMaxDepth:
+        parseFiniteInt(env.LCM_INCREMENTAL_MAX_DEPTH)
+          ?? toNumber(pc.incrementalMaxDepth) ?? 1,
+      leafChunkTokens: resolvedLeafChunkTokens,
+      bootstrapMaxTokens: resolvedBootstrapMaxTokens,
+      leafTargetTokens:
+        parseFiniteInt(env.LCM_LEAF_TARGET_TOKENS)
+          ?? toNumber(pc.leafTargetTokens) ?? 2400,
+      condensedTargetTokens:
+        parseFiniteInt(env.LCM_CONDENSED_TARGET_TOKENS)
+          ?? toNumber(pc.condensedTargetTokens) ?? 2000,
+      maxExpandTokens:
+        parseFiniteInt(env.LCM_MAX_EXPAND_TOKENS)
+          ?? toNumber(pc.maxExpandTokens) ?? 4000,
+      largeFileTokenThreshold:
+        parseFiniteInt(env.LCM_LARGE_FILE_TOKEN_THRESHOLD)
+          ?? toNumber(pc.largeFileThresholdTokens)
+          ?? toNumber(pc.largeFileTokenThreshold)
+          ?? 25000,
+      summaryProvider:
+        env.LCM_SUMMARY_PROVIDER?.trim() ?? toStr(pc.summaryProvider) ?? "",
+      summaryModel:
+        env.LCM_SUMMARY_MODEL?.trim() ?? toStr(pc.summaryModel) ?? "",
+      largeFileSummaryProvider:
+        env.LCM_LARGE_FILE_SUMMARY_PROVIDER?.trim() ?? toStr(pc.largeFileSummaryProvider) ?? "",
+      largeFileSummaryModel:
+        env.LCM_LARGE_FILE_SUMMARY_MODEL?.trim() ?? toStr(pc.largeFileSummaryModel) ?? "",
+      expansionProvider:
+        env.LCM_EXPANSION_PROVIDER?.trim() ?? toStr(pc.expansionProvider) ?? "",
+      expansionModel:
+        env.LCM_EXPANSION_MODEL?.trim() ?? toStr(pc.expansionModel) ?? "",
+      delegationTimeoutMs: envDelegationTimeoutMs ?? toNumber(pc.delegationTimeoutMs) ?? 120000,
+      summaryTimeoutMs:
+        parseFiniteInt(env.LCM_SUMMARY_TIMEOUT_MS)
+          ?? toNumber(pc.summaryTimeoutMs) ?? 60000,
+      timezone: env.TZ ?? toStr(pc.timezone) ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+      pruneHeartbeatOk:
+        env.LCM_PRUNE_HEARTBEAT_OK !== undefined
+          ? env.LCM_PRUNE_HEARTBEAT_OK === "true"
+          : toBool(pc.pruneHeartbeatOk) ?? false,
+      transcriptGcEnabled:
+        env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
+          ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"
+          : toBool(pc.transcriptGcEnabled) ?? false,
+      maxAssemblyTokenBudget:
+        parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)
+          ?? toNumber(pc.maxAssemblyTokenBudget) ?? undefined,
+      summaryMaxOverageFactor:
+        parseFiniteNumber(env.LCM_SUMMARY_MAX_OVERAGE_FACTOR)
+          ?? toNumber(pc.summaryMaxOverageFactor) ?? 3,
+      customInstructions:
+        env.LCM_CUSTOM_INSTRUCTIONS?.trim() ?? toStr(pc.customInstructions) ?? "",
+      circuitBreakerThreshold:
+        parseFiniteInt(env.LCM_CIRCUIT_BREAKER_THRESHOLD)
+          ?? toNumber(pc.circuitBreakerThreshold) ?? 5,
+      circuitBreakerCooldownMs:
+        parseFiniteInt(env.LCM_CIRCUIT_BREAKER_COOLDOWN_MS)
+          ?? toNumber(pc.circuitBreakerCooldownMs) ?? 1_800_000,
+      fallbackProviders:
+        parseFallbackProviders(env.LCM_FALLBACK_PROVIDERS)
+          ?? toFallbackProviderArray(pc.fallbackProviders) ?? [],
+      cacheAwareCompaction: {
+        enabled:
+          env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== undefined
+            ? env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== "false"
+            : toBool(cacheAwareCompaction?.enabled) ?? true,
+        maxColdCacheCatchupPasses:
+          parseFiniteInt(env.LCM_MAX_COLD_CACHE_CATCHUP_PASSES)
+            ?? toNumber(cacheAwareCompaction?.maxColdCacheCatchupPasses)
+            ?? 2,
+        hotCachePressureFactor: resolvedHotCachePressureFactor,
+        hotCacheBudgetHeadroomRatio: resolvedHotCacheBudgetHeadroomRatio,
+      },
+      dynamicLeafChunkTokens: {
+        enabled:
+          env.LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED !== undefined
+            ? env.LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED === "true"
+            : toBool(dynamicLeafChunkTokens?.enabled) ?? true,
+        max: resolvedDynamicLeafChunkMax,
+      },
     },
-    dynamicLeafChunkTokens: {
-      enabled:
-        env.LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED !== undefined
-          ? env.LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED === "true"
-          : toBool(dynamicLeafChunkTokens?.enabled) ?? true,
-      max: resolvedDynamicLeafChunkMax,
+    diagnostics: {
+      ignoreSessionPatternsSource: ignoreSessionPatterns.source,
+      statelessSessionPatternsSource: statelessSessionPatterns.source,
+      ignoreSessionPatternsEnvOverridesPluginConfig: ignoreSessionPatterns.envOverridesPluginConfig,
+      statelessSessionPatternsEnvOverridesPluginConfig:
+        statelessSessionPatterns.envOverridesPluginConfig,
     },
   };
+}
+
+/**
+ * Resolve LCM configuration with three-tier precedence:
+ *   1. Environment variables (highest — backward compat)
+ *   2. Plugin config object (from plugins.entries.lossless-claw.config)
+ *   3. Hardcoded defaults (lowest)
+ */
+export function resolveLcmConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  pluginConfig?: Record<string, unknown>,
+): LcmConfig {
+  return resolveLcmConfigWithDiagnostics(env, pluginConfig).config;
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -43,6 +43,7 @@ import {
   parseFileBlocks,
 } from "./large-files.js";
 import { describeLogError } from "./lcm-log.js";
+import { describeLcmConfigSource } from "./db/config.js";
 import { RetrievalEngine } from "./retrieval.js";
 import { compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
 import { logStartupBannerOnce } from "./startup-banner-log.js";
@@ -1298,17 +1299,24 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
     if (this.config.ignoreSessionPatterns.length > 0) {
+      const source = describeLcmConfigSource(
+        this.deps.configDiagnostics?.ignoreSessionPatternsSource ?? "default",
+      );
       logStartupBannerOnce({
         key: "ignore-session-patterns",
         log: (message) => this.deps.log.info(message),
-        message: `[lcm] Ignoring sessions matching ${this.config.ignoreSessionPatterns.length} pattern(s): ${this.config.ignoreSessionPatterns.join(", ")}`,
+        message: `[lcm] Ignoring sessions matching ${this.config.ignoreSessionPatterns.length} pattern(s) from ${source}: ${this.config.ignoreSessionPatterns.join(", ")}`,
       });
     }
-    if (this.config.skipStatelessSessions && this.config.statelessSessionPatterns.length > 0) {
+    if (this.config.statelessSessionPatterns.length > 0) {
+      const source = describeLcmConfigSource(
+        this.deps.configDiagnostics?.statelessSessionPatternsSource ?? "default",
+      );
+      const enforcement = this.config.skipStatelessSessions ? "" : " (skipStatelessSessions=false)";
       logStartupBannerOnce({
         key: "stateless-session-patterns",
         log: (message) => this.deps.log.info(message),
-        message: `[lcm] Stateless session patterns: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
+        message: `[lcm] Stateless session patterns${enforcement} from ${source}: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
       });
     }
     this.assembler = new ContextAssembler(

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveLcmConfig, resolveOpenclawStateDir } from "../db/config.js";
+import { resolveLcmConfigWithDiagnostics, resolveOpenclawStateDir } from "../db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection, normalizePath } from "../db/connection.js";
 import { LcmContextEngine } from "../engine.js";
 import { createLcmLogger, describeLogError } from "../lcm-log.js";
@@ -1283,8 +1283,25 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
   const modelAuth = getRuntimeModelAuth(api);
   const readEnv: ReadEnvFn = (key) => process.env[key];
   const pluginConfig = resolvePluginConfig(api);
-  const config = resolveLcmConfig(process.env, pluginConfig);
   const log = createLcmLogger(api);
+  const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
+
+  if (diagnostics.ignoreSessionPatternsEnvOverridesPluginConfig) {
+    logStartupBannerOnce({
+      key: "ignore-session-patterns-env-override",
+      log: (message) => log.warn(message),
+      message:
+        "[lcm] LCM_IGNORE_SESSION_PATTERNS from env overrides plugins.entries.lossless-claw.config.ignoreSessionPatterns; plugin config array will be ignored",
+    });
+  }
+  if (diagnostics.statelessSessionPatternsEnvOverridesPluginConfig) {
+    logStartupBannerOnce({
+      key: "stateless-session-patterns-env-override",
+      log: (message) => log.warn(message),
+      message:
+        "[lcm] LCM_STATELESS_SESSION_PATTERNS from env overrides plugins.entries.lossless-claw.config.statelessSessionPatterns; plugin config array will be ignored",
+    });
+  }
 
   // Read model overrides from plugin config
   if (pluginConfig) {
@@ -1368,6 +1385,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
 
   return {
     config,
+    configDiagnostics: diagnostics,
     isRuntimeManagedAuthProvider: (provider: string, providerApi?: string) => {
       const normalizedProvider = normalizeProviderId(provider);
       if (normalizedProvider === "openai-codex" || normalizedProvider === "github-copilot") {
@@ -1873,7 +1891,7 @@ const lcmPlugin = {
         value && typeof value === "object" && !Array.isArray(value)
           ? (value as Record<string, unknown>)
           : {};
-      return resolveLcmConfig(process.env, raw);
+      return resolveLcmConfigWithDiagnostics(process.env, raw).config;
     },
   },
 

--- a/src/startup-banner-log.ts
+++ b/src/startup-banner-log.ts
@@ -5,6 +5,8 @@ type StartupBannerKey =
   | "transcript-gc-enabled"
   | "ignore-session-patterns"
   | "stateless-session-patterns"
+  | "ignore-session-patterns-env-override"
+  | "stateless-session-patterns-env-override"
   | "state-dir";
 
 type StartupBannerLogState = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LcmConfig } from "./db/config.js";
+import type { LcmConfigDiagnostics } from "./db/config.js";
 
 /**
  * Minimal LLM completion interface needed by LCM for summarization.
@@ -106,6 +107,9 @@ export type IsSubagentSessionKeyFn = (sessionKey: string) => boolean;
 export interface LcmDependencies {
   /** LCM configuration (from env vars + plugin config) */
   config: LcmConfig;
+
+  /** Optional config resolution metadata for startup diagnostics. */
+  configDiagnostics?: LcmConfigDiagnostics;
 
   /** LLM completion function for summarization */
   complete: CompleteFn;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import manifest from "../openclaw.plugin.json" with { type: "json" };
-import { resolveLcmConfig, resolveOpenclawStateDir } from "../src/db/config.js";
+import {
+  resolveLcmConfig,
+  resolveLcmConfigWithDiagnostics,
+  resolveOpenclawStateDir,
+} from "../src/db/config.js";
 
 describe("resolveLcmConfig", () => {
   it("ships the bundled lossless-claw skill path in the manifest", () => {
@@ -157,6 +161,31 @@ describe("resolveLcmConfig", () => {
     expect(config.dynamicLeafChunkTokens).toEqual({
       enabled: true,
       max: 60000,
+    });
+  });
+
+  it("reports session pattern sources and env override diagnostics", () => {
+    const { config, diagnostics } = resolveLcmConfigWithDiagnostics(
+      {
+        LCM_IGNORE_SESSION_PATTERNS: "agent:*:cron:*, agent:main:subagent:**",
+        LCM_STATELESS_SESSION_PATTERNS: "agent:*:ephemeral:**",
+      } as NodeJS.ProcessEnv,
+      {
+        ignoreSessionPatterns: ["agent:*:test:*"],
+        statelessSessionPatterns: ["agent:*:preview:*"],
+      },
+    );
+
+    expect(config.ignoreSessionPatterns).toEqual([
+      "agent:*:cron:*",
+      "agent:main:subagent:**",
+    ]);
+    expect(config.statelessSessionPatterns).toEqual(["agent:*:ephemeral:**"]);
+    expect(diagnostics).toEqual({
+      ignoreSessionPatternsSource: "env",
+      statelessSessionPatternsSource: "env",
+      ignoreSessionPatternsEnvOverridesPluginConfig: true,
+      statelessSessionPatternsEnvOverridesPluginConfig: true,
     });
   });
 

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -225,12 +225,45 @@ describe("lcm plugin registration", () => {
     );
     expect(infoLog).toHaveBeenCalledWith("[lcm] Transcript GC enabled (default false)");
     expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Ignoring sessions matching 2 pattern(s) from plugin config: agent:*:cron:**, agent:main:subagent:**",
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Stateless session patterns from plugin config: 1 pattern(s): agent:*:subagent:**",
+    );
+    expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Compaction summarization model: (unconfigured)",
     );
     expect(sessionInfoLog).not.toHaveBeenCalled();
     expect(debugLog).toHaveBeenCalledWith(expect.stringContaining("[lcm] Migration successful"));
     expect(api.on).toHaveBeenCalledWith("before_reset", expect.any(Function));
     expect(api.on).toHaveBeenCalledWith("session_end", expect.any(Function));
+  });
+
+  it("logs env-backed pattern sources and override warnings during register", () => {
+    vi.stubEnv("LCM_IGNORE_SESSION_PATTERNS", "agent:*:cron:*, agent:main:subagent:**");
+    vi.stubEnv("LCM_STATELESS_SESSION_PATTERNS", "agent:*:ephemeral:**");
+
+    const { api, infoLog, warnLog } = buildApi({
+      enabled: true,
+      ignoreSessionPatterns: ["agent:*:test:*"],
+      statelessSessionPatterns: ["agent:*:preview:*"],
+      skipStatelessSessions: true,
+    });
+
+    lcmPlugin.register(api);
+
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Ignoring sessions matching 2 pattern(s) from env: agent:*:cron:*, agent:main:subagent:**",
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Stateless session patterns from env: 1 pattern(s): agent:*:ephemeral:**",
+    );
+    expect(warnLog).toHaveBeenCalledWith(
+      "[lcm] LCM_IGNORE_SESSION_PATTERNS from env overrides plugins.entries.lossless-claw.config.ignoreSessionPatterns; plugin config array will be ignored",
+    );
+    expect(warnLog).toHaveBeenCalledWith(
+      "[lcm] LCM_STATELESS_SESSION_PATTERNS from env overrides plugins.entries.lossless-claw.config.statelessSessionPatterns; plugin config array will be ignored",
+    );
   });
 
   it.each([
@@ -542,8 +575,8 @@ describe("lcm plugin registration", () => {
         "[lcm] Plugin loaded (enabled=true, db=",
         "[lcm] Transcript GC ",
         "[lcm] Compaction summarization model:",
-        "[lcm] Ignoring sessions matching",
-        "[lcm] Stateless session patterns:",
+        "[lcm] Ignoring sessions matching ",
+        "[lcm] Stateless session patterns",
       ].some((prefix) => message.startsWith(prefix)),
     );
 
@@ -551,8 +584,8 @@ describe("lcm plugin registration", () => {
       `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
       "[lcm] Transcript GC disabled (default false)",
       "[lcm] Compaction summarization model: (unconfigured)",
-      "[lcm] Ignoring sessions matching 2 pattern(s): agent:*:cron:**, agent:main:subagent:**",
-      "[lcm] Stateless session patterns: 1 pattern(s): agent:*:subagent:**",
+      "[lcm] Ignoring sessions matching 2 pattern(s) from plugin config: agent:*:cron:**, agent:main:subagent:**",
+      "[lcm] Stateless session patterns from plugin config: 1 pattern(s): agent:*:subagent:**",
     ].sort());
     expect(firstSessionMessages).toEqual([]);
     expect(secondSessionMessages).toEqual([]);


### PR DESCRIPTION
Closes #373

## Summary
- add source diagnostics for `ignoreSessionPatterns` and `statelessSessionPatterns`
- warn explicitly when env-backed pattern arrays replace plugin-config arrays
- carry config diagnostics into the engine so startup banners can attribute pattern sources
- extend config and plugin-registration tests for diagnostics, precedence, and logging

## Why
The workspace-support incident was harder to debug because runtime logs did not say where the resolved ignore/stateless patterns came from, and env overrides could silently replace plugin-config arrays.

## Validation
- `npm test`
- stacked validation branch: `npm test`
- isolated OpenClaw 2026.4.9 profile startup logged the full ignore/stateless pattern set from plugin config and showed the profile-local LCM DB path


Companion OpenClaw issue: openclaw/openclaw#64457
