### PR TITLE
[codex] Gate transcript GC behind an opt-in flag

### DIFF
--- a/.changeset/transcript-gc-disabled-by-default.md
+++ b/.changeset/transcript-gc-disabled-by-default.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add an opt-in `transcriptGcEnabled` config flag, defaulting it to `false`, and skip transcript-GC rewrites during `maintain()` unless the flag is enabled. Also add startup diagnostics and documentation for the new setting.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
           "ignoreSessionPatterns": [
             "agent:*:cron:**"
           ],
+          "transcriptGcEnabled": false,
           "summaryModel": "openai/gpt-5.4-mini",
           "expansionModel": "openai/gpt-5.4-mini",
           "delegationTimeoutMs": 300000,
@@ -171,6 +172,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_DELEGATION_TIMEOUT_MS` | `120000` | Max time to wait for delegated `lcm_expand_query` sub-agent completion |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Max time to wait for a single model-backed LCM summarizer call |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
+| `LCM_TRANSCRIPT_GC_ENABLED` | `false` | Enable transcript rewrite GC during `maintain()` |
+
+Transcript GC rewrites are disabled by default. Set `transcriptGcEnabled` or `LCM_TRANSCRIPT_GC_ENABLED` to turn them on explicitly.
 
 ### Expansion model override requirements
 
@@ -212,6 +216,7 @@ Plugin config equivalents:
 - `ignoreSessionPatterns`
 - `statelessSessionPatterns`
 - `skipStatelessSessions`
+- `transcriptGcEnabled`
 - `newSessionRetainDepth`
 - `summaryModel`
 - `summaryProvider`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "summaryTimeoutMs": 60000,
   "timezone": "America/Los_Angeles",
   "pruneHeartbeatOk": false,
+  "transcriptGcEnabled": false,
   "maxAssemblyTokenBudget": 30000,
   "summaryMaxOverageFactor": 3,
   "customInstructions": "",
@@ -105,6 +106,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `newSessionRetainDepth` | `integer` | `2` | `LCM_NEW_SESSION_RETAIN_DEPTH` | Controls what survives `/new`. `-1` keeps all context, `0` keeps summaries only, higher values keep only deeper summaries. |
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |
+| `transcriptGcEnabled` | `boolean` | `false` | `LCM_TRANSCRIPT_GC_ENABLED` | Enables transcript rewrite GC during `maintain()`; disabled by default so transcript rewrites stay opt-in. |
 
 ### Compaction thresholds and summary sizing
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -168,6 +168,10 @@
       "label": "Prune HEARTBEAT_OK",
       "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
     },
+    "transcriptGcEnabled": {
+      "label": "Transcript GC",
+      "help": "Enable transcript rewrite GC during maintain(); disabled by default"
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit fallback provider/model pairs for compaction summarization (e.g., [{\"provider\": \"anthropic\", \"model\": \"claude-haiku-4-5\"}])"
@@ -339,6 +343,9 @@
         "type": "string"
       },
       "pruneHeartbeatOk": {
+        "type": "boolean"
+      },
+      "transcriptGcEnabled": {
         "type": "boolean"
       },
       "databasePath": {

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -173,6 +173,15 @@ Why it matters:
 - lower values externalize more aggressively
 - higher values keep more payload inline but can bloat storage and compaction inputs
 
+### `transcriptGcEnabled`
+
+Controls whether `maintain()` rewrites transcript entries for already-externalized tool results.
+
+Why it matters:
+
+- keep this off unless you want transcript GC to mutate the live session file during maintenance
+- the default is `false`
+
 ## Compaction timing and shape
 
 ### `contextThreshold`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -56,6 +56,8 @@ export type LcmConfig = {
   timezone: string;
   /** When true, retroactively delete HEARTBEAT_OK turn cycles from LCM storage. */
   pruneHeartbeatOk: boolean;
+  /** When true, maintain() may rewrite transcript entries for transcript GC. */
+  transcriptGcEnabled: boolean;
   /** Hard ceiling for assembly token budget — caps runtime-provided and fallback budgets. */
   maxAssemblyTokenBudget?: number;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
@@ -305,6 +307,10 @@ export function resolveLcmConfig(
       env.LCM_PRUNE_HEARTBEAT_OK !== undefined
         ? env.LCM_PRUNE_HEARTBEAT_OK === "true"
         : toBool(pc.pruneHeartbeatOk) ?? false,
+    transcriptGcEnabled:
+      env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
+        ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"
+        : toBool(pc.transcriptGcEnabled) ?? false,
     maxAssemblyTokenBudget:
       parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)
         ?? toNumber(pc.maxAssemblyTokenBudget) ?? undefined,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1291,6 +1291,20 @@ export class LcmContextEngine implements ContextEngine {
         "[lcm] FTS5 unavailable in the current Node runtime; full_text search will fall back to LIKE and indexing is disabled",
       );
     }
+    if (this.config.ignoreSessionPatterns.length > 0) {
+      logStartupBannerOnce({
+        key: "ignore-session-patterns",
+        log: (message) => this.deps.log.info(message),
+        message: `[lcm] Ignoring sessions matching ${this.config.ignoreSessionPatterns.length} pattern(s): ${this.config.ignoreSessionPatterns.join(", ")}`,
+      });
+    }
+    if (this.config.skipStatelessSessions && this.config.statelessSessionPatterns.length > 0) {
+      logStartupBannerOnce({
+        key: "stateless-session-patterns",
+        log: (message) => this.deps.log.info(message),
+        message: `[lcm] Stateless session patterns: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
+      });
+    }
     this.assembler = new ContextAssembler(
       this.conversationStore,
       this.summaryStore,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1291,21 +1291,6 @@ export class LcmContextEngine implements ContextEngine {
         "[lcm] FTS5 unavailable in the current Node runtime; full_text search will fall back to LIKE and indexing is disabled",
       );
     }
-    if (this.config.ignoreSessionPatterns.length > 0) {
-      logStartupBannerOnce({
-        key: "ignore-session-patterns",
-        log: (message) => this.deps.log.info(message),
-        message: `[lcm] Ignoring sessions matching ${this.config.ignoreSessionPatterns.length} pattern(s): ${this.config.ignoreSessionPatterns.join(", ")}`,
-      });
-    }
-    if (this.config.skipStatelessSessions && this.config.statelessSessionPatterns.length > 0) {
-      logStartupBannerOnce({
-        key: "stateless-session-patterns",
-        log: (message) => this.deps.log.info(message),
-        message: `[lcm] Stateless session patterns: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
-      });
-    }
-
     this.assembler = new ContextAssembler(
       this.conversationStore,
       this.summaryStore,
@@ -3039,6 +3024,14 @@ export class LcmContextEngine implements ContextEngine {
         bytesFreed: 0,
         rewrittenEntries: 0,
         reason: "stateless session",
+      };
+    }
+    if (!this.config.transcriptGcEnabled) {
+      return {
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "transcript GC disabled",
       };
     }
     if (typeof params.runtimeContext?.rewriteTranscriptEntries !== "function") {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1272,6 +1272,12 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
     log.warn(buildLegacyAuthFallbackWarning());
   }
 
+  logStartupBannerOnce({
+    key: "transcript-gc-enabled",
+    log: (message) => log.info(message),
+    message: `[lcm] Transcript GC ${config.transcriptGcEnabled ? "enabled" : "disabled"} (default false)`,
+  });
+
   /** Resolve the best config object to hand to runtime.modelAuth for this lookup. */
   const resolveModelAuthConfig = (runtimeConfig: unknown): OpenClawPluginApi["config"] => {
     if (runtimeConfig && typeof runtimeConfig === "object") {

--- a/src/startup-banner-log.ts
+++ b/src/startup-banner-log.ts
@@ -2,6 +2,7 @@ type StartupBannerKey =
   | "plugin-loaded"
   | "compaction-model"
   | "fallback-providers"
+  | "transcript-gc-enabled"
   | "ignore-session-patterns"
   | "stateless-session-patterns";
 

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -39,6 +39,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     largeFileSummaryModel: "",
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     expansionProvider: "",

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -44,6 +44,7 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
     autocompactDisabled: false,
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
     summaryMaxOverageFactor: 3,
     delegationTimeoutMs: 120000,
     customInstructions: "",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -25,6 +25,7 @@ describe("resolveLcmConfig", () => {
     expect(config.summaryProvider).toBe("");
     expect(config.summaryModel).toBe("");
     expect(config.pruneHeartbeatOk).toBe(false);
+    expect(config.transcriptGcEnabled).toBe(false);
     expect(config.cacheAwareCompaction).toEqual({
       enabled: true,
       maxColdCacheCatchupPasses: 2,
@@ -50,6 +51,7 @@ describe("resolveLcmConfig", () => {
       leafMinFanout: 4,
       condensedMinFanout: 2,
       pruneHeartbeatOk: true,
+      transcriptGcEnabled: true,
       enabled: false,
       cacheAwareCompaction: {
         enabled: false,
@@ -77,6 +79,7 @@ describe("resolveLcmConfig", () => {
     expect(config.leafMinFanout).toBe(4);
     expect(config.condensedMinFanout).toBe(2);
     expect(config.pruneHeartbeatOk).toBe(true);
+    expect(config.transcriptGcEnabled).toBe(true);
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
       maxColdCacheCatchupPasses: 3,
@@ -99,6 +102,7 @@ describe("resolveLcmConfig", () => {
       LCM_IGNORE_SESSION_PATTERNS: "agent:*:cron:*, agent:main:subagent:**",
       LCM_STATELESS_SESSION_PATTERNS: "agent:*:ephemeral:**, agent:main:preview:*",
       LCM_SKIP_STATELESS_SESSIONS: "false",
+      LCM_TRANSCRIPT_GC_ENABLED: "true",
       LCM_CACHE_AWARE_COMPACTION_ENABLED: "false",
       LCM_MAX_COLD_CACHE_CATCHUP_PASSES: "4",
       LCM_HOT_CACHE_PRESSURE_FACTOR: "5.5",
@@ -113,6 +117,7 @@ describe("resolveLcmConfig", () => {
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
+      transcriptGcEnabled: false,
       enabled: true,
       cacheAwareCompaction: {
         enabled: true,
@@ -136,6 +141,7 @@ describe("resolveLcmConfig", () => {
       "agent:main:preview:*",
     ]);
     expect(config.skipStatelessSessions).toBe(false);
+    expect(config.transcriptGcEnabled).toBe(true);
     expect(config.contextThreshold).toBe(0.9); // env wins
     expect(config.freshTailCount).toBe(64); // env wins
     expect(config.newSessionRetainDepth).toBe(5); // env wins
@@ -455,6 +461,12 @@ describe("resolveLcmConfig", () => {
           minimum: 1,
         },
       },
+    });
+  });
+
+  it("ships a manifest with transcriptGcEnabled in schema", () => {
+    expect(manifest.configSchema.properties.transcriptGcEnabled).toEqual({
+      type: "boolean",
     });
   });
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -49,6 +49,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     summaryTimeoutMs: 60_000,
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     circuitBreakerThreshold: 5,
@@ -1733,7 +1734,10 @@ describe("LcmContextEngine.ingest content extraction", () => {
 
   it("maintain() requests transcript rewrites for summarized externalized tool results", async () => {
     await withTempHome(async () => {
-      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const engine = createEngineWithConfig({
+        largeFileTokenThreshold: 20,
+        transcriptGcEnabled: true,
+      });
       const sessionId = randomUUID();
       const sessionFile = createSessionFilePath("transcript-gc-maintain");
       const toolOutput = `${"tool output line\n".repeat(160)}done`;
@@ -1900,6 +1904,41 @@ describe("LcmContextEngine.ingest content extraction", () => {
         reason: "conversation already up to date",
       });
       expect(reconcileSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("maintain() skips transcript GC when transcriptGcEnabled is false", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({
+        transcriptGcEnabled: false,
+      });
+      const sessionId = randomUUID();
+      const sessionFile = createSessionFilePath("transcript-gc-disabled");
+      const rewriteTranscriptEntries = vi.fn();
+
+      const ingested = await engine.ingest({
+        sessionId,
+        message: makeMessage({ role: "user", content: "keep LCM active" }),
+      });
+
+      expect(ingested).toEqual({ ingested: true });
+
+      const result = await engine.maintain({
+        sessionId,
+        sessionFile,
+        runtimeContext: {
+          rewriteTranscriptEntries,
+        },
+      });
+
+      expect(result).toEqual({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "transcript GC disabled",
+      });
+      expect(rewriteTranscriptEntries).not.toHaveBeenCalled();
+      expect(await engine.getConversationStore().getConversationBySessionId(sessionId)).not.toBeNull();
     });
   });
 

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -29,6 +29,7 @@ const BASE_CONFIG: LcmConfig = {
   summaryTimeoutMs: 60_000,
   timezone: "UTC",
   pruneHeartbeatOk: false,
+  transcriptGcEnabled: false,
   summaryMaxOverageFactor: 3,
   expansionProvider: "",
   expansionModel: "",

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -85,6 +85,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       delegationTimeoutMs: 120000,
       timezone: "UTC",
       pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/lcm-expand-tool.test.ts
+++ b/test/lcm-expand-tool.test.ts
@@ -51,6 +51,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       largeFileSummaryModel: "",
       timezone: "UTC",
       pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -50,6 +50,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       largeFileSummaryModel: "",
       timezone: "UTC",
       pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -186,6 +186,7 @@ describe("lcm plugin registration", () => {
       ignoreSessionPatterns: ["agent:*:cron:**", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
+      transcriptGcEnabled: true,
       largeFileThresholdTokens: 12345,
     });
     lcmPlugin.register(api);
@@ -216,17 +217,13 @@ describe("lcm plugin registration", () => {
       ignoreSessionPatterns: ["agent:*:cron:**", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
+      transcriptGcEnabled: true,
       largeFileTokenThreshold: 12345,
     });
     expect(infoLog).toHaveBeenCalledWith(
       `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
     );
-    expect(infoLog).toHaveBeenCalledWith(
-      "[lcm] Ignoring sessions matching 2 pattern(s): agent:*:cron:**, agent:main:subagent:**",
-    );
-    expect(infoLog).toHaveBeenCalledWith(
-      "[lcm] Stateless session patterns: 1 pattern(s): agent:*:subagent:**",
-    );
+    expect(infoLog).toHaveBeenCalledWith("[lcm] Transcript GC enabled (default false)");
     expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Compaction summarization model: (unconfigured)",
     );
@@ -543,17 +540,15 @@ describe("lcm plugin registration", () => {
     const startupBannerMessages = [...firstMessages, ...secondMessages].filter((message) =>
       [
         "[lcm] Plugin loaded (enabled=true, db=",
+        "[lcm] Transcript GC ",
         "[lcm] Compaction summarization model:",
-        "[lcm] Ignoring sessions matching ",
-        "[lcm] Stateless session patterns:",
       ].some((prefix) => message.startsWith(prefix)),
     );
 
     expect(startupBannerMessages.sort()).toEqual([
       `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
+      "[lcm] Transcript GC disabled (default false)",
       "[lcm] Compaction summarization model: (unconfigured)",
-      "[lcm] Ignoring sessions matching 2 pattern(s): agent:*:cron:**, agent:main:subagent:**",
-      "[lcm] Stateless session patterns: 1 pattern(s): agent:*:subagent:**",
     ].sort());
     expect(firstSessionMessages).toEqual([]);
     expect(secondSessionMessages).toEqual([]);

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -542,6 +542,8 @@ describe("lcm plugin registration", () => {
         "[lcm] Plugin loaded (enabled=true, db=",
         "[lcm] Transcript GC ",
         "[lcm] Compaction summarization model:",
+        "[lcm] Ignoring sessions matching",
+        "[lcm] Stateless session patterns:",
       ].some((prefix) => message.startsWith(prefix)),
     );
 
@@ -549,6 +551,8 @@ describe("lcm plugin registration", () => {
       `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
       "[lcm] Transcript GC disabled (default false)",
       "[lcm] Compaction summarization model: (unconfigured)",
+      "[lcm] Ignoring sessions matching 2 pattern(s): agent:*:cron:**, agent:main:subagent:**",
+      "[lcm] Stateless session patterns: 1 pattern(s): agent:*:subagent:**",
     ].sort());
     expect(firstSessionMessages).toEqual([]);
     expect(secondSessionMessages).toEqual([]);

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -49,6 +49,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     summaryTimeoutMs: 60_000,
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
     summaryMaxOverageFactor: 3,
     expansionProvider: "",
     expansionModel: "",

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -39,6 +39,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       largeFileSummaryModel: "",
       timezone: "UTC",
       pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(async () => ({


### PR DESCRIPTION
Closes #374

## Summary
- add an opt-in `transcriptGcEnabled` config flag and default it to `false`
- make `maintain()` skip transcript-GC rewrite work unless the flag is enabled
- expose the new flag in the manifest and docs
- add regression coverage that keeps transcript-GC disabled by default while preserving the rest of LCM behavior

## Why
The incident transcript showed rewrite-based transcript GC can amplify large sessions. Making transcript GC explicit keeps the rest of LCM usable while we chase the host-owned rewrite behavior separately.

## Validation
- `npm test`
- stacked validation branch: `npm test`
- isolated OpenClaw 2026.4.9 profile startup logged `Transcript GC disabled (default false)` while the context engine still initialized and persisted a normal allowed-session turn on `agent:lcm-smoke:main`


Companion OpenClaw issue: openclaw/openclaw#64457
