### PR TITLE
fix: gate startup backfills with migration state

### DIFF
--- a/.changeset/startup-backfill-gating.md
+++ b/.changeset/startup-backfill-gating.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Stop rerunning startup summary and tool-call backfills after they complete successfully, while still retrying the same backfill version cleanly if startup fails before the completion marker is written.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -43,6 +43,14 @@ type FtsTableSpec = {
   staleSchemaPatterns?: string[];
 };
 
+const VERSIONED_BACKFILL_STEPS = {
+  backfillSummaryDepths: 1,
+  backfillSummaryMetadata: 1,
+  backfillToolCallColumns: 1,
+} as const;
+
+type VersionedBackfillStepName = keyof typeof VERSIONED_BACKFILL_STEPS;
+
 function ensureSummaryDepthColumn(db: DatabaseSync): void {
   const summaryColumns = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
   const hasDepth = summaryColumns.some((col) => col.name === "depth");
@@ -141,6 +149,82 @@ function runMigrationStep(
   } catch (error) {
     log?.info?.(
       `[lcm] migration step failed: step=${name} durationMs=${Date.now() - startedAt} error=${describeMigrationError(error)}`,
+    );
+    throw error;
+  }
+}
+
+function getVersionedBackfillSavepointName(stepName: VersionedBackfillStepName): string {
+  return `lcm_backfill_${stepName}`;
+}
+
+function hasCompletedVersionedBackfill(
+  db: DatabaseSync,
+  stepName: VersionedBackfillStepName,
+  algorithmVersion: number,
+): boolean {
+  const row = db
+    .prepare(
+      `SELECT 1
+       FROM lcm_migration_state
+       WHERE step_name = ? AND algorithm_version = ?
+       LIMIT 1`,
+    )
+    .get(stepName, algorithmVersion) as { 1?: number } | undefined;
+  return row != null;
+}
+
+function markVersionedBackfillComplete(
+  db: DatabaseSync,
+  stepName: VersionedBackfillStepName,
+  algorithmVersion: number,
+): void {
+  db.prepare(
+    `INSERT INTO lcm_migration_state (step_name, algorithm_version, completed_at)
+     VALUES (?, ?, datetime('now'))
+     ON CONFLICT(step_name, algorithm_version)
+     DO UPDATE SET completed_at = excluded.completed_at`,
+  ).run(stepName, algorithmVersion);
+}
+
+function rollbackSavepoint(db: DatabaseSync, savepointName: string): void {
+  try {
+    db.exec(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+  } finally {
+    db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+  }
+}
+
+function runVersionedBackfillStep(
+  db: DatabaseSync,
+  stepName: VersionedBackfillStepName,
+  log: MigrationLogger | undefined,
+  step: () => void,
+): void {
+  const algorithmVersion = VERSIONED_BACKFILL_STEPS[stepName];
+  if (hasCompletedVersionedBackfill(db, stepName, algorithmVersion)) {
+    log?.info?.(
+      `[lcm] migration step skipped: step=${stepName} algorithmVersion=${algorithmVersion} reason=already-complete`,
+    );
+    return;
+  }
+
+  const startedAt = Date.now();
+  const savepointName = getVersionedBackfillSavepointName(stepName);
+
+  db.exec(`SAVEPOINT ${savepointName}`);
+
+  try {
+    step();
+    markVersionedBackfillComplete(db, stepName, algorithmVersion);
+    db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+    log?.info?.(
+      `[lcm] migration step complete: step=${stepName} algorithmVersion=${algorithmVersion} durationMs=${Date.now() - startedAt}`,
+    );
+  } catch (error) {
+    rollbackSavepoint(db, savepointName);
+    log?.info?.(
+      `[lcm] migration step failed: step=${stepName} algorithmVersion=${algorithmVersion} durationMs=${Date.now() - startedAt} error=${describeMigrationError(error)}`,
     );
     throw error;
   }
@@ -710,6 +794,13 @@ export function runLcmMigrations(
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS lcm_migration_state (
+      step_name TEXT NOT NULL,
+      algorithm_version INTEGER NOT NULL,
+      completed_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (step_name, algorithm_version)
+    );
+
     -- Indexes
     CREATE INDEX IF NOT EXISTS messages_conv_seq_idx ON messages (conversation_id, seq);
     CREATE INDEX IF NOT EXISTS summaries_conv_created_idx ON summaries (conversation_id, created_at);
@@ -771,7 +862,7 @@ export function runLcmMigrations(
   runMigrationStep("ensureCompactionTelemetryColumns", log, () =>
     ensureCompactionTelemetryColumns(db),
   );
-  runMigrationStep("backfillSummaryDepths", log, () => backfillSummaryDepths(db));
+  runVersionedBackfillStep(db, "backfillSummaryDepths", log, () => backfillSummaryDepths(db));
   // Index on depth — created AFTER backfillSummaryDepths to avoid index
   // maintenance overhead during bulk depth updates on large existing DBs.
   runMigrationStep("createSummariesDepthIndex", log, () =>
@@ -779,8 +870,12 @@ export function runLcmMigrations(
       `CREATE INDEX IF NOT EXISTS summaries_conv_depth_kind_idx ON summaries (conversation_id, depth, kind)`,
     ),
   );
-  runMigrationStep("backfillSummaryMetadata", log, () => backfillSummaryMetadata(db));
-  runMigrationStep("backfillToolCallColumns", log, () => backfillToolCallColumns(db));
+  runVersionedBackfillStep(db, "backfillSummaryMetadata", log, () =>
+    backfillSummaryMetadata(db),
+  );
+  runVersionedBackfillStep(db, "backfillToolCallColumns", log, () =>
+    backfillToolCallColumns(db),
+  );
 
   const detectedFeatures = options?.fts5Available === false ? null : getLcmDbFeatures(db);
   const fts5Available = options?.fts5Available ?? detectedFeatures?.fts5Available ?? false;

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -16,6 +16,92 @@ afterEach(() => {
   }
 });
 
+/** Create an isolated file-backed database for migration tests. */
+function createTestDb(fileName: string) {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, fileName);
+  return getLcmConnection(dbPath);
+}
+
+/**
+ * Seed a pre-depth/pre-metadata summaries schema so startup migrations have
+ * real legacy rows to backfill.
+ */
+function seedLegacySummaryGraph(db: ReturnType<typeof getLcmConnection>): void {
+  db.exec(`
+    CREATE TABLE conversations (
+      conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      title TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE summaries (
+      summary_id TEXT PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      kind TEXT NOT NULL CHECK (kind IN ('leaf', 'condensed')),
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      file_ids TEXT NOT NULL DEFAULT '[]'
+    );
+
+    CREATE TABLE messages (
+      message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (conversation_id, seq)
+    );
+
+    CREATE TABLE summary_messages (
+      summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+      message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE RESTRICT,
+      ordinal INTEGER NOT NULL,
+      PRIMARY KEY (summary_id, message_id)
+    );
+
+    CREATE TABLE summary_parents (
+      summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+      parent_summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE RESTRICT,
+      ordinal INTEGER NOT NULL,
+      PRIMARY KEY (summary_id, parent_summary_id)
+    );
+  `);
+
+  db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+    1,
+    "legacy-session",
+  );
+
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, created_at, file_ids)
+     VALUES (?, ?, ?, ?, ?, ?, '[]')`,
+  ).run("sum-leaf", 1, "leaf", "leaf", 10, "2026-01-01 09:00:00");
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, created_at, file_ids)
+     VALUES (?, ?, ?, ?, ?, ?, '[]')`,
+  ).run("sum-condensed", 1, "condensed", "condensed", 20, "2026-01-01 10:00:00");
+
+  db.prepare(
+    `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(1, 1, 1, "user", "hello", 4, "2026-01-01 08:00:00");
+  db.prepare(
+    `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+     VALUES (?, ?, ?)`,
+  ).run("sum-leaf", 1, 0);
+  db.prepare(
+    `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+     VALUES (?, ?, ?)`,
+  ).run("sum-condensed", "sum-leaf", 0);
+}
+
 describe("runLcmMigrations summary depth backfill", () => {
   it("adds depth and metadata from summary lineage", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
@@ -125,6 +211,19 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(summaryColumns.some((column) => column.name === "descendant_count")).toBe(true);
     expect(summaryColumns.some((column) => column.name === "descendant_token_count")).toBe(true);
     expect(summaryColumns.some((column) => column.name === "source_message_token_count")).toBe(true);
+
+    const migrationStateRows = db
+      .prepare(
+        `SELECT step_name, algorithm_version
+         FROM lcm_migration_state
+         ORDER BY step_name`,
+      )
+      .all() as Array<{ step_name: string; algorithm_version: number }>;
+    expect(migrationStateRows).toEqual([
+      { step_name: "backfillSummaryDepths", algorithm_version: 1 },
+      { step_name: "backfillSummaryMetadata", algorithm_version: 1 },
+      { step_name: "backfillToolCallColumns", algorithm_version: 1 },
+    ]);
 
     const depthRows = db
       .prepare(
@@ -574,12 +673,70 @@ describe("runLcmMigrations summary depth backfill", () => {
     const dbPath = join(tempDir, "legacy-tool-call-id.db");
     const db = getLcmConnection(dbPath);
 
-    runLcmMigrations(db, { fts5Available: false });
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
 
-    db.prepare(
-      `INSERT INTO conversations (conversation_id, session_id, title)
-       VALUES (?, ?, ?)`,
-    ).run(1, "legacy-session", "Legacy");
+      CREATE TABLE messages (
+        message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        token_count INTEGER NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (conversation_id, seq)
+      );
+
+      CREATE TABLE message_parts (
+        part_id TEXT PRIMARY KEY,
+        message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL,
+        part_type TEXT NOT NULL CHECK (part_type IN (
+          'text', 'reasoning', 'tool', 'patch', 'file',
+          'subtask', 'compaction', 'step_start', 'step_finish',
+          'snapshot', 'agent', 'retry'
+        )),
+        ordinal INTEGER NOT NULL,
+        text_content TEXT,
+        is_ignored INTEGER,
+        is_synthetic INTEGER,
+        tool_call_id TEXT,
+        tool_name TEXT,
+        tool_status TEXT,
+        tool_input TEXT,
+        tool_output TEXT,
+        tool_error TEXT,
+        tool_title TEXT,
+        patch_hash TEXT,
+        patch_files TEXT,
+        file_mime TEXT,
+        file_name TEXT,
+        file_url TEXT,
+        subtask_prompt TEXT,
+        subtask_desc TEXT,
+        subtask_agent TEXT,
+        step_reason TEXT,
+        step_cost REAL,
+        step_tokens_in INTEGER,
+        step_tokens_out INTEGER,
+        snapshot_hash TEXT,
+        compaction_auto INTEGER,
+        metadata TEXT,
+        UNIQUE (message_id, ordinal)
+      );
+    `);
+
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id, title) VALUES (?, ?, ?)`).run(
+      1,
+      "legacy-session",
+      "Legacy",
+    );
     db.prepare(
       `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -627,5 +784,182 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(row.tool_call_id).toBe("fc_legacy_123");
     expect(row.tool_name).toBe("bash");
     expect(row.tool_input).toBe('{"cmd":"pwd"}');
+  });
+
+  it("skips completed backfills on repeat startup", () => {
+    const db = createTestDb("repeat-startup.db");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id, title) VALUES (?, ?, ?)`).run(
+      1,
+      "repeat-session",
+      "Repeat",
+    );
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, file_ids)
+       VALUES (?, ?, ?, ?, ?, '[]')`,
+    ).run("sum-leaf", 1, "leaf", "leaf", 5);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, file_ids)
+       VALUES (?, ?, ?, ?, ?, '[]')`,
+    ).run("sum-condensed", 1, "condensed", "condensed", 10);
+    db.prepare(
+      `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+       VALUES (?, ?, ?)`,
+    ).run("sum-condensed", "sum-leaf", 0);
+
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(1, 1, 1, "assistant", "", 0);
+    db.prepare(
+      `INSERT INTO message_parts (
+         part_id, message_id, session_id, part_type, ordinal, text_content,
+         tool_call_id, tool_name, tool_input, tool_output, metadata
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "part-1",
+      1,
+      "repeat-session",
+      "text",
+      0,
+      null,
+      null,
+      null,
+      null,
+      null,
+      JSON.stringify({
+        rawType: "function_call",
+        raw: {
+          call_id: "fc_repeat_123",
+          name: "bash",
+          arguments: { cmd: "pwd" },
+        },
+      }),
+    );
+
+    const logMessages: string[] = [];
+    runLcmMigrations(db, {
+      fts5Available: false,
+      log: {
+        info(message) {
+          logMessages.push(message);
+        },
+      },
+    });
+
+    const condensedRow = db.prepare(
+      `SELECT depth, earliest_at, latest_at, descendant_count, source_message_token_count
+       FROM summaries
+       WHERE summary_id = ?`,
+    ).get("sum-condensed") as {
+      depth: number;
+      earliest_at: string | null;
+      latest_at: string | null;
+      descendant_count: number;
+      source_message_token_count: number;
+    };
+    expect(condensedRow).toEqual({
+      depth: 0,
+      earliest_at: null,
+      latest_at: null,
+      descendant_count: 0,
+      source_message_token_count: 0,
+    });
+
+    const messagePartRow = db.prepare(
+      `SELECT tool_call_id, tool_name, tool_input
+       FROM message_parts
+       WHERE part_id = ?`,
+    ).get("part-1") as {
+      tool_call_id: string | null;
+      tool_name: string | null;
+      tool_input: string | null;
+    };
+    expect(messagePartRow).toEqual({
+      tool_call_id: null,
+      tool_name: null,
+      tool_input: null,
+    });
+
+    expect(logMessages.filter((message) => message.includes("migration step skipped"))).toEqual([
+      "[lcm] migration step skipped: step=backfillSummaryDepths algorithmVersion=1 reason=already-complete",
+      "[lcm] migration step skipped: step=backfillSummaryMetadata algorithmVersion=1 reason=already-complete",
+      "[lcm] migration step skipped: step=backfillToolCallColumns algorithmVersion=1 reason=already-complete",
+    ]);
+  });
+
+  it("retries a versioned backfill cleanly after the state write fails", () => {
+    const db = createTestDb("retry-state-write.db");
+    seedLegacySummaryGraph(db);
+
+    const failingDb = {
+      prepare(sql: string) {
+        if (sql.includes("INSERT INTO lcm_migration_state")) {
+          throw new Error("simulated state write failure");
+        }
+        return db.prepare(sql);
+      },
+      exec(sql: string) {
+        return db.exec(sql);
+      },
+    } as unknown as Parameters<typeof runLcmMigrations>[0];
+
+    expect(() => runLcmMigrations(failingDb, { fts5Available: false })).toThrow(
+      "simulated state write failure",
+    );
+
+    const failedDepthRow = db.prepare(
+      `SELECT depth, earliest_at, latest_at
+       FROM summaries
+       WHERE summary_id = ?`,
+    ).get("sum-condensed") as {
+      depth: number;
+      earliest_at: string | null;
+      latest_at: string | null;
+    };
+    expect(failedDepthRow).toEqual({
+      depth: 0,
+      earliest_at: null,
+      latest_at: null,
+    });
+
+    const stateRowsAfterFailure = db
+      .prepare(`SELECT step_name, algorithm_version FROM lcm_migration_state`)
+      .all() as Array<{ step_name: string; algorithm_version: number }>;
+    expect(stateRowsAfterFailure).toEqual([]);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const recoveredRow = db.prepare(
+      `SELECT depth, earliest_at, latest_at, descendant_count, source_message_token_count
+       FROM summaries
+       WHERE summary_id = ?`,
+    ).get("sum-condensed") as {
+      depth: number;
+      earliest_at: string | null;
+      latest_at: string | null;
+      descendant_count: number;
+      source_message_token_count: number;
+    };
+
+    expect(recoveredRow.depth).toBe(1);
+    expect(recoveredRow.earliest_at).toContain("2026-01-01");
+    expect(recoveredRow.latest_at).toContain("2026-01-01");
+    expect(recoveredRow.descendant_count).toBe(1);
+    expect(recoveredRow.source_message_token_count).toBe(4);
+
+    const stateRowsAfterRetry = db
+      .prepare(
+        `SELECT step_name, algorithm_version
+         FROM lcm_migration_state
+         ORDER BY step_name`,
+      )
+      .all() as Array<{ step_name: string; algorithm_version: number }>;
+    expect(stateRowsAfterRetry).toEqual([
+      { step_name: "backfillSummaryDepths", algorithm_version: 1 },
+      { step_name: "backfillSummaryMetadata", algorithm_version: 1 },
+      { step_name: "backfillToolCallColumns", algorithm_version: 1 },
+    ]);
   });
 });


### PR DESCRIPTION
## What
This PR adds additive startup backfill state to the SQLite migration path so the expensive summary and tool-call backfills stop rerunning after a successful startup, while still retrying cleanly if startup fails before the backfill version is marked complete.

## Why
Lossless-claw was rerunning heavy startup backfills on every launch. That added avoidable startup work and still lacked an explicit completion signal for partial-upgrade recovery.

## Changes
- Add `lcm_migration_state` for versioned backfill completion
- Gate startup backfills by step name and version
- Wrap backfills plus state writes in savepoints
- Add repeat-startup and retry-safety migration tests
- Add patch changeset for the runtime fix

## Testing
- `npm test -- test/migration.test.ts`
- Expect `test/migration.test.ts` to pass
