### PR TITLE
fix: refresh bootstrap checkpoint after afterTurn message ingestion

### DIFF
--- a/.changeset/warm-gifts-pull.md
+++ b/.changeset/warm-gifts-pull.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Refresh the bootstrap checkpoint after normal `afterTurn()` ingestion so persistent sessions can keep using the append-only bootstrap fast path after real conversation turns.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3546,6 +3546,17 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     try {
+      await this.refreshBootstrapState({
+        conversationId: conversation.conversationId,
+        sessionFile: params.sessionFile,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: bootstrap checkpoint refresh failed for ${sessionLabel}: ${describeLogError(err)}`,
+      );
+    }
+
+    try {
       const rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
       await this.updateCompactionTelemetry({
         conversationId: conversation.conversationId,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2668,6 +2668,65 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(reconcileSpy).not.toHaveBeenCalled();
   });
 
+  it("refreshes the bootstrap checkpoint after a normal afterTurn before the next append-only bootstrap", async () => {
+    const sessionFile = createSessionFilePath("append-only-after-turn-normal-ingest");
+    const sm = SessionManager.open(sessionFile);
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "seed user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "seed assistant" }],
+    } as AgentMessage);
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-append-only-after-turn-normal-ingest";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const realTurn = [
+      makeMessage({
+        role: "user",
+        content: "new user",
+      }),
+      makeMessage({
+        role: "assistant",
+        content: "new assistant",
+      }),
+    ];
+    for (const message of realTurn) {
+      sm.appendMessage(message as AgentMessage);
+    }
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: realTurn,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "tail user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "tail assistant" }],
+    } as AgentMessage);
+
+    const reconcileSpy = vi.spyOn(engine as any, "reconcileSessionTail");
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+    expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
   it("falls back to full reconciliation when append-only checkpoint validation mismatches", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Problem

The append-only bootstrap fast path (introduced in v0.7.0, PR #329) never works after real conversation turns. Every turn triggers a full JSONL transcript read instead.

**Root cause:** `refreshBootstrapState()` is called after heartbeat pruning and after `maintain()`, but never after regular message ingestion in `afterTurn()`. After ingesting new messages, the DB frontier advances past the stored checkpoint hash. The next bootstrap sees the mismatch and falls back to a full reconcile.

On a 4.4 MB session JSONL with constrained hardware (1-core LXC), this adds **~22 seconds per real conversation turn**. Heartbeat-only turns are unaffected because pruning ingests zero messages and the checkpoint stays valid.

## Fix

Add a `refreshBootstrapState()` call after successful message ingestion in `afterTurn()`, before compaction. The method, params, and plumbing all exist — it is already called on the heartbeat pruning path in the same function.

**+8 lines, no new methods or interfaces.**

## Evidence

Logs from a persistent session (v0.8.0, ~2,500 messages):

| Turn type | Bootstrap path | Time |
|-----------|---------------|------|
| Conversation | Full reconcile | 22,441ms |
| Conversation | Full reconcile | 21,883ms |
| Heartbeat | Checkpoint hit | 8ms |
| Conversation | Full reconcile | 21,997ms |

100% of real conversation turns hit the slow path. 100% of heartbeat-only turns hit the fast path.

## Regression scope

- **v0.5.3 and earlier**: Not affected (used file-stat-only checkpoint, no hash verification)
- **v0.7.0+**: Affected on every real conversation turn in every persistent session

Fixes #386