### PR TITLE
Add ollama provider to inferApiFromProvider()

### DIFF
--- a/.changeset/pr388-ollama-provider-fallback.md
+++ b/.changeset/pr388-ollama-provider-fallback.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix the built-in API-family fallback for `ollama` providers so summarization can use OpenAI-compatible Ollama models without requiring an explicit `models.providers.ollama.api` setting.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -551,6 +551,7 @@ function inferApiFromProvider(provider: string): string | undefined {
     "google-antigravity": "google-gemini-cli",
     "google-vertex": "google-vertex",
     "amazon-bedrock": "bedrock-converse-stream",
+    ollama: "openai-completions",
   };
   return map[normalized];
 }

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -355,6 +355,26 @@ describe("createLcmDependencies.complete provider config resolution", () => {
     expect(piAiMock.completeSimple).not.toHaveBeenCalled();
   });
 
+  it("falls back to openai-completions for ollama when no api family is configured", async () => {
+    await callComplete({
+      loadConfigResult: {},
+      provider: "ollama",
+      model: "kimi-k2.5:cloud",
+      runtimeConfig: {},
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "kimi-k2.5:cloud",
+        provider: "ollama",
+        api: "openai-completions",
+        baseUrl: "",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("preserves provider auth error metadata when completeSimple throws a 401 scope error", async () => {
     piAiMock.completeSimple.mockRejectedValue({
       statusCode: 401,


### PR DESCRIPTION
**Problem**  LCM fails to resolve API family for the ollama provider:  [lcm] unable to resolve API family for provider ollama; set models.providers.ollama.api explicitly instead of falling back implicitly.  **Trigger**  Setting summaryModel to any ollama-served model (e.g., ollama/glm-5.1, ollama/kimi-k2.5:cloud).  **Fix**  Add mapping ollama: openai-completions since Ollama uses OpenAI-compatible API.  **File**  src/plugin/index.ts, line ~553 in inferApiFromProvider()