### PR TITLE
fix: skip already-completed backfill migrations on startup

### DIFF
--- a/.changeset/skip-completed-backfills.md
+++ b/.changeset/skip-completed-backfills.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip already-completed backfill migrations on startup
+
+Three migration backfill functions (`backfillSummaryDepths`, `backfillSummaryMetadata`, `backfillToolCallColumns`) ran unconditionally on every gateway startup. On large databases (2K+ conversations, 70K+ messages), these O(conversations × summaries) operations took minutes, held SQLite write locks, and caused the gateway to fail health checks. If the process was killed mid-backfill, it restarted and ran the same expensive operations again — creating a startup death spiral.
+
+This change adds cheap sentinel queries before each backfill: if no rows need updating, the backfill is skipped entirely with an info log. Startup on an already-migrated DB drops from minutes to milliseconds.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -775,7 +775,23 @@ export function runLcmMigrations(
   runMigrationStep("ensureCompactionTelemetryColumns", log, () =>
     ensureCompactionTelemetryColumns(db),
   );
-  runMigrationStep("backfillSummaryDepths", log, () => backfillSummaryDepths(db));
+  // Skip expensive backfill migrations when the data is already populated.
+  // These backfills are O(conversations * summaries) and on large DBs (>2K conversations,
+  // >70K messages) they can take minutes, hold write locks, and cause the gateway to
+  // appear unresponsive. Check a cheap sentinel before running them.
+  const needsDepthBackfill = db
+    .prepare(`SELECT 1 FROM summaries WHERE kind = 'leaf' AND depth != 0 LIMIT 1`)
+    .get() != null
+    || db
+      .prepare(`SELECT 1 FROM summaries WHERE kind = 'condensed' AND depth = 0 LIMIT 1`)
+      .get() != null;
+
+  if (needsDepthBackfill) {
+    runMigrationStep("backfillSummaryDepths", log, () => backfillSummaryDepths(db));
+  } else {
+    log?.info?.(`[lcm] skipping backfillSummaryDepths (already populated)`);
+  }
+
   // Index on depth — created AFTER backfillSummaryDepths to avoid index
   // maintenance overhead during bulk depth updates on large existing DBs.
   runMigrationStep("createSummariesDepthIndex", log, () =>
@@ -783,8 +799,35 @@ export function runLcmMigrations(
       `CREATE INDEX IF NOT EXISTS summaries_conv_depth_kind_idx ON summaries (conversation_id, depth, kind)`,
     ),
   );
-  runMigrationStep("backfillSummaryMetadata", log, () => backfillSummaryMetadata(db));
-  runMigrationStep("backfillToolCallColumns", log, () => backfillToolCallColumns(db));
+
+  const needsMetadataBackfill = db
+    .prepare(`SELECT 1 FROM summaries WHERE earliest_at IS NULL LIMIT 1`)
+    .get() != null;
+
+  if (needsMetadataBackfill) {
+    runMigrationStep("backfillSummaryMetadata", log, () => backfillSummaryMetadata(db));
+  } else {
+    log?.info?.(`[lcm] skipping backfillSummaryMetadata (already populated)`);
+  }
+
+  const needsToolCallBackfill = db
+    .prepare(
+      `SELECT 1 FROM message_parts
+       WHERE tool_call_id IS NULL AND metadata IS NOT NULL
+       AND COALESCE(
+         json_extract(metadata, '$.toolCallId'),
+         json_extract(metadata, '$.raw.id'),
+         json_extract(metadata, '$.raw.call_id')
+       ) IS NOT NULL
+       LIMIT 1`,
+    )
+    .get() != null;
+
+  if (needsToolCallBackfill) {
+    runMigrationStep("backfillToolCallColumns", log, () => backfillToolCallColumns(db));
+  } else {
+    log?.info?.(`[lcm] skipping backfillToolCallColumns (already populated)`);
+  }
 
   const detectedFeatures = options?.fts5Available === false ? null : getLcmDbFeatures(db);
   const fts5Available = options?.fts5Available ?? detectedFeatures?.fts5Available ?? false;

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -650,3 +650,86 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(row.tool_input).toBe('{"cmd":"pwd"}');
   });
 });
+
+describe("runLcmMigrations skips completed backfills", () => {
+  it("skips depth backfill when all leaf summaries have depth 0 and all condensed summaries have depth > 0", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "skip-depth.db");
+    const db = getLcmConnection(dbPath);
+
+    // Run migrations once to get a fully-migrated DB
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Now run migrations again — the skip logic should fire because
+    // all leaves have depth=0 and all condensed summaries have depth>0
+    const logMessages: string[] = [];
+    runLcmMigrations(db, {
+      fts5Available: false,
+      log: { info: (msg: string) => logMessages.push(msg) },
+    });
+
+    expect(logMessages).toContainEqual(
+      expect.stringContaining("skipping backfillSummaryDepths (already populated)"),
+    );
+  });
+
+  it("skips metadata backfill when all summaries have earliest_at populated", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "skip-metadata.db");
+    const db = getLcmConnection(dbPath);
+
+    // Run migrations once to populate metadata
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Create a conversation + leaf summary to verify the sentinel query works
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      99,
+      "test-session-skip",
+    );
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(999, 99, 1, "user", "hello", 5, "2026-04-11 10:00:00");
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, depth, earliest_at, latest_at, source_message_token_count, file_ids)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '[]')`,
+    ).run("sum_skip_leaf", 99, "leaf", "test", 5, 0, "2026-04-11 10:00:00", "2026-04-11 10:00:00", 5);
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal) VALUES (?, ?, ?)`,
+    ).run("sum_skip_leaf", 999, 0);
+
+    // Run migrations again — should skip metadata backfill
+    const logMessages: string[] = [];
+    runLcmMigrations(db, {
+      fts5Available: false,
+      log: { info: (msg: string) => logMessages.push(msg) },
+    });
+
+    expect(logMessages).toContainEqual(
+      expect.stringContaining("skipping backfillSummaryMetadata (already populated)"),
+    );
+  });
+
+  it("skips tool call backfill when no rows need extraction", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "skip-toolcall.db");
+    const db = getLcmConnection(dbPath);
+
+    // Run migrations once (no legacy tool_call rows exist in a fresh DB)
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Running again should skip the tool call backfill
+    const logMessages: string[] = [];
+    runLcmMigrations(db, {
+      fts5Available: false,
+      log: { info: (msg: string) => logMessages.push(msg) },
+    });
+
+    expect(logMessages).toContainEqual(
+      expect.stringContaining("skipping backfillToolCallColumns (already populated)"),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Three migration backfill functions (`backfillSummaryDepths`, `backfillSummaryMetadata`, `backfillToolCallColumns`) run **unconditionally on every gateway startup**. On large databases (2K+ conversations, 70K+ messages), these O(conversations x summaries) operations:

1. Take minutes to complete
2. Hold SQLite write locks for the duration
3. Cause the gateway to fail health checks during startup
4. If the process is SIGKILL'd mid-backfill -> restart loop -> **startup death spiral**

We observed this on a 580MB database (2,135 conversations, 73,671 messages). The gateway would start, consume 3.2GB RAM and 106% CPU on backfills, get SIGKILL'd by systemd after the health check timeout, and repeat indefinitely.

The external lcm-bridge (read-only, `immutable=1`) was initially suspected but was not the cause - it holds no write locks.

## Fix

Add cheap sentinel queries before each backfill:

- **Depth backfill**: Skip if no leaf has `depth != 0` and no condensed has `depth = 0` (single `SELECT 1 ... LIMIT 1` query)
- **Metadata backfill**: Skip if no summary has `earliest_at IS NULL`
- **Tool call backfill**: Skip if no rows have `tool_call_id IS NULL AND metadata IS NOT NULL` with extractable values

On an already-migrated DB, startup drops from **minutes** to **milliseconds**. The sentinel queries use indexed columns and return immediately when data is populated.

When new data arrives that *does* need backfilling (e.g., a new conversation with summaries missing depth/metadata), the sentinel finds rows and the full backfill runs as before - so incremental migrations still work correctly.

## Testing

Added 3 test cases in `migration.test.ts`:
- Verifies depth backfill is skipped on a fully-migrated DB
- Verifies metadata backfill is skipped when `earliest_at` is populated
- Verifies tool call backfill is skipped when no legacy rows need extraction

## Changeset

Patch - this is a fix for startup performance, no API or behavior changes for correctly-migrated databases.