### PR TITLE
feat: add /lcm rotate and /lcm backup commands

### DIFF
--- a/.changeset/bright-taxis-teach.md
+++ b/.changeset/bright-taxis-teach.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add `/lcm backup` and `/lcm rotate` plugin commands so users can snapshot the SQLite database on demand and split oversized active LCM conversations without changing their live OpenClaw session identity. Rotation now checkpoints the current transcript frontier so the fresh row starts from now forward instead of replaying older transcript history.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For large sessions, neither command is a perfect “keep my live agent context, 
 - `/new` keeps writing into the same active LCM conversation row.
 - `/reset` changes OpenClaw session flow, which is heavier than users often want when their real problem is just LCM row size.
 
-`/lcm rotate` fills that gap. It archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions. If you want a snapshot first, run `/lcm backup` explicitly.
+`/lcm rotate` fills that gap. It replaces one rolling `rotate-latest` SQLite backup, archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions. If you want timestamped snapshots instead, run `/lcm backup`.
 
 `newSessionRetainDepth` (or `LCM_NEW_SESSION_RETAIN_DEPTH`) controls how much summary structure survives `/new`:
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For large sessions, neither command is a perfect “keep my live agent context, 
 - `/new` keeps writing into the same active LCM conversation row.
 - `/reset` changes OpenClaw session flow, which is heavier than users often want when their real problem is just LCM row size.
 
-`/lcm rotate` fills that gap. It creates a backup, archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions.
+`/lcm rotate` fills that gap. It archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions. If you want a snapshot first, run `/lcm backup` explicitly.
 
 `newSessionRetainDepth` (or `LCM_NEW_SESSION_RETAIN_DEPTH`) controls how much summary structure survives `/new`:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Nothing is lost. Raw messages stay in the database. Summaries link back to their
 The plugin now ships a bundled `lossless-claw` skill plus a small plugin command surface for supported OpenClaw chat/native command providers:
 
 - `/lcm` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
+- `/lcm backup` creates a timestamped backup of the current LCM SQLite database
+- `/lcm rotate` archives the active LCM row for the current session and starts a fresh row without changing the live OpenClaw session identity
 - `/lcm doctor` scans for broken or truncated summaries
 - `/lcm doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
 - `/lcm status` shows plugin, conversation, and maintenance state including deferred compaction debt
@@ -41,6 +43,8 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 These are plugin slash/native commands, not root shell CLI subcommands. Supported examples:
 
 - `/lcm`
+- `/lcm backup`
+- `/lcm rotate`
 - `/lcm doctor`
 - `/lcm doctor clean`
 - `/lossless`
@@ -271,6 +275,13 @@ Lossless-claw distinguishes OpenClaw's two session-reset commands:
 
 - `/new` keeps the active conversation row and all stored summaries, but prunes `context_items` so the next turn rebuilds context from retained summaries instead of the fresh tail.
 - `/reset` archives the active conversation row and creates a new active row for the same stable `sessionKey`, giving the next turn a clean LCM conversation while preserving prior history.
+
+For large sessions, neither command is a perfect “keep my live agent context, but stop writing into this giant active LCM row” tool:
+
+- `/new` keeps writing into the same active LCM conversation row.
+- `/reset` changes OpenClaw session flow, which is heavier than users often want when their real problem is just LCM row size.
+
+`/lcm rotate` fills that gap. It creates a backup, archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions.
 
 `newSessionRetainDepth` (or `LCM_NEW_SESSION_RETAIN_DEPTH`) controls how much summary structure survives `/new`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,6 +255,16 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 - status output also surfaces the latest API/cache telemetry so operators can see whether a deferred debt item is being preserved for cache-safety reasons
 - set `proactiveThresholdCompactionMode` to `inline` only if you need the legacy inline proactive compaction behavior for compatibility
 
+### `/lcm rotate`
+
+`/lcm rotate` exists for a different use case than `/new` or `/reset`:
+
+- `/new` keeps the same active LCM conversation row and only prunes context.
+- `/reset` changes OpenClaw session flow, which is sometimes more disruptive than users want.
+- `/lcm rotate` keeps the live OpenClaw session identity, but archives the current active LCM row and starts a fresh row for the same session.
+
+Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. The new row is checkpointed at the current transcript frontier so bootstrap starts from now forward instead of replaying older transcript history into the fresh row. If you want additional timestamped snapshots, run `/lcm backup` explicitly before `/lcm rotate`.
+
 ## Environment-only knobs outside plugin config
 
 These settings are not part of `plugins.entries.lossless-claw.config`, but they still affect the system:
@@ -284,6 +294,12 @@ Back it up with:
 ```bash
 cp "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/lcm.db" "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/lcm.db.backup"
 sqlite3 "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/lcm.db" ".backup ${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/lcm.db.backup"
+```
+
+Or from a supported OpenClaw chat/native command surface:
+
+```text
+/lcm backup
 ```
 
 ## Disabling lossless-claw

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createReadStream, statSync } from "node:fs";
 import { mkdir, open, stat, writeFile } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { join } from "node:path";
@@ -3550,20 +3550,22 @@ export class LcmContextEngine implements ContextEngine {
                   tokenCount: latestDbMessage.tokenCount,
                 })
               : null;
+            const frontierHash = latestDbHash ?? bootstrapState.lastProcessedEntryHash;
             // Short-circuit before the expensive backward scan: the fast-path can
-            // only succeed when the DB's latest hash still matches the checkpoint.
-            // When messages have been ingested since the last bootstrap this check
-            // fails and we skip straight to the async full-read slow path below,
-            // avoiding a backward scan that could never find a matching tail entry.
+            // only succeed when the current frontier still matches the checkpoint.
+            // A freshly rotated row may have no DB messages yet, so in that case
+            // the stored checkpoint hash acts as the frontier anchor. When the
+            // frontier no longer matches, skip straight to the async full-read
+            // slow path below and avoid a backward scan that cannot succeed.
             const canTryAppendOnlyFastPath =
-              latestDbHash !== null && latestDbHash === bootstrapState.lastProcessedEntryHash;
+              frontierHash !== null && frontierHash === bootstrapState.lastProcessedEntryHash;
 
             const tailEntryRaw = canTryAppendOnlyFastPath
               ? await readLastJsonlEntryBeforeOffset(
                   params.sessionFile,
                   bootstrapState.lastProcessedOffset,
                   true,
-                  (message) => createBootstrapEntryHash(toStoredMessage(message)) === latestDbHash,
+                  (message) => createBootstrapEntryHash(toStoredMessage(message)) === frontierHash,
                 )
               : null;
             const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
@@ -5251,7 +5253,7 @@ export class LcmContextEngine implements ContextEngine {
           let tailEntryHash: string | null;
           try {
             sessionFileStats = statSync(params.sessionFile);
-            const tailEntryRaw = readLastJsonlEntryBeforeOffset(
+            const tailEntryRaw = await readLastJsonlEntryBeforeOffset(
               params.sessionFile,
               sessionFileStats.size,
               true,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5247,16 +5247,25 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           const archivedMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
-          const sessionFileStats = statSync(params.sessionFile);
-          const tailEntryRaw = readLastJsonlEntryBeforeOffset(
-            params.sessionFile,
-            sessionFileStats.size,
-            true,
-          );
-          const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
-          const tailEntryHash = tailEntryMessage
-            ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
-            : null;
+          let sessionFileStats: ReturnType<typeof statSync>;
+          let tailEntryHash: string | null;
+          try {
+            sessionFileStats = statSync(params.sessionFile);
+            const tailEntryRaw = readLastJsonlEntryBeforeOffset(
+              params.sessionFile,
+              sessionFileStats.size,
+              true,
+            );
+            const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
+            tailEntryHash = tailEntryMessage
+              ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
+              : null;
+          } catch (error) {
+            return {
+              kind: "unavailable",
+              reason: `Lossless Claw could not read the current session transcript: ${describeLogError(error)}`,
+            };
+          }
 
           await this.conversationStore.archiveConversation(current.conversationId);
           const freshConversation = await this.conversationStore.createConversation({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1188,6 +1188,19 @@ async function readAppendedLeafPathMessages(params: {
   };
 }
 
+export type RotateSessionStorageResult =
+  | {
+      kind: "rotated";
+      archivedConversationId: number;
+      activeConversationId: number;
+      archivedMessageCount: number;
+      checkpointSize: number;
+    }
+  | {
+      kind: "unavailable";
+      reason: string;
+    };
+
 function readBootstrapMessageFromJsonLine(line: string | null): AgentMessage | null {
   if (!line) {
     return null;
@@ -3490,10 +3503,7 @@ export class LcmContextEngine implements ContextEngine {
           });
           const conversationId = conversation.conversationId;
           let existingCount = await this.conversationStore.getMessageCount(conversationId);
-          let bootstrapState =
-            existingCount > 0
-              ? await this.summaryStore.getConversationBootstrapState(conversationId)
-              : null;
+          let bootstrapState = await this.summaryStore.getConversationBootstrapState(conversationId);
 
           if (
             bootstrapState &&
@@ -3527,7 +3537,6 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           if (
-            existingCount > 0 &&
             bootstrapState &&
             bootstrapState.sessionFilePath === params.sessionFile &&
             sessionFileSize > bootstrapState.lastSeenSize &&
@@ -3541,7 +3550,6 @@ export class LcmContextEngine implements ContextEngine {
                   tokenCount: latestDbMessage.tokenCount,
                 })
               : null;
-
             // Short-circuit before the expensive backward scan: the fast-path can
             // only succeed when the DB's latest hash still matches the checkpoint.
             // When messages have been ingested since the last bootstrap this check
@@ -5192,6 +5200,88 @@ export class LcmContextEngine implements ContextEngine {
             nextSessionKey: params.nextSessionKey,
             createReplacement,
           });
+        }),
+    );
+  }
+
+  async rotateSessionStorage(params: {
+    sessionId?: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<RotateSessionStorageResult> {
+    const sessionId = params.sessionId?.trim();
+    const sessionKey = params.sessionKey?.trim();
+    if (!sessionId || !sessionKey) {
+      return {
+        kind: "unavailable",
+        reason: "Lossless Claw needs both the current session id and session key to rotate storage safely.",
+      };
+    }
+    if (this.shouldIgnoreSession({ sessionId, sessionKey })) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is excluded by ignoreSessionPatterns, so there is no active LCM conversation to rotate.",
+      };
+    }
+    if (this.isStatelessSession(sessionKey)) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is stateless in Lossless Claw, so there is no writable active LCM conversation to rotate.",
+      };
+    }
+
+    this.ensureMigrated();
+    return this.withSessionQueue(
+      this.resolveSessionQueueKey(sessionId, sessionKey),
+      async () =>
+        this.conversationStore.withTransaction(async () => {
+          const current = await this.conversationStore.getConversationForSession({
+            sessionId,
+            sessionKey,
+          });
+          if (!current?.active) {
+            return {
+              kind: "unavailable",
+              reason: "No active Lossless Claw conversation is stored for the current session.",
+            };
+          }
+
+          const archivedMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
+          const sessionFileStats = statSync(params.sessionFile);
+          const tailEntryRaw = readLastJsonlEntryBeforeOffset(
+            params.sessionFile,
+            sessionFileStats.size,
+            true,
+          );
+          const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
+          const tailEntryHash = tailEntryMessage
+            ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
+            : null;
+
+          await this.conversationStore.archiveConversation(current.conversationId);
+          const freshConversation = await this.conversationStore.createConversation({
+            sessionId,
+            sessionKey,
+            title: current.title ?? undefined,
+          });
+          await this.summaryStore.upsertConversationBootstrapState({
+            conversationId: freshConversation.conversationId,
+            sessionFilePath: params.sessionFile,
+            lastSeenSize: sessionFileStats.size,
+            lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+            lastProcessedOffset: sessionFileStats.size,
+            lastProcessedEntryHash: tailEntryHash,
+          });
+          this.deps.log.info(
+            `[lcm] rotate: archived conversation=${current.conversationId} session=${sessionId} sessionKey=${sessionKey} and created fresh conversation=${freshConversation.conversationId} checkpointSize=${sessionFileStats.size}`,
+          );
+          return {
+            kind: "rotated",
+            archivedConversationId: current.conversationId,
+            activeConversationId: freshConversation.conversationId,
+            archivedMessageCount,
+            checkpointSize: sessionFileStats.size,
+          };
         }),
     );
   }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1812,13 +1812,49 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
         const cfg = api.runtime.config.loadConfig();
         const parsed = parseAgentSessionKey(key);
         const agentId = normalizeAgentId(parsed?.agentId);
-        const storePath = api.runtime.channel.session.resolveStorePath(cfg.session?.store, {
+        const storePath = api.runtime.agent.session.resolveStorePath(cfg.session?.store, {
           agentId,
         });
-        const raw = readFileSync(storePath, "utf8");
-        const store = JSON.parse(raw) as Record<string, { sessionId?: string } | undefined>;
+        const store = api.runtime.agent.session.loadSessionStore(storePath) as Record<
+          string,
+          { sessionId?: string } | undefined
+        >;
         const sessionId = store[key]?.sessionId;
         return typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    resolveSessionTranscriptFile: async ({ sessionId, sessionKey }) => {
+      const normalizedSessionId = sessionId.trim();
+      if (!normalizedSessionId) {
+        return undefined;
+      }
+
+      try {
+        const cfg = api.runtime.config.loadConfig();
+        const normalizedSessionKey = sessionKey?.trim();
+        const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
+        const agentId = normalizeAgentId(parsed?.agentId);
+        const storePath = api.runtime.agent.session.resolveStorePath(cfg.session?.store, {
+          agentId,
+        });
+        const store = api.runtime.agent.session.loadSessionStore(storePath) as Record<
+          string,
+          { sessionId?: string; sessionFile?: string } | undefined
+        >;
+        const entry =
+          (normalizedSessionKey ? store[normalizedSessionKey] : undefined)
+          ?? Object.values(store).find((candidate) => candidate?.sessionId === normalizedSessionId);
+        const transcriptPath = api.runtime.agent.session.resolveSessionFilePath(
+          normalizedSessionId,
+          entry,
+          {
+            agentId,
+            storePath,
+          },
+        );
+        return transcriptPath.trim() || undefined;
       } catch {
         return undefined;
       }
@@ -1880,7 +1916,12 @@ function wirePluginHandlers(
   );
 
   api.registerCommand(
-    createLcmCommand({ db: shared.waitForDatabase, config: deps.config, deps }),
+    createLcmCommand({
+      db: shared.waitForDatabase,
+      config: deps.config,
+      deps,
+      getLcm: shared.waitForEngine,
+    }),
   );
 }
 

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -9,6 +9,7 @@ import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
+import { describeLogError } from "../lcm-log.js";
 import {
   applyDoctorCleaners,
   getDoctorCleanerApplyUnavailableReason,
@@ -131,6 +132,11 @@ function buildSection(title: string, lines: string[]): string {
 
 function buildStatLine(label: string, value: string): string {
   return `${label}: ${value}`;
+}
+
+function formatFailureReason(error: unknown): string {
+  const message = describeLogError(error).trim();
+  return message || "Unknown error";
 }
 
 function formatCompressionRatio(contextTokens: number, compressedTokens: number): string {
@@ -864,10 +870,21 @@ async function buildBackupText(params: {
     return lines.join("\n");
   }
 
-  const backupPath = createLcmDatabaseBackup(params.db, {
-    databasePath: params.config.databasePath,
-    label: "backup",
-  });
+  let backupPath: string | null;
+  try {
+    backupPath = createLcmDatabaseBackup(params.db, {
+      databasePath: params.config.databasePath,
+      label: "backup",
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("🛠️ Backup", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", formatFailureReason(error)),
+      ]),
+    );
+    return lines.join("\n");
+  }
   if (!backupPath) {
     lines.push(
       buildSection("🛠️ Backup", [
@@ -969,10 +986,30 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
-  const backupPath = createLcmDatabaseBackup(params.db, {
-    databasePath: params.config.databasePath,
-    label: "rotate",
-  });
+  lines.push(
+    buildSection("📍 Current conversation", [
+      buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
+      buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
+      buildStatLine("messages", formatNumber(current.stats.messageCount)),
+    ]),
+    "",
+  );
+
+  let backupPath: string | null;
+  try {
+    backupPath = createLcmDatabaseBackup(params.db, {
+      databasePath: params.config.databasePath,
+      label: "rotate",
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("💾 Backup", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", formatFailureReason(error)),
+      ]),
+    );
+    return lines.join("\n");
+  }
   if (!backupPath) {
     lines.push(
       buildSection("🛠️ Rotate", [
@@ -983,25 +1020,30 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
-  const result = await (await params.getLcm()).rotateSessionStorage({
-    sessionId,
-    sessionKey,
-    sessionFile: transcriptPath,
-  });
-
   lines.push(
-    buildSection("📍 Current conversation", [
-      buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
-      buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
-      buildStatLine("messages", formatNumber(current.stats.messageCount)),
-    ]),
-    "",
     buildSection("💾 Backup", [
       buildStatLine("status", "created"),
       buildStatLine("backup path", backupPath),
     ]),
     "",
   );
+
+  let result: RotateSessionStorageResult;
+  try {
+    result = await (await params.getLcm()).rotateSessionStorage({
+      sessionId,
+      sessionKey,
+      sessionFile: transcriptPath,
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", formatFailureReason(error)),
+      ]),
+    );
+    return lines.join("\n");
+  }
 
   if (result.kind === "unavailable") {
     lines.push(

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -908,6 +908,7 @@ async function buildBackupText(params: {
 async function buildRotateText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
+  config: LcmConfig;
   deps?: LcmDependencies;
   getLcm?: () => Promise<RotateCommandEngine>;
 }): Promise<string> {
@@ -974,11 +975,56 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
+  const unavailableReason = getLcmBackupUnavailableReason(params.config.databasePath);
+  if (unavailableReason) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", unavailableReason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
   lines.push(
     buildSection("📍 Current conversation", [
       buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
       buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
       buildStatLine("messages", formatNumber(current.stats.messageCount)),
+    ]),
+    "",
+  );
+
+  let backupPath: string | null;
+  try {
+    backupPath = createLcmDatabaseBackup(params.db, {
+      databasePath: params.config.databasePath,
+      label: "rotate",
+      replaceLatest: true,
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("💾 Backup", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", formatFailureReason(error)),
+      ]),
+    );
+    return lines.join("\n");
+  }
+  if (!backupPath) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "Lossless Claw could not create the rotate backup."),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("💾 Backup", [
+      buildStatLine("status", "replaced latest"),
+      buildStatLine("backup path", backupPath),
     ]),
     "",
   );
@@ -1306,6 +1352,7 @@ export function createLcmCommand(params: {
             text: await buildRotateText({
               ctx,
               db: await getDb(),
+              config: params.config,
               deps: params.deps,
               getLcm: params.getLcm,
             }),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -908,7 +908,6 @@ async function buildBackupText(params: {
 async function buildRotateText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
-  config: LcmConfig;
   deps?: LcmDependencies;
   getLcm?: () => Promise<RotateCommandEngine>;
 }): Promise<string> {
@@ -975,55 +974,11 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
-  const unavailableReason = getLcmBackupUnavailableReason(params.config.databasePath);
-  if (unavailableReason) {
-    lines.push(
-      buildSection("🛠️ Rotate", [
-        buildStatLine("status", "unavailable"),
-        buildStatLine("reason", unavailableReason),
-      ]),
-    );
-    return lines.join("\n");
-  }
-
   lines.push(
     buildSection("📍 Current conversation", [
       buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
       buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
       buildStatLine("messages", formatNumber(current.stats.messageCount)),
-    ]),
-    "",
-  );
-
-  let backupPath: string | null;
-  try {
-    backupPath = createLcmDatabaseBackup(params.db, {
-      databasePath: params.config.databasePath,
-      label: "rotate",
-    });
-  } catch (error) {
-    lines.push(
-      buildSection("💾 Backup", [
-        buildStatLine("status", "failed"),
-        buildStatLine("reason", formatFailureReason(error)),
-      ]),
-    );
-    return lines.join("\n");
-  }
-  if (!backupPath) {
-    lines.push(
-      buildSection("🛠️ Rotate", [
-        buildStatLine("status", "unavailable"),
-        buildStatLine("reason", "Lossless Claw could not create the required pre-rotate backup."),
-      ]),
-    );
-    return lines.join("\n");
-  }
-
-  lines.push(
-    buildSection("💾 Backup", [
-      buildStatLine("status", "created"),
-      buildStatLine("backup path", backupPath),
     ]),
     "",
   );
@@ -1351,7 +1306,6 @@ export function createLcmCommand(params: {
             text: await buildRotateText({
               ctx,
               db: await getDb(),
-              config: params.config,
               deps: params.deps,
               getLcm: params.getLcm,
             }),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1,12 +1,14 @@
-import { statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import packageJson from "../../package.json" with { type: "json" };
 import { formatTimestamp } from "../compaction.js";
 import type { LcmConfig } from "../db/config.js";
+import type { RotateSessionStorageResult } from "../engine.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
+import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import {
   applyDoctorCleaners,
   getDoctorCleanerApplyUnavailableReason,
@@ -64,9 +66,19 @@ type CurrentConversationResolution =
 
 type ParsedLcmCommand =
   | { kind: "status" }
+  | { kind: "backup" }
+  | { kind: "rotate" }
   | { kind: "doctor"; apply: boolean }
   | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
   | { kind: "help"; error?: string };
+
+type RotateCommandEngine = {
+  rotateSessionStorage(params: {
+    sessionId?: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<RotateSessionStorageResult>;
+};
 
 const DOCTOR_CLEANER_IDS = new Set<DoctorCleanerId>(getDoctorCleanerFilterIds());
 
@@ -192,6 +204,14 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return rest.length === 0
         ? { kind: "status" }
         : { kind: "help", error: "`/lcm status` does not accept extra arguments." };
+    case "backup":
+      return rest.length === 0
+        ? { kind: "backup" }
+        : { kind: "help", error: "`/lcm backup` does not accept extra arguments." };
+    case "rotate":
+      return rest.length === 0
+        ? { kind: "rotate" }
+        : { kind: "help", error: "`/lcm rotate` does not accept extra arguments." };
     case "doctor":
       if (rest.length === 0) {
         return { kind: "doctor", apply: false };
@@ -223,7 +243,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
     default:
       return {
         kind: "help",
-        error: `Unknown subcommand \`${head}\`. Supported: status, doctor, doctor clean, doctor apply, help.`,
+        error: `Unknown subcommand \`${head}\`. Supported: status, backup, rotate, doctor, doctor clean, doctor apply, help.`,
       };
   }
 }
@@ -504,6 +524,14 @@ function buildHelpText(error?: string): string {
         formatCommand(`${VISIBLE_COMMAND} status`),
         "Show plugin, Global, current-conversation, and compaction-maintenance status.",
       ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} backup`),
+        "Create a timestamped backup of the current LCM database.",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} rotate`),
+        "Archive the current LCM conversation row and start fresh storage for this same live session.",
+      ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor clean`),
@@ -520,6 +548,8 @@ function buildHelpText(error?: string): string {
       buildStatLine("subcommands", `Discover them with ${formatCommand(`${VISIBLE_COMMAND} help`)}.`),
       buildStatLine("alias", `${formatCommand(HIDDEN_ALIAS)} is accepted as a shorter alias.`),
       buildStatLine("current conversation", "Uses the active LCM session when the host exposes session identity."),
+      buildStatLine("`/new`", "Prunes context for the current LCM conversation. It does not split storage."),
+      buildStatLine("`/reset`", "Resets OpenClaw session flow. Use rotate when you only want a fresh LCM row."),
     ]),
   ];
   return lines.join("\n");
@@ -804,6 +834,204 @@ function isPassingQuickCheck(result: string): boolean {
   return result === "ok";
 }
 
+function getLcmBackupUnavailableReason(databasePath: string): string | null {
+  const trimmed = databasePath.trim();
+  if (!trimmed || trimmed === ":memory:" || trimmed.startsWith("file::memory:")) {
+    return "Backup requires a file-backed SQLite database.";
+  }
+  return null;
+}
+
+async function buildBackupText(params: {
+  db: DatabaseSync;
+  config: LcmConfig;
+}): Promise<string> {
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "💾 Lossless Claw Backup",
+    "",
+  ];
+
+  const unavailableReason = getLcmBackupUnavailableReason(params.config.databasePath);
+  if (unavailableReason) {
+    lines.push(
+      buildSection("🛠️ Backup", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", unavailableReason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const backupPath = createLcmDatabaseBackup(params.db, {
+    databasePath: params.config.databasePath,
+    label: "backup",
+  });
+  if (!backupPath) {
+    lines.push(
+      buildSection("🛠️ Backup", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "Lossless Claw could not determine a backup path."),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("🛠️ Backup", [
+      buildStatLine("status", "created"),
+      buildStatLine("db path", params.config.databasePath),
+      buildStatLine("backup path", backupPath),
+    ]),
+  );
+  return lines.join("\n");
+}
+
+async function buildRotateText(params: {
+  ctx: PluginCommandContext;
+  db: DatabaseSync;
+  config: LcmConfig;
+  deps?: LcmDependencies;
+  getLcm?: () => Promise<RotateCommandEngine>;
+}): Promise<string> {
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🪓 Lossless Claw Rotate",
+    "",
+  ];
+
+  const sessionKey = normalizeIdentity(params.ctx.sessionKey);
+  const sessionId = normalizeIdentity(params.ctx.sessionId);
+  if (!sessionKey || !sessionId) {
+    lines.push(
+      buildSection("📍 Current conversation", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine(
+          "reason",
+          "OpenClaw must expose both the active session key and session id for Lossless Claw to rotate storage safely.",
+        ),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const current = await resolveCurrentConversation({
+    ctx: params.ctx,
+    db: params.db,
+  });
+  if (current.kind === "unavailable") {
+    lines.push(
+      buildSection("📍 Current conversation", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", current.reason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  if (!params.deps || !params.getLcm) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "Rotate requires the runtime-backed LCM engine to be available."),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const transcriptPath = await params.deps.resolveSessionTranscriptFile({
+    sessionId,
+    sessionKey,
+  });
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine(
+          "reason",
+          "Lossless Claw could not resolve the active session transcript path, so it cannot checkpoint the new row safely.",
+        ),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const unavailableReason = getLcmBackupUnavailableReason(params.config.databasePath);
+  if (unavailableReason) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", unavailableReason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const backupPath = createLcmDatabaseBackup(params.db, {
+    databasePath: params.config.databasePath,
+    label: "rotate",
+  });
+  if (!backupPath) {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "Lossless Claw could not create the required pre-rotate backup."),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const result = await (await params.getLcm()).rotateSessionStorage({
+    sessionId,
+    sessionKey,
+    sessionFile: transcriptPath,
+  });
+
+  lines.push(
+    buildSection("📍 Current conversation", [
+      buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
+      buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
+      buildStatLine("messages", formatNumber(current.stats.messageCount)),
+    ]),
+    "",
+    buildSection("💾 Backup", [
+      buildStatLine("status", "created"),
+      buildStatLine("backup path", backupPath),
+    ]),
+    "",
+  );
+
+  if (result.kind === "unavailable") {
+    lines.push(
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", result.reason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("🛠️ Rotate", [
+      buildStatLine("status", "rotated"),
+      buildStatLine("archived conversation id", formatNumber(result.archivedConversationId)),
+      buildStatLine("new active conversation id", formatNumber(result.activeConversationId)),
+      buildStatLine("archived message count", formatNumber(result.archivedMessageCount)),
+      buildStatLine("checkpoint bytes", formatNumber(result.checkpointSize)),
+      buildStatLine("transcript", transcriptPath),
+      buildStatLine("mode", "start from now forward"),
+    ]),
+    "",
+    buildSection("🧭 Notes", [
+      "Archived history remains searchable across conversations.",
+      `${formatCommand("/new")} still prunes context only, and ${formatCommand("/reset")} still resets OpenClaw session flow.`,
+    ]),
+  );
+  return lines.join("\n");
+}
+
 async function buildDoctorCleanersApplyText(params: {
   db: DatabaseSync;
   config: LcmConfig;
@@ -1048,6 +1276,7 @@ export function createLcmCommand(params: {
   config: LcmConfig;
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
+  getLcm?: () => Promise<RotateCommandEngine>;
 }): OpenClawPluginCommandDefinition {
   const getDb = async (): Promise<DatabaseSync> =>
     typeof params.db === "function" ? await params.db() : params.db;
@@ -1061,13 +1290,30 @@ export function createLcmCommand(params: {
       telegram: "Lossless Claw is working...",
     },
     description:
-      "Show Lossless Claw health, scan broken summaries, inspect high-confidence junk candidates, and run scoped doctor actions.",
+      "Show Lossless Claw health, create DB backups, rotate the current LCM conversation row, inspect high-confidence junk candidates, and run scoped doctor actions.",
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);
       switch (parsed.kind) {
         case "status":
           return { text: await buildStatusText({ ctx, db: await getDb(), config: params.config }) };
+        case "backup":
+          return {
+            text: await buildBackupText({
+              db: await getDb(),
+              config: params.config,
+            }),
+          };
+        case "rotate":
+          return {
+            text: await buildRotateText({
+              ctx,
+              db: await getDb(),
+              config: params.config,
+              deps: params.deps,
+              getLcm: params.getLcm,
+            }),
+          };
         case "doctor":
           return parsed.apply
             ? {

--- a/src/plugin/lcm-db-backup.ts
+++ b/src/plugin/lcm-db-backup.ts
@@ -1,3 +1,4 @@
+import { rmSync, renameSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { getFileBackedDatabasePath } from "../db/connection.js";
@@ -29,6 +30,18 @@ export function buildLcmDatabaseBackupPath(databasePath: string, label: string):
   );
 }
 
+export function buildLcmDatabaseLatestBackupPath(databasePath: string, label: string): string | null {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(databasePath);
+  if (!fileBackedDatabasePath) {
+    return null;
+  }
+
+  return join(
+    dirname(fileBackedDatabasePath),
+    `${basename(fileBackedDatabasePath)}.${normalizeBackupLabel(label)}-latest.bak`,
+  );
+}
+
 export function writeLcmDatabaseBackup(db: DatabaseSync, backupPath: string): void {
   db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
 }
@@ -38,8 +51,27 @@ export function createLcmDatabaseBackup(
   options: {
     databasePath: string;
     label: string;
+    replaceLatest?: boolean;
   },
 ): string | null {
+  if (options.replaceLatest) {
+    const latestBackupPath = buildLcmDatabaseLatestBackupPath(options.databasePath, options.label);
+    const tempBackupPath = buildLcmDatabaseBackupPath(options.databasePath, `${options.label}-tmp`);
+    if (!latestBackupPath || !tempBackupPath) {
+      return null;
+    }
+
+    try {
+      writeLcmDatabaseBackup(db, tempBackupPath);
+      rmSync(latestBackupPath, { force: true });
+      renameSync(tempBackupPath, latestBackupPath);
+      return latestBackupPath;
+    } catch (error) {
+      rmSync(tempBackupPath, { force: true });
+      throw error;
+    }
+  }
+
   const backupPath = buildLcmDatabaseBackupPath(options.databasePath, options.label);
   if (!backupPath) {
     return null;

--- a/src/plugin/lcm-db-backup.ts
+++ b/src/plugin/lcm-db-backup.ts
@@ -1,0 +1,50 @@
+import { basename, dirname, join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { getFileBackedDatabasePath } from "../db/connection.js";
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function normalizeBackupLabel(label: string): string {
+  const normalized = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "backup";
+}
+
+export function buildLcmDatabaseBackupPath(databasePath: string, label: string): string | null {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(databasePath);
+  if (!fileBackedDatabasePath) {
+    return null;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return join(
+    dirname(fileBackedDatabasePath),
+    `${basename(fileBackedDatabasePath)}.${normalizeBackupLabel(label)}-${timestamp}-${suffix}.bak`,
+  );
+}
+
+export function writeLcmDatabaseBackup(db: DatabaseSync, backupPath: string): void {
+  db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
+}
+
+export function createLcmDatabaseBackup(
+  db: DatabaseSync,
+  options: {
+    databasePath: string;
+    label: string;
+  },
+): string | null {
+  const backupPath = buildLcmDatabaseBackupPath(options.databasePath, options.label);
+  if (!backupPath) {
+    return null;
+  }
+
+  writeLcmDatabaseBackup(db, backupPath);
+  return backupPath;
+}

--- a/src/plugin/lcm-doctor-cleaners.ts
+++ b/src/plugin/lcm-doctor-cleaners.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
-import { basename, dirname, join } from "node:path";
 import { getFileBackedDatabasePath } from "../db/connection.js";
+import { buildLcmDatabaseBackupPath, writeLcmDatabaseBackup } from "./lcm-db-backup.js";
 
 export type DoctorCleanerId =
   | "archived_subagents"
@@ -554,10 +554,6 @@ function deleteTempCleanerCandidates(db: DatabaseSync): number {
   );
 }
 
-function quoteSqlString(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
-}
-
 export function getDoctorCleanerApplyUnavailableReason(databasePath: string): string | null {
   return getFileBackedDatabasePath(databasePath)
     ? null
@@ -565,17 +561,7 @@ export function getDoctorCleanerApplyUnavailableReason(databasePath: string): st
 }
 
 function buildCleanerBackupPath(databasePath: string): string | null {
-  const fileBackedDatabasePath = getFileBackedDatabasePath(databasePath);
-  if (!fileBackedDatabasePath) {
-    return null;
-  }
-
-  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
-  const suffix = Math.random().toString(36).slice(2, 8);
-  return join(
-    dirname(fileBackedDatabasePath),
-    `${basename(fileBackedDatabasePath)}.doctor-cleaners-${timestamp}-${suffix}.bak`,
-  );
+  return buildLcmDatabaseBackupPath(databasePath, "doctor-cleaners");
 }
 
 export function applyDoctorCleaners(
@@ -611,7 +597,7 @@ export function applyDoctorCleaners(
     };
   }
 
-  db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
+  writeLcmDatabaseBackup(db, backupPath);
 
   let deletedConversations = 0;
   let deletedMessages = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,12 @@ export interface LcmDependencies {
   /** Resolve runtime session id from an agent session key */
   resolveSessionIdFromSessionKey: (sessionKey: string) => Promise<string | undefined>;
 
+  /** Resolve the current transcript file path for a session identity */
+  resolveSessionTranscriptFile: (params: {
+    sessionId: string;
+    sessionKey?: string;
+  }) => Promise<string | undefined>;
+
   /** Agent lane constant for subagents */
   agentLaneSubagent: string;
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -118,7 +118,7 @@ function createTestDeps(
     },
     resolveAgentDir: () => process.env.HOME ?? tmpdir(),
     resolveSessionIdFromSessionKey: async () => undefined,
-    resolveSessionTranscriptFile: async ({ sessionId }: { sessionId: string }) => sessionId,
+    resolveSessionTranscriptFile: async () => undefined,
     agentLaneSubagent: "subagent",
     log: {
       info: vi.fn(),
@@ -260,6 +260,7 @@ async function ingestAndReadStoredContent(params: {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   closeLcmConnection();
   resetDelegatedExpansionGrantsForTests();
   for (const dir of tempDirs.splice(0)) {
@@ -2747,6 +2748,33 @@ describe("LcmContextEngine.bootstrap", () => {
       limit: 5,
     });
     expect(searchResults.some((result) => result.conversationId === original!.conversationId)).toBe(true);
+  });
+
+  it("reports rotate as unavailable when the session transcript cannot be read", async () => {
+    const engine = createEngine();
+
+    const conversation = await engine.getConversationStore().createConversation({
+      sessionId: "rotate-unreadable-session",
+      sessionKey: "agent:main:main",
+    });
+    await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "seed",
+        tokenCount: 1,
+      },
+    ]);
+
+    const result = await engine.rotateSessionStorage({
+      sessionId: "rotate-unreadable-session",
+      sessionKey: "agent:main:main",
+      sessionFile: join(tmpdir(), `missing-rotate-transcript-${Date.now()}.jsonl`),
+    });
+
+    expect(result.kind).toBe("unavailable");
+    expect(result.reason).toContain("could not read the current session transcript");
   });
 
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -118,6 +118,7 @@ function createTestDeps(
     },
     resolveAgentDir: () => process.env.HOME ?? tmpdir(),
     resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async ({ sessionId }: { sessionId: string }) => sessionId,
     agentLaneSubagent: "subagent",
     log: {
       info: vi.fn(),
@@ -2655,6 +2656,97 @@ describe("LcmContextEngine.bootstrap", () => {
         (message) => (message.content[0] as { text: string }).text,
       ),
     );
+  });
+
+  it("rotates LCM storage for the current session without replaying prior transcript history", async () => {
+    const sessionFile = createSessionFilePath("lcm-rotate-storage");
+    const sessionKey = "agent:main:main";
+    const sessionId = "rotate-storage-session";
+    const sm = SessionManager.open(sessionFile);
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+
+    const engine = createEngine();
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const original = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(original).not.toBeNull();
+
+    const rotate = await engine.rotateSessionStorage({
+      sessionId,
+      sessionKey,
+      sessionFile,
+    });
+    expect(rotate).toEqual({
+      kind: "rotated",
+      archivedConversationId: original!.conversationId,
+      activeConversationId: expect.any(Number),
+      archivedMessageCount: 2,
+      checkpointSize: statSync(sessionFile).size,
+    });
+
+    const archived = await engine.getConversationStore().getConversation(original!.conversationId);
+    const active = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(archived?.active).toBe(false);
+    expect(active).not.toBeNull();
+    expect(active?.conversationId).not.toBe(original!.conversationId);
+    expect(await engine.getConversationStore().getMessageCount(active!.conversationId)).toBe(0);
+
+    const rotatedBootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(active!.conversationId);
+    expect(rotatedBootstrapState?.sessionFilePath).toBe(sessionFile);
+    expect(rotatedBootstrapState?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+    expect(rotatedBootstrapState?.lastProcessedEntryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const checkpointHit = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(checkpointHit.bootstrapped).toBe(false);
+    expect(checkpointHit.importedMessages).toBe(0);
+
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "new user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "new assistant" }],
+    } as AgentMessage);
+
+    const appended = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(appended).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const archivedMessages = await engine.getConversationStore().getMessages(original!.conversationId);
+    const activeMessages = await engine.getConversationStore().getMessages(active!.conversationId);
+    expect(archivedMessages.map((message) => message.content)).toEqual(["old user", "old assistant"]);
+    expect(activeMessages.map((message) => message.content)).toEqual(["new user", "new assistant"]);
+
+    const searchResults = await engine.getConversationStore().searchMessages({
+      query: "old user",
+      mode: "regex",
+      limit: 5,
+    });
+    expect(searchResults.some((result) => result.conversationId === original!.conversationId)).toBe(true);
   });
 
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1139,7 +1139,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("reason: disk full");
   });
 
-  it("rotates the current session with backup-first storage splitting", async () => {
+  it("rotates the current session without taking an automatic backup", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
@@ -1184,76 +1184,18 @@ describe("lcm command", () => {
       }),
     );
 
-    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
-
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
     expect(result.text).toContain("status: rotated");
     expect(result.text).toContain("archived conversation id: 7");
     expect(result.text).toContain("new active conversation id: 8");
     expect(result.text).toContain("archived message count: 42");
     expect(result.text).toContain("mode: start from now forward");
-    expect(backupPath).toBeTruthy();
-    expect(existsSync(backupPath!)).toBe(true);
+    expect(result.text).not.toContain("backup path:");
     expect(rotateSessionStorage).toHaveBeenCalledWith({
       sessionId: "rotate-session",
       sessionKey: "agent:main:main",
       sessionFile: transcriptPath,
     });
-  });
-
-  it("reports rotate failure when the pre-rotate backup throws", async () => {
-    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
-    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
-    tempDirs.add(transcriptPath);
-
-    const rotateSessionStorage = vi.fn(async () => ({
-      kind: "rotated" as const,
-      archivedConversationId: 7,
-      activeConversationId: 8,
-      archivedMessageCount: 42,
-      checkpointSize: 1234,
-    }));
-    const deps = {
-      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
-    } as unknown as LcmDependencies;
-    const fixture = createCommandFixture({
-      deps,
-      getLcm: async () => ({
-        rotateSessionStorage,
-      }),
-    });
-    tempDirs.add(fixture.tempDir);
-    dbPaths.add(fixture.dbPath);
-    vi.spyOn(fixture.db, "exec").mockImplementation(() => {
-      throw new Error("SQLITE_BUSY");
-    });
-
-    const currentConversation = await fixture.conversationStore.createConversation({
-      sessionId: "rotate-backup-failure-session",
-      sessionKey: "agent:main:main",
-    });
-    await fixture.conversationStore.createMessagesBulk([
-      {
-        conversationId: currentConversation.conversationId,
-        seq: 0,
-        role: "user",
-        content: "first message",
-        tokenCount: 2,
-      },
-    ]);
-
-    const result = await fixture.command.handler(
-      createCommandContext("rotate", {
-        sessionId: "rotate-backup-failure-session",
-        sessionKey: "agent:main:main",
-      }),
-    );
-
-    expect(result.text).toContain("🪓 Lossless Claw Rotate");
-    expect(result.text).toContain("conversation id:");
-    expect(result.text).toContain("status: failed");
-    expect(result.text).toContain("reason: SQLITE_BUSY");
-    expect(rotateSessionStorage).not.toHaveBeenCalled();
   });
 
   it("reports rotate failure when the engine rotate call throws", async () => {
@@ -1297,13 +1239,10 @@ describe("lcm command", () => {
       }),
     );
 
-    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
-    expect(result.text).toContain("status: created");
     expect(result.text).toContain("status: failed");
     expect(result.text).toContain("reason: rotate exploded");
-    expect(backupPath).toBeTruthy();
-    expect(existsSync(backupPath!)).toBe(true);
+    expect(result.text).not.toContain("backup path:");
   });
 
   it("reports rotate as unavailable when OpenClaw does not expose a session key", async () => {
@@ -1340,6 +1279,36 @@ describe("lcm command", () => {
     const result = await fixture.command.handler(
       createCommandContext("status", {
         sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain(`conversation id: ${active.conversationId}`);
+    expect(result.text).not.toContain(`conversation id: ${archived.conversationId}`);
+  });
+
+  it("prefers the active conversation when session_id fallback rows share the same timestamp", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "shared-session-id",
+      sessionKey: "agent:main:archived",
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "shared-session-id",
+      sessionKey: "agent:main:active",
+    });
+
+    const tiedTimestamp = "2026-04-11 22:57:00";
+    fixture.db
+      .prepare(`UPDATE conversations SET created_at = ? WHERE conversation_id IN (?, ?)`)
+      .run(tiedTimestamp, archived.conversationId, active.conversationId);
+
+    const result = await fixture.command.handler(
+      createCommandContext("status", {
+        sessionId: "shared-session-id",
       }),
     );
 

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -70,6 +70,7 @@ describe("lcm command", () => {
   const dbPaths = new Set<string>();
 
   afterEach(() => {
+    vi.restoreAllMocks();
     for (const dbPath of dbPaths) {
       closeLcmConnection(dbPath);
     }
@@ -1123,6 +1124,21 @@ describe("lcm command", () => {
     expect(existsSync(backupPath!)).toBe(true);
   });
 
+  it("reports backup failure with structured output", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    vi.spyOn(fixture.db, "exec").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const result = await fixture.command.handler(createCommandContext("backup"));
+
+    expect(result.text).toContain("💾 Lossless Claw Backup");
+    expect(result.text).toContain("status: failed");
+    expect(result.text).toContain("reason: disk full");
+  });
+
   it("rotates the current session with backup-first storage splitting", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
@@ -1183,6 +1199,111 @@ describe("lcm command", () => {
       sessionKey: "agent:main:main",
       sessionFile: transcriptPath,
     });
+  });
+
+  it("reports rotate failure when the pre-rotate backup throws", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorage = vi.fn(async () => ({
+      kind: "rotated" as const,
+      archivedConversationId: 7,
+      activeConversationId: 8,
+      archivedMessageCount: 42,
+      checkpointSize: 1234,
+    }));
+    const deps = {
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorage,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    vi.spyOn(fixture.db, "exec").mockImplementation(() => {
+      throw new Error("SQLITE_BUSY");
+    });
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-backup-failure-session",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-backup-failure-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("conversation id:");
+    expect(result.text).toContain("status: failed");
+    expect(result.text).toContain("reason: SQLITE_BUSY");
+    expect(rotateSessionStorage).not.toHaveBeenCalled();
+  });
+
+  it("reports rotate failure when the engine rotate call throws", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-engine-fail-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorage = vi.fn(async () => {
+      throw new Error("rotate exploded");
+    });
+    const deps = {
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorage,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-engine-failure-session",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-engine-failure-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: created");
+    expect(result.text).toContain("status: failed");
+    expect(result.text).toContain("reason: rotate exploded");
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
   });
 
   it("reports rotate as unavailable when OpenClaw does not expose a session key", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1139,7 +1139,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("reason: disk full");
   });
 
-  it("rotates the current session without taking an automatic backup", async () => {
+  it("rotates the current session and replaces the latest rotate backup", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
@@ -1184,18 +1184,88 @@ describe("lcm command", () => {
       }),
     );
 
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: replaced latest");
     expect(result.text).toContain("status: rotated");
     expect(result.text).toContain("archived conversation id: 7");
     expect(result.text).toContain("new active conversation id: 8");
     expect(result.text).toContain("archived message count: 42");
     expect(result.text).toContain("mode: start from now forward");
-    expect(result.text).not.toContain("backup path:");
+    expect(backupPath).toBeTruthy();
+    expect(backupPath?.endsWith(".rotate-latest.bak")).toBe(true);
+    expect(existsSync(backupPath!)).toBe(true);
+
+    const second = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
+    const secondBackupPath = second.text.match(/backup path: (.+)/)?.[1]?.trim();
+    expect(secondBackupPath).toBe(backupPath);
+    expect(existsSync(secondBackupPath!)).toBe(true);
+
     expect(rotateSessionStorage).toHaveBeenCalledWith({
       sessionId: "rotate-session",
       sessionKey: "agent:main:main",
       sessionFile: transcriptPath,
     });
+  });
+
+  it("reports rotate failure when replacing the latest rotate backup throws", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorage = vi.fn(async () => ({
+      kind: "rotated" as const,
+      archivedConversationId: 7,
+      activeConversationId: 8,
+      archivedMessageCount: 42,
+      checkpointSize: 1234,
+    }));
+    const deps = {
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorage,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    vi.spyOn(fixture.db, "exec").mockImplementation(() => {
+      throw new Error("SQLITE_BUSY");
+    });
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-backup-failure-session",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-backup-failure-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: failed");
+    expect(result.text).toContain("reason: SQLITE_BUSY");
+    expect(rotateSessionStorage).not.toHaveBeenCalled();
   });
 
   it("reports rotate failure when the engine rotate call throws", async () => {
@@ -1240,9 +1310,10 @@ describe("lcm command", () => {
     );
 
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: replaced latest");
     expect(result.text).toContain("status: failed");
     expect(result.text).toContain("reason: rotate exploded");
-    expect(result.text).not.toContain("backup path:");
+    expect(result.text).toContain("backup path:");
   });
 
   it("reports rotate as unavailable when OpenClaw does not expose a session key", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,7 +12,13 @@ import { createLcmCommand, __testing } from "../src/plugin/lcm-command.js";
 import type { LcmSummarizeFn } from "../src/summarize.js";
 import type { LcmDependencies } from "../src/types.js";
 
-function createCommandFixture(options?: { summarize?: LcmSummarizeFn; deps?: LcmDependencies }) {
+function createCommandFixture(options?: {
+  summarize?: LcmSummarizeFn;
+  deps?: LcmDependencies;
+  getLcm?: () => Promise<{
+    rotateSessionStorage: (...args: unknown[]) => Promise<unknown>;
+  }>;
+}) {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-command-"));
   const dbPath = join(tempDir, "lcm.db");
   const db = createLcmDatabaseConnection(dbPath);
@@ -26,6 +32,7 @@ function createCommandFixture(options?: { summarize?: LcmSummarizeFn; deps?: Lcm
     config,
     summarize: options?.summarize,
     deps: options?.deps,
+    getLcm: options?.getLcm,
   });
   return { tempDir, dbPath, db, command, conversationStore, summaryStore };
 }
@@ -1031,6 +1038,7 @@ describe("lcm command", () => {
       readLatestAssistantReply: vi.fn(() => undefined) as LcmDependencies["readLatestAssistantReply"],
       resolveAgentDir: vi.fn(() => tmpdir()) as LcmDependencies["resolveAgentDir"],
       resolveSessionIdFromSessionKey: vi.fn(async () => undefined) as LcmDependencies["resolveSessionIdFromSessionKey"],
+      resolveSessionTranscriptFile: vi.fn(async () => undefined) as LcmDependencies["resolveSessionTranscriptFile"],
       agentLaneSubagent: "subagent",
       log: {
         info: vi.fn(),
@@ -1100,6 +1108,124 @@ describe("lcm command", () => {
     expect(repaired?.content).not.toContain("[Truncated from 111 tokens]");
   });
 
+  it("creates a standalone database backup", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(createCommandContext("backup"));
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+
+    expect(result.text).toContain("💾 Lossless Claw Backup");
+    expect(result.text).toContain("status: created");
+    expect(result.text).toContain(`db path: ${fixture.dbPath}`);
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
+  });
+
+  it("rotates the current session with backup-first storage splitting", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorage = vi.fn(async () => ({
+      kind: "rotated" as const,
+      archivedConversationId: 7,
+      activeConversationId: 8,
+      archivedMessageCount: 42,
+      checkpointSize: 1234,
+    }));
+    const deps = {
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorage,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-session",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: rotated");
+    expect(result.text).toContain("archived conversation id: 7");
+    expect(result.text).toContain("new active conversation id: 8");
+    expect(result.text).toContain("archived message count: 42");
+    expect(result.text).toContain("mode: start from now forward");
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
+    expect(rotateSessionStorage).toHaveBeenCalledWith({
+      sessionId: "rotate-session",
+      sessionKey: "agent:main:main",
+      sessionFile: transcriptPath,
+    });
+  });
+
+  it("reports rotate as unavailable when OpenClaw does not expose a session key", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-missing-session-key",
+      }),
+    );
+
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: unavailable");
+    expect(result.text).toContain("OpenClaw must expose both the active session key and session id");
+  });
+
+  it("prefers the active conversation when multiple rows share the same session key", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "shared-key-old",
+      sessionKey: "agent:main:main",
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "shared-key-new",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await fixture.command.handler(
+      createCommandContext("status", {
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain(`conversation id: ${active.conversationId}`);
+    expect(result.text).not.toContain(`conversation id: ${archived.conversationId}`);
+  });
+
   it("falls back to help text for unsupported subcommands", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
@@ -1107,6 +1233,8 @@ describe("lcm command", () => {
 
     const result = await fixture.command.handler(createCommandContext("rewrite"));
     expect(result.text).toContain("⚠️ Unknown subcommand `rewrite`.");
+    expect(result.text).toContain("`/lossless backup`");
+    expect(result.text).toContain("`/lossless rotate`");
     expect(result.text).toContain("`/lossless help`");
     expect(result.text).toContain("`/lcm` is accepted as a shorter alias.");
   });


### PR DESCRIPTION
## Summary

Closes #394.

This adds two small plugin commands aimed at the large-session operational gap in lossless-claw:

- `/lcm backup` / `/lossless backup`
- `/lcm rotate` / `/lossless rotate`

The core user problem is that a long-lived OpenClaw session can accumulate into one very large active LCM conversation row because LCM correctly reuses the row for the stable `sessionKey`.

## Why not `/new` or `/reset`?

Today the existing commands solve adjacent problems, but not this one:

- `/new` prunes context, but keeps writing into the same active LCM row
- `/reset` changes OpenClaw session flow, which is heavier than users often want when the real issue is just LCM row size

This patch adds the missing middle ground: keep the live OpenClaw session identity, but split LCM storage.

## What changed

- adds `/lcm backup` and `/lossless backup` to create a timestamped SQLite snapshot on demand
- adds `/lcm rotate` and `/lossless rotate` to archive the current active LCM row and start a fresh row for the same live session
- reuses shared backup plumbing rather than inventing a second backup path
- fixes bootstrap so a freshly rotated empty conversation with checkpoint state starts **from now forward** instead of re-importing older transcript history
- prefers the active conversation when multiple rows share the same `sessionKey`
- hardens command and engine failure handling so backup / rotate return structured failure output instead of bubbling raw runtime errors
- documents why `/new`, `/reset`, and `/lcm rotate` solve different problems

## Why this is useful now

Cross-session search and retrieval change the tradeoff here in a good way: once archived rows remain searchable, splitting an oversized active row is usually a performance win.

The active row stays smaller and cheaper to bootstrap, assemble, and maintain, while archived history remains available for search and retrieval across conversations.

## Validation

- `npm test` ✅ (`40` files / `699` tests)
- `npm run build` ✅

New coverage includes:

- standalone `/lcm backup`
- `/lcm backup` structured failure output
- `/lcm rotate` backup-first behavior and command UX
- `/lcm rotate` structured failure output for backup/engine exceptions
- active-row preference when multiple rows share a `sessionKey`
- engine-level rotate path that archives the old row, creates a fresh row, and imports only newly appended transcript messages after the rotate checkpoint
- engine-level unreadable transcript handling for rotate

## Manual validation

- create or reuse a large active LCM conversation
- run `/lcm backup` and verify a timestamped SQLite backup is created
- run `/lcm rotate` and verify the current row is archived and a fresh active row is created for the same live session identity
- verify the next bootstrap starts from the transcript frontier instead of replaying older history into the fresh row
- verify new messages land in the fresh row and archived history remains searchable

## Patch safety

This is intended as a safe patch candidate for immediate rollout:

- no schema migration
- no change to existing `/new` semantics
- no change to existing `/reset` semantics
- no change to retrieval semantics beyond making split rows easier to manage operationally
- new commands are opt-in

## How to merge

- patch-safe and self-contained
- no migration or rollout coordination needed
- merge as a normal patch release if the command behavior looks good to you
