### PR TITLE
fix: preserve LCM history across session rotation

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1004,13 +1004,6 @@ function resolveBootstrapMaxTokens(config: Pick<LcmConfig, "bootstrapMaxTokens" 
   return Math.max(6000, Math.floor(leafChunkTokens * 0.3));
 }
 
-function hasTable(db: DatabaseSync, tableName: string): boolean {
-  const row = db
-    .prepare(`SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?`)
-    .get(tableName) as { present?: number } | undefined;
-  return row?.present === 1;
-}
-
 /**
  * Keep only the newest bootstrap messages that fit within the token budget.
  *
@@ -2624,62 +2617,6 @@ export class LcmContextEngine implements ContextEngine {
     });
   }
 
-  private purgeConversationForBootstrapRotation(conversationId: number): void {
-    this.db.prepare(`DELETE FROM context_items WHERE conversation_id = ?`).run(conversationId);
-    this.db
-      .prepare(
-        `DELETE FROM summary_messages
-         WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
-      )
-      .run(conversationId);
-    this.db
-      .prepare(
-        `DELETE FROM summary_parents
-         WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)
-            OR parent_summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
-      )
-      .run(conversationId, conversationId);
-    if (hasTable(this.db, "summaries_fts")) {
-      this.db
-        .prepare(
-          `DELETE FROM summaries_fts
-           WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
-        )
-        .run(conversationId);
-    }
-    if (hasTable(this.db, "summaries_fts_cjk")) {
-      this.db
-        .prepare(
-          `DELETE FROM summaries_fts_cjk
-           WHERE summary_id IN (SELECT summary_id FROM summaries WHERE conversation_id = ?)`,
-        )
-        .run(conversationId);
-    }
-    this.db.prepare(`DELETE FROM summaries WHERE conversation_id = ?`).run(conversationId);
-    this.db.prepare(`DELETE FROM large_files WHERE conversation_id = ?`).run(conversationId);
-    this.db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(conversationId);
-    this.db
-      .prepare(`DELETE FROM conversation_compaction_telemetry WHERE conversation_id = ?`)
-      .run(conversationId);
-    if (hasTable(this.db, "messages_fts")) {
-      this.db
-        .prepare(
-          `DELETE FROM messages_fts
-           WHERE rowid IN (SELECT message_id FROM messages WHERE conversation_id = ?)`,
-        )
-        .run(conversationId);
-    }
-    this.db.prepare(`DELETE FROM messages WHERE conversation_id = ?`).run(conversationId);
-    this.db
-      .prepare(
-        `UPDATE conversations
-         SET bootstrapped_at = NULL,
-             updated_at = datetime('now')
-         WHERE conversation_id = ?`,
-      )
-      .run(conversationId);
-  }
-
   async bootstrap(params: {
     sessionId: string;
     sessionFile: string;
@@ -2731,7 +2668,6 @@ export class LcmContextEngine implements ContextEngine {
           });
           const conversationId = conversation.conversationId;
           let existingCount = await this.conversationStore.getMessageCount(conversationId);
-          let reseedingAfterSessionFileRotation = false;
           let bootstrapState =
             existingCount > 0
               ? await this.summaryStore.getConversationBootstrapState(conversationId)
@@ -2744,11 +2680,7 @@ export class LcmContextEngine implements ContextEngine {
             this.deps.log.warn(
               `[lcm] bootstrap: session file rotated conversation=${conversationId} ${sessionLabel} oldFile=${bootstrapState.sessionFilePath} newFile=${params.sessionFile}`,
             );
-            this.purgeConversationForBootstrapRotation(conversationId);
             bootstrapState = null;
-            existingCount = 0;
-            reseedingAfterSessionFileRotation = true;
-            conversation.bootstrappedAt = null;
           }
 
           // If the transcript file is byte-for-byte unchanged from the last
@@ -2855,17 +2787,10 @@ export class LcmContextEngine implements ContextEngine {
           // First-time import path: no LCM rows yet, so seed directly from the
           // active leaf context snapshot.
           if (existingCount === 0) {
-            const bootstrapMessages =
-              reseedingAfterSessionFileRotation
-                // A rotated transcript replaces the canonical session file for an
-                // existing conversation. Replay the full rotated history so LCM
-                // keeps coverage parity with the live session instead of
-                // reapplying the first-bootstrap suffix cap.
-                ? historicalMessages
-                : trimBootstrapMessagesToBudget(
-                    historicalMessages,
-                    resolveBootstrapMaxTokens(this.config),
-                  );
+            const bootstrapMessages = trimBootstrapMessagesToBudget(
+              historicalMessages,
+              resolveBootstrapMaxTokens(this.config),
+            );
 
             if (bootstrapMessages.length === 0) {
               await this.conversationStore.markConversationBootstrapped(conversationId);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2731,6 +2731,7 @@ export class LcmContextEngine implements ContextEngine {
           });
           const conversationId = conversation.conversationId;
           let existingCount = await this.conversationStore.getMessageCount(conversationId);
+          let reseedingAfterSessionFileRotation = false;
           let bootstrapState =
             existingCount > 0
               ? await this.summaryStore.getConversationBootstrapState(conversationId)
@@ -2746,6 +2747,7 @@ export class LcmContextEngine implements ContextEngine {
             this.purgeConversationForBootstrapRotation(conversationId);
             bootstrapState = null;
             existingCount = 0;
+            reseedingAfterSessionFileRotation = true;
             conversation.bootstrappedAt = null;
           }
 
@@ -2853,10 +2855,17 @@ export class LcmContextEngine implements ContextEngine {
           // First-time import path: no LCM rows yet, so seed directly from the
           // active leaf context snapshot.
           if (existingCount === 0) {
-            const bootstrapMessages = trimBootstrapMessagesToBudget(
-              historicalMessages,
-              resolveBootstrapMaxTokens(this.config),
-            );
+            const bootstrapMessages =
+              reseedingAfterSessionFileRotation
+                // A rotated transcript replaces the canonical session file for an
+                // existing conversation. Replay the full rotated history so LCM
+                // keeps coverage parity with the live session instead of
+                // reapplying the first-bootstrap suffix cap.
+                ? historicalMessages
+                : trimBootstrapMessagesToBudget(
+                    historicalMessages,
+                    resolveBootstrapMaxTokens(this.config),
+                  );
 
             if (bootstrapMessages.length === 0) {
               await this.conversationStore.markConversationBootstrapped(conversationId);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2356,6 +2356,64 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(await engine.getSummaryStore().getSummary("sum_rotation_session_key_old")).toBeNull();
   });
 
+  it("replays the full rotated transcript instead of reapplying bootstrapMaxTokens", async () => {
+    const engine = createEngineWithConfig({ bootstrapMaxTokens: 250 });
+    const firstSessionId = "bootstrap-rotation-full-reseed-1";
+    const secondSessionId = "bootstrap-rotation-full-reseed-2";
+    const sessionKey = "agent:main:test:bootstrap-rotation-full-reseed";
+    const firstSessionFile = createSessionFilePath("rotation-full-reseed-old");
+    const firstManager = SessionManager.open(firstSessionFile);
+    firstManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old seed user" }],
+    } as AgentMessage);
+    firstManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old seed assistant" }],
+    } as AgentMessage);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const rotatedSessionFile = createSessionFilePath("rotation-full-reseed-new");
+    const rotatedManager = SessionManager.open(rotatedSessionFile);
+    const rotatedMessages = Array.from({ length: 5 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: [{ type: "text", text: `rotated turn ${index} ${"x".repeat(396)}` }],
+    })) as AgentMessage[];
+    for (const message of rotatedMessages) {
+      rotatedManager.appendMessage(message);
+    }
+
+    const second = await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: rotatedSessionFile,
+    });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 5,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(
+      rotatedMessages.map((message) => (message.content[0] as { text: string }).text),
+    );
+  });
+
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-tail");
     const sm = SessionManager.open(sessionFile);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2206,7 +2206,7 @@ describe("LcmContextEngine.bootstrap", () => {
     });
   });
 
-  it("purges stale conversation data and re-bootstraps when the session file rotates", async () => {
+  it("preserves existing conversation data when the session file rotates", async () => {
     const firstSessionFile = createSessionFilePath("rotation-old");
     const firstManager = SessionManager.open(firstSessionFile);
     firstManager.appendMessage({
@@ -2243,6 +2243,14 @@ describe("LcmContextEngine.bootstrap", () => {
     const rotatedManager = SessionManager.open(rotatedSessionFile);
     rotatedManager.appendMessage({
       role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "user",
       content: [{ type: "text", text: "new user" }],
     } as AgentMessage);
     rotatedManager.appendMessage({
@@ -2254,23 +2262,29 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(second).toEqual({
       bootstrapped: true,
       importedMessages: 2,
+      reason: "reconciled missing session messages",
     });
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored.map((message) => message.content)).toEqual(["new user", "new assistant"]);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old user",
+      "old assistant",
+      "new user",
+      "new assistant",
+    ]);
 
     const contextItems = await engine.getSummaryStore().getContextItems(conversation!.conversationId);
-    expect(contextItems).toHaveLength(2);
-    expect(contextItems.every((item) => item.itemType === "message")).toBe(true);
+    expect(contextItems.some((item) => item.itemType === "summary")).toBe(true);
+    expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(4);
 
     const rotatedBootstrapState = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);
     expect(rotatedBootstrapState?.sessionFilePath).toBe(rotatedSessionFile);
-    expect(await engine.getSummaryStore().getSummary("sum_rotation_old")).toBeNull();
+    expect(await engine.getSummaryStore().getSummary("sum_rotation_old")).not.toBeNull();
   });
 
-  it("purges stale conversation data when the session file rotates across a stable sessionKey", async () => {
+  it("preserves conversation history when the session file rotates across a stable sessionKey", async () => {
     const engine = createEngine();
     const firstSessionId = "bootstrap-rotation-session-key-1";
     const secondSessionId = "bootstrap-rotation-session-key-2";
@@ -2317,6 +2331,14 @@ describe("LcmContextEngine.bootstrap", () => {
     const rotatedManager = SessionManager.open(rotatedSessionFile);
     rotatedManager.appendMessage({
       role: "user",
+      content: [{ type: "text", text: "old keyed user" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old keyed assistant" }],
+    } as AgentMessage);
+    rotatedManager.appendMessage({
+      role: "user",
       content: [{ type: "text", text: "new keyed user" }],
     } as AgentMessage);
     rotatedManager.appendMessage({
@@ -2332,6 +2354,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(second).toEqual({
       bootstrapped: true,
       importedMessages: 2,
+      reason: "reconciled missing session messages",
     });
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -2343,20 +2366,25 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(conversation!.sessionId).toBe(secondSessionId);
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored.map((message) => message.content)).toEqual(["new keyed user", "new keyed assistant"]);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old keyed user",
+      "old keyed assistant",
+      "new keyed user",
+      "new keyed assistant",
+    ]);
 
     const contextItems = await engine.getSummaryStore().getContextItems(conversation!.conversationId);
-    expect(contextItems).toHaveLength(2);
-    expect(contextItems.every((item) => item.itemType === "message")).toBe(true);
+    expect(contextItems.some((item) => item.itemType === "summary")).toBe(true);
+    expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(4);
 
     const rotatedBootstrapState = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);
     expect(rotatedBootstrapState?.sessionFilePath).toBe(rotatedSessionFile);
-    expect(await engine.getSummaryStore().getSummary("sum_rotation_session_key_old")).toBeNull();
+    expect(await engine.getSummaryStore().getSummary("sum_rotation_session_key_old")).not.toBeNull();
   });
 
-  it("replays the full rotated transcript instead of reapplying bootstrapMaxTokens", async () => {
+  it("does not reapply bootstrapMaxTokens after session file rotation", async () => {
     const engine = createEngineWithConfig({ bootstrapMaxTokens: 250 });
     const firstSessionId = "bootstrap-rotation-full-reseed-1";
     const secondSessionId = "bootstrap-rotation-full-reseed-2";
@@ -2384,6 +2412,19 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const rotatedSessionFile = createSessionFilePath("rotation-full-reseed-new");
     const rotatedManager = SessionManager.open(rotatedSessionFile);
+    const originalMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "old seed user" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old seed assistant" }],
+      },
+    ] as AgentMessage[];
+    for (const message of originalMessages) {
+      rotatedManager.appendMessage(message);
+    }
     const rotatedMessages = Array.from({ length: 5 }, (_, index) => ({
       role: index % 2 === 0 ? "user" : "assistant",
       content: [{ type: "text", text: `rotated turn ${index} ${"x".repeat(396)}` }],
@@ -2400,6 +2441,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(second).toEqual({
       bootstrapped: true,
       importedMessages: 5,
+      reason: "reconciled missing session messages",
     });
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -2410,7 +2452,9 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual(
-      rotatedMessages.map((message) => (message.content[0] as { text: string }).text),
+      [...originalMessages, ...rotatedMessages].map(
+        (message) => (message.content[0] as { text: string }).text,
+      ),
     );
   });
 


### PR DESCRIPTION
## What
This PR fixes two regressions in LCM bootstrap handling when a session JSONL file rotates. It preserves the full rotated transcript for existing conversations and removes the automatic purge path so session-file changes no longer delete persisted history.

## Why
Production logs and DB inspection showed that session-file rotation was deleting messages and summaries from stable conversations, which broke incremental compaction, confused `/compact`, and violated the lossless contract. Existing data surgery is separate, but future rotations need to stop causing data loss.

## Changes
- Replay full rotated transcript for existing sessions
- Remove purge-on-rotation bootstrap path
- Preserve summaries, lineage, and context items
- Add regression coverage for non-destructive rotation handling
- Assert rotation imports only missing tail messages

## Testing
- `npx vitest run test/engine.test.ts -t "rotation|bootstrapMaxTokens|reconciles missing tail messages|conversation already has messages"`
- `npx vitest run test/engine.test.ts`
- Expected: rotation bootstrap tests pass and full engine test file stays green
