### PR TITLE
fix: dedupe topic transcript sessions in tui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Repository Instructions
 
+## Principles
+
+- Lossless means lossless. Do not delete, purge, truncate, or otherwise discard persisted user data unless the user has explicitly invoked a command or approved an action whose purpose is to remove that data.
+- Automatic maintenance, bootstrap, repair, migration, compaction, cleanup, or rotation code must preserve user data. If continuity is uncertain, prefer degraded coverage, stale markers, warnings, or follow-up repair work over destructive recovery.
+- Backups are not a substitute for this rule. The live system must not rely on being able to restore user data after an automatic delete.
+
 ## PR Review And Merge
 
 - Before merging a PR, check whether it changes user-facing behavior or should appear in npm release notes.

--- a/tui/data.go
+++ b/tui/data.go
@@ -211,25 +211,87 @@ func discoverSessionFiles(agent agentEntry) ([]sessionFileEntry, error) {
 		return nil, fmt.Errorf("glob sessions for agent %q: %w", agent.name, err)
 	}
 
-	sessions := make([]sessionFileEntry, 0, len(paths))
+	sessionsByKey := make(map[string]sessionFileEntry, len(paths))
 	for _, path := range paths {
 		info, err := os.Stat(path)
 		if err != nil {
 			continue
 		}
 		filename := filepath.Base(path)
-		sessions = append(sessions, sessionFileEntry{
+		entry := sessionFileEntry{
 			filename:  filename,
 			path:      path,
 			updatedAt: info.ModTime(),
 			byteSize:  info.Size(),
-		})
+		}
+		dedupKey := strings.TrimSuffix(filename, filepath.Ext(filename))
+		if canonicalID, err := readSessionHeaderID(path); err == nil && canonicalID != "" {
+			dedupKey = canonicalID
+		}
+		if existing, ok := sessionsByKey[dedupKey]; !ok || preferSessionFileEntry(entry, existing) {
+			sessionsByKey[dedupKey] = entry
+		}
+	}
+
+	sessions := make([]sessionFileEntry, 0, len(sessionsByKey))
+	for _, entry := range sessionsByKey {
+		sessions = append(sessions, entry)
 	}
 
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].updatedAt.After(sessions[j].updatedAt)
 	})
 	return sessions, nil
+}
+
+func readSessionHeaderID(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open session %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var header struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal(line, &header); err != nil {
+			return "", fmt.Errorf("decode session header %q: %w", path, err)
+		}
+		if header.Type == "session" && strings.TrimSpace(header.ID) != "" {
+			return strings.TrimSpace(header.ID), nil
+		}
+		return "", nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan session %q: %w", path, err)
+	}
+	return "", nil
+}
+
+func preferSessionFileEntry(candidate, existing sessionFileEntry) bool {
+	candidateStem := strings.TrimSuffix(candidate.filename, filepath.Ext(candidate.filename))
+	existingStem := strings.TrimSuffix(existing.filename, filepath.Ext(existing.filename))
+	_, candidateIsTopic := trimTopicSessionSuffix(candidateStem)
+	_, existingIsTopic := trimTopicSessionSuffix(existingStem)
+	if candidateIsTopic != existingIsTopic {
+		return candidateIsTopic
+	}
+	if !candidate.updatedAt.Equal(existing.updatedAt) {
+		return candidate.updatedAt.After(existing.updatedAt)
+	}
+	if candidate.byteSize != existing.byteSize {
+		return candidate.byteSize > existing.byteSize
+	}
+	return candidate.filename < existing.filename
 }
 
 func loadSessionBatch(files []sessionFileEntry, offset, limit int, lcmDBPath string) ([]sessionEntry, int, error) {

--- a/tui/sessions_test.go
+++ b/tui/sessions_test.go
@@ -171,6 +171,49 @@ func TestLoadSessionBatchResolvesTopicSessionFiles(t *testing.T) {
 	}
 }
 
+func TestDiscoverSessionFilesDedupesCanonicalSessionIDAndPrefersTopicTranscript(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "main")
+	sessionsDir := filepath.Join(agentDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+
+	const canonicalID = "fd9b66a7-ebbf-4a7b-8415-b5d366379cd2"
+	barePath := filepath.Join(sessionsDir, canonicalID+".jsonl")
+	topicPath := filepath.Join(sessionsDir, canonicalID+"-topic-47.jsonl")
+	bareContent := `{"type":"session","id":"` + canonicalID + `"}` + "\n" +
+		`{"type":"message","id":"1","message":{"role":"user","content":"bare"}}` + "\n"
+	topicContent := `{"type":"session","id":"` + canonicalID + `"}` + "\n" +
+		`{"type":"message","id":"1","message":{"role":"user","content":"topic"}}` + "\n"
+	if err := os.WriteFile(barePath, []byte(bareContent), 0o644); err != nil {
+		t.Fatalf("write bare session file: %v", err)
+	}
+	if err := os.WriteFile(topicPath, []byte(topicContent), 0o644); err != nil {
+		t.Fatalf("write topic session file: %v", err)
+	}
+	now := time.Now()
+	if err := os.Chtimes(barePath, now, now); err != nil {
+		t.Fatalf("set bare mtime: %v", err)
+	}
+	if err := os.Chtimes(topicPath, now.Add(-time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("set topic mtime: %v", err)
+	}
+
+	files, err := discoverSessionFiles(agentEntry{name: "main", path: agentDir})
+	if err != nil {
+		t.Fatalf("discover session files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 deduped session file, got %d", len(files))
+	}
+	if files[0].filename != canonicalID+"-topic-47.jsonl" {
+		t.Fatalf("expected topic transcript to win, got %q", files[0].filename)
+	}
+}
+
 func TestLookupConversationIDResolvesTopicSessionFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
Fix the TUI session list so it collapses duplicate transcript files that belong to the same logical session, and add the lossless-data handling principle to `AGENTS.md`.

## Why
When OpenClaw wrote both `<session-id>.jsonl` and `<session-id>-topic-<n>.jsonl` for the same Telegram topic session, the TUI rendered both as separate rows even though they mapped to one LCM conversation. That made session state look split and misleading during debugging.

## Changes
- Dedupe discovered session files by JSONL header session id
- Prefer topic-qualified transcripts when duplicate files exist
- Add regression coverage for duplicate bare/topic session files
- Document the no-automatic-data-deletion principle in `AGENTS.md`

## Testing
- `cd /Users/phaedrus/Projects/lossless-claw/tui && go test ./... -run 'Test(LoadSessionBatch|LookupConversationID|DiscoverSessionFiles)'`
- Expected: `ok github.com/Martian-Engineering/lossless-claw/tui`
