### PR TITLE
fix: strip comments from bundle to avoid install-time env-harvesting false positive

### DIFF
--- a/.changeset/strip-bundle-comments.md
+++ b/.changeset/strip-bundle-comments.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Strip comments from the pre-bundled dist/index.js so the OpenClaw install-time code safety scanner no longer flags JSDoc prose (e.g. "Fetch all context items") as a network-send pattern and blocks installation with an `env-harvesting` false positive.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dag"
   ],
   "scripts": {
-    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@mariozechner/*\"",
+    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@mariozechner/*\" --minify-whitespace",
     "changeset": "changeset",
     "release:verify": "npm run build && npm test && npm pack --dry-run",
     "test": "vitest run --dir test",


### PR DESCRIPTION
## Problem

OpenClaw's install-time security scanner has an `env-harvesting` rule that fires when both `process.env` and `/\bfetch\b/i` appear in the same source file. The pre-bundled `dist/index.js` contains `process.env` reads (for config like `LCM_SUMMARY_MODEL`, `OPENCLAW_STATE_DIR`) and the word "Fetch" in a JSDoc comment (`* 1. Fetch all context items for the conversation`). The case-insensitive regex matches the comment, triggering a **critical** finding that **blocks installation**.

Users see: *"Environment variable access combined with network send — possible credential harvesting"*

Reported by [@DBCrypt0](https://x.com/DBCrypt0/status/2043027968742621268).

## Fix

Add `--minify-whitespace` to the esbuild command. This strips all comments (including JSDoc) while keeping variable names and stack traces readable.

- Bundle shrinks from 712KB → 552KB
- Scanner no longer triggers the false positive
- All 695 tests pass
- No semantic change

## Verification

```js
// Before (triggers)
const src = fs.readFileSync('dist/index.js', 'utf8');
/process\.env/.test(src)                        // true
/\bfetch\b|\bpost\b|http\.request/i.test(src)  // true  ← JSDoc comment

// After (clean)
/process\.env/.test(src)                        // true
/\bfetch\b|\bpost\b|http\.request/i.test(src)  // false ← comments stripped
```