### PR TITLE
fix(engine): move bootstrap file I/O off the event loop

### DIFF
--- a/.changeset/async-bootstrap-sync-io.md
+++ b/.changeset/async-bootstrap-sync-io.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Convert bootstrap's file I/O off the Node.js event loop. `readFileSegment` and `readLastJsonlEntryBeforeOffset` previously used sync `openSync`/`readSync`/`statSync`, which could block the gateway for minutes while scanning multi-MB JSONL transcripts during the bootstrap append-only path. The bootstrap entry `statSync` and `refreshBootstrapState` helper are now async as well. The backward-scan loop now only reads new chunks when the current carry has no more newlines, and the fast path short-circuits before the backward scan when the DB's latest hash no longer matches the checkpoint (the common case during active sessions, where the scan can never succeed).

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
-import { closeSync, createReadStream, openSync, readSync, statSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { mkdir, open, stat, writeFile } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { createInterface } from "node:readline";
@@ -1044,90 +1045,73 @@ function trimBootstrapMessagesToBudget(messages: AgentMessage[], maxTokens: numb
   return kept;
 }
 
-function readFileSegment(sessionFile: string, offset: number): string | null {
-  let fd: number | null = null;
+async function readFileSegment(sessionFile: string, offset: number): Promise<string | null> {
+  let fh: FileHandle | null = null;
   try {
-    fd = openSync(sessionFile, "r");
-    const stats = statSync(sessionFile);
+    fh = await open(sessionFile, "r");
+    const stats = await fh.stat();
     const safeOffset = Math.max(0, Math.min(Math.floor(offset), stats.size));
     const length = stats.size - safeOffset;
     if (length <= 0) {
       return "";
     }
     const buffer = Buffer.alloc(length);
-    readSync(fd, buffer, 0, length, safeOffset);
+    await fh.read(buffer, 0, length, safeOffset);
     return buffer.toString("utf8");
   } catch {
     return null;
   } finally {
-    if (fd != null) {
-      closeSync(fd);
-    }
+    await fh?.close();
   }
 }
 
-function readLastJsonlEntryBeforeOffset(
+async function readLastJsonlEntryBeforeOffset(
   sessionFile: string,
   offset: number,
   messageOnly = false,
   matcher?: (message: AgentMessage) => boolean,
-): string | null {
+): Promise<string | null> {
   const chunkSize = 16_384;
-  let fd: number | null = null;
-  try {
-    const safeOffset = Math.max(0, Math.floor(offset));
-    if (safeOffset <= 0) {
-      return null;
-    }
+  const safeOffset = Math.max(0, Math.floor(offset));
+  if (safeOffset <= 0) {
+    return null;
+  }
 
-    fd = openSync(sessionFile, "r");
+  let fh: FileHandle | null = null;
+  try {
+    fh = await open(sessionFile, "r");
     let cursor = safeOffset;
     let carry = "";
-    let reachedStart = false;
-    while (cursor > 0 || (reachedStart && carry.length > 0)) {
-      if (!reachedStart) {
-        const start = Math.max(0, cursor - chunkSize);
-        const length = cursor - start;
-        const buffer = Buffer.alloc(length);
-        readSync(fd, buffer, 0, length, start);
-        carry = buffer.toString("utf8") + carry;
-        cursor = start;
-        if (start === 0) {
-          reachedStart = true;
-        }
-      }
-
+    while (true) {
       const trimmedEnd = carry.replace(/\s+$/u, "");
-      if (!trimmedEnd) {
-        if (reachedStart) break;
-        carry = "";
-        continue;
-      }
-
-      const newlineIndex = Math.max(trimmedEnd.lastIndexOf("\n"), trimmedEnd.lastIndexOf("\r"));
-      if (newlineIndex >= 0) {
-        const candidate = trimmedEnd.slice(newlineIndex + 1).trim();
-        if (candidate) {
-          if (messageOnly) {
-            let matchedMessage: AgentMessage | null = null;
-            try {
-              matchedMessage = extractBootstrapMessageCandidate(JSON.parse(candidate));
-            } catch { /* not valid JSON, skip */ }
-            if (!matchedMessage || (matcher && !matcher(matchedMessage))) {
-              carry = trimmedEnd.slice(0, newlineIndex);
-              continue;
+      if (trimmedEnd) {
+        const newlineIndex = Math.max(trimmedEnd.lastIndexOf("\n"), trimmedEnd.lastIndexOf("\r"));
+        if (newlineIndex >= 0) {
+          const candidate = trimmedEnd.slice(newlineIndex + 1).trim();
+          if (candidate) {
+            if (messageOnly) {
+              let matchedMessage: AgentMessage | null = null;
+              try {
+                matchedMessage = extractBootstrapMessageCandidate(JSON.parse(candidate));
+              } catch { /* not valid JSON, skip */ }
+              if (!matchedMessage || (matcher && !matcher(matchedMessage))) {
+                carry = trimmedEnd.slice(0, newlineIndex);
+                continue;
+              }
             }
+            return candidate;
           }
-          return candidate;
+          carry = trimmedEnd.slice(0, newlineIndex);
+          continue;
         }
-        carry = trimmedEnd.slice(0, newlineIndex);
-        continue;
       }
 
-      // No newline found — entire trimmedEnd is one line
-      if (reachedStart) {
+      // No more newlines in current carry — need more data from earlier in the file.
+      if (cursor <= 0) {
+        // Reached start-of-file: whatever is left is the first line.
         const firstLine = trimmedEnd.trim() || null;
-        if (firstLine && messageOnly) {
+        if (!firstLine) return null;
+        if (messageOnly) {
           let matchedMessage: AgentMessage | null = null;
           try {
             matchedMessage = extractBootstrapMessageCandidate(JSON.parse(firstLine));
@@ -1136,24 +1120,26 @@ function readLastJsonlEntryBeforeOffset(
         }
         return firstLine;
       }
-      // Need more data from earlier in the file
-      continue;
+
+      const start = Math.max(0, cursor - chunkSize);
+      const length = cursor - start;
+      const buffer = Buffer.alloc(length);
+      await fh.read(buffer, 0, length, start);
+      carry = buffer.toString("utf8") + carry;
+      cursor = start;
     }
-    return null;
   } catch {
     return null;
   } finally {
-    if (fd != null) {
-      closeSync(fd);
-    }
+    await fh?.close();
   }
 }
 
-function readAppendedLeafPathMessages(params: {
+async function readAppendedLeafPathMessages(params: {
   sessionFile: string;
   offset: number;
-}): { messages: AgentMessage[]; canUseAppendOnly: boolean; sawNonWhitespace: boolean } {
-  const raw = readFileSegment(params.sessionFile, params.offset);
+}): Promise<{ messages: AgentMessage[]; canUseAppendOnly: boolean; sawNonWhitespace: boolean }> {
+  const raw = await readFileSegment(params.sessionFile, params.offset);
   if (raw == null) {
     return { messages: [], canUseAppendOnly: false, sawNonWhitespace: false };
   }
@@ -2600,7 +2586,7 @@ export class LcmContextEngine implements ContextEngine {
     fileStats?: { size: number; mtimeMs: number };
   }): Promise<void> {
     const latestDbMessage = await this.conversationStore.getLastMessage(params.conversationId);
-    const fileStats = params.fileStats ?? statSync(params.sessionFile);
+    const fileStats = params.fileStats ?? (await stat(params.sessionFile));
     await this.summaryStore.upsertConversationBootstrapState({
       conversationId: params.conversationId,
       sessionFilePath: params.sessionFile,
@@ -2642,7 +2628,7 @@ export class LcmContextEngine implements ContextEngine {
       `session=${params.sessionId}`,
       ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
     ].join(" ");
-    const sessionFileStats = statSync(params.sessionFile);
+    const sessionFileStats = await stat(params.sessionFile);
     const sessionFileSize = sessionFileStats.size;
     const sessionFileMtimeMs = Math.trunc(sessionFileStats.mtimeMs);
 
@@ -2719,24 +2705,34 @@ export class LcmContextEngine implements ContextEngine {
                   tokenCount: latestDbMessage.tokenCount,
                 })
               : null;
-            const tailEntryRaw = readLastJsonlEntryBeforeOffset(
-              params.sessionFile,
-              bootstrapState.lastProcessedOffset,
-              true,
-              (message) => createBootstrapEntryHash(toStoredMessage(message)) === latestDbHash,
-            );
+
+            // Short-circuit before the expensive backward scan: the fast-path can
+            // only succeed when the DB's latest hash still matches the checkpoint.
+            // When messages have been ingested since the last bootstrap this check
+            // fails and we skip straight to the async full-read slow path below,
+            // avoiding a backward scan that could never find a matching tail entry.
+            const canTryAppendOnlyFastPath =
+              latestDbHash !== null && latestDbHash === bootstrapState.lastProcessedEntryHash;
+
+            const tailEntryRaw = canTryAppendOnlyFastPath
+              ? await readLastJsonlEntryBeforeOffset(
+                  params.sessionFile,
+                  bootstrapState.lastProcessedOffset,
+                  true,
+                  (message) => createBootstrapEntryHash(toStoredMessage(message)) === latestDbHash,
+                )
+              : null;
             const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
             const tailEntryHash = tailEntryMessage
               ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
               : null;
 
             if (
-              latestDbHash &&
-              latestDbHash === bootstrapState.lastProcessedEntryHash &&
+              canTryAppendOnlyFastPath &&
               tailEntryHash &&
               tailEntryHash === bootstrapState.lastProcessedEntryHash
             ) {
-              const appended = readAppendedLeafPathMessages({
+              const appended = await readAppendedLeafPathMessages({
                 sessionFile: params.sessionFile,
                 offset: bootstrapState.lastProcessedOffset,
               });

--- a/test/bootstrap-message-only.test.ts
+++ b/test/bootstrap-message-only.test.ts
@@ -42,114 +42,114 @@ const envelopedMessage = JSON.stringify({ type: "message", message: { role: "use
 const commentaryEnvelope = JSON.stringify({ type: "commentary", message: { role: "assistant", content: "ignore me" } });
 
 describe("readLastJsonlEntryBeforeOffset with messageOnly", () => {
-  it("messageOnly=true skips trailing cache-ttl entries and returns last message", () => {
+  it("messageOnly=true skips trailing cache-ttl entries and returns last message", async () => {
     const file = makeTmpJsonl([userMessage, assistantMessage, cacheTtl, cacheTtl]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.role).toBe("assistant");
     expect(parsed.content).toBe("hi there");
   });
 
-  it("messageOnly=true skips multiple non-message types (cache-ttl, tool-result, meta)", () => {
+  it("messageOnly=true skips multiple non-message types (cache-ttl, tool-result, meta)", async () => {
     const file = makeTmpJsonl([userMessage, assistantMessage, cacheTtl, toolResult, customMeta]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.role).toBe("assistant");
     expect(parsed.content).toBe("hi there");
   });
 
-  it("returns null when JSONL has only non-message entries and messageOnly=true", () => {
+  it("returns null when JSONL has only non-message entries and messageOnly=true", async () => {
     const file = makeTmpJsonl([cacheTtl, toolResult, customMeta]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).toBeNull();
   });
 
-  it("messageOnly=true and messageOnly=false return same result when last entry is a message", () => {
+  it("messageOnly=true and messageOnly=false return same result when last entry is a message", async () => {
     const file = makeTmpJsonl([userMessage, assistantMessage]);
     const offset = fileSize(file);
 
-    const withFlag = readLastJsonlEntryBeforeOffset(file, offset, true);
-    const withoutFlag = readLastJsonlEntryBeforeOffset(file, offset, false);
+    const withFlag = await readLastJsonlEntryBeforeOffset(file, offset, true);
+    const withoutFlag = await readLastJsonlEntryBeforeOffset(file, offset, false);
     expect(withFlag).toBe(withoutFlag);
   });
 
-  it("messageOnly=false (default) returns non-message entries", () => {
+  it("messageOnly=false (default) returns non-message entries", async () => {
     const file = makeTmpJsonl([userMessage, cacheTtl]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, false);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, false);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.type).toBe("openclaw.cache-ttl");
   });
 
-  it("default messageOnly parameter returns non-message entries (backward compat)", () => {
+  it("default messageOnly parameter returns non-message entries (backward compat)", async () => {
     const file = makeTmpJsonl([userMessage, cacheTtl]);
     const offset = fileSize(file);
 
     // Call without third argument — should behave like messageOnly=false
-    const result = readLastJsonlEntryBeforeOffset(file, offset);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.type).toBe("openclaw.cache-ttl");
   });
 
-  it("handles canonical SessionManager message envelopes", () => {
+  it("handles canonical SessionManager message envelopes", async () => {
     const file = makeTmpJsonl([envelopedMessage, cacheTtl]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.message.role).toBe("user");
     expect(parsed.message.content).toBe("wrapped");
   });
 
-  it("skips non-message envelopes even when they contain nested message-shaped data", () => {
+  it("skips non-message envelopes even when they contain nested message-shaped data", async () => {
     const file = makeTmpJsonl([userMessage, commentaryEnvelope]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.role).toBe("user");
     expect(parsed.content).toBe("hello");
   });
 
-  it("returns null for empty file", () => {
+  it("returns null for empty file", async () => {
     const file = makeTmpJsonl([]);
     const offset = fileSize(file);
-    expect(readLastJsonlEntryBeforeOffset(file, offset, true)).toBeNull();
+    await expect(readLastJsonlEntryBeforeOffset(file, offset, true)).resolves.toBeNull();
   });
 
-  it("returns null when offset is 0", () => {
+  it("returns null when offset is 0", async () => {
     const file = makeTmpJsonl([userMessage]);
-    expect(readLastJsonlEntryBeforeOffset(file, 0, true)).toBeNull();
+    await expect(readLastJsonlEntryBeforeOffset(file, 0, true)).resolves.toBeNull();
   });
 
-  it("finds message when it is the only entry (first line)", () => {
+  it("finds message when it is the only entry (first line)", async () => {
     const file = makeTmpJsonl([userMessage]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).not.toBeNull();
     const parsed = JSON.parse(result!);
     expect(parsed.role).toBe("user");
   });
 
-  it("returns null when only entry is non-message and messageOnly=true", () => {
+  it("returns null when only entry is non-message and messageOnly=true", async () => {
     const file = makeTmpJsonl([cacheTtl]);
     const offset = fileSize(file);
 
-    const result = readLastJsonlEntryBeforeOffset(file, offset, true);
+    const result = await readLastJsonlEntryBeforeOffset(file, offset, true);
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Convert `readFileSegment`, `readLastJsonlEntryBeforeOffset`, and the `statSync` calls in `bootstrap()` / `refreshBootstrapState()` to `fs/promises`, so a multi-MB session JSONL can no longer block the Node.js event loop for minutes during the append-only bootstrap path (freezing every gateway session, Control UI, CLI, and WebSocket connection).
- In `readLastJsonlEntryBeforeOffset`, only read a new chunk when the current carry has no more newlines to peel. The original re-read a chunk on every iteration even while still processing existing lines, which wasted I/O and amplified the implicit O(n^2) prepended-carry pattern.
- Short-circuit the append-only fast path before the backward scan when `latestDbHash !== bootstrapState.lastProcessedEntryHash`. That is the common case during active sessions — the DB frontier advances past the checkpoint between bootstraps, and the matcher can never find a matching tail entry in that state, so we skip straight to the async full-read slow path.

A patch-level changeset is included per `RELEASING.md`.

## Test plan

- [x] `npm test` — full vitest suite passes (695 tests, 40 files) on this branch
- [x] `npx tsc --noEmit` — no new type errors introduced in touched files (unrelated pre-existing errors elsewhere are unchanged)
- [x] `bootstrap-message-only.test.ts` updated to `await` the now-async `readLastJsonlEntryBeforeOffset`; all 12 cases still pass
- [ ] Soak test on a real large session: bootstrap no longer freezes the gateway; a `setTimeout` callback fires within ~100 ms while bootstrap is reconciling
- [ ] Maintainer review of the fast-path short-circuit to confirm no correctness regression when checkpoint hashes legitimately match

Co-Authored-By: WoCha <wocha@jetd.one> via Claude Code