### PR TITLE
fix(engine): guard bootstrap against missed /reset lifecycle split

### DIFF
--- a/.changeset/green-squids-wink.md
+++ b/.changeset/green-squids-wink.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Restrict the missed-`/reset` bootstrap fallback to confirmed missing transcript paths so transient `stat()` failures do not rotate a live conversation.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3003,6 +3003,42 @@ export class LcmContextEngine implements ContextEngine {
             });
           };
 
+          // Guard: when a sessionKey resumes on a new sessionId and the tracked
+          // transcript file has disappeared, treat it as a missed /reset and
+          // rotate the conversation before getOrCreate would re-attach to it.
+          const normalizedSessionKey = params.sessionKey?.trim();
+          if (normalizedSessionKey) {
+            const activeByKey = await this.conversationStore.getConversationBySessionKey(normalizedSessionKey);
+            if (activeByKey && activeByKey.sessionId !== params.sessionId) {
+              const activeBootstrapState = await this.summaryStore.getConversationBootstrapState(
+                activeByKey.conversationId,
+              );
+              const trackedSessionFile = activeBootstrapState?.sessionFilePath;
+              let trackedSessionFileMissing = false;
+              if (typeof trackedSessionFile === "string" && trackedSessionFile.length > 0) {
+                try { await stat(trackedSessionFile); } catch { trackedSessionFileMissing = true; }
+              }
+              const transcriptRotated =
+                typeof trackedSessionFile === "string" &&
+                trackedSessionFile.length > 0 &&
+                trackedSessionFile !== params.sessionFile;
+
+              if (transcriptRotated && trackedSessionFileMissing) {
+                this.deps.log.warn(
+                  `[lcm] bootstrap: detected reset/rollover without prior lifecycle split; rotating conversation=${activeByKey.conversationId} session=${params.sessionId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} oldFile=${trackedSessionFile} newFile=${params.sessionFile}`,
+                );
+                await this.applySessionReplacement({
+                  reason: "bootstrap session-file rollover fallback",
+                  sessionId: activeByKey.sessionId,
+                  sessionKey: normalizedSessionKey,
+                  nextSessionId: params.sessionId,
+                  nextSessionKey: normalizedSessionKey,
+                  createReplacement: true,
+                });
+              }
+            }
+          }
+
           const conversation = await this.conversationStore.getOrCreateConversation(params.sessionId, {
             sessionKey: params.sessionKey,
           });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -115,6 +115,14 @@ type ContextEngineMaintenanceRuntimeContext = Record<string, unknown> & {
   ) => Promise<ContextEngineMaintenanceResult>;
 };
 
+function getErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  const { code } = error as NodeJS.ErrnoException;
+  return typeof code === "string" ? code : undefined;
+}
+
 const TRANSCRIPT_GC_BATCH_SIZE = 12;
 const HOT_CACHE_HYSTERESIS_TURNS = 2;
 const DYNAMIC_LEAF_CHUNK_MEDIUM_MULTIPLIER = 1.5;
@@ -3016,7 +3024,18 @@ export class LcmContextEngine implements ContextEngine {
               const trackedSessionFile = activeBootstrapState?.sessionFilePath;
               let trackedSessionFileMissing = false;
               if (typeof trackedSessionFile === "string" && trackedSessionFile.length > 0) {
-                try { await stat(trackedSessionFile); } catch { trackedSessionFileMissing = true; }
+                try {
+                  await stat(trackedSessionFile);
+                } catch (err) {
+                  const code = getErrorCode(err);
+                  if (code === "ENOENT" || code === "ENOTDIR") {
+                    trackedSessionFileMissing = true;
+                  } else {
+                    this.deps.log.warn(
+                      `[lcm] bootstrap: could not verify tracked transcript path conversation=${activeByKey.conversationId} file=${trackedSessionFile} error=${describeLogError(err)}`,
+                    );
+                  }
+                }
               }
               const transcriptRotated =
                 typeof trackedSessionFile === "string" &&

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2581,6 +2581,104 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(await engine.getSummaryStore().getSummary("sum_rotation_session_key_old")).not.toBeNull();
   });
 
+  it("rotates to a fresh conversation when a stable sessionKey resumes on a new transcript after the old file disappears", async () => {
+    const engine = createEngine();
+    const firstSessionId = "bootstrap-missed-reset-fallback-1";
+    const secondSessionId = "bootstrap-missed-reset-fallback-2";
+    const sessionKey = "agent:main:test:bootstrap-missed-reset-fallback";
+    const firstSessionFile = createSessionFilePath("missed-reset-fallback-old");
+    const firstManager = SessionManager.open(firstSessionFile);
+    firstManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    firstManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_missed_reset_fallback_old",
+      conversationId: originalConversation!.conversationId,
+      kind: "leaf",
+      content: "old summary",
+      tokenCount: 5,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(originalConversation!.conversationId, "sum_missed_reset_fallback_old");
+
+    rmSync(firstSessionFile, { force: true });
+
+    const secondSessionFile = createSessionFilePath("missed-reset-fallback-new");
+    const secondManager = SessionManager.open(secondSessionFile);
+    secondManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "new user" }],
+    } as AgentMessage);
+    secondManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "new assistant" }],
+    } as AgentMessage);
+
+    const second = await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: secondSessionFile,
+    });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).not.toBeNull();
+    expect(activeConversation!.conversationId).not.toBe(originalConversation!.conversationId);
+    expect(activeConversation!.sessionId).toBe(secondSessionId);
+    expect(activeConversation!.active).toBe(true);
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.active).toBe(false);
+    expect(archivedConversation?.archivedAt).not.toBeNull();
+
+    const archivedMessages = await engine.getConversationStore().getMessages(
+      originalConversation!.conversationId,
+    );
+    expect(archivedMessages.map((message) => message.content)).toEqual([
+      "old user",
+      "old assistant",
+    ]);
+
+    const activeMessages = await engine.getConversationStore().getMessages(
+      activeConversation!.conversationId,
+    );
+    expect(activeMessages.map((message) => message.content)).toEqual([
+      "new user",
+      "new assistant",
+    ]);
+  });
+
   it("does not reapply bootstrapMaxTokens after session file rotation", async () => {
     const engine = createEngineWithConfig({ bootstrapMaxTokens: 250 });
     const firstSessionId = "bootstrap-rotation-full-reseed-1";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { appendFileSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { appendFileSync, chmodSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -2677,6 +2677,114 @@ describe("LcmContextEngine.bootstrap", () => {
       "new user",
       "new assistant",
     ]);
+  });
+
+  it("preserves the active conversation when the tracked transcript stat fails for a non-missing reason", async () => {
+    const engine = createEngine();
+    const firstSessionId = "bootstrap-stat-failure-fallback-1";
+    const secondSessionId = "bootstrap-stat-failure-fallback-2";
+    const sessionKey = "agent:main:test:bootstrap-stat-failure-fallback";
+    const firstSessionFile = createSessionFilePath("stat-failure-fallback-old");
+    const firstManager = SessionManager.open(firstSessionFile);
+    firstManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    firstManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_stat_failure_fallback_old",
+      conversationId: originalConversation!.conversationId,
+      kind: "leaf",
+      content: "old summary",
+      tokenCount: 5,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(originalConversation!.conversationId, "sum_stat_failure_fallback_old");
+
+    const secondSessionFile = createSessionFilePath("stat-failure-fallback-new");
+    const secondManager = SessionManager.open(secondSessionFile);
+    secondManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "old user" }],
+    } as AgentMessage);
+    secondManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "old assistant" }],
+    } as AgentMessage);
+    secondManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "new user" }],
+    } as AgentMessage);
+    secondManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "new assistant" }],
+    } as AgentMessage);
+
+    const firstSessionDir = dirname(firstSessionFile);
+    const firstSessionDirMode = statSync(firstSessionDir).mode & 0o777;
+    chmodSync(firstSessionDir, 0o000);
+
+    let second: Awaited<ReturnType<LcmContextEngine["bootstrap"]>>;
+    try {
+      second = await engine.bootstrap({
+        sessionId: secondSessionId,
+        sessionKey,
+        sessionFile: secondSessionFile,
+      });
+    } finally {
+      chmodSync(firstSessionDir, firstSessionDirMode);
+    }
+
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    expect(conversation!.conversationId).toBe(originalConversation!.conversationId);
+    expect(conversation!.sessionId).toBe(secondSessionId);
+    expect(conversation!.active).toBe(true);
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.archivedAt).toBeNull();
+
+    const storedMessages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(storedMessages.map((message) => message.content)).toEqual([
+      "old user",
+      "old assistant",
+      "new user",
+      "new assistant",
+    ]);
+
+    expect(await engine.getSummaryStore().getSummary("sum_stat_failure_fallback_old")).not.toBeNull();
   });
 
   it("does not reapply bootstrapMaxTokens after session file rotation", async () => {


### PR DESCRIPTION
After /reset, bootstrap can silently reattach to the previous active conversation instead of starting a new one.

This happens when the new session starts before the lifecycle split has been recorded. Bootstrap sees an existing active conversation for the same sessionKey and reuses it, even though the sessionId changed and the old transcript file is gone.

The fix adds a guard in bootstrap, before `getOrCreateConversation`: when the stored sessionId and sessionFile don't match the incoming ones, and the old tracked transcript path no longer exists, bootstrap treats it as a missed reset and rotates the conversation via the existing `applySessionReplacement` path.

Normal transcript rotation is not affected — the old file still exists in that case.

Tested locally:
- Normal /reset lifecycle handling
- Ordinary transcript rotation (old file still present)
- Missed-reset case (old transcript gone, new sessionId on same sessionKey)