### PR TITLE
Defer proactive compaction debt and surface LCM maintenance state

### DIFF
--- a/.changeset/deferred-compaction-maintenance.md
+++ b/.changeset/deferred-compaction-maintenance.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Added deferred proactive compaction as the default mode, with explicit maintenance debt tracking and status visibility so foreground turns no longer run threshold compaction inline unless compatibility mode is enabled.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
           "newSessionRetainDepth": 2,
           "contextThreshold": 0.75,
           "incrementalMaxDepth": 1,
+          "cacheAwareCompaction": {
+            "enabled": true,
+            "cacheTTLSeconds": 300
+          },
           "ignoreSessionPatterns": [
             "agent:*:cron:**"
           ],
@@ -176,9 +180,10 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 | `LCM_TRANSCRIPT_GC_ENABLED` | `false` | Enable transcript rewrite GC during `maintain()` |
 | `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | `deferred` | Choose whether proactive threshold compaction is deferred into maintenance debt or kept inline for legacy behavior |
+| `LCM_CACHE_TTL_SECONDS` | `300` | Cache TTL used by cache-aware deferred compaction when provider/runtime telemetry does not supply a more specific retention window |
 
 Transcript GC rewrites are disabled by default. Set `transcriptGcEnabled` or `LCM_TRANSCRIPT_GC_ENABLED` to turn them on explicitly.
-Deferred proactive compaction is also the default. Set `proactiveThresholdCompactionMode` or `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` to `inline` only if you need legacy foreground compaction behavior.
+Deferred proactive compaction is also the default. Set `proactiveThresholdCompactionMode` or `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` to `inline` only if you need legacy foreground compaction behavior. In deferred mode, lossless-claw records one coalesced prompt-mutating debt item after the turn, leaves background `maintain()` to process only non-prompt-mutating work while Anthropic cache is still hot, and then consumes that debt pre-assembly once the cache is cold or the prompt is approaching overflow.
 
 ### Expansion model override requirements
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 - `/lcm` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
 - `/lcm doctor` scans for broken or truncated summaries
 - `/lcm doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
+- `/lcm status` shows plugin, conversation, and maintenance state including deferred compaction debt
 - `/lossless` is an alias for `/lcm` on supported native command surfaces
 
 These are plugin slash/native commands, not root shell CLI subcommands. Supported examples:
@@ -128,6 +129,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
             "agent:*:cron:**"
           ],
           "transcriptGcEnabled": false,
+          "proactiveThresholdCompactionMode": "deferred",
           "summaryModel": "openai/gpt-5.4-mini",
           "expansionModel": "openai/gpt-5.4-mini",
           "delegationTimeoutMs": 300000,
@@ -173,8 +175,10 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Max time to wait for a single model-backed LCM summarizer call |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 | `LCM_TRANSCRIPT_GC_ENABLED` | `false` | Enable transcript rewrite GC during `maintain()` |
+| `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | `deferred` | Choose whether proactive threshold compaction is deferred into maintenance debt or kept inline for legacy behavior |
 
 Transcript GC rewrites are disabled by default. Set `transcriptGcEnabled` or `LCM_TRANSCRIPT_GC_ENABLED` to turn them on explicitly.
+Deferred proactive compaction is also the default. Set `proactiveThresholdCompactionMode` or `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` to `inline` only if you need legacy foreground compaction behavior.
 
 ### Expansion model override requirements
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | Key | Type | Default | Env override | Purpose |
 | --- | --- | --- | --- | --- |
 | `cacheAwareCompaction.enabled` | `boolean` | `true` | `LCM_CACHE_AWARE_COMPACTION_ENABLED` | Defers incremental leaf compaction more aggressively when prompt-cache telemetry indicates a hot cache. |
+| `cacheAwareCompaction.cacheTTLSeconds` | `integer` | `300` | `LCM_CACHE_TTL_SECONDS` | Fallback cache TTL used when deferred Anthropic compaction has provider/model telemetry but no explicit runtime cache-retention window. |
 | `cacheAwareCompaction.maxColdCacheCatchupPasses` | `integer` | `2` | `LCM_MAX_COLD_CACHE_CATCHUP_PASSES` | Maximum bounded catch-up passes allowed in one maintenance cycle when cache telemetry is cold. |
 | `cacheAwareCompaction.hotCachePressureFactor` | `number` | `4` | `LCM_HOT_CACHE_PRESSURE_FACTOR` | Multiplier applied to the hot-cache leaf trigger before raw-history pressure overrides cache preservation. |
 | `cacheAwareCompaction.hotCacheBudgetHeadroomRatio` | `number` | `0.2` | `LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO` | Minimum fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely. |
@@ -247,8 +248,11 @@ This keeps long-term history available while still giving users a real clean-sla
 Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 
 - deferred mode records a single coalesced maintenance debt row per conversation
-- `maintain()` can consume that debt when the host explicitly opts in to deferred execution
+- deferred mode persists provider/model/cache telemetry so Anthropic-family sessions can avoid rewriting a still-hot prompt cache
+- `maintain()` can still process non-prompt-mutating work when the host explicitly opts in to deferred execution, but it leaves prompt-mutating debt pending while Anthropic cache is still hot
+- `assemble()` consumes deferred prompt-mutating debt pre-assembly once the cache is cold or the next turn is already approaching overflow
 - `/lcm status` / `/lossless status` shows the current maintenance state, including pending/running/last-failure details
+- status output also surfaces the latest API/cache telemetry so operators can see whether a deferred debt item is being preserved for cache-safety reasons
 - set `proactiveThresholdCompactionMode` to `inline` only if you need the legacy inline proactive compaction behavior for compatibility
 
 ## Environment-only knobs outside plugin config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "circuitBreakerThreshold": 5,
   "circuitBreakerCooldownMs": 1800000,
   "fallbackProviders": [],
+  "proactiveThresholdCompactionMode": "deferred",
   "cacheAwareCompaction": {
     "enabled": true,
     "maxColdCacheCatchupPasses": 2,
@@ -111,6 +112,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |
 | `transcriptGcEnabled` | `boolean` | `false` | `LCM_TRANSCRIPT_GC_ENABLED` | Enables transcript rewrite GC during `maintain()`; disabled by default so transcript rewrites stay opt-in. |
+| `proactiveThresholdCompactionMode` | `"deferred" \| "inline"` | `"deferred"` | `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | Controls whether proactive threshold compaction is deferred into maintenance debt by default or run inline for legacy behavior. |
 
 > **Multi-profile note:** `OPENCLAW_STATE_DIR` (set by the host OpenClaw gateway) controls where state is stored. When two gateways run on the same host (e.g. separate bot personas), each gateway sets its own `OPENCLAW_STATE_DIR` and lossless-claw automatically uses that directory for the database, large-file payloads, auth-profile lookups, and legacy secrets — no per-profile plugin config is needed.
 
@@ -239,6 +241,15 @@ Lossless-claw treats OpenClaw reset commands differently:
 - `/reset` archives the active conversation row and creates a fresh active row for the same stable `sessionKey`
 
 This keeps long-term history available while still giving users a real clean-slate reset.
+
+### Deferred proactive compaction
+
+Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
+
+- deferred mode records a single coalesced maintenance debt row per conversation
+- `maintain()` can consume that debt when the host explicitly opts in to deferred execution
+- `/lcm status` / `/lossless status` shows the current maintenance state, including pending/running/last-failure details
+- set `proactiveThresholdCompactionMode` to `inline` only if you need the legacy inline proactive compaction behavior for compatibility
 
 ## Environment-only knobs outside plugin config
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -153,6 +153,10 @@
       "label": "Cache-Aware Compaction",
       "help": "When enabled, hot prompt cache defers incremental compaction while cold cache allows bounded catch-up passes"
     },
+    "cacheAwareCompaction.cacheTTLSeconds": {
+      "label": "Short Cache TTL (seconds)",
+      "help": "Treat short-lived prompt-cache entries as hot for this many seconds before deferred compaction may rewrite the prompt"
+    },
     "cacheAwareCompaction.maxColdCacheCatchupPasses": {
       "label": "Cold Cache Catch-Up Passes",
       "help": "Maximum incremental leaf passes allowed in one maintenance cycle when prompt cache is cold"
@@ -334,6 +338,10 @@
         "properties": {
           "enabled": {
             "type": "boolean"
+          },
+          "cacheTTLSeconds": {
+            "type": "integer",
+            "minimum": 1
           },
           "maxColdCacheCatchupPasses": {
             "type": "integer",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -185,6 +185,10 @@
       "label": "Transcript GC",
       "help": "Enable transcript rewrite GC during maintain(); disabled by default"
     },
+    "proactiveThresholdCompactionMode": {
+      "label": "Proactive Threshold Compaction Mode",
+      "help": "Choose deferred compaction debt by default or keep legacy inline proactive compaction"
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit fallback provider/model pairs for compaction summarization (e.g., [{\"provider\": \"anthropic\", \"model\": \"claude-haiku-4-5\"}])"
@@ -367,6 +371,13 @@
       },
       "transcriptGcEnabled": {
         "type": "boolean"
+      },
+      "proactiveThresholdCompactionMode": {
+        "type": "string",
+        "enum": [
+          "deferred",
+          "inline"
+        ]
       },
       "databasePath": {
         "description": "Path to LCM SQLite database (preferred key; alias of dbPath, default: <OPENCLAW_STATE_DIR>/lcm.db)",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -212,8 +212,10 @@ Controls whether proactive threshold compaction is deferred into maintenance deb
 Why it matters:
 
 - `deferred` is the default and avoids foreground turn stalls by recording one coalesced maintenance row per conversation
+- `deferred` also stores provider/model/cache telemetry so Anthropic-family sessions can avoid rewriting a still-hot prompt cache
 - `inline` preserves the legacy foreground compaction path for hosts that do not yet support deferred execution
 - `/lossless status` and `/lcm status` surface pending/running/last-failure maintenance state so operators can see when compaction is queued
+- background `maintain()` can still do non-prompt-mutating work, but prompt-mutating debt is consumed pre-assembly once cache is cold or the next turn is already approaching overflow
 
 ## Compaction timing and shape
 
@@ -338,6 +340,19 @@ Why it matters:
 #### `cacheAwareCompaction.enabled`
 
 Defers incremental leaf compaction more aggressively when prompt-cache telemetry indicates a hot cache.
+
+#### `cacheAwareCompaction.cacheTTLSeconds`
+
+Fallback cache TTL used when deferred Anthropic compaction has provider/model telemetry but no explicit runtime cache-retention window.
+
+Why it matters:
+
+- lets cache-safe deferred compaction stay conservative even when the host only knows that the turn was Anthropic-family, not the exact retention tier
+- keeps prompt-mutating debt pending until the cached prefix is likely cold
+
+Default:
+
+- `300`
 
 #### `cacheAwareCompaction.maxColdCacheCatchupPasses`
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -205,6 +205,16 @@ Why it matters:
 - keep this off unless you want transcript GC to mutate the live session file during maintenance
 - the default is `false`
 
+### `proactiveThresholdCompactionMode`
+
+Controls whether proactive threshold compaction is deferred into maintenance debt or kept inline for legacy behavior.
+
+Why it matters:
+
+- `deferred` is the default and avoids foreground turn stalls by recording one coalesced maintenance row per conversation
+- `inline` preserves the legacy foreground compaction path for hosts that do not yet support deferred execution
+- `/lossless status` and `/lcm status` surface pending/running/last-failure maintenance state so operators can see when compaction is queued
+
 ## Compaction timing and shape
 
 ### `contextThreshold`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -19,6 +19,7 @@ export function resolveOpenclawStateDir(env: NodeJS.ProcessEnv = process.env): s
 
 export type CacheAwareCompactionConfig = {
   enabled: boolean;
+  cacheTTLSeconds: number;
   maxColdCacheCatchupPasses: number;
   hotCachePressureFactor: number;
   hotCacheBudgetHeadroomRatio: number;
@@ -433,6 +434,10 @@ export function resolveLcmConfigWithDiagnostics(
           env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== undefined
             ? env.LCM_CACHE_AWARE_COMPACTION_ENABLED !== "false"
             : toBool(cacheAwareCompaction?.enabled) ?? true,
+        cacheTTLSeconds:
+          parseFiniteInt(env.LCM_CACHE_TTL_SECONDS)
+            ?? toNumber(cacheAwareCompaction?.cacheTTLSeconds)
+            ?? 300,
         maxColdCacheCatchupPasses:
           parseFiniteInt(env.LCM_MAX_COLD_CACHE_CATCHUP_PASSES)
             ?? toNumber(cacheAwareCompaction?.maxColdCacheCatchupPasses)

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -29,6 +29,8 @@ export type DynamicLeafChunkTokensConfig = {
   max: number;
 };
 
+export type ProactiveThresholdCompactionMode = "deferred" | "inline";
+
 export type LcmConfigSource = "env" | "plugin-config" | "default";
 
 export type LcmConfigDiagnostics = {
@@ -87,6 +89,8 @@ export type LcmConfig = {
   pruneHeartbeatOk: boolean;
   /** When true, maintain() may rewrite transcript entries for transcript GC. */
   transcriptGcEnabled: boolean;
+  /** Controls whether proactive threshold compaction runs inline or is deferred. */
+  proactiveThresholdCompactionMode: ProactiveThresholdCompactionMode;
   /** Hard ceiling for assembly token budget — caps runtime-provided and fallback budgets. */
   maxAssemblyTokenBudget?: number;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
@@ -180,6 +184,16 @@ function toStr(value: unknown): string | undefined {
   return undefined;
 }
 
+function toProactiveThresholdCompactionMode(
+  value: unknown,
+): ProactiveThresholdCompactionMode | undefined {
+  const normalized = toStr(value)?.toLowerCase();
+  if (normalized === "inline" || normalized === "deferred") {
+    return normalized;
+  }
+  return undefined;
+}
+
 /** Coerce a plugin config value into a trimmed string array when possible. */
 function toStrArray(value: unknown): string[] | undefined {
   if (Array.isArray(value)) {
@@ -265,6 +279,9 @@ export function resolveLcmConfigWithDiagnostics(
   const pc = pluginConfig ?? {};
   const cacheAwareCompaction = toRecord(pc.cacheAwareCompaction);
   const dynamicLeafChunkTokens = toRecord(pc.dynamicLeafChunkTokens);
+  const proactiveThresholdCompactionMode = toProactiveThresholdCompactionMode(
+    env.LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE,
+  ) ?? toProactiveThresholdCompactionMode(pc.proactiveThresholdCompactionMode) ?? "deferred";
   const resolvedLeafChunkTokens =
     parseFiniteInt(env.LCM_LEAF_CHUNK_TOKENS)
       ?? toNumber(pc.leafChunkTokens) ?? 20000;
@@ -393,6 +410,7 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
           ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"
           : toBool(pc.transcriptGcEnabled) ?? false,
+      proactiveThresholdCompactionMode,
       maxAssemblyTokenBudget:
         parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)
           ?? toNumber(pc.maxAssemblyTokenBudget) ?? undefined,

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -110,6 +110,10 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
     (col) => col.name === "tokens_accumulated_since_leaf_compaction",
   );
   const hasLastActivityBand = telemetryColumns.some((col) => col.name === "last_activity_band");
+  const hasLastApiCallAt = telemetryColumns.some((col) => col.name === "last_api_call_at");
+  const hasLastCacheTouchAt = telemetryColumns.some((col) => col.name === "last_cache_touch_at");
+  const hasProvider = telemetryColumns.some((col) => col.name === "provider");
+  const hasModel = telemetryColumns.some((col) => col.name === "model");
 
   if (!hasLastLeafCompactionAt) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_leaf_compaction_at TEXT`);
@@ -128,6 +132,18 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
     db.exec(
       `ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_activity_band TEXT NOT NULL DEFAULT 'low' CHECK (last_activity_band IN ('low', 'medium', 'high'))`,
     );
+  }
+  if (!hasLastApiCallAt) {
+    db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_api_call_at TEXT`);
+  }
+  if (!hasLastCacheTouchAt) {
+    db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_cache_touch_at TEXT`);
+  }
+  if (!hasProvider) {
+    db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN provider TEXT`);
+  }
+  if (!hasModel) {
+    db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN model TEXT`);
   }
 }
 
@@ -791,6 +807,10 @@ export function runLcmMigrations(
       tokens_accumulated_since_leaf_compaction INTEGER NOT NULL DEFAULT 0,
       last_activity_band TEXT NOT NULL DEFAULT 'low'
         CHECK (last_activity_band IN ('low', 'medium', 'high')),
+      last_api_call_at TEXT,
+      last_cache_touch_at TEXT,
+      provider TEXT,
+      model TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -794,6 +794,20 @@ export function runLcmMigrations(
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS conversation_compaction_maintenance (
+      conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      pending INTEGER NOT NULL DEFAULT 0,
+      requested_at TEXT,
+      reason TEXT,
+      running INTEGER NOT NULL DEFAULT 0,
+      last_started_at TEXT,
+      last_finished_at TEXT,
+      last_failure_summary TEXT,
+      token_budget INTEGER,
+      current_token_count INTEGER,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS lcm_migration_state (
       step_name TEXT NOT NULL,
       algorithm_version INTEGER NOT NULL,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -56,7 +56,6 @@ import {
 } from "./store/compaction-telemetry-store.js";
 import {
   CompactionMaintenanceStore,
-  type ConversationCompactionMaintenanceRecord,
 } from "./store/compaction-maintenance-store.js";
 import {
   ConversationStore,
@@ -4594,7 +4593,7 @@ export class LcmContextEngine implements ContextEngine {
     );
 
     return {
-      ok: true,
+      ok: !authFailure,
       compacted: rounds > 0,
       reason: authFailure
         ? "provider auth failure"

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -81,6 +81,9 @@ type PromptCacheSnapshot = {
   cacheState: CacheState;
   retention?: string;
   sawExplicitBreak: boolean;
+  lastCacheTouchAt?: Date;
+  provider?: string;
+  model?: string;
 };
 type IncrementalCompactionDecision = {
   shouldCompact: boolean;
@@ -1590,6 +1593,51 @@ export class LcmContextEngine implements ContextEngine {
     return telemetry.cacheState;
   }
 
+  /** Resolve the effective prompt-cache TTL in milliseconds for the stored retention class. */
+  private resolvePromptCacheTtlMs(retention?: string | null): number | null {
+    const normalized = retention?.trim().toLowerCase();
+    if (normalized === "none") {
+      return null;
+    }
+    if (normalized === "long" || normalized === "1h") {
+      return 60 * 60 * 1000;
+    }
+    return Math.max(1, this.config.cacheAwareCompaction.cacheTTLSeconds) * 1000;
+  }
+
+  /** Detect Anthropic-family sessions where local prompt rewrites can invalidate a hot prefix cache. */
+  private isAnthropicPromptCacheFamily(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+  ): boolean {
+    const provider = telemetry?.provider?.trim().toLowerCase() ?? "";
+    const model = telemetry?.model?.trim().toLowerCase() ?? "";
+    return provider.includes("anthropic") || model.includes("claude");
+  }
+
+  /** Determine whether the last prompt-cache touch is still within the active TTL window. */
+  private isPromptCacheStillHot(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+    now: Date = new Date(),
+  ): boolean {
+    const ttlMs = this.resolvePromptCacheTtlMs(telemetry?.retention ?? null);
+    if (!ttlMs) {
+      return false;
+    }
+    const touchAt = telemetry?.lastCacheTouchAt ?? telemetry?.lastObservedCacheHitAt ?? null;
+    if (!touchAt) {
+      return false;
+    }
+    return now.getTime() - touchAt.getTime() < ttlMs;
+  }
+
+  /** Delay prompt-mutating deferred compaction while Anthropic's exact-prefix cache is still hot. */
+  private shouldDelayPromptMutatingDeferredCompaction(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+    now: Date = new Date(),
+  ): boolean {
+    return this.isAnthropicPromptCacheFamily(telemetry) && this.isPromptCacheStillHot(telemetry, now);
+  }
+
   /** Decide whether a hot cache still has enough real token-budget headroom to skip incremental maintenance. */
   private isComfortablyUnderTokenBudget(params: {
     currentTokenCount?: number;
@@ -1734,16 +1782,25 @@ export class LcmContextEngine implements ContextEngine {
   /** Extract the current prompt-cache snapshot from runtime context, if present. */
   private readPromptCacheSnapshot(runtimeContext?: Record<string, unknown>): PromptCacheSnapshot | null {
     const promptCache = asRecord(runtimeContext?.promptCache);
-    if (!promptCache) {
+    const provider = safeString(runtimeContext?.provider)?.trim()
+      ?? safeString(runtimeContext?.providerId)?.trim();
+    const model = safeString(runtimeContext?.model)?.trim()
+      ?? safeString(runtimeContext?.modelId)?.trim();
+    if (!promptCache && !provider && !model) {
       return null;
     }
 
-    const lastCallUsage = asRecord(promptCache.lastCallUsage);
-    const observation = asRecord(promptCache.observation);
+    const lastCallUsage = asRecord(promptCache?.lastCallUsage);
+    const observation = asRecord(promptCache?.observation);
     const cacheRead = this.normalizeOptionalCount(lastCallUsage?.cacheRead);
     const cacheWrite = this.normalizeOptionalCount(lastCallUsage?.cacheWrite);
     const sawExplicitBreak = safeBoolean(observation?.broke) === true;
-    const retention = safeString(promptCache.retention)?.trim();
+    const retention = safeString(promptCache?.retention)?.trim();
+    const lastCacheTouchAtRaw = promptCache?.lastCacheTouchAt;
+    const lastCacheTouchAt =
+      typeof lastCacheTouchAtRaw === "number" && Number.isFinite(lastCacheTouchAtRaw)
+        ? new Date(lastCacheTouchAtRaw)
+        : undefined;
     const hasUsageSignal = cacheRead !== undefined || cacheWrite !== undefined;
     const hasObservationSignal =
       typeof observation?.cacheRead === "number"
@@ -1765,6 +1822,9 @@ export class LcmContextEngine implements ContextEngine {
       cacheState,
       ...(retention ? { retention } : {}),
       sawExplicitBreak,
+      ...(lastCacheTouchAt ? { lastCacheTouchAt } : {}),
+      ...(provider ? { provider } : {}),
+      ...(model ? { model } : {}),
     };
   }
 
@@ -1789,6 +1849,14 @@ export class LcmContextEngine implements ContextEngine {
       (existing?.turnsSinceLeafCompaction ?? 0) + 1;
     const tokensAccumulatedSinceLeafCompaction =
       params.rawTokensOutsideTail ?? existing?.tokensAccumulatedSinceLeafCompaction ?? 0;
+    const touchedPromptCache =
+      snapshot?.lastCacheTouchAt
+      ?? (
+        snapshot
+        && (snapshot.lastObservedCacheRead !== undefined || snapshot.lastObservedCacheWrite !== undefined)
+          ? now
+          : existing?.lastCacheTouchAt ?? null
+      );
     const lastActivityBand = this.classifyDynamicLeafActivityBand({
       lastActivityBand: existing?.lastActivityBand,
       tokensAccumulatedSinceLeafCompaction,
@@ -1814,13 +1882,17 @@ export class LcmContextEngine implements ContextEngine {
       turnsSinceLeafCompaction,
       tokensAccumulatedSinceLeafCompaction,
       lastActivityBand,
+      lastApiCallAt: now,
+      lastCacheTouchAt: touchedPromptCache,
+      provider: snapshot?.provider ?? existing?.provider ?? null,
+      model: snapshot?.model ?? existing?.model ?? null,
     });
     const updated = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
       params.conversationId,
     );
     if (updated) {
       this.deps.log.debug(
-        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
+        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} retention=${updated.retention ?? "null"} lastApiCallAt=${updated.lastApiCallAt?.toISOString() ?? "null"} lastCacheTouchAt=${updated.lastCacheTouchAt?.toISOString() ?? "null"} provider=${updated.provider ?? "null"} model=${updated.model ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
       );
     }
     return updated;
@@ -1846,6 +1918,10 @@ export class LcmContextEngine implements ContextEngine {
       turnsSinceLeafCompaction: 0,
       tokensAccumulatedSinceLeafCompaction: 0,
       lastActivityBand: params.activityBand ?? existing?.lastActivityBand ?? "low",
+      lastApiCallAt: existing?.lastApiCallAt ?? null,
+      lastCacheTouchAt: existing?.lastCacheTouchAt ?? null,
+      provider: existing?.provider ?? null,
+      model: existing?.model ?? null,
     });
     this.deps.log.debug(
       `[lcm] compaction telemetry reset after leaf compaction: conversation=${params.conversationId} cacheState=${existing?.cacheState ?? "unknown"} activityBand=${params.activityBand ?? existing?.lastActivityBand ?? "low"}`,
@@ -3758,6 +3834,12 @@ export class LcmContextEngine implements ContextEngine {
         }
 
         let deferredCompactionResult: ContextEngineMaintenanceResult | null = null;
+        const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+          conversation.conversationId,
+        );
+        const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+          conversation.conversationId,
+        );
         if (params.runtimeContext?.allowDeferredCompactionExecution === true) {
           const runtimeTokenBudget = (() => {
             const tokenBudget = asRecord(params.runtimeContext)?.tokenBudget;
@@ -3770,27 +3852,29 @@ export class LcmContextEngine implements ContextEngine {
             }
             return 128_000;
           })();
-          deferredCompactionResult = await this.consumeDeferredCompactionDebt({
-            conversationId: conversation.conversationId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            tokenBudget: this.applyAssemblyBudgetCap(runtimeTokenBudget),
-            currentTokenCount:
-              typeof params.runtimeContext?.currentTokenCount === "number"
-                ? Math.floor(params.runtimeContext.currentTokenCount as number)
-                : undefined,
-            runtimeContext: params.runtimeContext,
-            legacyParams: asRecord(params.runtimeContext),
-          });
-        } else {
-          const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
-            conversation.conversationId,
-          );
-          if (maintenance?.pending || maintenance?.running) {
+          if ((maintenance?.pending || maintenance?.running)
+            && this.shouldDelayPromptMutatingDeferredCompaction(telemetry)) {
             this.deps.log.info(
-              `[lcm] maintain: deferred compaction debt pending conversation=${conversation.conversationId} ${sessionLabel} but host runtimeContext.allowDeferredCompactionExecution is disabled`,
+              `[lcm] maintain: deferred compaction debt still hot-cache deferred conversation=${conversation.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
             );
+          } else {
+            deferredCompactionResult = await this.consumeDeferredCompactionDebt({
+              conversationId: conversation.conversationId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              tokenBudget: this.applyAssemblyBudgetCap(runtimeTokenBudget),
+              currentTokenCount:
+                typeof params.runtimeContext?.currentTokenCount === "number"
+                  ? Math.floor(params.runtimeContext.currentTokenCount as number)
+                  : undefined,
+              runtimeContext: params.runtimeContext,
+              legacyParams: asRecord(params.runtimeContext),
+            });
           }
+        } else if (maintenance?.pending || maintenance?.running) {
+          this.deps.log.info(
+            `[lcm] maintain: deferred compaction debt pending conversation=${conversation.conversationId} ${sessionLabel} but host runtimeContext.allowDeferredCompactionExecution is disabled`,
+          );
         }
 
         if (!this.config.transcriptGcEnabled) {
@@ -4250,7 +4334,7 @@ export class LcmContextEngine implements ContextEngine {
       const rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
       await this.updateCompactionTelemetry({
         conversationId: conversation.conversationId,
-        runtimeContext: asRecord(params.runtimeContext),
+        runtimeContext: legacyParams,
         tokenBudget,
         rawTokensOutsideTail: rawLeafTrigger.rawTokensOutsideTail,
       });
@@ -4272,7 +4356,9 @@ export class LcmContextEngine implements ContextEngine {
         liveContextTokens,
       );
       if (this.config.proactiveThresholdCompactionMode === "inline") {
+        let leafCompactionScheduled = false;
         if (leafDecision.shouldCompact) {
+          leafCompactionScheduled = true;
           this.compactLeafAsync({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
@@ -4290,18 +4376,20 @@ export class LcmContextEngine implements ContextEngine {
           });
         }
 
-        try {
-          await this.compact({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            sessionFile: params.sessionFile,
-            tokenBudget,
-            currentTokenCount: liveContextTokens,
-            compactionTarget: "threshold",
-            legacyParams,
-          });
-        } catch {
-          // Proactive compaction is best-effort in the post-turn lifecycle.
+        if (!leafCompactionScheduled) {
+          try {
+            await this.compact({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              sessionFile: params.sessionFile,
+              tokenBudget,
+              currentTokenCount: liveContextTokens,
+              compactionTarget: "threshold",
+              legacyParams,
+            });
+          } catch {
+            // Proactive compaction is best-effort in the post-turn lifecycle.
+          }
         }
       } else if (thresholdDecision.shouldCompact || leafDecision.shouldCompact) {
         await this.recordDeferredCompactionDebt({
@@ -4358,6 +4446,55 @@ export class LcmContextEngine implements ContextEngine {
         };
       }
 
+      const tokenBudget = this.applyAssemblyBudgetCap(
+        typeof params.tokenBudget === "number" &&
+        Number.isFinite(params.tokenBudget) &&
+        params.tokenBudget > 0
+          ? Math.floor(params.tokenBudget)
+          : 128_000,
+      );
+      const liveContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
+      const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+        conversation.conversationId,
+      );
+      const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+        conversation.conversationId,
+      );
+      const promptOverflowEmergency = liveContextTokens > tokenBudget;
+      if (
+        (maintenance?.pending || maintenance?.running)
+        && (
+          promptOverflowEmergency
+          || !this.shouldDelayPromptMutatingDeferredCompaction(telemetry)
+        )
+      ) {
+        const deferredLegacyParams =
+          telemetry?.provider || telemetry?.model
+            ? {
+                ...(telemetry.provider ? { provider: telemetry.provider } : {}),
+                ...(telemetry.model ? { model: telemetry.model } : {}),
+              }
+            : undefined;
+        try {
+          await this.consumeDeferredCompactionDebt({
+            conversationId: conversation.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            tokenBudget,
+            currentTokenCount: liveContextTokens,
+            legacyParams: deferredLegacyParams,
+          });
+        } catch (error) {
+          this.deps.log.warn(
+            `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
+          );
+        }
+      } else if (maintenance?.pending || maintenance?.running) {
+        this.deps.log.info(
+          `[lcm] assemble: deferred compaction still cache-hot for conversation=${conversation.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
+        );
+      }
+
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
       if (contextItems.length === 0) {
         this.deps.log.info(
@@ -4382,14 +4519,6 @@ export class LcmContextEngine implements ContextEngine {
           estimatedTokens: 0,
         };
       }
-
-      const tokenBudget = this.applyAssemblyBudgetCap(
-        typeof params.tokenBudget === "number" &&
-        Number.isFinite(params.tokenBudget) &&
-        params.tokenBudget > 0
-          ? Math.floor(params.tokenBudget)
-          : 128_000,
-      );
 
       const assembled = await this.assembler.assemble({
         conversationId: conversation.conversationId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -91,6 +91,7 @@ type IncrementalCompactionDecision = {
   maxPasses: number;
   rawTokensOutsideTail: number;
   threshold: number;
+  reason: string;
   leafChunkTokens: number;
   fallbackLeafChunkTokens: number[];
   activityBand: ActivityBand;
@@ -1956,6 +1957,7 @@ export class LcmContextEngine implements ContextEngine {
       maxPasses: params.maxPasses,
       rawTokensOutsideTail: params.rawTokensOutsideTail,
       threshold: params.threshold,
+      reason: params.reason,
       leafChunkTokens: params.preferredLeafChunkTokens,
       fallbackLeafChunkTokens: params.fallbackLeafChunkTokens,
       activityBand: params.activityBand,
@@ -2128,7 +2130,10 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
-  /** Consume deferred proactive-compaction debt when the host explicitly allows it. */
+  /**
+   * Consume deferred proactive-compaction debt while the caller already holds
+   * the per-session queue.
+   */
   private async consumeDeferredCompactionDebt(params: {
     conversationId: number;
     sessionId: string;
@@ -2156,9 +2161,13 @@ export class LcmContextEngine implements ContextEngine {
     });
 
     try {
-      const resolvedTokenBudget = this.applyAssemblyBudgetCap(
+      const recordedTokenBudget =
         maintenance.tokenBudget && maintenance.tokenBudget > 0
           ? maintenance.tokenBudget
+          : null;
+      const resolvedTokenBudget = this.applyAssemblyBudgetCap(
+        recordedTokenBudget != null
+          ? Math.min(params.tokenBudget, recordedTokenBudget)
           : params.tokenBudget,
       );
       const resolvedCurrentTokenCount = this.normalizeObservedTokenCount(
@@ -2237,6 +2246,71 @@ export class LcmContextEngine implements ContextEngine {
         reason: error instanceof Error ? error.message : "deferred compaction failed",
       };
     }
+  }
+
+  /**
+   * Re-check and consume deferred debt for assemble() while holding the
+   * session queue so pre-assembly writes cannot race queued maintenance.
+   */
+  private async maybeConsumeDeferredCompactionDebtForAssemble(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    currentTokenCount?: number;
+  }): Promise<void> {
+    const sessionLabel = [
+      `session=${params.sessionId}`,
+      ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+    ].join(" ");
+    await this.withSessionQueue(
+      this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+      async () => {
+        const maintenance =
+          await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+            params.conversationId,
+          );
+        if (!maintenance?.pending && !maintenance?.running) {
+          return;
+        }
+
+        const telemetry =
+          await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+            params.conversationId,
+          );
+        const promptOverflowEmergency =
+          (params.currentTokenCount ?? 0) > params.tokenBudget;
+        if (
+          promptOverflowEmergency
+          || !this.shouldDelayPromptMutatingDeferredCompaction(telemetry)
+        ) {
+          const deferredLegacyParams =
+            telemetry?.provider || telemetry?.model
+              ? {
+                  ...(telemetry.provider ? { provider: telemetry.provider } : {}),
+                  ...(telemetry.model ? { model: telemetry.model } : {}),
+                }
+              : undefined;
+          await this.consumeDeferredCompactionDebt({
+            conversationId: params.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            tokenBudget: params.tokenBudget,
+            currentTokenCount: params.currentTokenCount,
+            legacyParams: deferredLegacyParams,
+          });
+          return;
+        }
+
+        this.deps.log.info(
+          `[lcm] assemble: deferred compaction still cache-hot for conversation=${params.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
+        );
+      },
+      {
+        operationName: "assembleDeferredCompaction",
+        context: sessionLabel,
+      },
+    );
   }
 
   /** Run the actual compaction body without taking the per-session queue. */
@@ -4461,42 +4535,20 @@ export class LcmContextEngine implements ContextEngine {
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
-      const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
-        conversation.conversationId,
-      );
-      const promptOverflowEmergency = liveContextTokens > tokenBudget;
-      if (
-        (maintenance?.pending || maintenance?.running)
-        && (
-          promptOverflowEmergency
-          || !this.shouldDelayPromptMutatingDeferredCompaction(telemetry)
-        )
-      ) {
-        const deferredLegacyParams =
-          telemetry?.provider || telemetry?.model
-            ? {
-                ...(telemetry.provider ? { provider: telemetry.provider } : {}),
-                ...(telemetry.model ? { model: telemetry.model } : {}),
-              }
-            : undefined;
+      if (maintenance?.pending || maintenance?.running) {
         try {
-          await this.consumeDeferredCompactionDebt({
+          await this.maybeConsumeDeferredCompactionDebtForAssemble({
             conversationId: conversation.conversationId,
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             tokenBudget,
             currentTokenCount: liveContextTokens,
-            legacyParams: deferredLegacyParams,
           });
         } catch (error) {
           this.deps.log.warn(
             `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
           );
         }
-      } else if (maintenance?.pending || maintenance?.running) {
-        this.deps.log.info(
-          `[lcm] assemble: deferred compaction still cache-hot for conversation=${conversation.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
-        );
       }
 
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1623,7 +1623,11 @@ export class LcmContextEngine implements ContextEngine {
     if (!ttlMs) {
       return false;
     }
-    const touchAt = telemetry?.lastCacheTouchAt ?? telemetry?.lastObservedCacheHitAt ?? null;
+    const touchAt =
+      telemetry?.lastCacheTouchAt
+      ?? telemetry?.lastObservedCacheHitAt
+      ?? telemetry?.lastApiCallAt
+      ?? null;
     if (!touchAt) {
       return false;
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -55,6 +55,10 @@ import {
   type ActivityBand,
 } from "./store/compaction-telemetry-store.js";
 import {
+  CompactionMaintenanceStore,
+  type ConversationCompactionMaintenanceRecord,
+} from "./store/compaction-maintenance-store.js";
+import {
   ConversationStore,
   type ConversationRecord,
   type CreateMessagePartInput,
@@ -109,7 +113,23 @@ type ContextEngineMaintenanceResult = {
   rewrittenEntries: number;
   reason?: string;
 };
+type CompactionExecutionParams = {
+  conversationId: number;
+  sessionId: string;
+  sessionKey?: string;
+  tokenBudget: number;
+  currentTokenCount?: number;
+  compactionTarget?: "budget" | "threshold";
+  customInstructions?: string;
+  /** OpenClaw runtime param name (preferred). */
+  runtimeContext?: Record<string, unknown>;
+  /** Back-compat param name. */
+  legacyParams?: Record<string, unknown>;
+  /** Force compaction even if below threshold */
+  force?: boolean;
+};
 type ContextEngineMaintenanceRuntimeContext = Record<string, unknown> & {
+  allowDeferredCompactionExecution?: boolean;
   rewriteTranscriptEntries?: (
     request: TranscriptRewriteRequest,
   ) => Promise<ContextEngineMaintenanceResult>;
@@ -1195,6 +1215,7 @@ export class LcmContextEngine implements ContextEngine {
   private conversationStore: ConversationStore;
   private summaryStore: SummaryStore;
   private compactionTelemetryStore: CompactionTelemetryStore;
+  private compactionMaintenanceStore: CompactionMaintenanceStore;
   private assembler: ContextAssembler;
   private compaction: CompactionEngine;
   private retrieval: RetrievalEngine;
@@ -1264,13 +1285,15 @@ export class LcmContextEngine implements ContextEngine {
       name: "Lossless Context Management Engine",
       version: "0.1.0",
       ownsCompaction: migrationOk,
-    };
+      turnMaintenanceMode: "background",
+    } as ContextEngineInfo;
 
     this.conversationStore = new ConversationStore(this.db, {
       fts5Available: this.fts5Available,
     });
     this.summaryStore = new SummaryStore(this.db, { fts5Available: this.fts5Available });
     this.compactionTelemetryStore = new CompactionTelemetryStore(this.db);
+    this.compactionMaintenanceStore = new CompactionMaintenanceStore(this.db);
 
     if (!this.fts5Available) {
       this.deps.log.warn(
@@ -2006,6 +2029,312 @@ export class LcmContextEngine implements ContextEngine {
       allowCondensedPasses: cacheState !== "hot",
       reason: cacheState === "cold" ? "cold-cache-catchup" : "leaf-trigger",
     });
+  }
+
+  /** Persist a coalesced proactive-compaction debt record for later maintenance. */
+  private async recordDeferredCompactionDebt(params: {
+    conversationId: number;
+    reason: string;
+    tokenBudget: number;
+    currentTokenCount?: number;
+  }): Promise<void> {
+    await this.compactionMaintenanceStore.requestProactiveCompactionDebt({
+      conversationId: params.conversationId,
+      reason: params.reason,
+      tokenBudget: params.tokenBudget,
+      currentTokenCount: params.currentTokenCount ?? null,
+    });
+    this.deps.log.info(
+      `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"}`,
+    );
+  }
+
+  /** Consume deferred proactive-compaction debt when the host explicitly allows it. */
+  private async consumeDeferredCompactionDebt(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    currentTokenCount?: number;
+    runtimeContext?: ContextEngineMaintenanceRuntimeContext;
+    legacyParams?: Record<string, unknown>;
+  }): Promise<ContextEngineMaintenanceResult | null> {
+    const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+      params.conversationId,
+    );
+    if (!maintenance?.pending && !maintenance?.running) {
+      return null;
+    }
+
+    const sessionLabel = [
+      `session=${params.sessionId}`,
+      ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+    ].join(" ");
+
+    await this.compactionMaintenanceStore.markProactiveCompactionRunning({
+      conversationId: params.conversationId,
+      startedAt: new Date(),
+    });
+
+    try {
+      const resolvedTokenBudget = this.applyAssemblyBudgetCap(
+        maintenance.tokenBudget && maintenance.tokenBudget > 0
+          ? maintenance.tokenBudget
+          : params.tokenBudget,
+      );
+      const resolvedCurrentTokenCount = this.normalizeObservedTokenCount(
+        params.currentTokenCount ?? maintenance.currentTokenCount ?? undefined,
+      );
+
+      const result =
+        maintenance.reason?.trim() === "threshold"
+          ? await this.executeCompactionCore({
+              conversationId: params.conversationId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              tokenBudget: resolvedTokenBudget,
+              currentTokenCount: resolvedCurrentTokenCount,
+              compactionTarget: "threshold",
+              runtimeContext: params.runtimeContext,
+              legacyParams: params.legacyParams,
+            })
+          : await (async (): Promise<CompactResult> => {
+              const leafDecision = await this.evaluateIncrementalCompaction({
+                conversationId: params.conversationId,
+                tokenBudget: resolvedTokenBudget,
+                currentTokenCount: resolvedCurrentTokenCount,
+              });
+              if (!leafDecision.shouldCompact) {
+                return {
+                  ok: true,
+                  compacted: false,
+                  reason: "deferred compaction no longer needed",
+                };
+              }
+              return this.executeLeafCompactionCore({
+                conversationId: params.conversationId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                tokenBudget: resolvedTokenBudget,
+                currentTokenCount: resolvedCurrentTokenCount,
+                runtimeContext: params.runtimeContext,
+                legacyParams: params.legacyParams,
+                maxPasses: leafDecision.maxPasses,
+                leafChunkTokens: leafDecision.leafChunkTokens,
+                fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
+                activityBand: leafDecision.activityBand,
+                allowCondensedPasses: leafDecision.allowCondensedPasses,
+              });
+            })();
+      await this.compactionMaintenanceStore.markProactiveCompactionFinished({
+        conversationId: params.conversationId,
+        finishedAt: new Date(),
+        failureSummary: result.ok ? null : result.reason ?? "deferred compaction failed",
+        keepPending: !result.ok,
+      });
+      this.deps.log.info(
+        `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"}`,
+      );
+      return {
+        changed: result.compacted,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        ...(result.reason ? { reason: result.reason } : {}),
+      };
+    } catch (error) {
+      await this.compactionMaintenanceStore.markProactiveCompactionFinished({
+        conversationId: params.conversationId,
+        finishedAt: new Date(),
+        failureSummary: error instanceof Error ? error.message : String(error),
+        keepPending: true,
+      });
+      this.deps.log.warn(
+        `[lcm] maintain: deferred compaction failed conversation=${params.conversationId} ${sessionLabel}: ${describeLogError(error)}`,
+      );
+      return {
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: error instanceof Error ? error.message : "deferred compaction failed",
+      };
+    }
+  }
+
+  /** Run the actual compaction body without taking the per-session queue. */
+  private async executeCompactionCore(params: CompactionExecutionParams): Promise<CompactResult> {
+    const { force = false } = params;
+    const legacyParams = asRecord(params.runtimeContext) ?? params.legacyParams;
+    const lp = legacyParams ?? {};
+    const manualCompactionRequested =
+      (
+        lp as {
+          manualCompaction?: unknown;
+        }
+      ).manualCompaction === true;
+    const forceCompaction = force || manualCompactionRequested;
+    const resolvedTokenBudget = this.resolveTokenBudget({
+      tokenBudget: params.tokenBudget,
+      runtimeContext: params.runtimeContext,
+      legacyParams,
+    });
+    const tokenBudget = resolvedTokenBudget
+      ? this.applyAssemblyBudgetCap(resolvedTokenBudget)
+      : resolvedTokenBudget;
+    if (!tokenBudget) {
+      return {
+        ok: false,
+        compacted: false,
+        reason: "missing token budget in compact params",
+      };
+    }
+
+    const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
+      legacyParams,
+      customInstructions: params.customInstructions,
+      breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+    });
+    if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: "circuit breaker open",
+      };
+    }
+
+    const conversationId = params.conversationId;
+    const observedTokens = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
+        (
+          lp as {
+            currentTokenCount?: unknown;
+          }
+        ).currentTokenCount,
+    );
+    const decision =
+      observedTokens !== undefined
+        ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
+        : await this.compaction.evaluate(conversationId, tokenBudget);
+    const targetTokens =
+      params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
+    const liveContextStillExceedsTarget =
+      observedTokens !== undefined && observedTokens >= targetTokens;
+
+    if (!forceCompaction && !decision.shouldCompact) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: "below threshold",
+        result: {
+          tokensBefore: decision.currentTokens,
+        },
+      };
+    }
+
+    // Forced budget recovery should use the capped convergence loop so live
+    // overflow counts can drive recovery even when persisted context is already small.
+    const useSweep = manualCompactionRequested || params.compactionTarget === "threshold";
+    if (useSweep) {
+      const sweepResult = await this.compaction.compact({
+        conversationId,
+        tokenBudget,
+        summarize,
+        force: forceCompaction,
+        hardTrigger: false,
+        summaryModel,
+      });
+
+      if (sweepResult.authFailure && breakerKey) {
+        this.recordCompactionAuthFailure(breakerKey);
+      } else if (sweepResult.actionTaken && breakerKey) {
+        this.recordCompactionSuccess(breakerKey);
+      }
+      if (sweepResult.actionTaken) {
+        await this.markLeafCompactionTelemetrySuccess({ conversationId });
+      }
+
+      return {
+        ok: !sweepResult.authFailure && (sweepResult.actionTaken || !liveContextStillExceedsTarget),
+        compacted: sweepResult.actionTaken,
+        reason: sweepResult.authFailure
+          ? (sweepResult.actionTaken
+              ? "provider auth failure after partial compaction"
+              : "provider auth failure")
+          : sweepResult.actionTaken
+            ? "compacted"
+            : manualCompactionRequested
+              ? "nothing to compact"
+              : liveContextStillExceedsTarget
+                ? "live context still exceeds target"
+                : "already under target",
+        result: {
+          tokensBefore: decision.currentTokens,
+          tokensAfter: sweepResult.tokensAfter,
+          details: {
+            rounds: sweepResult.actionTaken ? 1 : 0,
+            targetTokens,
+          },
+        },
+      };
+    }
+
+    // When forced, use the token budget as target
+    const convergenceTargetTokens = forceCompaction
+      ? tokenBudget
+      : params.compactionTarget === "threshold"
+        ? decision.threshold
+        : tokenBudget;
+
+    // When forced (overflow recovery) and the caller did not supply an
+    // observed token count, assume we are at least at the token budget so
+    // compactUntilUnder does not bail with "already under target" while the
+    // live context is actually overflowing.
+    const effectiveCurrentTokens =
+      observedTokens !== undefined
+        ? observedTokens
+        : forceCompaction
+          ? tokenBudget
+          : undefined;
+    const compactResult = await this.compaction.compactUntilUnder({
+      conversationId,
+      tokenBudget,
+      targetTokens: convergenceTargetTokens,
+      ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
+      summarize,
+      summaryModel,
+    });
+
+    if (compactResult.authFailure && breakerKey) {
+      this.recordCompactionAuthFailure(breakerKey);
+    } else if (compactResult.rounds > 0 && breakerKey) {
+      this.recordCompactionSuccess(breakerKey);
+    }
+
+    const didCompact = compactResult.rounds > 0;
+    if (didCompact) {
+      await this.markLeafCompactionTelemetrySuccess({ conversationId });
+    }
+
+    return {
+      ok: compactResult.success,
+      compacted: didCompact,
+      reason: compactResult.authFailure
+        ? (didCompact
+            ? "provider auth failure after partial compaction"
+            : "provider auth failure")
+        : compactResult.success
+          ? didCompact
+            ? "compacted"
+            : "already under target"
+          : "could not reach target",
+      result: {
+        tokensBefore: decision.currentTokens,
+        tokensAfter: compactResult.finalTokens,
+        details: {
+          rounds: compactResult.rounds,
+          targetTokens: convergenceTargetTokens,
+        },
+      },
+    };
   }
 
   /** Resolve an LCM conversation id from a session key via the session store. */
@@ -3408,24 +3737,6 @@ export class LcmContextEngine implements ContextEngine {
         reason: "stateless session",
       };
     }
-    if (!this.config.transcriptGcEnabled) {
-      return {
-        changed: false,
-        bytesFreed: 0,
-        rewrittenEntries: 0,
-        reason: "transcript GC disabled",
-      };
-    }
-    if (typeof params.runtimeContext?.rewriteTranscriptEntries !== "function") {
-      return {
-        changed: false,
-        bytesFreed: 0,
-        rewrittenEntries: 0,
-        reason: "runtime rewrite helper unavailable",
-      };
-    }
-
-    const rewriteTranscriptEntries = params.runtimeContext.rewriteTranscriptEntries;
     const startedAt = Date.now();
     const sessionLabel = [
       `session=${params.sessionId}`,
@@ -3447,6 +3758,65 @@ export class LcmContextEngine implements ContextEngine {
           };
         }
 
+        let deferredCompactionResult: ContextEngineMaintenanceResult | null = null;
+        if (params.runtimeContext?.allowDeferredCompactionExecution === true) {
+          const runtimeTokenBudget = (() => {
+            const tokenBudget = asRecord(params.runtimeContext)?.tokenBudget;
+            if (
+              typeof tokenBudget === "number"
+              && Number.isFinite(tokenBudget)
+              && tokenBudget > 0
+            ) {
+              return Math.floor(tokenBudget);
+            }
+            return 128_000;
+          })();
+          deferredCompactionResult = await this.consumeDeferredCompactionDebt({
+            conversationId: conversation.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            tokenBudget: this.applyAssemblyBudgetCap(runtimeTokenBudget),
+            currentTokenCount:
+              typeof params.runtimeContext?.currentTokenCount === "number"
+                ? Math.floor(params.runtimeContext.currentTokenCount as number)
+                : undefined,
+            runtimeContext: params.runtimeContext,
+            legacyParams: asRecord(params.runtimeContext),
+          });
+        } else {
+          const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+            conversation.conversationId,
+          );
+          if (maintenance?.pending || maintenance?.running) {
+            this.deps.log.info(
+              `[lcm] maintain: deferred compaction debt pending conversation=${conversation.conversationId} ${sessionLabel} but host runtimeContext.allowDeferredCompactionExecution is disabled`,
+            );
+          }
+        }
+
+        if (!this.config.transcriptGcEnabled) {
+          return (
+            deferredCompactionResult ?? {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+              reason: "transcript GC disabled",
+            }
+          );
+        }
+
+        if (typeof params.runtimeContext?.rewriteTranscriptEntries !== "function") {
+          return (
+            deferredCompactionResult ?? {
+              changed: false,
+              bytesFreed: 0,
+              rewrittenEntries: 0,
+              reason: "runtime rewrite helper unavailable",
+            }
+          );
+        }
+
+        const rewriteTranscriptEntries = params.runtimeContext.rewriteTranscriptEntries;
         const candidates = await this.summaryStore.listTranscriptGcCandidates(
           conversation.conversationId,
           { limit: TRANSCRIPT_GC_BATCH_SIZE },
@@ -3455,7 +3825,7 @@ export class LcmContextEngine implements ContextEngine {
           this.deps.log.info(
             `[lcm] maintain: no transcript GC candidates conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
-          return {
+          return deferredCompactionResult ?? {
             changed: false,
             bytesFreed: 0,
             rewrittenEntries: 0,
@@ -3493,7 +3863,7 @@ export class LcmContextEngine implements ContextEngine {
           this.deps.log.info(
             `[lcm] maintain: no matching transcript entries conversation=${conversation.conversationId} ${sessionLabel} candidates=${candidates.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
-          return {
+          return deferredCompactionResult ?? {
             changed: false,
             bytesFreed: 0,
             rewrittenEntries: 0,
@@ -3518,10 +3888,19 @@ export class LcmContextEngine implements ContextEngine {
           }
         }
 
+        const combinedResult = deferredCompactionResult
+          ? {
+              changed: deferredCompactionResult.changed || result.changed,
+              bytesFreed: result.bytesFreed,
+              rewrittenEntries: result.rewrittenEntries,
+              reason: result.reason ?? deferredCompactionResult.reason,
+            }
+          : result;
+
         this.deps.log.info(
-          `[lcm] maintain: done conversation=${conversation.conversationId} ${sessionLabel} candidates=${candidates.length} replacements=${replacements.length} changed=${result.changed} rewrittenEntries=${result.rewrittenEntries} bytesFreed=${result.bytesFreed} duration=${formatDurationMs(Date.now() - startedAt)}`,
+          `[lcm] maintain: done conversation=${conversation.conversationId} ${sessionLabel} candidates=${candidates.length} replacements=${replacements.length} changed=${combinedResult.changed} rewrittenEntries=${combinedResult.rewrittenEntries} bytesFreed=${combinedResult.bytesFreed} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return result;
+        return combinedResult;
       },
       { operationName: "maintain", context: sessionLabel },
     );
@@ -3888,39 +4267,55 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget,
         currentTokenCount: liveContextTokens,
       });
-      if (leafDecision.shouldCompact) {
-        this.compactLeafAsync({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
+      const thresholdDecision = await this.compaction.evaluate(
+        conversation.conversationId,
+        tokenBudget,
+        liveContextTokens,
+      );
+      if (this.config.proactiveThresholdCompactionMode === "inline") {
+        if (leafDecision.shouldCompact) {
+          this.compactLeafAsync({
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+            tokenBudget,
+            currentTokenCount: liveContextTokens,
+            legacyParams,
+            maxPasses: leafDecision.maxPasses,
+            leafChunkTokens: leafDecision.leafChunkTokens,
+            fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
+            activityBand: leafDecision.activityBand,
+            allowCondensedPasses: leafDecision.allowCondensedPasses,
+          }).catch(() => {
+            // Leaf compaction is best-effort and should not fail the caller.
+          });
+        }
+
+        try {
+          await this.compact({
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+            tokenBudget,
+            currentTokenCount: liveContextTokens,
+            compactionTarget: "threshold",
+            legacyParams,
+          });
+        } catch {
+          // Proactive compaction is best-effort in the post-turn lifecycle.
+        }
+      } else if (thresholdDecision.shouldCompact || leafDecision.shouldCompact) {
+        await this.recordDeferredCompactionDebt({
+          conversationId: conversation.conversationId,
+          reason: thresholdDecision.shouldCompact ? "threshold" : leafDecision.reason,
           tokenBudget,
           currentTokenCount: liveContextTokens,
-          legacyParams,
-          maxPasses: leafDecision.maxPasses,
-          leafChunkTokens: leafDecision.leafChunkTokens,
-          fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
-          activityBand: leafDecision.activityBand,
-          allowCondensedPasses: leafDecision.allowCondensedPasses,
-        }).catch(() => {
-          // Leaf compaction is best-effort and should not fail the caller.
         });
       }
-    } catch {
-      // Leaf trigger checks are best-effort.
-    }
-
-    try {
-      await this.compact({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        tokenBudget,
-        currentTokenCount: liveContextTokens,
-        compactionTarget: "threshold",
-        legacyParams,
-      });
-    } catch {
-      // Proactive compaction is best-effort in the post-turn lifecycle.
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: compaction policy check failed for ${sessionLabel}: ${describeLogError(err)}`,
+      );
     }
 
     this.deps.log.info(
@@ -4067,6 +4462,158 @@ export class LcmContextEngine implements ContextEngine {
     return this.compaction.evaluateLeafTrigger(conversation.conversationId);
   }
 
+  /** Run one or more incremental leaf compaction passes without taking the per-session queue. */
+  private async executeLeafCompactionCore(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    currentTokenCount?: number;
+    customInstructions?: string;
+    /** OpenClaw runtime param name (preferred). */
+    runtimeContext?: Record<string, unknown>;
+    /** Back-compat param name. */
+    legacyParams?: Record<string, unknown>;
+    force?: boolean;
+    previousSummaryContent?: string;
+    maxPasses?: number;
+    leafChunkTokens?: number;
+    fallbackLeafChunkTokens?: number[];
+    activityBand?: ActivityBand;
+    allowCondensedPasses?: boolean;
+  }): Promise<CompactResult> {
+    const legacyParams = asRecord(params.runtimeContext) ?? params.legacyParams;
+    const observedTokens = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
+        (
+          (legacyParams ?? {}) as {
+            currentTokenCount?: unknown;
+          }
+        ).currentTokenCount,
+    );
+    const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
+      legacyParams,
+      customInstructions: params.customInstructions,
+      breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+    });
+    if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: "circuit breaker open",
+      };
+    }
+
+    const storedTokensBefore = await this.summaryStore.getContextTokenCount(params.conversationId);
+    const maxPasses =
+      typeof params.maxPasses === "number" && Number.isFinite(params.maxPasses) && params.maxPasses > 0
+        ? Math.floor(params.maxPasses)
+        : 1;
+    const fallbackLeafChunkTokens = Array.isArray(params.fallbackLeafChunkTokens)
+      ? [...new Set(
+        params.fallbackLeafChunkTokens
+          .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0)
+          .map((value) => Math.floor(value)),
+      )].sort((a, b) => b - a)
+      : [];
+    let activeLeafChunkTokens =
+      typeof params.leafChunkTokens === "number"
+        && Number.isFinite(params.leafChunkTokens)
+        && params.leafChunkTokens > 0
+        ? Math.floor(params.leafChunkTokens)
+        : fallbackLeafChunkTokens[0];
+    this.deps.log.info(
+      `[lcm] compactLeafAsync start: conversation=${params.conversationId} session=${params.sessionId} leafChunkTokens=${activeLeafChunkTokens ?? "null"} fallbackLeafChunkTokens=${fallbackLeafChunkTokens.join(",")} maxPasses=${maxPasses} activityBand=${params.activityBand ?? "unknown"} allowCondensedPasses=${params.allowCondensedPasses !== false}`,
+    );
+
+    let rounds = 0;
+    let finalTokens = observedTokens ?? storedTokensBefore;
+    let authFailure = false;
+
+    for (let pass = 0; pass < maxPasses; pass += 1) {
+      let leafResult: Awaited<ReturnType<typeof this.compaction.compactLeaf>> | undefined;
+      while (true) {
+        try {
+          leafResult = await this.compaction.compactLeaf({
+            conversationId: params.conversationId,
+            tokenBudget: params.tokenBudget,
+            summarize,
+            ...(activeLeafChunkTokens !== undefined ? { leafChunkTokens: activeLeafChunkTokens } : {}),
+            force: params.force,
+            previousSummaryContent: pass === 0 ? params.previousSummaryContent : undefined,
+            summaryModel,
+            allowCondensedPasses: params.allowCondensedPasses,
+          });
+          break;
+        } catch (err) {
+          const nextLeafChunkTokens = fallbackLeafChunkTokens.find(
+            (value) => activeLeafChunkTokens !== undefined && value < activeLeafChunkTokens,
+          );
+          if (!this.isRecoverableLeafChunkOverflowError(err) || nextLeafChunkTokens === undefined) {
+            throw err;
+          }
+          this.deps.log.warn(
+            `[lcm] compactLeafAsync: retrying with smaller leafChunkTokens=${nextLeafChunkTokens} after provider token-limit error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          activeLeafChunkTokens = nextLeafChunkTokens;
+        }
+      }
+      if (!leafResult) {
+        break;
+      }
+      finalTokens = leafResult.tokensAfter;
+
+      if (leafResult.authFailure) {
+        authFailure = true;
+        break;
+      }
+      if (!leafResult.actionTaken) {
+        break;
+      }
+      rounds += 1;
+      if (leafResult.tokensAfter >= leafResult.tokensBefore) {
+        break;
+      }
+    }
+
+    if (authFailure && breakerKey) {
+      this.recordCompactionAuthFailure(breakerKey);
+    } else if (rounds > 0 && breakerKey) {
+      this.recordCompactionSuccess(breakerKey);
+    }
+    if (rounds > 0) {
+      await this.markLeafCompactionTelemetrySuccess({
+        conversationId: params.conversationId,
+        activityBand: params.activityBand,
+      });
+    }
+
+    const tokensBefore = observedTokens ?? storedTokensBefore;
+    this.deps.log.debug(
+      `[lcm] compactLeafAsync result: conversation=${params.conversationId} session=${params.sessionId} rounds=${rounds} compacted=${rounds > 0} authFailure=${authFailure} finalLeafChunkTokens=${activeLeafChunkTokens ?? "null"} finalTokens=${finalTokens}`,
+    );
+
+    return {
+      ok: true,
+      compacted: rounds > 0,
+      reason: authFailure
+        ? "provider auth failure"
+        : rounds > 0
+          ? "compacted"
+          : "below threshold",
+      result: {
+        tokensBefore,
+        tokensAfter: finalTokens,
+        details: {
+          rounds,
+          targetTokens: params.tokenBudget,
+          mode: "leaf",
+          maxPasses,
+        },
+      },
+    };
+  }
+
   /** Run one or more incremental leaf compaction passes in the per-session queue. */
   async compactLeafAsync(params: {
     sessionId: string;
@@ -4109,7 +4656,6 @@ export class LcmContextEngine implements ContextEngine {
             reason: "no conversation found for session",
           };
         }
-
         const legacyParams = asRecord(params.runtimeContext) ?? params.legacyParams;
         const resolvedTokenBudget = this.resolveTokenBudget({
           tokenBudget: params.tokenBudget,
@@ -4126,140 +4672,23 @@ export class LcmContextEngine implements ContextEngine {
             reason: "missing token budget in compact params",
           };
         }
-
-        const lp = legacyParams ?? {};
-        const observedTokens = this.normalizeObservedTokenCount(
-          params.currentTokenCount ??
-            (
-              lp as {
-                currentTokenCount?: unknown;
-              }
-            ).currentTokenCount,
-        );
-        const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
-          legacyParams,
+        return this.executeLeafCompactionCore({
+          conversationId: conversation.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget,
+          currentTokenCount: params.currentTokenCount,
           customInstructions: params.customInstructions,
-          breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
+          force: params.force,
+          previousSummaryContent: params.previousSummaryContent,
+          maxPasses: params.maxPasses,
+          leafChunkTokens: params.leafChunkTokens,
+          fallbackLeafChunkTokens: params.fallbackLeafChunkTokens,
+          activityBand: params.activityBand,
+          allowCondensedPasses: params.allowCondensedPasses,
         });
-        if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
-          return {
-            ok: true,
-            compacted: false,
-            reason: "circuit breaker open",
-          };
-        }
-
-        const storedTokensBefore = await this.summaryStore.getContextTokenCount(
-          conversation.conversationId,
-        );
-        const maxPasses =
-          typeof params.maxPasses === "number" &&
-          Number.isFinite(params.maxPasses) &&
-          params.maxPasses > 0
-            ? Math.floor(params.maxPasses)
-            : 1;
-        const fallbackLeafChunkTokens = Array.isArray(params.fallbackLeafChunkTokens)
-          ? [...new Set(params.fallbackLeafChunkTokens
-            .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0)
-            .map((value) => Math.floor(value)))]
-              .sort((a, b) => b - a)
-          : [];
-        let activeLeafChunkTokens =
-          typeof params.leafChunkTokens === "number" &&
-          Number.isFinite(params.leafChunkTokens) &&
-          params.leafChunkTokens > 0
-            ? Math.floor(params.leafChunkTokens)
-            : fallbackLeafChunkTokens[0];
-        this.deps.log.info(
-          `[lcm] compactLeafAsync start: conversation=${conversation.conversationId} session=${params.sessionId} leafChunkTokens=${activeLeafChunkTokens ?? "null"} fallbackLeafChunkTokens=${fallbackLeafChunkTokens.join(",")} maxPasses=${maxPasses} activityBand=${params.activityBand ?? "unknown"} allowCondensedPasses=${params.allowCondensedPasses !== false}`,
-        );
-
-        let rounds = 0;
-        let finalTokens = observedTokens ?? storedTokensBefore;
-        let authFailure = false;
-
-        for (let pass = 0; pass < maxPasses; pass += 1) {
-          let leafResult: Awaited<ReturnType<typeof this.compaction.compactLeaf>> | undefined;
-          while (true) {
-            try {
-              leafResult = await this.compaction.compactLeaf({
-                conversationId: conversation.conversationId,
-                tokenBudget,
-                summarize,
-                ...(activeLeafChunkTokens !== undefined ? { leafChunkTokens: activeLeafChunkTokens } : {}),
-                force: params.force,
-                previousSummaryContent: pass === 0 ? params.previousSummaryContent : undefined,
-                summaryModel,
-                allowCondensedPasses: params.allowCondensedPasses,
-              });
-              break;
-            } catch (err) {
-              const nextLeafChunkTokens = fallbackLeafChunkTokens.find(
-                (value) => activeLeafChunkTokens !== undefined && value < activeLeafChunkTokens,
-              );
-              if (!this.isRecoverableLeafChunkOverflowError(err) || nextLeafChunkTokens === undefined) {
-                throw err;
-              }
-              this.deps.log.warn(
-                `[lcm] compactLeafAsync: retrying with smaller leafChunkTokens=${nextLeafChunkTokens} after provider token-limit error: ${err instanceof Error ? err.message : String(err)}`,
-              );
-              activeLeafChunkTokens = nextLeafChunkTokens;
-            }
-          }
-          if (!leafResult) {
-            break;
-          }
-          finalTokens = leafResult.tokensAfter;
-
-          if (leafResult.authFailure) {
-            authFailure = true;
-            break;
-          }
-          if (!leafResult.actionTaken) {
-            break;
-          }
-          rounds += 1;
-          if (leafResult.tokensAfter >= leafResult.tokensBefore) {
-            break;
-          }
-        }
-
-        if (authFailure && breakerKey) {
-          this.recordCompactionAuthFailure(breakerKey);
-        } else if (rounds > 0 && breakerKey) {
-          this.recordCompactionSuccess(breakerKey);
-        }
-        if (rounds > 0) {
-          await this.markLeafCompactionTelemetrySuccess({
-            conversationId: conversation.conversationId,
-            activityBand: params.activityBand,
-          });
-        }
-
-        const tokensBefore = observedTokens ?? storedTokensBefore;
-        this.deps.log.debug(
-          `[lcm] compactLeafAsync result: conversation=${conversation.conversationId} session=${params.sessionId} rounds=${rounds} compacted=${rounds > 0} authFailure=${authFailure} finalLeafChunkTokens=${activeLeafChunkTokens ?? "null"} finalTokens=${finalTokens}`,
-        );
-
-        return {
-          ok: true,
-          compacted: rounds > 0,
-          reason: authFailure
-            ? "provider auth failure"
-            : rounds > 0
-              ? "compacted"
-              : "below threshold",
-          result: {
-            tokensBefore,
-            tokensAfter: finalTokens,
-            details: {
-              rounds,
-              targetTokens: tokenBudget,
-              mode: "leaf",
-              maxPasses,
-            },
-          },
-        };
       },
     );
   }
@@ -4297,11 +4726,8 @@ export class LcmContextEngine implements ContextEngine {
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () => {
-        const { sessionId, force = false } = params;
-
-        // Look up conversation
         const conversation = await this.conversationStore.getConversationForSession({
-          sessionId,
+          sessionId: params.sessionId,
           sessionKey: params.sessionKey,
         });
         if (!conversation) {
@@ -4311,181 +4737,18 @@ export class LcmContextEngine implements ContextEngine {
             reason: "no conversation found for session",
           };
         }
-
-        const conversationId = conversation.conversationId;
-
-        const legacyParams = asRecord(params.runtimeContext) ?? params.legacyParams;
-        const lp = legacyParams ?? {};
-        const manualCompactionRequested =
-          (
-            lp as {
-              manualCompaction?: unknown;
-            }
-          ).manualCompaction === true;
-        const forceCompaction = force || manualCompactionRequested;
-        const resolvedTokenBudget = this.resolveTokenBudget({
+        return this.executeCompactionCore({
+          conversationId: conversation.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
           tokenBudget: params.tokenBudget,
-          runtimeContext: params.runtimeContext,
-          legacyParams,
-        });
-        const tokenBudget = resolvedTokenBudget
-          ? this.applyAssemblyBudgetCap(resolvedTokenBudget)
-          : resolvedTokenBudget;
-        if (!tokenBudget) {
-          return {
-            ok: false,
-            compacted: false,
-            reason: "missing token budget in compact params",
-          };
-        }
-
-        const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
-          legacyParams,
+          currentTokenCount: params.currentTokenCount,
+          compactionTarget: params.compactionTarget,
           customInstructions: params.customInstructions,
-          breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
+          force: params.force,
         });
-        if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
-          return {
-            ok: true,
-            compacted: false,
-            reason: "circuit breaker open",
-          };
-        }
-
-        // Evaluate whether compaction is needed (unless forced)
-        const observedTokens = this.normalizeObservedTokenCount(
-          params.currentTokenCount ??
-            (
-              lp as {
-                currentTokenCount?: unknown;
-              }
-            ).currentTokenCount,
-        );
-        const decision =
-          observedTokens !== undefined
-            ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
-            : await this.compaction.evaluate(conversationId, tokenBudget);
-        const targetTokens =
-          params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
-        const liveContextStillExceedsTarget =
-          observedTokens !== undefined && observedTokens >= targetTokens;
-
-        if (!forceCompaction && !decision.shouldCompact) {
-          return {
-            ok: true,
-            compacted: false,
-            reason: "below threshold",
-            result: {
-              tokensBefore: decision.currentTokens,
-            },
-          };
-        }
-
-        // Forced budget recovery should use the capped convergence loop so live
-        // overflow counts can drive recovery even when persisted context is already small.
-        const useSweep = manualCompactionRequested || params.compactionTarget === "threshold";
-        if (useSweep) {
-          const sweepResult = await this.compaction.compact({
-            conversationId,
-            tokenBudget,
-            summarize,
-            force: forceCompaction,
-            hardTrigger: false,
-            summaryModel,
-          });
-
-          if (sweepResult.authFailure && breakerKey) {
-            this.recordCompactionAuthFailure(breakerKey);
-          } else if (sweepResult.actionTaken && breakerKey) {
-            this.recordCompactionSuccess(breakerKey);
-          }
-          if (sweepResult.actionTaken) {
-            await this.markLeafCompactionTelemetrySuccess({ conversationId });
-          }
-
-          return {
-            ok: !sweepResult.authFailure && (sweepResult.actionTaken || !liveContextStillExceedsTarget),
-            compacted: sweepResult.actionTaken,
-            reason: sweepResult.authFailure
-              ? (sweepResult.actionTaken
-                  ? "provider auth failure after partial compaction"
-                  : "provider auth failure")
-              : sweepResult.actionTaken
-                ? "compacted"
-                : manualCompactionRequested
-                  ? "nothing to compact"
-                  : liveContextStillExceedsTarget
-                    ? "live context still exceeds target"
-                    : "already under target",
-            result: {
-              tokensBefore: decision.currentTokens,
-              tokensAfter: sweepResult.tokensAfter,
-              details: {
-                rounds: sweepResult.actionTaken ? 1 : 0,
-                targetTokens,
-              },
-            },
-          };
-        }
-
-        // When forced, use the token budget as target
-        const convergenceTargetTokens = forceCompaction
-          ? tokenBudget
-          : params.compactionTarget === "threshold"
-            ? decision.threshold
-            : tokenBudget;
-
-        // When forced (overflow recovery) and the caller did not supply an
-        // observed token count, assume we are at least at the token budget so
-        // compactUntilUnder does not bail with "already under target" while the
-        // live context is actually overflowing.
-        const effectiveCurrentTokens =
-          observedTokens !== undefined
-            ? observedTokens
-            : forceCompaction
-              ? tokenBudget
-              : undefined;
-        const compactResult = await this.compaction.compactUntilUnder({
-          conversationId,
-          tokenBudget,
-          targetTokens: convergenceTargetTokens,
-          ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
-          summarize,
-          summaryModel,
-        });
-
-        if (compactResult.authFailure && breakerKey) {
-          this.recordCompactionAuthFailure(breakerKey);
-        } else if (compactResult.rounds > 0 && breakerKey) {
-          this.recordCompactionSuccess(breakerKey);
-        }
-
-        const didCompact = compactResult.rounds > 0;
-        if (didCompact) {
-          await this.markLeafCompactionTelemetrySuccess({ conversationId });
-        }
-
-        return {
-          ok: compactResult.success,
-          compacted: didCompact,
-          reason: compactResult.authFailure
-            ? (didCompact
-                ? "provider auth failure after partial compaction"
-                : "provider auth failure")
-            : compactResult.success
-              ? didCompact
-                ? "compacted"
-                : "already under target"
-              : "could not reach target",
-          result: {
-            tokensBefore: decision.currentTokens,
-            tokensAfter: compactResult.finalTokens,
-            details: {
-              rounds: compactResult.rounds,
-              targetTokens: convergenceTargetTokens,
-            },
-          },
-        };
       },
     );
   }
@@ -4765,6 +5028,10 @@ export class LcmContextEngine implements ContextEngine {
 
   getCompactionTelemetryStore(): CompactionTelemetryStore {
     return this.compactionTelemetryStore;
+  }
+
+  getCompactionMaintenanceStore(): CompactionMaintenanceStore {
+    return this.compactionMaintenanceStore;
   }
 
   // ── Heartbeat pruning ──────────────────────────────────────────────────

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1324,6 +1324,11 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
     log: (message) => log.info(message),
     message: `[lcm] Transcript GC ${config.transcriptGcEnabled ? "enabled" : "disabled"} (default false)`,
   });
+  logStartupBannerOnce({
+    key: "proactive-threshold-compaction-mode",
+    log: (message) => log.info(message),
+    message: `[lcm] Proactive threshold compaction mode: ${config.proactiveThresholdCompactionMode} (default deferred)`,
+  });
 
   /** Resolve the best config object to hand to runtime.modelAuth for this lookup. */
   const resolveModelAuthConfig = (runtimeConfig: unknown): OpenClawPluginApi["config"] => {
@@ -2073,7 +2078,7 @@ const lcmPlugin = {
     logStartupBannerOnce({
       key: "plugin-loaded",
       log: (message) => deps.log.info(message),
-      message: `[lcm] Plugin loaded (enabled=${deps.config.enabled}, db=${deps.config.databasePath}, threshold=${deps.config.contextThreshold})`,
+      message: `[lcm] Plugin loaded (enabled=${deps.config.enabled}, db=${deps.config.databasePath}, threshold=${deps.config.contextThreshold}, proactiveThresholdCompactionMode=${deps.config.proactiveThresholdCompactionMode})`,
     });
     logStartupBannerOnce({
       key: "state-dir",

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -23,6 +23,7 @@ import {
   CompactionMaintenanceStore,
   type ConversationCompactionMaintenanceRecord,
 } from "../store/compaction-maintenance-store.js";
+import { CompactionTelemetryStore } from "../store/compaction-telemetry-store.js";
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
@@ -393,6 +394,13 @@ async function getConversationCompactionMaintenanceByConversationId(
   );
 }
 
+async function getConversationCompactionTelemetryByConversationId(
+  db: DatabaseSync,
+  conversationId: number,
+) {
+  return await new CompactionTelemetryStore(db).getConversationCompactionTelemetry(conversationId);
+}
+
 async function resolveCurrentConversation(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
@@ -578,6 +586,10 @@ async function buildStatusText(params: {
       params.db,
       current.stats.conversationId,
     );
+    const telemetry = await getConversationCompactionTelemetryByConversationId(
+      params.db,
+      current.stats.conversationId,
+    );
     const formatMaintenanceTime = (value: Date | null): string =>
       value ? formatTimestamp(value, params.config.timezone) : "never";
     lines.push(
@@ -631,6 +643,11 @@ async function buildStatusText(params: {
           "observed token count",
           maintenance?.currentTokenCount != null ? formatNumber(maintenance.currentTokenCount) : "unknown",
         ),
+        buildStatLine("last api call", formatMaintenanceTime(telemetry?.lastApiCallAt ?? null)),
+        buildStatLine("last cache touch", formatMaintenanceTime(telemetry?.lastCacheTouchAt ?? null)),
+        buildStatLine("cache retention", telemetry?.retention ?? "unknown"),
+        buildStatLine("cache state", telemetry?.cacheState ?? "unknown"),
+        buildStatLine("provider/model", [telemetry?.provider, telemetry?.model].filter(Boolean).join(" / ") || "unknown"),
       ]),
     );
   } else {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -20,9 +20,9 @@ import {
   type DoctorSummaryStats,
 } from "./lcm-doctor-shared.js";
 import {
+  CompactionMaintenanceStore,
   type ConversationCompactionMaintenanceRecord,
 } from "../store/compaction-maintenance-store.js";
-import { parseUtcTimestampOrNull } from "../store/parse-utc-timestamp.js";
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
@@ -384,60 +384,13 @@ function getConversationStatusBySessionId(
   return getConversationStatusStats(db, row.conversation_id);
 }
 
-function getConversationCompactionMaintenanceByConversationId(
+async function getConversationCompactionMaintenanceByConversationId(
   db: DatabaseSync,
   conversationId: number,
-): ConversationCompactionMaintenanceRecord | null {
-  const row = db
-    .prepare(
-      `SELECT
-         conversation_id,
-         pending,
-         requested_at,
-         reason,
-         running,
-         last_started_at,
-         last_finished_at,
-         last_failure_summary,
-         token_budget,
-         current_token_count,
-         updated_at
-       FROM conversation_compaction_maintenance
-       WHERE conversation_id = ?`,
-    )
-    .get(conversationId) as
-    | {
-        conversation_id: number;
-        pending: number;
-        requested_at: string | null;
-        reason: string | null;
-        running: number;
-        last_started_at: string | null;
-        last_finished_at: string | null;
-        last_failure_summary: string | null;
-        token_budget: number | null;
-        current_token_count: number | null;
-        updated_at: string;
-      }
-    | undefined;
-
-  if (!row) {
-    return null;
-  }
-
-  return {
-    conversationId: row.conversation_id,
-    pending: row.pending === 1,
-    requestedAt: parseUtcTimestampOrNull(row.requested_at),
-    reason: row.reason,
-    running: row.running === 1,
-    lastStartedAt: parseUtcTimestampOrNull(row.last_started_at),
-    lastFinishedAt: parseUtcTimestampOrNull(row.last_finished_at),
-    lastFailureSummary: row.last_failure_summary,
-    tokenBudget: row.token_budget,
-    currentTokenCount: row.current_token_count,
-    updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
-  };
+): Promise<ConversationCompactionMaintenanceRecord | null> {
+  return await new CompactionMaintenanceStore(db).getConversationCompactionMaintenance(
+    conversationId,
+  );
 }
 
 async function resolveCurrentConversation(params: {
@@ -621,7 +574,7 @@ async function buildStatusText(params: {
         truncated: 0,
         fallback: 0,
       };
-    const maintenance = getConversationCompactionMaintenanceByConversationId(
+    const maintenance = await getConversationCompactionMaintenanceByConversationId(
       params.db,
       current.stats.conversationId,
     );

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import packageJson from "../../package.json" with { type: "json" };
+import { formatTimestamp } from "../compaction.js";
 import type { LcmConfig } from "../db/config.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
@@ -18,6 +19,10 @@ import {
   getDoctorSummaryStats,
   type DoctorSummaryStats,
 } from "./lcm-doctor-shared.js";
+import {
+  type ConversationCompactionMaintenanceRecord,
+} from "../store/compaction-maintenance-store.js";
+import { parseUtcTimestampOrNull } from "../store/parse-utc-timestamp.js";
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
@@ -342,7 +347,13 @@ function getConversationStatusBySessionKey(
   sessionKey: string,
 ): LcmConversationStatusStats | null {
   const row = db
-    .prepare(`SELECT conversation_id FROM conversations WHERE session_key = ? LIMIT 1`)
+    .prepare(
+      `SELECT conversation_id
+       FROM conversations
+       WHERE session_key = ?
+       ORDER BY active DESC, created_at DESC
+       LIMIT 1`,
+    )
     .get(sessionKey) as { conversation_id: number } | undefined;
 
   if (!row) {
@@ -361,7 +372,7 @@ function getConversationStatusBySessionId(
       `SELECT conversation_id
        FROM conversations
        WHERE session_id = ?
-       ORDER BY created_at DESC
+       ORDER BY active DESC, created_at DESC
        LIMIT 1`,
     )
     .get(sessionId) as { conversation_id: number } | undefined;
@@ -371,6 +382,62 @@ function getConversationStatusBySessionId(
   }
 
   return getConversationStatusStats(db, row.conversation_id);
+}
+
+function getConversationCompactionMaintenanceByConversationId(
+  db: DatabaseSync,
+  conversationId: number,
+): ConversationCompactionMaintenanceRecord | null {
+  const row = db
+    .prepare(
+      `SELECT
+         conversation_id,
+         pending,
+         requested_at,
+         reason,
+         running,
+         last_started_at,
+         last_finished_at,
+         last_failure_summary,
+         token_budget,
+         current_token_count,
+         updated_at
+       FROM conversation_compaction_maintenance
+       WHERE conversation_id = ?`,
+    )
+    .get(conversationId) as
+    | {
+        conversation_id: number;
+        pending: number;
+        requested_at: string | null;
+        reason: string | null;
+        running: number;
+        last_started_at: string | null;
+        last_finished_at: string | null;
+        last_failure_summary: string | null;
+        token_budget: number | null;
+        current_token_count: number | null;
+        updated_at: string;
+      }
+    | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    conversationId: row.conversation_id,
+    pending: row.pending === 1,
+    requestedAt: parseUtcTimestampOrNull(row.requested_at),
+    reason: row.reason,
+    running: row.running === 1,
+    lastStartedAt: parseUtcTimestampOrNull(row.last_started_at),
+    lastFinishedAt: parseUtcTimestampOrNull(row.last_finished_at),
+    lastFailureSummary: row.last_failure_summary,
+    tokenBudget: row.token_budget,
+    currentTokenCount: row.current_token_count,
+    updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
+  };
 }
 
 async function resolveCurrentConversation(params: {
@@ -472,7 +539,10 @@ function buildHelpText(error?: string): string {
     "",
     buildSection("📘 Commands", [
       buildStatLine(formatCommand(VISIBLE_COMMAND), "Show compact status output."),
-      buildStatLine(formatCommand(`${VISIBLE_COMMAND} status`), "Show plugin, Global, and current-conversation status."),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} status`),
+        "Show plugin, Global, current-conversation, and compaction-maintenance status.",
+      ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor clean`),
@@ -551,6 +621,12 @@ async function buildStatusText(params: {
         truncated: 0,
         fallback: 0,
       };
+    const maintenance = getConversationCompactionMaintenanceByConversationId(
+      params.db,
+      current.stats.conversationId,
+    );
+    const formatMaintenanceTime = (value: Date | null): string =>
+      value ? formatTimestamp(value, params.config.timezone) : "never";
     lines.push(
       buildSection("📍 Current conversation", [
         buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
@@ -575,6 +651,32 @@ async function buildStatusText(params: {
           conversationDoctor.total > 0
             ? `${formatNumber(conversationDoctor.total)} issue(s) in this conversation`
             : "clean",
+        ),
+      ]),
+    );
+    lines.push(
+      "",
+      buildSection("🛠️ Maintenance", [
+        buildStatLine(
+          "state",
+          maintenance?.pending
+            ? "pending"
+            : maintenance?.running
+              ? "running"
+              : "idle",
+        ),
+        buildStatLine("requested at", formatMaintenanceTime(maintenance?.requestedAt ?? null)),
+        buildStatLine("reason", maintenance?.reason ?? "none"),
+        buildStatLine("last started", formatMaintenanceTime(maintenance?.lastStartedAt ?? null)),
+        buildStatLine("last finished", formatMaintenanceTime(maintenance?.lastFinishedAt ?? null)),
+        buildStatLine("last failure", maintenance?.lastFailureSummary ?? "none"),
+        buildStatLine(
+          "requested token budget",
+          maintenance?.tokenBudget != null ? formatNumber(maintenance.tokenBudget) : "unknown",
+        ),
+        buildStatLine(
+          "observed token count",
+          maintenance?.currentTokenCount != null ? formatNumber(maintenance.currentTokenCount) : "unknown",
         ),
       ]),
     );

--- a/src/startup-banner-log.ts
+++ b/src/startup-banner-log.ts
@@ -1,6 +1,7 @@
 type StartupBannerKey =
   | "plugin-loaded"
   | "compaction-model"
+  | "proactive-threshold-compaction-mode"
   | "fallback-providers"
   | "transcript-gc-enabled"
   | "ignore-session-patterns"

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -1,0 +1,219 @@
+import type { DatabaseSync } from "node:sqlite";
+import { withDatabaseTransaction } from "../transaction-mutex.js";
+import { parseUtcTimestampOrNull } from "./parse-utc-timestamp.js";
+
+export type ConversationCompactionMaintenanceRecord = {
+  conversationId: number;
+  pending: boolean;
+  requestedAt: Date | null;
+  reason: string | null;
+  running: boolean;
+  lastStartedAt: Date | null;
+  lastFinishedAt: Date | null;
+  lastFailureSummary: string | null;
+  tokenBudget: number | null;
+  currentTokenCount: number | null;
+  updatedAt: Date;
+};
+
+type ConversationCompactionMaintenanceRow = {
+  conversation_id: number;
+  pending: number;
+  requested_at: string | null;
+  reason: string | null;
+  running: number;
+  last_started_at: string | null;
+  last_finished_at: string | null;
+  last_failure_summary: string | null;
+  token_budget: number | null;
+  current_token_count: number | null;
+  updated_at: string;
+};
+
+function toMaintenanceRecord(
+  row: ConversationCompactionMaintenanceRow,
+): ConversationCompactionMaintenanceRecord {
+  return {
+    conversationId: row.conversation_id,
+    pending: row.pending === 1,
+    requestedAt: parseUtcTimestampOrNull(row.requested_at),
+    reason: row.reason,
+    running: row.running === 1,
+    lastStartedAt: parseUtcTimestampOrNull(row.last_started_at),
+    lastFinishedAt: parseUtcTimestampOrNull(row.last_finished_at),
+    lastFailureSummary: row.last_failure_summary,
+    tokenBudget: row.token_budget,
+    currentTokenCount: row.current_token_count,
+    updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
+  };
+}
+
+function mergeMaintenanceRecord(
+  conversationId: number,
+  existing: ConversationCompactionMaintenanceRecord | null,
+  patch: Partial<ConversationCompactionMaintenanceRecord>,
+): ConversationCompactionMaintenanceRecord {
+  return {
+    conversationId,
+    pending: patch.pending ?? existing?.pending ?? false,
+    requestedAt: patch.requestedAt !== undefined ? patch.requestedAt : existing?.requestedAt ?? null,
+    reason: patch.reason !== undefined ? patch.reason : existing?.reason ?? null,
+    running: patch.running ?? existing?.running ?? false,
+    lastStartedAt:
+      patch.lastStartedAt !== undefined ? patch.lastStartedAt : existing?.lastStartedAt ?? null,
+    lastFinishedAt:
+      patch.lastFinishedAt !== undefined ? patch.lastFinishedAt : existing?.lastFinishedAt ?? null,
+    lastFailureSummary:
+      patch.lastFailureSummary !== undefined
+        ? patch.lastFailureSummary
+        : existing?.lastFailureSummary ?? null,
+    tokenBudget: patch.tokenBudget !== undefined ? patch.tokenBudget : existing?.tokenBudget ?? null,
+    currentTokenCount:
+      patch.currentTokenCount !== undefined ? patch.currentTokenCount : existing?.currentTokenCount ?? null,
+    updatedAt: new Date(),
+  };
+}
+
+/**
+ * Persist and query per-conversation proactive-compaction maintenance state.
+ *
+ * The plugin records deferred compaction debt here and the host/runtime may opt
+ * in to consume it later. The row is intentionally coalesced: there is one
+ * maintenance record per conversation, not a queue of pending jobs.
+ */
+export class CompactionMaintenanceStore {
+  constructor(private readonly db: DatabaseSync) {}
+
+  /** Execute multiple maintenance writes atomically. */
+  withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    return withDatabaseTransaction(this.db, "BEGIN", fn);
+  }
+
+  /** Load the latest persisted maintenance state for a conversation. */
+  async getConversationCompactionMaintenance(
+    conversationId: number,
+  ): Promise<ConversationCompactionMaintenanceRecord | null> {
+    const row = this.db
+      .prepare(
+        `SELECT
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           last_started_at,
+           last_finished_at,
+           last_failure_summary,
+           token_budget,
+           current_token_count,
+           updated_at
+         FROM conversation_compaction_maintenance
+         WHERE conversation_id = ?`,
+      )
+      .get(conversationId) as ConversationCompactionMaintenanceRow | undefined;
+    return row ? toMaintenanceRecord(row) : null;
+  }
+
+  private async saveConversationCompactionMaintenance(
+    record: ConversationCompactionMaintenanceRecord,
+  ): Promise<void> {
+    this.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+         reason,
+         running,
+         last_started_at,
+         last_finished_at,
+         last_failure_summary,
+         token_budget,
+         current_token_count,
+         updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(conversation_id) DO UPDATE SET
+           pending = excluded.pending,
+           requested_at = excluded.requested_at,
+           reason = excluded.reason,
+           running = excluded.running,
+           last_started_at = excluded.last_started_at,
+           last_finished_at = excluded.last_finished_at,
+           last_failure_summary = excluded.last_failure_summary,
+           token_budget = excluded.token_budget,
+           current_token_count = excluded.current_token_count,
+           updated_at = datetime('now')`,
+      )
+      .run(
+        record.conversationId,
+        record.pending ? 1 : 0,
+        record.requestedAt?.toISOString() ?? null,
+        record.reason ?? null,
+        record.running ? 1 : 0,
+        record.lastStartedAt?.toISOString() ?? null,
+        record.lastFinishedAt?.toISOString() ?? null,
+        record.lastFailureSummary ?? null,
+        record.tokenBudget ?? null,
+        record.currentTokenCount ?? null,
+      );
+  }
+
+  /** Record or refresh deferred proactive-compaction debt for a conversation. */
+  async requestProactiveCompactionDebt(input: {
+    conversationId: number;
+    reason: string;
+    requestedAt?: Date;
+    tokenBudget?: number | null;
+    currentTokenCount?: number | null;
+  }): Promise<void> {
+    const existing = await this.getConversationCompactionMaintenance(input.conversationId);
+    await this.saveConversationCompactionMaintenance(
+      mergeMaintenanceRecord(input.conversationId, existing, {
+        pending: true,
+        requestedAt: input.requestedAt ?? new Date(),
+        reason: input.reason,
+        running: false,
+        tokenBudget: input.tokenBudget ?? existing?.tokenBudget ?? null,
+        currentTokenCount: input.currentTokenCount ?? existing?.currentTokenCount ?? null,
+      }),
+    );
+  }
+
+  /** Mark deferred proactive compaction as actively running. */
+  async markProactiveCompactionRunning(input: {
+    conversationId: number;
+    startedAt?: Date;
+  }): Promise<void> {
+    const existing = await this.getConversationCompactionMaintenance(input.conversationId);
+    await this.saveConversationCompactionMaintenance(
+      mergeMaintenanceRecord(input.conversationId, existing, {
+        pending: false,
+        running: true,
+        lastStartedAt: input.startedAt ?? new Date(),
+      }),
+    );
+  }
+
+  /** Mark deferred proactive compaction as finished. */
+  async markProactiveCompactionFinished(input: {
+    conversationId: number;
+    finishedAt?: Date;
+    failureSummary?: string | null;
+    keepPending?: boolean;
+  }): Promise<void> {
+    const existing = await this.getConversationCompactionMaintenance(input.conversationId);
+    const finishedAt = input.finishedAt ?? new Date();
+    const isFailure = input.failureSummary != null;
+    await this.saveConversationCompactionMaintenance(
+      mergeMaintenanceRecord(input.conversationId, existing, {
+        pending: input.keepPending ?? isFailure,
+        running: false,
+        lastFinishedAt: finishedAt,
+        lastFailureSummary:
+          input.failureSummary === undefined
+            ? existing?.lastFailureSummary ?? null
+            : input.failureSummary,
+      }),
+    );
+  }
+}

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -55,10 +55,10 @@ function mergeMaintenanceRecord(
 ): ConversationCompactionMaintenanceRecord {
   return {
     conversationId,
-    pending: patch.pending ?? existing?.pending ?? false,
+    pending: patch.pending !== undefined ? patch.pending : existing?.pending ?? false,
     requestedAt: patch.requestedAt !== undefined ? patch.requestedAt : existing?.requestedAt ?? null,
     reason: patch.reason !== undefined ? patch.reason : existing?.reason ?? null,
-    running: patch.running ?? existing?.running ?? false,
+    running: patch.running !== undefined ? patch.running : existing?.running ?? false,
     lastStartedAt:
       patch.lastStartedAt !== undefined ? patch.lastStartedAt : existing?.lastStartedAt ?? null,
     lastFinishedAt:

--- a/src/store/compaction-telemetry-store.ts
+++ b/src/store/compaction-telemetry-store.ts
@@ -17,6 +17,10 @@ export type ConversationCompactionTelemetryRecord = {
   turnsSinceLeafCompaction: number;
   tokensAccumulatedSinceLeafCompaction: number;
   lastActivityBand: ActivityBand;
+  lastApiCallAt: Date | null;
+  lastCacheTouchAt: Date | null;
+  provider: string | null;
+  model: string | null;
   updatedAt: Date;
 };
 
@@ -32,6 +36,10 @@ export type UpsertConversationCompactionTelemetryInput = {
   turnsSinceLeafCompaction?: number;
   tokensAccumulatedSinceLeafCompaction?: number;
   lastActivityBand?: ActivityBand;
+  lastApiCallAt?: Date | null;
+  lastCacheTouchAt?: Date | null;
+  provider?: string | null;
+  model?: string | null;
 };
 
 type ConversationCompactionTelemetryRow = {
@@ -46,6 +54,10 @@ type ConversationCompactionTelemetryRow = {
   turns_since_leaf_compaction: number | null;
   tokens_accumulated_since_leaf_compaction: number | null;
   last_activity_band: ActivityBand | null;
+  last_api_call_at: string | null;
+  last_cache_touch_at: string | null;
+  provider: string | null;
+  model: string | null;
   updated_at: string;
 };
 
@@ -64,6 +76,10 @@ function toConversationCompactionTelemetryRecord(
     turnsSinceLeafCompaction: row.turns_since_leaf_compaction ?? 0,
     tokensAccumulatedSinceLeafCompaction: row.tokens_accumulated_since_leaf_compaction ?? 0,
     lastActivityBand: row.last_activity_band ?? "low",
+    lastApiCallAt: parseUtcTimestampOrNull(row.last_api_call_at),
+    lastCacheTouchAt: parseUtcTimestampOrNull(row.last_cache_touch_at),
+    provider: row.provider,
+    model: row.model,
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -98,6 +114,10 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction,
            last_activity_band,
+           last_api_call_at,
+           last_cache_touch_at,
+           provider,
+           model,
            updated_at
          FROM conversation_compaction_telemetry
          WHERE conversation_id = ?`,
@@ -124,8 +144,12 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction,
            last_activity_band,
+           last_api_call_at,
+           last_cache_touch_at,
+           provider,
+           model,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            last_observed_cache_read = excluded.last_observed_cache_read,
            last_observed_cache_write = excluded.last_observed_cache_write,
@@ -137,6 +161,10 @@ export class CompactionTelemetryStore {
            turns_since_leaf_compaction = excluded.turns_since_leaf_compaction,
            tokens_accumulated_since_leaf_compaction = excluded.tokens_accumulated_since_leaf_compaction,
            last_activity_band = excluded.last_activity_band,
+           last_api_call_at = excluded.last_api_call_at,
+           last_cache_touch_at = excluded.last_cache_touch_at,
+           provider = excluded.provider,
+           model = excluded.model,
            updated_at = datetime('now')`,
       )
       .run(
@@ -151,6 +179,10 @@ export class CompactionTelemetryStore {
         input.turnsSinceLeafCompaction ?? 0,
         input.tokensAccumulatedSinceLeafCompaction ?? 0,
         input.lastActivityBand ?? "low",
+        input.lastApiCallAt?.toISOString() ?? null,
+        input.lastCacheTouchAt?.toISOString() ?? null,
+        input.provider ?? null,
+        input.model ?? null,
       );
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,3 +37,8 @@ export type {
   ConversationCompactionTelemetryRecord,
   UpsertConversationCompactionTelemetryInput,
 } from "./compaction-telemetry-store.js";
+
+export { CompactionMaintenanceStore } from "./compaction-maintenance-store.js";
+export type {
+  ConversationCompactionMaintenanceRecord,
+} from "./compaction-maintenance-store.js";

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -40,6 +40,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    proactiveThresholdCompactionMode: "deferred",
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     expansionProvider: "",

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -45,6 +45,7 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    proactiveThresholdCompactionMode: "deferred",
     summaryMaxOverageFactor: 3,
     delegationTimeoutMs: 120000,
     customInstructions: "",

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLcmDatabaseConnection, closeLcmConnection } from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { CompactionMaintenanceStore } from "../src/store/compaction-maintenance-store.js";
+
+const tempDirs: string[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+function createTestDb() {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-maintenance-store-"));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, "lcm.db");
+  const db = createLcmDatabaseConnection(dbPath);
+  dbs.push(db);
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+  return db;
+}
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    closeLcmConnection(db);
+  }
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("CompactionMaintenanceStore", () => {
+  it("allows pending and running flags to transition back to false", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-session",
+      sessionKey: "agent:main:maintenance-store:1",
+    });
+    const store = new CompactionMaintenanceStore(db);
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+
+    await store.markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+
+    await store.markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: null,
+      keepPending: false,
+    });
+
+    const record = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(record).not.toBeNull();
+    expect(record?.pending).toBe(false);
+    expect(record?.running).toBe(false);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -42,6 +42,7 @@ describe("resolveLcmConfig", () => {
     expect(config.proactiveThresholdCompactionMode).toBe("deferred");
     expect(config.cacheAwareCompaction).toEqual({
       enabled: true,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
@@ -71,6 +72,7 @@ describe("resolveLcmConfig", () => {
       enabled: false,
       cacheAwareCompaction: {
         enabled: false,
+        cacheTTLSeconds: 900,
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
@@ -100,6 +102,7 @@ describe("resolveLcmConfig", () => {
     expect(config.proactiveThresholdCompactionMode).toBe("inline");
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 900,
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
@@ -123,6 +126,7 @@ describe("resolveLcmConfig", () => {
       LCM_SKIP_STATELESS_SESSIONS: "false",
       LCM_TRANSCRIPT_GC_ENABLED: "true",
       LCM_CACHE_AWARE_COMPACTION_ENABLED: "false",
+      LCM_CACHE_TTL_SECONDS: "600",
       LCM_MAX_COLD_CACHE_CATCHUP_PASSES: "4",
       LCM_HOT_CACHE_PRESSURE_FACTOR: "5.5",
       LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO: "0.25",
@@ -143,6 +147,7 @@ describe("resolveLcmConfig", () => {
       enabled: true,
       cacheAwareCompaction: {
         enabled: true,
+        cacheTTLSeconds: 120,
         maxColdCacheCatchupPasses: 2,
         hotCachePressureFactor: 3,
         hotCacheBudgetHeadroomRatio: 0.1,
@@ -172,6 +177,7 @@ describe("resolveLcmConfig", () => {
     expect(config.incrementalMaxDepth).toBe(3); // env wins
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 600,
       maxColdCacheCatchupPasses: 4,
       hotCachePressureFactor: 5.5,
       hotCacheBudgetHeadroomRatio: 0.25,
@@ -331,6 +337,7 @@ describe("resolveLcmConfig", () => {
     const config = resolveLcmConfig({}, {
       cacheAwareCompaction: {
         enabled: false,
+        cacheTTLSeconds: 900,
         maxColdCacheCatchupPasses: 3,
         hotCachePressureFactor: 6,
         hotCacheBudgetHeadroomRatio: 0.35,
@@ -339,6 +346,7 @@ describe("resolveLcmConfig", () => {
 
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
+      cacheTTLSeconds: 900,
       maxColdCacheCatchupPasses: 3,
       hotCachePressureFactor: 6,
       hotCacheBudgetHeadroomRatio: 0.35,
@@ -552,6 +560,10 @@ describe("resolveLcmConfig", () => {
       properties: {
         enabled: {
           type: "boolean",
+        },
+        cacheTTLSeconds: {
+          type: "integer",
+          minimum: 1,
         },
         maxColdCacheCatchupPasses: {
           type: "integer",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,6 +39,7 @@ describe("resolveLcmConfig", () => {
     expect(config.summaryModel).toBe("");
     expect(config.pruneHeartbeatOk).toBe(false);
     expect(config.transcriptGcEnabled).toBe(false);
+    expect(config.proactiveThresholdCompactionMode).toBe("deferred");
     expect(config.cacheAwareCompaction).toEqual({
       enabled: true,
       maxColdCacheCatchupPasses: 2,
@@ -66,6 +67,7 @@ describe("resolveLcmConfig", () => {
       condensedMinFanout: 2,
       pruneHeartbeatOk: true,
       transcriptGcEnabled: true,
+      proactiveThresholdCompactionMode: "inline",
       enabled: false,
       cacheAwareCompaction: {
         enabled: false,
@@ -95,6 +97,7 @@ describe("resolveLcmConfig", () => {
     expect(config.condensedMinFanout).toBe(2);
     expect(config.pruneHeartbeatOk).toBe(true);
     expect(config.transcriptGcEnabled).toBe(true);
+    expect(config.proactiveThresholdCompactionMode).toBe("inline");
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
       maxColdCacheCatchupPasses: 3,
@@ -125,6 +128,7 @@ describe("resolveLcmConfig", () => {
       LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO: "0.25",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED: "true",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_MAX: "60000",
+      LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE: "inline",
     } as NodeJS.ProcessEnv;
     const pluginConfig = {
       contextThreshold: 0.5,
@@ -135,6 +139,7 @@ describe("resolveLcmConfig", () => {
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
       transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
       enabled: true,
       cacheAwareCompaction: {
         enabled: true,
@@ -159,6 +164,7 @@ describe("resolveLcmConfig", () => {
     ]);
     expect(config.skipStatelessSessions).toBe(false);
     expect(config.transcriptGcEnabled).toBe(true);
+    expect(config.proactiveThresholdCompactionMode).toBe("inline");
     expect(config.contextThreshold).toBe(0.9); // env wins
     expect(config.freshTailCount).toBe(64); // env wins
     expect(config.freshTailMaxTokens).toBe(32000); // env wins
@@ -529,6 +535,13 @@ describe("resolveLcmConfig", () => {
   it("ships a manifest with transcriptGcEnabled in schema", () => {
     expect(manifest.configSchema.properties.transcriptGcEnabled).toEqual({
       type: "boolean",
+    });
+  });
+
+  it("ships a manifest with proactiveThresholdCompactionMode in schema", () => {
+    expect(manifest.configSchema.properties.proactiveThresholdCompactionMode).toEqual({
+      type: "string",
+      enum: ["deferred", "inline"],
     });
   });
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -60,6 +60,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     fallbackProviders: [],
     cacheAwareCompaction: {
       enabled: true,
+      cacheTTLSeconds: 300,
       maxColdCacheCatchupPasses: 2,
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
@@ -4679,11 +4680,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect((compactLeafAsyncSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
       runtimeContext,
     );
-    expect(compactSpy).toHaveBeenCalled();
-    expect((compactSpy.mock.calls[0]?.[0] as { tokenBudget?: unknown }).tokenBudget).toBe(2048);
-    expect((compactSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
-      runtimeContext,
-    );
+    expect(compactSpy).not.toHaveBeenCalled();
   });
 
   it("afterTurn falls back to the default token budget when no budget is provided", async () => {
@@ -4812,10 +4809,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect((compactLeafAsyncSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
       legacyCompactionParams,
     );
-    expect(compactSpy).toHaveBeenCalled();
-    expect((compactSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
-      legacyCompactionParams,
-    );
+    expect(compactSpy).not.toHaveBeenCalled();
   });
 
   it("afterTurn prefers runtimeContext when both runtimeContext and legacyCompactionParams are set", async () => {
@@ -5030,6 +5024,49 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
   });
 
+  it("maintain() keeps deferred prompt-mutating debt pending while Anthropic cache is still hot", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-hot-cache";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "long",
+      lastCacheTouchAt: new Date(),
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    const evaluateIncrementalCompactionSpy = vi.spyOn(privateEngine, "evaluateIncrementalCompaction");
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-hot-cache-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(evaluateIncrementalCompactionSpy).not.toHaveBeenCalled();
+    expect(maintenanceResult.changed).toBe(false);
+  });
+
   it("maintain() keeps deferred leaf debt pending when compaction hits an auth failure", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
@@ -5083,6 +5120,56 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.lastFailureSummary).toBe("provider auth failure");
     expect(maintenanceResult.changed).toBe(false);
     expect(maintenanceResult.reason).toBe("provider auth failure");
+  });
+
+  it("assemble() consumes deferred Anthropic debt once the prompt cache is stale", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-stale-cache";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: new Date(Date.now() - 10 * 60 * 1000),
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "deferred compaction no longer needed",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "low",
+      leafChunkTokens: 20_000,
+      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+      cacheState: "cold",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
   });
 
   it("afterTurn persists prompt-cache telemetry for hot sessions", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5067,6 +5067,49 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenanceResult.changed).toBe(false);
   });
 
+  it("maintain() treats a recent Anthropic API call as a hot-cache touch when explicit cache telemetry is absent", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-recent-api-call";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "unknown",
+      retention: "short",
+      lastApiCallAt: new Date(),
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    const evaluateIncrementalCompactionSpy = vi.spyOn(privateEngine, "evaluateIncrementalCompaction");
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-recent-api-call"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(evaluateIncrementalCompactionSpy).not.toHaveBeenCalled();
+    expect(maintenanceResult.changed).toBe(false);
+  });
+
   it("maintain() keeps deferred leaf debt pending when compaction hits an auth failure", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5030,6 +5030,61 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
   });
 
+  it("maintain() keeps deferred leaf debt pending when compaction hits an auth failure", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const sessionId = "maintain-deferred-compaction-auth-failure";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 1_024,
+    });
+
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: true,
+      activityBand: "medium",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      reason: "forced-for-test",
+    });
+    vi.spyOn(privateEngine.compaction, "compactLeaf").mockResolvedValue({
+      actionTaken: false,
+      authFailure: true,
+      tokensBefore: 1_024,
+      tokensAfter: 1_024,
+      condensed: false,
+    });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-auth-failure-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.lastFailureSummary).toBe("provider auth failure");
+    expect(maintenanceResult.changed).toBe(false);
+    expect(maintenanceResult.reason).toBe("provider auth failure");
+  });
+
   it("afterTurn persists prompt-cache telemetry for hot sessions", async () => {
     const debugLog = vi.fn();
     const engine = createEngineWithDeps(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4868,20 +4868,31 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn records deferred compaction debt instead of compacting inline by default", async () => {
     const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (
+          conversationId: number,
+          leafChunkTokens?: number,
+        ) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
     const sessionId = "after-turn-deferred-compaction-debt";
-    vi.spyOn(engine as unknown as { evaluateIncrementalCompaction: () => Promise<unknown> }, "evaluateIncrementalCompaction").mockResolvedValue({
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
       shouldCompact: true,
-      reason: "leaf-trigger",
-      maxPasses: 1,
-      allowCondensedPasses: false,
-      activityBand: "high",
-      leafChunkTokens: 20_000,
-      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
-      triggerLeafChunkTokens: 20_000,
-      preferredLeafChunkTokens: 20_000,
       rawTokensOutsideTail: 50_000,
       threshold: 20_000,
     } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
     const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
     const compactSpy = vi.spyOn(engine, "compact");
 
@@ -5213,6 +5224,110 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.pending).toBe(false);
     expect(maintenance?.running).toBe(false);
     expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() waits for the session queue before consuming deferred debt", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      withSessionQueue<T>(queueKey: string, operation: () => Promise<T>): Promise<T>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-queued";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: new Date(Date.now() - 10 * 60 * 1000),
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const consumeSpy = vi.spyOn(privateEngine, "consumeDeferredCompactionDebt");
+
+    let releaseQueue!: () => void;
+    const heldQueue = privateEngine.withSessionQueue(sessionId, async () => {
+      await new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+    });
+
+    let assembleSettled = false;
+    const assemblePromise = engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    }).then((result) => {
+      assembleSettled = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consumeSpy).not.toHaveBeenCalled();
+    expect(assembleSettled).toBe(false);
+
+    releaseQueue();
+    await heldQueue;
+    const assembleResult = await assemblePromise;
+
+    expect(consumeSpy).toHaveBeenCalledTimes(1);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("maintain() re-evaluates deferred debt with the stricter current token budget", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-current-budget";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 1_024,
+    });
+
+    const evaluateIncrementalCompactionSpy = vi.spyOn(
+      privateEngine,
+      "evaluateIncrementalCompaction",
+    ).mockResolvedValue({
+      shouldCompact: false,
+      reason: "deferred compaction no longer needed",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "low",
+      leafChunkTokens: 20_000,
+      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+      cacheState: "unknown",
+    });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-current-budget"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 2_048,
+      },
+    });
+
+    expect(evaluateIncrementalCompactionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenBudget: 2_048,
+      }),
+    );
   });
 
   it("afterTurn persists prompt-cache telemetry for hot sessions", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -52,6 +52,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    proactiveThresholdCompactionMode: "deferred",
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     circuitBreakerThreshold: 5,
@@ -4569,7 +4570,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
   });
 
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
     const sessionId = "after-turn-proactive-compact";
     const privateEngine = engine as unknown as {
       compaction: {
@@ -4625,7 +4628,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
   });
 
   it("afterTurn resolves tokenBudget from runtimeContext and forwards it as legacyParams", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
     const sessionId = "after-turn-runtime-context";
     const runtimeContext = { provider: "anthropic", model: "claude-opus-4-5", tokenBudget: 2048 };
     const privateEngine = engine as unknown as {
@@ -4683,14 +4688,19 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn falls back to the default token budget when no budget is provided", async () => {
     const warnLog = vi.fn();
-    const engine = createEngineWithDepsOverrides({
-      log: {
-        info: vi.fn(),
-        warn: warnLog,
-        error: vi.fn(),
-        debug: vi.fn(),
+    const engine = createEngineWithDeps(
+      {
+        proactiveThresholdCompactionMode: "inline",
       },
-    });
+      {
+        log: {
+          info: vi.fn(),
+          warn: warnLog,
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
     const sessionId = "after-turn-default-token-budget";
     const privateEngine = engine as unknown as {
       compaction: {
@@ -4741,14 +4751,19 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn falls back to legacyCompactionParams when runtimeContext is missing", async () => {
     const errorLog = vi.fn();
-    const engine = createEngineWithDepsOverrides({
-      log: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: errorLog,
-        debug: vi.fn(),
+    const engine = createEngineWithDeps(
+      {
+        proactiveThresholdCompactionMode: "inline",
       },
-    });
+      {
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: errorLog,
+          debug: vi.fn(),
+        },
+      },
+    );
     const sessionId = "after-turn-legacy-compaction-params";
     const legacyCompactionParams = { provider: "anthropic", model: "claude-opus-4-5" };
     const privateEngine = engine as unknown as {
@@ -4804,7 +4819,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
   });
 
   it("afterTurn prefers runtimeContext when both runtimeContext and legacyCompactionParams are set", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
     const sessionId = "after-turn-runtime-context-priority";
     const runtimeContext = { provider: "anthropic", model: "claude-opus-4-5", source: "rt" };
     const legacyCompactionParams = {
@@ -4853,6 +4870,164 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect((compactSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
       runtimeContext,
     );
+  });
+
+  it("afterTurn records deferred compaction debt instead of compacting inline by default", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-deferred-compaction-debt";
+    vi.spyOn(engine as unknown as { evaluateIncrementalCompaction: () => Promise<unknown> }, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: true,
+      reason: "leaf-trigger",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 20_000,
+      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+      triggerLeafChunkTokens: 20_000,
+      preferredLeafChunkTokens: 20_000,
+      rawTokensOutsideTail: 50_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-deferred-compaction-debt"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
+    expect(compactSpy).not.toHaveBeenCalled();
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.reason).toBe("leaf-trigger");
+    expect(maintenance?.requestedAt).toBeInstanceOf(Date);
+  });
+
+  it("afterTurn records threshold debt even when the leaf trigger stays below threshold", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-threshold-deferred-compaction-debt";
+    vi.spyOn(
+      engine as unknown as { evaluateIncrementalCompaction: () => Promise<unknown> },
+      "evaluateIncrementalCompaction",
+    ).mockResolvedValue({
+      shouldCompact: false,
+      reason: "below-leaf-trigger",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "medium",
+      leafChunkTokens: 20_000,
+      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+      triggerLeafChunkTokens: 20_000,
+      preferredLeafChunkTokens: 20_000,
+      rawTokensOutsideTail: 10_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 480,
+      threshold: 300,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-threshold-deferred-compaction-debt"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 400,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.reason).toBe("threshold");
+    expect(maintenance?.tokenBudget).toBe(400);
+  });
+
+  it("maintain() leaves deferred compaction debt pending until the host opts in", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-deferred-compaction-disabled";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+
+    const compactSpy = vi.spyOn(engine, "compact");
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-disabled-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: false,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(compactSpy).not.toHaveBeenCalled();
+    expect(maintenanceResult.changed).toBe(false);
+  });
+
+  it("maintain() consumes deferred compaction debt only when the host opts in", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-deferred-compaction-enabled";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-enabled-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenanceResult.changed).toBe(false);
+    expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
   });
 
   it("afterTurn persists prompt-cache telemetry for hot sessions", async () => {
@@ -5094,7 +5269,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
   });
 
   it("afterTurn allows bounded catch-up passes when prompt cache is cold", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
     const sessionId = "after-turn-cold-cache-catchup";
     const privateEngine = engine as unknown as {
       compaction: {
@@ -5171,6 +5348,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(
       {
+        proactiveThresholdCompactionMode: "inline",
         dynamicLeafChunkTokens: {
           enabled: true,
           max: 40_000,
@@ -5247,6 +5425,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn bumps to the max working leaf chunk when cache-aware compaction is cold", async () => {
     const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
       dynamicLeafChunkTokens: {
         enabled: true,
         max: 40_000,

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -30,6 +30,7 @@ const BASE_CONFIG: LcmConfig = {
   timezone: "UTC",
   pruneHeartbeatOk: false,
   transcriptGcEnabled: false,
+  proactiveThresholdCompactionMode: "deferred",
   summaryMaxOverageFactor: 3,
   expansionProvider: "",
   expansionModel: "",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -220,6 +220,58 @@ describe("lcm command", () => {
     expect(result.text).toContain("doctor: 1 issue(s) in this conversation");
   });
 
+  it("reports deferred compaction maintenance state in status output", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "maintenance-status-session",
+      sessionKey: "agent:main:telegram:maintenance:1",
+      title: "Maintenance fixture",
+    });
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           last_started_at,
+           last_finished_at,
+           last_failure_summary,
+           token_budget,
+           current_token_count,
+           updated_at
+         ) VALUES (?, 1, ?, ?, 0, ?, ?, ?, ?, ?, datetime('now'))`,
+      )
+      .run(
+        conversation.conversationId,
+        "2026-04-12T00:00:00.000Z",
+        "budget-trigger",
+        "2026-04-12T00:05:00.000Z",
+        "2026-04-12T00:07:00.000Z",
+        "provider timeout",
+        128_000,
+        96_000,
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        sessionKey: "agent:main:telegram:maintenance:1",
+        sessionId: "maintenance-status-session",
+      }),
+    );
+
+    expect(result.text).toContain("**🛠️ Maintenance**");
+    expect(result.text).toContain("state: pending");
+    expect(result.text).toContain("reason: budget-trigger");
+    expect(result.text).toContain("last failure: provider timeout");
+    expect(result.text).toContain("requested token budget: 128,000");
+    expect(result.text).toContain("observed token count: 96,000");
+  });
+
   it("falls back to the active session id when the current session key is not stored yet", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -86,6 +86,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       timezone: "UTC",
       pruneHeartbeatOk: false,
       transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/lcm-expand-tool.test.ts
+++ b/test/lcm-expand-tool.test.ts
@@ -52,6 +52,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       timezone: "UTC",
       pruneHeartbeatOk: false,
       transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -51,6 +51,7 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
       timezone: "UTC",
       pruneHeartbeatOk: false,
       transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
       summaryMaxOverageFactor: 3,
     },
     complete: vi.fn(),

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -187,6 +187,7 @@ describe("lcm plugin registration", () => {
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
       transcriptGcEnabled: true,
+      proactiveThresholdCompactionMode: "inline",
       largeFileThresholdTokens: 12345,
     });
     lcmPlugin.register(api);
@@ -205,7 +206,10 @@ describe("lcm plugin registration", () => {
     const factory = getFactory();
     expect(factory).toBeTypeOf("function");
 
-    const engine = factory!() as { config: Record<string, unknown> };
+    const engine = factory!() as {
+      config: Record<string, unknown>;
+      info?: Record<string, unknown>;
+    };
     expect(engine.config).toMatchObject({
       enabled: true,
       contextThreshold: 0.33,
@@ -218,12 +222,19 @@ describe("lcm plugin registration", () => {
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
       transcriptGcEnabled: true,
+      proactiveThresholdCompactionMode: "inline",
       largeFileTokenThreshold: 12345,
     });
+    expect(engine.info).toMatchObject({
+      turnMaintenanceMode: "background",
+    });
     expect(infoLog).toHaveBeenCalledWith(
-      `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
+      `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33, proactiveThresholdCompactionMode=inline)`,
     );
     expect(infoLog).toHaveBeenCalledWith("[lcm] Transcript GC enabled (default false)");
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Proactive threshold compaction mode: inline (default deferred)",
+    );
     expect(infoLog).toHaveBeenCalledWith(
       "[lcm] Ignoring sessions matching 2 pattern(s) from plugin config: agent:*:cron:**, agent:main:subagent:**",
     );
@@ -550,6 +561,7 @@ describe("lcm plugin registration", () => {
       ignoreSessionPatterns: ["agent:*:cron:**", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
+      proactiveThresholdCompactionMode: "deferred",
     };
     const first = buildApi(pluginConfig);
     const second = buildApi(pluginConfig);
@@ -574,6 +586,7 @@ describe("lcm plugin registration", () => {
       [
         "[lcm] Plugin loaded (enabled=true, db=",
         "[lcm] Transcript GC ",
+        "[lcm] Proactive threshold compaction mode:",
         "[lcm] Compaction summarization model:",
         "[lcm] Ignoring sessions matching ",
         "[lcm] Stateless session patterns",
@@ -581,8 +594,9 @@ describe("lcm plugin registration", () => {
     );
 
     expect(startupBannerMessages.sort()).toEqual([
-      `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33)`,
+      `[lcm] Plugin loaded (enabled=true, db=${dbPath}, threshold=0.33, proactiveThresholdCompactionMode=deferred)`,
       "[lcm] Transcript GC disabled (default false)",
+      "[lcm] Proactive threshold compaction mode: deferred (default deferred)",
       "[lcm] Compaction summarization model: (unconfigured)",
       "[lcm] Ignoring sessions matching 2 pattern(s) from plugin config: agent:*:cron:**, agent:main:subagent:**",
       "[lcm] Stateless session patterns from plugin config: 1 pattern(s): agent:*:subagent:**",

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -50,6 +50,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    proactiveThresholdCompactionMode: "deferred",
     summaryMaxOverageFactor: 3,
     expansionProvider: "",
     expansionModel: "",


### PR DESCRIPTION
## Summary
Closes #407.

This changes proactive compaction from inline turn work into deferred maintenance debt by default, then makes that deferred path cache-safe for Anthropic. The result is a hybrid model: proactive compaction no longer blocks the foreground `afterTurn()` path, and prompt-mutating deferred compaction no longer rewrites a still-hot Anthropic cache.

## Why
- Inline proactive compaction can keep the main session lane busy after the assistant reply is already visible.
- That starves immediate follow-up turns and can push subagent completion announce traffic into timeouts.
- Anthropic prompt caching is exact-prefix, so rewriting the active prompt too soon can burn a freshly written cache and drive up cost.
- Orchestrator-heavy sessions make the pain worse: one main agent plus up to 4 subagents may all need fast LCM reads while one hot session is still writing.

## What Changed
- Added `proactiveThresholdCompactionMode: "deferred" | "inline"`; default is `"deferred"`.
- `afterTurn()` now records coalesced proactive compaction debt per conversation/session instead of running proactive threshold or leaf compaction inline.
- `maintain()` now consumes that debt only when runtime context explicitly allows deferred execution, and it skips prompt-mutating deferred compaction while Anthropic cache is still hot.
- `assemble()` now consumes deferred prompt-mutating compaction pre-assembly when the cache is cold or the prompt is approaching overflow.
- Added persistent maintenance state for pending/running/last success/last failure metadata.
- Added `cacheAwareCompaction.cacheTTLSeconds` (default `300`) and telemetry for `lastApiCallAt`, `lastCacheTouchAt`, `provider`, and `model`.
- Extended LCM status/command output and startup banners to surface maintenance state and cache-aware compaction context.
- Preserved the local same-turn safety guard in legacy `inline` mode so leaf and threshold compaction do not both fire on the same turn.
- Kept manual, overflow, and timeout compaction synchronous.
- Advertised `turnMaintenanceMode: "background"` for the companion OpenClaw host change.

## Safety
- Legacy `inline` mode remains available as a rollback/debug escape hatch.
- Read-only LCM tools continue to work while compaction debt is pending.
- Public tool inputs stay stable apart from the new config option.
- Anthropic-active sessions keep their hot cache unless compaction is needed for correctness or the cache has already gone cold.

## Validation
- `npm test` -> 40 files / 709 tests passed
- `npm run build` passed

## Companion Host Work
- Companion OpenClaw issue: openclaw/openclaw#65220
- Companion OpenClaw PR: openclaw/openclaw#65233
- Anthropic-native companion issue: openclaw/openclaw#65287
- Anthropic-native companion PR: openclaw/openclaw#65288
