### PR TITLE
feat(engine): budget-aware compaction deferral via budgetHeadroomRatio

### DIFF
--- a/.changeset/budget-headroom-ratio.md
+++ b/.changeset/budget-headroom-ratio.md
@@ -1,0 +1,7 @@
+---
+"@anthropic/lossless-claw": minor
+---
+
+feat(engine): add `budgetHeadroomRatio` to defer incremental compaction when under budget
+
+New opt-in config parameter `budgetHeadroomRatio` (env: `LCM_BUDGET_HEADROOM_RATIO`, default `0`) defers incremental leaf compaction while the current token count stays below `tokenBudget × (1 - ratio)`, regardless of cache state. Useful for non-Anthropic providers where cache telemetry is never reported and for large-context-window models. The hot-cache-specific `hotCacheBudgetHeadroomRatio` takes precedence when cache state is hot.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,8 @@ Most installations only need to override a handful of keys. If you want a comple
   "dynamicLeafChunkTokens": {
     "enabled": true,
     "max": 40000
-  }
+  },
+  "budgetHeadroomRatio": 0
 }
 ```
 
@@ -134,6 +135,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `largeFileTokenThreshold` | `integer` | alias of `largeFileThresholdTokens` | `LCM_LARGE_FILE_TOKEN_THRESHOLD` | Legacy alias accepted by the runtime. Prefer `largeFileThresholdTokens` in new config. |
 | `maxAssemblyTokenBudget` | `integer` | unset | `LCM_MAX_ASSEMBLY_TOKEN_BUDGET` | Optional hard cap for assembly and threshold evaluation, useful with smaller-context models. |
 | `maxExpandTokens` | `integer` | `4000` | `LCM_MAX_EXPAND_TOKENS` | Default token cap for `lcm_expand_query` responses. |
+| `budgetHeadroomRatio` | `number` | `0` | `LCM_BUDGET_HEADROOM_RATIO` | Fraction of token budget that must be consumed before incremental compaction proceeds, regardless of cache state. `0` disables (default, preserving eager compaction). The hot-cache-specific `hotCacheBudgetHeadroomRatio` takes precedence when cache state is hot. Clamped to [0, 0.95]. |
 
 ### Model selection, execution, and prompts
 
@@ -185,6 +187,10 @@ When cache-aware compaction is enabled:
 - cold cache still allows bounded catch-up passes via `cacheAwareCompaction.maxColdCacheCatchupPasses`
 
 When incremental leaf compaction still runs on a hot cache, follow-on condensed passes are suppressed so the maintenance cycle only pays for the leaf pass that was explicitly justified.
+
+#### `budgetHeadroomRatio`
+
+When set to a value greater than `0`, incremental compaction is also deferred for `"unknown"` and `"cold"` cache states as long as the current token count stays below `tokenBudget × (1 - budgetHeadroomRatio)`. This is useful for non-Anthropic providers where cache telemetry is never reported (`cacheState` stays `"unknown"` permanently) and for large-context-window models where eager leaf creation wastes summarization LLM calls while ample headroom remains. The hot-cache-specific `hotCacheBudgetHeadroomRatio` takes precedence when cache state is `"hot"`. Default is `0` (disabled).
 
 ## Behavior notes
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -188,6 +188,10 @@
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit fallback provider/model pairs for compaction summarization (e.g., [{\"provider\": \"anthropic\", \"model\": \"claude-haiku-4-5\"}])"
+    },
+    "budgetHeadroomRatio": {
+      "label": "Budget Headroom Ratio",
+      "help": "Fraction of token budget that must be consumed before incremental compaction runs, regardless of cache state (0 disables, 0.5 means defer until 50% used)"
     }
   },
   "configSchema": {
@@ -387,6 +391,11 @@
           "required": ["provider", "model"],
           "additionalProperties": false
         }
+      },
+      "budgetHeadroomRatio": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.95
       }
     }
   }

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -377,6 +377,23 @@ Default:
 
 - `max(leafChunkTokens, floor(leafChunkTokens * 2))`
 
+### `budgetHeadroomRatio`
+
+Fraction of token budget that must be consumed before incremental compaction proceeds, regardless of cache state. When the current token count is at or below `tokenBudget × (1 - budgetHeadroomRatio)`, incremental leaf passes are deferred. The hot-cache-specific `hotCacheBudgetHeadroomRatio` takes precedence when cache state is `"hot"`.
+
+Why it matters:
+
+- useful for non-Anthropic providers where cache telemetry is never reported, leaving `cacheState` permanently `"unknown"` — without this, those providers always compact eagerly regardless of budget headroom
+- useful for large-context-window models where eager leaf creation at 20k tokens wastes summarization LLM calls while 95%+ of the budget is still free
+- set to `0` (default) to preserve the existing eager compaction behaviour
+
+Good starting range:
+
+- `0` (disabled, default) — opt-in only
+- `0.5` — defer until 50% of budget is consumed
+
+Env override: `LCM_BUDGET_HEADROOM_RATIO`
+
 ## Summary quality and prompt controls
 
 ### `summaryMaxOverageFactor`
@@ -406,6 +423,7 @@ Why it matters:
 5. If hot-cache turns still compact too often, inspect the decision logs before changing anything else:
    - `reason=hot-cache-budget-headroom` means the new skip path is working.
    - `reason=hot-cache-defer` means raw-history pressure is below the configured hot-cache factor.
+   - `reason=budget-headroom` means context is under the general `budgetHeadroomRatio` threshold (applies to any cache state).
    - `allowCondensedPasses=false` on hot-cache turns is expected.
 6. If recall feels weak, revisit `freshTailCount`, `leafChunkTokens`, and summarizer model quality before changing anything else.
 7. Touch advanced knobs like fanout, large-file thresholds, custom instructions, and assembly caps only after a concrete symptom appears.

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -103,6 +103,15 @@ export type LcmConfig = {
   cacheAwareCompaction: CacheAwareCompactionConfig;
   /** Dynamic step-band policy for incremental leaf chunk sizing. */
   dynamicLeafChunkTokens: DynamicLeafChunkTokensConfig;
+  /**
+   * Fraction of token budget that must be consumed before incremental compaction
+   * proceeds, regardless of cache state.  When the current token count is at or
+   * below `tokenBudget * (1 - budgetHeadroomRatio)`, incremental leaf passes are
+   * deferred.  Set to 0 (the default) to disable — preserving the existing eager
+   * compaction behaviour.  The hot-cache-specific `hotCacheBudgetHeadroomRatio`
+   * takes precedence when cache state is "hot".
+   */
+  budgetHeadroomRatio: number;
 };
 
 /** Safely coerce an unknown value to a finite number, or return undefined. */
@@ -429,6 +438,14 @@ export function resolveLcmConfigWithDiagnostics(
             : toBool(dynamicLeafChunkTokens?.enabled) ?? true,
         max: resolvedDynamicLeafChunkMax,
       },
+      budgetHeadroomRatio: Math.min(
+        0.95,
+        Math.max(
+          0,
+          parseFiniteNumber(env.LCM_BUDGET_HEADROOM_RATIO)
+            ?? toNumber(pc.budgetHeadroomRatio) ?? 0,
+        ),
+      ),
     },
     diagnostics: {
       ignoreSessionPatternsSource: ignoreSessionPatterns.source,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1587,6 +1587,24 @@ export class LcmContextEngine implements ContextEngine {
     return params.currentTokenCount <= safeBudget;
   }
 
+  /** Decide whether the current token count is under the general budget headroom threshold. */
+  private isUnderBudgetHeadroom(params: {
+    currentTokenCount?: number;
+    tokenBudget: number;
+    ratio: number;
+  }): boolean {
+    if (
+      typeof params.currentTokenCount !== "number"
+      || !Number.isFinite(params.currentTokenCount)
+      || params.currentTokenCount < 0
+    ) {
+      return false;
+    }
+    const budget = Math.max(1, Math.floor(params.tokenBudget));
+    const safeBudget = Math.floor(budget * (1 - params.ratio));
+    return params.currentTokenCount <= safeBudget;
+  }
+
   /** Resolve bounded dynamic leaf chunk sizes from config and the active token budget. */
   private resolveDynamicLeafChunkBounds(tokenBudget?: number): DynamicLeafChunkBounds {
     const floor = Math.max(1, Math.floor(this.config.leafChunkTokens));
@@ -1985,6 +2003,30 @@ export class LcmContextEngine implements ContextEngine {
         maxPasses: 1,
         allowCondensedPasses: false,
         reason: "hot-cache-defer",
+      });
+    }
+
+    if (
+      this.config.budgetHeadroomRatio > 0
+      && this.isUnderBudgetHeadroom({
+        currentTokenCount: params.currentTokenCount,
+        tokenBudget: params.tokenBudget,
+        ratio: this.config.budgetHeadroomRatio,
+      })
+    ) {
+      return this.logIncrementalCompactionDecision({
+        conversationId: params.conversationId,
+        cacheState,
+        activityBand,
+        triggerLeafChunkTokens,
+        preferredLeafChunkTokens,
+        fallbackLeafChunkTokens,
+        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
+        threshold: leafTrigger.threshold,
+        shouldCompact: false,
+        maxPasses: 1,
+        allowCondensedPasses: false,
+        reason: "budget-headroom",
       });
     }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -49,6 +49,7 @@ describe("resolveLcmConfig", () => {
       enabled: true,
       max: 40000,
     });
+    expect(config.budgetHeadroomRatio).toBe(0);
   });
 
   it("reads values from plugin config", () => {
@@ -77,6 +78,7 @@ describe("resolveLcmConfig", () => {
         enabled: true,
         max: 50000,
       },
+      budgetHeadroomRatio: 0.4,
     });
     expect(config.enabled).toBe(false);
     expect(config.ignoreSessionPatterns).toEqual([
@@ -105,6 +107,7 @@ describe("resolveLcmConfig", () => {
       enabled: true,
       max: 80000,
     });
+    expect(config.budgetHeadroomRatio).toBe(0.4);
   });
 
   it("env vars override plugin config", () => {
@@ -125,6 +128,7 @@ describe("resolveLcmConfig", () => {
       LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO: "0.25",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED: "true",
       LCM_DYNAMIC_LEAF_CHUNK_TOKENS_MAX: "60000",
+      LCM_BUDGET_HEADROOM_RATIO: "0.5",
     } as NodeJS.ProcessEnv;
     const pluginConfig = {
       contextThreshold: 0.5,
@@ -146,6 +150,7 @@ describe("resolveLcmConfig", () => {
         enabled: false,
         max: 50000,
       },
+      budgetHeadroomRatio: 0.3,
     };
     const config = resolveLcmConfig(env, pluginConfig);
     expect(config.enabled).toBe(false); // env wins
@@ -174,6 +179,7 @@ describe("resolveLcmConfig", () => {
       enabled: true,
       max: 60000,
     });
+    expect(config.budgetHeadroomRatio).toBe(0.5); // env wins
   });
 
   it("reports session pattern sources and env override diagnostics", () => {
@@ -585,6 +591,21 @@ describe("resolveLcmConfig", () => {
       minimum: 1,
     });
   });
+
+  it("ships a manifest with budgetHeadroomRatio in schema", () => {
+    expect(manifest.configSchema.properties.budgetHeadroomRatio).toEqual({
+      type: "number",
+      minimum: 0,
+      maximum: 0.95,
+    });
+  });
+
+  it("clamps budgetHeadroomRatio to [0, 0.95]", () => {
+    expect(resolveLcmConfig({}, { budgetHeadroomRatio: -0.5 }).budgetHeadroomRatio).toBe(0);
+    expect(resolveLcmConfig({}, { budgetHeadroomRatio: 1.0 }).budgetHeadroomRatio).toBe(0.95);
+    expect(resolveLcmConfig({}, { budgetHeadroomRatio: 0.5 }).budgetHeadroomRatio).toBe(0.5);
+  });
+
   it("defaults summaryMaxOverageFactor to 3 and maxAssemblyTokenBudget to undefined", () => {
     const config = resolveLcmConfig({}, {});
     expect(config.bootstrapMaxTokens).toBe(6000);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5017,6 +5017,143 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
   });
 
+  it("evaluateIncrementalCompaction defers when budgetHeadroomRatio is set and context is under threshold", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {
+        budgetHeadroomRatio: 0.5,
+      },
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-budget-headroom-unknown";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    // No telemetry upserted — cacheState stays "unknown"
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 50_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 10_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 10_000, // well under 50% of 100k
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("unknown");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction compacts when budgetHeadroomRatio is 0 (default) even with headroom", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-budget-headroom-default-off";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 50_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 10_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 10_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.cacheState).toBe("unknown");
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=leaf-trigger"),
+    );
+  });
+
   it("evaluateIncrementalCompaction keeps hot-cache hysteresis for a recent cache hit", async () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(


### PR DESCRIPTION
## Summary

- Adds `budgetHeadroomRatio` config parameter (env: `LCM_BUDGET_HEADROOM_RATIO`, plugin config: `budgetHeadroomRatio`) that defers incremental leaf compaction when the current token count is below `tokenBudget × (1 - ratio)`
- Defaults to **0** (disabled) — preserving existing eager compaction behaviour as an opt-in model
- The hot-cache-specific `hotCacheBudgetHeadroomRatio` takes precedence when cache state is `"hot"`; the new parameter covers `"unknown"` and `"cold"` states
- Value clamped to [0, 0.95]

This is particularly useful for non-Anthropic providers where `cacheState` stays `"unknown"` permanently (no cache telemetry reported), and for large-context-window models where eager leaf creation at 20k tokens wastes summarization LLM calls with 95%+ budget headroom remaining.

See #409 for full design discussion including trade-off analysis (retrieval blackout during deferral, compaction storm mitigation via existing `maxPasses=1`, assembler fallback behaviour).

## Test plan

- [x] Config: default is 0, reads from plugin config, env var overrides plugin config, clamped to [0, 0.95]
- [x] Engine: `evaluateIncrementalCompaction` defers with reason `"budget-headroom"` when ratio > 0 and context is under threshold
- [x] Engine: default ratio 0 preserves existing `"leaf-trigger"` compaction behaviour
- [x] Full test suite passes (702/702)

Closes #409

Co-Authored-By: WoCha <wocha@jetd.one> via Claude Code