### PR TITLE
feat(engine): periodic background compaction sweep

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -62,7 +62,11 @@ import {
   type MessagePartType,
 } from "./store/conversation-store.js";
 import { SummaryStore } from "./store/summary-store.js";
-import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "./summarize.js";
+import {
+  createLcmSummarizeFromLegacyParams,
+  LcmProviderAuthError,
+  type LcmSummarizeFn,
+} from "./summarize.js";
 import type { LcmDependencies } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 
@@ -3926,6 +3930,129 @@ export class LcmContextEngine implements ContextEngine {
     this.deps.log.info(
       `[lcm] afterTurn: done conversation=${conversation.conversationId} ${sessionLabel} newMessages=${newMessages.length} dedupedMessages=${dedupedNewMessages.length} ingestedMessages=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
     );
+  }
+
+  /**
+   * Sweep active conversations for background compaction.
+   * Called periodically to compact idle sessions that haven't had recent turns.
+   */
+  async sweepActiveConversations(options?: {
+    summarize?: LcmSummarizeFn;
+    signal?: AbortSignal;
+  }): Promise<{ swept: number; compacted: number; errors: number }> {
+    if (options?.signal?.aborted) {
+      return { swept: 0, compacted: 0, errors: 0 };
+    }
+
+    this.ensureMigrated();
+    const rows = this.db.prepare(
+      `SELECT conversation_id, session_id, session_key
+       FROM conversations
+       WHERE active = 1 AND archived_at IS NULL`,
+    ).all() as Array<{
+      conversation_id: number;
+      session_id: string;
+      session_key: string | null;
+    }>;
+
+    let swept = 0;
+    let compacted = 0;
+    let errors = 0;
+
+    for (const row of rows) {
+      if (options?.signal?.aborted) {
+        break;
+      }
+
+      const sessionId = typeof row.session_id === "string" ? row.session_id.trim() : "";
+      const normalizedSessionKey =
+        typeof row.session_key === "string" && row.session_key.trim().length > 0
+          ? row.session_key.trim()
+          : undefined;
+
+      if (this.shouldIgnoreSession({ sessionId, sessionKey: normalizedSessionKey })) {
+        continue;
+      }
+      if (this.isStatelessSession(normalizedSessionKey)) {
+        continue;
+      }
+
+      const queueKey = this.resolveSessionQueueKey(sessionId, normalizedSessionKey);
+      const context = [
+        `conversation=${row.conversation_id}`,
+        ...(sessionId ? [`session=${sessionId}`] : []),
+        ...(normalizedSessionKey ? [`sessionKey=${normalizedSessionKey}`] : []),
+      ].join(" ");
+
+      swept += 1;
+
+      try {
+        const didCompact = await this.withSessionQueue(
+          queueKey,
+          async () => {
+            if (options?.signal?.aborted) {
+              return false;
+            }
+
+            const conversationId = Number(row.conversation_id);
+            if (!Number.isFinite(conversationId) || conversationId <= 0) {
+              return false;
+            }
+
+            const leafTrigger = await this.compaction.evaluateLeafTrigger(conversationId);
+            if (!leafTrigger.shouldCompact) {
+              return false;
+            }
+
+            const tokenBudget = this.applyAssemblyBudgetCap(128_000);
+            const resolvedSummarizer = options?.summarize
+              ? {
+                  summarize: options.summarize,
+                  summaryModel: "unknown",
+                  breakerKey: `sweep:${queueKey}`,
+                }
+              : await this.resolveSummarize({ breakerScope: `sweep:${queueKey}` });
+
+            if (
+              resolvedSummarizer.breakerKey
+              && this.isCircuitBreakerOpen(resolvedSummarizer.breakerKey)
+            ) {
+              return false;
+            }
+
+            const sweepResult = await this.compaction.compact({
+              conversationId,
+              tokenBudget,
+              summarize: resolvedSummarizer.summarize,
+              hardTrigger: false,
+              summaryModel: resolvedSummarizer.summaryModel,
+            });
+
+            if (sweepResult.authFailure && resolvedSummarizer.breakerKey) {
+              this.recordCompactionAuthFailure(resolvedSummarizer.breakerKey);
+            } else if (sweepResult.actionTaken && resolvedSummarizer.breakerKey) {
+              this.recordCompactionSuccess(resolvedSummarizer.breakerKey);
+            }
+
+            if (sweepResult.actionTaken) {
+              await this.markLeafCompactionTelemetrySuccess({ conversationId });
+            }
+
+            return sweepResult.actionTaken;
+          },
+          { operationName: "sweep", context },
+        );
+
+        if (didCompact) {
+          compacted += 1;
+        }
+      } catch (err) {
+        errors += 1;
+        this.deps.log.warn(`[lcm] sweep conversation failed: ${context} error=${describeLogError(err)}`);
+      }
+    }
+
+    return { swept, compacted, errors };
   }
 
   async assemble(params: {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -22,6 +22,13 @@ import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
 import { createLcmCommand } from "./lcm-command.js";
 import type { LcmDependencies } from "../types.js";
 
+type PeriodicSweepState = {
+  timer: ReturnType<typeof setInterval> | null;
+  running: boolean;
+};
+
+const periodicSweepByInit = new WeakMap<SharedLcmInit, PeriodicSweepState>();
+
 /** Parse `agent:<agentId>:<suffix...>` session keys. */
 function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
   const value = sessionKey.trim();
@@ -1832,6 +1839,43 @@ function wirePluginHandlers(
   deps: LcmDependencies,
   shared: SharedLcmInit,
 ): void {
+  const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+  const sweepState = periodicSweepByInit.get(shared) ?? { timer: null, running: false };
+  periodicSweepByInit.set(shared, sweepState);
+
+  const startPeriodicSweep = () => {
+    if (sweepState.timer) {
+      return;
+    }
+
+    sweepState.timer = setInterval(async () => {
+      if (sweepState.running) {
+        return;
+      }
+      sweepState.running = true;
+      try {
+        const engine = shared.getCachedEngine();
+        if (!engine) {
+          return;
+        }
+        const result = await engine.sweepActiveConversations();
+        if (result.swept > 0) {
+          deps.log.info(
+            `[lcm] sweep: checked=${result.swept} compacted=${result.compacted} errors=${result.errors}`,
+          );
+        }
+      } catch (err) {
+        deps.log.warn(`[lcm] sweep failed: ${describeLogError(err)}`);
+      } finally {
+        sweepState.running = false;
+      }
+    }, SWEEP_INTERVAL_MS);
+  };
+
+  shared.waitForEngine().then(startPeriodicSweep).catch((err) => {
+    deps.log.warn(`[lcm] sweep start deferred: ${describeLogError(err)}`);
+  });
+
   api.on("before_reset", async (event, ctx) => {
     await (await shared.waitForEngine()).handleBeforeReset({
       reason: event.reason,
@@ -1877,6 +1921,14 @@ function wirePluginHandlers(
   api.registerCommand(
     createLcmCommand({ db: shared.waitForDatabase, config: deps.config, deps }),
   );
+
+  api.on("gateway_stop", async () => {
+    if (sweepState.timer) {
+      clearInterval(sweepState.timer);
+      sweepState.timer = null;
+    }
+    sweepState.running = false;
+  });
 }
 
 const lcmPlugin = {


### PR DESCRIPTION
## Problem
LCM compaction currently advances on active turns (`afterTurn`) only. When a session goes idle, unsummarized raw turns can sit indefinitely, so dormant but important conversations never get background maintenance.

Operationally this shows up as active+unarchived conversations that keep growing until another foreground turn happens.

## What changed
- Added `LcmContextEngine.sweepActiveConversations()` in `src/engine.ts`.
  - Queries active conversations:
    - `SELECT conversation_id, session_id, session_key FROM conversations WHERE active = 1 AND archived_at IS NULL`
  - Skips ignored/stateless sessions.
  - Uses existing compaction evaluation (`evaluateLeafTrigger`) to detect eligible conversations.
  - Runs compaction via existing `compaction.compact(...)` flow.
  - Reuses circuit-breaker handling and returns sweep stats `{ swept, compacted, errors }`.
- Added periodic sweep loop in `src/plugin/index.ts`.
  - 5-minute interval.
  - Singleton guard per shared engine init.
  - Non-blocking overlap guard (`running` flag).
  - Best-effort error handling with warning logs.
  - Cleans up timer on `gateway_stop`.

## Design rationale
- Keeps compaction behavior aligned with existing engine policy rather than introducing a separate path.
- Uses per-session queue serialization to avoid ingest/compaction races.
- Keeps sweep best-effort and isolated from foreground request lifecycle.

## Backward compatibility
- No config migration required.
- Existing behavior remains unchanged except idle sessions now receive periodic maintenance.

## Configuration example
Current interval is fixed at 5 minutes in plugin wiring:

```ts
const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
```

This can be made configurable later if needed, but ships as a safe default to avoid extra surface area in this PR.
