### PR TITLE
feat(engine): session allowlist for LCM persistence

### DIFF
--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -47,6 +47,8 @@ export type LcmConfig = {
   ignoreSessionPatterns: string[];
   /** Glob patterns for session keys that may read from LCM but never write to it. */
   statelessSessionPatterns: string[];
+  /** Glob patterns for session keys allowed to persist to LCM. Empty means allow all sessions. */
+  sessionAllowlistPatterns: string[];
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
   contextThreshold: number;
@@ -324,6 +326,7 @@ export function resolveLcmConfigWithDiagnostics(
         ?? join(resolveOpenclawStateDir(env), "lcm-files"),
       ignoreSessionPatterns: ignoreSessionPatterns.patterns,
       statelessSessionPatterns: statelessSessionPatterns.patterns,
+      sessionAllowlistPatterns: [],
       skipStatelessSessions:
         env.LCM_SKIP_STATELESS_SESSIONS !== undefined
           ? env.LCM_SKIP_STATELESS_SESSIONS === "true"

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1203,6 +1203,8 @@ export class LcmContextEngine implements ContextEngine {
   private readonly fts5Available: boolean;
   private readonly ignoreSessionPatterns: RegExp[];
   private readonly statelessSessionPatterns: RegExp[];
+  private readonly sessionAllowlistPatterns: string[];
+  private readonly compiledSessionAllowlist: RegExp[];
   private sessionOperationQueues = new Map<
     string,
     { promise: Promise<void>; refCount: number }
@@ -1219,6 +1221,10 @@ export class LcmContextEngine implements ContextEngine {
     this.config = deps.config;
     this.ignoreSessionPatterns = compileSessionPatterns(this.config.ignoreSessionPatterns);
     this.statelessSessionPatterns = compileSessionPatterns(this.config.statelessSessionPatterns);
+    this.sessionAllowlistPatterns = Array.isArray(this.config.sessionAllowlistPatterns)
+      ? this.config.sessionAllowlistPatterns
+      : [];
+    this.compiledSessionAllowlist = compileSessionPatterns(this.sessionAllowlistPatterns);
     this.db = database;
 
     // Run migrations eagerly at construction time so the schema exists
@@ -1298,6 +1304,13 @@ export class LcmContextEngine implements ContextEngine {
         message: `[lcm] Stateless session patterns${enforcement} from ${source}: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
       });
     }
+    if (this.sessionAllowlistPatterns.length > 0) {
+      logStartupBannerOnce({
+        key: "session-allowlist-patterns",
+        log: (message) => this.deps.log.info(message),
+        message: `[lcm] Session allowlist enabled: ${this.sessionAllowlistPatterns.length} pattern(s): ${this.sessionAllowlistPatterns.join(", ")}`,
+      });
+    }
     this.assembler = new ContextAssembler(
       this.conversationStore,
       this.summaryStore,
@@ -1363,6 +1376,34 @@ export class LcmContextEngine implements ContextEngine {
       return false;
     }
     return matchesSessionPattern(trimmedKey, this.statelessSessionPatterns);
+  }
+
+  /** Check whether a session is allowed to persist into LCM. */
+  private isSessionAllowlisted(params: { sessionId?: string; sessionKey?: string }): boolean {
+    if (this.compiledSessionAllowlist.length === 0) {
+      return true;
+    }
+
+    const candidate =
+      typeof params.sessionKey === "string" && params.sessionKey.trim()
+        ? params.sessionKey.trim()
+        : (params.sessionId?.trim() ?? "");
+    if (!candidate) {
+      return false;
+    }
+
+    return matchesSessionPattern(candidate, this.compiledSessionAllowlist);
+  }
+
+  private logSessionAllowlistExclusion(params: { sessionId?: string; sessionKey?: string }): void {
+    const candidate =
+      typeof params.sessionKey === "string" && params.sessionKey.trim()
+        ? params.sessionKey.trim()
+        : (params.sessionId?.trim() ?? "");
+    if (!candidate) {
+      return;
+    }
+    this.deps.log.debug(`[lcm] session excluded by allowlist: ${candidate}`);
   }
 
   // ── Circuit breaker helpers ──────────────────────────────────────────────
@@ -2976,6 +3017,14 @@ export class LcmContextEngine implements ContextEngine {
         reason: "stateless session",
       };
     }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "session excluded by allowlist",
+      };
+    }
     this.ensureMigrated();
     const startedAt = Date.now();
     const sessionLabel = [
@@ -3668,6 +3717,10 @@ export class LcmContextEngine implements ContextEngine {
     if (this.isStatelessSession(params.sessionKey)) {
       return { ingested: false };
     }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
+      return { ingested: false };
+    }
     this.ensureMigrated();
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
@@ -3692,6 +3745,10 @@ export class LcmContextEngine implements ContextEngine {
       return { ingestedCount: 0 };
     }
     if (this.isStatelessSession(params.sessionKey)) {
+      return { ingestedCount: 0 };
+    }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
       return { ingestedCount: 0 };
     }
     this.ensureMigrated();
@@ -3744,6 +3801,10 @@ export class LcmContextEngine implements ContextEngine {
       return;
     }
     if (this.isStatelessSession(params.sessionKey)) {
+      return;
+    }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
       return;
     }
     this.ensureMigrated();
@@ -3943,6 +4004,14 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
     try {
+      const sessionAllowlisted = this.isSessionAllowlisted({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      });
+      if (!sessionAllowlisted) {
+        this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
+      }
+
       this.ensureMigrated();
       const startedAt = Date.now();
       const sessionLabel = [
@@ -4092,6 +4161,14 @@ export class LcmContextEngine implements ContextEngine {
         ok: true,
         compacted: false,
         reason: "stateless session",
+      };
+    }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
+      return {
+        ok: true,
+        compacted: false,
+        reason: "session excluded by allowlist",
       };
     }
     this.ensureMigrated();
@@ -4291,6 +4368,14 @@ export class LcmContextEngine implements ContextEngine {
         ok: true,
         compacted: false,
         reason: "stateless session",
+      };
+    }
+    if (!this.isSessionAllowlisted({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.logSessionAllowlistExclusion({ sessionId: params.sessionId, sessionKey: params.sessionKey });
+      return {
+        ok: true,
+        compacted: false,
+        reason: "session excluded by allowlist",
       };
     }
     this.ensureMigrated();

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1285,6 +1285,15 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
   const pluginConfig = resolvePluginConfig(api);
   const log = createLcmLogger(api);
   const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
+  const sessionAllowlistRaw = process.env.LCM_SESSION_ALLOWLIST ?? "";
+  const sessionAllowlistPatterns = sessionAllowlistRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const effectiveConfig = {
+    ...config,
+    sessionAllowlistPatterns,
+  };
 
   if (diagnostics.ignoreSessionPatternsEnvOverridesPluginConfig) {
     logStartupBannerOnce({
@@ -1322,7 +1331,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
   logStartupBannerOnce({
     key: "transcript-gc-enabled",
     log: (message) => log.info(message),
-    message: `[lcm] Transcript GC ${config.transcriptGcEnabled ? "enabled" : "disabled"} (default false)`,
+    message: `[lcm] Transcript GC ${effectiveConfig.transcriptGcEnabled ? "enabled" : "disabled"} (default false)`,
   });
 
   /** Resolve the best config object to hand to runtime.modelAuth for this lookup. */
@@ -1384,7 +1393,7 @@ function createLcmDependencies(api: OpenClawPluginApi): LcmDependencies {
   };
 
   return {
-    config,
+    config: effectiveConfig,
     configDiagnostics: diagnostics,
     isRuntimeManagedAuthProvider: (provider: string, providerApi?: string) => {
       const normalizedProvider = normalizeProviderId(provider);


### PR DESCRIPTION
## Problem
LCM currently persists for all sessions, including ephemeral subagents and one-shot lanes. On busy systems this causes avoidable DB growth and extra compaction churn.

Operators need a hard allowlist so only selected session keys are allowed to write into LCM.

## What changed
- Added `LCM_SESSION_ALLOWLIST` parsing in `src/plugin/index.ts`:
  - Comma-separated glob patterns.
  - Trimmed and normalized into `sessionAllowlistPatterns`.
  - Empty value keeps existing behavior (allow all sessions).
- Added `sessionAllowlistPatterns` to LCM config shape in `src/db/config.ts` (default `[]`).
- Enforced allowlist in `src/engine.ts` write/maintenance paths:
  - `afterTurn` (before ingestion)
  - `ingest` and `ingestBatch`
  - `bootstrap` (prevents creating/persisting new data for excluded sessions)
  - `compactLeafAsync` and `compact`
- Added explicit allowlist-aware behavior in `assemble`:
  - Excluded sessions can still read existing stored context if present.
  - Excluded sessions will not trigger new persistence paths.
- Reused existing session glob engine via `compileSessionPatterns(...)` + `matchesSessionPattern(...)` from `session-patterns.ts`.

## Design rationale
- Reuses established pattern semantics (`*` and `**`) to avoid introducing a new matcher.
- Applies allowlist checks where writes occur, keeping read-path behavior intact.
- Preserves backward compatibility by making allowlist opt-in.

## Backward compatibility
- Default remains unchanged: when `LCM_SESSION_ALLOWLIST` is empty/unset, all sessions are allowed.
- No migration required.

## Configuration examples
Allow only main and cron lanes:

```bash
export LCM_SESSION_ALLOWLIST="agent:main:*,agent:main:cron:**"
```

Allow only direct main chat and explicitly scoped worker lanes:

```bash
export LCM_SESSION_ALLOWLIST="agent:main:telegram:**,agent:worker-a:**"
```

Leave unset (or empty) to keep current all-session persistence behavior.
