### PR TITLE
fix(db): increase SQLite busy_timeout to 30 s for concurrent writers

### DIFF
--- a/.changeset/swift-poets-hang.md
+++ b/.changeset/swift-poets-hang.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Increase the SQLite busy timeout to 30 seconds to better tolerate concurrent writer contention without spurious `SQLITE_BUSY` failures.

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -3,7 +3,12 @@ import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 type ConnectionKey = string;
-const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+/**
+ * SQLite busy timeout in milliseconds.  30 s accommodates high-concurrency
+ * multi-agent setups where 10+ writers contend on the WAL.  The default 5 s
+ * proved insufficient in production with ≥13 concurrent lanes.
+ */
+const SQLITE_BUSY_TIMEOUT_MS = 30_000;
 
 const connectionsByPath = new Map<ConnectionKey, Set<DatabaseSync>>();
 const connectionIndex = new Map<DatabaseSync, ConnectionKey>();

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -280,7 +280,7 @@ describe("LcmContextEngine metadata", () => {
     const busy = db.prepare("PRAGMA busy_timeout").get() as { timeout?: number };
 
     expect(journal.journal_mode).toBe("wal");
-    expect(busy.timeout).toBe(5000);
+    expect(busy.timeout).toBe(30000);
   });
 });
 


### PR DESCRIPTION
With 10+ concurrent agent lanes all writing to the same WAL-mode SQLite database, the previous 5 s busy_timeout caused frequent SQLITE_BUSY errors under burst contention. 30 s accommodates realistic worst-case write serialization without risking indefinite hangs.