### PR TITLE
feat(summarize): round-robin profile rotation for concurrent summarizer calls

### DIFF
--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -2,6 +2,13 @@ import { describeLogError } from "./lcm-log.js";
 import type { LcmDependencies } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 
+/**
+ * Module-level atomic counter for round-robin profile rotation.
+ * Each concurrent summarizer invocation starts at a different offset
+ * to distribute load across auth profiles and avoid thundering-herd 429s.
+ */
+let _profileRotationCounter = 0;
+
 export type LcmSummarizeOptions = {
   previousSummary?: string;
   isCondensed?: boolean;
@@ -1188,11 +1195,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
 
     let lastAuthError: LcmProviderAuthError | undefined;
 
-    for (let index = 0; index < resolvedCandidates.length; index += 1) {
-      const candidate = resolvedCandidates[index]!;
+    // Rotate starting index to distribute concurrent calls across profiles
+    const startIndex = _profileRotationCounter++ % resolvedCandidates.length;
+    const orderedCandidates = [
+      ...resolvedCandidates.slice(startIndex),
+      ...resolvedCandidates.slice(0, startIndex),
+    ];
+
+    for (let index = 0; index < orderedCandidates.length; index += 1) {
+      const candidate = orderedCandidates[index]!;
       const provider = candidate.provider;
       const model = candidate.model;
-      const nextCandidate = index < resolvedCandidates.length - 1 ? resolvedCandidates[index + 1]! : undefined;
+      const nextCandidate = index < orderedCandidates.length - 1 ? orderedCandidates[index + 1]! : undefined;
       const authProfileId = candidate.useLegacyAuthProfile ? legacyAuthProfileId : undefined;
       const providerApi = resolveProviderApiFromLegacyConfig(params.legacyParams.config, provider);
       const lookupOptions = {


### PR DESCRIPTION
## Problem

When multiple concurrent summarization calls iterate the same candidate list in deterministic order, they all hit the first auth profile simultaneously — causing 429 rate-limit cascading that propagates through the fallback chain.

## Fix

Add a module-level rotation counter so each invocation of the summarizer starts at a different offset in the candidate array. This distributes load across all available auth profiles while preserving the full fallback chain for each individual call.

- Counter increments atomically per call (single-threaded Node, so no mutex needed)
- Original candidate array is not mutated
- Error reporting / fallback model selection still references the original unrotated list