### PR TITLE
fix(store): handle UNIQUE constraint races in createConversation

### DIFF
--- a/.changeset/neat-rockets-repair.md
+++ b/.changeset/neat-rockets-repair.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Handle conversation creation races on active session keys without crashing the caller.

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -279,27 +279,43 @@ export class ConversationStore {
   // ── Conversation operations ───────────────────────────────────────────────
 
   async createConversation(input: CreateConversationInput): Promise<ConversationRecord> {
-    const result = this.db
-      .prepare(
-        `INSERT INTO conversations (session_id, session_key, active, archived_at, title)
-         VALUES (?, ?, ?, ?, ?)`,
-      )
-      .run(
-        input.sessionId,
-        input.sessionKey ?? null,
-        input.active === false ? 0 : 1,
-        input.archivedAt?.toISOString() ?? null,
-        input.title ?? null,
-      );
+    try {
+      const result = this.db
+        .prepare(
+          `INSERT INTO conversations (session_id, session_key, active, archived_at, title)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          input.sessionId,
+          input.sessionKey ?? null,
+          input.active === false ? 0 : 1,
+          input.archivedAt?.toISOString() ?? null,
+          input.title ?? null,
+        );
 
-    const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, session_key, active, archived_at, title, bootstrapped_at, created_at, updated_at
-       FROM conversations WHERE conversation_id = ?`,
-      )
-      .get(Number(result.lastInsertRowid)) as unknown as ConversationRow;
+      const row = this.db
+        .prepare(
+          `SELECT conversation_id, session_id, session_key, active, archived_at, title, bootstrapped_at, created_at, updated_at
+         FROM conversations WHERE conversation_id = ?`,
+        )
+        .get(Number(result.lastInsertRowid)) as unknown as ConversationRow;
 
-    return toConversationRecord(row);
+      return toConversationRecord(row);
+    } catch (err: unknown) {
+      // Handle UNIQUE constraint race: another writer created the conversation first
+      if (
+        err instanceof Error &&
+        /UNIQUE constraint failed|SQLITE_CONSTRAINT_UNIQUE/i.test(err.message)
+      ) {
+        if (input.sessionKey) {
+          const existing = await this.getConversationBySessionKey(input.sessionKey);
+          if (existing) return existing;
+        }
+        const existing = await this.getConversationBySessionId(input.sessionId);
+        if (existing) return existing;
+      }
+      throw err;
+    }
   }
 
   async getConversation(conversationId: ConversationId): Promise<ConversationRecord | null> {

--- a/test/regression-2026-03-17.test.ts
+++ b/test/regression-2026-03-17.test.ts
@@ -135,6 +135,45 @@ describe("Session key continuity", () => {
 
     expect(conv1.conversationId).toBe(conv2.conversationId);
   });
+
+  it("recovers when the sessionKey insert loses a unique-constraint race", async () => {
+    const db = createTestDb();
+    const { convStore } = createStores(db);
+
+    const winner = await convStore.createConversation({
+      sessionId: "uuid-winner",
+      sessionKey: "agent:main:main",
+    });
+
+    const getByKey = convStore.getConversationBySessionKey.bind(convStore);
+    const getBySessionId = convStore.getConversationBySessionId.bind(convStore);
+    let firstByKeyMiss = true;
+    let firstBySessionIdMiss = true;
+
+    vi.spyOn(convStore, "getConversationBySessionKey").mockImplementation(async (sessionKey) => {
+      if (firstByKeyMiss) {
+        firstByKeyMiss = false;
+        return null;
+      }
+      return getByKey(sessionKey);
+    });
+
+    vi.spyOn(convStore, "getConversationBySessionId").mockImplementation(async (sessionId) => {
+      if (firstBySessionIdMiss) {
+        firstBySessionIdMiss = false;
+        return null;
+      }
+      return getBySessionId(sessionId);
+    });
+
+    const recovered = await convStore.getOrCreateConversation("uuid-loser", {
+      sessionKey: "agent:main:main",
+    });
+
+    expect(recovered.conversationId).toBe(winner.conversationId);
+    expect(recovered.sessionKey).toBe("agent:main:main");
+    expect(await convStore.getConversationBySessionId("uuid-loser")).toBeNull();
+  });
 });
 
 // ── ReDoS Protection (#76) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When multiple agent lanes simultaneously call `getOrCreateConversation` for the same `session_key`, the `INSERT` in `createConversation` can race against the unique partial index `conversations_active_session_key_idx ON conversations (session_key) WHERE active = 1 AND session_key IS NOT NULL`.

The loser of the race gets `SQLITE_CONSTRAINT_UNIQUE`, which propagates as an unhandled error and can crash the lane or leave stale state.

## Fix

Wrap the INSERT in a try/catch. On `UNIQUE constraint failed` / `SQLITE_CONSTRAINT_UNIQUE`, fall back to selecting the winning row by `sessionKey` (preferred) or `sessionId`. The caller gets a valid `ConversationRecord` either way.

## Impact

- Eliminates intermittent crashes under concurrent multi-agent workloads
- No behavior change for single-writer or non-racing scenarios
- `getOrCreateConversation` callers are unaffected — they already expect either path to return a record