### PR TITLE
Index message identity by verified hash

### DIFF
--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { getLcmDbFeatures } from "./features.js";
+import { buildMessageIdentityHash } from "../store/message-identity.js";
 import { parseUtcTimestampOrNull } from "../store/parse-utc-timestamp.js";
 
 type MigrationLogger = {
@@ -33,6 +34,12 @@ type SummaryParentEdgeRow = {
 
 type TableNameRow = {
   name?: string;
+};
+
+type MessageIdentityBackfillRow = {
+  message_id: number;
+  role: string;
+  content: string;
 };
 
 type FtsTableSpec = {
@@ -120,6 +127,35 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
     db.exec(
       `ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_activity_band TEXT NOT NULL DEFAULT 'low' CHECK (last_activity_band IN ('low', 'medium', 'high'))`,
     );
+  }
+}
+
+function ensureMessageIdentityHashColumn(db: DatabaseSync): void {
+  const messageColumns = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
+  const hasIdentityHash = messageColumns.some((col) => col.name === "identity_hash");
+  if (!hasIdentityHash) {
+    db.exec(`ALTER TABLE messages ADD COLUMN identity_hash TEXT`);
+  }
+}
+
+function backfillMessageIdentityHashes(db: DatabaseSync): void {
+  const selectStmt = db.prepare(
+    `SELECT message_id, role, content
+     FROM messages
+     WHERE identity_hash IS NULL OR identity_hash = ''
+     ORDER BY message_id
+     LIMIT ?`,
+  );
+  const updateStmt = db.prepare(`UPDATE messages SET identity_hash = ? WHERE message_id = ?`);
+
+  while (true) {
+    const rows = selectStmt.all(1_000) as MessageIdentityBackfillRow[];
+    if (rows.length === 0) {
+      return;
+    }
+    for (const row of rows) {
+      updateStmt.run(buildMessageIdentityHash(row.role, row.content), row.message_id);
+    }
   }
 }
 
@@ -586,6 +622,7 @@ export function runLcmMigrations(
       role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
       content TEXT NOT NULL,
       token_count INTEGER NOT NULL,
+      identity_hash TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       UNIQUE (conversation_id, seq)
     );
@@ -768,6 +805,17 @@ export function runLcmMigrations(
     ensureSummaryMetadataColumns(db),
   );
   runMigrationStep("ensureSummaryModelColumn", log, () => ensureSummaryModelColumn(db));
+  runMigrationStep("ensureMessageIdentityHashColumn", log, () =>
+    ensureMessageIdentityHashColumn(db),
+  );
+  runMigrationStep("backfillMessageIdentityHashes", log, () =>
+    backfillMessageIdentityHashes(db),
+  );
+  runMigrationStep("createMessagesIdentityHashIndex", log, () =>
+    db.exec(
+      `CREATE INDEX IF NOT EXISTS messages_conv_identity_hash_idx ON messages (conversation_id, identity_hash)`,
+    ),
+  );
   runMigrationStep("ensureCompactionTelemetryColumns", log, () =>
     ensureCompactionTelemetryColumns(db),
   );

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { withDatabaseTransaction } from "../transaction-mutex.js";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
 import { buildLikeSearchPlan, containsCjk, createFallbackSnippet } from "./full-text-fallback.js";
+import { buildMessageIdentityHash } from "./message-identity.js";
 import { parseUtcTimestamp, parseUtcTimestampOrNull } from "./parse-utc-timestamp.js";
 import { buildFtsOrderBy, type SearchSort } from "./full-text-sort.js";
 
@@ -30,6 +31,7 @@ export type CreateMessageInput = {
   role: MessageRole;
   content: string;
   tokenCount: number;
+  identityHash?: string;
 };
 
 export type MessageRecord = {
@@ -138,6 +140,11 @@ interface MessageSearchRow {
   snippet: string;
   rank: number;
   created_at: string;
+}
+
+interface MessageIdentityRow {
+  role: MessageRole;
+  content: string;
 }
 
 interface MessagePartRow {
@@ -434,10 +441,17 @@ export class ConversationStore {
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
     const result = this.db
       .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count)
-       VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash)
+       VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .run(input.conversationId, input.seq, input.role, input.content, input.tokenCount);
+      .run(
+        input.conversationId,
+        input.seq,
+        input.role,
+        input.content,
+        input.tokenCount,
+        input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
+      );
 
     const messageId = Number(result.lastInsertRowid);
 
@@ -458,8 +472,8 @@ export class ConversationStore {
       return [];
     }
     const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count)
-       VALUES (?, ?, ?, ?, ?)`,
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     );
     const selectStmt = this.db.prepare(
       `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
@@ -474,6 +488,7 @@ export class ConversationStore {
         input.role,
         input.content,
         input.tokenCount,
+        input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
       );
 
       const messageId = Number(result.lastInsertRowid);
@@ -535,16 +550,18 @@ export class ConversationStore {
     role: MessageRole,
     content: string,
   ): Promise<boolean> {
+    const identityHash = buildMessageIdentityHash(role, content);
     const row = this.db
       .prepare(
-        `SELECT 1 AS count
+        `SELECT role, content
        FROM messages
-       WHERE conversation_id = ? AND role = ? AND content = ?
-       LIMIT 1`,
+       WHERE conversation_id = ? AND identity_hash = ?
+       LIMIT 8`,
       )
-      .get(conversationId, role, content) as unknown as CountRow | undefined;
+      .all(conversationId, identityHash) as unknown as MessageIdentityRow[];
 
-    return row?.count === 1;
+    // The hash narrows candidates quickly; the raw-content check preserves exact identity.
+    return row.some((candidate) => candidate.role === role && candidate.content === content);
   }
 
   async countMessagesByIdentity(
@@ -552,15 +569,23 @@ export class ConversationStore {
     role: MessageRole,
     content: string,
   ): Promise<number> {
-    const row = this.db
+    const identityHash = buildMessageIdentityHash(role, content);
+    const rows = this.db
       .prepare(
-        `SELECT COUNT(*) AS count
+       `SELECT role, content
        FROM messages
-       WHERE conversation_id = ? AND role = ? AND content = ?`,
+       WHERE conversation_id = ? AND identity_hash = ?`,
       )
-      .get(conversationId, role, content) as unknown as CountRow | undefined;
+      .all(conversationId, identityHash) as unknown as MessageIdentityRow[];
 
-    return row?.count ?? 0;
+    // Count only verified matches so the hash stays a performance hint, not the source of truth.
+    let count = 0;
+    for (const candidate of rows) {
+      if (candidate.role === role && candidate.content === content) {
+        count += 1;
+      }
+    }
+    return count;
   }
 
   async getMessageById(messageId: MessageId): Promise<MessageRecord | null> {

--- a/src/store/message-identity.ts
+++ b/src/store/message-identity.ts
@@ -1,0 +1,13 @@
+import { createHash } from "node:crypto";
+
+export function buildMessageIdentityKey(role: string, content: string): string {
+  return `${role}\u0000${content}`;
+}
+
+export function buildMessageIdentityHash(role: string, content: string): string {
+  return createHash("sha256")
+    .update(role)
+    .update("\u0000")
+    .update(content)
+    .digest("hex");
+}

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeLcmConnection, getLcmConnection } from "../src/db/connection.js";
 import * as features from "../src/db/features.js";
 import { runLcmMigrations } from "../src/db/migration.js";
+import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 
 const tempDirs: string[] = [];
 
@@ -279,6 +280,71 @@ describe("runLcmMigrations summary depth backfill", () => {
         .prepare(`INSERT INTO conversations (session_id, session_key, active) VALUES (?, ?, 1)`)
         .run("duplicate-active-session", "agent:main:main"),
     ).toThrow();
+  });
+
+  it("backfills message identity hashes and indexes conversation hash lookups", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "identity-hash.db");
+    const db = getLcmConnection(dbPath);
+
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE messages (
+        message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        token_count INTEGER NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (conversation_id, seq)
+      );
+    `);
+
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      1,
+      "identity-hash-session",
+    );
+    db.prepare(
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(1, 1, "assistant", "hello from hash backfill", 5);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const messageColumns = db.prepare(`PRAGMA table_info(messages)`).all() as Array<{
+      name?: string;
+    }>;
+    expect(messageColumns.some((column) => column.name === "identity_hash")).toBe(true);
+
+    const row = db
+      .prepare(`SELECT identity_hash FROM messages WHERE conversation_id = ? AND seq = ?`)
+      .get(1, 1) as { identity_hash: string | null };
+    expect(row.identity_hash).toBe(
+      buildMessageIdentityHash("assistant", "hello from hash backfill"),
+    );
+
+    const planRows = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT role, content
+         FROM messages
+         WHERE conversation_id = ? AND identity_hash = ?`,
+      )
+      .all(1, row.identity_hash) as Array<{ detail?: string }>;
+    expect(
+      planRows.some((planRow) =>
+        (planRow.detail ?? "").includes("messages_conv_identity_hash_idx"),
+      ),
+    ).toBe(true);
   });
 
   it("skips FTS tables when fts5 is unavailable", () => {

--- a/tui/backfill.go
+++ b/tui/backfill.go
@@ -622,9 +622,9 @@ func applyBackfillImport(ctx context.Context, db *sql.DB, input backfillSessionI
 
 	for idx, msg := range input.messages {
 		result, err := tx.ExecContext(ctx, `
-			INSERT INTO messages (conversation_id, seq, role, content, token_count, created_at)
-			VALUES (?, ?, ?, ?, ?, ?)
-		`, conversationID, idx, msg.role, msg.content, estimateTokenCount(msg.content), msg.createdAt)
+			INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, conversationID, idx, msg.role, msg.content, estimateTokenCount(msg.content), messageIdentityHash(msg.role, msg.content), msg.createdAt)
 		if err != nil {
 			return backfillImportResult{}, fmt.Errorf("insert backfill message seq=%d: %w", idx, err)
 		}

--- a/tui/backfill_test.go
+++ b/tui/backfill_test.go
@@ -36,6 +36,7 @@ func TestBackfillImportCreatesConversationMessagesAndContext(t *testing.T) {
 
 	assertCount(t, db, `SELECT COUNT(*) FROM conversations WHERE session_id = 'session-import'`, 1)
 	assertCountQuery(t, db, `SELECT COUNT(*) FROM messages WHERE conversation_id = ?`, len(input.messages), result.conversationID)
+	assertCountQuery(t, db, `SELECT COUNT(*) FROM messages WHERE conversation_id = ? AND identity_hash IS NOT NULL AND identity_hash != ''`, len(input.messages), result.conversationID)
 	assertCountQuery(t, db, `SELECT COUNT(*) FROM context_items WHERE conversation_id = ? AND item_type = 'message'`, len(input.messages), result.conversationID)
 	assertCountQuery(t, db, `SELECT COUNT(*) FROM message_parts mp JOIN messages m ON m.message_id = mp.message_id WHERE m.conversation_id = ?`, len(input.messages), result.conversationID)
 }
@@ -449,6 +450,7 @@ func setupBackfillTestSchema(t *testing.T, db *sql.DB) {
 			role TEXT NOT NULL,
 			content TEXT NOT NULL,
 			token_count INTEGER NOT NULL,
+			identity_hash TEXT,
 			created_at TEXT NOT NULL,
 			UNIQUE (conversation_id, seq)
 		);

--- a/tui/message_identity.go
+++ b/tui/message_identity.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func messageIdentityHash(role, content string) string {
+	sum := sha256.New()
+	sum.Write([]byte(role))
+	sum.Write([]byte{0})
+	sum.Write([]byte(content))
+	return hex.EncodeToString(sum.Sum(nil))
+}

--- a/tui/transplant.go
+++ b/tui/transplant.go
@@ -884,9 +884,9 @@ func nextConversationMessageSeq(ctx context.Context, q sqlQueryer, conversationI
 
 func insertCopiedMessage(ctx context.Context, q sqlQueryer, targetConversationID, seq int64, source transplantMessage) (int64, error) {
 	result, err := q.ExecContext(ctx, `
-		INSERT INTO messages (conversation_id, seq, role, content, token_count, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, targetConversationID, seq, source.role, source.content, source.tokenCount, source.createdAt)
+		INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, targetConversationID, seq, source.role, source.content, source.tokenCount, messageIdentityHash(source.role, source.content), source.createdAt)
 	if err != nil {
 		return 0, fmt.Errorf("insert copied message from %d: %w", source.messageID, err)
 	}

--- a/tui/transplant_test.go
+++ b/tui/transplant_test.go
@@ -45,6 +45,7 @@ func TestApplyTransplantDeepCopiesMessages(t *testing.T) {
 			role TEXT NOT NULL,
 			content TEXT NOT NULL,
 			token_count INTEGER NOT NULL,
+			identity_hash TEXT,
 			created_at TEXT NOT NULL,
 			UNIQUE (conversation_id, seq)
 		);
@@ -162,6 +163,14 @@ func TestApplyTransplantDeepCopiesMessages(t *testing.T) {
 		FROM messages
 		WHERE conversation_id = 2
 		  AND content IN ('source one', 'source two')
+	`, 2)
+	assertCount(t, db, `
+		SELECT COUNT(*)
+		FROM messages
+		WHERE conversation_id = 2
+		  AND content IN ('source one', 'source two')
+		  AND identity_hash IS NOT NULL
+		  AND identity_hash != ''
 	`, 2)
 	assertCount(t, db, `
 		SELECT COUNT(*)


### PR DESCRIPTION
## Summary
- add a stored `identity_hash` column to `messages`
- backfill existing rows and add an index on `(conversation_id, identity_hash)`
- switch message-identity lookups to use the indexed hash path, with raw `role` + `content` verification after the indexed hit

## Why split this out
This PR is the narrow performance/correctness slice from #416.

It does **not** change `afterTurn()` scheduling, bootstrap time budgets, or deferred maintenance behavior.
That makes it easier to answer one focused question in review:

> Does a verified hash index make large-conversation identity lookups cheaper without changing lifecycle semantics?

## How it works
### Before
Message identity lookups scanned by full `role` + `content` equality inside a conversation.
That is correct, but it gets more expensive as conversations grow and reconcile has to ask repeated questions like:
- have we already seen this exact message?
- how many times has this exact message identity occurred?

```mermaid
flowchart LR
    A["reconcile / dedup asks for message identity"] --> B["scan messages in conversation"]
    B --> C["compare full role + content"]
    C --> D["answer hasMessage / countMessagesByIdentity"]
```

### After
We store a deterministic SHA-256 fingerprint for the same identity tuple (`role`, `content`).
Lookups first narrow candidates through the indexed hash, then verify the original `role` and `content` before returning a match or count.

```mermaid
flowchart LR
    A["reconcile / dedup asks for message identity"] --> B["compute identity_hash from role + content"]
    B --> C["indexed lookup by conversation_id + identity_hash"]
    C --> D{"candidate rows?"}
    D -- no --> E["not found"]
    D -- yes --> F["verify raw role + content"]
    F --> G["exact match / exact count"]
```

## Safety model
- The hash is a **performance hint**, not the source of truth.
- `hasMessage()` still verifies the original `role` and `content` after the indexed lookup.
- `countMessagesByIdentity()` counts only rows whose raw content still matches after the hash prefilter.
- Existing databases migrate in place: add column, backfill missing hashes in batches, create index.

## Why this matters operationally
This specifically targets the large-session reconcile/identity-lookup path.
It should help when bootstrap or replay needs to anchor against repeated identical messages such as empty tool outputs.

It is **not** the full lane-stall fix by itself. It does not move post-turn compaction off the hot path.

## Verification
- `git diff --check`
- `npx vitest run test/migration.test.ts`

## Related work
- Split out of #416
- Pairs well with #395 (`/lcm rotate`) for very large long-lived conversations
