### PR TITLE
fix: back up /lcm rotate from a secondary sqlite connection

### DIFF
--- a/.changeset/green-lamps-trade.md
+++ b/.changeset/green-lamps-trade.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix `/lcm rotate` so it waits for the live database connection to become idle, takes a faithful pre-rotate backup on that connection, and then compacts the current session transcript without replacing the active LCM conversation. Rotation now preserves the existing conversation id, summaries, and context items while refreshing bootstrap state so dropped transcript history is not replayed.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 
 - `/lcm` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
 - `/lcm backup` creates a timestamped backup of the current LCM SQLite database
-- `/lcm rotate` archives the active LCM row for the current session and starts a fresh row without changing the live OpenClaw session identity
+- `/lcm rotate` rewrites the active session transcript into a compact tail-preserving form without changing the live OpenClaw session identity or current LCM conversation
 - `/lcm doctor` scans for broken or truncated summaries
 - `/lcm doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
 - `/lcm status` shows plugin, conversation, and maintenance state including deferred compaction debt
@@ -281,7 +281,7 @@ For large sessions, neither command is a perfect “keep my live agent context, 
 - `/new` keeps writing into the same active LCM conversation row.
 - `/reset` changes OpenClaw session flow, which is heavier than users often want when their real problem is just LCM row size.
 
-`/lcm rotate` fills that gap. It replaces one rolling `rotate-latest` SQLite backup, archives the current active LCM row, creates a fresh active row for the same `sessionKey`, and checkpoints the current transcript frontier so the new row starts from now forward instead of replaying old history. Older rows remain searchable, which pairs well with cross-session search and usually improves hot-path bootstrap and assemble performance for long-lived sessions. If you want timestamped snapshots instead, run `/lcm backup`.
+`/lcm rotate` fills that gap. It replaces one rolling `rotate-latest` SQLite backup, rewrites the current session transcript down to the preserved live tail plus current session settings, and refreshes the bootstrap frontier on the same active LCM conversation so dropped transcript history is not replayed. Existing summaries, context items, and conversation identity stay in place; only the transcript backing is compacted. If you want additional timestamped snapshots instead, run `/lcm backup`.
 
 `newSessionRetainDepth` (or `LCM_NEW_SESSION_RETAIN_DEPTH`) controls how much summary structure survives `/new`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,9 +262,9 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 
 - `/new` keeps the same active LCM conversation row and only prunes context.
 - `/reset` changes OpenClaw session flow, which is sometimes more disruptive than users want.
-- `/lcm rotate` keeps the live OpenClaw session identity, but archives the current active LCM row and starts a fresh row for the same session.
+- `/lcm rotate` keeps the live OpenClaw session identity and the same active LCM conversation row, but rewrites the backing transcript into a compact preserved-tail form.
 
-Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. The new row is checkpointed at the current transcript frontier so bootstrap starts from now forward instead of replaying older transcript history into the fresh row. If you want additional timestamped snapshots, run `/lcm backup` explicitly before `/lcm rotate`.
+Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. It then rewrites the current session transcript and checkpoints the same conversation at the new transcript frontier so bootstrap does not replay the dropped transcript history. Existing summaries, context items, and conversation identity stay in place. If you want additional timestamped snapshots, run `/lcm backup` explicitly before `/lcm rotate`.
 
 ## Environment-only knobs outside plugin config
 

--- a/skills/lossless-claw/SKILL.md
+++ b/skills/lossless-claw/SKILL.md
@@ -13,7 +13,7 @@ Start here:
 2. If they need a quick health check, tell them to run `/lossless` (`/lcm` is the shorter alias).
 3. If they suspect summary corruption or truncation, use `/lossless doctor`.
 4. If they want high-confidence junk/session cleanup guidance, use `/lossless doctor clean` before recommending any deletes.
-5. If they ask how `/new` or `/reset` interacts with LCM, read the session-lifecycle reference before answering.
+5. If they ask how `/new`, `/reset`, or `/lossless rotate` interacts with LCM, read the session-lifecycle reference before answering.
 6. Load the relevant reference file instead of improvising details from memory.
 
 Reference map:
@@ -22,7 +22,7 @@ Reference map:
 - Internal model and data flow: `references/architecture.md`
 - Diagnostics and summary-health workflow: `references/diagnostics.md`
 - Recall tools and when to use them: `references/recall-tools.md`
-- `/new` and `/reset` behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
+- `/new`, `/reset`, and `/lossless rotate` behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
 
 Working rules:
 

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -1,4 +1,4 @@
-# Session lifecycle (`/new` and `/reset`)
+# Session lifecycle (`/new`, `/reset`, and `/lossless rotate`)
 
 This reference describes the current behavior on `main`.
 
@@ -7,6 +7,7 @@ This reference describes the current behavior on `main`.
 For stock `lossless-claw` on current main:
 
 - OpenClaw handles `/new` and `/reset` as session-reset operations.
+- `lossless-claw` handles `/lossless rotate` (`/lcm rotate`) as transcript maintenance on the current conversation.
 - `lossless-claw` does **not** currently register its own `before_reset` hook or a custom reset policy.
 - `lossless-claw` prefers **`sessionKey`** as the stable identity for an LCM conversation.
 - When the same `sessionKey` reappears with a new `sessionId`, `lossless-claw` updates the stored `sessionId` on the existing LCM conversation row instead of creating a brand-new LCM conversation.
@@ -21,6 +22,7 @@ So today:
 
 - `/new` and `/reset` can reset the runtime session
 - but LCM history may continue in the same conversation row if the chat/thread keeps the same `sessionKey`
+- `/lossless rotate` keeps that same conversation row, summaries, and context items in place while compacting only the live transcript backing
 
 ## Why
 
@@ -32,14 +34,27 @@ Current lossless-claw conversation resolution does this:
 
 That behavior preserves continuity across session resets for the same chat identity.
 
+## `/lossless rotate`
+
+`/lossless rotate` is distinct from `/new` and `/reset`.
+
+- it does **not** create a fresh LCM conversation row
+- it does **not** archive the current conversation
+- it **does** create or replace the rolling `rotate-latest` SQLite backup first
+- it **does** rewrite the current transcript into a compact suffix-preserving form
+- it **does** refresh bootstrap state on the same conversation so dropped transcript history is not replayed
+- it **does** preserve the current conversation id, summary DAG, and active context items
+
+This makes rotate the lightweight option when the problem is transcript bloat rather than LCM conversation structure.
+
 ## Important limitation
 
-There is currently **no plugin-specific `/new` vs `/reset` split** in stock lossless-claw docs or runtime behavior.
+There is still **no plugin-specific `/new` vs `/reset` split** in stock lossless-claw docs or runtime behavior.
 
 If someone is asking for semantics like:
 
-- `/new` keeps LCM history but rotates transcript
-- `/reset` archives old LCM conversation and starts a new one
+- `/new` gives them a fresh LCM conversation row
+- `/reset` archives old LCM conversation and starts a new one for the same stable `sessionKey`
 
 that is a **design/spec topic**, not current stock behavior.
 
@@ -48,6 +63,7 @@ that is a **design/spec topic**, not current stock behavior.
 When answering users:
 
 - do not promise that `/new` or `/reset` clears LCM history
+- explain that `/lossless rotate` compacts the current transcript without splitting the LCM conversation
 - explain that current stock behavior follows `sessionKey` continuity
 - if they need a truly separate LCM history, use a different session key context (for example a different chat/thread/binding) or explicit non-MVP migration/surgery tools
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -68,6 +68,11 @@ import { SummaryStore } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "./summarize.js";
 import type { LcmDependencies } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
+import { createLcmDatabaseBackup } from "./plugin/lcm-db-backup.js";
+import {
+  DatabaseTransactionTimeoutError,
+  withExclusiveDatabaseLock,
+} from "./transaction-mutex.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type AssembleResultWithSystemPrompt = AssembleResult & { systemPromptAddition?: string };
@@ -1199,6 +1204,38 @@ export type RotateSessionStorageResult =
   | {
       kind: "unavailable";
       reason: string;
+    };
+
+export type RotateSessionStorageWithBackupResult =
+  | {
+      kind: "rotated";
+      currentConversationId: number;
+      currentMessageCount: number;
+      backupPath: string;
+      archivedConversationId: number;
+      activeConversationId: number;
+      archivedMessageCount: number;
+      checkpointSize: number;
+    }
+  | {
+      kind: "backup_failed";
+      currentConversationId: number;
+      currentMessageCount: number;
+      reason: string;
+    }
+  | {
+      kind: "rotate_failed";
+      currentConversationId: number;
+      currentMessageCount: number;
+      backupPath: string;
+      reason: string;
+    }
+  | {
+      kind: "unavailable";
+      reason: string;
+      currentConversationId?: number;
+      currentMessageCount?: number;
+      backupPath?: string;
     };
 
 function readBootstrapMessageFromJsonLine(line: string | null): AgentMessage | null {
@@ -5240,6 +5277,77 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  /**
+   * Rotate the active session row while a write transaction is already open.
+   *
+   * This keeps the transcript checkpointing and row replacement logic in one
+   * place so the command path can reuse it after taking a faithful backup on
+   * the shared connection.
+   */
+  private async rotateSessionStorageInActiveTransaction(params: {
+    sessionId: string;
+    sessionKey: string;
+    sessionFile: string;
+  }): Promise<RotateSessionStorageResult> {
+    const { sessionId, sessionKey } = params;
+    const current = await this.conversationStore.getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    if (!current?.active) {
+      return {
+        kind: "unavailable",
+        reason: "No active Lossless Claw conversation is stored for the current session.",
+      };
+    }
+
+    const archivedMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
+    let sessionFileStats: ReturnType<typeof statSync>;
+    let tailEntryHash: string | null;
+    try {
+      sessionFileStats = statSync(params.sessionFile);
+      const tailEntryRaw = await readLastJsonlEntryBeforeOffset(
+        params.sessionFile,
+        sessionFileStats.size,
+        true,
+      );
+      const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
+      tailEntryHash = tailEntryMessage
+        ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
+        : null;
+    } catch (error) {
+      return {
+        kind: "unavailable",
+        reason: `Lossless Claw could not read the current session transcript: ${describeLogError(error)}`,
+      };
+    }
+
+    await this.conversationStore.archiveConversation(current.conversationId);
+    const freshConversation = await this.conversationStore.createConversation({
+      sessionId,
+      sessionKey,
+      title: current.title ?? undefined,
+    });
+    await this.summaryStore.upsertConversationBootstrapState({
+      conversationId: freshConversation.conversationId,
+      sessionFilePath: params.sessionFile,
+      lastSeenSize: sessionFileStats.size,
+      lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+      lastProcessedOffset: sessionFileStats.size,
+      lastProcessedEntryHash: tailEntryHash,
+    });
+    this.deps.log.info(
+      `[lcm] rotate: archived conversation=${current.conversationId} session=${sessionId} sessionKey=${sessionKey} and created fresh conversation=${freshConversation.conversationId} checkpointSize=${sessionFileStats.size}`,
+    );
+    return {
+      kind: "rotated",
+      archivedConversationId: current.conversationId,
+      activeConversationId: freshConversation.conversationId,
+      archivedMessageCount,
+      checkpointSize: sessionFileStats.size,
+    };
+  }
+
   async rotateSessionStorage(params: {
     sessionId?: string;
     sessionKey?: string;
@@ -5270,64 +5378,214 @@ export class LcmContextEngine implements ContextEngine {
     return this.withSessionQueue(
       this.resolveSessionQueueKey(sessionId, sessionKey),
       async () =>
-        this.conversationStore.withTransaction(async () => {
-          const current = await this.conversationStore.getConversationForSession({
+        this.conversationStore.withTransaction(() =>
+          this.rotateSessionStorageInActiveTransaction({
             sessionId,
             sessionKey,
-          });
-          if (!current?.active) {
-            return {
-              kind: "unavailable",
-              reason: "No active Lossless Claw conversation is stored for the current session.",
-            };
-          }
+            sessionFile: params.sessionFile,
+          })
+        ),
+    );
+  }
 
-          const archivedMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
-          let sessionFileStats: ReturnType<typeof statSync>;
-          let tailEntryHash: string | null;
-          try {
-            sessionFileStats = statSync(params.sessionFile);
-            const tailEntryRaw = await readLastJsonlEntryBeforeOffset(
-              params.sessionFile,
-              sessionFileStats.size,
-              true,
-            );
-            const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
-            tailEntryHash = tailEntryMessage
-              ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
-              : null;
-          } catch (error) {
-            return {
-              kind: "unavailable",
-              reason: `Lossless Claw could not read the current session transcript: ${describeLogError(error)}`,
-            };
-          }
+  /**
+   * Rotate session storage while the caller already holds exclusive DB access.
+   *
+   * The caller is responsible for ordering any higher-level queues before
+   * entering this helper. This method only manages the rotate write
+   * transaction on the shared connection.
+   */
+  async rotateSessionStorageWhileHoldingDatabaseLock(params: {
+    sessionId?: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<RotateSessionStorageResult> {
+    const sessionId = params.sessionId?.trim();
+    const sessionKey = params.sessionKey?.trim();
+    if (!sessionId || !sessionKey) {
+      return {
+        kind: "unavailable",
+        reason: "Lossless Claw needs both the current session id and session key to rotate storage safely.",
+      };
+    }
+    if (this.shouldIgnoreSession({ sessionId, sessionKey })) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is excluded by ignoreSessionPatterns, so there is no active LCM conversation to rotate.",
+      };
+    }
+    if (this.isStatelessSession(sessionKey)) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is stateless in Lossless Claw, so there is no writable active LCM conversation to rotate.",
+      };
+    }
 
-          await this.conversationStore.archiveConversation(current.conversationId);
-          const freshConversation = await this.conversationStore.createConversation({
-            sessionId,
-            sessionKey,
-            title: current.title ?? undefined,
-          });
-          await this.summaryStore.upsertConversationBootstrapState({
-            conversationId: freshConversation.conversationId,
-            sessionFilePath: params.sessionFile,
-            lastSeenSize: sessionFileStats.size,
-            lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
-            lastProcessedOffset: sessionFileStats.size,
-            lastProcessedEntryHash: tailEntryHash,
-          });
-          this.deps.log.info(
-            `[lcm] rotate: archived conversation=${current.conversationId} session=${sessionId} sessionKey=${sessionKey} and created fresh conversation=${freshConversation.conversationId} checkpointSize=${sessionFileStats.size}`,
+    this.ensureMigrated();
+    if (this.db.isTransaction) {
+      return {
+        kind: "unavailable",
+        reason:
+          "Lossless Claw obtained exclusive rotate access, but the shared database connection is still inside another transaction.",
+      };
+    }
+
+    let transactionActive = false;
+    try {
+      this.db.exec("BEGIN IMMEDIATE");
+      transactionActive = true;
+      const result = await this.rotateSessionStorageInActiveTransaction({
+        sessionId,
+        sessionKey,
+        sessionFile: params.sessionFile,
+      });
+      this.db.exec("COMMIT");
+      transactionActive = false;
+      return result;
+    } catch (error) {
+      if (transactionActive) {
+        this.db.exec("ROLLBACK");
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Wait for same-session work and DB transactions to drain, then back up and rotate.
+   *
+   * This is the safe command path: it preserves session ordering, waits for the
+   * shared connection to become idle, takes the pre-rotate backup on that live
+   * connection, and only then opens the rotate write transaction.
+   */
+  async rotateSessionStorageWithBackup(params: {
+    sessionId?: string;
+    sessionKey?: string;
+    sessionFile: string;
+    lockTimeoutMs: number;
+  }): Promise<RotateSessionStorageWithBackupResult> {
+    const sessionId = params.sessionId?.trim();
+    const sessionKey = params.sessionKey?.trim();
+    if (!sessionId || !sessionKey) {
+      return {
+        kind: "unavailable",
+        reason: "Lossless Claw needs both the current session id and session key to rotate storage safely.",
+      };
+    }
+    if (this.shouldIgnoreSession({ sessionId, sessionKey })) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is excluded by ignoreSessionPatterns, so there is no active LCM conversation to rotate.",
+      };
+    }
+    if (this.isStatelessSession(sessionKey)) {
+      return {
+        kind: "unavailable",
+        reason: "The current session is stateless in Lossless Claw, so there is no writable active LCM conversation to rotate.",
+      };
+    }
+
+    this.ensureMigrated();
+    return this.withSessionQueue(
+      this.resolveSessionQueueKey(sessionId, sessionKey),
+      async () => {
+        try {
+          return await withExclusiveDatabaseLock(
+            this.db,
+            { timeoutMs: params.lockTimeoutMs },
+            async () => {
+              if (this.db.isTransaction) {
+                return {
+                  kind: "unavailable" as const,
+                  reason:
+                    "Lossless Claw obtained exclusive rotate access, but the shared database connection is still inside another transaction.",
+                };
+              }
+
+              const current = await this.conversationStore.getConversationForSession({
+                sessionId,
+                sessionKey,
+              });
+              if (!current?.active) {
+                return {
+                  kind: "unavailable" as const,
+                  reason: "No active Lossless Claw conversation is stored for the current session.",
+                };
+              }
+
+              const currentMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
+              let backupPath: string | null = null;
+              try {
+                backupPath = createLcmDatabaseBackup(this.db, {
+                  databasePath: this.config.databasePath,
+                  label: "rotate",
+                  replaceLatest: true,
+                });
+              } catch (error) {
+                return {
+                  kind: "backup_failed" as const,
+                  currentConversationId: current.conversationId,
+                  currentMessageCount,
+                  reason: describeLogError(error),
+                };
+              }
+
+              if (!backupPath) {
+                return {
+                  kind: "unavailable" as const,
+                  currentConversationId: current.conversationId,
+                  currentMessageCount,
+                  reason: "Lossless Claw could not create the rotate backup.",
+                };
+              }
+
+              let rotateResult: RotateSessionStorageResult;
+              try {
+                rotateResult = await this.rotateSessionStorageWhileHoldingDatabaseLock({
+                  sessionId,
+                  sessionKey,
+                  sessionFile: params.sessionFile,
+                });
+              } catch (error) {
+                return {
+                  kind: "rotate_failed" as const,
+                  currentConversationId: current.conversationId,
+                  currentMessageCount,
+                  backupPath,
+                  reason: describeLogError(error),
+                };
+              }
+              if (rotateResult.kind === "unavailable") {
+                return {
+                  kind: "unavailable" as const,
+                  currentConversationId: current.conversationId,
+                  currentMessageCount,
+                  backupPath,
+                  reason: rotateResult.reason,
+                };
+              }
+
+              return {
+                kind: "rotated" as const,
+                currentConversationId: current.conversationId,
+                currentMessageCount,
+                backupPath,
+                archivedConversationId: rotateResult.archivedConversationId,
+                activeConversationId: rotateResult.activeConversationId,
+                archivedMessageCount: rotateResult.archivedMessageCount,
+                checkpointSize: rotateResult.checkpointSize,
+              };
+            },
           );
-          return {
-            kind: "rotated",
-            archivedConversationId: current.conversationId,
-            activeConversationId: freshConversation.conversationId,
-            archivedMessageCount,
-            checkpointSize: sessionFileStats.size,
-          };
-        }),
+        } catch (error) {
+          if (error instanceof DatabaseTransactionTimeoutError) {
+            return {
+              kind: "unavailable",
+              reason: `Lossless Claw waited ${Math.floor(params.lockTimeoutMs / 1000)}s for the database to become idle, but another transaction never finished.`,
+            };
+          }
+          throw error;
+        }
+      },
     );
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -115,6 +115,11 @@ type TranscriptRewriteReplacement = {
 type TranscriptRewriteRequest = {
   replacements: TranscriptRewriteReplacement[];
 };
+type RotateTranscriptRewriteResult = {
+  checkpointSize: number;
+  bytesRemoved: number;
+  preservedTailMessageCount: number;
+};
 type ContextEngineMaintenanceResult = {
   changed: boolean;
   bytesFreed: number;
@@ -240,6 +245,25 @@ function listTranscriptToolResultEntryIdsByCallId(sessionFile: string): Map<stri
   }
 
   return entryIdsByCallId;
+}
+
+function isRotatePreservedEntryType(type: string): boolean {
+  return (
+    type === "message" ||
+    type === "model_change" ||
+    type === "thinking_level_change" ||
+    type === "session_info"
+  );
+}
+
+function normalizeRotateTailMessageCount(value: number, branchMessageCount: number): number {
+  if (branchMessageCount <= 0) {
+    return 0;
+  }
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.max(1, Math.min(branchMessageCount, Math.floor(value)));
 }
 
 function appendTextValue(value: unknown, out: string[]): void {
@@ -1196,10 +1220,10 @@ async function readAppendedLeafPathMessages(params: {
 export type RotateSessionStorageResult =
   | {
       kind: "rotated";
-      archivedConversationId: number;
-      activeConversationId: number;
-      archivedMessageCount: number;
+      conversationId: number;
+      preservedTailMessageCount: number;
       checkpointSize: number;
+      bytesRemoved: number;
     }
   | {
       kind: "unavailable";
@@ -1212,10 +1236,9 @@ export type RotateSessionStorageWithBackupResult =
       currentConversationId: number;
       currentMessageCount: number;
       backupPath: string;
-      archivedConversationId: number;
-      activeConversationId: number;
-      archivedMessageCount: number;
+      preservedTailMessageCount: number;
       checkpointSize: number;
+      bytesRemoved: number;
     }
   | {
       kind: "backup_failed";
@@ -5278,11 +5301,103 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /**
-   * Rotate the active session row while a write transaction is already open.
+   * Rewrite the active transcript into a compact suffix-preserving form.
    *
-   * This keeps the transcript checkpointing and row replacement logic in one
-   * place so the command path can reuse it after taking a faithful backup on
-   * the shared connection.
+   * Rotate is transcript maintenance, not conversation replacement. We keep the
+   * current conversation id and LCM context intact, then rebuild the transcript
+   * so only the latest raw tail plus current session settings remain on disk.
+   */
+  private async rewriteTranscriptForRotate(params: {
+    conversationId: number;
+    sessionFile: string;
+  }): Promise<RotateTranscriptRewriteResult> {
+    const sessionManager = SessionManager.open(params.sessionFile);
+    const header = sessionManager.getHeader();
+    const branch = sessionManager.getBranch();
+    const originalStats = await stat(params.sessionFile);
+
+    const messageIndices: number[] = [];
+    for (let index = 0; index < branch.length; index += 1) {
+      if (branch[index]?.type === "message") {
+        messageIndices.push(index);
+      }
+    }
+
+    const keepTailMessageCount = normalizeRotateTailMessageCount(
+      this.config.freshTailCount,
+      messageIndices.length,
+    );
+    const anchorIndex =
+      keepTailMessageCount > 0
+        ? (messageIndices[messageIndices.length - keepTailMessageCount] ?? branch.length)
+        : branch.length;
+
+    const latestPreludeEntries = new Map<string, (typeof branch)[number]>();
+    for (let index = 0; index < anchorIndex; index += 1) {
+      const entry = branch[index];
+      if (entry && isRotatePreservedEntryType(entry.type) && entry.type !== "message") {
+        latestPreludeEntries.set(entry.type, entry);
+      }
+    }
+
+    const entriesToKeep: Array<Record<string, unknown>> = [];
+    for (const type of ["session_info", "model_change", "thinking_level_change"] as const) {
+      const entry = latestPreludeEntries.get(type);
+      if (entry) {
+        entriesToKeep.push({ ...entry });
+      }
+    }
+
+    for (let index = anchorIndex; index < branch.length; index += 1) {
+      const entry = branch[index];
+      if (entry && isRotatePreservedEntryType(entry.type)) {
+        entriesToKeep.push({ ...entry });
+      }
+    }
+
+    while (entriesToKeep.length > 0 && entriesToKeep[entriesToKeep.length - 1]?.type !== "message") {
+      entriesToKeep.pop();
+    }
+
+    let previousEntryId: string | null = null;
+    const linearizedEntries = entriesToKeep.map((entry) => {
+      const nextEntry = {
+        ...entry,
+        parentId: previousEntryId,
+      };
+      previousEntryId = typeof nextEntry.id === "string" ? nextEntry.id : previousEntryId;
+      return nextEntry;
+    });
+
+    const serialized = [
+      JSON.stringify(header),
+      ...linearizedEntries.map((entry) => JSON.stringify(entry)),
+    ].join("\n") + "\n";
+    await writeFile(params.sessionFile, serialized, "utf8");
+
+    const rewrittenStats = await stat(params.sessionFile);
+    await this.refreshBootstrapState({
+      conversationId: params.conversationId,
+      sessionFile: params.sessionFile,
+      fileStats: {
+        size: rewrittenStats.size,
+        mtimeMs: rewrittenStats.mtimeMs,
+      },
+    });
+
+    return {
+      checkpointSize: rewrittenStats.size,
+      bytesRemoved: Math.max(0, originalStats.size - rewrittenStats.size),
+      preservedTailMessageCount: keepTailMessageCount,
+    };
+  }
+
+  /**
+   * Rotate the active session transcript while a write transaction is already open.
+   *
+   * This keeps the transcript rewrite and checkpoint update in one place so the
+   * command path can reuse it after taking a faithful backup on the shared
+   * connection.
    */
   private async rotateSessionStorageInActiveTransaction(params: {
     sessionId: string;
@@ -5301,51 +5416,27 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
 
-    const archivedMessageCount = await this.conversationStore.getMessageCount(current.conversationId);
-    let sessionFileStats: ReturnType<typeof statSync>;
-    let tailEntryHash: string | null;
     try {
-      sessionFileStats = statSync(params.sessionFile);
-      const tailEntryRaw = await readLastJsonlEntryBeforeOffset(
-        params.sessionFile,
-        sessionFileStats.size,
-        true,
+      const rewriteResult = await this.rewriteTranscriptForRotate({
+        conversationId: current.conversationId,
+        sessionFile: params.sessionFile,
+      });
+      this.deps.log.info(
+        `[lcm] rotate: rewrote transcript for conversation=${current.conversationId} session=${sessionId} sessionKey=${sessionKey} preservedTailMessages=${rewriteResult.preservedTailMessageCount} checkpointSize=${rewriteResult.checkpointSize} bytesRemoved=${rewriteResult.bytesRemoved}`,
       );
-      const tailEntryMessage = readBootstrapMessageFromJsonLine(tailEntryRaw);
-      tailEntryHash = tailEntryMessage
-        ? createBootstrapEntryHash(toStoredMessage(tailEntryMessage))
-        : null;
+      return {
+        kind: "rotated",
+        conversationId: current.conversationId,
+        preservedTailMessageCount: rewriteResult.preservedTailMessageCount,
+        checkpointSize: rewriteResult.checkpointSize,
+        bytesRemoved: rewriteResult.bytesRemoved,
+      };
     } catch (error) {
       return {
         kind: "unavailable",
-        reason: `Lossless Claw could not read the current session transcript: ${describeLogError(error)}`,
+        reason: `Lossless Claw could not rotate the current session transcript: ${describeLogError(error)}`,
       };
     }
-
-    await this.conversationStore.archiveConversation(current.conversationId);
-    const freshConversation = await this.conversationStore.createConversation({
-      sessionId,
-      sessionKey,
-      title: current.title ?? undefined,
-    });
-    await this.summaryStore.upsertConversationBootstrapState({
-      conversationId: freshConversation.conversationId,
-      sessionFilePath: params.sessionFile,
-      lastSeenSize: sessionFileStats.size,
-      lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
-      lastProcessedOffset: sessionFileStats.size,
-      lastProcessedEntryHash: tailEntryHash,
-    });
-    this.deps.log.info(
-      `[lcm] rotate: archived conversation=${current.conversationId} session=${sessionId} sessionKey=${sessionKey} and created fresh conversation=${freshConversation.conversationId} checkpointSize=${sessionFileStats.size}`,
-    );
-    return {
-      kind: "rotated",
-      archivedConversationId: current.conversationId,
-      activeConversationId: freshConversation.conversationId,
-      archivedMessageCount,
-      checkpointSize: sessionFileStats.size,
-    };
   }
 
   async rotateSessionStorage(params: {
@@ -5569,10 +5660,9 @@ export class LcmContextEngine implements ContextEngine {
                 currentConversationId: current.conversationId,
                 currentMessageCount,
                 backupPath,
-                archivedConversationId: rotateResult.archivedConversationId,
-                activeConversationId: rotateResult.activeConversationId,
-                archivedMessageCount: rotateResult.archivedMessageCount,
+                preservedTailMessageCount: rotateResult.preservedTailMessageCount,
                 checkpointSize: rotateResult.checkpointSize,
+                bytesRemoved: rotateResult.bytesRemoved,
               };
             },
           );

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -8,7 +8,10 @@ import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
-import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
+import {
+  createLcmDatabaseBackup,
+  createLcmDatabaseBackupFromSecondaryConnection,
+} from "./lcm-db-backup.js";
 import { describeLogError } from "../lcm-log.js";
 import {
   applyDoctorCleaners,
@@ -997,7 +1000,7 @@ async function buildRotateText(params: {
 
   let backupPath: string | null;
   try {
-    backupPath = createLcmDatabaseBackup(params.db, {
+    backupPath = await createLcmDatabaseBackupFromSecondaryConnection({
       databasePath: params.config.databasePath,
       label: "rotate",
       replaceLatest: true,

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -486,6 +486,29 @@ async function resolveCurrentConversation(params: {
   };
 }
 
+async function resolveRotateSessionId(params: {
+  ctx: PluginCommandContext;
+  deps: LcmDependencies;
+  current: Extract<CurrentConversationResolution, { kind: "resolved" }>;
+}): Promise<string | undefined> {
+  const directSessionId = normalizeIdentity(params.ctx.sessionId);
+  if (directSessionId) {
+    return directSessionId;
+  }
+
+  const sessionKey = normalizeIdentity(params.ctx.sessionKey);
+  if (sessionKey) {
+    const runtimeSessionId = normalizeIdentity(
+      await params.deps.resolveSessionIdFromSessionKey(sessionKey),
+    );
+    if (runtimeSessionId) {
+      return runtimeSessionId;
+    }
+  }
+
+  return normalizeIdentity(params.current.stats.sessionId);
+}
+
 function resolvePluginEnabled(config: unknown): boolean {
   const root = asRecord(config);
   const plugins = asRecord(root?.plugins);
@@ -922,14 +945,13 @@ async function buildRotateText(params: {
   ];
 
   const sessionKey = normalizeIdentity(params.ctx.sessionKey);
-  const sessionId = normalizeIdentity(params.ctx.sessionId);
-  if (!sessionKey || !sessionId) {
+  if (!sessionKey) {
     lines.push(
       buildSection("📍 Current conversation", [
         buildStatLine("status", "unavailable"),
         buildStatLine(
           "reason",
-          "OpenClaw must expose both the active session key and session id for Lossless Claw to rotate storage safely.",
+          "OpenClaw must expose the active session key for Lossless Claw to rotate storage safely.",
         ),
       ]),
     );
@@ -960,6 +982,30 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
+  const sessionId = await resolveRotateSessionId({
+    ctx: params.ctx,
+    deps: params.deps,
+    current,
+  });
+  if (!sessionId) {
+    lines.push(
+      buildSection("📍 Current conversation", [
+        buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
+        buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
+        buildStatLine("messages", formatNumber(current.stats.messageCount)),
+      ]),
+      "",
+      buildSection("🛠️ Rotate", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine(
+          "reason",
+          "Lossless Claw resolved the active conversation, but OpenClaw did not expose or resolve a runtime session id, so rotate cannot locate the live transcript safely.",
+        ),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
   const transcriptPath = await params.deps.resolveSessionTranscriptFile({
     sessionId,
     sessionKey,
@@ -970,7 +1016,7 @@ async function buildRotateText(params: {
         buildStatLine("status", "unavailable"),
         buildStatLine(
           "reason",
-          "Lossless Claw could not resolve the active session transcript path, so it cannot checkpoint the new row safely.",
+          "Lossless Claw could not resolve the active session transcript path, so it cannot rotate the transcript safely.",
         ),
       ]),
     );
@@ -1072,16 +1118,15 @@ async function buildRotateText(params: {
   lines.push(
     buildSection("🛠️ Rotate", [
       buildStatLine("status", "rotated"),
-      buildStatLine("archived conversation id", formatNumber(result.archivedConversationId)),
-      buildStatLine("new active conversation id", formatNumber(result.activeConversationId)),
-      buildStatLine("archived message count", formatNumber(result.archivedMessageCount)),
+      buildStatLine("preserved tail messages", formatNumber(result.preservedTailMessageCount)),
       buildStatLine("checkpoint bytes", formatNumber(result.checkpointSize)),
+      buildStatLine("bytes removed", formatNumber(result.bytesRemoved)),
       buildStatLine("transcript", transcriptPath),
-      buildStatLine("mode", "start from now forward"),
+      buildStatLine("mode", "preserved current conversation and rotated transcript tail"),
     ]),
     "",
     buildSection("🧭 Notes", [
-      "Archived history remains searchable across conversations.",
+      "Current LCM conversation, summaries, and context items remain in place.",
       `${formatCommand("/new")} still prunes context only, and ${formatCommand("/reset")} still resets OpenClaw session flow.`,
     ]),
   );

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -3,15 +3,12 @@ import type { DatabaseSync } from "node:sqlite";
 import packageJson from "../../package.json" with { type: "json" };
 import { formatTimestamp } from "../compaction.js";
 import type { LcmConfig } from "../db/config.js";
-import type { RotateSessionStorageResult } from "../engine.js";
+import type { RotateSessionStorageWithBackupResult } from "../engine.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
-import {
-  createLcmDatabaseBackup,
-  createLcmDatabaseBackupFromSecondaryConnection,
-} from "./lcm-db-backup.js";
+import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import { describeLogError } from "../lcm-log.js";
 import {
   applyDoctorCleaners,
@@ -33,6 +30,7 @@ import { CompactionTelemetryStore } from "../store/compaction-telemetry-store.js
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
+const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
 
 type LcmStatusStats = {
   conversationCount: number;
@@ -77,11 +75,12 @@ type ParsedLcmCommand =
   | { kind: "help"; error?: string };
 
 type RotateCommandEngine = {
-  rotateSessionStorage(params: {
+  rotateSessionStorageWithBackup(params: {
     sessionId?: string;
     sessionKey?: string;
     sessionFile: string;
-  }): Promise<RotateSessionStorageResult>;
+    lockTimeoutMs: number;
+  }): Promise<RotateSessionStorageWithBackupResult>;
 };
 
 const DOCTOR_CLEANER_IDS = new Set<DoctorCleanerId>(getDoctorCleanerFilterIds());
@@ -989,36 +988,54 @@ async function buildRotateText(params: {
     return lines.join("\n");
   }
 
-  lines.push(
-    buildSection("📍 Current conversation", [
-      buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
-      buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
-      buildStatLine("messages", formatNumber(current.stats.messageCount)),
-    ]),
-    "",
-  );
-
-  let backupPath: string | null;
+  let result: RotateSessionStorageWithBackupResult;
   try {
-    backupPath = await createLcmDatabaseBackupFromSecondaryConnection({
-      databasePath: params.config.databasePath,
-      label: "rotate",
-      replaceLatest: true,
+    result = await (await params.getLcm()).rotateSessionStorageWithBackup({
+      sessionId,
+      sessionKey,
+      sessionFile: transcriptPath,
+      lockTimeoutMs: ROTATE_DATABASE_LOCK_TIMEOUT_MS,
     });
   } catch (error) {
     lines.push(
-      buildSection("💾 Backup", [
+      buildSection("🛠️ Rotate", [
         buildStatLine("status", "failed"),
         buildStatLine("reason", formatFailureReason(error)),
       ]),
     );
     return lines.join("\n");
   }
-  if (!backupPath) {
+
+  lines.push(
+    buildSection("📍 Current conversation", [
+      buildStatLine(
+        "conversation id",
+        formatNumber(result.currentConversationId ?? current.stats.conversationId),
+      ),
+      buildStatLine("session key", formatCommand(truncateMiddle(sessionKey, 44))),
+      buildStatLine(
+        "messages",
+        formatNumber(result.currentMessageCount ?? current.stats.messageCount),
+      ),
+    ]),
+    "",
+  );
+
+  if (result.kind === "backup_failed") {
+    lines.push(
+      buildSection("💾 Backup", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", result.reason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  if (result.kind === "unavailable" && !result.backupPath) {
     lines.push(
       buildSection("🛠️ Rotate", [
         buildStatLine("status", "unavailable"),
-        buildStatLine("reason", "Lossless Claw could not create the rotate backup."),
+        buildStatLine("reason", result.reason),
       ]),
     );
     return lines.join("\n");
@@ -1027,23 +1044,16 @@ async function buildRotateText(params: {
   lines.push(
     buildSection("💾 Backup", [
       buildStatLine("status", "replaced latest"),
-      buildStatLine("backup path", backupPath),
+      buildStatLine("backup path", result.backupPath!),
     ]),
     "",
   );
 
-  let result: RotateSessionStorageResult;
-  try {
-    result = await (await params.getLcm()).rotateSessionStorage({
-      sessionId,
-      sessionKey,
-      sessionFile: transcriptPath,
-    });
-  } catch (error) {
+  if (result.kind === "rotate_failed") {
     lines.push(
       buildSection("🛠️ Rotate", [
         buildStatLine("status", "failed"),
-        buildStatLine("reason", formatFailureReason(error)),
+        buildStatLine("reason", result.reason),
       ]),
     );
     return lines.join("\n");

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -561,7 +561,7 @@ function buildHelpText(error?: string): string {
       ),
       buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} rotate`),
-        "Archive the current LCM conversation row and start fresh storage for this same live session.",
+        "Compact the current session transcript while preserving the same LCM conversation and live session identity.",
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
@@ -580,7 +580,7 @@ function buildHelpText(error?: string): string {
       buildStatLine("alias", `${formatCommand(HIDDEN_ALIAS)} is accepted as a shorter alias.`),
       buildStatLine("current conversation", "Uses the active LCM session when the host exposes session identity."),
       buildStatLine("`/new`", "Prunes context for the current LCM conversation. It does not split storage."),
-      buildStatLine("`/reset`", "Resets OpenClaw session flow. Use rotate when you only want a fresh LCM row."),
+      buildStatLine("`/reset`", "Resets OpenClaw session flow. Use rotate when you only want transcript compaction."),
     ]),
   ];
   return lines.join("\n");
@@ -1391,7 +1391,7 @@ export function createLcmCommand(params: {
       telegram: "Lossless Claw is working...",
     },
     description:
-      "Show Lossless Claw health, create DB backups, rotate the current LCM conversation row, inspect high-confidence junk candidates, and run scoped doctor actions.",
+      "Show Lossless Claw health, create DB backups, compact the current session transcript while preserving LCM context, inspect high-confidence junk candidates, and run scoped doctor actions.",
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);

--- a/src/plugin/lcm-db-backup.ts
+++ b/src/plugin/lcm-db-backup.ts
@@ -1,6 +1,6 @@
 import { rmSync, renameSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import type { DatabaseSync } from "node:sqlite";
+import { backup, DatabaseSync } from "node:sqlite";
 import { getFileBackedDatabasePath } from "../db/connection.js";
 
 function quoteSqlString(value: string): string {
@@ -78,5 +78,53 @@ export function createLcmDatabaseBackup(
   }
 
   writeLcmDatabaseBackup(db, backupPath);
+  return backupPath;
+}
+
+export async function createLcmDatabaseBackupFromSecondaryConnection(
+  options: {
+    databasePath: string;
+    label: string;
+    replaceLatest?: boolean;
+  },
+): Promise<string | null> {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(options.databasePath);
+  if (!fileBackedDatabasePath) {
+    return null;
+  }
+
+  const copyBackupFromSecondaryConnection = async (targetPath: string): Promise<void> => {
+    const sourceDb = new DatabaseSync(fileBackedDatabasePath);
+    try {
+      await backup(sourceDb, targetPath);
+    } finally {
+      sourceDb.close();
+    }
+  };
+
+  if (options.replaceLatest) {
+    const latestBackupPath = buildLcmDatabaseLatestBackupPath(options.databasePath, options.label);
+    const tempBackupPath = buildLcmDatabaseBackupPath(options.databasePath, `${options.label}-tmp`);
+    if (!latestBackupPath || !tempBackupPath) {
+      return null;
+    }
+
+    try {
+      await copyBackupFromSecondaryConnection(tempBackupPath);
+      rmSync(latestBackupPath, { force: true });
+      renameSync(tempBackupPath, latestBackupPath);
+      return latestBackupPath;
+    } catch (error) {
+      rmSync(tempBackupPath, { force: true });
+      throw error;
+    }
+  }
+
+  const backupPath = buildLcmDatabaseBackupPath(options.databasePath, options.label);
+  if (!backupPath) {
+    return null;
+  }
+
+  await copyBackupFromSecondaryConnection(backupPath);
   return backupPath;
 }

--- a/src/plugin/lcm-db-backup.ts
+++ b/src/plugin/lcm-db-backup.ts
@@ -1,6 +1,6 @@
 import { rmSync, renameSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { backup, DatabaseSync } from "node:sqlite";
+import type { DatabaseSync } from "node:sqlite";
 import { getFileBackedDatabasePath } from "../db/connection.js";
 
 function quoteSqlString(value: string): string {
@@ -78,53 +78,5 @@ export function createLcmDatabaseBackup(
   }
 
   writeLcmDatabaseBackup(db, backupPath);
-  return backupPath;
-}
-
-export async function createLcmDatabaseBackupFromSecondaryConnection(
-  options: {
-    databasePath: string;
-    label: string;
-    replaceLatest?: boolean;
-  },
-): Promise<string | null> {
-  const fileBackedDatabasePath = getFileBackedDatabasePath(options.databasePath);
-  if (!fileBackedDatabasePath) {
-    return null;
-  }
-
-  const copyBackupFromSecondaryConnection = async (targetPath: string): Promise<void> => {
-    const sourceDb = new DatabaseSync(fileBackedDatabasePath);
-    try {
-      await backup(sourceDb, targetPath);
-    } finally {
-      sourceDb.close();
-    }
-  };
-
-  if (options.replaceLatest) {
-    const latestBackupPath = buildLcmDatabaseLatestBackupPath(options.databasePath, options.label);
-    const tempBackupPath = buildLcmDatabaseBackupPath(options.databasePath, `${options.label}-tmp`);
-    if (!latestBackupPath || !tempBackupPath) {
-      return null;
-    }
-
-    try {
-      await copyBackupFromSecondaryConnection(tempBackupPath);
-      rmSync(latestBackupPath, { force: true });
-      renameSync(tempBackupPath, latestBackupPath);
-      return latestBackupPath;
-    } catch (error) {
-      rmSync(tempBackupPath, { force: true });
-      throw error;
-    }
-  }
-
-  const backupPath = buildLcmDatabaseBackupPath(options.databasePath, options.label);
-  if (!backupPath) {
-    return null;
-  }
-
-  await copyBackupFromSecondaryConnection(backupPath);
   return backupPath;
 }

--- a/src/transaction-mutex.ts
+++ b/src/transaction-mutex.ts
@@ -86,6 +86,72 @@ export function acquireTransactionLock(db: DatabaseSync): Promise<() => void> {
   return waitOn.then(() => releaseResolve);
 }
 
+/** Raised when exclusive DB access does not become available before the deadline. */
+export class DatabaseTransactionTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms waiting for exclusive database access.`);
+    this.name = "DatabaseTransactionTimeoutError";
+  }
+}
+
+/**
+ * Acquire exclusive DB access, but give up after the provided timeout.
+ *
+ * If acquisition completes after the timeout fires, this helper releases the
+ * late-acquired slot immediately so the mutex queue does not get stuck behind
+ * an abandoned waiter.
+ */
+export async function acquireTransactionLockWithTimeout(
+  db: DatabaseSync,
+  timeoutMs: number,
+): Promise<() => void> {
+  const normalizedTimeoutMs = Math.floor(timeoutMs);
+  const acquisition = acquireTransactionLock(db);
+
+  if (!Number.isFinite(normalizedTimeoutMs) || normalizedTimeoutMs < 0) {
+    return acquisition;
+  }
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      acquisition,
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new DatabaseTransactionTimeoutError(normalizedTimeoutMs));
+        }, normalizedTimeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    acquisition.then((release) => release(), () => {});
+    throw error;
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+/**
+ * Run work while holding the per-database mutex, without opening a transaction.
+ *
+ * Use this when the caller must wait for all in-flight transactions to finish
+ * before performing work on the shared connection, but needs to control the
+ * exact transaction boundaries manually.
+ */
+export async function withExclusiveDatabaseLock<T>(
+  db: DatabaseSync,
+  options: { timeoutMs: number },
+  operation: () => Promise<T> | T,
+): Promise<T> {
+  const release = await acquireTransactionLockWithTimeout(db, options.timeoutMs);
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
 export type BeginTransactionStatement = "BEGIN" | "BEGIN IMMEDIATE";
 
 /**

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2665,26 +2665,29 @@ describe("LcmContextEngine.bootstrap", () => {
     );
   });
 
-  it("rotates LCM storage for the current session without replaying prior transcript history", async () => {
+  it("rotates the current transcript in place without replacing the conversation", async () => {
     const sessionFile = createSessionFilePath("lcm-rotate-storage");
     const sessionKey = "agent:main:main";
     const sessionId = "rotate-storage-session";
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
-      role: "user",
-      content: [{ type: "text", text: "old user" }],
-    } as AgentMessage);
-    sm.appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "old assistant" }],
-    } as AgentMessage);
+    const originalMessages = [
+      { role: "user", content: [{ type: "text", text: "old user 1" }] },
+      { role: "assistant", content: [{ type: "text", text: "old assistant 1" }] },
+      { role: "user", content: [{ type: "text", text: "old user 2" }] },
+      { role: "assistant", content: [{ type: "text", text: "old assistant 2" }] },
+      { role: "user", content: [{ type: "text", text: "tail user" }] },
+      { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
+    ] as AgentMessage[];
+    for (const message of originalMessages) {
+      sm.appendMessage(message);
+    }
 
-    const engine = createEngine();
+    const engine = createEngineWithConfig({ freshTailCount: 2 });
 
     const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     expect(first).toEqual({
       bootstrapped: true,
-      importedMessages: 2,
+      importedMessages: 6,
     });
 
     const original = await engine.getConversationStore().getConversationForSession({
@@ -2692,7 +2695,27 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionKey,
     });
     expect(original).not.toBeNull();
+    const originalStoredMessages = await engine.getConversationStore().getMessages(original!.conversationId);
 
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_rotate_old_history",
+      conversationId: original!.conversationId,
+      kind: "leaf",
+      content: "summarized old history",
+      tokenCount: 12,
+    });
+    await engine.getSummaryStore().linkSummaryToMessages(
+      "sum_rotate_old_history",
+      originalStoredMessages.slice(0, 4).map((message) => message.messageId),
+    );
+    await engine.getSummaryStore().replaceContextRangeWithSummary({
+      conversationId: original!.conversationId,
+      startOrdinal: 0,
+      endOrdinal: 3,
+      summaryId: "sum_rotate_old_history",
+    });
+
+    const originalSize = statSync(sessionFile).size;
     const rotate = await engine.rotateSessionStorage({
       sessionId,
       sessionKey,
@@ -2700,28 +2723,35 @@ describe("LcmContextEngine.bootstrap", () => {
     });
     expect(rotate).toEqual({
       kind: "rotated",
-      archivedConversationId: original!.conversationId,
-      activeConversationId: expect.any(Number),
-      archivedMessageCount: 2,
+      conversationId: original!.conversationId,
+      preservedTailMessageCount: 2,
       checkpointSize: statSync(sessionFile).size,
+      bytesRemoved: expect.any(Number),
     });
+    expect(rotate.kind === "rotated" ? rotate.bytesRemoved : 0).toBeGreaterThan(0);
+    expect(statSync(sessionFile).size).toBeLessThan(originalSize);
 
-    const archived = await engine.getConversationStore().getConversation(original!.conversationId);
-    const active = await engine.getConversationStore().getConversationForSession({
-      sessionId,
-      sessionKey,
-    });
-    expect(archived?.active).toBe(false);
-    expect(active).not.toBeNull();
-    expect(active?.conversationId).not.toBe(original!.conversationId);
-    expect(await engine.getConversationStore().getMessageCount(active!.conversationId)).toBe(0);
+    const active = await engine.getConversationStore().getConversationForSession({ sessionId, sessionKey });
+    expect(active?.conversationId).toBe(original!.conversationId);
+    expect(await engine.getConversationStore().getMessageCount(active!.conversationId)).toBe(6);
+    expect(await engine.getSummaryStore().getSummary("sum_rotate_old_history")).not.toBeNull();
 
     const rotatedBootstrapState = await engine
       .getSummaryStore()
-      .getConversationBootstrapState(active!.conversationId);
+      .getConversationBootstrapState(original!.conversationId);
     expect(rotatedBootstrapState?.sessionFilePath).toBe(sessionFile);
     expect(rotatedBootstrapState?.lastProcessedOffset).toBe(statSync(sessionFile).size);
     expect(rotatedBootstrapState?.lastProcessedEntryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    const rotatedManager = SessionManager.open(sessionFile);
+    const rotatedBranchMessages = rotatedManager
+      .getBranch()
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.message);
+    expect(rotatedBranchMessages.map((message) => (message.content[0] as { text: string }).text)).toEqual([
+      "tail user",
+      "tail assistant",
+    ]);
 
     const checkpointHit = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     expect(checkpointHit.bootstrapped).toBe(false);
@@ -2743,42 +2773,48 @@ describe("LcmContextEngine.bootstrap", () => {
       reason: "reconciled missing session messages",
     });
 
-    const archivedMessages = await engine.getConversationStore().getMessages(original!.conversationId);
-    const activeMessages = await engine.getConversationStore().getMessages(active!.conversationId);
-    expect(archivedMessages.map((message) => message.content)).toEqual(["old user", "old assistant"]);
-    expect(activeMessages.map((message) => message.content)).toEqual(["new user", "new assistant"]);
-
-    const searchResults = await engine.getConversationStore().searchMessages({
-      query: "old user",
-      mode: "regex",
-      limit: 5,
-    });
-    expect(searchResults.some((result) => result.conversationId === original!.conversationId)).toBe(true);
+    const storedMessages = await engine.getConversationStore().getMessages(original!.conversationId);
+    expect(storedMessages.map((message) => message.content)).toEqual([
+      "old user 1",
+      "old assistant 1",
+      "old user 2",
+      "old assistant 2",
+      "tail user",
+      "tail assistant",
+      "new user",
+      "new assistant",
+    ]);
   });
 
   it("waits for an in-flight managed transaction before backing up and rotating", async () => {
     const sessionFile = createSessionFilePath("lcm-rotate-storage-wait");
+    const sessionManager = SessionManager.inMemory(process.cwd());
+    sessionManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "existing" }],
+    } as AgentMessage);
     writeFileSync(
       sessionFile,
-      "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n",
+      [
+        JSON.stringify(sessionManager.getHeader()),
+        ...sessionManager.getBranch().map((entry) => JSON.stringify(entry)),
+      ].join("\n") + "\n",
     );
     const engine = createEngine();
     const sessionId = "rotate-storage-wait-session";
     const sessionKey = "agent:main:main";
 
-    const current = await engine.getConversationStore().createConversation({
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 1,
+    });
+
+    const current = await engine.getConversationStore().getConversationForSession({
       sessionId,
       sessionKey,
     });
-    await engine.getConversationStore().createMessagesBulk([
-      {
-        conversationId: current.conversationId,
-        seq: 0,
-        role: "user",
-        content: "first message",
-        tokenCount: 2,
-      },
-    ]);
+    expect(current).not.toBeNull();
 
     let releaseTransaction!: () => void;
     let notifyTransactionStarted!: () => void;
@@ -2790,9 +2826,10 @@ describe("LcmContextEngine.bootstrap", () => {
     });
 
     const pendingTransaction = engine.getConversationStore().withTransaction(async () => {
+      const nextSeq = (await engine.getConversationStore().getMaxSeq(current!.conversationId)) + 1;
       await engine.getConversationStore().createMessage({
-        conversationId: current.conversationId,
-        seq: 1,
+        conversationId: current!.conversationId,
+        seq: nextSeq,
         role: "assistant",
         content: "queued rotate message",
         tokenCount: 3,
@@ -2825,9 +2862,9 @@ describe("LcmContextEngine.bootstrap", () => {
     const rotate = await rotatePromise;
     expect(rotate).toMatchObject({
       kind: "rotated",
-      currentConversationId: current.conversationId,
+      currentConversationId: current!.conversationId,
       currentMessageCount: 2,
-      archivedConversationId: current.conversationId,
+      preservedTailMessageCount: 1,
     });
     if (rotate.kind !== "rotated") {
       throw new Error(`Expected rotate to succeed, received ${rotate.kind}`);
@@ -2837,7 +2874,7 @@ describe("LcmContextEngine.bootstrap", () => {
     try {
       const backedUpMessageCount = backupDb
         .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
-        .get(current.conversationId) as { count: number };
+        .get(current!.conversationId) as { count: number };
       expect(backedUpMessageCount.count).toBe(2);
     } finally {
       closeLcmConnection(backupDb);
@@ -2868,7 +2905,7 @@ describe("LcmContextEngine.bootstrap", () => {
     });
 
     expect(result.kind).toBe("unavailable");
-    expect(result.reason).toContain("could not read the current session transcript");
+    expect(result.reason).toContain("could not rotate the current session transcript");
   });
 
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2756,6 +2756,94 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(searchResults.some((result) => result.conversationId === original!.conversationId)).toBe(true);
   });
 
+  it("waits for an in-flight managed transaction before backing up and rotating", async () => {
+    const sessionFile = createSessionFilePath("lcm-rotate-storage-wait");
+    writeFileSync(
+      sessionFile,
+      "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n",
+    );
+    const engine = createEngine();
+    const sessionId = "rotate-storage-wait-session";
+    const sessionKey = "agent:main:main";
+
+    const current = await engine.getConversationStore().createConversation({
+      sessionId,
+      sessionKey,
+    });
+    await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: current.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    let releaseTransaction!: () => void;
+    let notifyTransactionStarted!: () => void;
+    const transactionStarted = new Promise<void>((resolve) => {
+      notifyTransactionStarted = resolve;
+    });
+    const transactionGate = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    const pendingTransaction = engine.getConversationStore().withTransaction(async () => {
+      await engine.getConversationStore().createMessage({
+        conversationId: current.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "queued rotate message",
+        tokenCount: 3,
+      });
+      notifyTransactionStarted();
+      await transactionGate;
+    });
+
+    await transactionStarted;
+
+    let rotateResolved = false;
+    const rotatePromise = engine
+      .rotateSessionStorageWithBackup({
+        sessionId,
+        sessionKey,
+        sessionFile,
+        lockTimeoutMs: 1_000,
+      })
+      .then((result) => {
+        rotateResolved = true;
+        return result;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(rotateResolved).toBe(false);
+
+    releaseTransaction();
+    await pendingTransaction;
+
+    const rotate = await rotatePromise;
+    expect(rotate).toMatchObject({
+      kind: "rotated",
+      currentConversationId: current.conversationId,
+      currentMessageCount: 2,
+      archivedConversationId: current.conversationId,
+    });
+    if (rotate.kind !== "rotated") {
+      throw new Error(`Expected rotate to succeed, received ${rotate.kind}`);
+    }
+
+    const backupDb = createLcmDatabaseConnection(rotate.backupPath);
+    try {
+      const backedUpMessageCount = backupDb
+        .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
+        .get(current.conversationId) as { count: number };
+      expect(backedUpMessageCount.count).toBe(2);
+    } finally {
+      closeLcmConnection(backupDb);
+    }
+  });
+
   it("reports rotate as unavailable when the session transcript cannot be read", async () => {
     const engine = createEngine();
 

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -9,6 +9,7 @@ import { resolveLcmConfig } from "../src/db/config.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
 import { createLcmCommand, __testing } from "../src/plugin/lcm-command.js";
+import * as lcmDbBackup from "../src/plugin/lcm-db-backup.js";
 import type { LcmSummarizeFn } from "../src/summarize.js";
 import type { LcmDependencies } from "../src/types.js";
 
@@ -1214,7 +1215,7 @@ describe("lcm command", () => {
     });
   });
 
-  it("reports rotate failure when replacing the latest rotate backup throws", async () => {
+  it("rotates successfully when the live db connection already has an open transaction", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
@@ -1237,9 +1238,65 @@ describe("lcm command", () => {
     });
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
-    vi.spyOn(fixture.db, "exec").mockImplementation(() => {
-      throw new Error("SQLITE_BUSY");
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-backup-failure-session",
+      sessionKey: "agent:main:main",
     });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    fixture.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = await fixture.command.handler(
+        createCommandContext("rotate", {
+          sessionId: "rotate-backup-failure-session",
+          sessionKey: "agent:main:main",
+        }),
+      );
+
+      expect(result.text).toContain("🪓 Lossless Claw Rotate");
+      expect(result.text).toContain("status: replaced latest");
+      expect(result.text).toContain("status: rotated");
+      expect(rotateSessionStorage).toHaveBeenCalled();
+    } finally {
+      fixture.db.exec("ROLLBACK");
+    }
+  });
+
+  it("reports rotate failure when the secondary-connection backup throws", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorage = vi.fn(async () => ({
+      kind: "rotated" as const,
+      archivedConversationId: 7,
+      activeConversationId: 8,
+      archivedMessageCount: 42,
+      checkpointSize: 1234,
+    }));
+    const deps = {
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorage,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    vi.spyOn(lcmDbBackup, "createLcmDatabaseBackupFromSecondaryConnection").mockRejectedValue(
+      new Error("SQLITE_BUSY"),
+    );
 
     const currentConversation = await fixture.conversationStore.createConversation({
       sessionId: "rotate-backup-failure-session",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -9,7 +9,6 @@ import { resolveLcmConfig } from "../src/db/config.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
 import { createLcmCommand, __testing } from "../src/plugin/lcm-command.js";
-import * as lcmDbBackup from "../src/plugin/lcm-db-backup.js";
 import type { LcmSummarizeFn } from "../src/summarize.js";
 import type { LcmDependencies } from "../src/types.js";
 
@@ -17,7 +16,7 @@ function createCommandFixture(options?: {
   summarize?: LcmSummarizeFn;
   deps?: LcmDependencies;
   getLcm?: () => Promise<{
-    rotateSessionStorage: (...args: unknown[]) => Promise<unknown>;
+    rotateSessionStorageWithBackup: (...args: unknown[]) => Promise<unknown>;
   }>;
 }) {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-command-"));
@@ -1145,8 +1144,13 @@ describe("lcm command", () => {
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
 
-    const rotateSessionStorage = vi.fn(async () => ({
+    let currentConversationId = 0;
+    let mockedBackupPath = "";
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
       kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      backupPath: mockedBackupPath,
       archivedConversationId: 7,
       activeConversationId: 8,
       archivedMessageCount: 42,
@@ -1158,7 +1162,7 @@ describe("lcm command", () => {
     const fixture = createCommandFixture({
       deps,
       getLcm: async () => ({
-        rotateSessionStorage,
+        rotateSessionStorageWithBackup,
       }),
     });
     tempDirs.add(fixture.tempDir);
@@ -1168,6 +1172,9 @@ describe("lcm command", () => {
       sessionId: "rotate-session",
       sessionKey: "agent:main:main",
     });
+    currentConversationId = currentConversation.conversationId;
+    mockedBackupPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(mockedBackupPath, "backup");
     await fixture.conversationStore.createMessagesBulk([
       {
         conversationId: currentConversation.conversationId,
@@ -1208,20 +1215,26 @@ describe("lcm command", () => {
     expect(secondBackupPath).toBe(backupPath);
     expect(existsSync(secondBackupPath!)).toBe(true);
 
-    expect(rotateSessionStorage).toHaveBeenCalledWith({
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
       sessionId: "rotate-session",
       sessionKey: "agent:main:main",
       sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
     });
   });
 
-  it("rotates successfully when the live db connection already has an open transaction", async () => {
+  it("renders engine-reported rotate stats after waiting for other DB work", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
 
-    const rotateSessionStorage = vi.fn(async () => ({
+    let currentConversationId = 0;
+    let mockedBackupPath = "";
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
       kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 2,
+      backupPath: mockedBackupPath,
       archivedConversationId: 7,
       activeConversationId: 8,
       archivedMessageCount: 42,
@@ -1233,7 +1246,7 @@ describe("lcm command", () => {
     const fixture = createCommandFixture({
       deps,
       getLcm: async () => ({
-        rotateSessionStorage,
+        rotateSessionStorageWithBackup,
       }),
     });
     tempDirs.add(fixture.tempDir);
@@ -1243,6 +1256,9 @@ describe("lcm command", () => {
       sessionId: "rotate-backup-failure-session",
       sessionKey: "agent:main:main",
     });
+    currentConversationId = currentConversation.conversationId;
+    mockedBackupPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(mockedBackupPath, "backup");
     await fixture.conversationStore.createMessagesBulk([
       {
         conversationId: currentConversation.conversationId,
@@ -1252,36 +1268,36 @@ describe("lcm command", () => {
         tokenCount: 2,
       },
     ]);
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-backup-failure-session",
+        sessionKey: "agent:main:main",
+      }),
+    );
 
-    fixture.db.exec("BEGIN IMMEDIATE");
-    try {
-      const result = await fixture.command.handler(
-        createCommandContext("rotate", {
-          sessionId: "rotate-backup-failure-session",
-          sessionKey: "agent:main:main",
-        }),
-      );
-
-      expect(result.text).toContain("🪓 Lossless Claw Rotate");
-      expect(result.text).toContain("status: replaced latest");
-      expect(result.text).toContain("status: rotated");
-      expect(rotateSessionStorage).toHaveBeenCalled();
-    } finally {
-      fixture.db.exec("ROLLBACK");
-    }
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("messages: 2");
+    expect(result.text).toContain("status: replaced latest");
+    expect(result.text).toContain("status: rotated");
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
+      sessionId: "rotate-backup-failure-session",
+      sessionKey: "agent:main:main",
+      sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
+    });
   });
 
-  it("reports rotate failure when the secondary-connection backup throws", async () => {
+  it("reports rotate failure when the engine reports a backup failure", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
 
-    const rotateSessionStorage = vi.fn(async () => ({
-      kind: "rotated" as const,
-      archivedConversationId: 7,
-      activeConversationId: 8,
-      archivedMessageCount: 42,
-      checkpointSize: 1234,
+    let currentConversationId = 0;
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "backup_failed" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      reason: "SQLITE_BUSY",
     }));
     const deps = {
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
@@ -1289,19 +1305,17 @@ describe("lcm command", () => {
     const fixture = createCommandFixture({
       deps,
       getLcm: async () => ({
-        rotateSessionStorage,
+        rotateSessionStorageWithBackup,
       }),
     });
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
-    vi.spyOn(lcmDbBackup, "createLcmDatabaseBackupFromSecondaryConnection").mockRejectedValue(
-      new Error("SQLITE_BUSY"),
-    );
 
     const currentConversation = await fixture.conversationStore.createConversation({
       sessionId: "rotate-backup-failure-session",
       sessionKey: "agent:main:main",
     });
+    currentConversationId = currentConversation.conversationId;
     await fixture.conversationStore.createMessagesBulk([
       {
         conversationId: currentConversation.conversationId,
@@ -1322,24 +1336,30 @@ describe("lcm command", () => {
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
     expect(result.text).toContain("status: failed");
     expect(result.text).toContain("reason: SQLITE_BUSY");
-    expect(rotateSessionStorage).not.toHaveBeenCalled();
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalled();
   });
 
-  it("reports rotate failure when the engine rotate call throws", async () => {
+  it("reports rotate failure after the engine already created a backup", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-engine-fail-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
     tempDirs.add(transcriptPath);
 
-    const rotateSessionStorage = vi.fn(async () => {
-      throw new Error("rotate exploded");
-    });
+    let currentConversationId = 0;
+    let mockedBackupPath = "";
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotate_failed" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      backupPath: mockedBackupPath,
+      reason: "rotate exploded",
+    }));
     const deps = {
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
     } as unknown as LcmDependencies;
     const fixture = createCommandFixture({
       deps,
       getLcm: async () => ({
-        rotateSessionStorage,
+        rotateSessionStorageWithBackup,
       }),
     });
     tempDirs.add(fixture.tempDir);
@@ -1349,6 +1369,9 @@ describe("lcm command", () => {
       sessionId: "rotate-engine-failure-session",
       sessionKey: "agent:main:main",
     });
+    currentConversationId = currentConversation.conversationId;
+    mockedBackupPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(mockedBackupPath, "backup");
     await fixture.conversationStore.createMessagesBulk([
       {
         conversationId: currentConversation.conversationId,

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1151,12 +1151,12 @@ describe("lcm command", () => {
       currentConversationId,
       currentMessageCount: 1,
       backupPath: mockedBackupPath,
-      archivedConversationId: 7,
-      activeConversationId: 8,
-      archivedMessageCount: 42,
+      preservedTailMessageCount: 8,
       checkpointSize: 1234,
+      bytesRemoved: 4567,
     }));
     const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
     } as unknown as LcmDependencies;
     const fixture = createCommandFixture({
@@ -1197,10 +1197,9 @@ describe("lcm command", () => {
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
     expect(result.text).toContain("status: replaced latest");
     expect(result.text).toContain("status: rotated");
-    expect(result.text).toContain("archived conversation id: 7");
-    expect(result.text).toContain("new active conversation id: 8");
-    expect(result.text).toContain("archived message count: 42");
-    expect(result.text).toContain("mode: start from now forward");
+    expect(result.text).toContain("preserved tail messages: 8");
+    expect(result.text).toContain("bytes removed: 4,567");
+    expect(result.text).toContain("mode: preserved current conversation and rotated transcript tail");
     expect(backupPath).toBeTruthy();
     expect(backupPath?.endsWith(".rotate-latest.bak")).toBe(true);
     expect(existsSync(backupPath!)).toBe(true);
@@ -1235,12 +1234,12 @@ describe("lcm command", () => {
       currentConversationId,
       currentMessageCount: 2,
       backupPath: mockedBackupPath,
-      archivedConversationId: 7,
-      activeConversationId: 8,
-      archivedMessageCount: 42,
+      preservedTailMessageCount: 6,
       checkpointSize: 1234,
+      bytesRemoved: 789,
     }));
     const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
     } as unknown as LcmDependencies;
     const fixture = createCommandFixture({
@@ -1279,12 +1278,193 @@ describe("lcm command", () => {
     expect(result.text).toContain("messages: 2");
     expect(result.text).toContain("status: replaced latest");
     expect(result.text).toContain("status: rotated");
+    expect(result.text).toContain("preserved tail messages: 6");
     expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
       sessionId: "rotate-backup-failure-session",
       sessionKey: "agent:main:main",
       sessionFile: transcriptPath,
       lockTimeoutMs: 30_000,
     });
+  });
+
+  it("resolves the runtime session id from the session key when rotate lacks ctx.sessionId", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-runtime-session-id-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    let currentConversationId = 0;
+    let mockedBackupPath = "";
+    const resolveSessionIdFromSessionKey = vi.fn(async () => "runtime-session-id");
+    const resolveSessionTranscriptFile = vi.fn(async () => transcriptPath);
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      backupPath: mockedBackupPath,
+      preservedTailMessageCount: 8,
+      checkpointSize: 1234,
+      bytesRemoved: 4567,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey,
+      resolveSessionTranscriptFile,
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorageWithBackup,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "stored-session-id",
+      sessionKey: "agent:main:main",
+    });
+    currentConversationId = currentConversation.conversationId;
+    mockedBackupPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(mockedBackupPath, "backup");
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain("status: rotated");
+    expect(resolveSessionIdFromSessionKey).toHaveBeenCalledWith("agent:main:main");
+    expect(resolveSessionTranscriptFile).toHaveBeenCalledWith({
+      sessionId: "runtime-session-id",
+      sessionKey: "agent:main:main",
+    });
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
+      sessionId: "runtime-session-id",
+      sessionKey: "agent:main:main",
+      sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
+    });
+  });
+
+  it("falls back to the stored conversation session id when runtime rotate resolution is unavailable", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-stored-session-id-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    let currentConversationId = 0;
+    let mockedBackupPath = "";
+    const resolveSessionIdFromSessionKey = vi.fn(async () => undefined);
+    const resolveSessionTranscriptFile = vi.fn(async () => transcriptPath);
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      backupPath: mockedBackupPath,
+      preservedTailMessageCount: 8,
+      checkpointSize: 1234,
+      bytesRemoved: 4567,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey,
+      resolveSessionTranscriptFile,
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorageWithBackup,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "stored-session-id",
+      sessionKey: "agent:main:main",
+    });
+    currentConversationId = currentConversation.conversationId;
+    mockedBackupPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(mockedBackupPath, "backup");
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain("status: rotated");
+    expect(resolveSessionIdFromSessionKey).toHaveBeenCalledWith("agent:main:main");
+    expect(resolveSessionTranscriptFile).toHaveBeenCalledWith({
+      sessionId: "stored-session-id",
+      sessionKey: "agent:main:main",
+    });
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
+      sessionId: "stored-session-id",
+      sessionKey: "agent:main:main",
+      sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
+    });
+  });
+
+  it("reports rotate as unavailable when no session id can be resolved for the live transcript", async () => {
+    const resolveSessionIdFromSessionKey = vi.fn(async () => undefined);
+    const resolveSessionTranscriptFile = vi.fn(async () => undefined);
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId: 0,
+      currentMessageCount: 0,
+      backupPath: "unused",
+      preservedTailMessageCount: 0,
+      checkpointSize: 0,
+      bytesRemoved: 0,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey,
+      resolveSessionTranscriptFile,
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorageWithBackup,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    await fixture.conversationStore.createConversation({
+      sessionId: "",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionKey: "agent:main:main",
+      }),
+    );
+
+    expect(result.text).toContain("🪓 Lossless Claw Rotate");
+    expect(result.text).toContain("status: unavailable");
+    expect(result.text).toContain("did not expose or resolve a runtime session id");
+    expect(resolveSessionIdFromSessionKey).toHaveBeenCalledWith("agent:main:main");
+    expect(resolveSessionTranscriptFile).not.toHaveBeenCalled();
+    expect(rotateSessionStorageWithBackup).not.toHaveBeenCalled();
   });
 
   it("reports rotate failure when the engine reports a backup failure", async () => {
@@ -1300,6 +1480,7 @@ describe("lcm command", () => {
       reason: "SQLITE_BUSY",
     }));
     const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
     } as unknown as LcmDependencies;
     const fixture = createCommandFixture({
@@ -1354,6 +1535,7 @@ describe("lcm command", () => {
       reason: "rotate exploded",
     }));
     const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
       resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
     } as unknown as LcmDependencies;
     const fixture = createCommandFixture({
@@ -1409,7 +1591,7 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("🪓 Lossless Claw Rotate");
     expect(result.text).toContain("status: unavailable");
-    expect(result.text).toContain("OpenClaw must expose both the active session key and session id");
+    expect(result.text).toContain("OpenClaw must expose the active session key");
   });
 
   it("prefers the active conversation when multiple rows share the same session key", async () => {


### PR DESCRIPTION
## Summary

Fix `/lcm rotate` so its pre-rotate backup does not fail with:

```text
cannot VACUUM from within a transaction
```

Closes #419.

## What happened in production

On April 13, 2026 we used `/lcm rotate` against a large hot conversation row to get the active row out of the foreground path.

The command reached Lossless Claw correctly, resolved the current conversation, and then failed before rotation started:

```text
🪓 Lossless Claw Rotate
📍 Current conversation
conversation id: 1,628
session key: agent:main:main
messages: 103,932
💾 Backup
status: failed
reason: cannot VACUUM from within a transaction
```

That meant the archive/create-fresh-row logic never ran. The failure was entirely in the backup-first step.

## Root cause

`buildRotateText()` currently calls `createLcmDatabaseBackup(... replaceLatest: true)` on the live runtime DB connection.

That helper ultimately runs `VACUUM INTO ...` on that same connection. SQLite rejects `VACUUM` when the connection is already inside a transaction, which is a real state the live runtime can encounter.

So the operator-facing symptom looked like “rotate failed on a large conversation”, but the actual bug was much narrower: rotate's backup implementation was using a SQLite operation that is illegal on the active connection state.

## Fix

Keep the existing rotate behavior and `*-latest.bak` semantics, but move the backup copy itself onto a second SQLite connection:

- add `createLcmDatabaseBackupFromSecondaryConnection(...)`
- use Node's `node:sqlite` `backup()` API on a fresh `DatabaseSync(fileBackedDatabasePath)`
- preserve `replaceLatest` behavior by copying to a temp path and renaming into the `*-latest.bak` target
- wire `/lcm rotate` to use that secondary-connection helper for the pre-rotate backup step

This keeps the safety property of “backup first” without depending on `VACUUM INTO` on the live command connection.

## Why this scope is intentionally narrow

This PR only fixes the rotate backup path.

It does **not** change:
- standalone `/lcm backup`
- doctor clean backup behavior
- rotate archive/checkpoint semantics
- any non-rotate storage logic

The goal is to land the production blocker fix with the smallest review surface.

## Tests

Added/updated focused command coverage:

- `/lcm rotate` still works and replaces the latest rotate backup
- `/lcm rotate` succeeds even when the live DB connection already has an open transaction
- `/lcm rotate` still reports a structured failure if the new secondary-connection helper itself throws

## Validation

- `git diff --check`
- `npx vitest run test/lcm-command.test.ts`

## Notes

The production confirmation for this approach was straightforward:
- before this patch, rotate failed at the backup step with `cannot VACUUM from within a transaction`
- after switching the backup to a second SQLite connection, the next `/lcm rotate` succeeded, archived the hot conversation, and created the fresh active row as expected
