### PR TITLE
fix: tighten verified hash identity lookups

### DIFF
--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -185,8 +185,19 @@ function backfillMessageIdentityHashes(db: DatabaseSync): void {
     if (rows.length === 0) {
       return;
     }
-    for (const row of rows) {
-      updateStmt.run(buildMessageIdentityHash(row.role, row.content), row.message_id);
+    db.exec(`BEGIN`);
+    try {
+      for (const row of rows) {
+        updateStmt.run(buildMessageIdentityHash(row.role, row.content), row.message_id);
+      }
+      db.exec(`COMMIT`);
+    } catch (error) {
+      try {
+        db.exec(`ROLLBACK`);
+      } catch {
+        // Preserve the original migration failure if rollback also errors.
+      }
+      throw error;
     }
   }
 }

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -142,11 +142,6 @@ interface MessageSearchRow {
   created_at: string;
 }
 
-interface MessageIdentityRow {
-  role: MessageRole;
-  content: string;
-}
-
 interface MessagePartRow {
   part_id: string;
   message_id: number;
@@ -553,15 +548,14 @@ export class ConversationStore {
     const identityHash = buildMessageIdentityHash(role, content);
     const row = this.db
       .prepare(
-        `SELECT role, content
+        `SELECT 1 AS count
        FROM messages
-       WHERE conversation_id = ? AND identity_hash = ?
-       LIMIT 8`,
+       WHERE conversation_id = ? AND identity_hash = ? AND role = ? AND content = ?
+       LIMIT 1`,
       )
-      .all(conversationId, identityHash) as unknown as MessageIdentityRow[];
+      .get(conversationId, identityHash, role, content) as unknown as CountRow | undefined;
 
-    // The hash narrows candidates quickly; the raw-content check preserves exact identity.
-    return row.some((candidate) => candidate.role === role && candidate.content === content);
+    return row?.count === 1;
   }
 
   async countMessagesByIdentity(
@@ -570,22 +564,15 @@ export class ConversationStore {
     content: string,
   ): Promise<number> {
     const identityHash = buildMessageIdentityHash(role, content);
-    const rows = this.db
+    const row = this.db
       .prepare(
-       `SELECT role, content
+        `SELECT COUNT(*) AS count
        FROM messages
-       WHERE conversation_id = ? AND identity_hash = ?`,
+       WHERE conversation_id = ? AND identity_hash = ? AND role = ? AND content = ?`,
       )
-      .all(conversationId, identityHash) as unknown as MessageIdentityRow[];
+      .get(conversationId, identityHash, role, content) as unknown as CountRow | undefined;
 
-    // Count only verified matches so the hash stays a performance hint, not the source of truth.
-    let count = 0;
-    for (const candidate of rows) {
-      if (candidate.role === role && candidate.content === content) {
-        count += 1;
-      }
-    }
-    return count;
+    return row?.count ?? 0;
   }
 
   async getMessageById(messageId: MessageId): Promise<MessageRecord | null> {

--- a/test/message-identity.test.ts
+++ b/test/message-identity.test.ts
@@ -1,0 +1,60 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { buildMessageIdentityHash } from "../src/store/message-identity.js";
+
+function createStoreFixture() {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+  return {
+    db,
+    store: new ConversationStore(db, { fts5Available }),
+  };
+}
+
+describe("ConversationStore message identity lookups", () => {
+  it("finds an exact match even when many rows share the same identity hash", async () => {
+    const { db, store } = createStoreFixture();
+
+    try {
+      const conversation = await store.createConversation({ sessionId: "identity-hash-match" });
+      const targetHash = buildMessageIdentityHash("assistant", "needle");
+
+      for (let index = 0; index < 8; index += 1) {
+        await store.createMessage({
+          conversationId: conversation.conversationId,
+          seq: index,
+          role: "assistant",
+          content: `decoy-${index}`,
+          tokenCount: 1,
+        });
+      }
+
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 8,
+        role: "assistant",
+        content: "needle",
+        tokenCount: 1,
+      });
+
+      db.prepare(`UPDATE messages SET identity_hash = ? WHERE conversation_id = ?`).run(
+        targetHash,
+        conversation.conversationId,
+      );
+
+      await expect(
+        store.hasMessage(conversation.conversationId, "assistant", "needle"),
+      ).resolves.toBe(true);
+      await expect(
+        store.countMessagesByIdentity(conversation.conversationId, "assistant", "needle"),
+      ).resolves.toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -467,6 +467,56 @@ describe("runLcmMigrations summary depth backfill", () => {
     ).toBe(true);
   });
 
+  it("backfills message identity hashes across multiple batches", () => {
+    const db = createTestDb("identity-hash-batches.db");
+
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE messages (
+        message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        token_count INTEGER NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (conversation_id, seq)
+      );
+    `);
+
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      1,
+      "identity-hash-batch-session",
+    );
+
+    const insertMessage = db.prepare(
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    for (let index = 0; index < 1_205; index += 1) {
+      insertMessage.run(1, index, "assistant", `batch message ${index}`, 3);
+    }
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const unhashedCount = db
+      .prepare(`SELECT COUNT(*) AS count FROM messages WHERE identity_hash IS NULL OR identity_hash = ''`)
+      .get() as { count: number };
+    expect(unhashedCount.count).toBe(0);
+
+    const sampledRow = db
+      .prepare(`SELECT identity_hash FROM messages WHERE conversation_id = ? AND seq = ?`)
+      .get(1, 1_204) as { identity_hash: string | null };
+    expect(sampledRow.identity_hash).toBe(buildMessageIdentityHash("assistant", "batch message 1204"));
+  });
+
   it("skips FTS tables when fts5 is unavailable", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## What
This follow-up tightens the verified-hash identity lookup path introduced in #417 by moving the final `role` + `content` verification back into SQLite, batching legacy `identity_hash` backfills inside explicit transactions, and adding regression coverage for both the lookup edge case and multi-batch migration behavior.

## Why
The merged PR left three worthwhile review comments on the table: `hasMessage()` still depended on an arbitrary `LIMIT`, `countMessagesByIdentity()` still pulled matching content into JS just to count verified rows, and the migration backfill still updated legacy rows without an explicit transaction. These are narrow correctness and startup-performance fixes that are easier to land separately now that #417 is merged.

## Changes
- Verify exact identity in SQL
- Count verified matches in SQL
- Batch backfill updates transactionally
- Add hash-collision regression test
- Add multi-batch migration test

## Testing
- `npx vitest run test/message-identity.test.ts test/migration.test.ts`
- Expected: both suites pass
