### PR TITLE
fix: report canonical lossless-claw engine id

### DIFF
--- a/.changeset/five-buses-confess.md
+++ b/.changeset/five-buses-confess.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Report the canonical `lossless-claw` context-engine id from the runtime engine metadata so newer OpenClaw builds accept the plugin's registered engine slot.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1297,7 +1297,7 @@ export class LcmContextEngine implements ContextEngine {
     // Without a working schema, ownsCompaction would disable the runtime's
     // built-in compaction safeguard and inflate the context budget.
     this.info = {
-      id: "lcm",
+      id: "lossless-claw",
       name: "Lossless Context Management Engine",
       version: "0.1.0",
       ownsCompaction: migrationOk,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -270,6 +270,11 @@ afterEach(() => {
 });
 
 describe("LcmContextEngine metadata", () => {
+  it("reports the registered lossless-claw engine id", () => {
+    const engine = createEngine();
+    expect(engine.info.id).toBe("lossless-claw");
+  });
+
   it("advertises ownsCompaction capability", () => {
     const engine = createEngine();
     expect(engine.info.ownsCompaction).toBe(true);

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -226,6 +226,7 @@ describe("lcm plugin registration", () => {
       largeFileTokenThreshold: 12345,
     });
     expect(engine.info).toMatchObject({
+      id: "lossless-claw",
       turnMaintenanceMode: "background",
     });
     expect(infoLog).toHaveBeenCalledWith(


### PR DESCRIPTION
## What
This PR updates `LcmContextEngine` to report the canonical `lossless-claw` context-engine id instead of the stale `lcm` alias, and adds regression coverage plus a patch changeset for the compatibility fix.

## Why
Newer OpenClaw builds now validate that a resolved context engine's `info.id` matches the registered engine slot. `lossless-claw` still reported `lcm`, so the runtime rejected the plugin before replies could start.

## Changes
- Return `lossless-claw` from engine metadata
- Assert engine id in metadata tests
- Assert plugin factory reports canonical id
- Add patch changeset for release notes

## Testing
- `npx vitest run test/engine.test.ts test/plugin-config-registration.test.ts`
- `npm run build`
- Expected: both test files pass and the bundle build succeeds
