### PR TITLE
fix: preserve compaction retry state after inline failures

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4501,16 +4501,33 @@ export class LcmContextEngine implements ContextEngine {
       return;
     }
 
-    try {
-      await this.refreshBootstrapState({
-        conversationId: conversation.conversationId,
-        sessionFile: params.sessionFile,
-      });
-    } catch (err) {
-      this.deps.log.warn(
-        `[lcm] afterTurn: bootstrap checkpoint refresh failed for ${sessionLabel}: ${describeLogError(err)}`,
-      );
-    }
+    const refreshAfterTurnBootstrapState = async (): Promise<void> => {
+      try {
+        await this.refreshBootstrapState({
+          conversationId: conversation.conversationId,
+          sessionFile: params.sessionFile,
+        });
+      } catch (err) {
+        this.deps.log.warn(
+          `[lcm] afterTurn: bootstrap checkpoint refresh failed for ${sessionLabel}: ${describeLogError(err)}`,
+        );
+      }
+    };
+    const recordAfterTurnCompactionRetry = async (reason: string): Promise<void> => {
+      try {
+        await this.recordDeferredCompactionDebt({
+          conversationId: conversation.conversationId,
+          reason,
+          tokenBudget,
+          currentTokenCount: liveContextTokens,
+        });
+      } catch (err) {
+        this.deps.log.warn(
+          `[lcm] afterTurn: failed to persist deferred compaction retry for ${sessionLabel}: ${describeLogError(err)}`,
+        );
+      }
+    };
+    let shouldRefreshBootstrapState = true;
 
     try {
       const rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
@@ -4541,36 +4558,76 @@ export class LcmContextEngine implements ContextEngine {
         let leafCompactionScheduled = false;
         if (leafDecision.shouldCompact) {
           leafCompactionScheduled = true;
-          this.compactLeafAsync({
+          shouldRefreshBootstrapState = false;
+          void (async () => {
+            try {
+              const compactResult = await this.compactLeafAsync({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                sessionFile: params.sessionFile,
+                tokenBudget,
+                currentTokenCount: liveContextTokens,
+                legacyParams,
+                maxPasses: leafDecision.maxPasses,
+                leafChunkTokens: leafDecision.leafChunkTokens,
+                fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
+                activityBand: leafDecision.activityBand,
+                allowCondensedPasses: leafDecision.allowCondensedPasses,
+              });
+              await this.withSessionQueue(
+                this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+                async () => {
+                  if (compactResult.ok) {
+                    await refreshAfterTurnBootstrapState();
+                    return;
+                  }
+                  await recordAfterTurnCompactionRetry(leafDecision.reason);
+                },
+                {
+                  operationName: "afterTurnLeafCompactionFinalize",
+                  context: sessionLabel,
+                },
+              );
+            } catch (err) {
+              try {
+                await this.withSessionQueue(
+                  this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+                  async () => {
+                    await recordAfterTurnCompactionRetry(leafDecision.reason);
+                  },
+                  {
+                    operationName: "afterTurnLeafCompactionFinalize",
+                    context: sessionLabel,
+                  },
+                );
+              } catch (recordErr) {
+                this.deps.log.warn(
+                  `[lcm] afterTurn: failed to queue deferred compaction retry for ${sessionLabel}: ${describeLogError(recordErr)}`,
+                );
+              }
+              this.deps.log.warn(
+                `[lcm] afterTurn: inline leaf compaction failed for ${sessionLabel}: ${describeLogError(err)}`,
+              );
+            }
+          })();
+        } else {
+          shouldRefreshBootstrapState = true;
+        }
+
+        if (!leafCompactionScheduled) {
+          const compactResult = await this.compact({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             sessionFile: params.sessionFile,
             tokenBudget,
             currentTokenCount: liveContextTokens,
+            compactionTarget: "threshold",
             legacyParams,
-            maxPasses: leafDecision.maxPasses,
-            leafChunkTokens: leafDecision.leafChunkTokens,
-            fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
-            activityBand: leafDecision.activityBand,
-            allowCondensedPasses: leafDecision.allowCondensedPasses,
-          }).catch(() => {
-            // Leaf compaction is best-effort and should not fail the caller.
           });
-        }
-
-        if (!leafCompactionScheduled) {
-          try {
-            await this.compact({
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              sessionFile: params.sessionFile,
-              tokenBudget,
-              currentTokenCount: liveContextTokens,
-              compactionTarget: "threshold",
-              legacyParams,
-            });
-          } catch {
-            // Proactive compaction is best-effort in the post-turn lifecycle.
+          const retryReason = thresholdDecision.shouldCompact ? "threshold" : null;
+          if (!compactResult.ok && retryReason) {
+            shouldRefreshBootstrapState = false;
+            await recordAfterTurnCompactionRetry(retryReason);
           }
         }
       } else if (thresholdDecision.shouldCompact || leafDecision.shouldCompact) {
@@ -4585,6 +4642,10 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.warn(
         `[lcm] afterTurn: compaction policy check failed for ${sessionLabel}: ${describeLogError(err)}`,
       );
+    }
+
+    if (shouldRefreshBootstrapState) {
+      await refreshAfterTurnBootstrapState();
     }
 
     this.deps.log.info(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4370,6 +4370,90 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  /**
+   * Run afterTurn inline leaf compaction and its state persistence in one queue slot.
+   *
+   * This preserves afterTurn's non-blocking behavior while ensuring later
+   * same-session work cannot observe stale bootstrap or retry-debt state between
+   * compaction completion and the follow-up persistence write.
+   */
+  private async runAfterTurnInlineLeafCompaction(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    tokenBudget: number;
+    currentTokenCount: number;
+    legacyParams?: Record<string, unknown>;
+    leafDecision: IncrementalCompactionDecision;
+    sessionLabel: string;
+  }): Promise<void> {
+    try {
+      await this.withSessionQueue(
+        this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+        async () => {
+          const recordAfterTurnCompactionRetry = async (): Promise<void> => {
+            try {
+              await this.recordDeferredCompactionDebt({
+                conversationId: params.conversationId,
+                reason: params.leafDecision.reason,
+                tokenBudget: params.tokenBudget,
+                currentTokenCount: params.currentTokenCount,
+              });
+            } catch (err) {
+              this.deps.log.warn(
+                `[lcm] afterTurn: failed to persist deferred compaction retry for ${params.sessionLabel}: ${describeLogError(err)}`,
+              );
+            }
+          };
+
+          try {
+            const compactResult = await this.executeLeafCompactionCore({
+              conversationId: params.conversationId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              tokenBudget: params.tokenBudget,
+              currentTokenCount: params.currentTokenCount,
+              legacyParams: params.legacyParams,
+              maxPasses: params.leafDecision.maxPasses,
+              leafChunkTokens: params.leafDecision.leafChunkTokens,
+              fallbackLeafChunkTokens: params.leafDecision.fallbackLeafChunkTokens,
+              activityBand: params.leafDecision.activityBand,
+              allowCondensedPasses: params.leafDecision.allowCondensedPasses,
+            });
+            if (compactResult.ok) {
+              try {
+                await this.refreshBootstrapState({
+                  conversationId: params.conversationId,
+                  sessionFile: params.sessionFile,
+                });
+              } catch (err) {
+                this.deps.log.warn(
+                  `[lcm] afterTurn: bootstrap checkpoint refresh failed for ${params.sessionLabel}: ${describeLogError(err)}`,
+                );
+              }
+              return;
+            }
+            await recordAfterTurnCompactionRetry();
+          } catch (err) {
+            await recordAfterTurnCompactionRetry();
+            this.deps.log.warn(
+              `[lcm] afterTurn: inline leaf compaction failed for ${params.sessionLabel}: ${describeLogError(err)}`,
+            );
+          }
+        },
+        {
+          operationName: "afterTurnLeafCompaction",
+          context: params.sessionLabel,
+        },
+      );
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: failed to queue inline leaf compaction for ${params.sessionLabel}: ${describeLogError(err)}`,
+      );
+    }
+  }
+
   async afterTurn(params: {
     sessionId: string;
     sessionKey?: string;
@@ -4559,57 +4643,17 @@ export class LcmContextEngine implements ContextEngine {
         if (leafDecision.shouldCompact) {
           leafCompactionScheduled = true;
           shouldRefreshBootstrapState = false;
-          void (async () => {
-            try {
-              const compactResult = await this.compactLeafAsync({
-                sessionId: params.sessionId,
-                sessionKey: params.sessionKey,
-                sessionFile: params.sessionFile,
-                tokenBudget,
-                currentTokenCount: liveContextTokens,
-                legacyParams,
-                maxPasses: leafDecision.maxPasses,
-                leafChunkTokens: leafDecision.leafChunkTokens,
-                fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
-                activityBand: leafDecision.activityBand,
-                allowCondensedPasses: leafDecision.allowCondensedPasses,
-              });
-              await this.withSessionQueue(
-                this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
-                async () => {
-                  if (compactResult.ok) {
-                    await refreshAfterTurnBootstrapState();
-                    return;
-                  }
-                  await recordAfterTurnCompactionRetry(leafDecision.reason);
-                },
-                {
-                  operationName: "afterTurnLeafCompactionFinalize",
-                  context: sessionLabel,
-                },
-              );
-            } catch (err) {
-              try {
-                await this.withSessionQueue(
-                  this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
-                  async () => {
-                    await recordAfterTurnCompactionRetry(leafDecision.reason);
-                  },
-                  {
-                    operationName: "afterTurnLeafCompactionFinalize",
-                    context: sessionLabel,
-                  },
-                );
-              } catch (recordErr) {
-                this.deps.log.warn(
-                  `[lcm] afterTurn: failed to queue deferred compaction retry for ${sessionLabel}: ${describeLogError(recordErr)}`,
-                );
-              }
-              this.deps.log.warn(
-                `[lcm] afterTurn: inline leaf compaction failed for ${sessionLabel}: ${describeLogError(err)}`,
-              );
-            }
-          })();
+          void this.runAfterTurnInlineLeafCompaction({
+            conversationId: conversation.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+            tokenBudget,
+            currentTokenCount: liveContextTokens,
+            legacyParams,
+            leafDecision,
+            sessionLabel,
+          });
         } else {
           shouldRefreshBootstrapState = true;
         }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4835,6 +4835,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     const evaluateLeafTriggerSpy = vi
@@ -4894,6 +4895,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
@@ -4907,7 +4909,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 1_536,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: true,
       compacted: false,
       reason: "below threshold",
@@ -4926,11 +4931,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
       runtimeContext,
     });
 
-    expect(compactLeafAsyncSpy).toHaveBeenCalled();
-    expect((compactLeafAsyncSpy.mock.calls[0]?.[0] as { tokenBudget?: unknown }).tokenBudget).toBe(2048);
-    expect((compactLeafAsyncSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
-      runtimeContext,
-    );
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalled();
+    });
+    expect((executeLeafCompactionCoreSpy.mock.calls[0]?.[0] as { tokenBudget?: unknown }).tokenBudget).toBe(2048);
+    expect((executeLeafCompactionCoreSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(runtimeContext);
     expect(compactSpy).not.toHaveBeenCalled();
   });
 
@@ -4964,6 +4969,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
@@ -4977,7 +4983,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 3_072,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: false,
       compacted: false,
       reason: "provider auth failure",
@@ -5013,7 +5022,108 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
     expect(maintenance?.reason).toBe("leaf-trigger");
     expect(maintenance?.tokenBudget).toBe(4_096);
-    expect(compactLeafAsyncSpy).toHaveBeenCalled();
+    expect(executeLeafCompactionCoreSpy).toHaveBeenCalled();
+  });
+
+  it("afterTurn keeps later same-session work behind inline leaf compaction persistence", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
+    const sessionId = "after-turn-inline-leaf-compaction-queue-order";
+    const sessionFile = createSessionFilePath("after-turn-inline-leaf-compaction-queue-order");
+    writeFileSync(sessionFile, "0123456789\n");
+
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const sessionFileStats = statSync(sessionFile);
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 1,
+      lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+      lastProcessedOffset: 1,
+      lastProcessedEntryHash: null,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 20_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 500,
+      threshold: 3_072,
+    });
+
+    let releaseLeafCompaction!: () => void;
+    let notifyLeafCompactionStarted!: () => void;
+    const leafCompactionStarted = new Promise<void>((resolve) => {
+      notifyLeafCompactionStarted = resolve;
+    });
+    const leafCompactionGate = new Promise<void>((resolve) => {
+      releaseLeafCompaction = resolve;
+    });
+
+    vi.spyOn(privateEngine, "executeLeafCompactionCore").mockImplementation(async () => {
+      notifyLeafCompactionStarted();
+      await leafCompactionGate;
+      return {
+        ok: false,
+        compacted: false,
+        reason: "provider auth failure",
+      };
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    await leafCompactionStarted;
+
+    let ingestResolved = false;
+    const ingestPromise = engine
+      .ingest({
+        sessionId,
+        message: makeMessage({ role: "user", content: "queued behind leaf compaction" }),
+      })
+      .then((result) => {
+        ingestResolved = true;
+        return result;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(ingestResolved).toBe(false);
+
+    releaseLeafCompaction();
+
+    const ingestResult = await ingestPromise;
+    expect(ingestResult.ingested).toBe(true);
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.reason).toBe("leaf-trigger");
   });
 
   it("afterTurn falls back to the default token budget when no budget is provided", async () => {
@@ -5041,6 +5151,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
@@ -5118,7 +5229,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 3_072,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: true,
       compacted: false,
       reason: "below threshold",
@@ -5138,10 +5252,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       legacyCompactionParams,
     });
 
-    expect(compactLeafAsyncSpy).toHaveBeenCalled();
-    expect((compactLeafAsyncSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(
-      legacyCompactionParams,
-    );
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalled();
+    });
+    expect((executeLeafCompactionCoreSpy.mock.calls[0]?.[0] as { legacyParams?: unknown }).legacyParams).toBe(legacyCompactionParams);
     expect(compactSpy).not.toHaveBeenCalled();
   });
 
@@ -6162,7 +6276,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 3_072,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: true,
       compacted: true,
       reason: "compacted",
@@ -6203,12 +6320,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
       },
     });
 
-    expect(compactLeafAsyncSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId,
-        maxPasses: 2,
-      }),
-    );
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          maxPasses: 2,
+        }),
+      );
+    });
   });
 
   it("afterTurn increases the working leaf chunk target for busy sessions when dynamic sizing is enabled", async () => {
@@ -6240,6 +6359,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
@@ -6255,7 +6375,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 3_072,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: true,
       compacted: true,
       reason: "compacted",
@@ -6274,14 +6397,16 @@ describe("LcmContextEngine fidelity and token budget", () => {
       tokenBudget: 128_000,
     });
 
-    expect(compactLeafAsyncSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId,
-        leafChunkTokens: 40_000,
-        fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
-        activityBand: "high",
-      }),
-    );
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          leafChunkTokens: 40_000,
+          fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+          activityBand: "high",
+        }),
+      );
+    });
     expect(infoLog).toHaveBeenCalledWith(
       expect.stringContaining("activityBand=high"),
     );
@@ -6308,6 +6433,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           observed?: number,
         ) => Promise<unknown>;
       };
+      executeLeafCompactionCore: (...args: unknown[]) => Promise<unknown>;
     };
 
     await engine.ingest({
@@ -6337,7 +6463,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       currentTokens: 500,
       threshold: 3_072,
     });
-    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
       ok: true,
       compacted: true,
       reason: "compacted",
@@ -6367,14 +6496,16 @@ describe("LcmContextEngine fidelity and token budget", () => {
       },
     });
 
-    expect(compactLeafAsyncSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId,
-        leafChunkTokens: 40_000,
-        fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
-        activityBand: "medium",
-      }),
-    );
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          leafChunkTokens: 40_000,
+          fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+          activityBand: "medium",
+        }),
+      );
+    });
   });
 
   it("evaluateIncrementalCompaction restricts hot-cache leaf-trigger maintenance to leaf-only passes", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4934,6 +4934,88 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(compactSpy).not.toHaveBeenCalled();
   });
 
+  it("afterTurn keeps the bootstrap checkpoint stale and records retry debt when inline leaf compaction fails", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
+    const sessionId = "after-turn-inline-leaf-compaction-failure";
+    const sessionFile = createSessionFilePath("after-turn-inline-leaf-compaction-failure");
+    writeFileSync(sessionFile, "0123456789\n");
+
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const sessionFileStats = statSync(sessionFile);
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 1,
+      lastSeenMtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+      lastProcessedOffset: 1,
+      lastProcessedEntryHash: null,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 20_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 500,
+      threshold: 3_072,
+    });
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync").mockResolvedValue({
+      ok: false,
+      compacted: false,
+      reason: "provider auth failure",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    await vi.waitFor(async () => {
+      const maintenance = await engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation.conversationId);
+      expect(maintenance?.pending).toBe(true);
+    });
+
+    const bootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation.conversationId);
+    expect(bootstrapState).not.toBeNull();
+    expect(bootstrapState?.lastSeenSize).toBe(1);
+    expect(bootstrapState?.lastProcessedOffset).toBe(1);
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.reason).toBe("leaf-trigger");
+    expect(maintenance?.tokenBudget).toBe(4_096);
+    expect(compactLeafAsyncSpy).toHaveBeenCalled();
+  });
+
   it("afterTurn falls back to the default token budget when no budget is provided", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(


### PR DESCRIPTION
## What
Fixes inline compaction failure handling so lossless-claw does not advance the bootstrap checkpoint when proactive inline compaction fails after `afterTurn()` ingestion. The fix preserves the old bootstrap checkpoint on inline compaction failure and records deferred retry debt so compaction can retry later after auth/config recovery.

## Why
Issue #426 reported that a compaction auth/config failure could leave `conversation_bootstrap_state.last_processed_offset` aligned with EOF even though no summary was written. That made the conversation look fully processed and prevented later retries once credentials or provider configuration were corrected.

## Root Cause
`afterTurn()` refreshed the bootstrap checkpoint immediately after ingest, before the inline compaction path had succeeded or failed. When inline leaf compaction then failed, the checkpoint had already advanced, so future bootstrap and recovery logic saw no stale frontier to revisit.

## Changes
- Delay `afterTurn()` bootstrap checkpoint refresh until the inline compaction outcome is known
- Preserve the prior bootstrap checkpoint when inline leaf compaction fails
- Record deferred retry debt on inline compaction failure so later `assemble()` or `maintain()` runs can retry
- Record retry debt for failed inline threshold compaction when threshold compaction was actually needed
- Add a regression test covering inline leaf compaction auth failure with a stale checkpoint

## Risks
- The inline leaf compaction finalize path now performs a follow-up queued write after async compaction completes, so the timing of checkpoint persistence changes slightly
- Verification covered targeted engine behavior and a build, not the entire repository test suite

## Testing
- `npx vitest run test/engine.test.ts -t "afterTurn keeps the bootstrap checkpoint stale and records retry debt when inline leaf compaction fails"`
  - Passed: `1 passed | 161 skipped`
- `npm test -- test/engine.test.ts`
  - Passed: `162 passed`
- `npm run build`
  - Passed: `dist/index.js` built successfully

Fixes #426
