### PR TITLE
feat: add guided lossless restore workflow

### DIFF
--- a/.changeset/curly-crows-double.md
+++ b/.changeset/curly-crows-double.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add guided `/lossless restore` support for `rotate-latest` and timestamped SQLite backups. The restore output now shows exact offline shell commands that archive the current database plus stale WAL/SHM sidecars before copying the chosen snapshot back into place, and bootstrap now treats a guided restore as authoritative so newer transcript history is not replayed into the restored conversation.

--- a/cli-metadata.js
+++ b/cli-metadata.js
@@ -1,0 +1,1 @@
+export { default } from "./dist/cli-metadata.js";

--- a/cli-metadata.ts
+++ b/cli-metadata.ts
@@ -1,0 +1,31 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveLcmConfigWithDiagnostics } from "./src/db/config.js";
+import { registerLcmCli } from "./src/plugin/lcm-cli.js";
+
+export default definePluginEntry({
+  id: "lossless-claw",
+  name: "Lossless Context Management",
+  description:
+    "DAG-based conversation summarization with incremental compaction, full-text search, and sub-agent expansion",
+  register(api) {
+    api.registerCli(
+      ({ program, config, logger }) => {
+        const pluginConfig = config.plugins?.entries?.["lossless-claw"]?.config ?? {};
+        registerLcmCli({
+          program,
+          config: resolveLcmConfigWithDiagnostics(process.env, pluginConfig).config,
+          logger,
+        });
+      },
+      {
+        descriptors: [
+          {
+            name: "lossless",
+            description: "Operate Lossless Claw maintenance commands outside the running gateway",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+  },
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,6 +266,22 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 
 Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. It then rewrites the current session transcript and checkpoints the same conversation at the new transcript frontier so bootstrap does not replay the dropped transcript history. Existing summaries, context items, and conversation identity stay in place. If you want additional timestamped snapshots, run `/lcm backup` explicitly before `/lcm rotate`.
 
+### `/lcm restore`
+
+`/lcm restore` is a guided operator surface for restoring one of those SQLite snapshots safely.
+
+- `/lcm restore` with no target lists the currently available restore targets.
+- `latest` maps to the rolling `rotate-latest` backup when it exists.
+- timestamped/manual snapshots use the stable target name derived from the `.bak` filename.
+- `/lcm restore <target>` prints the exact shell recipe to run after OpenClaw is stopped.
+
+The emitted restore recipe is intentionally conservative:
+
+- it archives the current `lcm.db` before overwriting it
+- it archives stale `lcm.db-wal` and `lcm.db-shm` sidecars instead of leaving them behind
+- it copies the chosen backup into place as the new main database file
+- it marks bootstrap checkpoints as restore-pending so the next startup trusts the restored DB snapshot and does not replay transcript history that was written after the backup was taken
+
 ## Environment-only knobs outside plugin config
 
 These settings are not part of `plugins.entries.lossless-claw.config`, but they still affect the system:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -273,14 +273,17 @@ Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backu
 - `/lcm restore` with no target lists the currently available restore targets.
 - `latest` maps to the rolling `rotate-latest` backup when it exists.
 - timestamped/manual snapshots use the stable target name derived from the `.bak` filename.
-- `/lcm restore <target>` prints the exact shell recipe to run after OpenClaw is stopped.
+- `/lcm restore <target>` prints the exact `openclaw lossless restore <target>` command to run from your shell.
 
-The emitted restore recipe is intentionally conservative:
+The external restore command is intentionally conservative:
 
+- it pins `OPENCLAW_STATE_DIR` so the stop/start/restore cycle targets the same OpenClaw profile as the running slash command
+- it stops the gateway before touching the database
 - it archives the current `lcm.db` before overwriting it
 - it archives stale `lcm.db-wal` and `lcm.db-shm` sidecars instead of leaving them behind
 - it copies the chosen backup into place as the new main database file
 - it marks bootstrap checkpoints as restore-pending so the next startup trusts the restored DB snapshot and does not replay transcript history that was written after the backup was taken
+- it starts the gateway again and verifies RPC health before reporting success
 
 ## Environment-only knobs outside plugin config
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dag"
   ],
   "scripts": {
-    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@mariozechner/*\" --minify-whitespace",
+    "build": "esbuild index.ts cli-metadata.ts --bundle --platform=node --target=node22 --format=esm --outdir=dist --external:openclaw --external:\"@mariozechner/*\" --minify-whitespace",
     "changeset": "changeset",
     "release:verify": "npm run build && npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
@@ -24,6 +24,7 @@
   },
   "files": [
     "dist/",
+    "cli-metadata.js",
     "skills/",
     "openclaw.plugin.json",
     "docs/",

--- a/skills/lossless-claw/SKILL.md
+++ b/skills/lossless-claw/SKILL.md
@@ -13,7 +13,7 @@ Start here:
 2. If they need a quick health check, tell them to run `/lossless` (`/lcm` is the shorter alias).
 3. If they suspect summary corruption or truncation, use `/lossless doctor`.
 4. If they want high-confidence junk/session cleanup guidance, use `/lossless doctor clean` before recommending any deletes.
-5. If they ask how `/new`, `/reset`, or `/lossless rotate` interacts with LCM, read the session-lifecycle reference before answering.
+5. If they ask how `/new`, `/reset`, `/lossless rotate`, or `/lossless restore` interacts with LCM, read the session-lifecycle reference before answering.
 6. Load the relevant reference file instead of improvising details from memory.
 
 Reference map:
@@ -22,7 +22,7 @@ Reference map:
 - Internal model and data flow: `references/architecture.md`
 - Diagnostics and summary-health workflow: `references/diagnostics.md`
 - Recall tools and when to use them: `references/recall-tools.md`
-- `/new`, `/reset`, and `/lossless rotate` behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
+- `/new`, `/reset`, `/lossless rotate`, and `/lossless restore` behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
 
 Working rules:
 

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -54,9 +54,10 @@ This makes rotate the lightweight option when the problem is transcript bloat ra
 - `/lossless restore` lists available restore targets
 - `/lossless restore latest` resolves the rolling rotate backup
 - `/lossless restore <timestamped-target>` resolves a named manual/timestamped snapshot
-- the command prints the exact shell recipe to run after OpenClaw is stopped
-- that recipe archives any existing `lcm.db`, `lcm.db-wal`, and `lcm.db-shm` files before copying the chosen snapshot into place
+- the command prints the exact `openclaw lossless restore <target>` command to run from your shell
+- that external command pins `OPENCLAW_STATE_DIR`, stops the gateway, archives any existing `lcm.db`, `lcm.db-wal`, and `lcm.db-shm` files, then copies the chosen snapshot into place
 - after the copy, it marks bootstrap checkpoints as restore-pending so startup trusts the restored DB and skips replaying transcript history newer than the backup
+- it then restarts the gateway and verifies RPC health before reporting success
 
 ## Important limitation
 

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -47,6 +47,17 @@ That behavior preserves continuity across session resets for the same chat ident
 
 This makes rotate the lightweight option when the problem is transcript bloat rather than LCM conversation structure.
 
+## `/lossless restore`
+
+`/lossless restore` is the safe follow-up path for those SQLite backups.
+
+- `/lossless restore` lists available restore targets
+- `/lossless restore latest` resolves the rolling rotate backup
+- `/lossless restore <timestamped-target>` resolves a named manual/timestamped snapshot
+- the command prints the exact shell recipe to run after OpenClaw is stopped
+- that recipe archives any existing `lcm.db`, `lcm.db-wal`, and `lcm.db-shm` files before copying the chosen snapshot into place
+- after the copy, it marks bootstrap checkpoints as restore-pending so startup trusts the restored DB and skips replaying transcript history newer than the backup
+
 ## Important limitation
 
 There is still **no plugin-specific `/new` vs `/reset` split** in stock lossless-claw docs or runtime behavior.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -162,6 +162,17 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
 }
 
+function ensureBootstrapStateColumns(db: DatabaseSync): void {
+  const bootstrapColumns = db.prepare(`PRAGMA table_info(conversation_bootstrap_state)`).all() as SummaryColumnInfo[];
+  const hasRestoreGuardPending = bootstrapColumns.some((col) => col.name === "restore_guard_pending");
+
+  if (!hasRestoreGuardPending) {
+    db.exec(
+      `ALTER TABLE conversation_bootstrap_state ADD COLUMN restore_guard_pending INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+}
+
 function ensureMessageIdentityHashColumn(db: DatabaseSync): void {
   const messageColumns = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
   const hasIdentityHash = messageColumns.some((col) => col.name === "identity_hash");
@@ -849,6 +860,7 @@ export function runLcmMigrations(
       last_seen_mtime_ms INTEGER NOT NULL,
       last_processed_offset INTEGER NOT NULL,
       last_processed_entry_hash TEXT,
+      restore_guard_pending INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -970,6 +982,9 @@ export function runLcmMigrations(
   );
   runMigrationStep("ensureCompactionTelemetryColumns", log, () =>
     ensureCompactionTelemetryColumns(db),
+  );
+  runMigrationStep("ensureBootstrapStateColumns", log, () =>
+    ensureBootstrapStateColumns(db),
   );
   runVersionedBackfillStep(db, "backfillSummaryDepths", log, () => backfillSummaryDepths(db));
   // Index on depth — created AFTER backfillSummaryDepths to avoid index

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3609,6 +3609,29 @@ export class LcmContextEngine implements ContextEngine {
             bootstrapState = null;
           }
 
+          // Guided restore marks checkpoints as restore-pending after a DB
+          // snapshot is copied back into place. On the next startup, trust the
+          // restored DB as the source of truth and advance the checkpoint to the
+          // live transcript EOF without replaying any transcript history.
+          if (
+            bootstrapState &&
+            bootstrapState.sessionFilePath === params.sessionFile &&
+            bootstrapState.restoreGuardPending
+          ) {
+            if (!conversation.bootstrappedAt) {
+              await this.conversationStore.markConversationBootstrapped(conversationId);
+            }
+            await persistBootstrapState(conversationId);
+            this.deps.log.info(
+              `[lcm] bootstrap: restore guard consumed conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} duration=${formatDurationMs(Date.now() - startedAt)}`,
+            );
+            return {
+              bootstrapped: false,
+              importedMessages: 0,
+              reason: "restore guard skipped transcript replay",
+            };
+          }
+
           // If the transcript file is byte-for-byte unchanged from the last
           // successful bootstrap checkpoint, skip reopening and reparsing it.
           if (

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -243,9 +243,10 @@ function resolvePluginConfig(api: OpenClawPluginApi): Record<string, unknown> | 
   return toPluginConfig(pluginEntry?.config);
 }
 
-/** CLI loads provide an empty runtime surface; skip gateway-only initialization there. */
+/** CLI metadata loads provide a truly empty runtime surface; skip gateway-only initialization there. */
 function shouldRegisterCliOnly(api: OpenClawPluginApi): boolean {
-  return typeof api.runtime?.logging?.getChildLogger !== "function";
+  const runtime = api.runtime;
+  return !!runtime && typeof runtime === "object" && Object.keys(runtime).length === 0;
 }
 
 /** Register the external `openclaw lossless` CLI surface with the resolved plugin config. */

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { createLcmExpandQueryTool } from "../tools/lcm-expand-query-tool.js";
 import { createLcmExpandTool } from "../tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
 import { createLcmCommand } from "./lcm-command.js";
+import { registerLcmCli } from "./lcm-cli.js";
 import type { LcmDependencies } from "../types.js";
 
 /** Parse `agent:<agentId>:<suffix...>` session keys. */
@@ -240,6 +241,33 @@ function resolvePluginConfig(api: OpenClawPluginApi): Record<string, unknown> | 
   const entries = toPluginConfig(plugins?.entries);
   const pluginEntry = toPluginConfig(entries?.["lossless-claw"]);
   return toPluginConfig(pluginEntry?.config);
+}
+
+/** CLI loads provide an empty runtime surface; skip gateway-only initialization there. */
+function shouldRegisterCliOnly(api: OpenClawPluginApi): boolean {
+  return typeof api.runtime?.logging?.getChildLogger !== "function";
+}
+
+/** Register the external `openclaw lossless` CLI surface with the resolved plugin config. */
+function registerLosslessCli(api: OpenClawPluginApi, config: LcmDependencies["config"]): void {
+  api.registerCli(
+    ({ program, logger }) => {
+      registerLcmCli({
+        program,
+        config,
+        logger,
+      });
+    },
+    {
+      descriptors: [
+        {
+          name: "lossless",
+          description: "Operate Lossless Claw maintenance commands outside the running gateway",
+          hasSubcommands: true,
+        },
+      ],
+    },
+  );
 }
 
 function truncateErrorMessage(message: string, maxChars = 240): string {
@@ -1942,7 +1970,15 @@ const lcmPlugin = {
   },
 
   register(api: OpenClawPluginApi) {
+    if (shouldRegisterCliOnly(api)) {
+      const config = resolveLcmConfigWithDiagnostics(process.env, resolvePluginConfig(api)).config;
+      registerLosslessCli(api, config);
+      return;
+    }
+
     const deps = createLcmDependencies(api);
+    registerLosslessCli(api, deps.config);
+
     const dbPath = deps.config.databasePath;
     const normalizedDbPath = normalizePath(dbPath);
 

--- a/src/plugin/lcm-cli.ts
+++ b/src/plugin/lcm-cli.ts
@@ -5,6 +5,8 @@ import {
   buildLcmRestoreCliCommand,
   listLcmRestoreTargets,
   type LcmRestoreExecutionResult,
+  type LcmRestoreRollbackResult,
+  rollbackLcmDatabaseRestore,
   restoreLcmDatabaseFromBackup,
 } from "./lcm-db-restore.js";
 
@@ -77,15 +79,39 @@ function renderRestoreTargets(config: LcmConfig, writer: Pick<NodeJS.WriteStream
   }
 }
 
-function buildRestoreFailureMessage(error: unknown, restore: LcmRestoreExecutionResult | null): string {
-  const baseMessage = error instanceof Error ? error.message : String(error);
-  if (!restore) {
+function buildRestoreFailureMessage(params: {
+  error: unknown;
+  restore: LcmRestoreExecutionResult | null;
+  rollback: LcmRestoreRollbackResult | null;
+  rollbackError: unknown;
+}): string {
+  const baseMessage = params.error instanceof Error ? params.error.message : String(params.error);
+  const rollbackErrorMessage =
+    params.rollbackError instanceof Error
+      ? params.rollbackError.message
+      : params.rollbackError
+        ? String(params.rollbackError)
+        : "";
+  if (params.rollback) {
+    const rollbackLines = [
+      "Restore failed, but Lossless Claw rolled the database back to its pre-restore snapshot.",
+      `Original error: ${baseMessage}`,
+      `Rollback quick_check: ${params.rollback.quickCheck}`,
+      params.rollback.rollbackDbArchivePath ? `Archived failed restore DB: ${params.rollback.rollbackDbArchivePath}` : null,
+      params.rollback.rollbackWalArchivePath ? `Archived failed restore WAL: ${params.rollback.rollbackWalArchivePath}` : null,
+      params.rollback.rollbackShmArchivePath ? `Archived failed restore SHM: ${params.rollback.rollbackShmArchivePath}` : null,
+      rollbackErrorMessage ? `Rollback follow-up error: ${rollbackErrorMessage}` : null,
+    ].filter((line): line is string => Boolean(line));
+    return rollbackLines.join("\n");
+  }
+
+  if (!params.restore) {
     return baseMessage;
   }
   const preservedState = [
-    restore.currentBackupPath ? `Previous DB backup: ${restore.currentBackupPath}` : null,
-    restore.walArchivePath ? `Archived WAL: ${restore.walArchivePath}` : null,
-    restore.shmArchivePath ? `Archived SHM: ${restore.shmArchivePath}` : null,
+    params.restore.currentBackupPath ? `Previous DB backup: ${params.restore.currentBackupPath}` : null,
+    params.restore.walArchivePath ? `Archived WAL: ${params.restore.walArchivePath}` : null,
+    params.restore.shmArchivePath ? `Archived SHM: ${params.restore.shmArchivePath}` : null,
   ].filter((line): line is string => Boolean(line));
   if (preservedState.length === 0) {
     return baseMessage;
@@ -119,6 +145,9 @@ export function runLcmRestoreCli(params: {
   writeLine("", writer);
 
   let restore: LcmRestoreExecutionResult | null = null;
+  let rollback: LcmRestoreRollbackResult | null = null;
+  let rollbackError: unknown = null;
+  let gatewayStarted = false;
   try {
     params.logger?.info?.(`[lcm] restore-cli: stopping gateway for target=${target.name}`);
     writeLine("1. Stopping gateway...", writer);
@@ -144,13 +173,53 @@ export function runLcmRestoreCli(params: {
     params.logger?.info?.(`[lcm] restore-cli: starting gateway after target=${target.name}`);
     writeLine("3. Starting gateway...", writer);
     runNestedOpenClawCommand(["gateway", "start", "--json"]);
+    gatewayStarted = true;
 
     writeLine("4. Verifying gateway health...", writer);
     runNestedOpenClawCommand(["gateway", "status", "--require-rpc", "--json"]);
     writeLine("", writer);
     writeLine("Restore completed and gateway health checks passed.", writer);
   } catch (error) {
-    throw new Error(buildRestoreFailureMessage(error, restore));
+    if (restore) {
+      try {
+        if (gatewayStarted) {
+          params.logger?.warn?.(`[lcm] restore-cli: restore verification failed; stopping gateway before rollback target=${target.name}`);
+          writeLine("5. Stopping gateway for rollback...", writer);
+          runNestedOpenClawCommand(["gateway", "stop", "--json"]);
+          gatewayStarted = false;
+        }
+
+        params.logger?.warn?.(`[lcm] restore-cli: rolling back failed restore target=${target.name}`);
+        writeLine("6. Rolling back to the previous database snapshot...", writer);
+        rollback = rollbackLcmDatabaseRestore({ restore });
+        writeLine(`   rollback quick_check: ${rollback.quickCheck}`, writer);
+        if (rollback.rollbackDbArchivePath) {
+          writeLine(`   archived failed restore db: ${rollback.rollbackDbArchivePath}`, writer);
+        }
+        if (rollback.rollbackWalArchivePath) {
+          writeLine(`   archived failed restore wal: ${rollback.rollbackWalArchivePath}`, writer);
+        }
+        if (rollback.rollbackShmArchivePath) {
+          writeLine(`   archived failed restore shm: ${rollback.rollbackShmArchivePath}`, writer);
+        }
+
+        params.logger?.warn?.(`[lcm] restore-cli: starting gateway after rollback target=${target.name}`);
+        writeLine("7. Starting gateway after rollback...", writer);
+        runNestedOpenClawCommand(["gateway", "start", "--json"]);
+
+        writeLine("8. Verifying gateway health after rollback...", writer);
+        runNestedOpenClawCommand(["gateway", "status", "--require-rpc", "--json"]);
+      } catch (rollbackFailure) {
+        rollbackError = rollbackFailure;
+      }
+    }
+
+    throw new Error(buildRestoreFailureMessage({
+      error,
+      restore,
+      rollback,
+      rollbackError,
+    }));
   }
 }
 

--- a/src/plugin/lcm-cli.ts
+++ b/src/plugin/lcm-cli.ts
@@ -1,0 +1,183 @@
+import { spawnSync } from "node:child_process";
+import type { Command } from "commander";
+import { resolveOpenclawStateDir, type LcmConfig } from "../db/config.js";
+import {
+  buildLcmRestoreCliCommand,
+  listLcmRestoreTargets,
+  type LcmRestoreExecutionResult,
+  restoreLcmDatabaseFromBackup,
+} from "./lcm-db-restore.js";
+
+type LcmCliLogger = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+type GatewayCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+function writeLine(line = "", writer: Pick<NodeJS.WriteStream, "write"> = process.stdout): void {
+  writer.write(`${line}\n`);
+}
+
+function readCommandOutput(stream: string | Buffer | null | undefined): string {
+  if (typeof stream === "string") {
+    return stream.trim();
+  }
+  if (Buffer.isBuffer(stream)) {
+    return stream.toString("utf8").trim();
+  }
+  return "";
+}
+
+/**
+ * Run a nested OpenClaw CLI command using the current process invocation.
+ */
+function runNestedOpenClawCommand(args: string[]): GatewayCommandResult {
+  const scriptPath = process.argv[1]?.trim();
+  const command = scriptPath ? process.execPath : "openclaw";
+  const commandArgs = scriptPath ? [scriptPath, ...args] : args;
+  const result = spawnSync(command, commandArgs, {
+    encoding: "utf8",
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = readCommandOutput(result.stdout);
+  const stderr = readCommandOutput(result.stderr);
+  if (result.status !== 0) {
+    const details = [stderr, stdout].filter(Boolean).join("\n");
+    throw new Error(details || `openclaw ${args.join(" ")} failed with exit code ${result.status ?? 1}`);
+  }
+  return { stdout, stderr };
+}
+
+/**
+ * Render the available restore targets as exact CLI invocations.
+ */
+function renderRestoreTargets(config: LcmConfig, writer: Pick<NodeJS.WriteStream, "write"> = process.stdout): void {
+  const targets = listLcmRestoreTargets(config.databasePath);
+  const stateDir = resolveOpenclawStateDir(process.env);
+  writeLine("Lossless Claw Restore", writer);
+  writeLine("", writer);
+  writeLine(`State dir: ${stateDir}`, writer);
+  if (targets.length === 0) {
+    writeLine("No restore snapshots were found for the configured LCM database.", writer);
+    writeLine("Create one first with `/lossless backup` or `/lossless rotate`.", writer);
+    return;
+  }
+
+  writeLine("Available targets:", writer);
+  for (const target of targets) {
+    const label = target.kind === "latest" ? "latest rotate backup" : target.label;
+    writeLine(`- ${target.name} (${label})`, writer);
+    writeLine(`  ${buildLcmRestoreCliCommand({ target: target.name, stateDir })}`, writer);
+  }
+}
+
+function buildRestoreFailureMessage(error: unknown, restore: LcmRestoreExecutionResult | null): string {
+  const baseMessage = error instanceof Error ? error.message : String(error);
+  if (!restore) {
+    return baseMessage;
+  }
+  const preservedState = [
+    restore.currentBackupPath ? `Previous DB backup: ${restore.currentBackupPath}` : null,
+    restore.walArchivePath ? `Archived WAL: ${restore.walArchivePath}` : null,
+    restore.shmArchivePath ? `Archived SHM: ${restore.shmArchivePath}` : null,
+  ].filter((line): line is string => Boolean(line));
+  if (preservedState.length === 0) {
+    return baseMessage;
+  }
+  return [baseMessage, ...preservedState].join("\n");
+}
+
+/**
+ * Execute the offline restore orchestration around the selected SQLite snapshot.
+ */
+export function runLcmRestoreCli(params: {
+  config: LcmConfig;
+  target: string;
+  logger?: LcmCliLogger;
+  writer?: Pick<NodeJS.WriteStream, "write">;
+}): void {
+  const writer = params.writer ?? process.stdout;
+  const target = listLcmRestoreTargets(params.config.databasePath).find(
+    (candidate) => candidate.name === params.target,
+  );
+  if (!target) {
+    throw new Error(`Unknown restore target "${params.target}". Run \`openclaw lossless restore\` to list available targets.`);
+  }
+
+  writeLine("Lossless Claw Restore", writer);
+  writeLine("", writer);
+  writeLine(`Target: ${target.name}`, writer);
+  writeLine(`Snapshot: ${target.backupPath}`, writer);
+  writeLine(`Database: ${params.config.databasePath}`, writer);
+  writeLine(`State dir: ${resolveOpenclawStateDir(process.env)}`, writer);
+  writeLine("", writer);
+
+  let restore: LcmRestoreExecutionResult | null = null;
+  try {
+    params.logger?.info?.(`[lcm] restore-cli: stopping gateway for target=${target.name}`);
+    writeLine("1. Stopping gateway...", writer);
+    runNestedOpenClawCommand(["gateway", "stop", "--json"]);
+
+    params.logger?.info?.(`[lcm] restore-cli: restoring snapshot ${target.backupPath}`);
+    writeLine("2. Restoring snapshot...", writer);
+    restore = restoreLcmDatabaseFromBackup({
+      databasePath: params.config.databasePath,
+      target,
+    });
+    writeLine(`   quick_check: ${restore.quickCheck}`, writer);
+    if (restore.currentBackupPath) {
+      writeLine(`   archived current db: ${restore.currentBackupPath}`, writer);
+    }
+    if (restore.walArchivePath) {
+      writeLine(`   archived wal: ${restore.walArchivePath}`, writer);
+    }
+    if (restore.shmArchivePath) {
+      writeLine(`   archived shm: ${restore.shmArchivePath}`, writer);
+    }
+
+    params.logger?.info?.(`[lcm] restore-cli: starting gateway after target=${target.name}`);
+    writeLine("3. Starting gateway...", writer);
+    runNestedOpenClawCommand(["gateway", "start", "--json"]);
+
+    writeLine("4. Verifying gateway health...", writer);
+    runNestedOpenClawCommand(["gateway", "status", "--require-rpc", "--json"]);
+    writeLine("", writer);
+    writeLine("Restore completed and gateway health checks passed.", writer);
+  } catch (error) {
+    throw new Error(buildRestoreFailureMessage(error, restore));
+  }
+}
+
+/**
+ * Register the `openclaw lossless` plugin CLI surface.
+ */
+export function registerLcmCli(params: {
+  program: Command;
+  config: LcmConfig;
+  logger?: LcmCliLogger;
+}): void {
+  const lossless = params.program
+    .command("lossless")
+    .description("Operate Lossless Claw maintenance commands outside the running gateway");
+
+  lossless
+    .command("restore [target]")
+    .description("List restorable snapshots or restore one safely with gateway orchestration")
+    .action((target?: string) => {
+      if (!target?.trim()) {
+        renderRestoreTargets(params.config);
+        return;
+      }
+      runLcmRestoreCli({
+        config: params.config,
+        target: target.trim(),
+        logger: params.logger,
+      });
+    });
+}

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -2,14 +2,14 @@ import { existsSync, statSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import packageJson from "../../package.json" with { type: "json" };
 import { formatTimestamp } from "../compaction.js";
-import type { LcmConfig } from "../db/config.js";
+import { resolveOpenclawStateDir, type LcmConfig } from "../db/config.js";
 import type { RotateSessionStorageWithBackupResult } from "../engine.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
-import { buildLcmRestoreShellScript, listLcmRestoreTargets } from "./lcm-db-restore.js";
+import { buildLcmRestoreCliCommand, listLcmRestoreTargets } from "./lcm-db-restore.js";
 import { describeLogError } from "../lcm-log.js";
 import {
   applyDoctorCleaners,
@@ -943,6 +943,7 @@ async function buildBackupText(params: {
 
 function buildRestoreTargetsSection(config: LcmConfig): string {
   const targets = listLcmRestoreTargets(config.databasePath);
+  const stateDir = resolveOpenclawStateDir(process.env);
   if (targets.length === 0) {
     return buildSection("💾 Restore targets", [
       buildStatLine("status", "unavailable"),
@@ -952,7 +953,11 @@ function buildRestoreTargetsSection(config: LcmConfig): string {
 
   return buildSection("💾 Restore targets", targets.map((target) => {
     const label = target.kind === "latest" ? "latest rotate backup" : target.label;
-    return `${formatCommand(`${VISIBLE_COMMAND} restore ${target.name}`)} · ${label} · ${target.backupPath}`;
+    const cliCommand = buildLcmRestoreCliCommand({
+      target: target.name,
+      stateDir,
+    });
+    return `${formatCommand(`${VISIBLE_COMMAND} restore ${target.name}`)} → ${formatCommand(cliCommand)} · ${label} · ${target.backupPath}`;
   }));
 }
 
@@ -987,9 +992,9 @@ function buildRestoreText(params: {
       buildRestoreTargetsSection(params.config),
       "",
       buildSection("🧭 Notes", [
-        `Run ${formatCommand(`${VISIBLE_COMMAND} restore latest`)} or one of the exact target commands above to render the shell restore recipe.`,
-        "Restore recipes archive the current DB and any stale WAL/SHM sidecars before replacing the main SQLite file.",
-        "After the restore copy, Lossless Claw marks bootstrap checkpoints as restore-pending so the next startup will not replay newer transcript history into the restored DB snapshot.",
+        `Run ${formatCommand(`${VISIBLE_COMMAND} restore latest`)} or one of the exact target commands above to reprint the offline OpenClaw restore command.`,
+        "The external command stops the gateway, archives the current DB plus any stale WAL/SHM sidecars, restores the chosen snapshot, then restarts and health-checks the gateway.",
+        "During the restore copy, Lossless Claw marks bootstrap checkpoints as restore-pending so the next startup will trust the restored DB snapshot instead of replaying newer transcript history into it.",
       ]),
     );
     return lines.join("\n");
@@ -1008,37 +1013,29 @@ function buildRestoreText(params: {
     return lines.join("\n");
   }
 
-  const shellScript = buildLcmRestoreShellScript({
-    databasePath: params.config.databasePath,
-    target,
+  const restoreCommand = buildLcmRestoreCliCommand({
+    target: target.name,
+    stateDir: resolveOpenclawStateDir(process.env),
   });
-  if (!shellScript) {
-    lines.push(
-      buildSection("💾 Restore target", [
-        buildStatLine("status", "unavailable"),
-        buildStatLine("reason", "Lossless Claw restore requires a file-backed SQLite database path."),
-      ]),
-    );
-    return lines.join("\n");
-  }
 
   lines.push(
     buildSection("💾 Restore target", [
       buildStatLine("status", "ready"),
       buildStatLine("target", target.name),
       buildStatLine("snapshot", target.backupPath),
+      buildStatLine("offline command", formatCommand(restoreCommand)),
       buildStatLine("preview command", formatCommand(`${VISIBLE_COMMAND} restore ${target.name}`)),
     ]),
     "",
     buildSection("🧭 Notes", [
-      "Stop OpenClaw before running this shell recipe so the live process is not holding the database open.",
-      "The recipe archives the current DB plus stale `-wal` and `-shm` sidecars instead of deleting them.",
-      "The final SQLite update marks restore checkpoints as pending so bootstrap will trust the restored DB and skip transcript replay on the next startup.",
+      "Run the external command from your shell, not inside the active OpenClaw slash-command session.",
+      "The command stops the gateway before touching the database, archives the current DB plus stale `-wal` and `-shm` sidecars instead of deleting them, then restores the chosen snapshot.",
+      "After the restore copy, Lossless Claw marks bootstrap checkpoints as pending so bootstrap will trust the restored DB, restart the gateway, and verify RPC health before reporting success.",
     ]),
     "",
-    "**🛠️ Shell Recipe**",
+    "**🛠️ External Command**",
     "```sh",
-    shellScript,
+    restoreCommand,
     "```",
   );
   return lines.join("\n");

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -9,6 +9,7 @@ import type { LcmDependencies } from "../types.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
+import { buildLcmRestoreShellScript, listLcmRestoreTargets } from "./lcm-db-restore.js";
 import { describeLogError } from "../lcm-log.js";
 import {
   applyDoctorCleaners,
@@ -69,6 +70,7 @@ type CurrentConversationResolution =
 type ParsedLcmCommand =
   | { kind: "status" }
   | { kind: "backup" }
+  | { kind: "restore"; target?: string }
   | { kind: "rotate" }
   | { kind: "doctor"; apply: boolean }
   | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
@@ -216,6 +218,10 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return rest.length === 0
         ? { kind: "backup" }
         : { kind: "help", error: "`/lcm backup` does not accept extra arguments." };
+    case "restore":
+      return rest.length <= 1
+        ? { kind: "restore", target: rest[0]?.trim() || undefined }
+        : { kind: "help", error: "`/lcm restore` accepts at most one restore target." };
     case "rotate":
       return rest.length === 0
         ? { kind: "rotate" }
@@ -251,7 +257,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
     default:
       return {
         kind: "help",
-        error: `Unknown subcommand \`${head}\`. Supported: status, backup, rotate, doctor, doctor clean, doctor apply, help.`,
+        error: `Unknown subcommand \`${head}\`. Supported: status, backup, restore, rotate, doctor, doctor clean, doctor apply, help.`,
       };
   }
 }
@@ -560,6 +566,10 @@ function buildHelpText(error?: string): string {
         "Create a timestamped backup of the current LCM database.",
       ),
       buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} restore`),
+        "List restorable DB snapshots and show the exact safe restore commands for each target.",
+      ),
+      buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} rotate`),
         "Compact the current session transcript while preserving the same LCM conversation and live session identity.",
       ),
@@ -579,6 +589,7 @@ function buildHelpText(error?: string): string {
       buildStatLine("subcommands", `Discover them with ${formatCommand(`${VISIBLE_COMMAND} help`)}.`),
       buildStatLine("alias", `${formatCommand(HIDDEN_ALIAS)} is accepted as a shorter alias.`),
       buildStatLine("current conversation", "Uses the active LCM session when the host exposes session identity."),
+      buildStatLine("restore safety", "Restore guidance assumes OpenClaw is stopped before you run the emitted shell commands."),
       buildStatLine("`/new`", "Prunes context for the current LCM conversation. It does not split storage."),
       buildStatLine("`/reset`", "Resets OpenClaw session flow. Use rotate when you only want transcript compaction."),
     ]),
@@ -926,6 +937,109 @@ async function buildBackupText(params: {
       buildStatLine("db path", params.config.databasePath),
       buildStatLine("backup path", backupPath),
     ]),
+  );
+  return lines.join("\n");
+}
+
+function buildRestoreTargetsSection(config: LcmConfig): string {
+  const targets = listLcmRestoreTargets(config.databasePath);
+  if (targets.length === 0) {
+    return buildSection("💾 Restore targets", [
+      buildStatLine("status", "unavailable"),
+      buildStatLine("reason", "No restore snapshots were found for the configured LCM database."),
+    ]);
+  }
+
+  return buildSection("💾 Restore targets", targets.map((target) => {
+    const label = target.kind === "latest" ? "latest rotate backup" : target.label;
+    return `${formatCommand(`${VISIBLE_COMMAND} restore ${target.name}`)} · ${label} · ${target.backupPath}`;
+  }));
+}
+
+function buildRestoreText(params: {
+  config: LcmConfig;
+  target?: string;
+}): string {
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🧯 Lossless Claw Restore",
+    "",
+  ];
+  const targets = listLcmRestoreTargets(params.config.databasePath);
+
+  if (targets.length === 0) {
+    lines.push(
+      buildSection("💾 Restore targets", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "No restore snapshots were found for the configured LCM database."),
+      ]),
+      "",
+      buildSection("🧭 Notes", [
+        "Run `/lossless backup` or `/lossless rotate` first to create a restorable SQLite snapshot.",
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  if (!params.target) {
+    lines.push(
+      buildRestoreTargetsSection(params.config),
+      "",
+      buildSection("🧭 Notes", [
+        `Run ${formatCommand(`${VISIBLE_COMMAND} restore latest`)} or one of the exact target commands above to render the shell restore recipe.`,
+        "Restore recipes archive the current DB and any stale WAL/SHM sidecars before replacing the main SQLite file.",
+        "After the restore copy, Lossless Claw marks bootstrap checkpoints as restore-pending so the next startup will not replay newer transcript history into the restored DB snapshot.",
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  const target = targets.find((candidate) => candidate.name === params.target);
+  if (!target) {
+    lines.push(
+      buildSection("💾 Restore target", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", `Unknown restore target \`${params.target}\`.`),
+      ]),
+      "",
+      buildRestoreTargetsSection(params.config),
+    );
+    return lines.join("\n");
+  }
+
+  const shellScript = buildLcmRestoreShellScript({
+    databasePath: params.config.databasePath,
+    target,
+  });
+  if (!shellScript) {
+    lines.push(
+      buildSection("💾 Restore target", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", "Lossless Claw restore requires a file-backed SQLite database path."),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("💾 Restore target", [
+      buildStatLine("status", "ready"),
+      buildStatLine("target", target.name),
+      buildStatLine("snapshot", target.backupPath),
+      buildStatLine("preview command", formatCommand(`${VISIBLE_COMMAND} restore ${target.name}`)),
+    ]),
+    "",
+    buildSection("🧭 Notes", [
+      "Stop OpenClaw before running this shell recipe so the live process is not holding the database open.",
+      "The recipe archives the current DB plus stale `-wal` and `-shm` sidecars instead of deleting them.",
+      "The final SQLite update marks restore checkpoints as pending so bootstrap will trust the restored DB and skip transcript replay on the next startup.",
+    ]),
+    "",
+    "**🛠️ Shell Recipe**",
+    "```sh",
+    shellScript,
+    "```",
   );
   return lines.join("\n");
 }
@@ -1391,7 +1505,7 @@ export function createLcmCommand(params: {
       telegram: "Lossless Claw is working...",
     },
     description:
-      "Show Lossless Claw health, create DB backups, compact the current session transcript while preserving LCM context, inspect high-confidence junk candidates, and run scoped doctor actions.",
+      "Show Lossless Claw health, create or safely restore DB snapshots, compact the current session transcript while preserving LCM context, inspect high-confidence junk candidates, and run scoped doctor actions.",
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);
@@ -1403,6 +1517,13 @@ export function createLcmCommand(params: {
             text: await buildBackupText({
               db: await getDb(),
               config: params.config,
+            }),
+          };
+        case "restore":
+          return {
+            text: buildRestoreText({
+              config: params.config,
+              target: parsed.target,
             }),
           };
         case "rotate":

--- a/src/plugin/lcm-db-restore.ts
+++ b/src/plugin/lcm-db-restore.ts
@@ -1,6 +1,13 @@
-import { readdirSync, statSync } from "node:fs";
+import { copyFileSync, existsSync, readdirSync, renameSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import { getFileBackedDatabasePath } from "../db/connection.js";
+import { getLcmDbFeatures } from "../db/features.js";
+import { runLcmMigrations } from "../db/migration.js";
+import {
+  closeLcmConnection,
+  createLcmDatabaseConnection,
+  getFileBackedDatabasePath,
+} from "../db/connection.js";
+import type { DatabaseSync } from "node:sqlite";
 
 export type LcmRestoreTarget = {
   name: string;
@@ -12,6 +19,24 @@ export type LcmRestoreTarget = {
 
 function quoteShellArg(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function formatRestoreStamp(): string {
+  return new Date().toISOString().replace(/[-:.]/g, "");
+}
+
+function readQuickCheckResult(db: DatabaseSync): string {
+  const rows = db.prepare(`PRAGMA quick_check`).all() as Array<{ quick_check?: string }>;
+  const results = rows
+    .map((row) => row.quick_check)
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+  if (results.length === 0) {
+    return "unknown";
+  }
+  if (results.length === 1 && results[0] === "ok") {
+    return "ok";
+  }
+  return results.join("; ");
 }
 
 function sanitizeShellPathFragment(value: string): string {
@@ -75,7 +100,92 @@ export function listLcmRestoreTargets(databasePath: string): LcmRestoreTarget[] 
 }
 
 /**
+ * Return the exact CLI command operators should run for an offline restore.
+ */
+export function buildLcmRestoreCliCommand(params: {
+  target: string;
+  stateDir?: string;
+}): string {
+  const command = `openclaw lossless restore ${quoteShellArg(params.target)}`;
+  if (!params.stateDir?.trim()) {
+    return command;
+  }
+  return `OPENCLAW_STATE_DIR=${quoteShellArg(params.stateDir)} ${command}`;
+}
+
+export type LcmRestoreExecutionResult = {
+  databasePath: string;
+  snapshotPath: string;
+  currentBackupPath: string | null;
+  walArchivePath: string | null;
+  shmArchivePath: string | null;
+  quickCheck: string;
+};
+
+/**
+ * Restore a chosen SQLite snapshot into place and mark bootstrap restore guard state.
+ */
+export function restoreLcmDatabaseFromBackup(params: {
+  databasePath: string;
+  target: LcmRestoreTarget;
+}): LcmRestoreExecutionResult {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(params.databasePath);
+  if (!fileBackedDatabasePath) {
+    throw new Error("Lossless Claw restore requires a file-backed SQLite database path.");
+  }
+  if (!existsSync(params.target.backupPath)) {
+    throw new Error(`Restore snapshot not found: ${params.target.backupPath}`);
+  }
+
+  const tag = sanitizeShellPathFragment(params.target.name);
+  const stamp = formatRestoreStamp();
+  const currentBackupPath = existsSync(fileBackedDatabasePath)
+    ? `${fileBackedDatabasePath}.pre-restore-${tag}-${stamp}.bak`
+    : null;
+  const walPath = `${fileBackedDatabasePath}-wal`;
+  const shmPath = `${fileBackedDatabasePath}-shm`;
+  const walArchivePath = existsSync(walPath)
+    ? `${walPath}.pre-restore-${tag}-${stamp}.bak`
+    : null;
+  const shmArchivePath = existsSync(shmPath)
+    ? `${shmPath}.pre-restore-${tag}-${stamp}.bak`
+    : null;
+
+  if (currentBackupPath) {
+    copyFileSync(fileBackedDatabasePath, currentBackupPath);
+  }
+  if (walArchivePath) {
+    renameSync(walPath, walArchivePath);
+  }
+  if (shmArchivePath) {
+    renameSync(shmPath, shmArchivePath);
+  }
+  copyFileSync(params.target.backupPath, fileBackedDatabasePath);
+
+  const db = createLcmDatabaseConnection(fileBackedDatabasePath);
+  try {
+    const { fts5Available } = getLcmDbFeatures(db);
+    runLcmMigrations(db, { fts5Available });
+    db.exec(`UPDATE conversation_bootstrap_state
+             SET restore_guard_pending = 1,
+                 updated_at = datetime('now')`);
+    return {
+      databasePath: fileBackedDatabasePath,
+      snapshotPath: params.target.backupPath,
+      currentBackupPath,
+      walArchivePath,
+      shmArchivePath,
+      quickCheck: readQuickCheckResult(db),
+    };
+  } finally {
+    closeLcmConnection(db);
+  }
+}
+
+/**
  * Build an exact shell recipe for restoring a chosen SQLite snapshot safely.
+ *
+ * Deprecated in favor of the external OpenClaw CLI command path.
  */
 export function buildLcmRestoreShellScript(params: {
   databasePath: string;
@@ -85,7 +195,6 @@ export function buildLcmRestoreShellScript(params: {
   if (!fileBackedDatabasePath) {
     return null;
   }
-
   const tag = sanitizeShellPathFragment(params.target.name);
   const db = quoteShellArg(fileBackedDatabasePath);
   const backup = quoteShellArg(params.target.backupPath);

--- a/src/plugin/lcm-db-restore.ts
+++ b/src/plugin/lcm-db-restore.ts
@@ -1,0 +1,114 @@
+import { readdirSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { getFileBackedDatabasePath } from "../db/connection.js";
+
+export type LcmRestoreTarget = {
+  name: string;
+  backupPath: string;
+  label: string;
+  kind: "latest" | "snapshot";
+  modifiedAtMs: number;
+};
+
+function quoteShellArg(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function sanitizeShellPathFragment(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-");
+  return normalized.replace(/^-+|-+$/g, "") || "restore";
+}
+
+/**
+ * Discover restorable SQLite snapshots for the configured LCM database path.
+ */
+export function listLcmRestoreTargets(databasePath: string): LcmRestoreTarget[] {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(databasePath);
+  if (!fileBackedDatabasePath) {
+    return [];
+  }
+
+  const dbDir = dirname(fileBackedDatabasePath);
+  const dbBase = basename(fileBackedDatabasePath);
+  const prefix = `${dbBase}.`;
+
+  const targets: LcmRestoreTarget[] = [];
+  for (const entry of readdirSync(dbDir)) {
+    if (!entry.startsWith(prefix) || !entry.endsWith(".bak")) {
+      continue;
+    }
+
+    const targetLabel = entry.slice(prefix.length, -".bak".length);
+    if (!targetLabel || targetLabel.includes("-tmp-")) {
+      continue;
+    }
+
+    const backupPath = join(dbDir, entry);
+    let stats;
+    try {
+      stats = statSync(backupPath);
+    } catch {
+      continue;
+    }
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    targets.push({
+      name: targetLabel === "rotate-latest" ? "latest" : targetLabel,
+      backupPath,
+      label: targetLabel,
+      kind: targetLabel === "rotate-latest" ? "latest" : "snapshot",
+      modifiedAtMs: stats.mtimeMs,
+    });
+  }
+
+  return targets.sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "latest" ? -1 : 1;
+    }
+    if (left.modifiedAtMs !== right.modifiedAtMs) {
+      return right.modifiedAtMs - left.modifiedAtMs;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
+/**
+ * Build an exact shell recipe for restoring a chosen SQLite snapshot safely.
+ */
+export function buildLcmRestoreShellScript(params: {
+  databasePath: string;
+  target: LcmRestoreTarget;
+}): string | null {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(params.databasePath);
+  if (!fileBackedDatabasePath) {
+    return null;
+  }
+
+  const tag = sanitizeShellPathFragment(params.target.name);
+  const db = quoteShellArg(fileBackedDatabasePath);
+  const backup = quoteShellArg(params.target.backupPath);
+
+  return [
+    "set -eu",
+    "",
+    `DB=${db}`,
+    `BACKUP=${backup}`,
+    "STAMP=\"$(date +%Y%m%d-%H%M%S)\"",
+    `CURRENT_BACKUP=\"$DB.pre-restore-${tag}-$STAMP.bak\"`,
+    `WAL_ARCHIVE=\"$DB-wal.pre-restore-${tag}-$STAMP.bak\"`,
+    `SHM_ARCHIVE=\"$DB-shm.pre-restore-${tag}-$STAMP.bak\"`,
+    "",
+    "[ -f \"$BACKUP\" ]",
+    "if [ -f \"$DB\" ]; then cp -p \"$DB\" \"$CURRENT_BACKUP\"; fi",
+    "if [ -f \"$DB-wal\" ]; then mv \"$DB-wal\" \"$WAL_ARCHIVE\"; fi",
+    "if [ -f \"$DB-shm\" ]; then mv \"$DB-shm\" \"$SHM_ARCHIVE\"; fi",
+    "cp -p \"$BACKUP\" \"$DB\"",
+    "sqlite3 \"$DB\" <<'SQL'",
+    "UPDATE conversation_bootstrap_state",
+    "SET restore_guard_pending = 1,",
+    "    updated_at = datetime('now');",
+    "SQL",
+  ].join("\n");
+}

--- a/src/plugin/lcm-db-restore.ts
+++ b/src/plugin/lcm-db-restore.ts
@@ -122,6 +122,102 @@ export type LcmRestoreExecutionResult = {
   quickCheck: string;
 };
 
+export type LcmRestoreRollbackResult = {
+  databasePath: string;
+  rollbackDbArchivePath: string | null;
+  rollbackWalArchivePath: string | null;
+  rollbackShmArchivePath: string | null;
+  restoredPreviousDb: boolean;
+  restoredWal: boolean;
+  restoredShm: boolean;
+  quickCheck: string;
+};
+
+function archiveActiveFile(path: string, suffix: string): string | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  const archivedPath = `${path}.${suffix}.bak`;
+  renameSync(path, archivedPath);
+  return archivedPath;
+}
+
+function quickCheckDatabaseAtPath(databasePath: string): string {
+  const db = createLcmDatabaseConnection(databasePath);
+  try {
+    return readQuickCheckResult(db);
+  } finally {
+    closeLcmConnection(db);
+  }
+}
+
+/**
+ * Restore the preserved pre-restore database and SQLite sidecars when a restore-orchestration step fails.
+ */
+export function rollbackLcmDatabaseRestore(params: {
+  restore: Pick<LcmRestoreExecutionResult, "databasePath" | "currentBackupPath" | "walArchivePath" | "shmArchivePath">;
+}): LcmRestoreRollbackResult {
+  const fileBackedDatabasePath = getFileBackedDatabasePath(params.restore.databasePath);
+  if (!fileBackedDatabasePath) {
+    throw new Error("Lossless Claw restore rollback requires a file-backed SQLite database path.");
+  }
+
+  const canRestorePreviousDb =
+    typeof params.restore.currentBackupPath === "string" && existsSync(params.restore.currentBackupPath);
+  const walPath = `${fileBackedDatabasePath}-wal`;
+  const shmPath = `${fileBackedDatabasePath}-shm`;
+  const rollbackTag = `failed-restore-${formatRestoreStamp()}`;
+
+  const rollbackDbArchivePath = canRestorePreviousDb
+    ? archiveActiveFile(fileBackedDatabasePath, rollbackTag)
+    : null;
+  const rollbackWalArchivePath = canRestorePreviousDb
+    ? archiveActiveFile(walPath, rollbackTag)
+    : null;
+  const rollbackShmArchivePath = canRestorePreviousDb
+    ? archiveActiveFile(shmPath, rollbackTag)
+    : null;
+
+  let restoredPreviousDb = false;
+  if (canRestorePreviousDb) {
+    copyFileSync(params.restore.currentBackupPath!, fileBackedDatabasePath);
+    restoredPreviousDb = true;
+  }
+
+  let restoredWal = false;
+  if (
+    restoredPreviousDb &&
+    typeof params.restore.walArchivePath === "string" &&
+    existsSync(params.restore.walArchivePath)
+  ) {
+    renameSync(params.restore.walArchivePath, walPath);
+    restoredWal = true;
+  }
+
+  let restoredShm = false;
+  if (
+    restoredPreviousDb &&
+    typeof params.restore.shmArchivePath === "string" &&
+    existsSync(params.restore.shmArchivePath)
+  ) {
+    renameSync(params.restore.shmArchivePath, shmPath);
+    restoredShm = true;
+  }
+
+  return {
+    databasePath: fileBackedDatabasePath,
+    rollbackDbArchivePath,
+    rollbackWalArchivePath,
+    rollbackShmArchivePath,
+    restoredPreviousDb,
+    restoredWal,
+    restoredShm,
+    quickCheck: existsSync(fileBackedDatabasePath)
+      ? quickCheckDatabaseAtPath(fileBackedDatabasePath)
+      : "unknown",
+  };
+}
+
 /**
  * Restore a chosen SQLite snapshot into place and mark bootstrap restore guard state.
  */
@@ -160,25 +256,42 @@ export function restoreLcmDatabaseFromBackup(params: {
   if (shmArchivePath) {
     renameSync(shmPath, shmArchivePath);
   }
-  copyFileSync(params.target.backupPath, fileBackedDatabasePath);
-
-  const db = createLcmDatabaseConnection(fileBackedDatabasePath);
   try {
-    const { fts5Available } = getLcmDbFeatures(db);
-    runLcmMigrations(db, { fts5Available });
-    db.exec(`UPDATE conversation_bootstrap_state
-             SET restore_guard_pending = 1,
-                 updated_at = datetime('now')`);
-    return {
-      databasePath: fileBackedDatabasePath,
-      snapshotPath: params.target.backupPath,
-      currentBackupPath,
-      walArchivePath,
-      shmArchivePath,
-      quickCheck: readQuickCheckResult(db),
-    };
-  } finally {
-    closeLcmConnection(db);
+    copyFileSync(params.target.backupPath, fileBackedDatabasePath);
+
+    const db = createLcmDatabaseConnection(fileBackedDatabasePath);
+    try {
+      const { fts5Available } = getLcmDbFeatures(db);
+      runLcmMigrations(db, { fts5Available });
+      db.exec(`UPDATE conversation_bootstrap_state
+               SET restore_guard_pending = 1,
+                   updated_at = datetime('now')`);
+      return {
+        databasePath: fileBackedDatabasePath,
+        snapshotPath: params.target.backupPath,
+        currentBackupPath,
+        walArchivePath,
+        shmArchivePath,
+        quickCheck: readQuickCheckResult(db),
+      };
+    } finally {
+      closeLcmConnection(db);
+    }
+  } catch (error) {
+    try {
+      rollbackLcmDatabaseRestore({
+        restore: {
+          databasePath: fileBackedDatabasePath,
+          currentBackupPath,
+          walArchivePath,
+          shmArchivePath,
+        },
+      });
+    } catch {
+      // Preserve the original restore error. The CLI layer reports preserved
+      // archive paths and handles higher-level orchestration rollback details.
+    }
+    throw error;
   }
 }
 

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -109,6 +109,7 @@ export type UpsertConversationBootstrapStateInput = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash?: string | null;
+  restoreGuardPending?: boolean;
 };
 
 export type ConversationBootstrapStateRecord = {
@@ -118,6 +119,7 @@ export type ConversationBootstrapStateRecord = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash: string | null;
+  restoreGuardPending: boolean;
   updatedAt: Date;
 };
 
@@ -218,6 +220,7 @@ interface ConversationBootstrapStateRow {
   last_seen_mtime_ms: number;
   last_processed_offset: number;
   last_processed_entry_hash: string | null;
+  restore_guard_pending: number;
   updated_at: string;
 }
 
@@ -319,6 +322,7 @@ function toConversationBootstrapStateRecord(
     lastSeenMtimeMs: row.last_seen_mtime_ms,
     lastProcessedOffset: row.last_processed_offset,
     lastProcessedEntryHash: row.last_processed_entry_hash,
+    restoreGuardPending: row.restore_guard_pending === 1,
     updatedAt: parseUtcTimestamp(row.updated_at),
   };
 }
@@ -1466,7 +1470,7 @@ export class SummaryStore {
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
+                last_processed_offset, last_processed_entry_hash, restore_guard_pending, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )
@@ -1485,15 +1489,17 @@ export class SummaryStore {
            last_seen_size,
            last_seen_mtime_ms,
            last_processed_offset,
-           last_processed_entry_hash
+           last_processed_entry_hash,
+           restore_guard_pending
          )
-         VALUES (?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (conversation_id) DO UPDATE SET
            session_file_path = excluded.session_file_path,
            last_seen_size = excluded.last_seen_size,
            last_seen_mtime_ms = excluded.last_seen_mtime_ms,
            last_processed_offset = excluded.last_processed_offset,
            last_processed_entry_hash = excluded.last_processed_entry_hash,
+           restore_guard_pending = excluded.restore_guard_pending,
            updated_at = datetime('now')`,
       )
       .run(
@@ -1503,12 +1509,13 @@ export class SummaryStore {
         Math.max(0, Math.floor(input.lastSeenMtimeMs)),
         Math.max(0, Math.floor(input.lastProcessedOffset)),
         input.lastProcessedEntryHash ?? null,
+        input.restoreGuardPending === true ? 1 : 0,
       );
 
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
+                last_processed_offset, last_processed_entry_hash, restore_guard_pending, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )

--- a/test/cli-metadata.test.ts
+++ b/test/cli-metadata.test.ts
@@ -1,0 +1,50 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import plugin from "../cli-metadata.js";
+
+describe("lossless-claw cli metadata entry", () => {
+  it("registers the external restore command surface", async () => {
+    const registerCli = vi.fn();
+    const api = {
+      id: "lossless-claw",
+      name: "Lossless Context Management",
+      registerCli,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as unknown as OpenClawPluginApi;
+
+    plugin.register(api);
+
+    const register = registerCli.mock.calls[0]?.[0];
+    const program = new Command();
+
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    await register({
+      program,
+      config: {
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              config: {
+                dbPath: "/tmp/lossless-cli-metadata.db",
+              },
+            },
+          },
+        },
+      },
+      logger: api.logger,
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    const losslessCommand = program.commands.find((command) => command.name() === "lossless");
+    const restoreCommand = losslessCommand?.commands.find((command) => command.name() === "restore");
+
+    expect(losslessCommand?.description()).toContain("maintenance commands outside the running gateway");
+    expect(restoreCommand?.description()).toContain("restore one safely with gateway orchestration");
+  });
+});

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2368,6 +2368,85 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(second.reason).toBe("already bootstrapped");
   });
 
+  it("consumes restore guards without replaying transcript history and resumes future tail imports", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("restore-guard");
+    const sm = SessionManager.open(sessionFile);
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "second" }],
+    } as AgentMessage);
+
+    const engine = createEngineAtDatabasePath(dbPath);
+    const sessionId = "bootstrap-restore-guard";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+    expect(first.importedMessages).toBe(2);
+
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "restored tail user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "restored tail assistant" }],
+    } as AgentMessage);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const rawDb = createLcmDatabaseConnection(dbPath);
+    try {
+      rawDb
+        .prepare(
+          `UPDATE conversation_bootstrap_state
+           SET restore_guard_pending = 1
+           WHERE conversation_id = ?`,
+        )
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: "restore guard skipped transcript replay",
+    });
+    expect(await engine.getConversationStore().getMessageCount(conversation!.conversationId)).toBe(2);
+
+    const bootstrapStateAfterGuard = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(bootstrapStateAfterGuard?.restoreGuardPending).toBe(false);
+    expect(bootstrapStateAfterGuard?.lastSeenSize).toBe(statSync(sessionFile).size);
+
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "fresh tail user" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "fresh tail assistant" }],
+    } as AgentMessage);
+
+    const third = await engine.bootstrap({ sessionId, sessionFile });
+    expect(third).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+    expect(await engine.getConversationStore().getMessageCount(conversation!.conversationId)).toBe(4);
+  });
+
   it("preserves ordinary bootstrap behavior when no checkpoint exists", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);

--- a/test/lcm-cli.test.ts
+++ b/test/lcm-cli.test.ts
@@ -1,0 +1,145 @@
+import { copyFileSync, existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveLcmConfig } from "../src/db/config.js";
+import { createLcmDatabaseConnection, closeLcmConnection } from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { runLcmRestoreCli } from "../src/plugin/lcm-cli.js";
+
+const mocks = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: mocks.spawnSync,
+}));
+
+type RestoreFixture = {
+  tempDir: string;
+  dbPath: string;
+};
+
+function createRestoreFixture(): RestoreFixture {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-cli-"));
+  const dbPath = join(tempDir, "lcm.db");
+  const db = createLcmDatabaseConnection(dbPath);
+  try {
+    const { fts5Available } = getLcmDbFeatures(db);
+    runLcmMigrations(db, { fts5Available });
+  } finally {
+    closeLcmConnection(db);
+  }
+
+  copyFileSync(dbPath, join(tempDir, "lcm.db.rotate-latest.bak"));
+  writeFileSync(`${dbPath}-wal`, "wal");
+  writeFileSync(`${dbPath}-shm`, "shm");
+
+  return { tempDir, dbPath };
+}
+
+describe("lossless restore cli", () => {
+  const tempDirs = new Set<string>();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.spawnSync.mockReset();
+    vi.unstubAllEnvs();
+    for (const tempDir of tempDirs) {
+      closeLcmConnection(join(tempDir, "lcm.db"));
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDirs.clear();
+  });
+
+  it("stops, restores, restarts, and verifies gateway health", () => {
+    const fixture = createRestoreFixture();
+    tempDirs.add(fixture.tempDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-restore-profile");
+
+    mocks.spawnSync.mockReturnValue({
+      status: 0,
+      stdout: "{}",
+      stderr: "",
+    });
+
+    let output = "";
+    runLcmRestoreCli({
+      config: resolveLcmConfig({}, { dbPath: fixture.dbPath }),
+      target: "latest",
+      writer: {
+        write(chunk: string) {
+          output += chunk;
+          return true;
+        },
+      },
+    });
+
+    const invokedArgs = mocks.spawnSync.mock.calls.map((call) => (call[1] as string[]).join(" "));
+    expect(invokedArgs).toHaveLength(3);
+    expect(invokedArgs[0]).toContain("gateway stop --json");
+    expect(invokedArgs[1]).toContain("gateway start --json");
+    expect(invokedArgs[2]).toContain("gateway status --require-rpc --json");
+    expect(output).toContain("State dir: /tmp/openclaw-restore-profile");
+    expect(output).toContain("Restore completed and gateway health checks passed.");
+    expect(output).toContain("archived current db:");
+    expect(output).toContain("archived wal:");
+    expect(output).toContain("archived shm:");
+    expect(existsSync(`${fixture.dbPath}-wal`)).toBe(false);
+    expect(existsSync(`${fixture.dbPath}-shm`)).toBe(false);
+    expect(
+      readdirSync(fixture.tempDir).some(
+        (entry) => entry.startsWith("lcm.db.pre-restore-latest-") && entry.endsWith(".bak"),
+      ),
+    ).toBe(true);
+    expect(
+      readdirSync(fixture.tempDir).some(
+        (entry) => entry.startsWith("lcm.db-wal.pre-restore-latest-") && entry.endsWith(".bak"),
+      ),
+    ).toBe(true);
+    expect(
+      readdirSync(fixture.tempDir).some(
+        (entry) => entry.startsWith("lcm.db-shm.pre-restore-latest-") && entry.endsWith(".bak"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports preserved archive paths when gateway restart fails after restore", () => {
+    const fixture = createRestoreFixture();
+    tempDirs.add(fixture.tempDir);
+
+    mocks.spawnSync
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: "",
+        stderr: "gateway start failed",
+      });
+
+    let thrown: Error | null = null;
+    try {
+      runLcmRestoreCli({
+        config: resolveLcmConfig({}, { dbPath: fixture.dbPath }),
+        target: "latest",
+        writer: {
+          write() {
+            return true;
+          },
+        },
+      });
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toMatch(/gateway start failed/);
+    expect(thrown?.message).toMatch(/Previous DB backup: .*pre-restore-latest-/);
+    expect(thrown?.message).toMatch(/Archived WAL: .*pre-restore-latest-/);
+    expect(thrown?.message).toMatch(/Archived SHM: .*pre-restore-latest-/);
+  });
+});

--- a/test/lcm-cli.test.ts
+++ b/test/lcm-cli.test.ts
@@ -39,6 +39,33 @@ function createRestoreFixture(): RestoreFixture {
   return { tempDir, dbPath };
 }
 
+function addLiveDbMarker(dbPath: string): void {
+  const db = createLcmDatabaseConnection(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS rollback_marker (
+        value TEXT NOT NULL
+      );
+      DELETE FROM rollback_marker;
+      INSERT INTO rollback_marker (value) VALUES ('live-db-state');
+    `);
+  } finally {
+    closeLcmConnection(db);
+  }
+}
+
+function hasLiveDbMarker(dbPath: string): boolean {
+  const db = createLcmDatabaseConnection(dbPath);
+  try {
+    const row = db.prepare(`SELECT COUNT(*) AS total FROM rollback_marker`).get() as { total?: number };
+    return (row.total ?? 0) > 0;
+  } catch {
+    return false;
+  } finally {
+    closeLcmConnection(db);
+  }
+}
+
 describe("lossless restore cli", () => {
   const tempDirs = new Set<string>();
 
@@ -105,9 +132,10 @@ describe("lossless restore cli", () => {
     ).toBe(true);
   });
 
-  it("reports preserved archive paths when gateway restart fails after restore", () => {
+  it("rolls back to the previous database when gateway restart fails after restore", () => {
     const fixture = createRestoreFixture();
     tempDirs.add(fixture.tempDir);
+    addLiveDbMarker(fixture.dbPath);
 
     mocks.spawnSync
       .mockReturnValueOnce({
@@ -119,15 +147,27 @@ describe("lossless restore cli", () => {
         status: 1,
         stdout: "",
         stderr: "gateway start failed",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
       });
 
     let thrown: Error | null = null;
+    let output = "";
     try {
       runLcmRestoreCli({
         config: resolveLcmConfig({}, { dbPath: fixture.dbPath }),
         target: "latest",
         writer: {
-          write() {
+          write(chunk: string) {
+            output += chunk;
             return true;
           },
         },
@@ -136,10 +176,94 @@ describe("lossless restore cli", () => {
       thrown = error as Error;
     }
 
+    const invokedArgs = mocks.spawnSync.mock.calls.map((call) => (call[1] as string[]).join(" "));
+
     expect(thrown).toBeInstanceOf(Error);
     expect(thrown?.message).toMatch(/gateway start failed/);
-    expect(thrown?.message).toMatch(/Previous DB backup: .*pre-restore-latest-/);
-    expect(thrown?.message).toMatch(/Archived WAL: .*pre-restore-latest-/);
-    expect(thrown?.message).toMatch(/Archived SHM: .*pre-restore-latest-/);
+    expect(thrown?.message).toMatch(/rolled the database back to its pre-restore snapshot/);
+    expect(thrown?.message).toMatch(/Rollback quick_check: ok/);
+    expect(thrown?.message).toMatch(/Archived failed restore DB: .*failed-restore-/);
+    expect(invokedArgs).toEqual([
+      expect.stringContaining("gateway stop --json"),
+      expect.stringContaining("gateway start --json"),
+      expect.stringContaining("gateway start --json"),
+      expect.stringContaining("gateway status --require-rpc --json"),
+    ]);
+    expect(output).toContain("6. Rolling back to the previous database snapshot...");
+    expect(output).toContain("7. Starting gateway after rollback...");
+    expect(output).toContain("8. Verifying gateway health after rollback...");
+    expect(hasLiveDbMarker(fixture.dbPath)).toBe(true);
+  });
+
+  it("stops the gateway again and rolls back when post-start health checks fail", () => {
+    const fixture = createRestoreFixture();
+    tempDirs.add(fixture.tempDir);
+    addLiveDbMarker(fixture.dbPath);
+
+    mocks.spawnSync
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: "",
+        stderr: "gateway health check failed",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "{}",
+        stderr: "",
+      });
+
+    let thrown: Error | null = null;
+    let output = "";
+    try {
+      runLcmRestoreCli({
+        config: resolveLcmConfig({}, { dbPath: fixture.dbPath }),
+        target: "latest",
+        writer: {
+          write(chunk: string) {
+            output += chunk;
+            return true;
+          },
+        },
+      });
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    const invokedArgs = mocks.spawnSync.mock.calls.map((call) => (call[1] as string[]).join(" "));
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown?.message).toMatch(/gateway health check failed/);
+    expect(thrown?.message).toMatch(/rolled the database back to its pre-restore snapshot/);
+    expect(invokedArgs).toEqual([
+      expect.stringContaining("gateway stop --json"),
+      expect.stringContaining("gateway start --json"),
+      expect.stringContaining("gateway status --require-rpc --json"),
+      expect.stringContaining("gateway stop --json"),
+      expect.stringContaining("gateway start --json"),
+      expect.stringContaining("gateway status --require-rpc --json"),
+    ]);
+    expect(output).toContain("5. Stopping gateway for rollback...");
+    expect(output).toContain("6. Rolling back to the previous database snapshot...");
+    expect(hasLiveDbMarker(fixture.dbPath)).toBe(true);
   });
 });

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1139,6 +1139,46 @@ describe("lcm command", () => {
     expect(result.text).toContain("reason: disk full");
   });
 
+  it("lists exact restore target commands for available backups", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const latestPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    const timestampedPath = join(fixture.tempDir, "lcm.db.backup-20260413t010203z-abcd12.bak");
+    writeFileSync(latestPath, "latest");
+    writeFileSync(timestampedPath, "timestamped");
+
+    const result = await fixture.command.handler(createCommandContext("restore"));
+
+    expect(result.text).toContain("🧯 Lossless Claw Restore");
+    expect(result.text).toContain("`/lossless restore latest`");
+    expect(result.text).toContain("`/lossless restore backup-20260413t010203z-abcd12`");
+    expect(result.text).toContain(latestPath);
+    expect(result.text).toContain(timestampedPath);
+    expect(result.text).toContain("restore-pending");
+  });
+
+  it("renders a safe restore shell recipe for a selected target", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const latestPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
+    writeFileSync(latestPath, "latest");
+
+    const result = await fixture.command.handler(createCommandContext("restore latest"));
+
+    expect(result.text).toContain("🧯 Lossless Claw Restore");
+    expect(result.text).toContain("status: ready");
+    expect(result.text).toContain(`snapshot: ${latestPath}`);
+    expect(result.text).toContain("Stop OpenClaw before running this shell recipe");
+    expect(result.text).toContain("mv \"$DB-wal\" \"$WAL_ARCHIVE\"");
+    expect(result.text).toContain("mv \"$DB-shm\" \"$SHM_ARCHIVE\"");
+    expect(result.text).toContain("cp -p \"$BACKUP\" \"$DB\"");
+    expect(result.text).toContain("restore_guard_pending = 1");
+  });
+
   it("rotates the current session and replaces the latest rotate backup", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
@@ -1657,6 +1697,7 @@ describe("lcm command", () => {
     const result = await fixture.command.handler(createCommandContext("rewrite"));
     expect(result.text).toContain("⚠️ Unknown subcommand `rewrite`.");
     expect(result.text).toContain("`/lossless backup`");
+    expect(result.text).toContain("`/lossless restore`");
     expect(result.text).toContain("`/lossless rotate`");
     expect(result.text).toContain("`/lossless help`");
     expect(result.text).toContain("`/lcm` is accepted as a shorter alias.");

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1143,6 +1143,7 @@ describe("lcm command", () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-restore-profile");
 
     const latestPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
     const timestampedPath = join(fixture.tempDir, "lcm.db.backup-20260413t010203z-abcd12.bak");
@@ -1154,15 +1155,17 @@ describe("lcm command", () => {
     expect(result.text).toContain("🧯 Lossless Claw Restore");
     expect(result.text).toContain("`/lossless restore latest`");
     expect(result.text).toContain("`/lossless restore backup-20260413t010203z-abcd12`");
+    expect(result.text).toContain("`OPENCLAW_STATE_DIR='/tmp/openclaw-restore-profile' openclaw lossless restore 'latest'`");
     expect(result.text).toContain(latestPath);
     expect(result.text).toContain(timestampedPath);
     expect(result.text).toContain("restore-pending");
   });
 
-  it("renders a safe restore shell recipe for a selected target", async () => {
+  it("renders the external restore command for a selected target", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-restore-profile");
 
     const latestPath = join(fixture.tempDir, "lcm.db.rotate-latest.bak");
     writeFileSync(latestPath, "latest");
@@ -1172,11 +1175,10 @@ describe("lcm command", () => {
     expect(result.text).toContain("🧯 Lossless Claw Restore");
     expect(result.text).toContain("status: ready");
     expect(result.text).toContain(`snapshot: ${latestPath}`);
-    expect(result.text).toContain("Stop OpenClaw before running this shell recipe");
-    expect(result.text).toContain("mv \"$DB-wal\" \"$WAL_ARCHIVE\"");
-    expect(result.text).toContain("mv \"$DB-shm\" \"$SHM_ARCHIVE\"");
-    expect(result.text).toContain("cp -p \"$BACKUP\" \"$DB\"");
-    expect(result.text).toContain("restore_guard_pending = 1");
+    expect(result.text).toContain("offline command: `OPENCLAW_STATE_DIR='/tmp/openclaw-restore-profile' openclaw lossless restore 'latest'`");
+    expect(result.text).toContain("Run the external command from your shell");
+    expect(result.text).toContain("stops the gateway before touching the database");
+    expect(result.text).toContain("verify RPC health before reporting success");
   });
 
   it("rotates the current session and replaces the latest rotate backup", async () => {

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -799,6 +799,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       "last_seen_mtime_ms",
       "last_processed_offset",
       "last_processed_entry_hash",
+      "restore_guard_pending",
       "updated_at",
     ]);
   });

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -278,6 +278,48 @@ describe("lcm plugin registration", () => {
     );
   });
 
+  it("registers the external CLI surface without initializing runtime-only services during cli-only loads", () => {
+    const registerContextEngine = vi.fn();
+    const registerCommand = vi.fn();
+    const registerCli = vi.fn();
+    const api = {
+      id: "lossless-claw",
+      name: "Lossless Context Management",
+      source: "/tmp/lossless-claw",
+      config: {},
+      pluginConfig: {
+        enabled: true,
+        dbPath: "/tmp/lossless-cli-only.db",
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      registerContextEngine,
+      registerTool: vi.fn(),
+      registerHook: vi.fn(),
+      registerHttpHandler: vi.fn(),
+      registerHttpRoute: vi.fn(),
+      registerChannel: vi.fn(),
+      registerGatewayMethod: vi.fn(),
+      registerCli,
+      registerService: vi.fn(),
+      registerProvider: vi.fn(),
+      registerCommand,
+      resolvePath: vi.fn(() => "/tmp/fake-agent"),
+      on: vi.fn(),
+    } as unknown as OpenClawPluginApi;
+
+    lcmPlugin.register(api);
+
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    expect(registerContextEngine).not.toHaveBeenCalled();
+    expect(registerCommand).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["missing", undefined],
     ["invalid", ["not-a-plugin-config"]],


### PR DESCRIPTION
## What
Adds a guided `/lossless restore` workflow for Lossless Claw. The plugin now lists available SQLite restore targets, emits the exact offline shell recipe for restoring either the rolling `rotate-latest` backup or timestamped snapshots, archives any stale SQLite sidecars during restore, and marks restored bootstrap state so startup does not replay transcript history newer than the restored snapshot.

## Why
Restore was still manual and error-prone after the rotate rework. Restoring only `lcm.db` could leave stale `-wal` and `-shm` files behind and could also cause Lossless Claw to bulk-import transcript history written after the backup was taken, which defeated the point of restoring the snapshot.

## Changes
- Add `/lossless restore` target discovery
- Emit exact offline restore shell recipes
- Archive stale SQLite WAL and SHM sidecars
- Add bootstrap restore guard semantics
- Document restore behavior in operator docs
- Update bundled lossless skill references
- Add a patch changeset for release notes

| File | Change |
|------|--------|
| `.changeset/curly-crows-double.md` | Adds release note entry for restore workflow |
| `docs/configuration.md` | Documents `/lcm restore` behavior and safety semantics |
| `skills/lossless-claw/SKILL.md` | Points skill users to restore lifecycle guidance |
| `skills/lossless-claw/references/session-lifecycle.md` | Documents restore behavior alongside rotate/new/reset |
| `src/db/migration.ts` | Adds restore guard column to bootstrap state |
| `src/engine.ts` | Consumes restore guard before transcript replay |
| `src/plugin/lcm-command.ts` | Adds restore command parsing and output |
| `src/plugin/lcm-db-restore.ts` | Implements restore target discovery and shell recipe generation |
| `src/store/summary-store.ts` | Persists restore guard state in bootstrap records |
| `test/engine.test.ts` | Covers one-shot restore guard bootstrap behavior |
| `test/lcm-command.test.ts` | Covers restore listing and emitted shell recipe |
| `test/migration.test.ts` | Covers bootstrap restore guard schema |

## Testing
- `npm test`
- `npm run build`
- Expected: all tests pass and the package bundles successfully
