### PR TITLE
fix: use summary content recency for query recall

### DIFF
--- a/.changeset/silent-cougars-travel.md
+++ b/.changeset/silent-cougars-travel.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Apply content-recency sorting consistently to CJK summary full-text search so recent summarized content does not lose to older but stronger trigram matches.

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1035,6 +1035,7 @@ export class SummaryStore {
               input.conversationId,
               input.since,
               input.before,
+              input.sort,
             );
             if (trigramResults.length > 0) {
               return trigramResults;
@@ -1210,6 +1211,7 @@ export class SummaryStore {
     conversationId?: number,
     since?: Date,
     before?: Date,
+    sort?: SearchSort,
   ): SummarySearchResult[] {
     const cjkSegments = this.extractCjkSegments(query).filter((segment) => segment.length >= 3);
     if (cjkSegments.length === 0) {
@@ -1248,6 +1250,7 @@ export class SummaryStore {
       args.push(before.toISOString());
     }
     args.push(limit);
+    const orderBy = buildFtsOrderBy(sort, SUMMARY_SEARCH_TIME_EXPR);
 
     const sql = `SELECT
          f.summary_id,
@@ -1259,7 +1262,7 @@ export class SummaryStore {
        FROM summaries_fts_cjk f
        JOIN summaries s ON s.summary_id = f.summary_id
        WHERE ${where.join(" AND ")}
-       ORDER BY rank, ${SUMMARY_SEARCH_TIME_EXPR} DESC
+       ORDER BY ${orderBy}
        LIMIT ?`;
     const rows = this.db.prepare(sql).all(...args) as unknown as SummarySearchRow[];
     return rows.map(toSearchResult);

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -77,6 +77,7 @@ export type SummarySearchResult = {
   conversationId: number;
   kind: SummaryKind;
   snippet: string;
+  /** Effective search timestamp: latest covered content when known, else row creation time. */
   createdAt: Date;
   rank?: number;
 };
@@ -174,6 +175,9 @@ interface SummarySearchRow {
   rank: number;
   created_at: string;
 }
+
+const SUMMARY_SEARCH_TIME_EXPR = "COALESCE(s.latest_at, s.created_at)";
+const SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED = "COALESCE(latest_at, created_at)";
 
 interface MaxOrdinalRow {
   max_ordinal: number;
@@ -1087,15 +1091,15 @@ export class SummaryStore {
       args.push(conversationId);
     }
     if (since) {
-      where.push("julianday(s.created_at) >= julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR}) >= julianday(?)`);
       args.push(since.toISOString());
     }
     if (before) {
-      where.push("julianday(s.created_at) < julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR}) < julianday(?)`);
       args.push(before.toISOString());
     }
     args.push(limit);
-    const orderBy = buildFtsOrderBy(sort, "s.created_at");
+    const orderBy = buildFtsOrderBy(sort, SUMMARY_SEARCH_TIME_EXPR);
 
     const sql = `SELECT
          summaries_fts.summary_id,
@@ -1103,7 +1107,7 @@ export class SummaryStore {
          s.kind,
          snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
          rank,
-         s.created_at
+         ${SUMMARY_SEARCH_TIME_EXPR} AS created_at
        FROM summaries_fts
        JOIN summaries s ON s.summary_id = summaries_fts.summary_id
        WHERE ${where.join(" AND ")}
@@ -1132,11 +1136,11 @@ export class SummaryStore {
       args.push(conversationId);
     }
     if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) >= julianday(?)`);
       args.push(since.toISOString());
     }
     if (before) {
-      where.push("julianday(created_at) < julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) < julianday(?)`);
       args.push(before.toISOString());
     }
     args.push(limit);
@@ -1146,10 +1150,11 @@ export class SummaryStore {
       .prepare(
         `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
                 earliest_at, latest_at, descendant_count, descendant_token_count,
-                source_message_token_count, model, created_at
+                source_message_token_count, model,
+                ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} AS created_at
          FROM summaries
          ${whereClause}
-         ORDER BY created_at DESC
+         ORDER BY ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} DESC
          LIMIT ?`,
       )
       .all(...args) as unknown as SummaryRow[];
@@ -1235,11 +1240,11 @@ export class SummaryStore {
       args.push(conversationId);
     }
     if (since) {
-      where.push("julianday(s.created_at) >= julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR}) >= julianday(?)`);
       args.push(since.toISOString());
     }
     if (before) {
-      where.push("julianday(s.created_at) < julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR}) < julianday(?)`);
       args.push(before.toISOString());
     }
     args.push(limit);
@@ -1250,11 +1255,11 @@ export class SummaryStore {
          s.kind,
          snippet(summaries_fts_cjk, 1, '', '', '...', 32) AS snippet,
          rank,
-         s.created_at
+         ${SUMMARY_SEARCH_TIME_EXPR} AS created_at
        FROM summaries_fts_cjk f
        JOIN summaries s ON s.summary_id = f.summary_id
        WHERE ${where.join(" AND ")}
-       ORDER BY rank
+       ORDER BY rank, ${SUMMARY_SEARCH_TIME_EXPR} DESC
        LIMIT ?`;
     const rows = this.db.prepare(sql).all(...args) as unknown as SummarySearchRow[];
     return rows.map(toSearchResult);
@@ -1309,11 +1314,11 @@ export class SummaryStore {
       args.push(conversationId);
     }
     if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) >= julianday(?)`);
       args.push(since.toISOString());
     }
     if (before) {
-      where.push("julianday(created_at) < julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) < julianday(?)`);
       args.push(before.toISOString());
     }
     args.push(limit);
@@ -1322,10 +1327,11 @@ export class SummaryStore {
       .prepare(
         `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
                 earliest_at, latest_at, descendant_count, descendant_token_count,
-                source_message_token_count, model, created_at
+                source_message_token_count, model,
+                ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} AS created_at
          FROM summaries
          WHERE ${where.join(" AND ")}
-         ORDER BY created_at DESC
+         ORDER BY ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} DESC
          LIMIT ?`,
       )
       .all(...args) as unknown as SummaryRow[];
@@ -1366,11 +1372,11 @@ export class SummaryStore {
       args.push(conversationId);
     }
     if (since) {
-      where.push("julianday(created_at) >= julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) >= julianday(?)`);
       args.push(since.toISOString());
     }
     if (before) {
-      where.push("julianday(created_at) < julianday(?)");
+      where.push(`julianday(${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED}) < julianday(?)`);
       args.push(before.toISOString());
     }
     const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
@@ -1378,10 +1384,11 @@ export class SummaryStore {
       .prepare(
         `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
                 earliest_at, latest_at, descendant_count, descendant_token_count,
-                source_message_token_count, model, created_at
+                source_message_token_count, model,
+                ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} AS created_at
          FROM summaries
          ${whereClause}
-         ORDER BY created_at DESC`,
+         ORDER BY ${SUMMARY_SEARCH_TIME_EXPR_UNQUALIFIED} DESC`,
       )
       .all(...args) as unknown as SummaryRow[];
 

--- a/test/retrieval-sort.test.ts
+++ b/test/retrieval-sort.test.ts
@@ -7,11 +7,21 @@ import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
 
 const itIfFts5 = detectFts5Support() ? it : it.skip;
+const itIfTrigram = detectTrigramSupport() ? it : it.skip;
 
 function detectFts5Support(): boolean {
   const db = new DatabaseSync(":memory:");
   try {
     return getLcmDbFeatures(db).fts5Available;
+  } finally {
+    db.close();
+  }
+}
+
+function detectTrigramSupport(): boolean {
+  const db = new DatabaseSync(":memory:");
+  try {
+    return getLcmDbFeatures(db).trigramTokenizerAvailable;
   } finally {
     db.close();
   }
@@ -210,6 +220,59 @@ describe("RetrievalEngine sort modes", () => {
       expect(filteredResult.summaries.map((summary) => summary.summaryId)).toEqual([
         "sum_recent_content_older_compaction",
       ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  itIfTrigram("applies recency ordering to CJK trigram summary search", async () => {
+    const { db, conversationStore, summaryStore } = createStores();
+
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-cjk-content-recency",
+      });
+      await summaryStore.insertSummary({
+        summaryId: "sum_cjk_old_content_recent_compaction",
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: "端到端测试结果 端到端测试结果 端到端测试结果 旧记录",
+        tokenCount: 12,
+        latestAt: new Date("2026-01-01T00:00:00.000Z"),
+      });
+      await summaryStore.insertSummary({
+        summaryId: "sum_cjk_recent_content_older_compaction",
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: "最近的端到端测试结果",
+        tokenCount: 6,
+        latestAt: new Date("2026-01-09T00:00:00.000Z"),
+      });
+
+      db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+        "2026-01-10T00:00:00.000Z",
+        "sum_cjk_old_content_recent_compaction",
+      );
+      db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+        "2026-01-05T00:00:00.000Z",
+        "sum_cjk_recent_content_older_compaction",
+      );
+
+      const result = await summaryStore.searchSummaries({
+        query: "端到端测试结果",
+        mode: "full_text",
+        conversationId: conversation.conversationId,
+        limit: 2,
+        sort: "recency",
+      });
+
+      expect(result.map((summary) => summary.summaryId)).toEqual([
+        "sum_cjk_recent_content_older_compaction",
+        "sum_cjk_old_content_recent_compaction",
+      ]);
+      expect(result[0]?.createdAt.toISOString()).toBe("2026-01-09T00:00:00.000Z");
     } finally {
       db.close();
     }

--- a/test/retrieval-sort.test.ts
+++ b/test/retrieval-sort.test.ts
@@ -147,4 +147,71 @@ describe("RetrievalEngine sort modes", () => {
       db.close();
     }
   });
+
+  itIfFts5("uses content recency instead of compaction time for summary recency and time filters", async () => {
+    const { db, conversationStore, summaryStore } = createStores();
+    const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-content-recency",
+      });
+      await summaryStore.insertSummary({
+        summaryId: "sum_old_content_recent_compaction",
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: "pagedrop launch notes pagedrop launch notes legacy request",
+        tokenCount: 12,
+        latestAt: new Date("2026-01-01T00:00:00.000Z"),
+      });
+      await summaryStore.insertSummary({
+        summaryId: "sum_recent_content_older_compaction",
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: "pagedrop launch notes current request details",
+        tokenCount: 10,
+        latestAt: new Date("2026-01-09T00:00:00.000Z"),
+      });
+
+      db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+        "2026-01-10T00:00:00.000Z",
+        "sum_old_content_recent_compaction",
+      );
+      db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+        "2026-01-05T00:00:00.000Z",
+        "sum_recent_content_older_compaction",
+      );
+
+      const recencyResult = await retrieval.grep({
+        query: '"pagedrop launch notes"',
+        mode: "full_text",
+        scope: "summaries",
+        conversationId: conversation.conversationId,
+        limit: 2,
+        sort: "recency",
+      });
+      const filteredResult = await retrieval.grep({
+        query: '"pagedrop launch notes"',
+        mode: "full_text",
+        scope: "summaries",
+        conversationId: conversation.conversationId,
+        since: new Date("2026-01-05T00:00:00.000Z"),
+        limit: 2,
+        sort: "recency",
+      });
+
+      expect(recencyResult.summaries.map((summary) => summary.summaryId)).toEqual([
+        "sum_recent_content_older_compaction",
+        "sum_old_content_recent_compaction",
+      ]);
+      expect(recencyResult.summaries[0]?.createdAt.toISOString()).toBe("2026-01-09T00:00:00.000Z");
+      expect(filteredResult.summaries.map((summary) => summary.summaryId)).toEqual([
+        "sum_recent_content_older_compaction",
+      ]);
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/test/summary-store.test.ts
+++ b/test/summary-store.test.ts
@@ -11,6 +11,7 @@ function createStores() {
   const { fts5Available } = getLcmDbFeatures(db);
   runLcmMigrations(db, { fts5Available });
   return {
+    db,
     conversationStore: new ConversationStore(db, { fts5Available }),
     summaryStore: new SummaryStore(db, { fts5Available }),
   };
@@ -93,6 +94,74 @@ describe("SummaryStore shallow-tree helpers", () => {
       {
         messageId: firstMessage.messageId,
         summaryId: "sum_leaf_a",
+      },
+    ]);
+  });
+
+  it("uses content recency for fallback summary search ordering and time filters", async () => {
+    const { db, conversationStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "summary-store-search-time",
+      title: "Summary search time",
+    });
+
+    await summaryStore.insertSummary({
+      summaryId: "sum_regex_old_content_recent_compaction",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "pagedrop regression historical request",
+      tokenCount: 5,
+      latestAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    await summaryStore.insertSummary({
+      summaryId: "sum_regex_recent_content_older_compaction",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "pagedrop regression recent request",
+      tokenCount: 5,
+      latestAt: new Date("2026-01-09T00:00:00.000Z"),
+    });
+
+    db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+      "2026-01-10T00:00:00.000Z",
+      "sum_regex_old_content_recent_compaction",
+    );
+    db.prepare("UPDATE summaries SET created_at = ? WHERE summary_id = ?").run(
+      "2026-01-05T00:00:00.000Z",
+      "sum_regex_recent_content_older_compaction",
+    );
+
+    await expect(
+      summaryStore.searchSummaries({
+        conversationId: conversation.conversationId,
+        query: "pagedrop regression",
+        mode: "regex",
+        limit: 10,
+      }),
+    ).resolves.toMatchObject([
+      {
+        summaryId: "sum_regex_recent_content_older_compaction",
+        createdAt: new Date("2026-01-09T00:00:00.000Z"),
+      },
+      {
+        summaryId: "sum_regex_old_content_recent_compaction",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ]);
+
+    await expect(
+      summaryStore.searchSummaries({
+        conversationId: conversation.conversationId,
+        query: "pagedrop regression",
+        mode: "regex",
+        since: new Date("2026-01-05T00:00:00.000Z"),
+        limit: 10,
+      }),
+    ).resolves.toMatchObject([
+      {
+        summaryId: "sum_regex_recent_content_older_compaction",
       },
     ]);
   });


### PR DESCRIPTION
## What
This PR makes summary search treat a summary's effective time as `COALESCE(latest_at, created_at)` so query-mode recall prefers when the summarized content happened, not when compaction happened to write the row.

## Why
A recent `lcm_expand_query` call about pagedrop work returned an older pagedrop sequence from the same conversation because an older topic had been compacted more recently. That made summary recency and `since` filtering key off compaction time instead of content recency, which is the wrong signal for recall.

## Changes
- Use `latest_at` for summary search recency
- Apply content time to summary filters
- Keep fallback summary search behavior aligned
- Add stale-content compaction regression tests

## Testing
- `npx vitest run test/retrieval-sort.test.ts test/summary-store.test.ts`
- `npx vitest run test/circuit-breaker.test.ts`
- `npm test`

## Notes
This changes user-visible recall behavior, so it should get a patch changeset before merge or immediately after in a follow-up PR.
