### PR TITLE
fix: execute deferred Anthropic leaf debt after TTL expiry despite cache smoothing

### DIFF
--- a/.changeset/young-shoes-hide.md
+++ b/.changeset/young-shoes-hide.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep deferred Anthropic leaf compaction moving once the prompt-cache TTL has gone stale, even if cache-aware cold-observation smoothing still treats the session as effectively hot for routing-noise protection.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1737,6 +1737,26 @@ export class LcmContextEngine implements ContextEngine {
     return this.isAnthropicPromptCacheFamily(telemetry) && this.isPromptCacheStillHot(telemetry, now);
   }
 
+  /** Keep deferred Anthropic leaf debt moving once the TTL-safe cache hold has expired. */
+  private shouldForceDeferredAnthropicLeafCompaction(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+    leafDecision: IncrementalCompactionDecision,
+  ): boolean {
+    if (leafDecision.shouldCompact) {
+      return false;
+    }
+    if (
+      leafDecision.reason !== "hot-cache-budget-headroom"
+      && leafDecision.reason !== "hot-cache-defer"
+    ) {
+      return false;
+    }
+    if (!this.isAnthropicPromptCacheFamily(telemetry)) {
+      return false;
+    }
+    return !this.shouldDelayPromptMutatingDeferredCompaction(telemetry);
+  }
+
   /** Decide whether a hot cache still has enough real token-budget headroom to skip incremental maintenance. */
   private isComfortablyUnderTokenBudget(params: {
     currentTokenCount?: number;
@@ -2294,17 +2314,26 @@ export class LcmContextEngine implements ContextEngine {
               legacyParams: params.legacyParams,
             })
           : await (async (): Promise<CompactResult> => {
+              const telemetry =
+                await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+                  params.conversationId,
+                );
               const leafDecision = await this.evaluateIncrementalCompaction({
                 conversationId: params.conversationId,
                 tokenBudget: resolvedTokenBudget,
                 currentTokenCount: resolvedCurrentTokenCount,
               });
               if (!leafDecision.shouldCompact) {
-                return {
-                  ok: true,
-                  compacted: false,
-                  reason: "deferred compaction no longer needed",
-                };
+                if (!this.shouldForceDeferredAnthropicLeafCompaction(telemetry, leafDecision)) {
+                  return {
+                    ok: true,
+                    compacted: false,
+                    reason: "deferred compaction no longer needed",
+                  };
+                }
+                this.deps.log.info(
+                  `[lcm] maintain: deferred Anthropic leaf debt ignoring effective hot-cache state after TTL expiry conversation=${params.conversationId} ${sessionLabel} reason=${leafDecision.reason} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
+                );
               }
               return this.executeLeafCompactionCore({
                 conversationId: params.conversationId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1757,6 +1757,21 @@ export class LcmContextEngine implements ContextEngine {
     return !this.shouldDelayPromptMutatingDeferredCompaction(telemetry);
   }
 
+  /** Use the post-TTL catch-up envelope when stale Anthropic debt must override hot-cache smoothing. */
+  private resolveDeferredLeafCompactionExecutionDecision(params: {
+    telemetry: ConversationCompactionTelemetryRecord | null;
+    leafDecision: IncrementalCompactionDecision;
+  }): IncrementalCompactionDecision {
+    if (!this.shouldForceDeferredAnthropicLeafCompaction(params.telemetry, params.leafDecision)) {
+      return params.leafDecision;
+    }
+    return {
+      ...params.leafDecision,
+      maxPasses: Math.max(1, this.config.cacheAwareCompaction.maxColdCacheCatchupPasses),
+      allowCondensedPasses: true,
+    };
+  }
+
   /** Decide whether a hot cache still has enough real token-budget headroom to skip incremental maintenance. */
   private isComfortablyUnderTokenBudget(params: {
     currentTokenCount?: number;
@@ -2323,8 +2338,13 @@ export class LcmContextEngine implements ContextEngine {
                 tokenBudget: resolvedTokenBudget,
                 currentTokenCount: resolvedCurrentTokenCount,
               });
+              const executionLeafDecision =
+                this.resolveDeferredLeafCompactionExecutionDecision({
+                  telemetry,
+                  leafDecision,
+                });
               if (!leafDecision.shouldCompact) {
-                if (!this.shouldForceDeferredAnthropicLeafCompaction(telemetry, leafDecision)) {
+                if (executionLeafDecision === leafDecision) {
                   return {
                     ok: true,
                     compacted: false,
@@ -2343,11 +2363,11 @@ export class LcmContextEngine implements ContextEngine {
                 currentTokenCount: resolvedCurrentTokenCount,
                 runtimeContext: params.runtimeContext,
                 legacyParams: params.legacyParams,
-                maxPasses: leafDecision.maxPasses,
-                leafChunkTokens: leafDecision.leafChunkTokens,
-                fallbackLeafChunkTokens: leafDecision.fallbackLeafChunkTokens,
-                activityBand: leafDecision.activityBand,
-                allowCondensedPasses: leafDecision.allowCondensedPasses,
+                maxPasses: executionLeafDecision.maxPasses,
+                leafChunkTokens: executionLeafDecision.leafChunkTokens,
+                fallbackLeafChunkTokens: executionLeafDecision.fallbackLeafChunkTokens,
+                activityBand: executionLeafDecision.activityBand,
+                allowCondensedPasses: executionLeafDecision.allowCondensedPasses,
               });
             })();
       await this.compactionMaintenanceStore.markProactiveCompactionFinished({

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5477,6 +5477,77 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
+  it("assemble() still executes deferred Anthropic leaf debt after TTL expiry when cache smoothing remains effectively hot", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      executeLeafCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-stale-ttl-hysteresis";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: new Date(Date.now() - 10 * 60 * 1000),
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "medium",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 55_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeLeafCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: conversation.conversationId,
+        sessionId,
+        tokenBudget: 4_096,
+        maxPasses: 1,
+        leafChunkTokens: 40_000,
+        allowCondensedPasses: false,
+      }),
+    );
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
   it("assemble() waits for the session queue before consuming deferred debt", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5538,9 +5538,87 @@ describe("LcmContextEngine fidelity and token budget", () => {
         conversationId: conversation.conversationId,
         sessionId,
         tokenBudget: 4_096,
-        maxPasses: 1,
+        maxPasses: 2,
         leafChunkTokens: 40_000,
-        allowCondensedPasses: false,
+        allowCondensedPasses: true,
+      }),
+    );
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() uses cold-cache catch-up passes when stale Anthropic debt overrides hot-cache smoothing", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      compaction: {
+        compactLeaf: (input: {
+          allowCondensedPasses?: boolean;
+        }) => Promise<unknown>;
+      };
+    };
+    const sessionId = "assemble-deferred-compaction-stale-ttl-catchup";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: new Date(Date.now() - 10 * 60 * 1000),
+      lastObservedCacheHitAt: new Date(),
+      consecutiveColdObservations: 1,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "medium",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 55_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+    const compactLeafSpy = vi
+      .spyOn(privateEngine.compaction, "compactLeaf")
+      .mockResolvedValueOnce({
+        actionTaken: true,
+        tokensBefore: 900,
+        tokensAfter: 700,
+        condensed: false,
+      })
+      .mockResolvedValueOnce({
+        actionTaken: false,
+        tokensBefore: 700,
+        tokensAfter: 700,
+        condensed: false,
+      });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(compactLeafSpy).toHaveBeenCalledTimes(2);
+    expect(compactLeafSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        allowCondensedPasses: true,
       }),
     );
     expect(maintenance?.pending).toBe(false);


### PR DESCRIPTION
## What
This PR fixes an interaction between cache-aware routing-noise protection (#362) and deferred proactive compaction (#408). When incremental evaluation suppresses compaction due to hot-cache hysteresis, deferred Anthropic sessions were incorrectly terminating their maintenance debt instead of continuing after the prompt-cache TTL expired.

## Why
The #362 fix introduced cache-aware hysteresis that suppresses unnecessary compaction when a cache is 'effectively hot' for routing purposes. However, this was also suppressing legitimate deferred leaf compaction in Anthropic sessions whose actual cache TTL had gone stale. The TTL-safety check in #408 said 'safe to compact,' but the routing-noise heuristic could override that decision.

## Changes
- Adds `shouldForceDeferredAnthropicLeafCompaction()` to check whether deferred Anthropic leaf debt should override cache-aware 'no compaction' once TTL is stale
- Routes override through `executeLeafCompactionCore` instead of terminating maintenance debt early
- Adds regression test for the specific case (TTL stale + routing-noise hysteresis keeping cache state 'effectively hot')
- Preserves existing behavior for inline mode and non-TTL-gated paths

## Testing
- Focused Vitest regression coverage: 'assemble() still executes deferred Anthropic leaf debt after TTL expiry when cache smoothing remains effectively hot'
- Full `test/engine.test.ts` suite passing
- Build check passing

Fixes: #408
Related to: #362