### PR TITLE
fix: preserve deferred compaction debt and scale catch-up passes

### DIFF
--- a/.changeset/ten-cars-hunt.md
+++ b/.changeset/ten-cars-hunt.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep deferred incremental compaction debt pending until oversized raw backlog is actually compacted, and let budget-triggered catch-up scale passes with prompt overage instead of forcing one pass per turn.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -108,6 +108,8 @@ type DynamicLeafChunkBounds = {
   high: number;
   max: number;
 };
+const DEFERRED_COMPACTION_STILL_NEEDED_REASON = "deferred compaction still needed";
+const MAX_BUDGET_TRIGGER_CATCHUP_PASSES = 10;
 type TranscriptRewriteReplacement = {
   entryId: string;
   message: AgentMessage;
@@ -1799,6 +1801,23 @@ export class LcmContextEngine implements ContextEngine {
     return params.currentTokenCount <= safeBudget;
   }
 
+  /** Scale budget-trigger catch-up passes by how far the prompt exceeds threshold. */
+  private resolveBudgetTriggerCatchupPasses(params: {
+    currentTokens: number;
+    threshold: number;
+    leafChunkTokens: number;
+  }): number {
+    const overage = Math.max(0, params.currentTokens - params.threshold);
+    if (overage <= 0) {
+      return 1;
+    }
+    const chunkTokens = Math.max(1, Math.floor(params.leafChunkTokens));
+    return Math.max(
+      1,
+      Math.min(MAX_BUDGET_TRIGGER_CATCHUP_PASSES, Math.ceil(overage / chunkTokens)),
+    );
+  }
+
   /** Resolve bounded dynamic leaf chunk sizes from config and the active token budget. */
   private resolveDynamicLeafChunkBounds(tokenBudget?: number): DynamicLeafChunkBounds {
     const floor = Math.max(1, Math.floor(this.config.leafChunkTokens));
@@ -2180,6 +2199,11 @@ export class LcmContextEngine implements ContextEngine {
       params.currentTokenCount,
     );
     if (budgetDecision.shouldCompact) {
+      const maxPasses = this.resolveBudgetTriggerCatchupPasses({
+        currentTokens: budgetDecision.currentTokens,
+        threshold: budgetDecision.threshold,
+        leafChunkTokens: preferredLeafChunkTokens,
+      });
       return this.logIncrementalCompactionDecision({
         conversationId: params.conversationId,
         cacheState,
@@ -2190,7 +2214,7 @@ export class LcmContextEngine implements ContextEngine {
         rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
         threshold: leafTrigger.threshold,
         shouldCompact: true,
-        maxPasses: 1,
+        maxPasses,
         allowCondensedPasses: true,
         reason: "budget-trigger",
       });
@@ -2352,11 +2376,15 @@ export class LcmContextEngine implements ContextEngine {
                   leafDecision,
                 });
               if (!leafDecision.shouldCompact) {
+                const deferredLeafStillNeeded =
+                  leafDecision.rawTokensOutsideTail >= leafDecision.threshold;
                 if (executionLeafDecision === leafDecision) {
                   return {
                     ok: true,
                     compacted: false,
-                    reason: "deferred compaction no longer needed",
+                    reason: deferredLeafStillNeeded
+                      ? DEFERRED_COMPACTION_STILL_NEEDED_REASON
+                      : "deferred compaction no longer needed",
                   };
                 }
                 this.deps.log.info(
@@ -2382,7 +2410,7 @@ export class LcmContextEngine implements ContextEngine {
         conversationId: params.conversationId,
         finishedAt: new Date(),
         failureSummary: result.ok ? null : result.reason ?? "deferred compaction failed",
-        keepPending: !result.ok,
+        keepPending: !result.ok || result.reason === DEFERRED_COMPACTION_STILL_NEEDED_REASON,
       });
       this.deps.log.info(
         `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"}`,
@@ -4704,8 +4732,16 @@ export class LcmContextEngine implements ContextEngine {
     };
     let shouldRefreshBootstrapState = true;
 
+    let rawLeafTrigger:
+      | {
+          shouldCompact: boolean;
+          rawTokensOutsideTail: number;
+          threshold: number;
+        }
+      | null = null;
+
     try {
-      const rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
+      rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
       await this.updateCompactionTelemetry({
         conversationId: conversation.conversationId,
         runtimeContext: legacyParams,
@@ -4765,10 +4801,14 @@ export class LcmContextEngine implements ContextEngine {
             await recordAfterTurnCompactionRetry(retryReason);
           }
         }
-      } else if (thresholdDecision.shouldCompact || leafDecision.shouldCompact) {
+      } else if (thresholdDecision.shouldCompact || rawLeafTrigger?.shouldCompact) {
         await this.recordDeferredCompactionDebt({
           conversationId: conversation.conversationId,
-          reason: thresholdDecision.shouldCompact ? "threshold" : leafDecision.reason,
+          reason: thresholdDecision.shouldCompact
+            ? "threshold"
+            : leafDecision.shouldCompact
+              ? leafDecision.reason
+              : "leaf-trigger",
           tokenBudget,
           currentTokenCount: liveContextTokens,
         });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5516,6 +5516,70 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.requestedAt).toBeInstanceOf(Date);
   });
 
+  it("afterTurn records deferred leaf debt even when cache heuristics defer execution", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-hot-cache-deferred-leaf-debt";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (
+          conversationId: number,
+          leafChunkTokens?: number,
+        ) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 55_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      cacheState: "hot",
+      maxPasses: 1,
+      rawTokensOutsideTail: 55_000,
+      threshold: 20_000,
+      leafChunkTokens: 20_000,
+      fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+      activityBand: "low",
+      allowCondensedPasses: false,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-hot-cache-deferred-leaf-debt"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
+    expect(compactSpy).not.toHaveBeenCalled();
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.reason).toBe("leaf-trigger");
+  });
+
   it("afterTurn records threshold debt even when the leaf trigger stays below threshold", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-threshold-deferred-compaction-debt";
@@ -5631,6 +5695,53 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
     expect(maintenanceResult.changed).toBe(false);
     expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
+  });
+
+  it("maintain() keeps deferred leaf debt pending when raw backlog still exceeds the trigger", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-still-needed";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 1_024,
+    });
+
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 55_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-still-needed"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenanceResult.changed).toBe(false);
+    expect(maintenanceResult.reason).toBe("deferred compaction still needed");
   });
 
   it("maintain() keeps deferred prompt-mutating debt pending while Anthropic cache is still hot", async () => {
@@ -5820,6 +5931,48 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation.conversationId);
     expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() keeps deferred leaf debt pending while a hot-cache recheck still exceeds the trigger", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-still-needed";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 1_024,
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 55_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
     expect(maintenance?.running).toBe(false);
     expect(assembleResult.messages).toHaveLength(1);
   });
@@ -6236,6 +6389,90 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.leafChunkTokens).toBe(40_000);
     expect(infoLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction scales budget-trigger passes by prompt overage", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-budget-trigger-catchup";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+        leafChunkTokens: number;
+        maxPasses: number;
+        allowCondensedPasses: boolean;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "hot",
+      lastObservedCacheRead: 2_048,
+      turnsSinceLeafCompaction: 1,
+      tokensAccumulatedSinceLeafCompaction: 90_000,
+      lastActivityBand: "high",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 90_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 205_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 205_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.cacheState).toBe("hot");
+    expect(decision.leafChunkTokens).toBe(40_000);
+    expect(decision.maxPasses).toBe(4);
+    expect(decision.allowCondensedPasses).toBe(true);
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=budget-trigger"),
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("maxPasses=4"),
     );
   });
 


### PR DESCRIPTION
## What
Fix deferred incremental compaction so large raw backlogs stay queued until they are actually compacted, and make budget-trigger compaction scale catch-up passes with prompt overage instead of always running a single pass.

## Why
Live conversations were recording deferred leaf debt and then immediately clearing it as "no longer needed" while raw backlog was still far above the leaf trigger. At the same time, once deferred maintenance crossed the threshold compaction line it only did one pass per turn, which stretched cache recovery across many turns instead of breaking once and catching up.

## Changes
- Keep deferred leaf debt pending while backlog still exceeds trigger
- Record deferred leaf debt whenever raw backlog crosses trigger
- Scale budget-trigger passes from prompt overage
- Add regressions for deferred maintain and assemble paths

## Testing
- `pnpm vitest run test/engine.test.ts`
- Expected: `171/171` engine tests pass

Changeset: this behavior change should be reviewed for release-note coverage before merge.
