### PR TITLE
fix: use resolved summary plugin config fallback

### DIFF
--- a/.changeset/quiet-crabs-resolve.md
+++ b/.changeset/quiet-crabs-resolve.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use the resolved plugin summary config when runtime config is unavailable so compaction keeps the configured summary model instead of falling back to emergency truncation.

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1018,7 +1018,12 @@ function resolveSummaryCandidates(params: {
           };
         })
       : undefined;
-  const nestedPluginConfig = runtimeConfig?.plugins?.entries?.["lossless-claw"]?.config;
+  const directPluginConfig = params.deps.config as {
+    summaryModel?: unknown;
+    summaryProvider?: unknown;
+  };
+  const nestedPluginConfig =
+    runtimeConfig?.plugins?.entries?.["lossless-claw"]?.config ?? directPluginConfig;
 
   const resolutionCandidates: SummaryResolutionCandidate[] = [
     {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -188,6 +188,26 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(vi.mocked(deps.resolveModel)).toHaveBeenCalledWith("gpt-4.1", "qiniu");
   });
 
+  it("uses resolved plugin summary config from deps when runtime config is unavailable", async () => {
+    const deps = makeDeps({
+      config: {
+        ...makeDeps().config,
+        summaryProvider: "openrouter",
+        summaryModel: "openrouter/z-ai/glm-5.1",
+      },
+    });
+
+    await createLcmSummarizeFromLegacyParams({
+      deps,
+      legacyParams: {},
+    });
+
+    expect(vi.mocked(deps.resolveModel)).toHaveBeenCalledWith(
+      "openrouter/z-ai/glm-5.1",
+      "openrouter",
+    );
+  });
+
   it("prefers env summaryModel over compaction model and session model", async () => {
     vi.stubEnv("LCM_SUMMARY_MODEL", "gpt-4o-mini");
     vi.stubEnv("LCM_SUMMARY_PROVIDER", "openai-resp");


### PR DESCRIPTION
## Summary
- fall back to the resolved LCM plugin config from deps.config when full runtime config is unavailable
- preserve existing runtime config precedence when plugins.entries.lossless-claw.config is present
- add a regression test for plugin summaryModel/summaryProvider resolved through deps.config
- add a patch changeset

## Why
Some OpenClaw compaction paths call createLcmSummarizeFromLegacyParams without legacyParams.config even though the plugin config has already been resolved into deps.config. In that shape, summaryModel/summaryProvider were ignored and LCM could resolve no summary candidates, causing emergency truncation despite valid plugin config.

## Verification
- docker container Node runtime: node v24.14.0
- npm ci --include=dev
- ./node_modules/.bin/vitest run test/summarize.test.ts: 48 passed
- npm run build