### PR TITLE
fix: unify lcm-tui provider config

### DIFF
--- a/.changeset/silly-melons-argue.md
+++ b/.changeset/silly-melons-argue.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Unify `lcm-tui` summary provider configuration across doctor, repair, rewrite, and backfill so the standalone commands honor the same provider, model, and base URL overrides as interactive rewrite.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -237,6 +237,32 @@ The confirmation screen shows:
 
 Each interactive operation also has a standalone CLI equivalent for scripting and batch operations.
 
+### `lcm-tui doctor`
+
+Scans for genuinely truncated summaries and can rewrite them in place. This is narrower than `repair`: it looks for specific truncation marker shapes instead of the generic fallback-summary marker.
+
+```bash
+# Preview repairs for one conversation
+lcm-tui doctor 44 --show-diff
+
+# Apply repairs with an OpenAI-compatible backend
+lcm-tui doctor 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
+
+# Scan only across every conversation
+lcm-tui doctor --all
+```
+
+| Flag | Description |
+|------|-------------|
+| `--apply` | Write repaired summaries to the database |
+| `--summary` | Scan only and show counts |
+| `--all` | Scan all conversations (discovery mode only) |
+| `--provider <id>` | API provider (default: anthropic) |
+| `--model <model>` | API model (default: `claude-haiku-4-5`) |
+| `--base-url <url>` | Custom API base URL (overrides config and env) |
+| `--show-diff` | Show unified diff for each fix |
+| `--timestamps` | Inject timestamps into rewrite source text |
+
 ### `lcm-tui repair`
 
 Finds and fixes corrupted summaries (those containing the `[LCM fallback summary]` marker from failed summarization attempts).
@@ -253,6 +279,9 @@ lcm-tui repair 44 --apply
 
 # Repair a specific summary
 lcm-tui repair 44 --summary-id sum_abc123 --apply
+
+# Repair through an OpenAI-compatible backend
+lcm-tui repair 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
 ```
 
 The repair process:
@@ -260,7 +289,7 @@ The repair process:
 2. Orders them bottom-up: leaves first (in context ordinal order), then condensed nodes by ascending depth
 3. Reconstructs source material from linked messages (leaves) or child summaries (condensed)
 4. Resolves `previous_context` for each node (for deduplication in the prompt)
-5. Sends to Anthropic API with the appropriate depth prompt
+5. Sends to the resolved provider API with the appropriate depth prompt
 6. Updates the database in a single transaction
 
 | Flag | Description |
@@ -268,6 +297,9 @@ The repair process:
 | `--apply` | Write repairs to database (default: dry run) |
 | `--all` | Scan all conversations |
 | `--summary-id <id>` | Target a specific summary |
+| `--provider <id>` | API provider (inferred from `--model` when omitted) |
+| `--model <model>` | API model (default depends on provider) |
+| `--base-url <url>` | Custom API base URL (overrides config and env) |
 | `--verbose` | Show content hashes and previews |
 
 ### `lcm-tui rewrite`
@@ -484,13 +516,14 @@ Resolution order:
 
 If the provider auth profile mode is `oauth` (not `api_key`), set the provider API key environment variable explicitly.
 
-Interactive rewrite (`w`/`W`) can be configured with:
+Summary-producing operations (`doctor`, `repair`, `rewrite`, `backfill`, and interactive rewrite `w`/`W`) can be configured with:
 - `LCM_TUI_SUMMARY_PROVIDER`
 - `LCM_TUI_SUMMARY_MODEL`
 - `LCM_TUI_SUMMARY_BASE_URL`
-- `LCM_TUI_CONVERSATION_WINDOW_SIZE` (default `200`)
 
 It also honors `LCM_SUMMARY_PROVIDER` / `LCM_SUMMARY_MODEL` / `LCM_SUMMARY_BASE_URL` as fallback.
+
+Separately, the conversation browser window size uses `LCM_TUI_CONVERSATION_WINDOW_SIZE` (default `200`).
 
 ## Database
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -51,12 +51,12 @@ lcm-tui --db /path/to/lcm.db    # custom database path
 Each interactive operation has a standalone CLI equivalent for scripting:
 
 ```bash
-lcm-tui doctor 44 --show-diff                        # preview real truncation repairs
-lcm-tui repair 44 --apply                           # fix corrupted summaries
-lcm-tui rewrite 44 --all --apply --diff              # re-summarize everything
+lcm-tui doctor 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
+lcm-tui repair 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
+lcm-tui rewrite 44 --all --apply --diff --provider openai --model gpt-5.3-codex
 lcm-tui dissolve 44 --summary-id sum_abc --apply     # undo a condensation
 lcm-tui transplant 18 653 --apply                    # copy DAG between conversations
-lcm-tui backfill my-agent session_abc --apply        # import + compact historical session
+lcm-tui backfill my-agent session_abc --apply --provider openai --model gpt-5.3-codex
 lcm-tui backfill my-agent session_abc --apply --recompact --single-root # re-fold existing import to one root
 lcm-tui prompts --list                               # show active prompt sources
 ```
@@ -69,7 +69,7 @@ Full reference with keybindings, screen descriptions, flag tables, and troublesh
 
 The TUI reads directly from the LCM SQLite database (`~/.openclaw/lcm.db`) and session JSONL files (`~/.openclaw/agents/`). Write operations (rewrite, repair, dissolve, transplant, backfill) use transactions. Changes take effect on the next conversation turn — no restart needed.
 
-Rewrite, repair, and backfill compaction operations call provider APIs directly. By default they use Anthropic (`claude-sonnet-4-20250514`), and rewrite/backfill also support OpenAI (`--provider openai --model gpt-5.3-codex`) with `OPENAI_API_KEY`.
+Doctor, repair, rewrite, and backfill compaction operations all accept `--provider`, `--model`, and `--base-url`, and they also honor `LCM_TUI_SUMMARY_PROVIDER`, `LCM_TUI_SUMMARY_MODEL`, and `LCM_TUI_SUMMARY_BASE_URL` before falling back to the legacy `LCM_SUMMARY_*` settings. By default, repair/rewrite/backfill use Anthropic (`claude-sonnet-4-20250514`), while doctor keeps its lighter default (`claude-haiku-4-5`).
 
 ## License
 

--- a/tui/backfill.go
+++ b/tui/backfill.go
@@ -127,6 +127,11 @@ func runBackfillCommand(args []string) error {
 	}
 	defer db.Close()
 
+	settings := resolveTUISummaryRuntimeSettings(paths, opts.provider, opts.model, opts.baseURL, "", "")
+	opts.provider = settings.provider
+	opts.model = settings.model
+	opts.baseURL = settings.baseURL
+
 	ctx := context.Background()
 	input := backfillSessionInput{
 		agent:       opts.agent,
@@ -187,7 +192,7 @@ func runBackfillCommand(args []string) error {
 		apiKey:   apiKey,
 		http:     &http.Client{Timeout: defaultHTTPTimeout},
 		model:    opts.model,
-		baseURL:  resolveProviderBaseURL(paths, opts.provider, opts.baseURL),
+		baseURL:  opts.baseURL,
 	}
 
 	result, stats, err := runBackfillWorkflow(ctx, db, opts, input, client.summarize)
@@ -355,7 +360,6 @@ func parseBackfillArgs(args []string) (backfillOptions, error) {
 	if opts.promptDir != "" {
 		opts.promptDir = expandHomePath(opts.promptDir)
 	}
-	opts.provider, opts.model = resolveSummaryProviderModel(opts.provider, opts.model)
 	return opts, nil
 }
 
@@ -425,6 +429,10 @@ Flags:
   --provider <id>              API provider (inferred from model when omitted)
   --model <id>                 API model (default: provider-specific)
   --base-url <url>             custom API base URL (overrides openclaw.json and env)
+
+Env:
+  LCM_TUI_SUMMARY_PROVIDER / LCM_TUI_SUMMARY_MODEL / LCM_TUI_SUMMARY_BASE_URL
+  fall back to LCM_SUMMARY_PROVIDER / LCM_SUMMARY_MODEL / LCM_SUMMARY_BASE_URL
 `)
 }
 

--- a/tui/base_url_test.go
+++ b/tui/base_url_test.go
@@ -65,6 +65,111 @@ func TestResolveInteractiveRewriteProviderModelUsesTUISummaryBaseURL(t *testing.
 	}
 }
 
+func TestResolveTUISummaryRuntimeSettingsPrefersCLIOverEnv(t *testing.T) {
+	t.Setenv("LCM_TUI_SUMMARY_PROVIDER", "openai")
+	t.Setenv("LCM_TUI_SUMMARY_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_TUI_SUMMARY_BASE_URL", "https://tui.example.com/openai/")
+	t.Setenv("LCM_SUMMARY_PROVIDER", "anthropic")
+	t.Setenv("LCM_SUMMARY_MODEL", "claude-sonnet-4-20250514")
+	t.Setenv("LCM_SUMMARY_BASE_URL", "https://summary.example.com/anthropic/")
+
+	settings := resolveTUISummaryRuntimeSettings(
+		appDataPaths{},
+		"openai",
+		"glm-5",
+		"https://flag.example.com/openai/",
+		"",
+		"",
+	)
+
+	if settings.provider != "openai" {
+		t.Fatalf("expected provider openai, got %q", settings.provider)
+	}
+	if settings.model != "glm-5" {
+		t.Fatalf("expected model glm-5, got %q", settings.model)
+	}
+	if settings.baseURL != "https://flag.example.com/openai" {
+		t.Fatalf("expected CLI base URL override, got %q", settings.baseURL)
+	}
+}
+
+func TestResolveTUISummaryRuntimeSettingsUsesTUIEnvBeforeLegacyEnv(t *testing.T) {
+	t.Setenv("LCM_TUI_SUMMARY_PROVIDER", "openai")
+	t.Setenv("LCM_TUI_SUMMARY_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_TUI_SUMMARY_BASE_URL", "https://tui.example.com/openai/")
+	t.Setenv("LCM_SUMMARY_PROVIDER", "anthropic")
+	t.Setenv("LCM_SUMMARY_MODEL", "claude-sonnet-4-20250514")
+	t.Setenv("LCM_SUMMARY_BASE_URL", "https://summary.example.com/anthropic/")
+
+	settings := resolveTUISummaryRuntimeSettings(appDataPaths{}, "", "", "", doctorDefaultProvider, doctorDefaultModel)
+	if settings.provider != "openai" {
+		t.Fatalf("expected TUI env provider, got %q", settings.provider)
+	}
+	if settings.model != "gpt-5.3-codex" {
+		t.Fatalf("expected TUI env model, got %q", settings.model)
+	}
+	if settings.baseURL != "https://tui.example.com/openai" {
+		t.Fatalf("expected TUI env base URL, got %q", settings.baseURL)
+	}
+}
+
+func TestResolveTUISummaryRuntimeSettingsUsesDoctorDefaults(t *testing.T) {
+	settings := resolveTUISummaryRuntimeSettings(appDataPaths{}, "", "", "", doctorDefaultProvider, doctorDefaultModel)
+	if settings.provider != doctorDefaultProvider {
+		t.Fatalf("expected doctor default provider %q, got %q", doctorDefaultProvider, settings.provider)
+	}
+	if settings.model != doctorDefaultModel {
+		t.Fatalf("expected doctor default model %q, got %q", doctorDefaultModel, settings.model)
+	}
+	if settings.baseURL != defaultAnthropicBaseURL {
+		t.Fatalf("expected Anthropic default base URL %q, got %q", defaultAnthropicBaseURL, settings.baseURL)
+	}
+}
+
+func TestParseRepairArgsAcceptsProviderModelBaseURL(t *testing.T) {
+	opts, conversationID, err := parseRepairArgs([]string{
+		"44",
+		"--apply",
+		"--provider", "openai",
+		"--model", "glm-5",
+		"--base-url", "https://proxy.example.com/openai/",
+	})
+	if err != nil {
+		t.Fatalf("parseRepairArgs returned error: %v", err)
+	}
+	if conversationID != 44 {
+		t.Fatalf("expected conversation ID 44, got %d", conversationID)
+	}
+	if opts.provider != "openai" || opts.model != "glm-5" {
+		t.Fatalf("expected provider/model to round-trip, got %q/%q", opts.provider, opts.model)
+	}
+	if opts.baseURL != "https://proxy.example.com/openai/" {
+		t.Fatalf("expected base URL to round-trip, got %q", opts.baseURL)
+	}
+}
+
+func TestParseDoctorArgsAcceptsBaseURL(t *testing.T) {
+	opts, conversationID, hasConversationID, err := parseDoctorArgs([]string{
+		"44",
+		"--apply",
+		"--provider", "openai",
+		"--model", "glm-5",
+		"--base-url", "https://proxy.example.com/openai/",
+	})
+	if err != nil {
+		t.Fatalf("parseDoctorArgs returned error: %v", err)
+	}
+	if !hasConversationID || conversationID != 44 {
+		t.Fatalf("expected conversation ID 44, got hasID=%v id=%d", hasConversationID, conversationID)
+	}
+	if opts.provider != "openai" || opts.model != "glm-5" {
+		t.Fatalf("expected provider/model to round-trip, got %q/%q", opts.provider, opts.model)
+	}
+	if opts.baseURL != "https://proxy.example.com/openai/" {
+		t.Fatalf("expected base URL to round-trip, got %q", opts.baseURL)
+	}
+}
+
 func TestParseRewriteArgsAcceptsBaseURL(t *testing.T) {
 	opts, conversationID, err := parseRewriteArgs([]string{
 		"44",

--- a/tui/doctor.go
+++ b/tui/doctor.go
@@ -30,6 +30,7 @@ type doctorOptions struct {
 	all        bool
 	provider   string
 	model      string
+	baseURL    string
 	showDiff   bool
 	timestamps bool
 }
@@ -114,6 +115,11 @@ func runDoctorCommand(args []string) error {
 		return nil
 	}
 
+	settings := resolveTUISummaryRuntimeSettings(paths, opts.provider, opts.model, opts.baseURL, doctorDefaultProvider, doctorDefaultModel)
+	opts.provider = settings.provider
+	opts.model = settings.model
+	opts.baseURL = settings.baseURL
+
 	fmt.Printf("Doctor found %d broken summaries in conversation %d.\n", len(plan.targets), conversationID)
 	printDoctorPlan(plan)
 	fmt.Println()
@@ -141,6 +147,7 @@ func runDoctorCommand(args []string) error {
 			apiKey:   apiKey,
 			http:     &http.Client{Timeout: defaultHTTPTimeout},
 			model:    opts.model,
+			baseURL:  opts.baseURL,
 		}
 	}
 
@@ -165,6 +172,7 @@ func parseDoctorArgs(args []string) (doctorOptions, int64, bool, error) {
 	all := fs.Bool("all", false, "scan all conversations")
 	provider := fs.String("provider", "", "provider id (e.g. anthropic, openai)")
 	model := fs.String("model", "", "summary model id")
+	baseURL := fs.String("base-url", "", "custom API base URL")
 	showDiff := fs.Bool("show-diff", false, "show unified diff for each fix")
 	timestamps := fs.Bool("timestamps", false, "inject timestamps into the rewrite source")
 
@@ -180,10 +188,12 @@ func parseDoctorArgs(args []string) (doctorOptions, int64, bool, error) {
 		apply:      *apply,
 		summary:    *summary || *all,
 		all:        *all,
+		baseURL:    strings.TrimSpace(*baseURL),
 		showDiff:   *showDiff,
 		timestamps: *timestamps,
 	}
-	opts.provider, opts.model = resolveDoctorProviderModel(strings.TrimSpace(*provider), strings.TrimSpace(*model))
+	opts.provider = strings.TrimSpace(*provider)
+	opts.model = strings.TrimSpace(*model)
 
 	if opts.apply && opts.summary {
 		return doctorOptions{}, 0, false, fmt.Errorf("--apply cannot be combined with scan-only flags\n%s", doctorUsageText())
@@ -216,7 +226,7 @@ func normalizeDoctorArgs(args []string) ([]string, error) {
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		takesValue := arg == "--provider" || arg == "--model"
+		takesValue := arg == "--provider" || arg == "--model" || arg == "--base-url"
 		if takesValue {
 			if i+1 >= len(args) {
 				return nil, fmt.Errorf("missing value for %s", arg)
@@ -225,7 +235,7 @@ func normalizeDoctorArgs(args []string) ([]string, error) {
 			i++
 			continue
 		}
-		if strings.HasPrefix(arg, "--provider=") || strings.HasPrefix(arg, "--model=") {
+		if strings.HasPrefix(arg, "--provider=") || strings.HasPrefix(arg, "--model=") || strings.HasPrefix(arg, "--base-url=") {
 			flags = append(flags, arg)
 			continue
 		}
@@ -244,7 +254,7 @@ func normalizeDoctorArgs(args []string) ([]string, error) {
 
 func doctorUsageText() string {
 	return strings.TrimSpace(`Usage:
-  lcm-tui doctor <conversation_id> [--show-diff] [--timestamps] [--apply]
+  lcm-tui doctor <conversation_id> [--show-diff] [--timestamps] [--apply] [--provider <id>] [--model <model>] [--base-url <url>]
   lcm-tui doctor <conversation_id> --summary
   lcm-tui doctor --summary
   lcm-tui doctor --all
@@ -255,19 +265,14 @@ Flags:
   --all               scan all conversations (discovery mode only)
   --provider <id>     API provider (default: anthropic)
   --model <model>     API model (default: claude-haiku-4-5)
+  --base-url <url>    custom API base URL (overrides config and env)
   --show-diff         show unified diff for each fix
   --timestamps        inject timestamps into rewrite source text
-`)
-}
 
-func resolveDoctorProviderModel(providerHint, modelHint string) (string, string) {
-	if strings.TrimSpace(modelHint) == "" {
-		switch normalizeProviderID(providerHint) {
-		case "", "anthropic":
-			return doctorDefaultProvider, doctorDefaultModel
-		}
-	}
-	return resolveSummaryProviderModel(providerHint, modelHint)
+Env:
+  LCM_TUI_SUMMARY_PROVIDER / LCM_TUI_SUMMARY_MODEL / LCM_TUI_SUMMARY_BASE_URL
+  fall back to LCM_SUMMARY_PROVIDER / LCM_SUMMARY_MODEL / LCM_SUMMARY_BASE_URL
+`)
 }
 
 // buildDoctorPlan keeps the repair order bottom-up so parent rewrites can consume repaired children.
@@ -514,8 +519,8 @@ func detectDoctorMarker(content string) string {
 	if idx >= 0 && len(content)-idx < doctorNewMarkerWindow {
 		return "new"
 	}
-	fidx := strings.Index(content, doctorLCMFallbackMarker)
-	if fidx >= 0 && len(content)-fidx < doctorFallbackWindow {
+	fidx := strings.LastIndex(content, doctorLCMFallbackMarker)
+	if fidx > 0 && len(content)-fidx < doctorFallbackWindow && content[fidx-1] == '\n' {
 		return "fallback"
 	}
 	return ""

--- a/tui/main.go
+++ b/tui/main.go
@@ -1355,19 +1355,8 @@ func (m model) startPendingRewriteAPI() tea.Cmd {
 }
 
 func resolveInteractiveRewriteProviderModel(paths appDataPaths) (string, string, string) {
-	provider := strings.TrimSpace(os.Getenv("LCM_TUI_SUMMARY_PROVIDER"))
-	if provider == "" {
-		provider = strings.TrimSpace(os.Getenv("LCM_SUMMARY_PROVIDER"))
-	}
-
-	model := strings.TrimSpace(os.Getenv("LCM_TUI_SUMMARY_MODEL"))
-	if model == "" {
-		model = strings.TrimSpace(os.Getenv("LCM_SUMMARY_MODEL"))
-	}
-	resolvedProvider, resolvedModel := resolveSummaryProviderModel(provider, model)
-	baseURL := strings.TrimSpace(os.Getenv("LCM_TUI_SUMMARY_BASE_URL"))
-	baseURL = resolveProviderBaseURL(paths, resolvedProvider, baseURL)
-	return resolvedProvider, resolvedModel, baseURL
+	settings := resolveTUISummaryRuntimeSettings(paths, "", "", "", "", "")
+	return settings.provider, settings.model, settings.baseURL
 }
 
 func rewriteSpinnerTickCmd() tea.Cmd {

--- a/tui/repair.go
+++ b/tui/repair.go
@@ -47,6 +47,9 @@ type repairOptions struct {
 	all       bool
 	summaryID string
 	verbose   bool
+	provider  string
+	model     string
+	baseURL   string
 }
 
 type repairSummary struct {
@@ -178,16 +181,21 @@ func runRepairCommand(args []string) error {
 
 	var client *anthropicClient
 	if opts.apply {
-		apiKey, err := resolveAnthropicAPIKey(paths)
+		settings := resolveTUISummaryRuntimeSettings(paths, opts.provider, opts.model, opts.baseURL, "", "")
+		opts.provider = settings.provider
+		opts.model = settings.model
+		opts.baseURL = settings.baseURL
+
+		apiKey, err := resolveProviderAPIKey(paths, opts.provider)
 		if err != nil {
 			return err
 		}
 		client = &anthropicClient{
-			provider: defaultLLMProvider,
+			provider: opts.provider,
 			apiKey:   apiKey,
 			http:     &http.Client{Timeout: defaultHTTPTimeout},
-			model:    anthropicModel,
-			baseURL:  resolveProviderBaseURL(paths, defaultLLMProvider, ""),
+			model:    opts.model,
+			baseURL:  opts.baseURL,
 		}
 	}
 
@@ -218,6 +226,9 @@ func parseRepairArgs(args []string) (repairOptions, int64, error) {
 	all := fs.Bool("all", false, "scan all conversations")
 	summaryID := fs.String("summary-id", "", "repair a specific summary ID")
 	verbose := fs.Bool("verbose", false, "include old content hash and preview")
+	provider := fs.String("provider", "", "provider id (e.g. anthropic, openai)")
+	model := fs.String("model", "", "summary model id")
+	baseURL := fs.String("base-url", "", "custom API base URL")
 
 	normalizedArgs, err := normalizeRepairArgs(args)
 	if err != nil {
@@ -236,6 +247,9 @@ func parseRepairArgs(args []string) (repairOptions, int64, error) {
 		all:       *all,
 		summaryID: strings.TrimSpace(*summaryID),
 		verbose:   *verbose,
+		provider:  strings.TrimSpace(*provider),
+		model:     strings.TrimSpace(*model),
+		baseURL:   strings.TrimSpace(*baseURL),
 	}
 	if opts.apply {
 		opts.dryRun = false
@@ -270,8 +284,16 @@ func normalizeRepairArgs(args []string) ([]string, error) {
 		switch {
 		case arg == "--apply" || arg == "--dry-run" || arg == "--all" || arg == "--verbose":
 			flags = append(flags, arg)
+		case strings.HasPrefix(arg, "--provider="), strings.HasPrefix(arg, "--model="), strings.HasPrefix(arg, "--base-url="):
+			flags = append(flags, arg)
 		case strings.HasPrefix(arg, "--summary-id="):
 			flags = append(flags, arg)
+		case arg == "--provider" || arg == "--model" || arg == "--base-url":
+			if i+1 >= len(args) {
+				return nil, errors.New("missing value for " + arg)
+			}
+			flags = append(flags, arg, args[i+1])
+			i++
 		case arg == "--summary-id":
 			if i+1 >= len(args) {
 				return nil, errors.New("missing value for --summary-id")
@@ -290,9 +312,13 @@ func normalizeRepairArgs(args []string) ([]string, error) {
 func repairUsageText() string {
 	return strings.TrimSpace(`
 Usage:
-  lcm-tui repair <conversation_id> [--dry-run] [--summary-id <id>]
-  lcm-tui repair <conversation_id> --apply [--summary-id <id>]
-  lcm-tui repair --all [--dry-run|--apply]
+  lcm-tui repair <conversation_id> [--dry-run] [--summary-id <id>] [--provider <id>] [--model <model>] [--base-url <url>]
+  lcm-tui repair <conversation_id> --apply [--summary-id <id>] [--provider <id>] [--model <model>] [--base-url <url>]
+  lcm-tui repair --all [--dry-run|--apply] [--provider <id>] [--model <model>] [--base-url <url>]
+
+Env:
+  LCM_TUI_SUMMARY_PROVIDER / LCM_TUI_SUMMARY_MODEL / LCM_TUI_SUMMARY_BASE_URL
+  fall back to LCM_SUMMARY_PROVIDER / LCM_SUMMARY_MODEL / LCM_SUMMARY_BASE_URL
 `)
 }
 

--- a/tui/rewrite.go
+++ b/tui/rewrite.go
@@ -73,6 +73,11 @@ func runRewriteCommand(args []string) error {
 	}
 	defer db.Close()
 
+	settings := resolveTUISummaryRuntimeSettings(paths, opts.provider, opts.model, opts.baseURL, "", "")
+	opts.provider = settings.provider
+	opts.model = settings.model
+	opts.baseURL = settings.baseURL
+
 	ctx := context.Background()
 	targets, err := loadRewriteTargets(ctx, db, conversationID, opts)
 	if err != nil {
@@ -101,7 +106,7 @@ func runRewriteCommand(args []string) error {
 			apiKey:   apiKey,
 			http:     &http.Client{Timeout: defaultHTTPTimeout},
 			model:    opts.model,
-			baseURL:  resolveProviderBaseURL(paths, opts.provider, opts.baseURL),
+			baseURL:  opts.baseURL,
 		}
 	} else {
 		apiKey, err := resolveProviderAPIKey(paths, opts.provider)
@@ -111,7 +116,7 @@ func runRewriteCommand(args []string) error {
 				apiKey:   apiKey,
 				http:     &http.Client{Timeout: defaultHTTPTimeout},
 				model:    opts.model,
-				baseURL:  resolveProviderBaseURL(paths, opts.provider, opts.baseURL),
+				baseURL:  opts.baseURL,
 			}
 		}
 		if client == nil {
@@ -237,7 +242,6 @@ func parseRewriteArgs(args []string) (rewriteOptions, int64, error) {
 	if opts.promptDir != "" {
 		opts.promptDir = expandHomePath(opts.promptDir)
 	}
-	opts.provider, opts.model = resolveSummaryProviderModel(opts.provider, opts.model)
 	if opts.apply {
 		opts.dryRun = false
 	}
@@ -332,6 +336,10 @@ Flags:
   --diff              show unified diff
   --timestamps        inject timestamps into source text (default true)
   --tz <timezone>     timezone for timestamps (e.g. America/Los_Angeles; default: system local)
+
+Env:
+  LCM_TUI_SUMMARY_PROVIDER / LCM_TUI_SUMMARY_MODEL / LCM_TUI_SUMMARY_BASE_URL
+  fall back to LCM_SUMMARY_PROVIDER / LCM_SUMMARY_MODEL / LCM_SUMMARY_BASE_URL
 `)
 }
 

--- a/tui/summary_runtime.go
+++ b/tui/summary_runtime.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+type summaryRuntimeSettings struct {
+	provider string
+	model    string
+	baseURL  string
+}
+
+// resolveTUISummaryRuntimeSettings centralizes standalone/interactive summary
+// provider resolution so every lcm-tui summarization entrypoint honors the
+// same CLI, TUI env, legacy env, config, and provider-default precedence.
+func resolveTUISummaryRuntimeSettings(
+	paths appDataPaths,
+	cliProvider string,
+	cliModel string,
+	cliBaseURL string,
+	defaultProvider string,
+	defaultModel string,
+) summaryRuntimeSettings {
+	providerHint := firstNonEmptyString(
+		cliProvider,
+		os.Getenv("LCM_TUI_SUMMARY_PROVIDER"),
+		os.Getenv("LCM_SUMMARY_PROVIDER"),
+		defaultProvider,
+	)
+	modelHint := firstNonEmptyString(
+		cliModel,
+		os.Getenv("LCM_TUI_SUMMARY_MODEL"),
+		os.Getenv("LCM_SUMMARY_MODEL"),
+		defaultModel,
+	)
+	provider, model := resolveSummaryProviderModel(providerHint, modelHint)
+
+	baseURLHint := firstNonEmptyString(
+		cliBaseURL,
+		os.Getenv("LCM_TUI_SUMMARY_BASE_URL"),
+	)
+
+	return summaryRuntimeSettings{
+		provider: provider,
+		model:    model,
+		baseURL:  resolveProviderBaseURL(paths, provider, baseURLHint),
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What
This PR unifies how `lcm-tui` resolves summary provider settings so doctor, repair, rewrite, backfill, and interactive rewrite all honor the same provider, model, and base URL overrides.

## Why
Issue #460 called out that the TUI command surface had drifted: `rewrite` and `backfill` supported richer provider overrides than `repair`, `doctor` was missing base URL parity, and `LCM_TUI_SUMMARY_*` only applied to interactive rewrite. Bringing those paths back into alignment makes TUI maintenance workflows more predictable and easier to route through alternate providers or proxies.

## Changes
- Add shared TUI summary runtime resolver
- Wire resolver into doctor, repair, rewrite, backfill
- Add provider/model/base-url flags to repair
- Add base-url flag to doctor
- Reuse shared env fallback in interactive rewrite
- Cover config precedence with Go tests
- Update TUI docs and README
- Add patch changeset for release notes

| File | Change |
|------|--------|
| `tui/summary_runtime.go` | Added shared provider/model/base-url resolution |
| `tui/repair.go` | Added CLI provider config parity |
| `tui/doctor.go` | Added shared runtime config and base URL support |
| `tui/rewrite.go` | Switched to shared runtime config resolver |
| `tui/backfill.go` | Switched to shared runtime config resolver |
| `tui/main.go` | Reused shared resolver for interactive rewrite |
| `tui/base_url_test.go` | Added precedence and parser regression tests |
| `docs/tui.md` | Documented doctor/repair/runtime config parity |
| `tui/README.md` | Updated CLI examples and config summary |
| `.changeset/silly-melons-argue.md` | Added patch release note |

## Testing
- `cd tui && go test ./...`
- Expected outcome: TUI unit test suite passes, including new provider precedence coverage