### PR TITLE
feat(tui): support Codex OAuth via codex CLI delegate

### DIFF
--- a/.changeset/calm-rivers-glow.md
+++ b/.changeset/calm-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Document `lcm-tui` Codex OAuth flows with the explicit `openai-codex` provider so repair, rewrite, doctor, and backfill examples match the new Codex CLI delegate path after `codex login`.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ tui/lcm-tui
 dist/
 tui/tui
 
-# CE planning artifacts
+# CE planning artifacts (local agent scratch, never commit)
 docs/plans/
+docs/brainstorms/
+.compound-engineering/
 TASK.md
+BRIEF.md
+PROGRESS.md

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -245,8 +245,8 @@ Scans for genuinely truncated summaries and can rewrite them in place. This is n
 # Preview repairs for one conversation
 lcm-tui doctor 44 --show-diff
 
-# Apply repairs with an OpenAI-compatible backend
-lcm-tui doctor 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
+# Apply repairs through Codex CLI OAuth after `codex login`
+lcm-tui doctor 44 --apply --provider openai-codex --model gpt-5.3-codex
 
 # Scan only across every conversation
 lcm-tui doctor --all
@@ -262,6 +262,8 @@ lcm-tui doctor --all
 | `--base-url <url>` | Custom API base URL (overrides config and env) |
 | `--show-diff` | Show unified diff for each fix |
 | `--timestamps` | Inject timestamps into rewrite source text |
+
+Use `--provider openai-codex` when you want ChatGPT Plus/Pro OAuth from the Codex CLI. Keep `--provider openai` for direct OpenAI-compatible HTTP calls with a raw `OPENAI_API_KEY`, including custom `--base-url` proxies.
 
 ### `lcm-tui repair`
 
@@ -280,7 +282,10 @@ lcm-tui repair 44 --apply
 # Repair a specific summary
 lcm-tui repair 44 --summary-id sum_abc123 --apply
 
-# Repair through an OpenAI-compatible backend
+# Repair through Codex CLI OAuth after `codex login`
+lcm-tui repair 44 --apply --provider openai-codex --model gpt-5.3-codex
+
+# Repair through a custom OpenAI-compatible proxy with a raw API key
 lcm-tui repair 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
 ```
 
@@ -316,10 +321,10 @@ lcm-tui rewrite 44 --depth 0 --apply
 # Rewrite everything bottom-up
 lcm-tui rewrite 44 --all --apply --diff
 
-# Rewrite with OpenAI Responses API
-lcm-tui rewrite 44 --summary sum_abc123 --provider openai --model gpt-5.3-codex --apply
+# Rewrite with Codex CLI OAuth after `codex login`
+lcm-tui rewrite 44 --summary sum_abc123 --provider openai-codex --model gpt-5.3-codex --apply
 
-# Rewrite through a custom OpenAI-compatible proxy
+# Rewrite through a custom OpenAI-compatible proxy with a raw API key
 lcm-tui rewrite 44 --summary sum_abc123 --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai --apply
 
 # Use custom prompt templates
@@ -412,10 +417,10 @@ lcm-tui backfill my-agent session_abc123 --apply --recompact --single-root
 # Import + compact + transplant into an active conversation
 lcm-tui backfill my-agent session_abc123 --apply --transplant-to 653
 
-# Backfill using OpenAI
-lcm-tui backfill my-agent session_abc123 --apply --provider openai --model gpt-5.3-codex
+# Backfill using Codex CLI OAuth after `codex login`
+lcm-tui backfill my-agent session_abc123 --apply --provider openai-codex --model gpt-5.3-codex
 
-# Backfill through a custom OpenAI-compatible proxy
+# Backfill through a custom OpenAI-compatible proxy with a raw API key
 lcm-tui backfill my-agent session_abc123 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
 ```
 

--- a/tui/README.md
+++ b/tui/README.md
@@ -51,15 +51,17 @@ lcm-tui --db /path/to/lcm.db    # custom database path
 Each interactive operation has a standalone CLI equivalent for scripting:
 
 ```bash
-lcm-tui doctor 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
-lcm-tui repair 44 --apply --provider openai --model gpt-5.3-codex --base-url https://proxy.example.com/openai
-lcm-tui rewrite 44 --all --apply --diff --provider openai --model gpt-5.3-codex
+lcm-tui doctor 44 --apply --provider openai-codex --model gpt-5.3-codex
+lcm-tui repair 44 --apply --provider openai-codex --model gpt-5.3-codex
+lcm-tui rewrite 44 --all --apply --diff --provider openai-codex --model gpt-5.3-codex
 lcm-tui dissolve 44 --summary-id sum_abc --apply     # undo a condensation
 lcm-tui transplant 18 653 --apply                    # copy DAG between conversations
-lcm-tui backfill my-agent session_abc --apply --provider openai --model gpt-5.3-codex
+lcm-tui backfill my-agent session_abc --apply --provider openai-codex --model gpt-5.3-codex
 lcm-tui backfill my-agent session_abc --apply --recompact --single-root # re-fold existing import to one root
 lcm-tui prompts --list                               # show active prompt sources
 ```
+
+Use `--provider openai-codex` after `codex login` when you want the TUI to delegate through the Codex CLI OAuth session. Keep `--provider openai` for direct OpenAI-compatible HTTP calls with a raw `OPENAI_API_KEY`.
 
 ## Documentation
 

--- a/tui/codex_oauth_test.go
+++ b/tui/codex_oauth_test.go
@@ -1,0 +1,494 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHasCodexOAuth(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string)
+		want  bool
+	}{
+		{
+			name:  "no ~/.codex dir",
+			setup: func(t *testing.T, home string) {},
+			want:  false,
+		},
+		{
+			name: "auth.json absent",
+			setup: func(t *testing.T, home string) {
+				if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+		{
+			name: "auth.json empty",
+			setup: func(t *testing.T, home string) {
+				dir := filepath.Join(home, ".codex")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "auth.json"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+		{
+			name: "auth.json present with content",
+			setup: func(t *testing.T, home string) {
+				dir := filepath.Join(home, ".codex")
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"access":"mock"}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: true,
+		},
+		{
+			name: "auth.json is a directory",
+			setup: func(t *testing.T, home string) {
+				if err := os.MkdirAll(filepath.Join(home, ".codex", "auth.json"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			tt.setup(t, home)
+			if got := hasCodexOAuth(); got != tt.want {
+				t.Fatalf("hasCodexOAuth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeOpenAICodexOAuthDelegatesToCLI(t *testing.T) {
+	seedCodexAuth(t)
+	stubCodexCLI(t)
+
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("LCM_HELPER_STDOUT", "Codex CLI summary")
+	t.Setenv("LCM_EXPECT_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_EXPECT_PROMPT_SHA256", hashPrompt(cliSummarizationSystemPrompt+"\n\n"+"say hello"))
+	t.Setenv("OPENAI_API_KEY", "should-be-filtered")
+
+	httpCalled := false
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			httpCalled = true
+			return jsonResponse(500, `{"error":"should not be called"}`), nil
+		})},
+	}
+
+	summary, err := client.summarize(context.Background(), "say hello", 200)
+	if err != nil {
+		t.Fatalf("summarize returned error: %v", err)
+	}
+	if httpCalled {
+		t.Fatal("HTTP transport was called for Codex OAuth path; expected delegation to codex CLI")
+	}
+	if summary != "Codex CLI summary" {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+}
+
+func TestSummarizeOpenAICodexAPIKeyHitsDirectAPI(t *testing.T) {
+	seedCodexAuth(t)
+
+	var capturedAuth string
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "sk-oai-test-key",
+		model:    "gpt-5.3-codex",
+		baseURL:  "https://api.openai.com",
+		http: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedAuth = req.Header.Get("Authorization")
+			return jsonResponse(200, `{
+				"output":[{"type":"message","content":[{"type":"output_text","text":"Direct API response."}]}]
+			}`), nil
+		})},
+	}
+
+	summary, err := client.summarize(context.Background(), "prompt", 200)
+	if err != nil {
+		t.Fatalf("summarize returned error: %v", err)
+	}
+	if capturedAuth != "Bearer sk-oai-test-key" {
+		t.Fatalf("expected direct API bearer header, got %q", capturedAuth)
+	}
+	if summary != "Direct API response." {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+}
+
+func TestSummarizeRejectsEmptyKeyForCodexWithoutOAuth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil })},
+	}
+
+	_, err := client.summarize(context.Background(), "prompt", 200)
+	if err == nil {
+		t.Fatal("expected summarize error when empty key and no Codex OAuth")
+	}
+	if !strings.Contains(err.Error(), "missing API key") {
+		t.Fatalf("expected missing-key error, got %v", err)
+	}
+}
+
+func TestResolveProviderAPIKeyOpenAICodexWithOAuthReturnsEmpty(t *testing.T) {
+	seedCodexAuth(t)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	paths := appDataPaths{
+		openclawDir:      t.TempDir(),
+		openclawCredsDir: t.TempDir(),
+		openclawConfig:   filepath.Join(t.TempDir(), "openclaw.json"),
+		openclawEnv:      filepath.Join(t.TempDir(), ".env"),
+	}
+
+	key, err := resolveProviderAPIKey(paths, "openai-codex")
+	if err != nil {
+		t.Fatalf("resolveProviderAPIKey returned error: %v", err)
+	}
+	if key != "" {
+		t.Fatalf("expected empty key sentinel, got %q", key)
+	}
+}
+
+func TestResolveProviderAPIKeyOpenAICodexHintsCodexLogin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "")
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "openclaw.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	paths := appDataPaths{
+		openclawDir:      t.TempDir(),
+		openclawCredsDir: t.TempDir(),
+		openclawConfig:   configPath,
+		openclawEnv:      filepath.Join(t.TempDir(), ".env"),
+	}
+
+	_, err := resolveProviderAPIKey(paths, "openai-codex")
+	if err == nil {
+		t.Fatal("expected resolveProviderAPIKey error when no key and no OAuth")
+	}
+	if !strings.Contains(err.Error(), "codex login") {
+		t.Fatalf("expected error to suggest `codex login`, got %v", err)
+	}
+}
+
+func TestSummarizeOpenAICodexOAuthMissingCLIReturnsActionableError(t *testing.T) {
+	seedCodexAuth(t)
+
+	originalLookup := lookupCLIPath
+	lookupCLIPath = func(file string) (string, error) {
+		if file != "codex" {
+			t.Fatalf("unexpected lookup path: %q", file)
+		}
+		return "", exec.ErrNotFound
+	}
+	t.Cleanup(func() { lookupCLIPath = originalLookup })
+
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil })},
+	}
+
+	_, err := client.summarize(context.Background(), "prompt", 200)
+	if err == nil {
+		t.Fatal("expected error when codex CLI is missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "codex") || !strings.Contains(msg, "not found") {
+		t.Fatalf("expected error to mention missing codex CLI, got %q", msg)
+	}
+	if !strings.Contains(msg, "OPENAI_API_KEY") {
+		t.Fatalf("expected error to mention OPENAI_API_KEY fallback, got %q", msg)
+	}
+}
+
+func TestSummarizeOpenAICodexOAuthSurfacesCLIStderr(t *testing.T) {
+	seedCodexAuth(t)
+	stubCodexCLI(t)
+
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("LCM_EXPECT_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_HELPER_STDERR", "codex: refresh failed 401")
+	t.Setenv("LCM_HELPER_EXIT_CODE", "2")
+
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil })},
+	}
+
+	_, err := client.summarize(context.Background(), "prompt", 200)
+	if err == nil {
+		t.Fatal("expected error when codex CLI exits non-zero")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "codex CLI exited 2") {
+		t.Fatalf("expected exit code in error, got %q", msg)
+	}
+	if !strings.Contains(msg, "refresh failed") {
+		t.Fatalf("expected stderr text in error, got %q", msg)
+	}
+}
+
+func TestSummarizeOpenAICodexOAuthRejectsEmptyCLIOutput(t *testing.T) {
+	seedCodexAuth(t)
+	stubCodexCLI(t)
+
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("LCM_EXPECT_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_HELPER_STDOUT", "")
+
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil })},
+	}
+
+	_, err := client.summarize(context.Background(), "prompt", 200)
+	if err == nil {
+		t.Fatal("expected error when codex CLI returns empty output")
+	}
+	if !strings.Contains(err.Error(), "empty output") {
+		t.Fatalf("expected empty-output error, got %v", err)
+	}
+}
+
+func TestSummarizeOpenAICodexOAuthRejectsOversizeCLIOutput(t *testing.T) {
+	seedCodexAuth(t)
+	stubCodexCLI(t)
+
+	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	t.Setenv("LCM_EXPECT_MODEL", "gpt-5.3-codex")
+	t.Setenv("LCM_HELPER_STDOUT", strings.Repeat("word ", 200))
+
+	client := &anthropicClient{
+		provider: "openai-codex",
+		apiKey:   "",
+		model:    "gpt-5.3-codex",
+		http:     &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) { return nil, nil })},
+	}
+
+	_, err := client.summarize(context.Background(), "prompt", 32)
+	if err == nil {
+		t.Fatal("expected error when codex CLI output exceeds token budget")
+	}
+	if !strings.Contains(err.Error(), "exceeded target token budget") {
+		t.Fatalf("expected token-budget error, got %v", err)
+	}
+}
+
+func TestFilteredOpenAIChildEnv(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"HOME=/root",
+		"OPENAI_API_KEY=sk-leak",
+		"OPENAI_BASE_URL=https://evil.example.com",
+		"OPENAI_ORG_ID=org-abc",
+		"OPENAI_PROJECT=proj-xyz",
+		"LANG=en_US.UTF-8",
+		"ANTHROPIC_API_KEY=sk-ant-untouched",
+	}
+	out := filteredOpenAIChildEnv(append([]string(nil), in...))
+
+	for _, e := range out {
+		if strings.HasPrefix(e, "OPENAI_") {
+			t.Fatalf("OPENAI_* leaked: %q", e)
+		}
+	}
+
+	seenAnthropic := false
+	seenPath := false
+	for _, e := range out {
+		if e == "ANTHROPIC_API_KEY=sk-ant-untouched" {
+			seenAnthropic = true
+		}
+		if e == "PATH=/usr/bin" {
+			seenPath = true
+		}
+	}
+	if !seenAnthropic {
+		t.Fatal("expected ANTHROPIC_API_KEY to survive filter")
+	}
+	if !seenPath {
+		t.Fatal("expected PATH to survive filter")
+	}
+}
+
+// seedCodexAuth writes a minimal ~/.codex/auth.json into a temp HOME so
+// hasCodexOAuth() returns true for the duration of the test.
+func seedCodexAuth(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"access":"mock"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stubCodexCLI(t *testing.T) {
+	t.Helper()
+
+	originalLookup := lookupCLIPath
+	originalExec := execCLICommand
+	lookupCLIPath = func(file string) (string, error) {
+		if file != "codex" {
+			t.Fatalf("unexpected lookup path: %q", file)
+		}
+		return "/tmp/fake-codex", nil
+	}
+	execCLICommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := append([]string{"-test.run=TestHelperProcessCodexCLI", "--", name}, args...)
+		return exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	}
+	t.Cleanup(func() {
+		lookupCLIPath = originalLookup
+		execCLICommand = originalExec
+	})
+}
+
+func TestHelperProcessCodexCLI(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	separator := -1
+	for i, arg := range args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(args) {
+		_, _ = os.Stderr.WriteString("missing helper args")
+		os.Exit(2)
+	}
+
+	cliArgs := args[separator+2:]
+	expectedModel := os.Getenv("LCM_EXPECT_MODEL")
+	expectedPromptHash := os.Getenv("LCM_EXPECT_PROMPT_SHA256")
+
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "OPENAI_") {
+			_, _ = os.Stderr.WriteString("OPENAI_* env var leaked to child: " + e)
+			os.Exit(3)
+		}
+	}
+	if !containsArgs(cliArgs, "exec") {
+		_, _ = os.Stderr.WriteString("missing exec subcommand")
+		os.Exit(4)
+	}
+	if !containsArgs(cliArgs, "--skip-git-repo-check") {
+		_, _ = os.Stderr.WriteString("missing --skip-git-repo-check")
+		os.Exit(5)
+	}
+	if !containsArgs(cliArgs, "--ephemeral") {
+		_, _ = os.Stderr.WriteString("missing --ephemeral")
+		os.Exit(6)
+	}
+	if !containsArgPair(cliArgs, "--color", "never") {
+		_, _ = os.Stderr.WriteString("missing --color never")
+		os.Exit(13)
+	}
+	if !containsArgPair(cliArgs, "--sandbox", "read-only") {
+		_, _ = os.Stderr.WriteString("missing --sandbox read-only")
+		os.Exit(14)
+	}
+	if !containsArgs(cliArgs, "-") {
+		_, _ = os.Stderr.WriteString("missing positional `-` for stdin prompt")
+		os.Exit(15)
+	}
+	if expectedModel != "" && !containsArgPair(cliArgs, "-m", expectedModel) {
+		_, _ = os.Stderr.WriteString("missing or wrong model")
+		os.Exit(7)
+	}
+	outputPath := extractArgValue(cliArgs, "--output-last-message")
+	if outputPath == "" {
+		_, _ = os.Stderr.WriteString("missing --output-last-message")
+		os.Exit(8)
+	}
+
+	if expectedPromptHash != "" {
+		prompt, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			_, _ = os.Stderr.WriteString("failed to read stdin")
+			os.Exit(9)
+		}
+		if hashPrompt(string(prompt)) != expectedPromptHash {
+			_, _ = os.Stderr.WriteString("stdin prompt hash mismatch")
+			os.Exit(10)
+		}
+	}
+
+	if err := os.WriteFile(outputPath, []byte(os.Getenv("LCM_HELPER_STDOUT")), 0o600); err != nil {
+		_, _ = os.Stderr.WriteString("failed to write output file")
+		os.Exit(11)
+	}
+	if stderr := os.Getenv("LCM_HELPER_STDERR"); stderr != "" {
+		_, _ = os.Stderr.WriteString(stderr)
+	}
+	if codeText := strings.TrimSpace(os.Getenv("LCM_HELPER_EXIT_CODE")); codeText != "" {
+		code, err := strconv.Atoi(codeText)
+		if err != nil {
+			_, _ = os.Stderr.WriteString("bad exit code")
+			os.Exit(12)
+		}
+		os.Exit(code)
+	}
+	os.Exit(0)
+}
+
+func extractArgValue(args []string, flag string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/tui/repair.go
+++ b/tui/repair.go
@@ -41,6 +41,11 @@ var (
 	cliOutputTokenSlack = 128
 )
 
+// cliSummarizationSystemPrompt is the system directive sent to CLI-delegated
+// summarizers (claude CLI, codex CLI). It constrains the CLI to output only
+// the requested summary, with no preamble, commentary, or protocol tokens.
+const cliSummarizationSystemPrompt = "You are a summarization engine. Output ONLY the requested summary. No preamble, no conversation, no questions, no commentary. Never output HEARTBEAT_OK or any protocol tokens."
+
 type repairOptions struct {
 	apply     bool
 	dryRun    bool
@@ -948,7 +953,10 @@ Files
 
 func (c *anthropicClient) summarize(ctx context.Context, prompt string, targetTokens int) (string, error) {
 	provider, model := resolveSummaryProviderModel(c.provider, c.model)
-	if strings.TrimSpace(c.apiKey) == "" {
+	// Codex OAuth path has no raw API key: the codex CLI reads ~/.codex/auth.json
+	// directly. Allow an empty apiKey to reach summarizeOpenAI, which routes to
+	// the CLI delegate when hasCodexOAuth() is true.
+	if strings.TrimSpace(c.apiKey) == "" && !(provider == "openai-codex" && hasCodexOAuth()) {
 		return "", fmt.Errorf("missing API key for provider %q", provider)
 	}
 	if c.http == nil {
@@ -1051,7 +1059,7 @@ func summarizeViaCLI(ctx context.Context, model, prompt string, targetTokens int
 		"--print",
 		"--input-format", "text",
 		"--output-format", "text",
-		"--system-prompt", "You are a summarization engine. Output ONLY the requested summary. No preamble, no conversation, no questions, no commentary. Never output HEARTBEAT_OK or any protocol tokens.",
+		"--system-prompt", cliSummarizationSystemPrompt,
 		"--model", model,
 	)
 	cmd.Dir = os.TempDir()
@@ -1088,7 +1096,110 @@ func summarizeViaCLI(ctx context.Context, model, prompt string, targetTokens int
 	return result, nil
 }
 
+// filteredOpenAIChildEnv returns env with all OPENAI_* vars stripped, so a
+// CLI-delegated codex subprocess reads credentials and endpoint config from
+// ~/.codex/ alone. Filtering the whole prefix (not just OPENAI_API_KEY)
+// prevents a misconfigured OPENAI_BASE_URL or proxy var from re-routing
+// OAuth-authenticated traffic to an unintended endpoint.
+func filteredOpenAIChildEnv(env []string) []string {
+	filtered := env[:0]
+	for _, e := range env {
+		if strings.HasPrefix(e, "OPENAI_") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}
+
+// hasCodexOAuth reports whether ~/.codex/auth.json exists and is non-empty.
+// Presence of that file is how the user indicates they have logged in to the
+// Codex CLI; the binary itself handles OAuth refresh against ChatGPT Plus/Pro.
+func hasCodexOAuth() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir() && info.Size() > 0
+}
+
+// summarizeViaCodexCLI delegates summarization to the `codex` CLI binary when
+// the user has a Codex OAuth session (~/.codex/auth.json) but no raw
+// OPENAI_API_KEY. Mirrors summarizeViaCLI's shape for Anthropic OAuth.
+//
+// The Codex CLI lacks a --system-prompt flag, so the system directive is
+// prepended to the stdin payload. The --output-last-message flag captures just
+// the model's final message, avoiding session/status preamble that `codex exec`
+// writes to stdout.
+func summarizeViaCodexCLI(ctx context.Context, model, prompt string, targetTokens int) (string, error) {
+	codexPath, err := lookupCLIPath("codex")
+	if err != nil {
+		return "", fmt.Errorf("codex OAuth detected but `codex` CLI not found in PATH: install Codex CLI or set OPENAI_API_KEY")
+	}
+
+	outputFile, err := os.CreateTemp("", "lcm-codex-output-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create codex output file: %w", err)
+	}
+	outputPath := outputFile.Name()
+	_ = outputFile.Close()
+	defer os.Remove(outputPath)
+
+	cmd := execCLICommand(ctx, codexPath,
+		"exec",
+		"--skip-git-repo-check",
+		"--color", "never",
+		"--ephemeral",
+		"--sandbox", "read-only",
+		"--output-last-message", outputPath,
+		"-m", model,
+		"-",
+	)
+	cmd.Dir = os.TempDir()
+	cmd.Stdin = strings.NewReader(cliSummarizationSystemPrompt + "\n\n" + prompt)
+	cmd.Env = filteredOpenAIChildEnv(os.Environ())
+
+	if _, err := cmd.Output(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("codex CLI exited %d: %s", exitErr.ExitCode(), strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("codex CLI: %w", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("read codex CLI output: %w", err)
+	}
+	result := strings.TrimSpace(string(data))
+	if result == "" {
+		return "", fmt.Errorf("codex CLI returned empty output")
+	}
+	estimatedTokens := estimateTokenCount(result)
+	if estimatedTokens > targetTokens+cliOutputTokenSlack {
+		return "", fmt.Errorf(
+			"codex CLI output exceeded target token budget: got %d tokens for target %d",
+			estimatedTokens,
+			targetTokens,
+		)
+	}
+	return result, nil
+}
+
 func (c *anthropicClient) summarizeOpenAI(ctx context.Context, model, prompt string, targetTokens int) (string, error) {
+	// Codex ChatGPT Plus/Pro OAuth cannot authenticate against api.openai.com
+	// with a raw key because no key exists for that plan. When the openai-codex
+	// provider is selected with no OPENAI_API_KEY but a populated
+	// ~/.codex/auth.json is present, delegate to the `codex` CLI which already
+	// holds valid OAuth credentials and handles token refresh transparently.
+	if normalizeProviderID(c.provider) == "openai-codex" && strings.TrimSpace(c.apiKey) == "" && hasCodexOAuth() {
+		return summarizeViaCodexCLI(ctx, model, prompt, targetTokens)
+	}
+
 	reqBody := openAIResponsesRequest{
 		Model:           model,
 		MaxOutputTokens: targetTokens,
@@ -1379,6 +1490,15 @@ func resolveProviderAPIKey(paths appDataPaths, provider string) (string, error) 
 		}
 	}
 
+	// Codex OAuth fallback: when ~/.codex/auth.json exists the codex CLI
+	// can handle auth itself. Return an empty apiKey with nil error so the
+	// caller routes to summarizeViaCodexCLI. Placed before the OpenClaw
+	// auth-profile and credential-file lookups because those don't apply to
+	// ChatGPT Plus/Pro plans, which have no API-key equivalent.
+	if normalizedProvider == "openai-codex" && hasCodexOAuth() {
+		return "", nil
+	}
+
 	// Check CLAUDE_CODE_OAUTH_TOKEN env var (setup-token / OAuth support).
 	if normalizedProvider == "anthropic" {
 		if oauthToken := strings.TrimSpace(os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")); oauthToken != "" {
@@ -1422,11 +1542,15 @@ func resolveProviderAPIKey(paths appDataPaths, provider string) (string, error) 
 		}
 	}
 
-	return "", fmt.Errorf(
+	msg := fmt.Sprintf(
 		"unable to resolve API key for provider %q; set one of: %s",
 		normalizedProvider,
 		strings.Join(envCandidates, ", "),
 	)
+	if normalizedProvider == "openai-codex" {
+		msg += " (or run `codex login` to populate ~/.codex/auth.json)"
+	}
+	return "", errors.New(msg)
 }
 
 // readSetupTokenFromSecrets reads an Anthropic setup-token from ~/.openclaw/secrets.json.


### PR DESCRIPTION
## Summary

Adds Codex OAuth support to `lcm-tui` so ChatGPT Plus/Pro subscribers
can run `repair`, `rewrite`, `doctor`, and `backfill` against the
`openai-codex` provider without a raw `OPENAI_API_KEY`. Mirrors the
Anthropic OAuth delegate that PR #58 added (closing #57). Counterpart
to PR #273 which closed the plugin-side gap for the runtime.

Closes #469.

## Problem

Before this change, `summarizeOpenAI` (`tui/repair.go`) posted
directly to `/v1/responses` with a `Bearer` header. For
`openai-codex`, `providerAPIEnvCandidates` only returned
`OPENAI_API_KEY`, so ChatGPT Plus/Pro users (whose credentials live in
`~/.codex/auth.json` and have no API-key equivalent) hit
`unable to resolve API key for provider "openai-codex"` and could not
use the TUI.

## Approach

Same shape as `summarizeViaCLI` for Anthropic:

- `hasCodexOAuth()` probes `~/.codex/auth.json` for presence and
  non-zero size.
- `summarizeViaCodexCLI()` executes `codex exec` with the prompt on
  stdin, captures the final message via `--output-last-message`, and
  applies the same token-budget gate as the Claude path.
- `summarize()` allows an empty `apiKey` when `provider ==
  "openai-codex"` and OAuth is present; `summarizeOpenAI()` routes to
  the CLI delegate in that case.
- `resolveProviderAPIKey()` returns `("", nil)` as an empty-string
  sentinel when Codex OAuth is available, so callers proceed to the
  CLI delegate instead of failing hard. The error message for
  `openai-codex` also hints at `codex login` when neither an API key
  nor OAuth is configured.

### Security posture

- `--sandbox read-only` is passed explicitly to `codex exec`, so a
  prompt-injection attack via summarized content cannot prompt Codex
  to perform writes or execution. Summarization needs only text
  generation.
- A new `filteredOpenAIChildEnv` strips every `OPENAI_*` variable
  (not just `OPENAI_API_KEY`) before the child process starts, so
  `OPENAI_BASE_URL` / `OPENAI_ORG_ID` / proxy settings cannot
  re-route OAuth-authenticated traffic to an unintended endpoint.

### Precedence

`OPENAI_API_KEY` still wins over Codex OAuth when both are present.
This keeps existing direct-API flows (Ollama Cloud, OpenRouter,
Azure) working untouched. OAuth is the fallback.

## Interaction with #460

Open issue #460 proposes removing CLI delegation entirely in favor of
direct HTTP. The two requests are compatible:

- #460 applies to the **API-key path** (where a raw key exists and
  direct HTTP avoids ARG_MAX by streaming the prompt as the body).
- This PR addresses the **OAuth path**, where Codex ChatGPT Plus/Pro
  users have no API-key equivalent. CLI delegation is the only
  available route until OpenAI exposes OAuth-backed API access.
- Both `summarizeViaCLI` and the new `summarizeViaCodexCLI` stream
  the prompt on stdin (not argv), so neither is affected by #459's
  ARG_MAX failure mode.

## Test plan

- [x] Unit tests in `tui/codex_oauth_test.go`:
  - `hasCodexOAuth` table test: absent / empty / present / directory.
  - `summarize` delegates to codex CLI when OAuth is present and no
    API key (HTTP transport asserted never called).
  - Direct-HTTP path still used when `OPENAI_API_KEY` is set.
  - Empty key + no OAuth still errors with "missing API key".
  - `resolveProviderAPIKey` returns empty sentinel under OAuth and
    hints at `codex login` without OAuth.
  - CLI missing from PATH returns an actionable error naming both
    auth paths.
  - Non-zero CLI exit surfaces stderr.
  - Empty and oversized CLI output are rejected.
  - `filteredOpenAIChildEnv` removes every `OPENAI_*` and preserves
    unrelated env.
- [x] `TestHelperProcessCodexCLI` asserts the CLI argv:
  `exec`, `--skip-git-repo-check`, `--color never`, `--ephemeral`,
  `--sandbox read-only`, `--output-last-message <file>`,
  `-m <model>`, `-`, and that no `OPENAI_*` env leaks.
- [x] `go test ./tui/...` passes (28 tests).
- [x] `go vet ./tui/...` clean.
- [x] `gofmt -l tui/` clean.
- [x] `npm test` (the CI suite) passes all 775 tests.

## Manual verification (recommended after merge)

With `~/.codex/auth.json` populated by `codex login`, no
`OPENAI_API_KEY` in env, and a corrupted summary:

```
lcm-tui repair <conversation_id> --apply --provider openai-codex --model gpt-5.3-codex
```

The repair should run through the `codex` CLI and complete without an
`unable to resolve API key` error.
