### PR TITLE
fix: drop trailing empty-content assistant from assembled context

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1056,6 +1056,22 @@ export class ContextAssembler {
       .filter((entry) => entry.segment === "freshTail")
       .map((entry) => entry.message);
     const repaired = sanitizeToolUseResultPairing(cleaned) as AgentMessage[];
+    // Guard: Anthropic rejects a prompt ending with an empty-content assistant
+    // message ("does not support assistant message prefill"). Post-compaction
+    // assembly can produce this shape. Drop it so the conversation ends on the
+    // last real user/assistant turn.
+    if (repaired.length > 0) {
+      const last = repaired[repaired.length - 1];
+      const content = (last as { content?: unknown }).content;
+      const isEmpty =
+        content === undefined ||
+        content === null ||
+        (typeof content === "string" && content.trim() === "") ||
+        (Array.isArray(content) && content.length === 0);
+      if (last.role === "assistant" && isEmpty) {
+        repaired.pop();
+      }
+    }
     return {
       messages: repaired,
       estimatedTokens,

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import type { ContextEngine } from "openclaw/plugin-sdk";
-import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
+import {
+  sanitizeToolUseResultPairing,
+  stripTrailingEmptyAssistantPrefill,
+} from "./transcript-repair.js";
 import type {
   ConversationStore,
   MessagePartRecord,
@@ -1055,23 +1058,9 @@ export class ContextAssembler {
     const preSanitizeFreshTailMessages = cleanedEntries
       .filter((entry) => entry.segment === "freshTail")
       .map((entry) => entry.message);
-    const repaired = sanitizeToolUseResultPairing(cleaned) as AgentMessage[];
-    // Guard: Anthropic rejects a prompt ending with an empty-content assistant
-    // message ("does not support assistant message prefill"). Post-compaction
-    // assembly can produce this shape. Drop it so the conversation ends on the
-    // last real user/assistant turn.
-    if (repaired.length > 0) {
-      const last = repaired[repaired.length - 1];
-      const content = (last as { content?: unknown }).content;
-      const isEmpty =
-        content === undefined ||
-        content === null ||
-        (typeof content === "string" && content.trim() === "") ||
-        (Array.isArray(content) && content.length === 0);
-      if (last.role === "assistant" && isEmpty) {
-        repaired.pop();
-      }
-    }
+    const repaired = stripTrailingEmptyAssistantPrefill(
+      sanitizeToolUseResultPairing(cleaned),
+    ) as AgentMessage[];
     return {
       messages: repaired,
       estimatedTokens,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -45,6 +45,7 @@ import {
 } from "./large-files.js";
 import { describeLogError } from "./lcm-log.js";
 import { describeLcmConfigSource } from "./db/config.js";
+import { stripTrailingEmptyAssistantPrefill } from "./transcript-repair.js";
 import { RetrievalEngine } from "./retrieval.js";
 import { compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
 import { logStartupBannerOnce } from "./startup-banner-log.js";
@@ -5208,9 +5209,15 @@ export class LcmContextEngine implements ContextEngine {
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
   }): Promise<AssembleResult> {
+    // Anthropic providers reject prompts that end with an empty-content
+    // assistant message. A failed generation can leave such a message
+    // persisted in the session jsonl, and any fallback path here that
+    // returns params.messages unchanged would ship the bad shape to the
+    // provider. Strip once up-front so every return path is safe.
+    const liveMessages = stripTrailingEmptyAssistantPrefill(params.messages);
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
       return {
-        messages: params.messages,
+        messages: liveMessages,
         estimatedTokens: 0,
       };
     }
@@ -5231,7 +5238,7 @@ export class LcmContextEngine implements ContextEngine {
           `[lcm] assemble: conversation lookup missed ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return {
-          messages: params.messages,
+          messages: liveMessages,
           estimatedTokens: 0,
         };
       }
@@ -5280,7 +5287,7 @@ export class LcmContextEngine implements ContextEngine {
           `[lcm] assemble: no context items conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return {
-          messages: params.messages,
+          messages: liveMessages,
           estimatedTokens: 0,
         };
       }
@@ -5294,7 +5301,7 @@ export class LcmContextEngine implements ContextEngine {
           `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return {
-          messages: params.messages,
+          messages: liveMessages,
           estimatedTokens: 0,
         };
       }
@@ -5322,7 +5329,7 @@ export class LcmContextEngine implements ContextEngine {
           `[lcm] assemble: empty assembled output, using live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return {
-          messages: params.messages,
+          messages: liveMessages,
           estimatedTokens: 0,
         };
       }
@@ -5358,7 +5365,7 @@ export class LcmContextEngine implements ContextEngine {
         `[lcm] assemble: failed for session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} error=${describeLogError(err)}`,
       );
       return {
-        messages: params.messages,
+        messages: liveMessages,
         estimatedTokens: 0,
       };
     }

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -298,3 +298,31 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(message
   const changedOrMoved = changed || moved;
   return changedOrMoved ? out : messages;
 }
+
+/**
+ * Drop a trailing assistant message whose content is empty.
+ *
+ * Anthropic providers such as `claude-sonnet-4-6` reject a prompt that ends
+ * with an empty-content assistant entry ("does not support assistant message
+ * prefill. The conversation must end with a user message."). Post-compaction
+ * assembly can produce this shape when a cleanup pass evicts the final
+ * assistant turn's content without removing the envelope.
+ *
+ * No-op when the tail is non-empty or not an assistant role.
+ */
+export function stripTrailingEmptyAssistantPrefill<T extends AgentMessageLike>(
+  messages: T[],
+): T[] {
+  if (messages.length === 0) return messages;
+  const last = messages[messages.length - 1];
+  if (!last || typeof last !== "object") return messages;
+  if (last.role !== "assistant") return messages;
+  const content = (last as { content?: unknown }).content;
+  const isEmpty =
+    content === undefined ||
+    content === null ||
+    (typeof content === "string" && content.trim() === "") ||
+    (Array.isArray(content) && content.length === 0);
+  if (!isEmpty) return messages;
+  return messages.slice(0, -1);
+}

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -475,6 +475,31 @@ describe("LcmContextEngine ignored sessions", () => {
     expect(included.messages[0]?.content).toBe("persisted context");
   });
 
+  it("strips trailing empty-content assistant on fallback returns from assemble", async () => {
+    // Regression: when a generation fails mid-response, OC persists the
+    // assistant message to the jsonl with content:[] and an errorMessage.
+    // If the next turn takes a non-compaction path (no context items yet,
+    // for example), assemble() used to return the live messages unchanged,
+    // and Anthropic 400s with "does not support assistant message prefill".
+    const engine = createEngine();
+
+    const liveMessages = [
+      makeMessage({ role: "user", content: "what's the weather?" }),
+      makeMessage({ role: "assistant", content: [] }),
+    ];
+    const result = await engine.assemble({
+      sessionId: includedSessionId,
+      sessionKey: includedSessionKey,
+      messages: liveMessages,
+      tokenBudget: 500,
+    });
+
+    // Empty-content assistant tail should be dropped regardless of which
+    // fallback path the engine takes.
+    expect(result.messages).toHaveLength(1);
+    expect((result.messages[0] as { role?: string }).role).toBe("user");
+  });
+
   it("skips compact for ignored sessions while compact still evaluates included sessions", async () => {
     const engine = createEngineWithConfig({
       ignoreSessionPatterns: ["agent:*:cron:**"],

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeToolUseResultPairing } from "../src/transcript-repair.js";
+import {
+  sanitizeToolUseResultPairing,
+  stripTrailingEmptyAssistantPrefill,
+} from "../src/transcript-repair.js";
 
 describe("sanitizeToolUseResultPairing", () => {
   it("moves OpenAI reasoning blocks before function_call blocks", () => {
@@ -63,5 +66,72 @@ describe("sanitizeToolUseResultPairing", () => {
       ],
       isError: true,
     });
+  });
+});
+
+describe("stripTrailingEmptyAssistantPrefill", () => {
+  it("drops a trailing assistant message with empty-array content", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [] },
+    ];
+    const out = stripTrailingEmptyAssistantPrefill(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("user");
+  });
+
+  it("drops a trailing assistant message with undefined content", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant" },
+    ];
+    const out = stripTrailingEmptyAssistantPrefill(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("user");
+  });
+
+  it("drops a trailing assistant message with an empty string content", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: "   " },
+    ];
+    const out = stripTrailingEmptyAssistantPrefill(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("user");
+  });
+
+  it("keeps a trailing assistant message with real content", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ];
+    const out = stripTrailingEmptyAssistantPrefill(messages);
+    expect(out).toHaveLength(2);
+    expect(out[1]?.role).toBe("assistant");
+  });
+
+  it("keeps a trailing user message even if empty", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+      { role: "user", content: [] },
+    ];
+    const out = stripTrailingEmptyAssistantPrefill(messages);
+    expect(out).toHaveLength(2);
+    expect(out[1]?.role).toBe("user");
+  });
+
+  it("is a no-op on an empty list", () => {
+    const out = stripTrailingEmptyAssistantPrefill([]);
+    expect(out).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [] },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(messages));
+    stripTrailingEmptyAssistantPrefill(messages);
+    expect(messages).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Problem

When an Anthropic-backed agent session triggers LCM compaction mid-session, subsequent turns can fail with:

```
400 {"type":"invalid_request_error","message":"This model does not support assistant message prefill. The conversation must end with a user message."}
```

`assemble()` occasionally returns a message list whose final entry is `{ role: "assistant", content: [] }`. Anthropic models that don't support assistant prefill (e.g. `claude-sonnet-4-6`) reject this shape.

The existing `sanitizeToolUseResultPairing` pass strips dangling `tool_use` pairings but does not remove an empty-content assistant tail, so the bad shape reaches the provider.

## Repro

1. Run an agent backed by `anthropic/claude-sonnet-4-6` with LCM enabled.
2. Accumulate enough context to breach the compaction threshold.
3. Trigger compaction (proactive or manual).
4. Send another user turn.

Observed: the next prompt posted to the Anthropic API ends with `{"role":"assistant","content":[]}` and the turn fails. Each retry appends another empty-assistant entry to the session transcript, so the failure is sticky until the session is reset.

## Fix

In `src/transcript-repair.ts`, add a helper `stripTrailingEmptyAssistantPrefill` that pops a trailing assistant message whose content is undefined, null, empty string, or empty array. `ContextAssembler.assemble()` chains this helper after `sanitizeToolUseResultPairing` before returning.

No-op in the common case; prevents the 400 in the post-compaction edge case.

## Tests

Regression tests included in `test/transcript-repair.test.ts`:

- drops empty-array content
- drops undefined content
- drops whitespace-only string content
- keeps a real assistant tail
- keeps a trailing empty user message (not affected)
- no-op on empty list
- does not mutate input

All 10 tests in `transcript-repair.test.ts` pass locally (3 existing + 7 new).

## Risk

- Surgical: a small guard localised to the final step of `assemble()`.
- Harmless in the non-repro case.
- If a legitimate empty-content assistant were part of a valid conversation, dropping it just means the next turn re-emits the assistant output.