### PR TITLE
fix(migration): add ensureMessagePartsTable belt-and-suspenders guard

### DIFF
--- a/.changeset/fuzzy-forks-flow.md
+++ b/.changeset/fuzzy-forks-flow.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix LCM migration recovery when existing databases are missing the `message_parts` table.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -168,6 +168,73 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
 }
 
+/**
+ * Belt-and-suspenders guard: create `message_parts` if it does not yet exist.
+ *
+ * `message_parts` is defined inside the large `db.exec()` block in
+ * `runLcmMigrations`.  On some Node.js SQLite builds (particularly
+ * `node:sqlite` before v22.12) a syntax error or constraint-check mismatch
+ * anywhere in that block causes the exec to stop early, silently leaving
+ * tables that appear later in the string uncreated.  Any subsequent INSERT
+ * into `message_parts` then throws "no such table".
+ *
+ * This function probes `sqlite_master` directly and creates the table +
+ * indexes when absent, matching the pattern used for column guards
+ * (`ensureSummaryDepthColumn`, `ensureMessageIdentityHashColumn`, …).
+ */
+function ensureMessagePartsTable(db: DatabaseSync): void {
+  const tables = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'message_parts'`)
+    .all() as { name: string }[];
+  if (tables.length > 0) return;
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS message_parts (
+      part_id TEXT PRIMARY KEY,
+      message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      part_type TEXT NOT NULL CHECK (part_type IN (
+        'text', 'reasoning', 'tool', 'patch', 'file',
+        'subtask', 'compaction', 'step_start', 'step_finish',
+        'snapshot', 'agent', 'retry'
+      )),
+      ordinal INTEGER NOT NULL,
+      text_content TEXT,
+      is_ignored INTEGER,
+      is_synthetic INTEGER,
+      tool_call_id TEXT,
+      tool_name TEXT,
+      tool_status TEXT,
+      tool_input TEXT,
+      tool_output TEXT,
+      tool_error TEXT,
+      tool_title TEXT,
+      patch_hash TEXT,
+      patch_files TEXT,
+      file_mime TEXT,
+      file_name TEXT,
+      file_url TEXT,
+      subtask_prompt TEXT,
+      subtask_desc TEXT,
+      subtask_agent TEXT,
+      step_reason TEXT,
+      step_cost REAL,
+      step_tokens_in INTEGER,
+      step_tokens_out INTEGER,
+      snapshot_hash TEXT,
+      compaction_auto INTEGER,
+      metadata TEXT,
+      UNIQUE (message_id, ordinal)
+    )
+  `);
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS message_parts_message_idx ON message_parts (message_id)`,
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS message_parts_type_idx ON message_parts (part_type)`,
+  );
+}
+
 function ensureMessageIdentityHashColumn(db: DatabaseSync): void {
   const messageColumns = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
   const hasIdentityHash = messageColumns.some((col) => col.name === "identity_hash");
@@ -982,6 +1049,9 @@ export function runLcmMigrations(
     runMigrationStep("ensureMessageIdentityHashColumn", log, () =>
       ensureMessageIdentityHashColumn(db),
     );
+    // Belt-and-suspenders: ensure message_parts exists even if the bulk
+    // CREATE TABLE block above was interrupted before reaching it.
+    runMigrationStep("ensureMessagePartsTable", log, () => ensureMessagePartsTable(db));
     runMigrationStep("backfillMessageIdentityHashes", log, () =>
       backfillMessageIdentityHashes(db, { managesOwnTransaction: false }),
     );

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -803,6 +803,92 @@ describe("runLcmMigrations summary depth backfill", () => {
     ]);
   });
 
+  it("creates message_parts when the bulk schema create did not", () => {
+    const db = createTestDb("missing-message-parts.db");
+    let skippedBulkMessagePartsCreate = false;
+
+    const instrumentedDb = {
+      prepare(sql: string) {
+        return db.prepare(sql);
+      },
+      exec(sql: string) {
+        const isInitialSchemaCreate =
+          !skippedBulkMessagePartsCreate &&
+          sql.includes("CREATE TABLE IF NOT EXISTS message_parts") &&
+          sql.includes("CREATE TABLE IF NOT EXISTS lcm_migration_state");
+        if (!isInitialSchemaCreate) {
+          return db.exec(sql);
+        }
+
+        // Simulate the Node sqlite bulk-exec failure mode by letting the rest of
+        // the schema block run while omitting only the original message_parts DDL.
+        skippedBulkMessagePartsCreate = true;
+        const schemaWithoutMessageParts = sql
+          .replace(
+            /\n\s*CREATE TABLE IF NOT EXISTS message_parts \([\s\S]*?\n\s*\);\n\s*\n\s*CREATE TABLE IF NOT EXISTS summary_messages/,
+            "\n\n    CREATE TABLE IF NOT EXISTS summary_messages",
+          )
+          .replace(
+            /\n\s*CREATE INDEX IF NOT EXISTS message_parts_message_idx ON message_parts \(message_id\);/,
+            "",
+          )
+          .replace(
+            /\n\s*CREATE INDEX IF NOT EXISTS message_parts_type_idx ON message_parts \(part_type\);/,
+            "",
+          );
+        expect(schemaWithoutMessageParts).not.toContain(
+          "CREATE TABLE IF NOT EXISTS message_parts",
+        );
+        return db.exec(schemaWithoutMessageParts);
+      },
+    } as unknown as Parameters<typeof runLcmMigrations>[0];
+
+    runLcmMigrations(instrumentedDb, { fts5Available: false });
+
+    expect(skippedBulkMessagePartsCreate).toBe(true);
+    const tableRow = db
+      .prepare(
+        `SELECT name
+         FROM sqlite_master
+         WHERE type = 'table' AND name = 'message_parts'`,
+      )
+      .get() as { name?: string } | undefined;
+    expect(tableRow?.name).toBe("message_parts");
+
+    const indexRows = db
+      .prepare(
+        `SELECT name
+         FROM sqlite_master
+         WHERE type = 'index' AND name IN (?, ?)
+         ORDER BY name`,
+      )
+      .all("message_parts_message_idx", "message_parts_type_idx") as Array<{
+      name: string;
+    }>;
+    expect(indexRows.map((row) => row.name)).toEqual([
+      "message_parts_message_idx",
+      "message_parts_type_idx",
+    ]);
+
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      1,
+      "partial-schema-session",
+    );
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(1, 1, 1, "assistant", "hello", 1);
+    db.prepare(
+      `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, text_content)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("part-1", 1, "partial-schema-session", "text", 0, "hello");
+
+    const partRow = db
+      .prepare(`SELECT text_content FROM message_parts WHERE part_id = ?`)
+      .get("part-1") as { text_content?: string } | undefined;
+    expect(partRow?.text_content).toBe("hello");
+  });
+
   it("backfills legacy tool_call_id values from metadata.raw.call_id", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Problem

On some Node.js `node:sqlite` builds (notably before v22.12), a multi-statement `db.exec()` block can silently stop processing when it encounters a syntax error or constraint-check mismatch. Because `message_parts` is defined **after** `messages` and `summaries` in the large `runLcmMigrations` bulk CREATE block, it's vulnerable to this failure mode.

**Symptom:**
```
SqliteError: no such table: message_parts
```

This is a hard crash on any INSERT or SELECT against `message_parts`, which kills the context engine entirely.

Reproduced on a production Mac Mini running Node.js v25.6.1 (arm64, Darwin 25.2.0) with a 531 MB `lcm.db`.

## Fix

Add `ensureMessagePartsTable()` following the exact same probe-and-create pattern already used in this codebase for:
- `ensureSummaryDepthColumn()`
- `ensureSummaryMetadataColumns()`
- `ensureSummaryModelColumn()`
- `ensureMessageIdentityHashColumn()`

The function checks `sqlite_master` directly and creates the table + indexes only when absent. It's registered as a `runMigrationStep()` after `ensureMessageIdentityHashColumn` so it runs idempotently on every boot for existing databases.

## Why not just fix the bulk exec block?

The bulk exec failure is an upstream Node.js bug. Defensive migration steps are the established pattern here — they decouple schema existence from the correctness of any single `db.exec()` call and survive partial failures, hot reloads, and stale `migrated = true` flags.