### PR TITLE
fix: strip thinking-only assistant messages to prevent Bedrock empty content rejection

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -536,6 +536,28 @@ export function pickToolIsError(parts: MessagePartRecord[]): boolean | undefined
   return undefined;
 }
 
+// ── Thinking-only detection ─────────────────────────────────────────────────
+
+const THINKING_LIKE_TYPES = new Set(["thinking", "redacted_thinking", "reasoning"]);
+
+/**
+ * Returns true when every block in a content array is a thinking/reasoning
+ * block (including redacted_thinking).  Such messages carry no visible text
+ * or tool calls; downstream dropThinkingBlocks() would strip them all,
+ * leaving an empty content array that Bedrock rejects.
+ *
+ * @internal Exported for testing only.
+ */
+export function isThinkingOnlyContent(content: unknown[]): boolean {
+  if (content.length === 0) return false;
+  return content.every(
+    (block) =>
+      !!block &&
+      typeof block === "object" &&
+      THINKING_LIKE_TYPES.has((block as { type?: unknown }).type as string),
+  );
+}
+
 function extractToolCallId(block: { id?: unknown; call_id?: unknown }): string | null {
   if (typeof block.id === "string" && block.id.length > 0) {
     return block.id;
@@ -1039,12 +1061,18 @@ export class ContextAssembler {
     // tool-use-only turns are stored with content="" and zero message_parts,
     // or when filterNonFreshAssistantToolCalls strips all tool_use blocks.
     // Anthropic (and other providers) reject empty content arrays/strings.
+    //
+    // Also filter out assistant messages whose content consists entirely of
+    // thinking/reasoning blocks.  These carry no visible text or tool calls;
+    // when the downstream provider strips thinking blocks (dropThinkingBlocks)
+    // the message ends up with empty content, which Bedrock rejects with
+    // "ValidationException: content field is empty".
     const cleanedEntries = normalizedEntries.filter(
       (entry) =>
         !(
           entry.message?.role === "assistant" &&
           (Array.isArray(entry.message.content)
-            ? entry.message.content.length === 0
+            ? entry.message.content.length === 0 || isThinkingOnlyContent(entry.message.content)
             : !entry.message.content)
         ),
     );

--- a/test/assembler-blocks.test.ts
+++ b/test/assembler-blocks.test.ts
@@ -5,6 +5,7 @@ import {
   blockFromPart,
   tokenizeText,
   scoreRelevance,
+  isThinkingOnlyContent,
 } from "../src/assembler.js";
 import type { MessagePartRecord } from "../src/store/conversation-store.js";
 
@@ -646,5 +647,67 @@ describe("scoreRelevance", () => {
     const direct = scoreRelevance("login page handler", "login");
     expect(score).toBeGreaterThan(0);
     expect(direct).toBeGreaterThan(0);
+  });
+});
+
+describe("isThinkingOnlyContent", () => {
+  it("returns false for empty content", () => {
+    expect(isThinkingOnlyContent([])).toBe(false);
+  });
+
+  it("returns true for content with only a thinking block", () => {
+    expect(
+      isThinkingOnlyContent([{ type: "thinking", thinking: "some reasoning" }]),
+    ).toBe(true);
+  });
+
+  it("returns true for content with only a redacted_thinking block", () => {
+    expect(
+      isThinkingOnlyContent([{ type: "redacted_thinking", data: "xxx" }]),
+    ).toBe(true);
+  });
+
+  it("returns true for content with only a reasoning block", () => {
+    expect(
+      isThinkingOnlyContent([{ type: "reasoning", text: "some reasoning" }]),
+    ).toBe(true);
+  });
+
+  it("returns true for content with mixed thinking/reasoning blocks only", () => {
+    expect(
+      isThinkingOnlyContent([
+        { type: "thinking", thinking: "step 1" },
+        { type: "redacted_thinking", data: "xxx" },
+        { type: "reasoning", text: "step 2" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when content includes a text block", () => {
+    expect(
+      isThinkingOnlyContent([
+        { type: "thinking", thinking: "some reasoning" },
+        { type: "text", text: "visible output" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false when content includes a tool_use block", () => {
+    expect(
+      isThinkingOnlyContent([
+        { type: "thinking", thinking: "some reasoning" },
+        { type: "tool_use", id: "toolu_123", name: "read", input: {} },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false for content with only a text block", () => {
+    expect(
+      isThinkingOnlyContent([{ type: "text", text: "hello" }]),
+    ).toBe(false);
+  });
+
+  it("returns false for non-object content items", () => {
+    expect(isThinkingOnlyContent([null as any, undefined as any])).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

When lossless-claw reassembles messages from the database, assistant messages that contain **only** thinking/reasoning/redacted_thinking blocks (with no visible text or tool calls) pass through the existing empty-content filter in the assembler because their content array is non-empty (length > 0).

These messages then reach OpenClaw core, where `dropThinkingBlocks()` strips all thinking blocks, leaving an empty content array (or a single text block with `text: ""`). The Bedrock provider's `convertMessages` function filters out text blocks where `text.trim().length === 0`, producing a completely empty content array that Bedrock rejects with:

```
ValidationException: The content field in the Message object at messages.N is empty.
Add a ContentBlock object to the content field and try again.
```

### Why this is worse with lossless-claw

Without lossless-claw, the default context engine works with live conversation messages where thinking blocks are typically paired with visible text or tool calls. Lossless-claw faithfully reconstructs **all** stored message parts from the database (including raw thinking blocks), and the fresh tail includes these thinking-only messages unchanged — creating more opportunities for this edge case to surface.

This is particularly common with extended-thinking models (Claude with thinking enabled) where some assistant turns consist entirely of thinking blocks — for instance when the model reasons internally before delegating to tool calls that were later orphan-stripped by `filterNonFreshAssistantToolCalls`.

### Reproduction path

1. Use an extended-thinking model (e.g. Claude Opus with thinking enabled)
2. Have lossless-claw enabled
3. Over a conversation, some assistant turns will have only thinking blocks
4. When context is reassembled, these messages survive the empty-content filter
5. OpenClaw core's `dropThinkingBlocks()` strips the thinking blocks
6. Bedrock rejects the empty content → `ValidationException`

## Fix

Extend the `cleanedEntries` filter in the assembler to also detect and drop assistant messages whose content consists entirely of thinking/reasoning/redacted_thinking blocks. These messages carry no semantic value after thinking-block removal, so dropping them is safe and prevents the downstream empty-content error.

### Changes

- **`src/assembler.ts`**: Add `isThinkingOnlyContent()` helper and extend the `cleanedEntries` filter
- **`test/assembler-blocks.test.ts`**: Add 9 unit tests for `isThinkingOnlyContent()`

### Complementary fix

This pairs with [openclaw/openclaw#71623](https://github.com/openclaw/openclaw/pull/71623) which addresses the same issue from the OpenClaw core side by using a non-empty placeholder in `dropThinkingBlocks()`. Both fixes are independent and provide defense-in-depth — the lossless-claw fix prevents the problematic messages from reaching the core pipeline at all.

## Test results

All 784 tests pass (775 existing + 9 new).