### PR TITLE
fix: prefer model-level api from runtime config over inferApiFromProvider fallback

### DIFF
--- a/.changeset/model-api-runtime-precedence.md
+++ b/.changeset/model-api-runtime-precedence.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prefer model-level runtime `api` declarations over provider and catalog API defaults when dispatching LCM summarizer requests.

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,6 @@
 export { default } from "./src/plugin/index.js";
-export { buildCompleteSimpleOptions, shouldOmitTemperatureForApi } from "./src/plugin/index.js";
+export {
+  buildCompleteSimpleOptions,
+  resolveModelApiFromRuntimeConfig,
+  shouldOmitTemperatureForApi,
+} from "./src/plugin/index.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "0.66.1",

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -742,6 +742,45 @@ function resolveProviderApiFromRuntimeConfig(
   return typeof api === "string" && api.trim() ? api.trim() : undefined;
 }
 
+/**
+ * Resolve the api family for a specific model from runtime config.
+ *
+ * Walks `models.providers.<provider>.models[]` looking for a matching id and
+ * returns its `api` field if declared. Lets users override the api per model
+ * (e.g. when a single provider name maps to differently-shaped endpoints).
+ */
+export function resolveModelApiFromRuntimeConfig(
+  runtimeConfig: unknown,
+  provider: string,
+  model: string,
+): string | undefined {
+  if (!isRecord(runtimeConfig)) {
+    return undefined;
+  }
+  const providers = (runtimeConfig as { models?: { providers?: Record<string, unknown> } }).models
+    ?.providers;
+  if (!providers || !isRecord(providers)) {
+    return undefined;
+  }
+  const value = findProviderConfigValue(providers, provider);
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const models = value.models;
+  if (!Array.isArray(models)) {
+    return undefined;
+  }
+  const target = model.trim();
+  for (const entry of models) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.id !== "string") continue;
+    if (entry.id.trim() !== target) continue;
+    const api = entry.api;
+    return typeof api === "string" && api.trim() ? api.trim() : undefined;
+  }
+  return undefined;
+}
+
 /** Resolve runtime.modelAuth from plugin runtime when available. */
 function getRuntimeModelAuth(api: OpenClawPluginApi): RuntimeModelAuth | undefined {
   const runtime = api.runtime as OpenClawPluginApi["runtime"] & {
@@ -1540,6 +1579,7 @@ function createLcmDependencies(
             ? knownModel.api.trim()
             : undefined) ||
           providerApi?.trim() ||
+          resolveModelApiFromRuntimeConfig(effectiveRuntimeConfig, providerId, modelId) ||
           resolveProviderApiFromRuntimeConfig(effectiveRuntimeConfig, providerId) ||
           (() => {
             if (typeof mod.getModels !== "function") {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1574,13 +1574,22 @@ function createLcmDependencies(
 
         const knownModel =
           typeof mod.getModel === "function" ? mod.getModel(providerId, modelId) : undefined;
-        const fallbackApi =
-          (isRecord(knownModel) && typeof knownModel.api === "string" && knownModel.api.trim()
-            ? knownModel.api.trim()
-            : undefined) ||
+        const modelRuntimeApi = resolveModelApiFromRuntimeConfig(
+          effectiveRuntimeConfig,
+          providerId,
+          modelId,
+        );
+        const providerRuntimeApi =
           providerApi?.trim() ||
-          resolveModelApiFromRuntimeConfig(effectiveRuntimeConfig, providerId, modelId) ||
-          resolveProviderApiFromRuntimeConfig(effectiveRuntimeConfig, providerId) ||
+          resolveProviderApiFromRuntimeConfig(effectiveRuntimeConfig, providerId);
+        const knownModelApi =
+          isRecord(knownModel) && typeof knownModel.api === "string" && knownModel.api.trim()
+            ? knownModel.api.trim()
+            : undefined;
+        const fallbackApi =
+          modelRuntimeApi ||
+          providerRuntimeApi ||
+          knownModelApi ||
           (() => {
             if (typeof mod.getModels !== "function") {
               return undefined;
@@ -1624,10 +1633,7 @@ function createLcmDependencies(
                 ...knownModel,
                 id: knownModel.id,
                 provider: knownModel.provider,
-                api:
-                  typeof providerLevelConfig.api === "string" && providerLevelConfig.api.trim()
-                    ? providerLevelConfig.api.trim()
-                    : knownModel.api,
+                api: modelRuntimeApi || providerRuntimeApi || knownModel.api,
                 // Provider config must be able to override built-in transport defaults.
                 // Otherwise built-in providers like `openai` keep their catalog baseUrl
                 // (`https://api.openai.com/v1`) even when OpenClaw runtime config points

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -85,6 +85,7 @@ async function callComplete(params: {
   loadConfigResult: Record<string, unknown>;
   provider: string;
   model: string;
+  providerApi?: string;
   runtimeConfig?: unknown;
 }) {
   const { api, getFactory, loadConfig } = buildApi(params.loadConfigResult);
@@ -99,6 +100,7 @@ async function callComplete(params: {
       complete: (input: {
         provider: string;
         model: string;
+        providerApi?: string;
         runtimeConfig?: unknown;
         messages: Array<{ role: string; content: string }>;
         maxTokens: number;
@@ -111,6 +113,7 @@ async function callComplete(params: {
     const result = await engine.deps.complete({
       provider: params.provider,
       model: params.model,
+      providerApi: params.providerApi,
       runtimeConfig: params.runtimeConfig,
       messages: [{ role: "user", content: "Summarize this." }],
       maxTokens: 256,
@@ -223,6 +226,75 @@ describe("createLcmDependencies.complete provider config resolution", () => {
         headers: {
           Authorization: "Bearer test",
         },
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("prefers model-level runtime api over known model and provider api", async () => {
+    piAiMock.getModel.mockReturnValue({
+      id: "gpt-5.4-mini",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      name: "GPT-5.4 Mini",
+      baseUrl: "https://chatgpt.com/backend-api/v1",
+    });
+
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-codex-responses",
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-5.4-mini", api: "openai-completions" }],
+          },
+        },
+      },
+    };
+
+    await callComplete({
+      loadConfigResult: runtimeConfig,
+      provider: "openai-codex",
+      model: "gpt-5.4-mini",
+      providerApi: "openai-codex-responses",
+      runtimeConfig,
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "gpt-5.4-mini",
+        provider: "openai-codex",
+        api: "openai-completions",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("prefers model-level runtime api over provider api when model is custom", async () => {
+    await callComplete({
+      loadConfigResult: {},
+      provider: "openai-codex",
+      model: "custom-mini",
+      providerApi: "openai-codex-responses",
+      runtimeConfig: {
+        models: {
+          providers: {
+            "openai-codex": {
+              models: [{ id: "custom-mini", api: "openai-completions" }],
+            },
+          },
+        },
+      },
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "custom-mini",
+        provider: "openai-codex",
+        api: "openai-completions",
       }),
       expect.any(Object),
       expect.any(Object),

--- a/test/resolve-model-api-from-runtime-config.test.ts
+++ b/test/resolve-model-api-from-runtime-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelApiFromRuntimeConfig } from "../index.js";
+
+describe("resolveModelApiFromRuntimeConfig", () => {
+  const config = {
+    models: {
+      providers: {
+        "openai-codex": {
+          baseUrl: "https://api.openai.com/v1",
+          models: [
+            { id: "gpt-5.4-mini", api: "openai-completions" },
+            { id: "gpt-4o", api: "openai-completions" },
+          ],
+        },
+        codex: {
+          baseUrl: "https://chatgpt.com/backend-api/v1",
+          models: [{ id: "gpt-5.4-mini", api: "openai-codex-responses" }],
+        },
+        "no-api": {
+          models: [{ id: "some-model" }],
+        },
+      },
+    },
+  };
+
+  it("returns model-level api when declared", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "openai-codex", "gpt-5.4-mini")).toBe(
+      "openai-completions",
+    );
+  });
+
+  it("differentiates same model id across providers", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "codex", "gpt-5.4-mini")).toBe(
+      "openai-codex-responses",
+    );
+  });
+
+  it("matches provider id case-insensitively", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "OpenAI-Codex", "gpt-5.4-mini")).toBe(
+      "openai-completions",
+    );
+  });
+
+  it("returns undefined when model has no api declared", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "no-api", "some-model")).toBeUndefined();
+  });
+
+  it("returns undefined when model id is unknown for provider", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "openai-codex", "missing")).toBeUndefined();
+  });
+
+  it("returns undefined when provider is unknown", () => {
+    expect(resolveModelApiFromRuntimeConfig(config, "missing", "any")).toBeUndefined();
+  });
+
+  it("returns undefined when runtime config is malformed", () => {
+    expect(resolveModelApiFromRuntimeConfig(undefined, "openai-codex", "gpt-5.4-mini")).toBeUndefined();
+    expect(resolveModelApiFromRuntimeConfig(null, "openai-codex", "gpt-5.4-mini")).toBeUndefined();
+    expect(resolveModelApiFromRuntimeConfig({}, "openai-codex", "gpt-5.4-mini")).toBeUndefined();
+    expect(
+      resolveModelApiFromRuntimeConfig({ models: { providers: "bad" } }, "openai-codex", "x"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
…ider fallback

Resolves #251. When a user declares `models.providers.<p>.models[*].api` in runtime config, that declaration should win over the hardcoded `inferApiFromProvider()` map.

Concrete repro: setting `summaryModel: "openai-codex/gpt-5.4-mini"` against the paid OpenAI API endpoint (where the `openai-codex` provider is configured with `baseUrl: https://api.openai.com/v1` and the model declares `api: "openai-completions"`) was failing every compaction call with `error_message=Not Found`. The dispatch-site fallback chain at `src/plugin/index.ts:1535-1556` couldn't see the user-declared api because:
  - `mod.getModel(provider, model)` returned a model object without `.api`
  - `resolveProviderApiFromRuntimeConfig` only looked at provider-level `api`
  - The first-models-list fallback hit a different model So the chain bottomed out at `inferApiFromProvider("openai-codex")` → `"openai-codex-responses"`, sending Codex Responses-shaped requests to api.openai.com which doesn't speak that protocol.

Fix: add `resolveModelApiFromRuntimeConfig(config, provider, model)` that walks `models.providers.<p>.models[]` and returns the matching model's `api` if declared. Slot it into the dispatch chain right after the provider-level runtime resolver and before the first-models-list and `inferApiFromProvider` fallbacks.

Behavior is purely additive: users who don't declare `models[].api` see no change, and `inferApiFromProvider`'s existing semantics for Codex CLI auth users (no explicit api) are preserved.

- Adds: `resolveModelApiFromRuntimeConfig` (exported for testability)
- Tests: 7 new cases covering happy path, case-insensitive provider match, multi-provider disambiguation, missing/malformed config, missing api field
- All 782 tests pass (43 + 1 new file, 775 + 7 new cases)
- Build clean (esbuild → 624kb)