### PR TITLE
fix: prevent assistant prefill errors in assemble() early-return paths

### DIFF
--- a/.changeset/fix-assemble-prefill-fallback.md
+++ b/.changeset/fix-assemble-prefill-fallback.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent assistant-prefill failures on assemble fallback paths while preserving valid assembled assistant turns.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5208,11 +5208,8 @@ export class LcmContextEngine implements ContextEngine {
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
   }): Promise<AssembleResult> {
-    // Return a NEW array (breaking reference equality with params.messages)
-    // and strip trailing assistant messages to prevent prefill errors.
-    // The runtime hook checks `assembled.messages !== sourceMessages` — if
-    // the same reference is returned, it passes raw messages straight to the
-    // API which may end on an assistant turn and trigger a prefill rejection.
+    // Return a new fallback array so the runtime hook treats this as assembled
+    // context, and remove assistant prefill tails from fallback-only paths.
     const safeFallback = (): AssembleResult => {
       const msgs = params.messages.slice();
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
@@ -5344,14 +5341,6 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble-debug conversation=${conversation.conversationId} ${sessionLabel} cacheAwareState=${cacheAwareState} messagesHash=${assembled.debug.finalMessagesHash} preSanitizeHash=${assembled.debug.preSanitizeMessagesHash} previousAssembledCount=${prefixChange.previousCount} commonPrefixCount=${prefixChange.commonPrefixCount} commonPrefixHash=${prefixChange.commonPrefixHash} previousWasPrefix=${prefixChange.previousWasPrefix} firstDivergenceIndex=${prefixChange.firstDivergenceIndex} previousDivergenceMessage=${prefixChange.previousDivergenceMessage} currentDivergenceMessage=${prefixChange.currentDivergenceMessage} evictableCount=${assembled.debug.preSanitizeEvictableCount} evictableHash=${assembled.debug.preSanitizeEvictableHash} freshTailSegmentCount=${assembled.debug.preSanitizeFreshTailCount} freshTailSegmentHash=${assembled.debug.preSanitizeFreshTailHash} selectionMode=${assembled.debug.selectionMode} freshTailOrdinal=${assembled.debug.freshTailOrdinal} orphanStrippingOrdinal=${assembled.debug.orphanStrippingOrdinal} baseFreshTailCount=${assembled.debug.baseFreshTailCount} freshTailCount=${assembled.debug.freshTailCount} tailTokens=${assembled.debug.tailTokens} remainingBudget=${assembled.debug.remainingBudget} evictableTotalTokens=${assembled.debug.evictableTotalTokens} promotedToolResults=${assembled.debug.promotedToolResultCount} promotedOrdinals=${promotedOrdinals} removedToolUseBlocks=${assembled.debug.removedToolUseBlockCount} touchedAssistantMessages=${assembled.debug.touchedAssistantMessageCount}`,
         );
-      }
-
-      // Strip trailing assistant messages from assembled output to prevent prefill errors
-      while (
-        assembled.messages.length > 0 &&
-        assembled.messages[assembled.messages.length - 1]?.role === "assistant"
-      ) {
-        assembled.messages.pop();
       }
 
       const result: AssembleResult = {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5208,11 +5208,21 @@ export class LcmContextEngine implements ContextEngine {
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
   }): Promise<AssembleResult> {
+    // Return a NEW array (breaking reference equality with params.messages)
+    // and strip trailing assistant messages to prevent prefill errors.
+    // The runtime hook checks `assembled.messages !== sourceMessages` — if
+    // the same reference is returned, it passes raw messages straight to the
+    // API which may end on an assistant turn and trigger a prefill rejection.
+    const safeFallback = (): AssembleResult => {
+      const msgs = params.messages.slice();
+      while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
+        msgs.pop();
+      }
+      return { messages: msgs, estimatedTokens: 0 };
+    };
+
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
-      return {
-        messages: params.messages,
-        estimatedTokens: 0,
-      };
+      return safeFallback();
     }
     try {
       this.ensureMigrated();
@@ -5230,10 +5240,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: conversation lookup missed ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
-          messages: params.messages,
-          estimatedTokens: 0,
-        };
+        return safeFallback();
       }
 
       const tokenBudget = this.applyAssemblyBudgetCap(
@@ -5279,10 +5286,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: no context items conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
-          messages: params.messages,
-          estimatedTokens: 0,
-        };
+        return safeFallback();
       }
 
       // Guard against incomplete bootstrap/coverage: if the DB only has
@@ -5293,10 +5297,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
-          messages: params.messages,
-          estimatedTokens: 0,
-        };
+        return safeFallback();
       }
 
       const assembled = await this.assembler.assemble({
@@ -5321,10 +5322,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: empty assembled output, using live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
-          messages: params.messages,
-          estimatedTokens: 0,
-        };
+        return safeFallback();
       }
 
       this.deps.log.info(
@@ -5348,6 +5346,14 @@ export class LcmContextEngine implements ContextEngine {
         );
       }
 
+      // Strip trailing assistant messages from assembled output to prevent prefill errors
+      while (
+        assembled.messages.length > 0 &&
+        assembled.messages[assembled.messages.length - 1]?.role === "assistant"
+      ) {
+        assembled.messages.pop();
+      }
+
       const result: AssembleResult = {
         messages: assembled.messages,
         estimatedTokens: assembled.estimatedTokens,
@@ -5357,10 +5363,7 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.info(
         `[lcm] assemble: failed for session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} error=${describeLogError(err)}`,
       );
-      return {
-        messages: params.messages,
-        estimatedTokens: 0,
-      };
+      return safeFallback();
     }
   }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4021,7 +4021,7 @@ describe("LcmContextEngine.bootstrap", () => {
 // ── Assemble canonical path with fallback ───────────────────────────────────
 
 describe("LcmContextEngine.assemble canonical path", () => {
-  it("falls back to live messages when no DB conversation exists", async () => {
+  it("strips assistant prefill tails when no DB conversation exists", async () => {
     const engine = createEngine();
     const liveMessages: AgentMessage[] = [
       { role: "user", content: "first turn" },
@@ -4034,7 +4034,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 100,
     });
 
-    expect(result.messages).toBe(liveMessages);
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
     expect(result.estimatedTokens).toBe(0);
   });
 
@@ -4058,7 +4059,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 256,
     });
 
-    expect(result.messages).toBe(liveMessages);
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
   });
 
@@ -4140,7 +4142,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 1000,
     });
 
-    expect(result.messages).toBe(liveMessages);
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- All 6 early-return paths in `assemble()` returned `params.messages` by the **same object reference**. The runtime context engine hook (`installContextEngineLoopHook`) checks `assembled.messages !== sourceMessages` — when the reference matched, it treated the result as "no assembly occurred" and passed the raw `sourceMessages` directly to the Anthropic API. If `sourceMessages` ended on an assistant turn, models that don't support prefill (e.g. `claude-sonnet-4-6`) rejected the request.
- Introduces a `safeFallback()` helper that returns a **new array** (via `.slice()`, breaking reference equality) and strips trailing assistant messages before returning. All 6 early-return paths now use it.
- The main success path also strips trailing assistant messages as a belt-and-suspenders guard.

## Error reproduced

```
FailoverError: LLM request rejected: This model does not support assistant message prefill.
The conversation must end with a user message.
```

Triggered on `lane=session:agent:main:main` when the embedded agent context ended on an assistant turn and `assemble()` hit an early-return path (typically site 3: `contextItems.length === 0`, which fires at every embedded sub-agent bootstrap before context is stored).

## Test plan

- [ ] Verify gateway starts cleanly with the patched plugin
- [ ] Trigger an embedded agent run that previously hit the prefill error (e.g. sub-agent bootstrap with no stored context)
- [ ] Confirm no `assistant message prefill` errors in logs
- [ ] Verify normal LCM assembly still works (conversation with compacted history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)