### PR TITLE
fix: prevent Bedrock empty-content rejection from dedup gaps and thinking-only messages

### DIFF
--- a/.changeset/quiet-tail-replays.md
+++ b/.changeset/quiet-tail-replays.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent replayed Bedrock transcript tails from being reingested after compaction by matching against the actual stored message tail and treating fully matched suffixes as already stored.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -21,6 +21,24 @@ const TOOL_CALL_TYPES = new Set([
   "function_call",
 ]);
 
+/** Block types that represent model-internal reasoning and will be stripped
+ *  by the provider layer before sending to the API. If an assistant message
+ *  contains *only* these block types, it should be treated as empty. */
+const THINKING_LIKE_TYPES = new Set(["thinking", "redacted_thinking", "reasoning"]);
+
+/** Returns true when every block in the content array is a thinking/reasoning
+ *  block that will be stripped downstream, leaving the message with an empty
+ *  content array (which Bedrock and other providers reject). */
+function isThinkingOnlyContent(content: unknown[]): boolean {
+  if (content.length === 0) return false;
+  return content.every(
+    (block) =>
+      !!block &&
+      typeof block === "object" &&
+      THINKING_LIKE_TYPES.has((block as Record<string, unknown>).type as string),
+  );
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface AssembleContextInput {
@@ -1035,16 +1053,19 @@ export class ContextAssembler {
       return entry;
     });
 
-    // Filter out assistant messages with empty content — these can occur when
-    // tool-use-only turns are stored with content="" and zero message_parts,
-    // or when filterNonFreshAssistantToolCalls strips all tool_use blocks.
-    // Anthropic (and other providers) reject empty content arrays/strings.
+    // Filter out assistant messages with empty or thinking-only content —
+    // these can occur when tool-use-only turns are stored with content=""
+    // and zero message_parts, when filterNonFreshAssistantToolCalls strips
+    // all tool_use blocks, or when a turn contains only thinking/reasoning
+    // blocks that will be stripped by the provider layer, leaving an empty
+    // content array. Anthropic/Bedrock reject empty content arrays/strings.
     const cleanedEntries = normalizedEntries.filter(
       (entry) =>
         !(
           entry.message?.role === "assistant" &&
           (Array.isArray(entry.message.content)
-            ? entry.message.content.length === 0
+            ? entry.message.content.length === 0 ||
+              isThinkingOnlyContent(entry.message.content)
             : !entry.message.content)
         ),
     );

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4377,23 +4377,42 @@ export class LcmContextEngine implements ContextEngine {
 
     const conversationId = conversation.conversationId;
     const storedMessageCount = await this.conversationStore.getMessageCount(conversationId);
-    if (storedMessageCount === 0 || storedMessageCount > batch.length) {
-      return batch;
+    if (storedMessageCount === 0) return batch;
+
+    const lastDbMessage = await this.conversationStore.getLastMessage(conversationId);
+    if (!lastDbMessage) return batch;
+
+    const storedBatch = batch.map((m) => toStoredMessage(m));
+
+    // When the DB already has more messages than the incoming batch,
+    // the batch may be a tail-only replay. Try tail-matching first,
+    // then fall back to suffix-matching.
+    if (storedMessageCount > batch.length) {
+      return this.deduplicateOversizedBatch(
+        conversationId,
+        batch,
+        storedBatch,
+        storedMessageCount,
+        lastDbMessage,
+      );
     }
 
     // Aligned-tail check: DB's last message must match the message at the
     // exact replay boundary in the incoming batch. This replaces the
     // hasMessage() check which could false-positive on any repeated content.
-    const lastDbMessage = await this.conversationStore.getLastMessage(conversationId);
-    if (!lastDbMessage) return batch;
-
-    const storedBatch = batch.map((m) => toStoredMessage(m));
     const batchAtBoundary = storedBatch[storedMessageCount - 1]!;
     if (
       messageIdentity(lastDbMessage.role, lastDbMessage.content) !==
       messageIdentity(batchAtBoundary.role, batchAtBoundary.content)
     ) {
-      return batch;
+      // Prefix mismatch — attempt suffix fallback before giving up.
+      return this.deduplicateSuffixFallback(
+        conversationId,
+        batch,
+        storedBatch,
+        storedMessageCount,
+        "prefix-mismatch",
+      );
     }
 
     // Full proof: incoming batch must start with the entire stored transcript
@@ -4416,6 +4435,127 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     return batch.slice(storedMessageCount);
+  }
+
+  /**
+   * Handle the case where the DB has more messages than the incoming batch.
+   * The batch is likely a tail-only replay after compaction — try to match
+   * the entire batch against the tail of stored messages.
+   */
+  private async deduplicateOversizedBatch(
+    conversationId: number,
+    batch: AgentMessage[],
+    storedBatch: ReturnType<typeof toStoredMessage>[],
+    storedMessageCount: number,
+    lastDbMessage: { role: string; content: string },
+  ): Promise<AgentMessage[]> {
+    const lastBatchIdentity = messageIdentity(
+      storedBatch[storedBatch.length - 1]!.role,
+      storedBatch[storedBatch.length - 1]!.content,
+    );
+    const lastDbIdentity = messageIdentity(lastDbMessage.role, lastDbMessage.content);
+
+    // Quick check: if the last DB message matches the last batch message,
+    // verify that the entire batch matches the DB tail.
+    if (lastDbIdentity === lastBatchIdentity) {
+      const tailAfterSeq = storedMessageCount - batch.length;
+      const tailMessages = await this.conversationStore.getMessages(conversationId, {
+        afterSeq: tailAfterSeq,
+        limit: batch.length,
+      });
+      if (tailMessages.length === batch.length) {
+        let tailMatch = true;
+        for (let i = 0; i < batch.length; i++) {
+          if (
+            messageIdentity(tailMessages[i]!.role, tailMessages[i]!.content) !==
+            messageIdentity(storedBatch[i]!.role, storedBatch[i]!.content)
+          ) {
+            tailMatch = false;
+            break;
+          }
+        }
+        if (tailMatch) {
+          this.deps.log.info(
+            `[lcm] dedup: tail-match detected, batch already fully stored ` +
+              `(storedCount=${storedMessageCount} batchLen=${batch.length}), skipping entire batch`,
+          );
+          return [];
+        }
+      }
+    }
+
+    // Fall back to suffix matching.
+    return this.deduplicateSuffixFallback(
+      conversationId,
+      batch,
+      storedBatch,
+      storedMessageCount,
+      "oversized",
+    );
+  }
+
+  /**
+   * Suffix-matching fallback: scan the batch from the end looking for a
+   * boundary where the stored transcript's tail aligns with a suffix of the
+   * batch. Returns only the genuinely new messages after that boundary.
+   */
+  private async deduplicateSuffixFallback(
+    conversationId: number,
+    batch: AgentMessage[],
+    storedBatch: ReturnType<typeof toStoredMessage>[],
+    storedMessageCount: number,
+    context: string,
+  ): Promise<AgentMessage[]> {
+    const allStored = await this.conversationStore.getMessages(conversationId, {
+      limit: storedMessageCount,
+    });
+    if (allStored.length === 0) return batch;
+
+    const lastStoredIdentity = messageIdentity(
+      allStored[allStored.length - 1]!.role,
+      allStored[allStored.length - 1]!.content,
+    );
+
+    for (let k = batch.length - 1; k >= 0; k--) {
+      if (
+        messageIdentity(storedBatch[k]!.role, storedBatch[k]!.content) !== lastStoredIdentity
+      ) {
+        continue;
+      }
+      const matchLen = Math.min(k + 1, allStored.length);
+      const startDb = allStored.length - matchLen;
+      let suffixMatch = true;
+      for (let j = 0; j < matchLen; j++) {
+        if (
+          messageIdentity(
+            allStored[startDb + j]!.role,
+            allStored[startDb + j]!.content,
+          ) !==
+          messageIdentity(
+            storedBatch[k - matchLen + 1 + j]!.role,
+            storedBatch[k - matchLen + 1 + j]!.content,
+          )
+        ) {
+          suffixMatch = false;
+          break;
+        }
+      }
+      if (suffixMatch && k + 1 < batch.length) {
+        const newSlice = batch.slice(k + 1);
+        this.deps.log.info(
+          `[lcm] dedup: ${context} suffix-match at batch[${k}], ` +
+            `returning ${newSlice.length} new messages ` +
+            `(storedCount=${storedMessageCount} batchLen=${batch.length})`,
+        );
+        return newSlice;
+      }
+    }
+
+    this.deps.log.warn(
+      `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
+        `no overlap found — ingesting full batch`,
+    );
+    return batch;
   }
   /**
    * Rebuild a compact tool-result message from stored message parts.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4456,13 +4456,13 @@ export class LcmContextEngine implements ContextEngine {
     const lastDbIdentity = messageIdentity(lastDbMessage.role, lastDbMessage.content);
 
     // Quick check: if the last DB message matches the last batch message,
-    // verify that the entire batch matches the DB tail.
+    // verify that the entire batch matches the actual DB tail. Message seq
+    // can have gaps after maintenance deletes, so do not derive seq from count.
     if (lastDbIdentity === lastBatchIdentity) {
-      const tailAfterSeq = storedMessageCount - batch.length;
-      const tailMessages = await this.conversationStore.getMessages(conversationId, {
-        afterSeq: tailAfterSeq,
-        limit: batch.length,
+      const storedMessages = await this.conversationStore.getMessages(conversationId, {
+        limit: storedMessageCount,
       });
+      const tailMessages = storedMessages.slice(-batch.length);
       if (tailMessages.length === batch.length) {
         let tailMatch = true;
         for (let i = 0; i < batch.length; i++) {
@@ -4540,8 +4540,8 @@ export class LcmContextEngine implements ContextEngine {
           break;
         }
       }
-      if (suffixMatch && k + 1 < batch.length) {
-        const newSlice = batch.slice(k + 1);
+      const newSlice = batch.slice(k + 1);
+      if (suffixMatch && (newSlice.length > 0 || matchLen > 1)) {
         this.deps.log.info(
           `[lcm] dedup: ${context} suffix-match at batch[${k}], ` +
             `returning ${newSlice.length} new messages ` +

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4584,6 +4584,49 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages[2]?.role).toBe("user");
   });
 
+  it("filters thinking-only assistant messages during assembly", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "Explain the result." }),
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Internal reasoning only." }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Keep reasoning with visible output." },
+          { type: "text", text: "Visible answer." },
+        ],
+      } as AgentMessage,
+    });
+
+    const assembled = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+
+    expect(assembled.messages).toHaveLength(2);
+    expect(assembled.messages[0]?.role).toBe("user");
+    const assistant = assembled.messages[1] as {
+      role: string;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content?.map((block) => block.type)).toEqual(["thinking", "text"]);
+    expect(assistant.content?.[1]?.text).toBe("Visible answer.");
+  });
+
   it("rebuilds raw function_call blocks from stored columns when raw arguments are objects", async () => {
     const engine = createEngine();
     const sessionId = "session-openai-function-call-raw-arguments-object";
@@ -8149,6 +8192,102 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       "more work",
       "",
       "done again",
+    ]);
+  });
+
+  it("skips fully replayed suffix batches when the stored prefix is absent", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-full-suffix-replay";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-full-suffix-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old B" }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-full-suffix-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "compacted old A" }),
+        makeMessage({ role: "user", content: "old B" }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["old B", "old C"]);
+  });
+
+  it("uses the actual stored tail for oversized single-message replays", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-oversized-single-tail";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-single-tail"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "assistant", content: "old B" }),
+        makeMessage({ role: "user", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-single-tail-2"),
+      messages: [
+        makeMessage({ role: "system", content: "system prompt" }),
+        makeMessage({ role: "user", content: "old C" }),
+      ],
+      prePromptMessageCount: 1,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["old A", "old B", "old C"]);
+  });
+
+  it("does not treat a one-message terminal match as a fully replayed batch", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-terminal-single-match";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-terminal-single-match"),
+      messages: [makeMessage({ role: "assistant", content: "same answer" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-terminal-single-match-2"),
+      messages: [
+        makeMessage({ role: "user", content: "new question" }),
+        makeMessage({ role: "assistant", content: "same answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "same answer",
+      "new question",
+      "same answer",
     ]);
   });
 


### PR DESCRIPTION
## Problem

When using Bedrock models (e.g. Claude Opus 4), lossless-claw triggers `content field is empty` API errors from two independent root causes:

### 1. `deduplicateAfterTurnBatch` returns full batch when `storedCount > batchLen`

After compaction reduces the session transcript, the stored message count can exceed the incoming batch length. The current code at this branch:

```typescript
if (storedMessageCount === 0 || storedMessageCount > batch.length) {
  return batch;  // ← returns full batch, causing duplicate ingestion
}
```

This causes previously-stored messages to be re-ingested, leading to duplicate entries that can produce empty content arrays after dedup reconciliation downstream.

### 2. Thinking-only assistant messages pass the empty-content filter

Assistant messages containing only `thinking`/`redacted_thinking`/`reasoning` blocks have `content.length > 0`, so they pass the existing empty-content filter in the assembler. However, the provider layer strips all thinking blocks before sending to the API, leaving an empty content array — which Bedrock rejects.

## Fix

### deduplicateAfterTurnBatch (engine.ts)

- When `storedCount > batchLen`: attempt **tail-matching** (entire batch already stored → return `[]`) and **suffix-matching** (partial overlap → return only new messages) before falling back to full ingestion
- When prefix alignment fails: attempt **suffix fallback** instead of immediately returning the full batch
- Added structured log messages for each dedup path (`[lcm] dedup: ...`)

### Thinking-only filter (assembler.ts)

- Added `isThinkingOnlyContent()` helper that detects content arrays where every block is a thinking-like type (`thinking`, `redacted_thinking`, `reasoning`)
- Extended the `cleanedEntries` filter to strip these messages alongside empty-content messages

## Testing

- Production hotpatch running since 2026-04-26 on openclaw@2026.4.24 with Bedrock Claude Opus 4 — zero recurrence of the `content field is empty` error after patching
- Build passes (`npm run build`)
- No new TypeScript errors introduced (same error count as `main`)

## Related

- Supersedes #498 (closed, thinking-only filter only — this PR adds the dedup fix as well)
- Addresses Bedrock-specific `content field is empty` / `ValidationException` errors
