### PR TITLE
Rework deferred compaction drain safely

### DIFF
--- a/.changeset/safe-deferred-compaction-drain.md
+++ b/.changeset/safe-deferred-compaction-drain.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Drain deferred compaction debt only after foreground after-turn maintenance finishes so background work cannot race bootstrap refreshes or hot prompt-cache paths.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5198,6 +5198,13 @@ export class LcmContextEngine implements ContextEngine {
       }
     };
     let shouldRefreshBootstrapState = true;
+    let deferredCompactionDrain:
+      | {
+          reason: string;
+          tokenBudget: number;
+          currentTokenCount: number;
+        }
+      | null = null;
 
     let rawLeafTrigger:
       | {
@@ -5282,14 +5289,11 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
         });
         if (compactionTelemetry?.provider || compactionTelemetry?.model) {
-          this.scheduleDeferredCompactionDebtDrain({
-            conversationId: conversation.conversationId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
+          deferredCompactionDrain = {
             tokenBudget,
             currentTokenCount: observedCurrentTokenCount,
             reason: deferredReason,
-          });
+          };
         } else {
           this.deps.log.info(
             `[lcm] background deferred compaction not scheduled conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
@@ -5304,6 +5308,17 @@ export class LcmContextEngine implements ContextEngine {
 
     if (shouldRefreshBootstrapState) {
       await refreshAfterTurnBootstrapState();
+    }
+
+    if (deferredCompactionDrain) {
+      this.scheduleDeferredCompactionDebtDrain({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget: deferredCompactionDrain.tokenBudget,
+        currentTokenCount: deferredCompactionDrain.currentTokenCount,
+        reason: deferredCompactionDrain.reason,
+      });
     }
 
     this.deps.log.info(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -158,6 +158,14 @@ type ContextEngineMaintenanceRuntimeContext = Record<string, unknown> & {
     request: TranscriptRewriteRequest,
   ) => Promise<ContextEngineMaintenanceResult>;
 };
+type DeferredCompactionDebtDrainParams = {
+  conversationId: number;
+  sessionId: string;
+  sessionKey?: string;
+  tokenBudget: number;
+  currentTokenCount?: number;
+  reason: string;
+};
 
 function getErrorCode(error: unknown): string | undefined {
   if (!(error instanceof Error)) {
@@ -2524,6 +2532,93 @@ export class LcmContextEngine implements ContextEngine {
     });
     this.deps.log.info(
       `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"}`,
+    );
+  }
+
+  /** Try deferred compaction later without letting it jump ahead of foreground work. */
+  private scheduleDeferredCompactionDebtDrain(params: DeferredCompactionDebtDrainParams): void {
+    const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
+    setImmediate(() => {
+      void this.drainDeferredCompactionDebtIfIdle({
+        ...params,
+        queueKey,
+      }).catch((err) => {
+        this.deps.log.warn(
+          `[lcm] background deferred compaction failed conversation=${params.conversationId} session=${params.sessionId}: ${describeLogError(err)}`,
+        );
+      });
+    });
+  }
+
+  /**
+   * Consume durable debt only when the session queue is idle and cache policy says
+   * prompt mutation is safe. Any skipped attempt leaves the maintenance row
+   * pending for assemble() or a later host-approved maintain() pass.
+   */
+  private async drainDeferredCompactionDebtIfIdle(
+    params: DeferredCompactionDebtDrainParams & { queueKey: string },
+  ): Promise<void> {
+    const sessionLabel = [
+      `session=${params.sessionId}`,
+      ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+    ].join(" ");
+    if (this.sessionOperationQueues.has(params.queueKey)) {
+      this.deps.log.info(
+        `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=session-queue-busy debtReason=${params.reason}`,
+      );
+      return;
+    }
+
+    await this.withSessionQueue(
+      params.queueKey,
+      async () => {
+        const maintenance =
+          await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+            params.conversationId,
+          );
+        if (!maintenance?.pending && !maintenance?.running) {
+          this.deps.log.info(
+            `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=no-pending-debt debtReason=${params.reason}`,
+          );
+          return;
+        }
+
+        const telemetry =
+          await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+            params.conversationId,
+          );
+        if (this.shouldDelayPromptMutatingDeferredCompaction(telemetry)) {
+          this.deps.log.info(
+            `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=hot-cache retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"} debtReason=${maintenance.reason ?? params.reason}`,
+          );
+          return;
+        }
+
+        const legacyParams =
+          telemetry?.provider || telemetry?.model
+            ? {
+                ...(telemetry.provider ? { provider: telemetry.provider } : {}),
+                ...(telemetry.model ? { model: telemetry.model } : {}),
+              }
+            : undefined;
+        const result = await this.consumeDeferredCompactionDebt({
+          conversationId: params.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget: params.tokenBudget,
+          currentTokenCount: params.currentTokenCount,
+          legacyParams,
+        });
+        if (result) {
+          this.deps.log.info(
+            `[lcm] background deferred compaction done conversation=${params.conversationId} ${sessionLabel} changed=${result.changed} reason=${result.reason ?? "none"} debtReason=${maintenance.reason ?? params.reason}`,
+          );
+        }
+      },
+      {
+        operationName: "backgroundDeferredCompaction",
+        context: sessionLabel,
+      },
     );
   }
 
@@ -5111,10 +5206,11 @@ export class LcmContextEngine implements ContextEngine {
           threshold: number;
         }
       | null = null;
+    let compactionTelemetry: ConversationCompactionTelemetryRecord | null = null;
 
     try {
       rawLeafTrigger = await this.compaction.evaluateLeafTrigger(conversation.conversationId);
-      await this.updateCompactionTelemetry({
+      compactionTelemetry = await this.updateCompactionTelemetry({
         conversationId: conversation.conversationId,
         runtimeContext: legacyParams,
         tokenBudget,
@@ -5174,16 +5270,31 @@ export class LcmContextEngine implements ContextEngine {
           }
         }
       } else if (thresholdDecision.shouldCompact || rawLeafTrigger?.shouldCompact) {
+        const deferredReason = thresholdDecision.shouldCompact
+          ? "threshold"
+          : leafDecision.shouldCompact
+            ? leafDecision.reason
+            : "leaf-trigger";
         await this.recordDeferredCompactionDebt({
           conversationId: conversation.conversationId,
-          reason: thresholdDecision.shouldCompact
-            ? "threshold"
-            : leafDecision.shouldCompact
-              ? leafDecision.reason
-              : "leaf-trigger",
+          reason: deferredReason,
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
         });
+        if (compactionTelemetry?.provider || compactionTelemetry?.model) {
+          this.scheduleDeferredCompactionDebtDrain({
+            conversationId: conversation.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            tokenBudget,
+            currentTokenCount: observedCurrentTokenCount,
+            reason: deferredReason,
+          });
+        } else {
+          this.deps.log.info(
+            `[lcm] background deferred compaction not scheduled conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
+          );
+        }
       }
     } catch (err) {
       this.deps.log.warn(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -216,6 +216,10 @@ function makeMessage(params: { role?: string; content: unknown }): AgentMessage 
   } as AgentMessage;
 }
 
+async function flushImmediate(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 function corruptSessionFilePreservingObservedStats(sessionFile: string): void {
   const originalStats = statSync(sessionFile);
   writeFileSync(sessionFile, "x".repeat(originalStats.size));
@@ -4385,6 +4389,54 @@ describe("LcmContextEngine.assemble canonical path", () => {
     ).toBe(true);
   });
 
+  it("assemble still forwards cache-stability options with deferred-maintenance observability", async () => {
+    const engine = createEngineWithConfig({
+      freshTailCount: 2,
+      freshTailMaxTokens: 123,
+      promptAwareEviction: false,
+    });
+    const privateEngine = engine as unknown as {
+      assembler: {
+        assemble: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const sessionId = "session-assembly-options-stable-with-observability";
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "persisted message" } as AgentMessage,
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "hot",
+      retention: "long",
+      lastObservedCacheHitAt: new Date(),
+      lastCacheTouchAt: new Date(),
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    const assembleSpy = vi.spyOn(privateEngine.assembler, "assemble");
+
+    await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "live message" })],
+      tokenBudget: 10_000,
+      prompt: "persisted",
+    });
+
+    expect(assembleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        freshTailCount: 2,
+        freshTailMaxTokens: 123,
+        promptAwareEviction: false,
+        prompt: "persisted",
+        orphanStrippingOrdinal: undefined,
+      }),
+    );
+  });
+
   it("clears stable orphan stripping state when cache-aware state is cold", async () => {
     const engine = createEngine();
     const sessionId = "session-cold-cache-clears-orphan-stripping-state";
@@ -6075,6 +6127,238 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
     expect(maintenance?.reason).toBe("threshold");
     expect(maintenance?.tokenBudget).toBe(400);
+  });
+
+  it("afterTurn does not background-compact prompt-mutating debt while Anthropic cache is hot", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-hot-cache-deferred";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 60_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 60_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const consumeDeferredCompactionDebtSpy = vi.spyOn(
+      privateEngine,
+      "consumeDeferredCompactionDebt",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-hot-cache-deferred"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+      runtimeContext: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        promptCache: {
+          retention: "long",
+          lastCallUsage: {
+            input: 8_000,
+            cacheRead: 7_000,
+            cacheWrite: 0,
+          },
+        },
+      },
+    });
+
+    await flushImmediate();
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(consumeDeferredCompactionDebtSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+  });
+
+  it("afterTurn keeps deferred debt durable when background drain finds the session busy", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-busy-debt-durable";
+    const privateEngine = engine as unknown as {
+      withSessionQueue<T>(queueKey: string, operation: () => Promise<T>): Promise<T>;
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 60_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: true,
+      reason: "leaf-trigger",
+      maxPasses: 1,
+      allowCondensedPasses: true,
+      activityBand: "medium",
+      leafChunkTokens: 30_000,
+      fallbackLeafChunkTokens: [30_000, 20_000],
+      rawTokensOutsideTail: 60_000,
+      threshold: 30_000,
+      cacheState: "cold",
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const consumeDeferredCompactionDebtSpy = vi.spyOn(
+      privateEngine,
+      "consumeDeferredCompactionDebt",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-busy-debt-durable"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+      runtimeContext: {
+        provider: "openai",
+        model: "gpt-5.1",
+      },
+    });
+
+    let releaseQueue!: () => void;
+    const heldQueue = privateEngine.withSessionQueue(sessionId, async () => {
+      await new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+    });
+
+    await flushImmediate();
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(consumeDeferredCompactionDebtSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+
+    releaseQueue();
+    await heldQueue;
+  });
+
+  it("afterTurn drains deferred debt in the background when cache policy allows it", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-safe-drain";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      executeLeafCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 60_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: true,
+      reason: "cold-cache-catchup",
+      maxPasses: 2,
+      allowCondensedPasses: true,
+      activityBand: "medium",
+      leafChunkTokens: 30_000,
+      fallbackLeafChunkTokens: [30_000, 20_000],
+      rawTokensOutsideTail: 60_000,
+      threshold: 30_000,
+      cacheState: "cold",
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const executeLeafCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeLeafCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-safe-drain"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+      runtimeContext: {
+        provider: "openai",
+        model: "gpt-5.1",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(executeLeafCompactionCoreSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          tokenBudget: 4_096,
+          maxPasses: 2,
+          allowCondensedPasses: true,
+        }),
+      );
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
   });
 
   it("maintain() leaves deferred compaction debt pending until the host opts in", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6142,6 +6142,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
         ) => Promise<unknown>;
       };
       evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      refreshBootstrapState: (params: unknown) => Promise<void>;
       consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
     };
     vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
@@ -6247,8 +6248,20 @@ describe("LcmContextEngine fidelity and token budget", () => {
       privateEngine,
       "consumeDeferredCompactionDebt",
     );
+    let releaseRefresh!: () => void;
+    let resolveRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      resolveRefreshStarted = resolve;
+    });
+    const refreshRelease = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    vi.spyOn(privateEngine, "refreshBootstrapState").mockImplementation(async () => {
+      resolveRefreshStarted();
+      await refreshRelease;
+    });
 
-    await engine.afterTurn({
+    const afterTurnPromise = engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("after-turn-background-busy-debt-durable"),
       messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
@@ -6260,6 +6273,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
       },
     });
 
+    await refreshStarted;
+    await flushImmediate();
+    expect(consumeDeferredCompactionDebtSpy).not.toHaveBeenCalled();
+
     let releaseQueue!: () => void;
     const heldQueue = privateEngine.withSessionQueue(sessionId, async () => {
       await new Promise<void>((resolve) => {
@@ -6267,6 +6284,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
       });
     });
 
+    releaseRefresh();
+    await afterTurnPromise;
     await flushImmediate();
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);


### PR DESCRIPTION
## Summary

This is the fresh-main replacement for #416 and supersedes the original PR.

It keeps the useful parts of #416 — safer deferred maintenance, lifecycle observability, and cache-aware gating — but drops the unsafe fire-and-forget shape that could mutate prompt/cache state during hot foreground turns.

## What changed

- Adds a conservative deferred compaction drain that runs only when the session lane is idle/safe.
- Preserves durable compaction debt instead of losing optional maintenance when foreground turns cannot run it.
- Keeps cache safety gates in place so deferred work does not destabilize prompt-cache prefixes.
- Adds lifecycle tracing around the deferred drain path.
- Adds regression coverage for idle-gated deferred drain behavior, cache gating, and debt preservation.

## Supersedes

Supersedes #416 (`fix/lcm-hot-path-stability`). The original PR should not be merged as-is; this branch is the intended replacement implementation.

## Validation

Previously validated locally on this branch:

- focused engine tests for the new deferred-drain behavior
- project build/test gate reported clean in the worker handoff

I'll rerun/refresh gates before merge prep if needed.
