### PR TITLE
fix: apply ingest protections during bootstrap import

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3768,6 +3768,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     conversationId: number;
     historicalMessages: AgentMessage[];
+    checkpointEntryHash?: string | null;
   }): Promise<{
     blockedByImportCap: boolean;
     importedMessages: number;
@@ -3868,10 +3869,24 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     if (anchorIndex < 0) {
-      this.deps.log.info(
-        `[lcm] reconcileSessionTail: no anchor for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=false`,
-      );
-      return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
+      const checkpointEntryHash = params.checkpointEntryHash;
+      if (checkpointEntryHash) {
+        // Externalized bootstrap rows no longer match raw JSONL content, so
+        // fall back to the raw transcript checkpoint before declaring no overlap.
+        for (let index = storedHistoricalMessages.length - 1; index >= 0; index--) {
+          if (createBootstrapEntryHash(storedHistoricalMessages[index]) === checkpointEntryHash) {
+            anchorIndex = index;
+            break;
+          }
+        }
+      }
+
+      if (anchorIndex < 0) {
+        this.deps.log.info(
+          `[lcm] reconcileSessionTail: no anchor for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=false`,
+        );
+        return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
+      }
     }
     if (anchorIndex >= historicalMessages.length - 1) {
       this.deps.log.info(
@@ -3910,15 +3925,15 @@ export class LcmContextEngine implements ContextEngine {
   /**
    * Persist bootstrap checkpoint metadata anchored to the current DB frontier.
    *
-   * We intentionally checkpoint the session file's current EOF while hashing the
-   * latest persisted DB message. This keeps append-only recovery aligned with the
-   * canonical LCM frontier even when trailing transcript entries are pruned or
-   * otherwise noncanonical.
+   * By default, the frontier hash follows the latest persisted DB message. The
+   * first-time bootstrap path can override it with the raw transcript hash so
+   * later reconciliation can anchor entries whose DB content was externalized.
    */
   private async refreshBootstrapState(params: {
     conversationId: number;
     sessionFile: string;
     fileStats?: { size: number; mtimeMs: number };
+    lastProcessedEntryHash?: string | null;
   }): Promise<void> {
     const latestDbMessage = await this.conversationStore.getLastMessage(params.conversationId);
     const fileStats = params.fileStats ?? (await stat(params.sessionFile));
@@ -3928,13 +3943,16 @@ export class LcmContextEngine implements ContextEngine {
       lastSeenSize: fileStats.size,
       lastSeenMtimeMs: Math.trunc(fileStats.mtimeMs),
       lastProcessedOffset: fileStats.size,
-      lastProcessedEntryHash: latestDbMessage
-        ? createBootstrapEntryHash({
-            role: latestDbMessage.role,
-            content: latestDbMessage.content,
-            tokenCount: latestDbMessage.tokenCount,
-          })
-        : null,
+      lastProcessedEntryHash:
+        params.lastProcessedEntryHash !== undefined
+          ? params.lastProcessedEntryHash
+          : latestDbMessage
+            ? createBootstrapEntryHash({
+                role: latestDbMessage.role,
+                content: latestDbMessage.content,
+                tokenCount: latestDbMessage.tokenCount,
+              })
+            : null,
     });
   }
 
@@ -3973,6 +3991,7 @@ export class LcmContextEngine implements ContextEngine {
         this.conversationStore.withTransaction(async () => {
           const persistBootstrapState = async (
             conversationId: number,
+            lastProcessedEntryHash?: string | null,
           ): Promise<void> => {
             await this.refreshBootstrapState({
               conversationId,
@@ -3981,6 +4000,7 @@ export class LcmContextEngine implements ContextEngine {
                 size: sessionFileSize,
                 mtimeMs: sessionFileMtimeMs,
               },
+              lastProcessedEntryHash,
             });
             // Update the file-level cache so subsequent bootstraps against an
             // unchanged file can skip the full read via the cache guard.
@@ -4215,28 +4235,24 @@ export class LcmContextEngine implements ContextEngine {
               };
             }
 
-            const nextSeq = (await this.conversationStore.getMaxSeq(conversationId)) + 1;
-            const bulkInput = bootstrapMessages.map((message, index) => {
-              const stored = toStoredMessage(message);
-              return {
-                conversationId,
-                seq: nextSeq + index,
-                role: stored.role,
-                content: stored.content,
-                tokenCount: stored.tokenCount,
-              };
-            });
-
-            const inserted = await this.conversationStore.createMessagesBulk(bulkInput);
-            await this.summaryStore.appendContextMessages(
-              conversationId,
-              inserted.map((record) => record.messageId),
-            );
+            let importedMessages = 0;
+            for (const message of bootstrapMessages) {
+              const result = await this.ingestSingle({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                message,
+              });
+              if (result.ingested) {
+                importedMessages += 1;
+              }
+            }
             await this.conversationStore.markConversationBootstrapped(conversationId);
 
             // Prune HEARTBEAT_OK turns from the freshly imported data
+            let prunedMessages = 0;
             if (this.config.pruneHeartbeatOk) {
               const pruned = await this.pruneHeartbeatOkTurns(conversationId);
+              prunedMessages = pruned;
               if (pruned > 0) {
                 this.clearStableOrphanStrippingOrdinal(conversationId);
                 this.deps.log.info(
@@ -4245,17 +4261,23 @@ export class LcmContextEngine implements ContextEngine {
               }
             }
 
-            await persistBootstrapState(conversationId);
-            if (inserted.length > 0) {
+            const lastImportedHash =
+              prunedMessages === 0 && bootstrapMessages.length > 0
+                ? createBootstrapEntryHash(
+                    toStoredMessage(bootstrapMessages[bootstrapMessages.length - 1]),
+                  )
+                : undefined;
+            await persistBootstrapState(conversationId, lastImportedHash);
+            if (importedMessages > 0) {
               this.clearStableOrphanStrippingOrdinal(conversationId);
             }
             this.deps.log.info(
-              `[lcm] bootstrap: initial import conversation=${conversationId} ${sessionLabel} importedMessages=${inserted.length} sourceMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
+              `[lcm] bootstrap: initial import conversation=${conversationId} ${sessionLabel} importedMessages=${importedMessages} sourceMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
             );
 
             return {
               bootstrapped: true,
-              importedMessages: inserted.length,
+              importedMessages,
             };
           }
 
@@ -4266,6 +4288,7 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
             conversationId,
             historicalMessages,
+            checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
           });
           this.deps.log.info(
             `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3728,16 +3728,16 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(reconcileSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the bulk import path for initial bootstrap", async () => {
-    const sessionFile = createSessionFilePath("bulk");
+  it("uses the live ingest path for initial bootstrap", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-ingest-path");
     const sm = SessionManager.open(sessionFile);
     sm.appendMessage({
       role: "user",
-      content: [{ type: "text", text: "bulk one" }],
+      content: [{ type: "text", text: "ingest one" }],
     } as AgentMessage);
     sm.appendMessage({
       role: "assistant",
-      content: [{ type: "text", text: "bulk two" }],
+      content: [{ type: "text", text: "ingest two" }],
     } as AgentMessage);
 
     const warnLog = vi.fn();
@@ -3753,13 +3753,185 @@ describe("LcmContextEngine.bootstrap", () => {
     const singleSpy = vi.spyOn(engine.getConversationStore(), "createMessage");
 
     const result = await engine.bootstrap({
-      sessionId: "bootstrap-bulk",
+      sessionId: "bootstrap-ingest-path",
       sessionFile,
     });
 
     expect(result.bootstrapped).toBe(true);
-    expect(bulkSpy).toHaveBeenCalledTimes(1);
-    expect(singleSpy).not.toHaveBeenCalled();
+    expect(result.importedMessages).toBe(2);
+    expect(bulkSpy).not.toHaveBeenCalled();
+    expect(singleSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("externalizes oversized file blocks during first-time bootstrap and still reconciles later tail messages", async () => {
+    await withTempHome(async () => {
+      const sessionFile = createSessionFilePath("bootstrap-large-file-parity");
+      const fileText = `${"bootstrap file line\n".repeat(160)}done`;
+      writeFileSync(
+        sessionFile,
+        `${JSON.stringify({
+          role: "user",
+          content: `<file name="bootstrap.md" mime="text/markdown">${fileText}</file>`,
+        })}\n`,
+        "utf8",
+      );
+
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = "bootstrap-large-file-parity";
+      const first = await engine.bootstrap({ sessionId, sessionFile });
+      expect(first).toEqual({
+        bootstrapped: true,
+        importedMessages: 1,
+      });
+
+      const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const initiallyStored = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(initiallyStored).toHaveLength(1);
+      expect(initiallyStored[0].content).toContain("[LCM File: file_");
+      expect(initiallyStored[0].content).not.toContain("<file name=");
+      expect(initiallyStored[0].content).not.toContain(fileText.slice(0, 64));
+
+      const fileIdMatch = initiallyStored[0].content.match(/file_[a-f0-9]{16}/);
+      expect(fileIdMatch).not.toBeNull();
+      const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+      expect(storedFile).not.toBeNull();
+      expect(storedFile!.fileName).toBe("bootstrap.md");
+      expect(readFileSync(storedFile!.storageUri, "utf8")).toBe(fileText);
+
+      const parts = await engine.getConversationStore().getMessageParts(initiallyStored[0].messageId);
+      expect(parts).toHaveLength(1);
+      expect(parts[0].textContent).toContain("[LCM File: file_");
+
+      appendFileSync(
+        sessionFile,
+        `${JSON.stringify({
+          role: "assistant",
+          content: [{ type: "text", text: "tail after externalized bootstrap" }],
+        })}\n`,
+        "utf8",
+      );
+
+      const second = await engine.bootstrap({ sessionId, sessionFile });
+      expect(second).toEqual({
+        bootstrapped: true,
+        importedMessages: 1,
+        reason: "reconciled missing session messages",
+      });
+
+      const afterReconcile = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(afterReconcile.map((message) => message.content)).toEqual([
+        initiallyStored[0].content,
+        "tail after externalized bootstrap",
+      ]);
+    });
+  });
+
+  it("externalizes inline images during first-time bootstrap", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const sessionFile = createSessionFilePath("bootstrap-inline-image-parity");
+    const base64Image = `iVBOR${"A".repeat(600)}`;
+    writeFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        role: "user",
+        content: `[media attached: bootstrap.png]\n${base64Image}\n`,
+      })}\n`,
+      "utf8",
+    );
+
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = "bootstrap-inline-image-parity";
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("[User image: bootstrap.png");
+    expect(messages[0].content).not.toContain(base64Image.slice(0, 32));
+
+    const fileIdMatch = messages[0].content.match(/file_[a-f0-9]{16}/);
+    expect(fileIdMatch).not.toBeNull();
+    const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+    expect(storedFile).not.toBeNull();
+    expect(storedFile!.mimeType).toBe("image/png");
+    expect(storedFile!.storageUri).toContain(`${largeFilesDir}/${conversation!.conversationId}/`);
+  });
+
+  it("externalizes oversized tool results during first-time bootstrap", async () => {
+    await withTempHome(async () => {
+      const sessionFile = createSessionFilePath("bootstrap-tool-result-parity");
+      const sm = SessionManager.open(sessionFile);
+      const toolOutput = `${"bootstrap tool output\n".repeat(160)}done`;
+      sm.appendMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bootstrap_externalized",
+            name: "exec",
+            input: { cmd: "cat large.txt" },
+          },
+        ],
+      } as AgentMessage);
+      sm.appendMessage({
+        role: "toolResult",
+        toolCallId: "call_bootstrap_externalized",
+        toolName: "exec",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_bootstrap_externalized",
+            name: "exec",
+            content: [{ type: "text", text: toolOutput }],
+          },
+        ],
+      } as AgentMessage);
+
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = "bootstrap-tool-result-parity";
+      const result = await engine.bootstrap({ sessionId, sessionFile });
+      expect(result.bootstrapped).toBe(true);
+      expect(result.importedMessages).toBe(2);
+
+      const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+      const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+      expect(messages).toHaveLength(2);
+      expect(messages[1].content).toContain("[LCM Tool Output: file_");
+      expect(messages[1].content).toContain("tool=exec");
+      expect(messages[1].content).not.toContain(toolOutput.slice(0, 64));
+
+      const fileIdMatch = messages[1].content.match(/file_[a-f0-9]{16}/);
+      expect(fileIdMatch).not.toBeNull();
+      const fileId = fileIdMatch![0];
+      const storedFile = await engine.getSummaryStore().getLargeFile(fileId);
+      expect(storedFile).not.toBeNull();
+      expect(storedFile!.fileName).toBe("exec.txt");
+      expect(readFileSync(storedFile!.storageUri, "utf8")).toBe(toolOutput);
+
+      const parts = await engine.getConversationStore().getMessageParts(messages[1].messageId);
+      expect(parts).toHaveLength(1);
+      const metadata = JSON.parse(parts[0].metadata ?? "{}") as Record<string, unknown>;
+      expect(metadata).toMatchObject({
+        externalizedFileId: fileId,
+        originalByteSize: Buffer.byteLength(toolOutput, "utf8"),
+        toolOutputExternalized: true,
+        externalizationReason: "large_tool_result",
+      });
+    });
   });
 
   it("limits first-time bootstrap imports to the newest messages within bootstrapMaxTokens", async () => {


### PR DESCRIPTION
## What
First-time bootstrap now imports transcript messages through the live ingest pipeline so oversized files, inline images, and tool results receive the same externalization protections as normal ingest. This also keeps raw transcript checkpoint anchoring available for later reconciliation when stored DB content has been replaced with externalized placeholders. Fixes #492.

## Why
Initial bootstrap previously bulk-inserted raw stored-message rows, bypassing interceptLargeFiles, interceptInlineImages, and interceptLargeToolResults. Large payloads could remain inline even though live ingest would externalize or summarize them.

## Changes
- Route bootstrap through ingestSingle
- Preserve raw checkpoint anchoring
- Add bootstrap externalization tests
- Keep bootstrap reconciliation covered

## Testing
- npx vitest run test/engine.test.ts --testNamePattern "bootstrap|externalizes"
- npm test
- npm run build