### PR TITLE
fix: externalize oversized raw payloads

### DIFF
--- a/.changeset/raw-payload-externalizer.md
+++ b/.changeset/raw-payload-externalizer.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Externalize oversized raw message payloads into large file records after existing file, image, and tool-result interceptors run.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -39,6 +39,7 @@ import {
 import {
   extensionFromNameOrMime,
   formatFileReference,
+  formatRawPayloadReference,
   formatToolOutputReference,
   generateExplorationSummary,
   parseFileBlocks,
@@ -459,6 +460,12 @@ const TOOL_RAW_TYPES: ReadonlySet<string> = new Set([
   "toolResult",
   "tool_use_result",
 ]);
+const REPLAY_CRITICAL_RAW_TYPES: ReadonlySet<string> = new Set([
+  ...TOOL_RAW_TYPES,
+  "thinking",
+  "reasoning",
+]);
+const RAW_PAYLOAD_EXTERNALIZATION_REASON = "large_raw_message";
 
 function looksLikeJsonPayload(value: string): boolean {
   if (typeof value !== "string") return false;
@@ -565,6 +572,60 @@ function extractReasoningText(record: Record<string, unknown>): string | undefin
     .map((chunk) => chunk.trim())
     .filter((chunk, idx, arr) => chunk.length > 0 && arr.indexOf(chunk) === idx);
   return normalized.length > 0 ? normalized.join("\n") : undefined;
+}
+
+/** Return true when a raw block should remain structurally replayable. */
+function hasReplayCriticalRawBlock(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasReplayCriticalRawBlock(entry));
+  }
+
+  const record = value as Record<string, unknown>;
+  const rawType = safeString(record.type) ?? safeString(record.rawType);
+  if (rawType && REPLAY_CRITICAL_RAW_TYPES.has(rawType)) {
+    return true;
+  }
+
+  for (const key of STRUCTURED_NESTED_FIELD_KEYS) {
+    if (hasReplayCriticalRawBlock(record[key])) {
+      return true;
+    }
+  }
+  for (const key of STRUCTURED_ARRAY_FIELD_KEYS) {
+    if (hasReplayCriticalRawBlock(record[key])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Serialize the original message content that backs a generic raw-payload reference. */
+function serializeRawPayloadContent(message: AgentMessage, fallbackContent: string): {
+  content: string;
+  mimeType: string;
+} | null {
+  if (!("content" in message)) {
+    return null;
+  }
+  if (typeof message.content === "string") {
+    return {
+      content: message.content,
+      mimeType: "text/plain",
+    };
+  }
+
+  const serialized = JSON.stringify(message.content);
+  if (typeof serialized !== "string") {
+    return null;
+  }
+  return {
+    content: serialized || fallbackContent,
+    mimeType: "application/json",
+  };
 }
 
 function normalizeUnknownBlock(value: unknown): {
@@ -802,6 +863,13 @@ function buildMessageParts(params: {
   const topLevelIsError =
     safeBoolean(topLevel.isError) ??
     safeBoolean(topLevel.is_error);
+  const rawPayloadExternalized = safeBoolean(topLevel.rawPayloadExternalized);
+  const externalizedFileId = safeString(topLevel.externalizedFileId);
+  const originalByteSize =
+    typeof topLevel.originalByteSize === "number"
+      ? topLevel.originalByteSize
+      : undefined;
+  const externalizationReason = safeString(topLevel.externalizationReason);
 
   // BashExecutionMessage: preserve a synthetic text part so output is round-trippable.
   if (!("content" in message) && "command" in message && "output" in message) {
@@ -848,6 +916,10 @@ function buildMessageParts(params: {
           toolCallId: topLevelToolCallId,
           toolName: topLevelToolName,
           isError: topLevelIsError,
+          rawPayloadExternalized: rawPayloadExternalized || undefined,
+          externalizedFileId,
+          originalByteSize,
+          externalizationReason,
         }),
       },
     ];
@@ -3090,6 +3162,18 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  private static isExternalizedReferenceContent(value: string): boolean {
+    const trimmed = value.trim();
+    return (
+      trimmed.startsWith("[LCM File:") ||
+      trimmed.startsWith("[LCM Tool Output:") ||
+      trimmed.includes("LCM file: file_") ||
+      /\[(?:User|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]/.test(
+        trimmed,
+      )
+    );
+  }
+
   /** Resolve the configured externalized-payload directory for one conversation. */
   private largeFilesDirForConversation(conversationId: number): string {
     return join(this.config.largeFilesDir, String(conversationId));
@@ -3754,6 +3838,66 @@ export class LcmContextEngine implements ContextEngine {
         content: rewrittenContent,
       } as AgentMessage,
       fileIds,
+    };
+  }
+
+  /** Externalize oversized raw messages that survived role-specific interceptors. */
+  private async interceptLargeRawPayload(params: {
+    conversationId: number;
+    message: AgentMessage;
+    stored: StoredMessage;
+  }): Promise<{ rewrittenMessage: AgentMessage; stored: StoredMessage } | null> {
+    const threshold = Math.max(1, this.config.largeFileTokenThreshold);
+    if (params.stored.tokenCount < threshold) {
+      return null;
+    }
+    if (params.stored.role === "tool") {
+      return null;
+    }
+    if (LcmContextEngine.isExternalizedReferenceContent(params.stored.content)) {
+      return null;
+    }
+    if ("content" in params.message && hasReplayCriticalRawBlock(params.message.content)) {
+      return null;
+    }
+
+    const rawPayload = serializeRawPayloadContent(params.message, params.stored.content);
+    if (!rawPayload || rawPayload.content.length === 0) {
+      return null;
+    }
+
+    const role = typeof params.message.role === "string" ? params.message.role : params.stored.role;
+    const externalized = await this.externalizeLargeTextPayload({
+      conversationId: params.conversationId,
+      content: rawPayload.content,
+      fileName: `raw-${role}-payload.${rawPayload.mimeType === "application/json" ? "json" : "txt"}`,
+      mimeType: rawPayload.mimeType,
+      formatReference: ({ fileId, byteSize, summary }) =>
+        formatRawPayloadReference({
+          fileId,
+          role,
+          byteSize,
+          reason: RAW_PAYLOAD_EXTERNALIZATION_REASON,
+          summary,
+        }),
+    });
+
+    const rewrittenMessage = {
+      ...params.message,
+      content: externalized.reference,
+      rawPayloadExternalized: true,
+      externalizedFileId: externalized.fileId,
+      originalByteSize: externalized.byteSize,
+      externalizationReason: RAW_PAYLOAD_EXTERNALIZATION_REASON,
+    } as AgentMessage;
+
+    return {
+      rewrittenMessage,
+      stored: {
+        ...params.stored,
+        content: externalized.reference,
+        tokenCount: estimateTokens(externalized.reference),
+      },
     };
   }
 
@@ -4755,6 +4899,16 @@ export class LcmContextEngine implements ContextEngine {
         stored.content = rewrittenStored.content;
         stored.tokenCount = rewrittenStored.tokenCount;
       }
+    }
+
+    const rawPayloadIntercepted = await this.interceptLargeRawPayload({
+      conversationId,
+      message: messageForParts,
+      stored,
+    });
+    if (rawPayloadIntercepted) {
+      messageForParts = rawPayloadIntercepted.rewrittenMessage;
+      stored = rawPayloadIntercepted.stored;
     }
 
     // Determine next sequence number

--- a/src/large-files.ts
+++ b/src/large-files.ts
@@ -531,6 +531,27 @@ export function formatToolOutputReference(input: {
   ].join("\n");
 }
 
+export function formatRawPayloadReference(input: {
+  fileId: string;
+  role: string;
+  byteSize: number;
+  reason: string;
+  summary: string;
+}): string {
+  const role = input.role.trim() || "unknown";
+  const reason = input.reason.trim() || "large_raw_message";
+  const byteSize = Math.max(0, input.byteSize);
+
+  return [
+    `[LCM Raw Payload: ${input.fileId} | role=${role} | reason=${reason} | ${byteSize.toLocaleString("en-US")} bytes]`,
+    "",
+    "Exploration Summary:",
+    input.summary.trim() || "(no summary available)",
+    "",
+    "Use lcm_describe with the file id to inspect the full payload.",
+  ].join("\n");
+}
+
 export async function generateExplorationSummary(input: ExplorationSummaryInput): Promise<string> {
   const extension = extensionFromNameOrMime(input.fileName, input.mimeType);
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1457,6 +1457,177 @@ describe("LcmContextEngine.ingest content extraction", () => {
     });
   });
 
+  it("externalizes oversized plain user text as a raw payload", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = randomUUID();
+      const rawText = `${"plain raw message line\n".repeat(160)}done`;
+
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({ role: "user", content: rawText }),
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const messages = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toContain("[LCM Raw Payload: file_");
+      expect(messages[0].content).toContain("role=user");
+      expect(messages[0].content).toContain("reason=large_raw_message");
+      expect(messages[0].content).not.toContain(rawText.slice(0, 64));
+
+      const fileIdMatch = messages[0].content.match(/file_[a-f0-9]{16}/);
+      expect(fileIdMatch).not.toBeNull();
+      const fileId = fileIdMatch![0];
+      const storedFile = await engine.getSummaryStore().getLargeFile(fileId);
+      expect(storedFile).not.toBeNull();
+      expect(storedFile!.fileName).toBe("raw-user-payload.txt");
+      expect(storedFile!.mimeType).toBe("text/plain");
+      expect(readFileSync(storedFile!.storageUri, "utf8")).toBe(rawText);
+
+      const parts = await engine.getConversationStore().getMessageParts(messages[0].messageId);
+      expect(parts).toHaveLength(1);
+      expect(parts[0].textContent).toBe(messages[0].content);
+      const metadata = JSON.parse(parts[0].metadata ?? "{}") as Record<string, unknown>;
+      expect(metadata).toMatchObject({
+        originalRole: "user",
+        rawPayloadExternalized: true,
+        externalizedFileId: fileId,
+        originalByteSize: Buffer.byteLength(rawText, "utf8"),
+        externalizationReason: "large_raw_message",
+      });
+    });
+  });
+
+  it("keeps plain user text inline when below the raw-payload threshold", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 100_000 });
+      const sessionId = randomUUID();
+      const rawText = "short raw message";
+
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({ role: "user", content: rawText }),
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const messages = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe(rawText);
+
+      const largeFiles = await engine
+        .getSummaryStore()
+        .getLargeFilesByConversation(conversation!.conversationId);
+      expect(largeFiles).toHaveLength(0);
+    });
+  });
+
+  it("externalizes oversized non-file non-tool raw payloads", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = randomUUID();
+      const rawBlob = "RAW_VENDOR_PAYLOAD ".repeat(220);
+      const rawPayload = [{ type: "vendor_payload", blob: rawBlob, status: "ok" }];
+
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({ role: "assistant", content: rawPayload }),
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const messages = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toContain("[LCM Raw Payload: file_");
+      expect(messages[0].content).toContain("role=assistant");
+      expect(messages[0].content).not.toContain(rawBlob.slice(0, 64));
+
+      const fileIdMatch = messages[0].content.match(/file_[a-f0-9]{16}/);
+      expect(fileIdMatch).not.toBeNull();
+      const storedFile = await engine.getSummaryStore().getLargeFile(fileIdMatch![0]);
+      expect(storedFile).not.toBeNull();
+      expect(storedFile!.fileName).toBe("raw-assistant-payload.json");
+      expect(storedFile!.mimeType).toBe("application/json");
+      expect(readFileSync(storedFile!.storageUri, "utf8")).toBe(JSON.stringify(rawPayload));
+
+      const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+      const assembled = await assembler.assemble({
+        conversationId: conversation!.conversationId,
+        tokenBudget: 10_000,
+      });
+      const assembledMessage = assembled.messages[0] as {
+        role: string;
+        content?: Array<{ type?: unknown; text?: unknown }>;
+      };
+      expect(assembledMessage.role).toBe("assistant");
+      expect(assembledMessage.content?.[0]?.type).toBe("text");
+      expect(String(assembledMessage.content?.[0]?.text)).toContain("[LCM Raw Payload:");
+    });
+  });
+
+  it("does not externalize assistant tool or reasoning blocks generically", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = randomUUID();
+      const largeReasoning = "protected reasoning ".repeat(220);
+      const largeInput = "protected tool input ".repeat(220);
+
+      await engine.ingest({
+        sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "reasoning", summary: [{ text: largeReasoning }] },
+            {
+              type: "toolCall",
+              id: "call_protected",
+              name: "exec",
+              input: { cmd: largeInput },
+            },
+          ],
+        } as AgentMessage,
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const messages = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).not.toContain("[LCM Raw Payload:");
+
+      const largeFiles = await engine
+        .getSummaryStore()
+        .getLargeFilesByConversation(conversation!.conversationId);
+      expect(largeFiles).toHaveLength(0);
+
+      const parts = await engine.getConversationStore().getMessageParts(messages[0].messageId);
+      expect(parts.map((part) => part.partType)).toEqual(["reasoning", "tool"]);
+      expect(parts[1].toolCallId).toBe("call_protected");
+      expect(parts[1].toolName).toBe("exec");
+    });
+  });
+
   it("stores externalized inline images under largeFilesDir", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);


### PR DESCRIPTION
## What
Adds a conservative generic raw-message externalizer that runs after existing file, image, and tool-result interceptors. Oversized safe raw payloads are stored in `large_files` and replaced in message text with an `LCM Raw Payload` reference. References include file id, role, byte size, and the externalization reason.

## Why
Fixes #492 by preventing oversized non-file raw messages from remaining inline when role-specific externalizers do not apply, while preserving replay-critical assistant tool/reasoning structures.

## Changes
- Add raw payload references
- Externalize safe oversized raw messages
- Preserve tool/reasoning structured blocks
- Add focused ingestion regressions
- Add patch changeset

## Testing
- `npm test -- --run test/engine.test.ts`
- `npm run build`
- `npm test`