### PR TITLE
fix: add overflow assembly diagnostics

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -12,6 +12,71 @@ import { estimateTokens } from "./estimate-tokens.js";
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type AssemblySegment = "evictable" | "freshTail";
 
+export interface AssemblyOverflowContributor {
+  /** Context item ordinal in the persisted conversation window. */
+  ordinal: number;
+  /** Estimated token cost for the emitted prompt item. */
+  tokens: number;
+  /** Whether this item survived budget selection. */
+  selected: boolean;
+  /** Raw message id when the contributor is a message. */
+  messageId?: number;
+  /** Raw message sequence when the contributor is a message. */
+  seq?: number;
+  /** Raw message role when the contributor is a message. */
+  role?: MessageRole | "toolResult";
+  /** Summary id when the contributor is a summary. */
+  summaryId?: string;
+  /** Summary kind when the contributor is a summary. */
+  summaryKind?: SummaryRecord["kind"];
+  /** Summary depth when the contributor is a summary. */
+  summaryDepth?: number;
+}
+
+export interface AssemblyDuplicateCluster {
+  /** Depersonalized duplicate key or content hash. */
+  key: string;
+  /** Number of context items in this duplicate cluster. */
+  count: number;
+  /** Sum of estimated tokens in the duplicate cluster. */
+  tokens: number;
+  /** Context item ordinals participating in the cluster. */
+  ordinals: number[];
+  /** Message sequence hints when available. */
+  seqs?: number[];
+  /** Duplicate source kind. */
+  kind: "message-ref" | "summary-ref" | "message-content";
+}
+
+export interface AssemblyOverflowDiagnostics {
+  /** Token budget used by this assembly pass. */
+  tokenBudget: number;
+  /** Estimated token total for all resolved context items before selection. */
+  totalContextTokens: number;
+  /** Estimated raw-message tokens before selection. */
+  rawMessageTokens: number;
+  /** Estimated summary tokens before selection. */
+  summaryTokens: number;
+  /** Number of resolved raw messages before selection. */
+  rawMessageCount: number;
+  /** Number of resolved summaries before selection. */
+  summaryCount: number;
+  /** Number of resolved context items before selection. */
+  totalContextItems: number;
+  /** Raw messages selected for the assembled prompt. */
+  selectedRawMessageCount: number;
+  /** Summaries selected for the assembled prompt. */
+  selectedSummaryCount: number;
+  /** Duplicate context-reference clusters found before selection. */
+  duplicateRefClusters: AssemblyDuplicateCluster[];
+  /** Duplicate raw message-content clusters found before selection. */
+  duplicateMessageClusters: AssemblyDuplicateCluster[];
+  /** Largest raw-message token contributors. */
+  topMessageContributors: AssemblyOverflowContributor[];
+  /** Largest summary token contributors. */
+  topSummaryContributors: AssemblyOverflowContributor[];
+}
+
 const TOOL_CALL_TYPES = new Set([
   "toolCall",
   "toolUse",
@@ -69,6 +134,7 @@ export interface AssembleContextResult {
     preSanitizeFreshTailHash: string;
     preSanitizeMessagesHash: string;
     finalMessagesHash: string;
+    overflowDiagnostics: AssemblyOverflowDiagnostics;
   };
 }
 
@@ -678,6 +744,10 @@ function hashMessages(messages: AgentMessage[]): string {
   return createHash("sha256").update(JSON.stringify(messages)).digest("hex").slice(0, 16);
 }
 
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
 /** Format a Date for XML attributes in the agent's timezone. */
 function formatDateForAttribute(date: Date, timezone?: string): string {
   const tz = timezone ?? "UTC";
@@ -757,6 +827,120 @@ interface ResolvedItem {
   isMessage: boolean;
   /** Pre-extracted plain text used for relevance scoring */
   text: string;
+  /** Source raw message id when this item resolves a message. */
+  messageId?: number;
+  /** Source raw message sequence when this item resolves a message. */
+  seq?: number;
+  /** Source raw message role when this item resolves a message. */
+  sourceRole?: MessageRole;
+  /** Source summary record when this item resolves a summary. */
+  summary?: SummaryRecord;
+}
+
+function topContributors(
+  items: ResolvedItem[],
+  selectedOrdinals: Set<number>,
+  isMessage: boolean,
+): AssemblyOverflowContributor[] {
+  return items
+    .filter((item) => item.isMessage === isMessage)
+    .slice()
+    .sort((a, b) => b.tokens - a.tokens || a.ordinal - b.ordinal)
+    .slice(0, 5)
+    .map((item) => ({
+      ordinal: item.ordinal,
+      tokens: item.tokens,
+      selected: selectedOrdinals.has(item.ordinal),
+      ...(item.messageId != null ? { messageId: item.messageId } : {}),
+      ...(item.seq != null ? { seq: item.seq } : {}),
+      ...(item.sourceRole ? { role: item.sourceRole } : {}),
+      ...(item.summary
+        ? {
+            summaryId: item.summary.summaryId,
+            summaryKind: item.summary.kind,
+            summaryDepth: item.summary.depth,
+          }
+        : {}),
+    }));
+}
+
+function buildRefDuplicateClusters(items: ResolvedItem[]): AssemblyDuplicateCluster[] {
+  const clusters = new Map<string, ResolvedItem[]>();
+  for (const item of items) {
+    const key = item.isMessage
+      ? item.messageId == null ? null : `message:${item.messageId}`
+      : item.summary == null ? null : `summary:${item.summary.summaryId}`;
+    if (!key) {
+      continue;
+    }
+    const existing = clusters.get(key) ?? [];
+    existing.push(item);
+    clusters.set(key, existing);
+  }
+  return formatDuplicateClusters(clusters, (key) =>
+    key.startsWith("message:") ? "message-ref" : "summary-ref",
+  );
+}
+
+function buildMessageContentDuplicateClusters(items: ResolvedItem[]): AssemblyDuplicateCluster[] {
+  const clusters = new Map<string, ResolvedItem[]>();
+  for (const item of items) {
+    if (!item.isMessage || item.text.length === 0) {
+      continue;
+    }
+    const hash = hashText(item.text);
+    const existing = clusters.get(hash) ?? [];
+    existing.push(item);
+    clusters.set(hash, existing);
+  }
+  return formatDuplicateClusters(clusters, () => "message-content");
+}
+
+function formatDuplicateClusters(
+  clusters: Map<string, ResolvedItem[]>,
+  kindForKey: (key: string) => AssemblyDuplicateCluster["kind"],
+): AssemblyDuplicateCluster[] {
+  return [...clusters.entries()]
+    .filter(([, items]) => items.length > 1)
+    .map(([key, items]) => ({
+      key,
+      kind: kindForKey(key),
+      count: items.length,
+      tokens: items.reduce((sum, item) => sum + item.tokens, 0),
+      ordinals: items.map((item) => item.ordinal).slice(0, 8),
+      ...(items.some((item) => item.seq != null)
+        ? { seqs: items.flatMap((item) => item.seq == null ? [] : [item.seq]).slice(0, 8) }
+        : {}),
+    }))
+    .sort((a, b) => b.tokens - a.tokens || b.count - a.count || a.key.localeCompare(b.key))
+    .slice(0, 5);
+}
+
+function buildOverflowDiagnostics(
+  params: {
+    resolved: ResolvedItem[];
+    selected: ResolvedItem[];
+    tokenBudget: number;
+  },
+): AssemblyOverflowDiagnostics {
+  const selectedOrdinals = new Set(params.selected.map((item) => item.ordinal));
+  const rawMessageItems = params.resolved.filter((item) => item.isMessage);
+  const summaryItems = params.resolved.filter((item) => !item.isMessage);
+  return {
+    tokenBudget: params.tokenBudget,
+    totalContextTokens: params.resolved.reduce((sum, item) => sum + item.tokens, 0),
+    rawMessageTokens: rawMessageItems.reduce((sum, item) => sum + item.tokens, 0),
+    summaryTokens: summaryItems.reduce((sum, item) => sum + item.tokens, 0),
+    rawMessageCount: rawMessageItems.length,
+    summaryCount: summaryItems.length,
+    totalContextItems: params.resolved.length,
+    selectedRawMessageCount: params.selected.filter((item) => item.isMessage).length,
+    selectedSummaryCount: params.selected.filter((item) => !item.isMessage).length,
+    duplicateRefClusters: buildRefDuplicateClusters(params.resolved),
+    duplicateMessageClusters: buildMessageContentDuplicateClusters(params.resolved),
+    topMessageContributors: topContributors(params.resolved, selectedOrdinals, true),
+    topSummaryContributors: topContributors(params.resolved, selectedOrdinals, false),
+  };
 }
 
 function resolveFreshTailOrdinal(
@@ -1012,6 +1196,11 @@ export class ContextAssembler {
     selected.push(...freshTail);
 
     const estimatedTokens = evictableTokens + tailTokens;
+    const overflowDiagnostics = buildOverflowDiagnostics({
+      resolved,
+      selected,
+      tokenBudget,
+    });
 
     // Normalize assistant string content to array blocks (some providers return
     // content as a plain string; Anthropic expects content block arrays).
@@ -1083,6 +1272,7 @@ export class ContextAssembler {
         preSanitizeFreshTailHash: hashMessages(preSanitizeFreshTailMessages),
         preSanitizeMessagesHash: hashMessages(cleaned as AgentMessage[]),
         finalMessagesHash: hashMessages(repaired),
+        overflowDiagnostics,
       },
     };
   }
@@ -1193,6 +1383,9 @@ export class ContextAssembler {
       tokens: tokenCount,
       isMessage: true,
       text: contentText,
+      messageId: msg.messageId,
+      seq: msg.seq,
+      sourceRole: msg.role,
     };
   }
 
@@ -1216,6 +1409,7 @@ export class ContextAssembler {
       tokens,
       isMessage: false,
       text: summary.content,
+      summary,
     };
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -24,6 +24,7 @@ import {
   pickToolCallId,
   pickToolIsError,
   pickToolName,
+  type AssemblyOverflowDiagnostics,
 } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import type { LcmConfig } from "./db/config.js";
@@ -79,6 +80,12 @@ type AssemblePrefixSnapshot = {
   serializedMessages: string[];
   messageSummaries: string[];
   fullHash: string;
+};
+
+type BootstrapImportObservation = {
+  importedMessages: number;
+  reason: string | null;
+  observedAt: Date;
 };
 
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
@@ -310,6 +317,33 @@ function describeAssembledPrefixChange(
       ? "none"
       : (currentSnapshot.messageSummaries[commonPrefixCount] ?? "(end)"),
   };
+}
+
+function shouldLogOverflowDiagnostics(params: {
+  diagnostics: AssemblyOverflowDiagnostics;
+  assembledTokens: number;
+  liveContextTokens: number;
+}): boolean {
+  const budget = Math.max(1, params.diagnostics.tokenBudget);
+  return (
+    params.diagnostics.totalContextTokens > budget ||
+    params.assembledTokens >= Math.floor(budget * 0.9) ||
+    params.liveContextTokens >= Math.floor(budget * 0.9) ||
+    params.diagnostics.duplicateRefClusters.length > 0 ||
+    params.diagnostics.duplicateMessageClusters.length > 0
+  );
+}
+
+function formatOverflowDiagnosticsForLog(params: {
+  diagnostics: AssemblyOverflowDiagnostics;
+  recentBootstrapImport?: BootstrapImportObservation;
+}): string {
+  const recent = params.recentBootstrapImport;
+  return JSON.stringify({
+    ...params.diagnostics,
+    recentBootstrapImportCount: recent?.importedMessages ?? null,
+    recentBootstrapImportReason: recent?.reason ?? null,
+  });
 }
 
 function safeString(value: unknown): string | undefined {
@@ -1455,6 +1489,7 @@ export class LcmContextEngine implements ContextEngine {
   >();
   private previousAssembledMessagesByConversation = new Map<number, AssemblePrefixSnapshot>();
   private stableOrphanStrippingOrdinalsByConversation = new Map<number, number>();
+  private recentBootstrapImportsByConversation = new Map<number, BootstrapImportObservation>();
   private largeFileTextSummarizerResolved = false;
   private largeFileTextSummarizer?: (prompt: string) => Promise<string | null>;
   private deps: LcmDependencies;
@@ -3490,6 +3525,27 @@ export class LcmContextEngine implements ContextEngine {
     }
   }
 
+  /** Store the latest bootstrap import count for assembly overflow diagnostics. */
+  private recordRecentBootstrapImport(
+    conversationId: number,
+    importedMessages: number,
+    reason: string | null,
+  ): void {
+    this.recentBootstrapImportsByConversation.delete(conversationId);
+    this.recentBootstrapImportsByConversation.set(conversationId, {
+      importedMessages: Math.max(0, Math.floor(importedMessages)),
+      reason,
+      observedAt: new Date(),
+    });
+    while (this.recentBootstrapImportsByConversation.size > MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS) {
+      const oldestConversationId = this.recentBootstrapImportsByConversation.keys().next().value;
+      if (typeof oldestConversationId !== "number") {
+        break;
+      }
+      this.recentBootstrapImportsByConversation.delete(oldestConversationId);
+    }
+  }
+
   /**
    * Return the stable orphan-stripping ordinal for a conversation and refresh its
    * recency so the bounded cache behaves as an LRU.
@@ -4342,6 +4398,18 @@ export class LcmContextEngine implements ContextEngine {
           `[lcm] bootstrap: heartbeat pruning failed: ${describeLogError(err)}`,
         );
       }
+    }
+
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    if (conversation) {
+      this.recordRecentBootstrapImport(
+        conversation.conversationId,
+        result.importedMessages,
+        result.reason ?? null,
+      );
     }
 
     this.deps.log.info(
@@ -5343,8 +5411,20 @@ export class LcmContextEngine implements ContextEngine {
           assembled.debug.promotedOrdinals.length > 0
             ? assembled.debug.promotedOrdinals.join(",")
             : "none";
+        const overflowDiagnostics = shouldLogOverflowDiagnostics({
+          diagnostics: assembled.debug.overflowDiagnostics,
+          assembledTokens: assembled.estimatedTokens,
+          liveContextTokens,
+        })
+          ? ` overflowDiagnostics=${formatOverflowDiagnosticsForLog({
+              diagnostics: assembled.debug.overflowDiagnostics,
+              recentBootstrapImport: this.recentBootstrapImportsByConversation.get(
+                conversation.conversationId,
+              ),
+            })}`
+          : "";
         this.deps.log.info(
-          `[lcm] assemble-debug conversation=${conversation.conversationId} ${sessionLabel} cacheAwareState=${cacheAwareState} messagesHash=${assembled.debug.finalMessagesHash} preSanitizeHash=${assembled.debug.preSanitizeMessagesHash} previousAssembledCount=${prefixChange.previousCount} commonPrefixCount=${prefixChange.commonPrefixCount} commonPrefixHash=${prefixChange.commonPrefixHash} previousWasPrefix=${prefixChange.previousWasPrefix} firstDivergenceIndex=${prefixChange.firstDivergenceIndex} previousDivergenceMessage=${prefixChange.previousDivergenceMessage} currentDivergenceMessage=${prefixChange.currentDivergenceMessage} evictableCount=${assembled.debug.preSanitizeEvictableCount} evictableHash=${assembled.debug.preSanitizeEvictableHash} freshTailSegmentCount=${assembled.debug.preSanitizeFreshTailCount} freshTailSegmentHash=${assembled.debug.preSanitizeFreshTailHash} selectionMode=${assembled.debug.selectionMode} freshTailOrdinal=${assembled.debug.freshTailOrdinal} orphanStrippingOrdinal=${assembled.debug.orphanStrippingOrdinal} baseFreshTailCount=${assembled.debug.baseFreshTailCount} freshTailCount=${assembled.debug.freshTailCount} tailTokens=${assembled.debug.tailTokens} remainingBudget=${assembled.debug.remainingBudget} evictableTotalTokens=${assembled.debug.evictableTotalTokens} promotedToolResults=${assembled.debug.promotedToolResultCount} promotedOrdinals=${promotedOrdinals} removedToolUseBlocks=${assembled.debug.removedToolUseBlockCount} touchedAssistantMessages=${assembled.debug.touchedAssistantMessageCount}`,
+          `[lcm] assemble-debug conversation=${conversation.conversationId} ${sessionLabel} cacheAwareState=${cacheAwareState} messagesHash=${assembled.debug.finalMessagesHash} preSanitizeHash=${assembled.debug.preSanitizeMessagesHash} previousAssembledCount=${prefixChange.previousCount} commonPrefixCount=${prefixChange.commonPrefixCount} commonPrefixHash=${prefixChange.commonPrefixHash} previousWasPrefix=${prefixChange.previousWasPrefix} firstDivergenceIndex=${prefixChange.firstDivergenceIndex} previousDivergenceMessage=${prefixChange.previousDivergenceMessage} currentDivergenceMessage=${prefixChange.currentDivergenceMessage} evictableCount=${assembled.debug.preSanitizeEvictableCount} evictableHash=${assembled.debug.preSanitizeEvictableHash} freshTailSegmentCount=${assembled.debug.preSanitizeFreshTailCount} freshTailSegmentHash=${assembled.debug.preSanitizeFreshTailHash} selectionMode=${assembled.debug.selectionMode} freshTailOrdinal=${assembled.debug.freshTailOrdinal} orphanStrippingOrdinal=${assembled.debug.orphanStrippingOrdinal} baseFreshTailCount=${assembled.debug.baseFreshTailCount} freshTailCount=${assembled.debug.freshTailCount} tailTokens=${assembled.debug.tailTokens} remainingBudget=${assembled.debug.remainingBudget} evictableTotalTokens=${assembled.debug.evictableTotalTokens} promotedToolResults=${assembled.debug.promotedToolResultCount} promotedOrdinals=${promotedOrdinals} removedToolUseBlocks=${assembled.debug.removedToolUseBlockCount} touchedAssistantMessages=${assembled.debug.touchedAssistantMessageCount}${overflowDiagnostics}`,
         );
       }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4525,6 +4525,94 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(assembleDebugLog).toContain("currentDivergenceMessage=user|content=text");
   });
 
+  it("adds compact overflow diagnostics to stressed assemble debug logs", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: infoLog,
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "session-overflow-diagnostics";
+    const secretMarker = "PRIVATE_OVERFLOW_MARKER";
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "user",
+        content: `large prompt contributor ${secretMarker} ${"x".repeat(1200)}`,
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: `second prompt contributor ${"y".repeat(600)}`,
+      } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    (
+      engine as unknown as {
+        recordRecentBootstrapImport: (
+          conversationId: number,
+          importedMessages: number,
+          reason: string | null,
+        ) => void;
+      }
+    ).recordRecentBootstrapImport(
+      conversation!.conversationId,
+      7,
+      "reconciled missing session messages",
+    );
+
+    await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 100,
+    });
+
+    const assembleDebugLog = infoLog.mock.calls
+      .map((call: unknown[]) => call[0])
+      .find(
+        (entry: unknown) =>
+          typeof entry === "string" &&
+          entry.includes("[lcm] assemble-debug") &&
+          entry.includes("overflowDiagnostics="),
+      ) as string | undefined;
+
+    expect(assembleDebugLog).toEqual(expect.any(String));
+    expect(assembleDebugLog).not.toContain(secretMarker);
+    const diagnostics = JSON.parse(
+      assembleDebugLog!
+        .slice(assembleDebugLog!.indexOf("overflowDiagnostics="))
+        .replace("overflowDiagnostics=", ""),
+    ) as Record<string, unknown>;
+    expect(diagnostics).toMatchObject({
+      tokenBudget: 100,
+      rawMessageCount: 2,
+      summaryCount: 0,
+      totalContextItems: 2,
+      recentBootstrapImportCount: 7,
+      recentBootstrapImportReason: "reconciled missing session messages",
+    });
+    expect(diagnostics.topMessageContributors).toEqual([
+      expect.objectContaining({
+        seq: 1,
+        role: "user",
+        selected: true,
+      }),
+      expect.objectContaining({
+        seq: 2,
+        role: "assistant",
+        selected: true,
+      }),
+    ]);
+  });
+
   it("repairs OpenAI function_call transcripts without dropping reasoning blocks", async () => {
     const engine = createEngine();
     const sessionId = "session-openai-function-call";

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -799,6 +799,90 @@ describe("LCM integration: ingest -> assemble", () => {
     expect(summaryMsg!.content).toContain("This is a leaf summary");
   });
 
+  it("emits depersonalized overflow diagnostics with top contributors", async () => {
+    const [small, large, duplicate] = await ingestMessages(convStore, sumStore, 3, {
+      contentFn: (i) => {
+        if (i === 0) return "tiny";
+        if (i === 1) return `large message ${"x".repeat(800)}`;
+        return `repeated content ${"y".repeat(120)}`;
+      },
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+    const duplicateText = duplicate.content;
+    const secondDuplicate = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 4,
+      role: "assistant",
+      content: duplicateText,
+      tokenCount: estimateTokens(duplicateText),
+    });
+    await sumStore.appendContextMessage(CONV_ID, secondDuplicate.messageId);
+
+    const summaryId = "sum_overflow_diag";
+    await sumStore.insertSummary({
+      summaryId,
+      conversationId: CONV_ID,
+      kind: "leaf",
+      content: `summary contributor ${"z".repeat(500)}`,
+      tokenCount: 125,
+    });
+    await sumStore.appendContextSummary(CONV_ID, summaryId);
+    sumStore._contextItems.push({
+      conversationId: CONV_ID,
+      ordinal: 5,
+      itemType: "message",
+      messageId: large.messageId,
+      summaryId: null,
+      createdAt: new Date(),
+    });
+
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 150,
+      freshTailCount: 1,
+    });
+
+    const diagnostics = result.debug?.overflowDiagnostics;
+    expect(diagnostics).toMatchObject({
+      tokenBudget: 150,
+      rawMessageCount: 5,
+      summaryCount: 1,
+      totalContextItems: 6,
+    });
+    expect(diagnostics?.rawMessageTokens).toBeGreaterThan(diagnostics?.summaryTokens ?? 0);
+    expect(diagnostics?.duplicateRefClusters).toEqual([
+      expect.objectContaining({
+        kind: "message-ref",
+        count: 2,
+        ordinals: [1, 5],
+        seqs: [2, 2],
+      }),
+    ]);
+    expect(diagnostics?.duplicateMessageClusters).toContainEqual(
+      expect.objectContaining({
+        kind: "message-content",
+        count: 2,
+        seqs: [2, 2],
+      }),
+    );
+    expect(diagnostics?.topMessageContributors[0]).toMatchObject({
+      messageId: large.messageId,
+      seq: 2,
+      role: "assistant",
+    });
+    expect(diagnostics?.topMessageContributors[0]?.tokens).toBeGreaterThanOrEqual(
+      diagnostics?.topMessageContributors[1]?.tokens ?? 0,
+    );
+    expect(diagnostics?.topSummaryContributors[0]).toMatchObject({
+      summaryId,
+      summaryKind: "leaf",
+      summaryDepth: 0,
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain("large message");
+    expect(JSON.stringify(diagnostics)).not.toContain("summary contributor");
+    expect(small.messageId).toBeGreaterThan(0);
+  });
+
   it("empty conversation returns empty result", async () => {
     const result = await assembler.assemble({
       conversationId: CONV_ID,


### PR DESCRIPTION
## What
Adds compact, depersonalized overflow diagnostics to LCM assembly debug output for stressed prompt budgets. References #495.

## Why
Large assembled prompts need observability that explains token pressure, duplicate context, and largest contributors without dumping private message or summary content.

## Changes
- Add overflow diagnostic payload
- Track raw vs summary token split
- Report duplicate clusters
- Report top token contributors
- Include recent bootstrap import count

## Testing
- `npm test`
- `npm run build`