### PR TITLE
Use runtime prompt tokens for after-turn compaction

### DIFF
--- a/.changeset/runtime-prompt-token-compaction.md
+++ b/.changeset/runtime-prompt-token-compaction.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use runtime prompt token counts for after-turn compaction decisions when OpenClaw provides usage data, falling back to transcript estimates only when runtime counts are unavailable.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1072,6 +1072,99 @@ function estimateSessionTokenCountForAfterTurn(messages: AgentMessage[]): number
   return total;
 }
 
+function normalizeNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function firstRuntimeTokenCount(record: Record<string, unknown> | null, keys: string[]): number | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const count = normalizeNonNegativeInteger(record[key]);
+    if (count !== undefined) {
+      return count;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract the runtime prompt token count from OpenClaw runtimeContext.
+ *
+ * OpenClaw derives this as: input + cacheRead + cacheWrite from the
+ * normalizeUsage() result.  The runtimeContext carries it three ways:
+ *   1. runtimeContext.currentTokenCount  — direct value (preferred)
+ *   2. runtimeContext.usage             — {input, cacheRead, cacheWrite, ...}
+ *   3. runtimeContext.promptCache.lastCallUsage — same normalized shape
+ *
+ * normalizeUsage() maps provider-specific fields (prompt_tokens, input_tokens,
+ * cache_read, etc.) to the canonical {input, cacheRead, cacheWrite} shape,
+ * so the lastCallUsage passed to LCM is already provider-normalized.
+ */
+/**
+ * Sum prompt tokens from a usage record.
+ *
+ * Supports two shapes:
+ * - Normalized (OpenClaw internal): {input, cacheRead, cacheWrite}
+ * - Raw provider: {prompt_tokens, ...}
+ *
+ * normalizeUsage() maps raw provider fields (prompt_tokens, cache_read, etc.)
+ * to the canonical normalized shape before LCM receives runtimeContext.
+ * We accept both shapes to be robust to direct test calls and future changes.
+ */
+function sumPromptTokensFromUsageRecord(record: Record<string, unknown> | null): number | undefined {
+  if (!record) {
+    return undefined;
+  }
+  // Normalized shape: input + cacheRead + cacheWrite
+  const input = normalizeNonNegativeInteger(record["input"]);
+  const cacheRead = normalizeNonNegativeInteger(record["cacheRead"]);
+  const cacheWrite = normalizeNonNegativeInteger(record["cacheWrite"]);
+  if (input !== undefined || cacheRead !== undefined || cacheWrite !== undefined) {
+    return (input ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0);
+  }
+  // Raw provider shape: prompt_tokens (already includes cache reads)
+  const rawPromptTokens = normalizeNonNegativeInteger(
+    record["prompt_tokens"] ?? record["promptTokens"] ?? record["input_tokens"] ?? record["inputTokens"],
+  );
+  if (rawPromptTokens !== undefined) {
+    return rawPromptTokens;
+  }
+  return undefined;
+}
+
+function extractRuntimePromptTokenCount(runtimeContext?: Record<string, unknown>): number | undefined {
+  const ctx = asRecord(runtimeContext);
+  if (!ctx) {
+    return undefined;
+  }
+
+  // 1. Direct currentTokenCount (already derived by OpenClaw: input+cacheRead+cacheWrite)
+  const direct = normalizeNonNegativeInteger(ctx["currentTokenCount"]);
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  // 2. Sum from runtimeContext.usage (normalizeUsage output: {input, cacheRead, cacheWrite})
+  const usageSum = sumPromptTokensFromUsageRecord(asRecord(ctx["usage"]) ?? asRecord(ctx["lastCallUsage"]));
+  if (usageSum !== undefined && usageSum > 0) {
+    return usageSum;
+  }
+
+  // 3. Sum from promptCache.lastCallUsage (same normalized shape)
+  const promptCache = asRecord(ctx["promptCache"]);
+  const promptCacheUsageSum = sumPromptTokensFromUsageRecord(asRecord(promptCache?.["lastCallUsage"]));
+  if (promptCacheUsageSum !== undefined && promptCacheUsageSum > 0) {
+    return promptCacheUsageSum;
+  }
+
+  return undefined;
+}
+
 function isBootstrapMessage(value: unknown): value is AgentMessage {
   if (!value || typeof value !== "object") {
     return false;
@@ -5293,14 +5386,22 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
 
+    const estimatedContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
+    const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
+    const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
+      (
+        (legacyParams ?? {}) as {
+          currentTokenCount?: unknown;
+        }
+      ).currentTokenCount,
+    );
     const observedCurrentTokenCount =
-      this.normalizeObservedTokenCount(
-        (
-          (legacyParams ?? {}) as {
-            currentTokenCount?: unknown;
-          }
-        ).currentTokenCount,
-      ) ?? estimateSessionTokenCountForAfterTurn(params.messages);
+      runtimePromptTokens ?? suppliedCurrentTokenCount ?? estimatedContextTokens;
+    if (runtimePromptTokens !== undefined) {
+      this.deps.log.debug(
+        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} estimatedTokenCount=${estimatedContextTokens}`,
+      );
+    }
     const conversation = await this.conversationStore.getConversationForSession({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7171,6 +7171,62 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
   });
 
+  it("afterTurn prefers runtime prompt tokens over transcript estimates for compaction decisions", async () => {
+    const debugLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: debugLog,
+        },
+      },
+    );
+    const sessionId = "after-turn-runtime-prompt-tokens";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 204_800,
+      threshold: 98_304,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-runtime-prompt-tokens"),
+      messages: [makeMessage({ role: "assistant", content: "small transcript estimate" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 128_000,
+      runtimeContext: {
+        usage: {
+          prompt_tokens: 204_800,
+        },
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), 204_800);
+    expect(debugLog).toHaveBeenCalledWith(
+      expect.stringContaining("using runtime prompt token count currentTokenCount=204800"),
+    );
+  });
+
   it("evaluateIncrementalCompaction skips hot-cache maintenance when real budget headroom is comfortable", async () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(


### PR DESCRIPTION
## Summary

Fixes LCM's after-turn compaction telemetry undercounting live prompt tokens.

**Root cause**: `afterTurn` computed `currentTokenCount` from a transcript estimate (`estimateSessionTokenCountForAfterTurn`), which can diverge significantly from the actual API prompt token count. In a real incident, LCM telemetry showed ~92k tokens while the runtime was at ~204.8k.

**Solution** — check three sources in priority order:
1. `runtimeContext.currentTokenCount` — already derived by OpenClaw as `input + cacheRead + cacheWrite`
2. `runtimeContext.usage` — OpenClaw `normalizeUsage()` output: `{input, cacheRead, cacheWrite}`
3. `runtimeContext.promptCache.lastCallUsage` — same normalized shape

Both normalized and raw provider usage shapes are supported (e.g., `prompt_tokens` in addition to `input + cacheRead + cacheWrite`).

Transcript estimation remains the final fallback when none of the above are available.

## Changes

- `src/engine.ts`: New `sumPromptTokensFromUsageRecord()` + rewritten `extractRuntimePromptTokenCount()` with correct priority and shape handling
- `test/engine.test.ts`: Test now validates the `evaluateSpy` is called with the runtime token count

## Test plan

- `npm test -- --run test/engine.test.ts` ✅ 193/193
- `npm test` ✅ 796/796

Fixes #514.