### PR TITLE
fix: externalize native user image blocks

### DIFF
--- a/.changeset/native-image-blocks.md
+++ b/.changeset/native-image-blocks.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Externalize native user image blocks as image files before generic raw payload fallback.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3378,6 +3378,93 @@ export class LcmContextEngine implements ContextEngine {
     return null;
   }
 
+  private static extensionForImageMimeType(mimeType: string): string | null {
+    switch (mimeType.toLowerCase()) {
+      case "image/jpeg":
+      case "image/jpg":
+        return "jpg";
+      case "image/png":
+        return "png";
+      case "image/gif":
+        return "gif";
+      case "image/webp":
+        return "webp";
+      case "image/svg+xml":
+        return "svg";
+      default:
+        return null;
+    }
+  }
+
+  private static normalizeNativeImageBlock(value: unknown): {
+    base64Data: string;
+    extension: string;
+    mimeType: string;
+  } | null {
+    const record = asRecord(value);
+    if (!record || record.type !== "image") {
+      return null;
+    }
+
+    const rawData = safeString(record.data);
+    if (!rawData) {
+      return null;
+    }
+
+    const dataUrlMatch = rawData.match(/^data:([^;,]+);base64,(.*)$/s);
+    const declaredMimeType =
+      dataUrlMatch?.[1] ??
+      safeString(record.mimeType) ??
+      safeString(record.mime_type) ??
+      safeString(record.mediaType) ??
+      safeString(record.media_type);
+    const base64Data = (dataUrlMatch?.[2] ?? rawData).replace(/\s+/g, "");
+    if (!base64Data || !/^[A-Za-z0-9+/]+={0,2}$/.test(base64Data)) {
+      return null;
+    }
+
+    const detected = LcmContextEngine.detectBase64ImageType(base64Data);
+    const mimeType = detected?.mimeType ?? declaredMimeType;
+    if (!mimeType?.toLowerCase().startsWith("image/")) {
+      return null;
+    }
+
+    const extension = detected?.extension ?? LcmContextEngine.extensionForImageMimeType(mimeType);
+    return extension ? { base64Data, extension, mimeType } : null;
+  }
+
+  private static basenameForImageReference(pathLike: string): string | null {
+    const baseName = pathLike.trim().split(/[\\/]/).filter(Boolean).pop();
+    if (!baseName) {
+      return null;
+    }
+    return baseName.replace(/[^\w.\-@]+/g, "_") || null;
+  }
+
+  private static inferNativeImageFileName(params: {
+    content: unknown[];
+    imageIndex: number;
+    extension: string;
+  }): string {
+    for (let index = params.imageIndex - 1; index >= 0; index -= 1) {
+      const entry = asRecord(params.content[index]);
+      const text = entry?.type === "text" ? safeString(entry.text) : undefined;
+      if (!text) {
+        continue;
+      }
+
+      const mediaMatch = text.match(/\[media attached(?:\s+\d+\/\d+)?:\s*([^\s\]|()]+)/i);
+      const fileName = mediaMatch?.[1]
+        ? LcmContextEngine.basenameForImageReference(mediaMatch[1])
+        : null;
+      if (fileName) {
+        return fileName;
+      }
+    }
+
+    return `user-image.${params.extension}`;
+  }
+
   private static isExternalizedImageReference(value: string): boolean {
     if (typeof value !== "string") return false;
     return /^\[(?:User|Tool|Assistant|Image) image: .*LCM file: file_[a-f0-9]{16}\]$/.test(
@@ -3448,6 +3535,60 @@ export class LcmContextEngine implements ContextEngine {
 
     const reference = `[${params.label}: ${fileName} (${params.mimeType}, ${byteSize.toLocaleString("en-US")} bytes) | LCM file: ${fileId}]`;
     return { fileId, byteSize, summary, reference };
+  }
+
+  private async interceptNativeUserImageBlocks(params: {
+    conversationId: number;
+    message: AgentMessage;
+  }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
+    if (params.message.role !== "user" || !("content" in params.message)) {
+      return null;
+    }
+    if (!Array.isArray(params.message.content)) {
+      return null;
+    }
+
+    const rewrittenContent: unknown[] = [];
+    const fileIds: string[] = [];
+    let changed = false;
+
+    for (let index = 0; index < params.message.content.length; index += 1) {
+      const block = params.message.content[index];
+      const image = LcmContextEngine.normalizeNativeImageBlock(block);
+      if (!image) {
+        rewrittenContent.push(block);
+        continue;
+      }
+
+      const externalized = await this.externalizeImage({
+        conversationId: params.conversationId,
+        base64Data: image.base64Data,
+        fileName: LcmContextEngine.inferNativeImageFileName({
+          content: params.message.content,
+          imageIndex: index,
+          extension: image.extension,
+        }),
+        extension: image.extension,
+        mimeType: image.mimeType,
+        label: "User image",
+      });
+
+      rewrittenContent.push({ type: "text", text: externalized.reference });
+      fileIds.push(externalized.fileId);
+      changed = true;
+    }
+
+    if (!changed) {
+      return null;
+    }
+
+    return {
+      rewrittenMessage: {
+        ...params.message,
+        content: rewrittenContent,
+      } as AgentMessage,
+      fileIds,
+    };
   }
 
   private async interceptInlineImages(params: {
@@ -5275,6 +5416,15 @@ export class LcmContextEngine implements ContextEngine {
         stored = toStoredMessage(messageForParts);
       }
     } else {
+      const nativeImageIntercepted = await this.interceptNativeUserImageBlocks({
+        conversationId,
+        message: messageForParts,
+      });
+      if (nativeImageIntercepted) {
+        messageForParts = nativeImageIntercepted.rewrittenMessage;
+        stored = toStoredMessage(messageForParts);
+      }
+
       const imageIntercepted = await this.interceptInlineImages({
         conversationId,
         content: stored.content,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1672,6 +1672,70 @@ describe("LcmContextEngine.ingest content extraction", () => {
     );
   });
 
+  it("externalizes native user image blocks before raw payload fallback", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `/9j/${"A".repeat(600)}`;
+    const userText =
+      "[media attached: /Users/example/inbound/screenshot.jpg (image/jpeg)]\nplease inspect";
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "user",
+        content: [
+          { type: "text", text: userText },
+          { type: "image", data: base64Image, mimeType: "image/jpeg" },
+        ],
+      }),
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("please inspect");
+    expect(messages[0].content).toContain("[User image: screenshot.jpg");
+    expect(messages[0].content).not.toContain("[LCM Raw Payload:");
+    expect(messages[0].content).not.toContain(base64Image.slice(0, 32));
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+    expect(largeFiles[0].fileName).toBe("screenshot.jpg");
+    expect(largeFiles[0].mimeType).toBe("image/jpeg");
+    expect(readFileSync(largeFiles[0].storageUri)).toEqual(Buffer.from(base64Image, "base64"));
+
+    const parts = await engine.getConversationStore().getMessageParts(messages[0].messageId);
+    expect(parts.map((part) => part.partType)).toEqual(["text", "text"]);
+    expect(JSON.stringify(parts)).not.toContain(base64Image.slice(0, 32));
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+    const assembledUser = assembled.messages[0] as {
+      role: string;
+      content?: Array<{ type?: unknown; text?: unknown }>;
+    };
+    expect(assembledUser.role).toBe("user");
+    expect(assembledUser.content?.[0]?.text).toContain("please inspect");
+    expect(assembledUser.content?.[1]?.text).toContain("[User image: screenshot.jpg");
+    expect(JSON.stringify(assembled.messages)).not.toContain(base64Image.slice(0, 32));
+  });
+
   it("externalizes oversized tool-result payloads into large_files", async () => {
     await withTempHome(async () => {
       const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });


### PR DESCRIPTION
## What
Externalizes top-level native user image blocks before the generic raw-payload fallback, preserving adjacent text as normal conversation content.

## Why
Vision turns from OpenClaw can arrive as text plus `{ type: "image", data, mimeType }`. Lossless was storing that whole content array as `raw-user-payload.json`, which avoided base64 leakage but hid the caption/text and image behind a generic raw payload.

## Changes
- Detect native user image blocks
- Store images as LCM files
- Preserve text blocks inline
- Keep raw-payload fallback
- Add regression coverage
- Add patch changeset

## Testing
- `npx vitest run test/engine.test.ts -t "native user image"`
- `npx vitest run test/engine.test.ts -t "LcmContextEngine.ingest content extraction"`
- `npm run build`