### PR TITLE
fix: declare OpenClaw metadata and centralize SDK imports

### DIFF
--- a/.changeset/openclaw-compat-metadata.md
+++ b/.changeset/openclaw-compat-metadata.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare OpenClaw plugin API compatibility metadata and route plugin SDK type imports through the local compatibility bridge.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,14 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.2.17",
+      "minGatewayVersion": "2026.2.17"
+    },
+    "build": {
+      "openclawVersion": "2026.2.17"
+    }
   },
   "repository": {
     "type": "git",

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { ContextEngine } from "openclaw/plugin-sdk";
+import type { ContextEngine } from "./openclaw-bridge.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 import type {
   ConversationStore,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -16,7 +16,7 @@ import type {
   IngestResult,
   SubagentEndReason,
   SubagentSpawnPreparation,
-} from "openclaw/plugin-sdk";
+} from "./openclaw-bridge.js";
 import {
   blockFromPart,
   contentFromParts,

--- a/src/lcm-log.ts
+++ b/src/lcm-log.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "./openclaw-bridge.js";
 import type { LcmDependencies } from "./types.js";
 
 export type LcmLogger = LcmDependencies["log"];

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -5,6 +5,7 @@
  */
 
 export type {
+  AnyAgentTool,
   ContextEngine,
   ContextEngineInfo,
   AssembleResult,
@@ -12,6 +13,9 @@ export type {
   IngestResult,
   IngestBatchResult,
   BootstrapResult,
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
   SubagentSpawnPreparation,
   SubagentEndReason,
 } from "openclaw/plugin-sdk";

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -7,7 +7,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../openclaw-bridge.js";
 import { resolveLcmConfigWithDiagnostics, resolveOpenclawStateDir } from "../db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection, normalizePath } from "../db/connection.js";
 import { LcmContextEngine } from "../engine.js";

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -6,7 +6,7 @@ import type { LcmConfig } from "../db/config.js";
 import type { RotateSessionStorageWithBackupResult } from "../engine.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
-import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "openclaw/plugin-sdk";
+import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "../openclaw-bridge.js";
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import { describeLogError } from "../lcm-log.js";

--- a/src/tools/common.ts
+++ b/src/tools/common.ts
@@ -1,4 +1,4 @@
-import type { AnyAgentTool as OpenClawAnyAgentTool } from "openclaw/plugin-sdk";
+import type { AnyAgentTool as OpenClawAnyAgentTool } from "../openclaw-bridge.js";
 
 export type AnyAgentTool = OpenClawAnyAgentTool;
 

--- a/test/index-complete-model-auth.test.ts
+++ b/test/index-complete-model-auth.test.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
 

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
 

--- a/test/index-secret-ref-auth-profiles.test.ts
+++ b/test/index-secret-ref-auth-profiles.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
 

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import * as connectionModule from "../src/db/connection.js";
 import { closeLcmConnection } from "../src/db/connection.js";

--- a/test/plugin-prompt-hook.test.ts
+++ b/test/plugin-prompt-hook.test.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
 import { clearAllSharedInit } from "../src/plugin/shared-init.js";


### PR DESCRIPTION
## Summary
- declare `openclaw.compat.pluginApi` / gateway compatibility metadata
- centralize root SDK imports behind the existing compatibility bridge

## Why
This PR comes from an OpenClaw core maintainer compatibility pass across Crabpot's visible plugin fixtures. The goal is to improve the overall OpenClaw plugin experience by helping widely used plugins clear high-signal Crabpot/plugin-inspector findings before they become install, ClawHub, or compatibility problems.

Relevant projects:
- OpenClaw: https://github.com/openclaw/openclaw
- Crabpot compatibility reports: https://github.com/openclaw/crabpot
- plugin-inspector: https://github.com/openclaw/plugin-inspector

## Crabpot findings
Discovered in Crabpot at `openclaw/crabpot@3b5131e345404e551ab09f6af686462fa8095ef2`:

- `package-plugin-api-compat-missing`: https://github.com/openclaw/crabpot/blob/3b5131e345404e551ab09f6af686462fa8095ef2/reports/crabpot-report.md#L1234-L1239
- `legacy-root-sdk-import`: https://github.com/openclaw/crabpot/blob/3b5131e345404e551ab09f6af686462fa8095ef2/reports/crabpot-report.md#L273-L284

## Maintainer test instructions
You can verify this package with plugin-inspector from this repo:

```bash
npx @openclaw/plugin-inspector check --plugin-root . --openclaw /path/to/openclaw --json
```

For a local plugin-inspector checkout, use:

```bash
node /path/to/plugin-inspector/src/cli.js check --plugin-root . --openclaw /path/to/openclaw --json
```

## Local validation
- `npm ci`
- `npm run release:verify`
- `node /Users/vincentkoc/GIT/_Perso/plugin-inspector/src/cli.js check --plugin-root . --openclaw /Users/vincentkoc/GIT/_Perso/openclaw --json`
- GitHub CI: https://github.com/Martian-Engineering/lossless-claw/actions/runs/25082483369

## Remaining findings
The remaining runtime registration/dependency-install reports are plugin-inspector follow-ups, not plugin package changes. The remaining root import is intentionally centralized in the bridge because this repo is locked to `openclaw@2026.2.17`, which does not expose newer SDK subpaths.
