### PR TITLE
fix(cache): treat Codex prompt cache as mutation-sensitive

### DIFF
--- a/.changeset/codex-cache-mutation-policy.md
+++ b/.changeset/codex-cache-mutation-policy.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Treat Codex prompt-cache writes and recent cache touches as mutation-sensitive so deferred compaction does not rewrite hot cached prompts before the cache TTL expires.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2089,13 +2089,23 @@ export class LcmContextEngine implements ContextEngine {
     return Math.max(1, this.config.cacheAwareCompaction.cacheTTLSeconds) * 1000;
   }
 
-  /** Detect Anthropic-family sessions where local prompt rewrites can invalidate a hot prefix cache. */
-  private isAnthropicPromptCacheFamily(
+  /** Detect prompt-cache families where local prompt rewrites can invalidate a hot prefix cache. */
+  private isPromptCacheMutationSensitiveFamily(
     telemetry: ConversationCompactionTelemetryRecord | null,
   ): boolean {
     const provider = telemetry?.provider?.trim().toLowerCase() ?? "";
     const model = telemetry?.model?.trim().toLowerCase() ?? "";
-    return provider.includes("anthropic") || model.includes("claude");
+    const identifiers = [provider, model];
+    return identifiers.some((identifier) =>
+      identifier.includes("anthropic")
+      || identifier.includes("claude")
+      || identifier.includes("openai-codex")
+      || identifier.includes("openai_codex")
+      || identifier.includes("github-copilot")
+      || identifier.includes("github_copilot")
+      || identifier.includes("codex-cli")
+      || identifier.includes("codex_cli")
+    );
   }
 
   /** Determine whether the last prompt-cache touch is still within the active TTL window. */
@@ -2118,16 +2128,31 @@ export class LcmContextEngine implements ContextEngine {
     return now.getTime() - touchAt.getTime() < ttlMs;
   }
 
-  /** Delay prompt-mutating deferred compaction while Anthropic's exact-prefix cache is still hot. */
+  /** Return true when an explicit prompt-cache break is newer than any cache hit. */
+  private hasFreshPromptCacheBreak(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+  ): boolean {
+    return Boolean(
+      telemetry?.lastObservedCacheBreakAt
+        && (
+          !telemetry.lastObservedCacheHitAt
+          || telemetry.lastObservedCacheBreakAt >= telemetry.lastObservedCacheHitAt
+        ),
+    );
+  }
+
+  /** Delay prompt-mutating deferred compaction while a mutation-sensitive prompt cache is hot. */
   private shouldDelayPromptMutatingDeferredCompaction(
     telemetry: ConversationCompactionTelemetryRecord | null,
     now: Date = new Date(),
   ): boolean {
-    return this.isAnthropicPromptCacheFamily(telemetry) && this.isPromptCacheStillHot(telemetry, now);
+    return this.isPromptCacheMutationSensitiveFamily(telemetry)
+      && !this.hasFreshPromptCacheBreak(telemetry)
+      && this.isPromptCacheStillHot(telemetry, now);
   }
 
-  /** Keep deferred Anthropic leaf debt moving once the TTL-safe cache hold has expired. */
-  private shouldForceDeferredAnthropicLeafCompaction(
+  /** Keep deferred mutation-sensitive leaf debt moving once the TTL-safe cache hold has expired. */
+  private shouldForceDeferredPromptCacheLeafCompaction(
     telemetry: ConversationCompactionTelemetryRecord | null,
     leafDecision: IncrementalCompactionDecision,
   ): boolean {
@@ -2140,18 +2165,18 @@ export class LcmContextEngine implements ContextEngine {
     ) {
       return false;
     }
-    if (!this.isAnthropicPromptCacheFamily(telemetry)) {
+    if (!this.isPromptCacheMutationSensitiveFamily(telemetry)) {
       return false;
     }
     return !this.shouldDelayPromptMutatingDeferredCompaction(telemetry);
   }
 
-  /** Use the post-TTL catch-up envelope when stale Anthropic debt must override hot-cache smoothing. */
+  /** Use the post-TTL catch-up envelope when stale cache debt must override hot-cache smoothing. */
   private resolveDeferredLeafCompactionExecutionDecision(params: {
     telemetry: ConversationCompactionTelemetryRecord | null;
     leafDecision: IncrementalCompactionDecision;
   }): IncrementalCompactionDecision {
-    if (!this.shouldForceDeferredAnthropicLeafCompaction(params.telemetry, params.leafDecision)) {
+    if (!this.shouldForceDeferredPromptCacheLeafCompaction(params.telemetry, params.leafDecision)) {
       return params.leafDecision;
     }
     return {
@@ -2356,6 +2381,8 @@ export class LcmContextEngine implements ContextEngine {
     if (sawExplicitBreak) {
       cacheState = "cold";
     } else if (typeof cacheRead === "number" && cacheRead > 0) {
+      cacheState = "hot";
+    } else if (typeof cacheWrite === "number" && cacheWrite > 0) {
       cacheState = "hot";
     } else if (hasUsageSignal || hasObservationSignal) {
       cacheState = "cold";
@@ -2906,7 +2933,7 @@ export class LcmContextEngine implements ContextEngine {
                   };
                 }
                 this.deps.log.info(
-                  `[lcm] maintain: deferred Anthropic leaf debt ignoring effective hot-cache state after TTL expiry conversation=${params.conversationId} ${sessionLabel} reason=${leafDecision.reason} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
+                  `[lcm] maintain: deferred prompt-cache leaf debt ignoring effective hot-cache state after TTL expiry conversation=${params.conversationId} ${sessionLabel} reason=${leafDecision.reason} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
                 );
               }
               return this.executeLeafCompactionCore({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2128,15 +2128,29 @@ export class LcmContextEngine implements ContextEngine {
     return now.getTime() - touchAt.getTime() < ttlMs;
   }
 
-  /** Return true when an explicit prompt-cache break is newer than any cache hit. */
+  private latestPromptCacheTouchSignalAt(
+    telemetry: ConversationCompactionTelemetryRecord | null,
+  ): Date | null {
+    const candidates = [
+      telemetry?.lastCacheTouchAt,
+      telemetry?.lastObservedCacheHitAt,
+    ].filter((value): value is Date => value instanceof Date);
+    return candidates.reduce<Date | null>(
+      (latest, value) => (!latest || value > latest ? value : latest),
+      null,
+    );
+  }
+
+  /** Return true when an explicit prompt-cache break is newer than any cache touch signal. */
   private hasFreshPromptCacheBreak(
     telemetry: ConversationCompactionTelemetryRecord | null,
   ): boolean {
+    const lastCacheTouchSignalAt = this.latestPromptCacheTouchSignalAt(telemetry);
     return Boolean(
       telemetry?.lastObservedCacheBreakAt
         && (
-          !telemetry.lastObservedCacheHitAt
-          || telemetry.lastObservedCacheBreakAt >= telemetry.lastObservedCacheHitAt
+          !lastCacheTouchSignalAt
+          || telemetry.lastObservedCacheBreakAt >= lastCacheTouchSignalAt
         ),
     );
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2018,12 +2018,16 @@ export class LcmContextEngine implements ContextEngine {
     return telemetry.turnsSinceLeafCompaction <= HOT_CACHE_HYSTERESIS_TURNS;
   }
 
-  /** Treat weak observed cache reuse as cold, even if older telemetry still looks hot. */
+  /** Treat weak observed cache reuse without a cache write as cold, even if older telemetry still looks hot. */
   private isObservedCacheReadShareCold(
     telemetry: ConversationCompactionTelemetryRecord | null,
   ): boolean {
     const cacheRead = telemetry?.lastObservedCacheRead;
+    const cacheWrite = telemetry?.lastObservedCacheWrite;
     const promptTokenCount = telemetry?.lastObservedPromptTokenCount;
+    if (typeof cacheWrite === "number" && Number.isFinite(cacheWrite) && cacheWrite > 0) {
+      return false;
+    }
     if (
       typeof cacheRead !== "number"
       || !Number.isFinite(cacheRead)

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7318,6 +7318,50 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
   });
 
+  it("maintain() treats Codex cache touches after explicit breaks as hot again", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-codex-break-then-touch";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    const now = new Date();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: now,
+      lastObservedCacheBreakAt: new Date(now.getTime() - 1_000),
+      provider: "openai-codex-responses",
+      model: "gpt-5.5",
+    });
+    const evaluateIncrementalCompactionSpy = vi.spyOn(privateEngine, "evaluateIncrementalCompaction");
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-codex-break-then-touch"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(evaluateIncrementalCompactionSpy).not.toHaveBeenCalled();
+    expect(maintenanceResult.changed).toBe(false);
+  });
+
   it("maintain() consumes deferred Codex debt after the prompt cache TTL expires", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6808,6 +6808,88 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
   });
 
+  it("afterTurn treats Codex cache-write-only telemetry as mutation-sensitive", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-background-codex-cache-write-deferred";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+      refreshBootstrapState: (params: unknown) => Promise<void>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 60_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "hot-cache-budget-headroom",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 60_000,
+      threshold: 40_000,
+      cacheState: "hot",
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const consumeDeferredCompactionDebtSpy = vi.spyOn(
+      privateEngine,
+      "consumeDeferredCompactionDebt",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-background-codex-cache-write-deferred"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+      runtimeContext: {
+        provider: "openai-codex-responses",
+        model: "gpt-5.5",
+        promptCache: {
+          retention: "short",
+          lastCallUsage: {
+            input: 8_000,
+            cacheRead: 0,
+            cacheWrite: 8_000,
+          },
+        },
+      },
+    });
+
+    await flushImmediate();
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    const telemetry = await engine
+      .getCompactionTelemetryStore()
+      .getConversationCompactionTelemetry(conversation!.conversationId);
+    expect(consumeDeferredCompactionDebtSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(telemetry?.cacheState).toBe("hot");
+    expect(telemetry?.lastObservedCacheWrite).toBe(8_000);
+    expect(telemetry?.lastCacheTouchAt).toBeInstanceOf(Date);
+  });
+
   it("afterTurn keeps deferred debt durable when background drain finds the session busy", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-background-busy-debt-durable";
@@ -7134,6 +7216,161 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
     expect(evaluateIncrementalCompactionSpy).not.toHaveBeenCalled();
     expect(maintenanceResult.changed).toBe(false);
+  });
+
+  it("maintain() keeps deferred prompt-mutating debt pending while Codex cache is still hot", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-codex-hot-cache";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "unknown",
+      retention: "short",
+      lastCacheTouchAt: new Date(),
+      provider: "openai-codex-responses",
+      model: "gpt-5.5",
+    });
+
+    const evaluateIncrementalCompactionSpy = vi.spyOn(privateEngine, "evaluateIncrementalCompaction");
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-codex-hot-cache"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(evaluateIncrementalCompactionSpy).not.toHaveBeenCalled();
+    expect(maintenanceResult.changed).toBe(false);
+  });
+
+  it("maintain() lets explicit Codex cache breaks override recent cache touches", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-codex-explicit-break";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    const now = new Date();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: now,
+      lastObservedCacheBreakAt: now,
+      provider: "openai-codex-responses",
+      model: "gpt-5.5",
+    });
+    const evaluateIncrementalCompactionSpy = vi
+      .spyOn(privateEngine, "evaluateIncrementalCompaction")
+      .mockResolvedValue({
+        shouldCompact: false,
+        reason: "deferred compaction no longer needed",
+        maxPasses: 1,
+        allowCondensedPasses: false,
+        activityBand: "low",
+        leafChunkTokens: 20_000,
+        fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+        rawTokensOutsideTail: 0,
+        threshold: 20_000,
+        cacheState: "cold",
+      });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-codex-explicit-break"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(evaluateIncrementalCompactionSpy).toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
+  });
+
+  it("maintain() consumes deferred Codex debt after the prompt cache TTL expires", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-codex-stale-cache";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      retention: "short",
+      lastCacheTouchAt: new Date(Date.now() - 10 * 60 * 1000),
+      provider: "github-copilot",
+      model: "gpt-5.5",
+    });
+    const evaluateIncrementalCompactionSpy = vi
+      .spyOn(privateEngine, "evaluateIncrementalCompaction")
+      .mockResolvedValue({
+        shouldCompact: false,
+        reason: "deferred compaction no longer needed",
+        maxPasses: 1,
+        allowCondensedPasses: false,
+        activityBand: "low",
+        leafChunkTokens: 20_000,
+        fallbackLeafChunkTokens: [20_000, 15_000, 10_000],
+        rawTokensOutsideTail: 0,
+        threshold: 20_000,
+        cacheState: "cold",
+      });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-codex-stale-cache"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(evaluateIncrementalCompactionSpy).toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
   });
 
   it("maintain() treats a recent Anthropic API call as a hot-cache touch when explicit cache telemetry is absent", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -8183,6 +8183,92 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
   });
 
+  it("evaluateIncrementalCompaction keeps cache-write-only telemetry hot", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-cache-write-only-hot";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+        allowCondensedPasses: boolean;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "hot",
+      lastObservedCacheRead: 0,
+      lastObservedCacheWrite: 8_000,
+      lastObservedPromptTokenCount: 16_000,
+      lastCacheTouchAt: new Date(),
+      turnsSinceLeafCompaction: 1,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.cacheState).toBe("hot");
+    expect(decision.allowCondensedPasses).toBe(false);
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("cacheReadSharePct=0.0%"),
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("cacheWrite=8000"),
+    );
+  });
+
   it("evaluateIncrementalCompaction scales budget-trigger passes by prompt overage", async () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(


### PR DESCRIPTION
## Summary

Refs Martian-Engineering/lossless-claw#534 and openclaw/openclaw#74233. Companion host-side PR: openclaw/openclaw#74255.

This PR fixes the LCM cache-policy side of the OpenClaw/LCM context instability investigation. LCM already delayed some prompt mutations around Anthropic prompt-cache windows, but the policy was Anthropic/Claude-specific. OpenClaw's Codex Responses route can also have cache-sensitive prompt windows, especially with provider identifiers such as `openai-codex`, `openai-codex-responses`, and `github-copilot`.

The practical failure mode: LCM could see a cache-write-only turn, or a still-recent cache touch, and still allow prompt-leaf compaction to rewrite the prompt too soon. That is exactly the kind of prompt mutation that can break cache reuse and make subsequent context/cost behavior look erratic.

## Three-PR Map

```mermaid
flowchart LR
  A["OpenClaw #74255\nPrompt authority"] --> D["Stop raw history from\nfalse-failing fitted prompts"]
  B["LCM #535\nCache mutation policy"] --> E["Delay deferred prompt rewrites\nwhile cache is still hot"]
  C["LCM #536\nAssembly provenance"] --> F["Expose assembly/fallback facts\nto the host"]
  B --> C
```

- openclaw/openclaw#74255 is the main production fix: the host should hard-check the assembled prompt, not the full raw transcript, unless explicitly opted in.
- #535 is cache hardening: Codex/OpenClaw prompt-cache providers now get the same mutation-sensitive protection Anthropic had.
- #536 is observability: LCM returns compact provenance so future cache/context blow-ups can be diagnosed without log archaeology.

## Root Cause

The old policy asked a provider-family question that was too narrow: "is this Anthropic/Claude?" That missed Codex/OpenClaw provider shapes even though they can be prompt-cache sensitive in the same operational way.

There were also hot/cold classification edge cases. A turn with only cache writes is not cold; it is evidence that the cache was just touched. A recent `lastCacheTouchAt` inside the retention window should also be treated as cache-sensitive unless LCM has observed a fresh explicit cache break. If a newer cache touch arrives after an older break observation, the old break must not remain sticky forever.

## What This Changes

- Replaces the Anthropic-only family check with a mutation-sensitive prompt-cache family check.
- Covers Anthropic/Claude plus OpenClaw Codex provider identifiers, including `openai-codex`, `openai-codex-responses`, `github-copilot`, and Codex CLI spelling variants.
- Treats cache-write-only usage as hot/cache-sensitive.
- Keeps cache-write-only telemetry hot in the inline incremental-compaction path, rather than letting a zero cache-read share force cold-cache catch-up.
- Treats recent `lastCacheTouchAt` within the retention TTL as hot for mutation-delay purposes.
- Preserves fresh explicit cache-break observations as cold so known breaks still allow catch-up compaction.
- Clears stale break pressure when a newer cache touch has been observed.
- Applies the generalized delay and post-TTL catch-up behavior anywhere the old policy was Anthropic-only.
- Adds a patch changeset.

## What The Policy Does

This does not disable compaction. It changes when deferred prompt-leaf mutations are allowed to run:

- cache read or cache write observed: delay prompt mutation while the cache window is hot
- cache-write-only turn: still delay, because the prompt cache was just touched
- recent `lastCacheTouchAt`: delay until retention expires
- fresh explicit cache break: treat as cold and allow catch-up work
- newer cache touch after an old break: treat as hot again
- TTL expired: allow deferred work to run

That gives Codex/OpenClaw cache windows the same protection shape already intended for Anthropic.

## Validation

- `npx vitest run test/engine.test.ts -t "low cache-read share|cache-write-only telemetry|Codex cache-write-only|explicit Codex cache breaks|breaks as hot again|prompt cache TTL"`
- `npm test`
- `npm run build`
- `npm run release:verify`

## Review Notes

The key review question is whether the generalized provider-family predicate is broad enough to catch the OpenClaw Codex paths without making explicit cache-break observations sticky. The tests cover cache read, cache write only, inline cache-write-only state, explicit break, break-then-newer-touch, hot retention TTL, expired TTL, Anthropic, and Codex provider cases.