### PR TITLE
feat(assemble): expose LCM assembly provenance

### DIFF
--- a/.changeset/lcm-assembly-provenance.md
+++ b/.changeset/lcm-assembly-provenance.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Expose assembly provenance and prompt-authority metadata from LCM assemble results so hosts can distinguish assembled prompts from live fallback paths.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6121,9 +6121,12 @@ export class LcmContextEngine implements ContextEngine {
       }
 
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
-      const summaryContextItemCount = contextItems.filter(
-        (item) => item.itemType === "summary",
-      ).length;
+      let summaryContextItemCount = 0;
+      for (const item of contextItems) {
+        if (item.itemType === "summary") {
+          summaryContextItemCount += 1;
+        }
+      }
       const rawContextItemCount = contextItems.length - summaryContextItemCount;
       const contextDiagnostics = {
         contextItemCount: contextItems.length,
@@ -6184,13 +6187,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: assembled context has no user turns, falling back to live context to prevent prefill errors conversation=${conversation.conversationId} ${sessionLabel} assembledMessages=${assembled.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return buildAssembleResult({
-          messages: params.messages,
-          estimatedTokens: 0,
-          mode: "live_fallback",
-          fallbackReason: "no_user_turn",
-          ...contextDiagnostics,
-        });
+        return safeFallback("no_user_turn", contextDiagnostics);
       }
 
       this.deps.log.info(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6051,9 +6051,10 @@ export class LcmContextEngine implements ContextEngine {
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
         msgs.pop();
       }
+      const estimatedTokens = estimateSessionTokenCountForAfterTurn(msgs);
       return buildAssembleResult({
         messages: msgs,
-        estimatedTokens: 0,
+        estimatedTokens,
         mode: "live_fallback",
         fallbackReason,
         ...diagnostics,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -107,6 +107,36 @@ type PromptCacheSnapshot = {
   provider?: string;
   model?: string;
 };
+type LcmAssemblyFallbackReason =
+  | "ignored_session"
+  | "conversation_miss"
+  | "no_context_items"
+  | "db_trails_live"
+  | "empty_assembled"
+  | "no_user_turn"
+  | "error";
+type LcmAssemblyProvenance = {
+  engine: "lossless-claw";
+  mode: "assembled" | "live_fallback";
+  fallbackReason?: LcmAssemblyFallbackReason;
+  inputMessageCount: number;
+  outputMessageCount: number;
+  contextItemCount?: number;
+  rawContextItemCount?: number;
+  summaryContextItemCount?: number;
+  estimatedTokens: number;
+  cacheState?: CacheState;
+  selectionMode?: "full-fit" | "prompt-aware" | "chronological";
+  hashes?: {
+    finalMessages?: string;
+    preSanitizeMessages?: string;
+    commonPrefix?: string;
+  };
+};
+type LcmAssembleResult = AssembleResult & {
+  promptAuthority: "assembled";
+  lcmAssembly: LcmAssemblyProvenance;
+};
 type IncrementalCompactionDecision = {
   shouldCompact: boolean;
   cacheState: CacheState;
@@ -5970,18 +6000,68 @@ export class LcmContextEngine implements ContextEngine {
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
   }): Promise<AssembleResult> {
+    const buildAssembleResult = (input: {
+      messages: AgentMessage[];
+      estimatedTokens: number;
+      mode: LcmAssemblyProvenance["mode"];
+      fallbackReason?: LcmAssemblyFallbackReason;
+      contextItemCount?: number;
+      rawContextItemCount?: number;
+      summaryContextItemCount?: number;
+      cacheState?: CacheState;
+      selectionMode?: LcmAssemblyProvenance["selectionMode"];
+      hashes?: LcmAssemblyProvenance["hashes"];
+    }): LcmAssembleResult => ({
+      messages: input.messages,
+      estimatedTokens: input.estimatedTokens,
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        engine: "lossless-claw",
+        mode: input.mode,
+        ...(input.fallbackReason ? { fallbackReason: input.fallbackReason } : {}),
+        inputMessageCount: params.messages.length,
+        outputMessageCount: input.messages.length,
+        ...(input.contextItemCount !== undefined
+          ? { contextItemCount: input.contextItemCount }
+          : {}),
+        ...(input.rawContextItemCount !== undefined
+          ? { rawContextItemCount: input.rawContextItemCount }
+          : {}),
+        ...(input.summaryContextItemCount !== undefined
+          ? { summaryContextItemCount: input.summaryContextItemCount }
+          : {}),
+        estimatedTokens: input.estimatedTokens,
+        ...(input.cacheState ? { cacheState: input.cacheState } : {}),
+        ...(input.selectionMode ? { selectionMode: input.selectionMode } : {}),
+        ...(input.hashes ? { hashes: input.hashes } : {}),
+      },
+    });
     // Return a new fallback array so the runtime hook treats this as assembled
     // context, and remove assistant prefill tails from fallback-only paths.
-    const safeFallback = (): AssembleResult => {
+    const safeFallback = (
+      fallbackReason: LcmAssemblyFallbackReason,
+      diagnostics: {
+        contextItemCount?: number;
+        rawContextItemCount?: number;
+        summaryContextItemCount?: number;
+        cacheState?: CacheState;
+      } = {},
+    ): LcmAssembleResult => {
       const msgs = params.messages.slice();
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
         msgs.pop();
       }
-      return { messages: msgs, estimatedTokens: 0 };
+      return buildAssembleResult({
+        messages: msgs,
+        estimatedTokens: 0,
+        mode: "live_fallback",
+        fallbackReason,
+        ...diagnostics,
+      });
     };
 
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
-      return safeFallback();
+      return safeFallback("ignored_session");
     }
     try {
       this.ensureMigrated();
@@ -5999,7 +6079,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: conversation lookup missed ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return safeFallback();
+        return safeFallback("conversation_miss");
       }
 
       const tokenBudget = this.applyAssemblyBudgetCap(
@@ -6041,22 +6121,32 @@ export class LcmContextEngine implements ContextEngine {
       }
 
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+      const summaryContextItemCount = contextItems.filter(
+        (item) => item.itemType === "summary",
+      ).length;
+      const rawContextItemCount = contextItems.length - summaryContextItemCount;
+      const contextDiagnostics = {
+        contextItemCount: contextItems.length,
+        rawContextItemCount,
+        summaryContextItemCount,
+        cacheState: cacheAwareState,
+      };
       if (contextItems.length === 0) {
         this.deps.log.info(
           `[lcm] assemble: no context items conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return safeFallback();
+        return safeFallback("no_context_items", contextDiagnostics);
       }
 
       // Guard against incomplete bootstrap/coverage: if the DB only has
       // raw context items and clearly trails the current live history, keep
       // the live path to avoid dropping prompt context.
-      const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
+      const hasSummaryItems = summaryContextItemCount > 0;
       if (!hasSummaryItems && contextItems.length < params.messages.length) {
         this.deps.log.info(
           `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return safeFallback();
+        return safeFallback("db_trails_live", contextDiagnostics);
       }
 
       const assembled = await this.assembler.assemble({
@@ -6081,7 +6171,7 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: empty assembled output, using live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return safeFallback();
+        return safeFallback("empty_assembled", contextDiagnostics);
       }
 
       // Guard: if assembled context contains no user turns at all (e.g. a new session
@@ -6094,10 +6184,13 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: assembled context has no user turns, falling back to live context to prevent prefill errors conversation=${conversation.conversationId} ${sessionLabel} assembledMessages=${assembled.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
+        return buildAssembleResult({
           messages: params.messages,
           estimatedTokens: 0,
-        };
+          mode: "live_fallback",
+          fallbackReason: "no_user_turn",
+          ...contextDiagnostics,
+        });
       }
 
       this.deps.log.info(
@@ -6133,16 +6226,26 @@ export class LcmContextEngine implements ContextEngine {
         );
       }
 
-      const result: AssembleResult = {
+      const result = buildAssembleResult({
         messages: assembled.messages,
         estimatedTokens: assembled.estimatedTokens,
-      };
+        mode: "assembled",
+        ...contextDiagnostics,
+        selectionMode: assembled.debug?.selectionMode,
+        hashes: assembled.debug
+          ? {
+              finalMessages: assembled.debug.finalMessagesHash,
+              preSanitizeMessages: assembled.debug.preSanitizeMessagesHash,
+              commonPrefix: prefixChange.commonPrefixHash,
+            }
+          : undefined,
+      });
       return result;
     } catch (err) {
       this.deps.log.info(
         `[lcm] assemble: failed for session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} error=${describeLogError(err)}`,
       );
-      return safeFallback();
+      return safeFallback("error");
     }
   }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -473,16 +473,17 @@ describe("LcmContextEngine ignored sessions", () => {
 
     expect(ignored).toMatchObject({
       messages: liveMessages,
-      estimatedTokens: 0,
+      estimatedTokens: ignored.estimatedTokens,
       promptAuthority: "assembled",
       lcmAssembly: {
         mode: "live_fallback",
         fallbackReason: "ignored_session",
         inputMessageCount: 1,
         outputMessageCount: 1,
-        estimatedTokens: 0,
+        estimatedTokens: ignored.estimatedTokens,
       },
     });
+    expect(ignored.estimatedTokens).toBeGreaterThan(0);
     expect(included.messages).toHaveLength(1);
     expect(included.messages[0]?.content).toBe("persisted context");
   });
@@ -4497,7 +4498,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
 
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
-    expect(result.estimatedTokens).toBe(0);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4505,7 +4506,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         fallbackReason: "conversation_miss",
         inputMessageCount: 2,
         outputMessageCount: 1,
-        estimatedTokens: 0,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });
@@ -4523,7 +4524,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 100,
     });
 
-    expect(result.estimatedTokens).toBe(0);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4534,6 +4535,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         contextItemCount: 0,
         rawContextItemCount: 0,
         summaryContextItemCount: 0,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });
@@ -4560,7 +4562,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
 
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
-    expect(result.estimatedTokens).toBe(0);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4571,6 +4573,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         contextItemCount: 1,
         rawContextItemCount: 1,
         summaryContextItemCount: 0,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });
@@ -4670,7 +4673,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
 
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
-    expect(result.estimatedTokens).toBe(0);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4678,7 +4681,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         fallbackReason: "error",
         inputMessageCount: 1,
         outputMessageCount: 1,
-        estimatedTokens: 0,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });
@@ -4714,6 +4717,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).toStrictEqual([
       { role: "user", content: "live fallback message" },
     ]);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4722,6 +4726,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         inputMessageCount: 1,
         outputMessageCount: 1,
         contextItemCount: 1,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });
@@ -4754,7 +4759,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     // Should fall back to live context, not return the assistant-only DB context
     expect(result.messages).toEqual(liveMessages);
     expect(result.messages).not.toBe(liveMessages);
-    expect(result.estimatedTokens).toBe(0);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",
       lcmAssembly: {
@@ -4763,6 +4768,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
         inputMessageCount: 1,
         outputMessageCount: 1,
         contextItemCount: 1,
+        estimatedTokens: result.estimatedTokens,
       },
     });
   });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -471,9 +471,17 @@ describe("LcmContextEngine ignored sessions", () => {
       tokenBudget: 500,
     });
 
-    expect(ignored).toEqual({
+    expect(ignored).toMatchObject({
       messages: liveMessages,
       estimatedTokens: 0,
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "ignored_session",
+        inputMessageCount: 1,
+        outputMessageCount: 1,
+        estimatedTokens: 0,
+      },
     });
     expect(included.messages).toHaveLength(1);
     expect(included.messages[0]?.content).toBe("persisted context");
@@ -4432,6 +4440,48 @@ describe("LcmContextEngine.bootstrap", () => {
 // ── Assemble canonical path with fallback ───────────────────────────────────
 
 describe("LcmContextEngine.assemble canonical path", () => {
+  function assemblyProvenance(result: unknown): {
+    promptAuthority?: string;
+    lcmAssembly?: {
+      mode?: string;
+      fallbackReason?: string;
+      inputMessageCount?: number;
+      outputMessageCount?: number;
+      contextItemCount?: number;
+      rawContextItemCount?: number;
+      summaryContextItemCount?: number;
+      estimatedTokens?: number;
+      cacheState?: string;
+      selectionMode?: string;
+      hashes?: {
+        finalMessages?: string;
+        preSanitizeMessages?: string;
+        commonPrefix?: string;
+      };
+    };
+  } {
+    return result as {
+      promptAuthority?: string;
+      lcmAssembly?: {
+        mode?: string;
+        fallbackReason?: string;
+        inputMessageCount?: number;
+        outputMessageCount?: number;
+        contextItemCount?: number;
+        rawContextItemCount?: number;
+        summaryContextItemCount?: number;
+        estimatedTokens?: number;
+        cacheState?: string;
+        selectionMode?: string;
+        hashes?: {
+          finalMessages?: string;
+          preSanitizeMessages?: string;
+          commonPrefix?: string;
+        };
+      };
+    };
+  }
+
   it("strips assistant prefill tails when no DB conversation exists", async () => {
     const engine = createEngine();
     const liveMessages: AgentMessage[] = [
@@ -4448,6 +4498,44 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
     expect(result.estimatedTokens).toBe(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "conversation_miss",
+        inputMessageCount: 2,
+        outputMessageCount: 1,
+        estimatedTokens: 0,
+      },
+    });
+  });
+
+  it("emits provenance when a stored conversation has no context items", async () => {
+    const engine = createEngine();
+    const sessionId = "session-no-context-items";
+    await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [{ role: "user", content: "live turn" }] as AgentMessage[],
+      tokenBudget: 100,
+    });
+
+    expect(result.estimatedTokens).toBe(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "no_context_items",
+        inputMessageCount: 1,
+        outputMessageCount: 1,
+        contextItemCount: 0,
+        rawContextItemCount: 0,
+        summaryContextItemCount: 0,
+      },
+    });
   });
 
   it("falls back when DB context clearly trails live context", async () => {
@@ -4473,6 +4561,18 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "db_trails_live",
+        inputMessageCount: 3,
+        outputMessageCount: 3,
+        contextItemCount: 1,
+        rawContextItemCount: 1,
+        summaryContextItemCount: 0,
+      },
+    });
   });
 
   it("assembles context from DB when coverage exists", async () => {
@@ -4501,6 +4601,21 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages[0].content).toBe("persisted message one");
     expect(result.messages[1].role).toBe("assistant");
     expect(result.estimatedTokens).toBeGreaterThan(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "assembled",
+        inputMessageCount: 1,
+        outputMessageCount: 2,
+        contextItemCount: 2,
+        rawContextItemCount: 2,
+        summaryContextItemCount: 0,
+        estimatedTokens: result.estimatedTokens,
+      },
+    });
+    expect(assemblyProvenance(result).lcmAssembly?.hashes?.finalMessages).toEqual(
+      expect.any(String),
+    );
   });
 
   it("respects token budget in assembled output", async () => {
@@ -4556,6 +4671,59 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "error",
+        inputMessageCount: 1,
+        outputMessageCount: 1,
+        estimatedTokens: 0,
+      },
+    });
+  });
+
+  it("emits provenance when assembled output is empty", async () => {
+    const engine = createEngine();
+    const sessionId = "session-empty-assembled-output";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "persisted message" } as AgentMessage,
+    });
+
+    const originalAssembler = (engine as unknown as { assembler: { assemble: unknown } }).assembler;
+    (engine as unknown as { assembler: { assemble: () => Promise<unknown> } }).assembler = {
+      ...originalAssembler,
+      assemble: async () => ({
+        messages: [],
+        estimatedTokens: 0,
+        stats: {
+          rawMessageCount: 0,
+          summaryCount: 0,
+          totalContextItems: 1,
+        },
+      }),
+    };
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [{ role: "user", content: "live fallback message" }] as AgentMessage[],
+      tokenBudget: 1000,
+    });
+
+    expect(result.messages).toStrictEqual([
+      { role: "user", content: "live fallback message" },
+    ]);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "empty_assembled",
+        inputMessageCount: 1,
+        outputMessageCount: 1,
+        contextItemCount: 1,
+      },
+    });
   });
 
   it("falls back to live context when assembled result has no user turns (cold-cache new session)", async () => {
@@ -4586,6 +4754,16 @@ describe("LcmContextEngine.assemble canonical path", () => {
     // Should fall back to live context, not return the assistant-only DB context
     expect(result.messages).toBe(liveMessages);
     expect(result.estimatedTokens).toBe(0);
+    expect(assemblyProvenance(result)).toMatchObject({
+      promptAuthority: "assembled",
+      lcmAssembly: {
+        mode: "live_fallback",
+        fallbackReason: "no_user_turn",
+        inputMessageCount: 1,
+        outputMessageCount: 1,
+        contextItemCount: 1,
+      },
+    });
   });
 
   it("does not fall back when assembled result has user turns even if it ends with assistant", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4752,7 +4752,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
     });
 
     // Should fall back to live context, not return the assistant-only DB context
-    expect(result.messages).toBe(liveMessages);
+    expect(result.messages).toEqual(liveMessages);
+    expect(result.messages).not.toBe(liveMessages);
     expect(result.estimatedTokens).toBe(0);
     expect(assemblyProvenance(result)).toMatchObject({
       promptAuthority: "assembled",


### PR DESCRIPTION
## Summary

Refs Martian-Engineering/lossless-claw#534 and openclaw/openclaw#74233. Companion host-side PR: openclaw/openclaw#74255.

This PR makes LCM assembly provenance host-readable. LCM already had useful debug facts in logs, but OpenClaw hosts generally received only the returned `messages` and `estimatedTokens`. That meant future context blow-ups, cache breaks, or fallback paths could be visible in local logs but not in the host-side result that made the prompt decision.

The change is backward-compatible: older hosts can ignore the extra fields, while newer hosts can consume `promptAuthority: "assembled"` and optionally read namespaced `lcmAssembly` diagnostics to understand exactly what kind of prompt LCM returned.

## Three-PR Map

```mermaid
flowchart LR
  A["OpenClaw #74255\nConsumes prompt authority"] --> D["Host trusts assembled prompt\nby default"]
  B["LCM #535\nProtects hot cache windows"] --> E["Fewer accidental\nprompt-cache breaks"]
  C["LCM #536\nEmits assembly provenance"] --> F["Host can see mode, fallback,\ncounts, tokens, cache, hashes"]
  C --> A
```

- openclaw/openclaw#74255 fixes the host behavior that rejected fitted assembled prompts because raw history was large. It consumes the `promptAuthority` contract.
- #535 hardens when LCM is allowed to mutate prompt leaves around Codex/OpenClaw cache windows.
- #536 gives hosts compact proof of what LCM assembled and why, so the next incident report can point to metadata instead of reconstructing behavior from logs. The `lcmAssembly` object is namespaced diagnostic metadata and remains safe for older hosts to ignore.

## Root Cause

Without host-visible provenance, three very different outcomes looked too similar from OpenClaw's side:

- LCM assembled a normal fitted prompt.
- LCM intentionally fell back to live messages because there was no usable context record.
- LCM hit an edge fallback, such as DB-trails-live, empty output, no user turn, or an assembler error.

Those distinctions matter when diagnosing context growth, cache behavior, and apparent forgetfulness. The host needs to know whether `messages` came from normal assembly or from a fallback path, and whether those returned messages are the actual prompt authority.

## What This Changes

- Returns `promptAuthority: "assembled"` for normal LCM assembly and live fallback results, because returned `messages` are the actual prompt the host should evaluate.
- Adds namespaced `lcmAssembly` provenance using an intersection type so older OpenClaw hosts ignore it safely.
- Includes compact diagnostics: assembly mode, fallback reason, input/output message counts, context item counts, estimated tokens, cache state, selection mode, and stable hashes when available.
- Estimates fallback tokens from the actual fallback messages, so non-empty live fallbacks no longer report zero-token diagnostics.
- Preserves existing log diagnostics; this PR exposes the same facts to the host instead of making logs the only evidence source.
- Covers normal assembly plus fallback paths for ignored sessions, missing conversations, no context items, DB-trails-live, empty assembled output, no user turn, and assembler errors.
- Adds a patch changeset.

## What The Provenance Fields Do

`promptAuthority` tells the host which prompt surface should be authoritative for hard overflow decisions. In normal LCM behavior this is `"assembled"`, meaning the returned `messages` should be checked, not the raw pre-assembly transcript.

`lcmAssembly.mode` tells the host whether LCM returned a normal assembled prompt or a live fallback.

`lcmAssembly.fallbackReason` explains why a fallback happened, when there is one.

The count/token/cache/hash fields give enough stable evidence to compare incidents without exposing full prompt contents. They are diagnostics, not behavior changes.

## Validation

- `npx vitest run test/engine.test.ts -t "assemble canonical path"`
- `npm test`
- `npm run build`
- `npm run release:verify`

## Review Notes

This PR can merge independently from #535. Its host-side prompt-authority consumer is openclaw/openclaw#74255, but the full provenance payload remains compatible with older hosts because the new metadata is optional and namespaced.