### PR TITLE
fix: Resolve DeepSeek (and other providers) API routing when model catalog lacks baseUrl/api

### DIFF
--- a/.changeset/deepseek-provider-routing.md
+++ b/.changeset/deepseek-provider-routing.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Resolve uncataloged DeepSeek and other known provider models to their expected API family and base URL defaults when OpenClaw model metadata is unavailable.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -747,6 +747,7 @@ function inferApiFromProvider(provider: string): string | undefined {
   const normalized = normalizeProviderId(provider);
   const map: Record<string, string> = {
     anthropic: "anthropic-messages",
+    deepseek: "openai-completions",
     openai: "openai-responses",
     [OPENAI_CODEX_PROVIDER_ID]: OPENAI_CODEX_RESPONSES_API,
     "github-copilot": OPENAI_CODEX_RESPONSES_API,

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -749,9 +749,13 @@ function inferApiFromProvider(provider: string): string | undefined {
   const map: Record<string, string> = {
     anthropic: "anthropic-messages",
     deepseek: "openai-completions",
+    groq: "openai-completions",
+    mistral: "openai-completions",
     openai: "openai-responses",
     [OPENAI_CODEX_PROVIDER_ID]: OPENAI_CODEX_RESPONSES_API,
     "github-copilot": OPENAI_CODEX_RESPONSES_API,
+    openrouter: "openai-completions",
+    together: "openai-completions",
     google: "google-generative-ai",
     "google-gemini-cli": "google-gemini-cli",
     "google-antigravity": "google-gemini-cli",

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -707,7 +707,8 @@ function resolveProviderModelBaseUrl(params: {
     typeof params.configuredBaseUrl === "string" ? params.configuredBaseUrl : undefined;
   const fallbackBaseUrl =
     typeof params.fallbackBaseUrl === "string" ? params.fallbackBaseUrl : undefined;
-  const baseUrl = configuredBaseUrl ?? fallbackBaseUrl ?? "";
+  const baseUrl =
+    configuredBaseUrl ?? fallbackBaseUrl ?? inferBaseUrlFromProvider(params.provider) ?? "";
   return shouldUseNativeCodexBaseUrl({ provider: params.provider, api: params.api, baseUrl })
     ? OPENAI_CODEX_RESPONSES_BASE_URL
     : baseUrl;
@@ -764,6 +765,24 @@ function inferApiFromProvider(provider: string): string | undefined {
 /** Codex Responses rejects `temperature`; omit it for that API family. */
 export function shouldOmitTemperatureForApi(api: string | undefined): boolean {
   return isOpenAICodexResponsesApi(api);
+}
+
+/** Resolve known provider base URLs when model lookup misses. */
+function inferBaseUrlFromProvider(provider: string): string | undefined {
+  const normalized = normalizeProviderId(provider);
+  const map: Record<string, string> = {
+    anthropic: "https://api.anthropic.com",
+    deepseek: "https://api.deepseek.com",
+    openai: "https://api.openai.com/v1",
+    "openai-codex": "https://api.openai.com/v1",
+    google: "https://generativelanguage.googleapis.com/v1beta",
+    groq: "https://api.groq.com/openai/v1",
+    mistral: "https://api.mistral.ai",
+    together: "https://api.together.xyz",
+    openrouter: "https://openrouter.ai/api/v1",
+    ollama: "http://localhost:11434",
+  };
+  return map[normalized];
 }
 
 /** Build provider-aware options for pi-ai completeSimple. */

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -493,7 +493,7 @@ describe("createLcmDependencies.complete provider config resolution", () => {
         id: "kimi-k2.5:cloud",
         provider: "ollama",
         api: "openai-completions",
-        baseUrl: "",
+        baseUrl: "http://localhost:11434",
       }),
       expect.any(Object),
       expect.any(Object),

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -500,6 +500,32 @@ describe("createLcmDependencies.complete provider config resolution", () => {
     );
   });
 
+  it.each([
+    ["deepseek", "https://api.deepseek.com"],
+    ["groq", "https://api.groq.com/openai/v1"],
+    ["mistral", "https://api.mistral.ai"],
+    ["openrouter", "https://openrouter.ai/api/v1"],
+    ["together", "https://api.together.xyz"],
+  ])("falls back to OpenAI-compatible routing for %s", async (provider, baseUrl) => {
+    await callComplete({
+      loadConfigResult: {},
+      provider,
+      model: "unit-model",
+      runtimeConfig: {},
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "unit-model",
+        provider,
+        api: "openai-completions",
+        baseUrl,
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("preserves provider auth error metadata when completeSimple throws a 401 scope error", async () => {
     piAiMock.completeSimple.mockRejectedValue({
       statusCode: 401,


### PR DESCRIPTION
## Problem

The lossless-claw plugin relies on OpenClaw's model catalog to resolve two critical routing fields when building `completeSimple` options:

1. **`api`** — the API protocol family (e.g. `"openai-completions"`, `"anthropic-messages"`)
2. **`baseUrl`** — the HTTP endpoint for the provider

When a provider is configured via `openclaw.json` `models.providers` without declaring these fields explicitly, and the installed model catalog does not contain entries for those providers, the plugin silently falls back to:

- `api`: `undefined` (which pi-ai resolves to a default, often mismatched)
- `baseUrl`: `""` (empty string, which routes to `https://api.openai.com/v1`)

This causes silent **401 Unauthorized** errors for providers like DeepSeek, Groq, Together, and Mistral that have their own API endpoints but use the OpenAI-compatible protocol.

## Root Cause

- The `inferApiFromProvider` map only covered `openai`, `openai-codex`, `google`, and `anthropic`. Any other provider returned `undefined`, leading pi-ai to use its own default API resolution.
- The `baseUrl` fallback was always `""`, meaning requests for providers without an explicit model catalog URL were routed to OpenAI's endpoint.

## Fix (2 commits)

### 1. `inferApiFromProvider`: Add `deepseek` (60a8f8e)

Extended the existing `inferApiFromProvider` map:

```typescript
deepseek: "openai-completions",
```

This tells the plugin to use the OpenAI-compatible completions API for DeepSeek models, matching how DeepSeek's API surface works.

### 2. `inferBaseUrlFromProvider`: Known provider base URL map (this PR)

Added a new `inferBaseUrlFromProvider(provider)` function that maps well-known providers to their correct API base URLs:

| Provider     | Base URL                                         |
|--------------|--------------------------------------------------|
| deepseek     | `https://api.deepseek.com`                       |
| anthropic    | `https://api.anthropic.com`                      |
| openai       | `https://api.openai.com/v1`                      |
| openai-codex | `https://api.openai.com/v1`                      |
| google       | `https://generativelanguage.googleapis.com/v1beta`|
| groq         | `https://api.groq.com/openai/v1`                 |
| mistral      | `https://api.mistral.ai`                         |
| together     | `https://api.together.xyz`                       |
| openrouter   | `https://openrouter.ai/api/v1`                   |
| ollama       | `http://localhost:11434`                         |

This is used as the final fallback in two code paths where empty string was previously the default:

- **Known-model route** (lines ~1664-1667): when `providerLevelConfig.baseUrl` is not a string and `knownModel.baseUrl` is not a string
- **Fallback route** (lines ~1693-1696): when `providerLevelConfig.baseUrl` is not a string and the model was resolved from config without a URL

## Verification

Build: **813/813 tests passing**.

In production at 99% cache hit rate, the fix was verified by observing successful DeepSeek compaction:

```
[lossless-claw] Compaction summarization model: deepseek/deepseek-v4-flash (default)
[lossless-claw] LCM compaction leaf pass (normal): 66363 -> 46884
```

## Notes

- The `baseUrl` map stores the endpoint without trailing slashes where possible, consistent with how OpenClaw's model catalog formats URLs.
- Providers using OpenAI-compatible endpoints share the same `"openai-completions"` api value.
- The previous commit (60a8f8e) added the api fix; this commit adds the parallel baseUrl fix. Both are needed together for a provider like DeepSeek that is not in the default model catalog.

## Related

- Closes gap for any OpenAI-compatible provider not in the model catalog
- Follows the same pattern as the existing `inferApiFromProvider` function
- Together with 60a8f8e, fully resolves DeepSeek integration