### PR TITLE
fix: handle Codex summary provider errors

### DIFF
--- a/.changeset/codex-summary-provider-fallback.md
+++ b/.changeset/codex-summary-provider-fallback.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix `openai-codex` summarization for modern Codex model ids that are not present in the local `pi-ai` model catalog.
+
+Lossless now resolves native Codex transport defaults for these models and treats explicit provider error responses as provider failures, allowing configured fallback models to run instead of retrying as an empty summary and falling back to truncation.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -152,7 +152,7 @@ const AUTH_ERROR_STATUS_KEYS = ["status", "statusCode", "status_code"] as const;
 const AUTH_ERROR_NESTED_KEYS = ["error", "response", "cause", "details", "data", "body"] as const;
 
 type CompletionBridgeErrorInfo = {
-  kind: "provider_auth";
+  kind: "provider_auth" | "provider_error";
   statusCode?: number;
   code?: string;
   message?: string;
@@ -348,6 +348,26 @@ function detectProviderAuthError(error: unknown): CompletionBridgeErrorInfo | un
     ...(statusCode !== undefined ? { statusCode } : {}),
     ...(directCode ? { code: directCode } : {}),
     ...(normalizedMessage ? { message: truncateErrorMessage(normalizedMessage) } : {}),
+  };
+}
+
+function detectProviderBridgeError(error: unknown): CompletionBridgeErrorInfo {
+  const statusCode = extractErrorStatusCode(error);
+  const directCode =
+    isRecord(error) && typeof error.code === "string" && error.code.trim()
+      ? error.code.trim()
+      : isRecord(error) &&
+          isRecord(error.error) &&
+          typeof error.error.code === "string" &&
+          error.error.code.trim()
+        ? error.error.code.trim()
+        : undefined;
+
+  return {
+    kind: "provider_error",
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    ...(directCode ? { code: directCode } : {}),
+    message: truncateErrorMessage(describeLogError(error)),
   };
 }
 
@@ -626,14 +646,110 @@ function normalizeProviderId(provider: string): string {
   return provider.trim().toLowerCase();
 }
 
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
+const OPENAI_CODEX_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
+const OPENAI_CODEX_NATIVE_BASE_URLS = new Set([
+  "https://chatgpt.com/backend-api",
+  "https://chatgpt.com/backend-api/v1",
+  OPENAI_CODEX_RESPONSES_BASE_URL,
+  `${OPENAI_CODEX_RESPONSES_BASE_URL}/v1`,
+]);
+const OPENAI_CODEX_NATIVE_MODEL_IDS = new Set([
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.4-pro",
+  "gpt-5.5",
+  "gpt-5.5-pro",
+]);
+
+function isOpenAICodexProvider(provider: string): boolean {
+  return normalizeProviderId(provider) === OPENAI_CODEX_PROVIDER_ID;
+}
+
+function isOpenAICodexResponsesApi(api: string | undefined): boolean {
+  return (api ?? "").trim().toLowerCase() === OPENAI_CODEX_RESPONSES_API;
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function shouldUseNativeCodexBaseUrl(params: {
+  provider: string;
+  api: string | undefined;
+  baseUrl: string | undefined;
+}): boolean {
+  if (!isOpenAICodexProvider(params.provider) || !isOpenAICodexResponsesApi(params.api)) {
+    return false;
+  }
+
+  const baseUrl = params.baseUrl?.trim();
+  if (!baseUrl) {
+    return true;
+  }
+
+  const normalized = normalizeBaseUrl(baseUrl);
+  return normalized === OPENAI_API_BASE_URL || OPENAI_CODEX_NATIVE_BASE_URLS.has(normalized);
+}
+
+function resolveProviderModelBaseUrl(params: {
+  provider: string;
+  api: string | undefined;
+  configuredBaseUrl: unknown;
+  fallbackBaseUrl: unknown;
+}): string {
+  const configuredBaseUrl =
+    typeof params.configuredBaseUrl === "string" ? params.configuredBaseUrl : undefined;
+  const fallbackBaseUrl =
+    typeof params.fallbackBaseUrl === "string" ? params.fallbackBaseUrl : undefined;
+  const baseUrl = configuredBaseUrl ?? fallbackBaseUrl ?? "";
+  return shouldUseNativeCodexBaseUrl({ provider: params.provider, api: params.api, baseUrl })
+    ? OPENAI_CODEX_RESPONSES_BASE_URL
+    : baseUrl;
+}
+
+function getOpenAICodexNativeModelDefaults(params: {
+  provider: string;
+  model: string;
+  api: string | undefined;
+}): {
+  reasoning?: boolean;
+  input?: string[];
+  contextWindow?: number;
+  maxTokens?: number;
+} {
+  // OpenClaw can know about newer ChatGPT Codex models before the pi-ai
+  // package does.  Give those uncataloged models the same broad capabilities as
+  // the native Codex provider instead of falling back to a text-only stub.
+  if (
+    !isOpenAICodexProvider(params.provider) ||
+    !isOpenAICodexResponsesApi(params.api) ||
+    !OPENAI_CODEX_NATIVE_MODEL_IDS.has(params.model.trim().toLowerCase())
+  ) {
+    return {};
+  }
+
+  return {
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+  };
+}
+
 /** Resolve known provider API defaults when model lookup misses. */
 function inferApiFromProvider(provider: string): string | undefined {
   const normalized = normalizeProviderId(provider);
   const map: Record<string, string> = {
     anthropic: "anthropic-messages",
     openai: "openai-responses",
-    "openai-codex": "openai-codex-responses",
-    "github-copilot": "openai-codex-responses",
+    [OPENAI_CODEX_PROVIDER_ID]: OPENAI_CODEX_RESPONSES_API,
+    "github-copilot": OPENAI_CODEX_RESPONSES_API,
     google: "google-generative-ai",
     "google-gemini-cli": "google-gemini-cli",
     "google-antigravity": "google-gemini-cli",
@@ -646,7 +762,7 @@ function inferApiFromProvider(provider: string): string | undefined {
 
 /** Codex Responses rejects `temperature`; omit it for that API family. */
 export function shouldOmitTemperatureForApi(api: string | undefined): boolean {
-  return (api ?? "").trim().toLowerCase() === "openai-codex-responses";
+  return isOpenAICodexResponsesApi(api);
 }
 
 /** Build provider-aware options for pi-ai completeSimple. */
@@ -796,18 +912,24 @@ function buildModelAuthLookupModel(params: {
   api?: string;
   contextWindow?: number;
 }): RuntimeModelAuthModel {
+  const api = params.api?.trim() || inferApiFromProvider(params.provider) || "";
+  const codexDefaults = getOpenAICodexNativeModelDefaults({
+    provider: params.provider,
+    model: params.model,
+    api,
+  });
   const contextWindow =
     typeof params.contextWindow === "number" && Number.isFinite(params.contextWindow) && params.contextWindow > 0
       ? params.contextWindow
-      : 1_000_000;
+      : codexDefaults.contextWindow ?? 1_000_000;
 
   return {
     id: params.model,
     name: params.model,
     provider: params.provider,
-    api: params.api?.trim() || inferApiFromProvider(params.provider) || "",
-    reasoning: false,
-    input: ["text"],
+    api,
+    reasoning: codexDefaults.reasoning ?? false,
+    input: codexDefaults.input ?? ["text"],
     cost: {
       input: 0,
       output: 0,
@@ -815,7 +937,7 @@ function buildModelAuthLookupModel(params: {
       cacheWrite: 0,
     },
     contextWindow,
-    maxTokens: 8_000,
+    maxTokens: codexDefaults.maxTokens ?? 8_000,
   };
 }
 
@@ -1624,6 +1746,16 @@ function createLcmDependencies(
           return isRecord(cfg) ? cfg : {};
         })();
 
+        const resolvedKnownApi =
+          isRecord(knownModel) && typeof knownModel.api === "string"
+            ? modelRuntimeApi || providerRuntimeApi || knownModel.api
+            : undefined;
+        const codexDefaults = getOpenAICodexNativeModelDefaults({
+          provider: providerId,
+          model: modelId,
+          api: fallbackApi,
+        });
+
         let resolvedModel =
           isRecord(knownModel) &&
           typeof knownModel.api === "string" &&
@@ -1633,19 +1765,19 @@ function createLcmDependencies(
                 ...knownModel,
                 id: knownModel.id,
                 provider: knownModel.provider,
-                api: modelRuntimeApi || providerRuntimeApi || knownModel.api,
+                api: resolvedKnownApi ?? knownModel.api,
                 // Provider config must be able to override built-in transport defaults.
                 // Otherwise built-in providers like `openai` keep their catalog baseUrl
                 // (`https://api.openai.com/v1`) even when OpenClaw runtime config points
                 // that provider id at a custom proxy.
                 // Always set baseUrl to a string — pi-ai's detectCompat() crashes when
                 // baseUrl is undefined.
-                baseUrl:
-                  typeof providerLevelConfig.baseUrl === "string"
-                    ? providerLevelConfig.baseUrl
-                    : typeof knownModel.baseUrl === "string"
-                      ? knownModel.baseUrl
-                      : "",
+                baseUrl: resolveProviderModelBaseUrl({
+                  provider: providerId,
+                  api: resolvedKnownApi ?? knownModel.api,
+                  configuredBaseUrl: providerLevelConfig.baseUrl,
+                  fallbackBaseUrl: knownModel.baseUrl,
+                }),
                 ...(isRecord(providerLevelConfig.headers)
                   ? {
                       headers: {
@@ -1660,21 +1792,24 @@ function createLcmDependencies(
                 name: modelId,
                 provider: providerId,
                 api: fallbackApi,
-                reasoning: false,
-                input: ["text"],
+                reasoning: codexDefaults.reasoning ?? false,
+                input: codexDefaults.input ?? ["text"],
                 cost: {
                   input: 0,
                   output: 0,
                   cacheRead: 0,
                   cacheWrite: 0,
                 },
-                contextWindow: 1_000_000,
-                maxTokens: 8_000,
+                contextWindow: codexDefaults.contextWindow ?? 1_000_000,
+                maxTokens: codexDefaults.maxTokens ?? 8_000,
                 // Always set baseUrl to a string — pi-ai's detectCompat() crashes when
                 // baseUrl is undefined.
-                baseUrl: typeof providerLevelConfig.baseUrl === "string"
-                  ? providerLevelConfig.baseUrl
-                  : "",
+                baseUrl: resolveProviderModelBaseUrl({
+                  provider: providerId,
+                  api: fallbackApi,
+                  configuredBaseUrl: providerLevelConfig.baseUrl,
+                  fallbackBaseUrl: undefined,
+                }),
                 ...(isRecord(providerLevelConfig.headers)
                   ? { headers: providerLevelConfig.headers }
                   : {}),
@@ -1853,10 +1988,12 @@ function createLcmDependencies(
                 message: err.message,
               }
             : undefined;
+        const providerError = !authError && !configError ? detectProviderBridgeError(err) : undefined;
         return {
           content: [],
           ...(authError ? { error: authError } : {}),
           ...(configError ? { error: configError } : {}),
+          ...(providerError ? { error: providerError } : {}),
         };
       }
     },

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -80,6 +80,13 @@ type ProviderAuthFailure = {
   missingModelRequestScope: boolean;
 };
 
+type ProviderResponseFailure = {
+  statusCode?: number;
+  message?: string;
+  code?: string;
+  finishReason?: string;
+};
+
 /**
  * Signals that the summarizer hit a provider-auth failure and callers should
  * avoid treating the result like an empty summary.
@@ -96,6 +103,25 @@ export class LcmProviderAuthError extends Error {
   }) {
     super(buildProviderAuthWarning(params));
     this.name = "LcmProviderAuthError";
+    this.provider = params.provider;
+    this.model = params.model;
+    this.failure = params.failure;
+  }
+}
+
+/** Signals that a provider returned an explicit non-auth error response. */
+class LcmProviderResponseError extends Error {
+  readonly provider: string;
+  readonly model: string;
+  readonly failure: ProviderResponseFailure;
+
+  constructor(params: {
+    provider: string;
+    model: string;
+    failure: ProviderResponseFailure;
+  }) {
+    super(buildProviderResponseWarning(params));
+    this.name = "LcmProviderResponseError";
     this.provider = params.provider;
     this.model = params.model;
     this.failure = params.failure;
@@ -547,6 +573,95 @@ function buildProviderAuthWarning(params: {
       ? ` Detail: ${params.failure.message}`
       : "";
   return `[lcm] compaction failed: ${detail}. Check that the configured summaryProvider has valid API credentials. Current: ${params.provider}/${params.model}${messageSuffix}`;
+}
+
+function getProviderResponseFinishReason(value: Record<string, unknown>): string | undefined {
+  for (const key of ["finish_reason", "stopReason", "stop_reason", "status"]) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+function getProviderResponseErrorCode(value: Record<string, unknown>): string | undefined {
+  if (typeof value.code === "string" && value.code.trim()) {
+    return value.code.trim();
+  }
+  if (isRecord(value.error) && typeof value.error.code === "string" && value.error.code.trim()) {
+    return value.error.code.trim();
+  }
+  return undefined;
+}
+
+function getProviderResponseErrorMessage(value: Record<string, unknown>): string | undefined {
+  const textParts: string[] = [];
+  for (const key of ["errorMessage", "message"]) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      textParts.push(candidate.trim());
+    }
+  }
+  if (isRecord(value.error)) {
+    collectAuthFailureText(value.error, textParts);
+  }
+  return textParts.length > 0
+    ? truncateDiagnosticText(textParts.join(" ").replace(/\s+/g, " ").trim(), 240)
+    : undefined;
+}
+
+function extractProviderResponseFailure(value: unknown): ProviderResponseFailure | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  // Treat only structural provider-error signals as failures. A plain
+  // `errorMessage` string can be part of an overloaded empty response that the
+  // existing conservative retry path still knows how to recover from.
+  const statusCode = extractAuthFailureStatusCode(value);
+  const finishReason = getProviderResponseFinishReason(value);
+  const normalizedFinishReason = finishReason?.toLowerCase();
+  const nestedError = isRecord(value.error) ? value.error : undefined;
+  const nestedErrorKind = typeof nestedError?.kind === "string" ? nestedError.kind : undefined;
+  const hasExplicitErrorSignal =
+    normalizedFinishReason === "error" ||
+    normalizedFinishReason === "failed" ||
+    normalizedFinishReason === "cancelled" ||
+    (statusCode !== undefined && statusCode >= 400) ||
+    (nestedErrorKind !== undefined && nestedErrorKind !== "provider_auth");
+  if (!hasExplicitErrorSignal) {
+    return undefined;
+  }
+
+  const code = getProviderResponseErrorCode(value);
+  const message = getProviderResponseErrorMessage(value);
+  return {
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    ...(finishReason ? { finishReason } : {}),
+    ...(code ? { code } : {}),
+    ...(message ? { message } : {}),
+  };
+}
+
+function buildProviderResponseWarning(params: {
+  provider: string;
+  model: string;
+  failure: ProviderResponseFailure;
+}): string {
+  const detailParts: string[] = [];
+  if (params.failure.statusCode !== undefined) {
+    detailParts.push(String(params.failure.statusCode));
+  }
+  if (params.failure.finishReason) {
+    detailParts.push(`finish=${params.failure.finishReason}`);
+  }
+  if (params.failure.code) {
+    detailParts.push(`code=${params.failure.code}`);
+  }
+  const detail = detailParts.length > 0 ? ` (${detailParts.join(" / ")})` : "";
+  const messageSuffix = params.failure.message ? ` Detail: ${params.failure.message}` : "";
+  return `[lcm] provider error response${detail}; provider=${params.provider}; model=${params.model}${messageSuffix}`;
 }
 
 /**
@@ -1278,12 +1393,20 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             params.deps.log.warn(retryAuthError.message);
             throw retryAuthError;
           }
+          const directResponseFailure = extractProviderResponseFailure(directResult);
+          if (directResponseFailure) {
+            throw new LcmProviderResponseError({
+              provider,
+              model,
+              failure: directResponseFailure,
+            });
+          }
           params.deps.log.info(
             `[lcm] summarizer auth retry succeeded; provider=${provider}; model=${model}; source=direct-credentials`,
           );
           return directResult;
         } catch (directErr) {
-          if (directErr instanceof LcmProviderAuthError) {
+          if (directErr instanceof LcmProviderAuthError || directErr instanceof LcmProviderResponseError) {
             throw directErr;
           }
           // Catch path: real errors carry structural signals (HTTP 401, error.kind),
@@ -1318,10 +1441,21 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             requireStructuralSignal: true,
           });
           if (!authFailure) {
-            return result;
+            const responseFailure = extractProviderResponseFailure(result);
+            if (!responseFailure) {
+              return result;
+            }
+            throw new LcmProviderResponseError({
+              provider,
+              model,
+              failure: responseFailure,
+            });
           }
           return retryWithoutModelAuth(authFailure, reasoning);
         } catch (err) {
+          if (err instanceof LcmProviderResponseError) {
+            throw err;
+          }
           const authFailure = extractProviderAuthFailure(err);
           if (!authFailure) {
             throw err;
@@ -1345,6 +1479,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             continue;
           }
           throw lastAuthError;
+        }
+        if (err instanceof LcmProviderResponseError) {
+          params.deps.log.warn(err.message);
+          if (nextCandidate) {
+            params.deps.log.warn(
+              `[lcm] PROVIDER FALLBACK: ${provider}/${model} provider error → trying ${nextCandidate.provider}/${nextCandidate.model}`,
+            );
+            const backoffMs = Math.min(500 * Math.pow(2, index), 8000);
+            await new Promise((r) => setTimeout(r, backoffMs));
+            continue;
+          }
+          break;
         }
         const errMsg = err instanceof Error ? err.message : String(err);
         const isTimeout = errMsg.includes("summarizer timeout");
@@ -1462,6 +1608,19 @@ export async function createLcmSummarizeFromLegacyParams(params: {
               continue;
             }
             throw lastAuthError;
+          }
+          if (retryErr instanceof LcmProviderResponseError) {
+            params.deps.log.warn(retryErr.message);
+            if (nextCandidate) {
+              params.deps.log.warn(
+                `[lcm] PROVIDER FALLBACK: ${provider}/${model} provider error on retry → trying ${nextCandidate.provider}/${nextCandidate.model}`,
+              );
+              const backoffMs = Math.min(500 * Math.pow(2, index), 8000);
+              await new Promise((r) => setTimeout(r, backoffMs));
+              continue;
+            }
+            summary = initialSummary;
+            continue;
           }
           // Retry is best-effort; log and proceed to deterministic fallback.
           const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -301,6 +301,59 @@ describe("createLcmDependencies.complete provider config resolution", () => {
     );
   });
 
+  it("uses native Codex transport defaults for uncataloged openai-codex models", async () => {
+    await callComplete({
+      loadConfigResult: {},
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      runtimeConfig: {},
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text", "image"],
+        maxTokens: 128_000,
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps custom Codex proxy baseUrl when openai-codex uses native transport", async () => {
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://codex-proxy.example.test/v1",
+          },
+        },
+      },
+    };
+
+    await callComplete({
+      loadConfigResult: runtimeConfig,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      runtimeConfig,
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://codex-proxy.example.test/v1",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("overrides built-in transport defaults for known providers with runtime provider config", async () => {
     piAiMock.getModel.mockReturnValue({
       id: "gpt-5.4",
@@ -473,7 +526,7 @@ describe("createLcmDependencies.complete provider config resolution", () => {
     });
   });
 
-  it("does not mislabel non-config provider errors as provider_config", async () => {
+  it("labels non-config provider errors without mislabeling them as provider_config", async () => {
     piAiMock.completeSimple.mockRejectedValue(new Error("gateway timed out"));
 
     const { result } = await callComplete({
@@ -501,7 +554,15 @@ describe("createLcmDependencies.complete provider config resolution", () => {
 
     expect(result).toMatchObject({
       content: [],
+      error: {
+        kind: "provider_error",
+        message: "gateway timed out",
+      },
     });
-    expect(result).not.toHaveProperty("error");
+    expect(result).not.toMatchObject({
+      error: {
+        kind: "provider_config",
+      },
+    });
   });
 });

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -1061,6 +1061,78 @@ describe("createLcmSummarizeFromLegacyParams", () => {
       expect(diagnostics).toContain("anthropic/claude-sonnet-4-6");
     });
 
+    it("falls back to the next resolved model when the provider returns an error response", async () => {
+      const deps = makeDeps({
+        resolveModel: vi.fn((modelRef?: string, providerHint?: string) => {
+          if (modelRef === "gpt-5.4") {
+            return { provider: providerHint ?? "openai-codex", model: "gpt-5.4" };
+          }
+          if (modelRef === "anthropic/claude-sonnet-4-6") {
+            return { provider: "anthropic", model: "claude-sonnet-4-6" };
+          }
+          throw new Error(`unexpected modelRef: ${String(modelRef)}`);
+        }),
+        complete: vi.fn(async ({ provider }: { provider?: string }) => {
+          if (provider === "openai-codex") {
+            return {
+              content: [],
+              stopReason: "error",
+              errorMessage: "Not Found",
+              request_api: "openai-codex-responses",
+            };
+          }
+          return {
+            content: [{ type: "text", text: "Recovered summary from provider fallback." }],
+          };
+        }),
+      });
+
+      const summarize = await createSummarizeFn({
+        deps,
+        legacyParams: {
+          provider: "openai-codex",
+          model: "gpt-5.4",
+          config: {
+            plugins: {
+              entries: {
+                "lossless-claw": {
+                  config: {
+                    summaryProvider: "openai-codex",
+                    summaryModel: "gpt-5.4",
+                  },
+                },
+              },
+            },
+            agents: {
+              defaults: {
+                model: "anthropic/claude-sonnet-4-6",
+              },
+            },
+          },
+        },
+      });
+
+      const summary = await summarize!("A".repeat(8_000), false);
+
+      expect(summary).toBe("Recovered summary from provider fallback.");
+      expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(deps.complete).mock.calls[0]?.[0]).toMatchObject({
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      });
+      expect(vi.mocked(deps.complete).mock.calls[1]?.[0]).toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      });
+
+      const diagnostics = getDepsLogText(deps);
+      expect(diagnostics).toContain("provider error response");
+      expect(diagnostics).toContain("finish=error");
+      expect(diagnostics).toContain("PROVIDER FALLBACK");
+      expect(diagnostics).not.toContain("retrying with conservative settings");
+      expect(diagnostics).not.toContain("falling back to truncation");
+    });
+
     it("falls back to the next resolved model when retry also returns an empty overloaded response", async () => {
       const deps = makeDeps({
           resolveModel: vi.fn((modelRef?: string, providerHint?: string) => {


### PR DESCRIPTION
## What
Fixes #541 by resolving native Codex transport defaults for modern `openai-codex` summary models and by treating explicit provider error responses as provider failures.

## Why
`summaryModel: "openai-codex/gpt-5.4"` could miss the local `pi-ai` model catalog, call the wrong Codex endpoint shape, receive `Not Found`, and then fall into empty-summary retry/truncation instead of trying configured fallback models.

## Changes
- Add native Codex defaults
- Preserve provider error metadata
- Fallback on provider errors
- Add summary regression tests
- Add patch changeset

## Testing
- `PATH=/Users/phaedrus/.local/share/mise/installs/node/22.17.0/bin:$PATH npm test -- --run test/index-complete-provider-config.test.ts test/summarize.test.ts`
- `PATH=/Users/phaedrus/.local/share/mise/installs/node/22.17.0/bin:$PATH npm run build`
- `PATH=/Users/phaedrus/.local/share/mise/installs/node/22.17.0/bin:$PATH npm test`
