### PR TITLE
[Lossless Codex] Read-only Codex access to OpenClaw LCM memory (1/3)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "lossless-claw-local",
+  "interface": {
+    "displayName": "Lossless Claw Local"
+  },
+  "plugins": [
+    {
+      "name": "codex-lcm-reader",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codex-lcm-reader"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.changeset/codex-lcm-reader-plugin.md
+++ b/.changeset/codex-lcm-reader-plugin.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add a repo-local Codex Desktop LCM Reader plugin that exposes current LCM search and expansion tools against a local database in read-only mode.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "files": [
     "dist/",
     "skills/",
+    "plugins/",
+    ".agents/plugins/marketplace.json",
     "openclaw.plugin.json",
     "docs/",
     "README.md",

--- a/plugins/codex-lcm-reader/.codex-plugin/plugin.json
+++ b/plugins/codex-lcm-reader/.codex-plugin/plugin.json
@@ -21,9 +21,9 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Codex LCM Reader",
+    "displayName": "Lossless Codex",
     "shortDescription": "Search local OpenClaw LCM memory from Codex",
-    "longDescription": "Codex LCM Reader gives Codex Desktop read-only tools for inspecting a local lossless-claw SQLite database. It exposes bounded recall tools for grep, describe, expand, and expand-query style evidence retrieval without mutating OpenClaw memory.",
+    "longDescription": "Lossless Codex gives Codex Desktop read-only tools for inspecting a local lossless-claw SQLite database. It exposes bounded recall tools for grep, describe, expand, and expand-query style evidence retrieval without mutating OpenClaw memory.",
     "developerName": "Martian Engineering",
     "category": "Engineering",
     "capabilities": [

--- a/plugins/codex-lcm-reader/.codex-plugin/plugin.json
+++ b/plugins/codex-lcm-reader/.codex-plugin/plugin.json
@@ -1,0 +1,46 @@
+{
+  "name": "codex-lcm-reader",
+  "version": "0.1.0",
+  "description": "Read-only Codex Desktop access to a local OpenClaw lossless-claw LCM database.",
+  "author": {
+    "name": "Martian Engineering",
+    "email": "support@martian.engineering",
+    "url": "https://github.com/Martian-Engineering"
+  },
+  "homepage": "https://github.com/Martian-Engineering/lossless-claw",
+  "repository": "https://github.com/Martian-Engineering/lossless-claw",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "openclaw",
+    "lossless-claw",
+    "lcm",
+    "memory",
+    "sqlite"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Codex LCM Reader",
+    "shortDescription": "Search local OpenClaw LCM memory from Codex",
+    "longDescription": "Codex LCM Reader gives Codex Desktop read-only tools for inspecting a local lossless-claw SQLite database. It exposes bounded recall tools for grep, describe, expand, and expand-query style evidence retrieval without mutating OpenClaw memory.",
+    "developerName": "Martian Engineering",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
+    "websiteURL": "https://github.com/Martian-Engineering/lossless-claw",
+    "privacyPolicyURL": "https://github.com/Martian-Engineering/lossless-claw",
+    "termsOfServiceURL": "https://github.com/Martian-Engineering/lossless-claw",
+    "defaultPrompt": [
+      "Search my local LCM memory",
+      "What did OpenClaw work on yesterday?",
+      "Find prior context for this repo"
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/lcm-reader.svg",
+    "logo": "./assets/lcm-reader.svg",
+    "screenshots": []
+  }
+}

--- a/plugins/codex-lcm-reader/.mcp.json
+++ b/plugins/codex-lcm-reader/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "codex-lcm-reader": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./scripts/mcp-server.mjs"],
+      "cwd": "."
+    }
+  }
+}

--- a/plugins/codex-lcm-reader/README.md
+++ b/plugins/codex-lcm-reader/README.md
@@ -13,6 +13,17 @@ The plugin does not mutate OpenClaw state, run LCM maintenance, build rollups, w
 
 ## Install Into Codex Desktop
 
+Prerequisites:
+
+- Codex Desktop must be able to launch `node`.
+- `node` must support `node:sqlite`; check with:
+
+```bash
+node -e "import('node:sqlite').then(() => console.log('node:sqlite ok'))"
+```
+
+If Codex Desktop is launched from the macOS GUI and cannot see your shell `PATH`, either launch Codex from a shell that can run `node`, or adjust your local Codex/plugin environment so the `node` command resolves to Node 22+.
+
 For local development from a `lossless-claw` checkout:
 
 1. Keep this plugin directory at `plugins/codex-lcm-reader`.
@@ -22,27 +33,43 @@ For local development from a `lossless-claw` checkout:
 
 For a home-local install:
 
-1. Copy `plugins/codex-lcm-reader` to `~/plugins/codex-lcm-reader`.
-2. Add this entry to `~/.agents/plugins/marketplace.json`:
+1. Copy `plugins/codex-lcm-reader` to `~/plugins/codex-lcm-reader`:
+
+```bash
+mkdir -p ~/plugins ~/.agents/plugins
+cp -R plugins/codex-lcm-reader ~/plugins/codex-lcm-reader
+```
+
+2. Add a complete marketplace file at `~/.agents/plugins/marketplace.json`, or merge the `codex-lcm-reader` entry into your existing file:
 
 ```json
 {
-  "name": "codex-lcm-reader",
-  "source": {
-    "source": "local",
-    "path": "./plugins/codex-lcm-reader"
+  "name": "lossless-codex-local",
+  "interface": {
+    "displayName": "Lossless Codex Local"
   },
-  "policy": {
-    "installation": "INSTALLED_BY_DEFAULT",
-    "authentication": "ON_INSTALL"
-  },
-  "category": "Engineering"
+  "plugins": [
+    {
+      "name": "codex-lcm-reader",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codex-lcm-reader"
+      },
+      "policy": {
+        "installation": "INSTALLED_BY_DEFAULT",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
 }
 ```
 
 3. Restart Codex Desktop.
 
 Codex should then expose the plugin as **Lossless Codex** with read-only LCM tools.
+
+When using a non-default database path from Codex Desktop, make sure the Codex process receives `LCM_CODEX_DB_PATH=/absolute/path/to/lcm.db` or another supported DB-path variable. The plugin falls back to `~/.openclaw/lcm.db` only when no explicit path is provided.
 
 ## Database Path
 

--- a/plugins/codex-lcm-reader/README.md
+++ b/plugins/codex-lcm-reader/README.md
@@ -56,7 +56,7 @@ cp -R plugins/codex-lcm-reader ~/plugins/codex-lcm-reader
         "path": "./plugins/codex-lcm-reader"
       },
       "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
+        "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Engineering"

--- a/plugins/codex-lcm-reader/README.md
+++ b/plugins/codex-lcm-reader/README.md
@@ -1,6 +1,6 @@
-# Codex LCM Reader
+# Lossless Codex
 
-Codex LCM Reader is a repo-local Codex Desktop plugin for read-only access to a local OpenClaw lossless-claw LCM SQLite database.
+Lossless Codex is a Codex Desktop plugin for read-only access to a local OpenClaw lossless-claw LCM SQLite database. The package folder is `codex-lcm-reader` so existing plugin installs and branch names remain stable.
 
 This first slice intentionally exposes only the tools that exist on current lossless-claw `main`:
 
@@ -10,6 +10,39 @@ This first slice intentionally exposes only the tools that exist on current loss
 - `lcm_expand_query`
 
 The plugin does not mutate OpenClaw state, run LCM maintenance, build rollups, write Cortex memory, or write OpenClaw tasks. It opens SQLite in read-only mode and enables `PRAGMA query_only = ON`.
+
+## Install Into Codex Desktop
+
+For local development from a `lossless-claw` checkout:
+
+1. Keep this plugin directory at `plugins/codex-lcm-reader`.
+2. Ensure `.agents/plugins/marketplace.json` includes the `codex-lcm-reader` local plugin entry.
+3. Restart Codex Desktop or refresh its plugin registry.
+4. Point the plugin at an LCM database with `LCM_CODEX_DB_PATH=/absolute/path/to/lcm.db` when the default `~/.openclaw/lcm.db` is not the database you want.
+
+For a home-local install:
+
+1. Copy `plugins/codex-lcm-reader` to `~/plugins/codex-lcm-reader`.
+2. Add this entry to `~/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "codex-lcm-reader",
+  "source": {
+    "source": "local",
+    "path": "./plugins/codex-lcm-reader"
+  },
+  "policy": {
+    "installation": "INSTALLED_BY_DEFAULT",
+    "authentication": "ON_INSTALL"
+  },
+  "category": "Engineering"
+}
+```
+
+3. Restart Codex Desktop.
+
+Codex should then expose the plugin as **Lossless Codex** with read-only LCM tools.
 
 ## Database Path
 

--- a/plugins/codex-lcm-reader/README.md
+++ b/plugins/codex-lcm-reader/README.md
@@ -1,0 +1,38 @@
+# Codex LCM Reader
+
+Codex LCM Reader is a repo-local Codex Desktop plugin for read-only access to a local OpenClaw lossless-claw LCM SQLite database.
+
+This first slice intentionally exposes only the tools that exist on current lossless-claw `main`:
+
+- `lcm_grep`
+- `lcm_describe`
+- `lcm_expand`
+- `lcm_expand_query`
+
+The plugin does not mutate OpenClaw state, run LCM maintenance, build rollups, write Cortex memory, or write OpenClaw tasks. It opens SQLite in read-only mode and enables `PRAGMA query_only = ON`.
+
+## Database Path
+
+The MCP server resolves the database path in this order:
+
+1. `LCM_CODEX_DB_PATH`
+2. `LCM_DATABASE_PATH`
+3. `LOSSLESS_CLAW_DB_PATH`
+4. `OPENCLAW_LCM_DB_PATH`
+5. `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`
+
+Use `LCM_CODEX_DB_PATH` when pointing Codex Desktop at a production database copy for migration or compatibility rehearsal.
+
+## Tool Semantics
+
+`lcm_grep` searches messages and summaries with bounded result limits. Regex mode scans a bounded newest-first slice; full-text mode uses LCM FTS tables when available and falls back to escaped `LIKE` predicates.
+
+`lcm_describe` returns cheap metadata and lineage for a known summary or file ID.
+
+`lcm_expand` expands known summary IDs through the persisted summary DAG and returns bounded evidence text.
+
+`lcm_expand_query` finds seed summaries by query, expands them, and returns an evidence bundle for Codex to synthesize from. Unlike OpenClaw's in-runtime `lcm_expand_query`, this local Codex adapter does not spawn an OpenClaw sub-agent.
+
+## Proof Rule
+
+LCM output is evidence, not authority. Verify exact commands, SHAs, file paths, timestamps, root cause, and shipped status against source evidence or the relevant external authority before asserting them.

--- a/plugins/codex-lcm-reader/README.md
+++ b/plugins/codex-lcm-reader/README.md
@@ -25,9 +25,9 @@ Use `LCM_CODEX_DB_PATH` when pointing Codex Desktop at a production database cop
 
 ## Tool Semantics
 
-`lcm_grep` searches messages and summaries with bounded result limits. Regex mode scans a bounded newest-first slice; full-text mode uses LCM FTS tables when available and falls back to escaped `LIKE` predicates.
+`lcm_grep` searches messages and summaries with bounded result limits. Regex mode scans a bounded slice; full-text mode uses LCM FTS tables when available and falls back to escaped `LIKE` predicates. Use `sort: "oldest"` for first-occurrence style discovery.
 
-`lcm_describe` returns cheap metadata and lineage for a known summary or file ID.
+`lcm_describe` returns cheap metadata and lineage for a known summary, `message:<id>`, numeric message ID, or file ID.
 
 `lcm_expand` expands known summary IDs through the persisted summary DAG and returns bounded evidence text.
 

--- a/plugins/codex-lcm-reader/assets/lcm-reader.svg
+++ b/plugins/codex-lcm-reader/assets/lcm-reader.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Codex LCM Reader">
+  <rect width="64" height="64" rx="14" fill="#0f172a"/>
+  <path d="M18 18h28a4 4 0 0 1 4 4v20a4 4 0 0 1-4 4H18a4 4 0 0 1-4-4V22a4 4 0 0 1 4-4Z" fill="#1d4ed8"/>
+  <path d="M20 26h24M20 33h18M20 40h10" stroke="#dbeafe" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="45" cy="41" r="7" fill="#38bdf8"/>
+  <path d="m50 46 5 5" stroke="#bae6fd" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -17,6 +17,7 @@ const MAX_EXPAND_NODES = 1_000;
 const DEFAULT_DESCRIBE_CHARS = 24_000;
 const MAX_DESCRIBE_CHARS = 120_000;
 const MAX_QUERY_ECHO_CHARS = 1_000;
+const MAX_LIKE_TERMS = 32;
 
 function textResult(text, details = undefined) {
   return {
@@ -168,7 +169,7 @@ function likeTerms(query) {
     const normalized = (match[1] ?? match[2] ?? "").trim().replace(edge, "").toLowerCase();
     if (normalized && !terms.includes(normalized)) terms.push(normalized);
   }
-  return terms;
+  return terms.slice(0, MAX_LIKE_TERMS);
 }
 
 function createSnippet(content, query, maxLen = 220) {

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -99,6 +99,36 @@ function ftsTableUsable(db, tableName) {
   }
 }
 
+function ftsRankedScopeUsable(db, scope) {
+  try {
+    if (scope === "messages") {
+      if (!ftsTableUsable(db, "messages_fts")) return false;
+      db.prepare(
+        `SELECT m.message_id
+         FROM messages_fts
+         JOIN messages m ON m.message_id = messages_fts.rowid
+         WHERE messages_fts MATCH ?
+         LIMIT 1`,
+      ).all('"__lossless_codex_probe_no_hit__"');
+      return true;
+    }
+    if (scope === "summaries") {
+      if (!ftsTableUsable(db, "summaries_fts")) return false;
+      db.prepare(
+        `SELECT s.summary_id
+         FROM summaries_fts
+         JOIN summaries s ON s.summary_id = summaries_fts.summary_id
+         WHERE summaries_fts MATCH ?
+         LIMIT 1`,
+      ).all('"__lossless_codex_probe_no_hit__"');
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
 function requiredSchema(db) {
   const required = ["conversations", "messages", "summaries", "summary_parents", "summary_messages"];
   const missing = required.filter((name) => !tableExists(db, name));
@@ -433,8 +463,7 @@ function lcmGrep(db, params, context = {}) {
   const rankedScopeAvailable =
     mode === "full_text" &&
     scope !== "both" &&
-    ((scope === "messages" && ftsTableUsable(db, "messages_fts")) ||
-      (scope === "summaries" && ftsTableUsable(db, "summaries_fts")));
+    ftsRankedScopeUsable(db, scope);
   const effectiveSort =
     (requestedSort === "relevance" || requestedSort === "hybrid") && !rankedScopeAvailable
       ? "recency"

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -16,6 +16,7 @@ const DEFAULT_MAX_EXPAND_NODES = 200;
 const MAX_EXPAND_NODES = 1_000;
 const DEFAULT_DESCRIBE_CHARS = 24_000;
 const MAX_DESCRIBE_CHARS = 120_000;
+const MAX_QUERY_ECHO_CHARS = 1_000;
 
 function textResult(text, details = undefined) {
   return {
@@ -695,6 +696,8 @@ function lcmExpandQuery(db, params) {
     ? params.summaryIds.filter((id) => typeof id === "string" && id.trim()).map((id) => id.trim())
     : [];
   const query = readString(params.query);
+  const promptEcho = truncateChars(prompt, MAX_QUERY_ECHO_CHARS);
+  const queryEcho = truncateChars(query ?? "", MAX_QUERY_ECHO_CHARS);
   if (summaryIds.length === 0) {
     if (!query) throw new Error("summaryIds or query is required.");
     const matches = searchSummaries(db, {
@@ -720,15 +723,30 @@ function lcmExpandQuery(db, params) {
     }
   }
   if (summaryIds.length === 0) {
-    return jsonTextResult({ tool: "lcm_expand_query", prompt, query, summaryIds: [], text: "", note: "No seed summaries matched." });
+    return jsonTextResult({
+      tool: "lcm_expand_query",
+      prompt: promptEcho.text,
+      prompt_truncated: promptEcho.truncated,
+      prompt_original_length: promptEcho.originalLength,
+      query: query ? queryEcho.text : undefined,
+      query_truncated: query ? queryEcho.truncated : undefined,
+      query_original_length: query ? queryEcho.originalLength : undefined,
+      summaryIds: [],
+      text: "",
+      note: "No seed summaries matched.",
+    });
   }
   summaryIds = summaryIds.slice(0, MAX_SUMMARY_IDS);
   const expansion = lcmExpand(db, { ...params, summaryIds });
   const details = expansion.structuredContent;
   return jsonTextResult({
     tool: "lcm_expand_query",
-    prompt,
-    query,
+    prompt: promptEcho.text,
+    prompt_truncated: promptEcho.truncated,
+    prompt_original_length: promptEcho.originalLength,
+    query: query ? queryEcho.text : undefined,
+    query_truncated: query ? queryEcho.truncated : undefined,
+    query_original_length: query ? queryEcho.originalLength : undefined,
     summaryIds,
     text: details.text,
     expanded: details.expanded,

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -1,0 +1,684 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+const SERVER_NAME = "codex-lcm-reader";
+const SERVER_VERSION = "0.1.0";
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+const DEFAULT_SCAN_LIMIT = 5_000;
+const MAX_EXPAND_TOKENS = 120_000;
+
+function textResult(text, details = undefined) {
+  return {
+    content: [{ type: "text", text }],
+    ...(details === undefined ? {} : { structuredContent: details }),
+  };
+}
+
+function jsonTextResult(payload) {
+  return textResult(JSON.stringify(payload, null, 2), payload);
+}
+
+function clampInt(value, fallback, min, max) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+function readString(value, fallback = undefined) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function parseDateParam(value, name) {
+  if (value == null || value === "") return undefined;
+  if (typeof value !== "string") throw new Error(`${name} must be an ISO timestamp string.`);
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error(`${name} must be a valid ISO timestamp.`);
+  return date.toISOString();
+}
+
+function resolveOpenclawStateDir(env = process.env) {
+  return env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), ".openclaw");
+}
+
+export function resolveDatabasePath(env = process.env) {
+  const explicit =
+    env.LCM_CODEX_DB_PATH?.trim() ||
+    env.LCM_DATABASE_PATH?.trim() ||
+    env.LOSSLESS_CLAW_DB_PATH?.trim() ||
+    env.OPENCLAW_LCM_DB_PATH?.trim();
+  return explicit ? resolve(explicit) : join(resolveOpenclawStateDir(env), "lcm.db");
+}
+
+export function openReadOnlyDatabase(dbPath = resolveDatabasePath()) {
+  if (!existsSync(dbPath)) {
+    throw new Error(
+      `LCM database not found at ${dbPath}. Set LCM_CODEX_DB_PATH or LCM_DATABASE_PATH.`,
+    );
+  }
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  db.exec("PRAGMA query_only = ON");
+  db.exec("PRAGMA busy_timeout = 5000");
+  return db;
+}
+
+function tableExists(db, tableName) {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?")
+    .get(tableName);
+  return !!row;
+}
+
+function requiredSchema(db) {
+  const required = ["conversations", "messages", "summaries", "summary_parents", "summary_messages"];
+  const missing = required.filter((name) => !tableExists(db, name));
+  if (missing.length > 0) {
+    throw new Error(`LCM database is missing required tables: ${missing.join(", ")}`);
+  }
+}
+
+function sanitizeFts5Query(raw) {
+  const parts = [];
+  const phraseRegex = /"([^"]+)"/g;
+  let match;
+  let lastIndex = 0;
+  while ((match = phraseRegex.exec(raw)) !== null) {
+    const before = raw.slice(lastIndex, match.index);
+    for (const token of before.split(/\s+/).filter(Boolean)) {
+      parts.push(`"${token.replace(/"/g, "")}"`);
+    }
+    const phrase = match[1].replace(/"/g, "").trim();
+    if (phrase) parts.push(`"${phrase}"`);
+    lastIndex = match.index + match[0].length;
+  }
+  for (const token of raw.slice(lastIndex).split(/\s+/).filter(Boolean)) {
+    parts.push(`"${token.replace(/"/g, "")}"`);
+  }
+  return parts.length > 0 ? parts.join(" ") : '""';
+}
+
+function escapeLike(term) {
+  return term.replace(/([\\%_])/g, "\\$1");
+}
+
+function likeTerms(query) {
+  const terms = [];
+  const rawTermRe = /"([^"]+)"|(\S+)/g;
+  const edge = /^[`'"()[\]{}<>.,:;!?*_+=|\\/-]+|[`'"()[\]{}<>.,:;!?*_+=|\\/-]+$/g;
+  for (const match of query.matchAll(rawTermRe)) {
+    const normalized = (match[1] ?? match[2] ?? "").trim().replace(edge, "").toLowerCase();
+    if (normalized && !terms.includes(normalized)) terms.push(normalized);
+  }
+  return terms;
+}
+
+function createSnippet(content, query, maxLen = 220) {
+  const text = String(content ?? "").replace(/\s+/g, " ").trim();
+  if (text.length <= maxLen) return text;
+  const terms = likeTerms(query);
+  const haystack = text.toLowerCase();
+  let index = -1;
+  for (const term of terms) {
+    const found = haystack.indexOf(term);
+    if (found >= 0 && (index < 0 || found < index)) index = found;
+  }
+  if (index < 0) return `${text.slice(0, maxLen - 3).trimEnd()}...`;
+  const start = Math.max(0, index - 60);
+  const end = Math.min(text.length, start + maxLen);
+  return `${start > 0 ? "..." : ""}${text.slice(start, end).trim()}${end < text.length ? "..." : ""}`;
+}
+
+function buildScope(params, alias = "") {
+  const prefix = alias ? `${alias}.` : "";
+  const where = [];
+  const args = [];
+  if (params.conversationId != null) {
+    const id = Number(params.conversationId);
+    if (!Number.isInteger(id) || id <= 0) throw new Error("conversationId must be a positive integer.");
+    where.push(`${prefix}conversation_id = ?`);
+    args.push(id);
+  }
+  const since = parseDateParam(params.since, "since");
+  const before = parseDateParam(params.before, "before");
+  if (since && before && new Date(since).getTime() >= new Date(before).getTime()) {
+    throw new Error("since must be earlier than before.");
+  }
+  return { where, args, since, before };
+}
+
+function orderBy(sort, createdExpr, rankExpr = "rank") {
+  switch (sort) {
+    case "relevance":
+      return `${rankExpr} ASC, ${createdExpr} DESC`;
+    case "hybrid":
+      return `(${rankExpr} / (1 + ((julianday('now') - julianday(${createdExpr})) * 24 * 0.001))) ASC, ${createdExpr} DESC`;
+    default:
+      return `${createdExpr} DESC`;
+  }
+}
+
+function searchMessages(db, params) {
+  const query = readString(params.pattern ?? params.query);
+  if (!query) throw new Error("pattern is required.");
+  const mode = params.mode === "full_text" ? "full_text" : "regex";
+  const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
+  const sort = params.sort === "relevance" || params.sort === "hybrid" ? params.sort : "recency";
+  const scope = buildScope(params, "m");
+
+  if (mode === "full_text" && tableExists(db, "messages_fts")) {
+    const where = ["messages_fts MATCH ?", ...scope.where];
+    const args = [sanitizeFts5Query(query), ...scope.args];
+    if (scope.since) {
+      where.push("julianday(m.created_at) >= julianday(?)");
+      args.push(scope.since);
+    }
+    if (scope.before) {
+      where.push("julianday(m.created_at) < julianday(?)");
+      args.push(scope.before);
+    }
+    args.push(limit);
+    return db
+      .prepare(
+        `SELECT
+           'message:' || m.message_id AS id,
+           m.message_id,
+           m.conversation_id,
+           m.role AS kind,
+           snippet(messages_fts, 0, '', '', '...', 32) AS snippet,
+           m.created_at,
+           rank
+         FROM messages_fts
+         JOIN messages m ON m.message_id = messages_fts.rowid
+         WHERE ${where.join(" AND ")}
+         ORDER BY ${orderBy(sort, "m.created_at")}
+         LIMIT ?`,
+      )
+      .all(...args)
+      .map((row) => ({ type: "message", ...row }));
+  }
+
+  const terms = mode === "full_text" ? likeTerms(query) : [];
+  const where = [...scope.where];
+  const args = [...scope.args];
+  if (scope.since) {
+    where.push("julianday(m.created_at) >= julianday(?)");
+    args.push(scope.since);
+  }
+  if (scope.before) {
+    where.push("julianday(m.created_at) < julianday(?)");
+    args.push(scope.before);
+  }
+  if (mode === "full_text") {
+    for (const term of terms) {
+      where.push("LOWER(m.content) LIKE ? ESCAPE '\\'");
+      args.push(`%${escapeLike(term)}%`);
+    }
+  }
+  args.push(clampInt(params.scanLimit, DEFAULT_SCAN_LIMIT, limit, 50_000));
+  const rows = db
+    .prepare(
+      `SELECT
+         'message:' || m.message_id AS id,
+         m.message_id,
+         m.conversation_id,
+         m.role AS kind,
+         m.content,
+         m.created_at
+       FROM messages m
+       ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+       ORDER BY m.created_at DESC
+       LIMIT ?`,
+    )
+    .all(...args);
+  const regex = mode === "regex" ? new RegExp(query, params.caseSensitive === true ? "" : "i") : undefined;
+  return rows
+    .filter((row) => (regex ? regex.test(String(row.content ?? "")) : true))
+    .slice(0, limit)
+    .map((row) => ({
+      type: "message",
+      id: row.id,
+      message_id: row.message_id,
+      conversation_id: row.conversation_id,
+      kind: row.kind,
+      snippet: createSnippet(row.content, query),
+      created_at: row.created_at,
+    }));
+}
+
+function searchSummaries(db, params) {
+  const query = readString(params.pattern ?? params.query);
+  if (!query) throw new Error("pattern is required.");
+  const mode = params.mode === "full_text" ? "full_text" : "regex";
+  const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
+  const sort = params.sort === "relevance" || params.sort === "hybrid" ? params.sort : "recency";
+  const scope = buildScope(params, "s");
+  const timeExpr = "COALESCE(s.latest_at, s.created_at)";
+
+  if (mode === "full_text" && tableExists(db, "summaries_fts")) {
+    const where = ["summaries_fts MATCH ?", ...scope.where];
+    const args = [sanitizeFts5Query(query), ...scope.args];
+    if (scope.since) {
+      where.push(`julianday(${timeExpr}) >= julianday(?)`);
+      args.push(scope.since);
+    }
+    if (scope.before) {
+      where.push(`julianday(${timeExpr}) < julianday(?)`);
+      args.push(scope.before);
+    }
+    args.push(limit);
+    return db
+      .prepare(
+        `SELECT
+           s.summary_id AS id,
+           s.summary_id,
+           s.conversation_id,
+           s.kind,
+           snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
+           ${timeExpr} AS created_at,
+           rank
+         FROM summaries_fts
+         JOIN summaries s ON s.summary_id = summaries_fts.summary_id
+         WHERE ${where.join(" AND ")}
+         ORDER BY ${orderBy(sort, timeExpr)}
+         LIMIT ?`,
+      )
+      .all(...args)
+      .map((row) => ({ type: "summary", ...row }));
+  }
+
+  const terms = mode === "full_text" ? likeTerms(query) : [];
+  const where = [...scope.where];
+  const args = [...scope.args];
+  if (scope.since) {
+    where.push(`julianday(${timeExpr}) >= julianday(?)`);
+    args.push(scope.since);
+  }
+  if (scope.before) {
+    where.push(`julianday(${timeExpr}) < julianday(?)`);
+    args.push(scope.before);
+  }
+  if (mode === "full_text") {
+    for (const term of terms) {
+      where.push("LOWER(s.content) LIKE ? ESCAPE '\\'");
+      args.push(`%${escapeLike(term)}%`);
+    }
+  }
+  args.push(clampInt(params.scanLimit, DEFAULT_SCAN_LIMIT, limit, 50_000));
+  const rows = db
+    .prepare(
+      `SELECT
+         s.summary_id AS id,
+         s.summary_id,
+         s.conversation_id,
+         s.kind,
+         s.content,
+         ${timeExpr} AS created_at
+       FROM summaries s
+       ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+       ORDER BY ${timeExpr} DESC
+       LIMIT ?`,
+    )
+    .all(...args);
+  const regex = mode === "regex" ? new RegExp(query, params.caseSensitive === true ? "" : "i") : undefined;
+  return rows
+    .filter((row) => (regex ? regex.test(String(row.content ?? "")) : true))
+    .slice(0, limit)
+    .map((row) => ({
+      type: "summary",
+      id: row.id,
+      summary_id: row.summary_id,
+      conversation_id: row.conversation_id,
+      kind: row.kind,
+      snippet: createSnippet(row.content, query),
+      created_at: row.created_at,
+    }));
+}
+
+function lcmGrep(db, params) {
+  const scope = params.scope === "messages" || params.scope === "summaries" ? params.scope : "both";
+  const results = [];
+  if (scope === "messages" || scope === "both") results.push(...searchMessages(db, params));
+  if (scope === "summaries" || scope === "both") results.push(...searchSummaries(db, params));
+  const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
+  results.sort((a, b) => String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")));
+  return jsonTextResult({
+    tool: "lcm_grep",
+    databasePath: resolveDatabasePath(),
+    mode: params.mode === "full_text" ? "full_text" : "regex",
+    scope,
+    count: Math.min(results.length, limit),
+    results: results.slice(0, limit),
+    note: "Codex LCM Reader is read-only and bounded. Expand IDs before treating snippets as proof.",
+  });
+}
+
+function describeSummary(db, id) {
+  const summary = db
+    .prepare(
+      `SELECT summary_id, conversation_id, kind, depth, content, token_count, file_ids,
+              earliest_at, latest_at, descendant_count, descendant_token_count,
+              source_message_token_count, model, created_at
+       FROM summaries WHERE summary_id = ?`,
+    )
+    .get(id);
+  if (!summary) return undefined;
+  const parentIds = db
+    .prepare(`SELECT parent_summary_id FROM summary_parents WHERE summary_id = ? ORDER BY ordinal ASC`)
+    .all(id)
+    .map((row) => row.parent_summary_id);
+  const childIds = db
+    .prepare(`SELECT summary_id FROM summary_parents WHERE parent_summary_id = ? ORDER BY ordinal ASC`)
+    .all(id)
+    .map((row) => row.summary_id);
+  const messageIds = db
+    .prepare(`SELECT message_id FROM summary_messages WHERE summary_id = ? ORDER BY ordinal ASC`)
+    .all(id)
+    .map((row) => row.message_id);
+  return { type: "summary", ...summary, parentIds, childIds, messageIds };
+}
+
+function describeFile(db, id) {
+  if (!tableExists(db, "large_files")) return undefined;
+  const file = db
+    .prepare(
+      `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri,
+              exploration_summary, created_at
+       FROM large_files WHERE file_id = ?`,
+    )
+    .get(id);
+  return file ? { type: "file", ...file } : undefined;
+}
+
+function lcmDescribe(db, params) {
+  const id = readString(params.id);
+  if (!id) throw new Error("id is required.");
+  const result = id.startsWith("file_") ? describeFile(db, id) : describeSummary(db, id);
+  if (!result) return jsonTextResult({ error: `Not found: ${id}` });
+  if (params.conversationId != null && result.conversation_id !== Number(params.conversationId)) {
+    return jsonTextResult({ error: `Not found in conversation ${params.conversationId}: ${id}` });
+  }
+  return jsonTextResult({
+    tool: "lcm_describe",
+    item: result,
+    note: "This is source evidence. Use expand for subtree context.",
+  });
+}
+
+function estimateTokens(text) {
+  return Math.ceil(String(text ?? "").length / 4);
+}
+
+function truncateTokens(text, maxTokens) {
+  const maxChars = Math.max(0, maxTokens * 4);
+  const value = String(text ?? "");
+  return value.length <= maxChars ? value : `${value.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n...(truncated)`;
+}
+
+function expandSummary(db, summaryId, options = {}) {
+  const maxDepth = clampInt(options.maxDepth, 4, 0, 24);
+  const rows = db
+    .prepare(
+      `WITH RECURSIVE subtree(summary_id, parent_summary_id, depth_from_root, path) AS (
+         SELECT ?, NULL, 0, ''
+         UNION ALL
+         SELECT sp.summary_id, sp.parent_summary_id, subtree.depth_from_root + 1,
+                CASE WHEN subtree.path = '' THEN printf('%04d', sp.ordinal)
+                     ELSE subtree.path || '.' || printf('%04d', sp.ordinal)
+                END
+         FROM summary_parents sp
+         JOIN subtree ON sp.parent_summary_id = subtree.summary_id
+         WHERE subtree.depth_from_root < ?
+       )
+       SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
+              s.earliest_at, s.latest_at, s.created_at, subtree.depth_from_root,
+              subtree.parent_summary_id, subtree.path
+       FROM subtree
+       JOIN summaries s ON s.summary_id = subtree.summary_id
+       ORDER BY subtree.depth_from_root ASC, subtree.path ASC, s.created_at ASC`,
+    )
+    .all(summaryId, maxDepth);
+  return rows;
+}
+
+function lcmExpand(db, params) {
+  const rawIds = Array.isArray(params.summaryIds)
+    ? params.summaryIds
+    : readString(params.summaryId)
+      ? [readString(params.summaryId)]
+      : [];
+  const summaryIds = rawIds.filter((id) => typeof id === "string" && id.trim()).map((id) => id.trim());
+  if (summaryIds.length === 0) throw new Error("summaryId or summaryIds is required.");
+  const tokenCap = clampInt(params.tokenCap, 24_000, 1_000, MAX_EXPAND_TOKENS);
+  const expanded = [];
+  let rendered = "";
+  for (const id of summaryIds) {
+    const rows = expandSummary(db, id, params);
+    if (rows.length === 0) {
+      expanded.push({ summaryId: id, error: "not found" });
+      continue;
+    }
+    const items = [];
+    for (const row of rows) {
+      const header = `[${row.summary_id}] ${row.kind} depth=${row.depth} conversation=${row.conversation_id} time=${row.latest_at ?? row.created_at}`;
+      const block = `${header}\n${row.content ?? ""}`.trim();
+      if (estimateTokens(`${rendered}\n\n${block}`) > tokenCap) {
+        items.push({ summaryId: row.summary_id, omitted: true, reason: "tokenCap" });
+        continue;
+      }
+      rendered += `${rendered ? "\n\n" : ""}${block}`;
+      items.push(row);
+    }
+    expanded.push({ summaryId: id, items });
+  }
+  return jsonTextResult({
+    tool: "lcm_expand",
+    summaryIds,
+    tokenCap,
+    text: truncateTokens(rendered, tokenCap),
+    expanded,
+    note: "Read-only Codex expansion. Use the returned source IDs as evidence anchors.",
+  });
+}
+
+function lcmExpandQuery(db, params) {
+  const prompt = readString(params.prompt, "");
+  let summaryIds = Array.isArray(params.summaryIds)
+    ? params.summaryIds.filter((id) => typeof id === "string" && id.trim()).map((id) => id.trim())
+    : [];
+  const query = readString(params.query);
+  if (summaryIds.length === 0) {
+    if (!query) throw new Error("summaryIds or query is required.");
+    const matches = searchSummaries(db, {
+      ...params,
+      pattern: query,
+      mode: params.mode === "regex" ? "regex" : "full_text",
+      limit: clampInt(params.seedLimit, 12, 1, 50),
+    });
+    summaryIds = matches.map((row) => row.summary_id).filter(Boolean);
+  }
+  if (summaryIds.length === 0) {
+    return jsonTextResult({ tool: "lcm_expand_query", prompt, query, summaryIds: [], text: "", note: "No seed summaries matched." });
+  }
+  const expansion = lcmExpand(db, { ...params, summaryIds });
+  const details = expansion.structuredContent;
+  return jsonTextResult({
+    tool: "lcm_expand_query",
+    prompt,
+    query,
+    summaryIds,
+    text: details.text,
+    expanded: details.expanded,
+    note: "Codex-local adapter: returns expanded evidence for Codex to synthesize. It does not spawn an OpenClaw sub-agent.",
+  });
+}
+
+const currentTools = [
+  {
+    name: "lcm_grep",
+    description: "Search local LCM messages and summaries. Defaults to bounded all-conversation search because Codex Desktop has no OpenClaw session identity.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pattern: { type: "string" },
+        mode: { type: "string", enum: ["regex", "full_text"], default: "regex" },
+        scope: { type: "string", enum: ["messages", "summaries", "both"], default: "both" },
+        limit: { type: "number", default: DEFAULT_LIMIT },
+        scanLimit: { type: "number", default: DEFAULT_SCAN_LIMIT },
+        conversationId: { type: "number" },
+        since: { type: "string" },
+        before: { type: "string" },
+        sort: { type: "string", enum: ["recency", "relevance", "hybrid"], default: "recency" },
+      },
+      required: ["pattern"],
+      additionalProperties: true,
+    },
+    handler: lcmGrep,
+  },
+  {
+    name: "lcm_describe",
+    description: "Describe one LCM summary or file ID from the local database.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        conversationId: { type: "number" },
+      },
+      required: ["id"],
+      additionalProperties: true,
+    },
+    handler: lcmDescribe,
+  },
+  {
+    name: "lcm_expand",
+    description: "Expand one or more known summary IDs into bounded source evidence.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        summaryId: { type: "string" },
+        summaryIds: { type: "array", items: { type: "string" } },
+        maxDepth: { type: "number", default: 4 },
+        tokenCap: { type: "number", default: 24000 },
+      },
+      additionalProperties: true,
+    },
+    handler: lcmExpand,
+  },
+  {
+    name: "lcm_expand_query",
+    description: "Find seed summaries by query or use provided IDs, then return expanded evidence for Codex to synthesize from.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prompt: { type: "string" },
+        query: { type: "string" },
+        summaryIds: { type: "array", items: { type: "string" } },
+        seedLimit: { type: "number", default: 12 },
+        tokenCap: { type: "number", default: 24000 },
+        conversationId: { type: "number" },
+      },
+      additionalProperties: true,
+    },
+    handler: lcmExpandQuery,
+  },
+];
+
+export function createTools() {
+  return currentTools;
+}
+
+export async function callTool(name, args, options = {}) {
+  const tool = createTools().find((entry) => entry.name === name);
+  if (!tool) throw new Error(`Unknown tool: ${name}`);
+  const db = options.db ?? openReadOnlyDatabase(options.dbPath);
+  const shouldClose = !options.db;
+  try {
+    requiredSchema(db);
+    return await tool.handler(db, args ?? {});
+  } finally {
+    if (shouldClose) db.close();
+  }
+}
+
+class McpServer {
+  constructor() {
+    this.buffer = Buffer.alloc(0);
+  }
+
+  start() {
+    process.stdin.on("data", (chunk) => this.onData(chunk));
+    process.stdin.on("end", () => process.exit(0));
+  }
+
+  onData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (true) {
+      const headerEnd = this.buffer.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+      const header = this.buffer.slice(0, headerEnd).toString("utf8");
+      const match = /Content-Length:\s*(\d+)/i.exec(header);
+      if (!match) {
+        this.buffer = Buffer.alloc(0);
+        return;
+      }
+      const length = Number(match[1]);
+      const bodyStart = headerEnd + 4;
+      const bodyEnd = bodyStart + length;
+      if (this.buffer.length < bodyEnd) return;
+      const body = this.buffer.slice(bodyStart, bodyEnd).toString("utf8");
+      this.buffer = this.buffer.slice(bodyEnd);
+      this.handleMessage(body).catch((error) => {
+        this.respond(null, undefined, { code: -32603, message: error.message });
+      });
+    }
+  }
+
+  async handleMessage(body) {
+    const message = JSON.parse(body);
+    if (message.id == null) return;
+    try {
+      if (message.method === "initialize") {
+        this.respond(message.id, {
+          protocolVersion: message.params?.protocolVersion ?? "2024-11-05",
+          capabilities: { tools: {} },
+          serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+        });
+        return;
+      }
+      if (message.method === "tools/list") {
+        this.respond(message.id, {
+          tools: createTools().map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+          })),
+        });
+        return;
+      }
+      if (message.method === "tools/call") {
+        const result = await callTool(message.params?.name, message.params?.arguments ?? {});
+        this.respond(message.id, result);
+        return;
+      }
+      this.respond(message.id, undefined, { code: -32601, message: `Unknown method: ${message.method}` });
+    } catch (error) {
+      this.respond(message.id, undefined, {
+        code: -32000,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  respond(id, result, error = undefined) {
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, ...(error ? { error } : { result }) });
+    process.stdout.write(`Content-Length: ${Buffer.byteLength(payload, "utf8")}\r\n\r\n${payload}`);
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  new McpServer().start();
+}

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -71,7 +71,7 @@ export function resolveDatabasePath(env = process.env) {
 export function openReadOnlyDatabase(dbPath = resolveDatabasePath()) {
   if (!existsSync(dbPath)) {
     throw new Error(
-      `LCM database not found at ${dbPath}. Set LCM_CODEX_DB_PATH or LCM_DATABASE_PATH.`,
+      `LCM database not found at ${dbPath}. Set LCM_CODEX_DB_PATH, LCM_DATABASE_PATH, LOSSLESS_CLAW_DB_PATH, or OPENCLAW_LCM_DB_PATH.`,
     );
   }
   const db = new DatabaseSync(dbPath, { readOnly: true });
@@ -99,12 +99,21 @@ function ftsTableUsable(db, tableName) {
   }
 }
 
+function tableColumns(db, tableName) {
+  try {
+    return db.prepare(`PRAGMA table_info(${tableName})`).all().map((row) => row.name);
+  } catch {
+    return [];
+  }
+}
+
 function ftsRankedScopeUsable(db, scope) {
   try {
     if (scope === "messages") {
       if (!ftsTableUsable(db, "messages_fts")) return false;
+      if (!tableColumns(db, "messages_fts").includes("content")) return false;
       db.prepare(
-        `SELECT m.message_id
+        `SELECT m.message_id, snippet(messages_fts, 0, '', '', '...', 32) AS snippet
          FROM messages_fts
          JOIN messages m ON m.message_id = messages_fts.rowid
          WHERE messages_fts MATCH ?
@@ -114,8 +123,10 @@ function ftsRankedScopeUsable(db, scope) {
     }
     if (scope === "summaries") {
       if (!ftsTableUsable(db, "summaries_fts")) return false;
+      const columns = tableColumns(db, "summaries_fts");
+      if (!columns.includes("summary_id") || !columns.includes("content")) return false;
       db.prepare(
-        `SELECT s.summary_id
+        `SELECT s.summary_id, snippet(summaries_fts, 1, '', '', '...', 32) AS snippet
          FROM summaries_fts
          JOIN summaries s ON s.summary_id = summaries_fts.summary_id
          WHERE summaries_fts MATCH ?
@@ -279,7 +290,7 @@ function searchMessages(db, params) {
   const terms = mode === "full_text" ? likeTerms(query) : [];
   if (mode === "full_text" && terms.length === 0) return [];
 
-  if (mode === "full_text" && tableExists(db, "messages_fts")) {
+  if (mode === "full_text" && ftsRankedScopeUsable(db, "messages")) {
     try {
       const where = ["messages_fts MATCH ?", ...scope.where];
       const args = [sanitizeFts5Query(query), ...scope.args];
@@ -374,7 +385,7 @@ function searchSummaries(db, params) {
   const terms = mode === "full_text" ? likeTerms(query) : [];
   if (mode === "full_text" && terms.length === 0) return [];
 
-  if (mode === "full_text" && tableExists(db, "summaries_fts")) {
+  if (mode === "full_text" && ftsRankedScopeUsable(db, "summaries")) {
     try {
       const where = ["summaries_fts MATCH ?", ...scope.where];
       const args = [sanitizeFts5Query(query), ...scope.args];
@@ -794,6 +805,7 @@ const currentTools = [
         pattern: { type: "string" },
         mode: { type: "string", enum: ["regex", "full_text"], default: "regex" },
         scope: { type: "string", enum: ["messages", "summaries", "both"], default: "both" },
+        caseSensitive: { type: "boolean", default: false },
         limit: { type: "number", default: DEFAULT_LIMIT },
         scanLimit: { type: "number", default: DEFAULT_SCAN_LIMIT },
         conversationId: { type: "number" },
@@ -832,6 +844,7 @@ const currentTools = [
         maxDepth: { type: "number", default: 4 },
         maxNodes: { type: "number", default: DEFAULT_MAX_EXPAND_NODES },
         tokenCap: { type: "number", default: 24000 },
+        conversationId: { type: "number" },
       },
       additionalProperties: true,
     },
@@ -846,10 +859,14 @@ const currentTools = [
         prompt: { type: "string" },
         query: { type: "string" },
         summaryIds: { type: "array", items: { type: "string" } },
+        mode: { type: "string", enum: ["regex", "full_text"], default: "full_text" },
         seedLimit: { type: "number", default: 12 },
         tokenCap: { type: "number", default: 24000 },
         maxNodes: { type: "number", default: DEFAULT_MAX_EXPAND_NODES },
+        maxDepth: { type: "number", default: 4 },
         conversationId: { type: "number" },
+        since: { type: "string" },
+        before: { type: "string" },
       },
       additionalProperties: true,
     },

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -156,6 +156,8 @@ function orderBy(sort, createdExpr, rankExpr = "rank") {
       return `${rankExpr} ASC, ${createdExpr} DESC`;
     case "hybrid":
       return `(${rankExpr} / (1 + ((julianday('now') - julianday(${createdExpr})) * 24 * 0.001))) ASC, ${createdExpr} DESC`;
+    case "oldest":
+      return `${createdExpr} ASC`;
     default:
       return `${createdExpr} DESC`;
   }
@@ -166,7 +168,10 @@ function searchMessages(db, params) {
   if (!query) throw new Error("pattern is required.");
   const mode = params.mode === "full_text" ? "full_text" : "regex";
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  const sort = params.sort === "relevance" || params.sort === "hybrid" ? params.sort : "recency";
+  const sort =
+    params.sort === "relevance" || params.sort === "hybrid" || params.sort === "oldest"
+      ? params.sort
+      : "recency";
   const scope = buildScope(params, "m");
 
   if (mode === "full_text" && tableExists(db, "messages_fts")) {
@@ -230,7 +235,7 @@ function searchMessages(db, params) {
          m.created_at
        FROM messages m
        ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-       ORDER BY m.created_at DESC
+       ORDER BY ${sort === "oldest" ? "m.created_at ASC" : "m.created_at DESC"}
        LIMIT ?`,
     )
     .all(...args);
@@ -254,7 +259,10 @@ function searchSummaries(db, params) {
   if (!query) throw new Error("pattern is required.");
   const mode = params.mode === "full_text" ? "full_text" : "regex";
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  const sort = params.sort === "relevance" || params.sort === "hybrid" ? params.sort : "recency";
+  const sort =
+    params.sort === "relevance" || params.sort === "hybrid" || params.sort === "oldest"
+      ? params.sort
+      : "recency";
   const scope = buildScope(params, "s");
   const timeExpr = "COALESCE(s.latest_at, s.created_at)";
 
@@ -319,7 +327,7 @@ function searchSummaries(db, params) {
          ${timeExpr} AS created_at
        FROM summaries s
        ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-       ORDER BY ${timeExpr} DESC
+       ORDER BY ${sort === "oldest" ? `${timeExpr} ASC` : `${timeExpr} DESC`}
        LIMIT ?`,
     )
     .all(...args);
@@ -344,7 +352,11 @@ function lcmGrep(db, params) {
   if (scope === "messages" || scope === "both") results.push(...searchMessages(db, params));
   if (scope === "summaries" || scope === "both") results.push(...searchSummaries(db, params));
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  results.sort((a, b) => String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")));
+  if (params.sort === "oldest") {
+    results.sort((a, b) => String(a.created_at ?? "").localeCompare(String(b.created_at ?? "")));
+  } else {
+    results.sort((a, b) => String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")));
+  }
   return jsonTextResult({
     tool: "lcm_grep",
     databasePath: resolveDatabasePath(),
@@ -393,10 +405,33 @@ function describeFile(db, id) {
   return file ? { type: "file", ...file } : undefined;
 }
 
+function describeMessage(db, rawId) {
+  const id = rawId.startsWith("message:") ? rawId.slice("message:".length) : rawId;
+  const messageId = Number(id);
+  if (!Number.isInteger(messageId) || messageId <= 0) return undefined;
+  const message = db
+    .prepare(
+      `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
+       FROM messages WHERE message_id = ?`,
+    )
+    .get(messageId);
+  if (!message) return undefined;
+  const summaryIds = db
+    .prepare(`SELECT summary_id FROM summary_messages WHERE message_id = ? ORDER BY ordinal ASC`)
+    .all(messageId)
+    .map((row) => row.summary_id);
+  return { type: "message", ...message, summaryIds };
+}
+
 function lcmDescribe(db, params) {
   const id = readString(params.id);
   if (!id) throw new Error("id is required.");
-  const result = id.startsWith("file_") ? describeFile(db, id) : describeSummary(db, id);
+  const result =
+    id.startsWith("file_")
+      ? describeFile(db, id)
+      : id.startsWith("message:") || /^\d+$/.test(id)
+        ? describeMessage(db, id)
+        : describeSummary(db, id);
   if (!result) return jsonTextResult({ error: `Not found: ${id}` });
   if (params.conversationId != null && result.conversation_id !== Number(params.conversationId)) {
     return jsonTextResult({ error: `Not found in conversation ${params.conversationId}: ${id}` });
@@ -404,7 +439,10 @@ function lcmDescribe(db, params) {
   return jsonTextResult({
     tool: "lcm_describe",
     item: result,
-    note: "This is source evidence. Use expand for subtree context.",
+    note:
+      result.type === "message"
+        ? "This is a source message. Use linked summary IDs for broader context."
+        : "This is source evidence. Use expand for subtree context.",
   });
 }
 
@@ -531,7 +569,7 @@ const currentTools = [
         conversationId: { type: "number" },
         since: { type: "string" },
         before: { type: "string" },
-        sort: { type: "string", enum: ["recency", "relevance", "hybrid"], default: "recency" },
+        sort: { type: "string", enum: ["recency", "relevance", "hybrid", "oldest"], default: "recency" },
       },
       required: ["pattern"],
       additionalProperties: true,
@@ -540,7 +578,7 @@ const currentTools = [
   },
   {
     name: "lcm_describe",
-    description: "Describe one LCM summary or file ID from the local database.",
+    description: "Describe one LCM summary, message, or file ID from the local database.",
     inputSchema: {
       type: "object",
       properties: {

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -931,7 +931,7 @@ class McpServer {
     try {
       if (message.method === "initialize") {
         this.respond(message.id, {
-          protocolVersion: message.params?.protocolVersion ?? "2024-11-05",
+          protocolVersion: "2024-11-05",
           capabilities: { tools: {} },
           serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         });

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -11,6 +11,11 @@ const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 200;
 const DEFAULT_SCAN_LIMIT = 5_000;
 const MAX_EXPAND_TOKENS = 120_000;
+const MAX_SUMMARY_IDS = 20;
+const DEFAULT_MAX_EXPAND_NODES = 200;
+const MAX_EXPAND_NODES = 1_000;
+const DEFAULT_DESCRIBE_CHARS = 24_000;
+const MAX_DESCRIBE_CHARS = 120_000;
 
 function textResult(text, details = undefined) {
   return {
@@ -39,6 +44,13 @@ function parseDateParam(value, name) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) throw new Error(`${name} must be a valid ISO timestamp.`);
   return date.toISOString();
+}
+
+function readPositiveInt(value, name) {
+  if (value == null) return undefined;
+  const id = Number(value);
+  if (!Number.isInteger(id) || id <= 0) throw new Error(`${name} must be a positive integer.`);
+  return id;
 }
 
 function resolveOpenclawStateDir(env = process.env) {
@@ -78,6 +90,36 @@ function requiredSchema(db) {
   const missing = required.filter((name) => !tableExists(db, name));
   if (missing.length > 0) {
     throw new Error(`LCM database is missing required tables: ${missing.join(", ")}`);
+  }
+  const requiredColumns = {
+    messages: ["message_id", "conversation_id", "seq", "role", "content", "token_count", "created_at"],
+    summaries: [
+      "summary_id",
+      "conversation_id",
+      "kind",
+      "depth",
+      "content",
+      "token_count",
+      "file_ids",
+      "earliest_at",
+      "latest_at",
+      "descendant_count",
+      "descendant_token_count",
+      "source_message_token_count",
+      "model",
+      "created_at",
+    ],
+    summary_parents: ["summary_id", "parent_summary_id", "ordinal"],
+    summary_messages: ["summary_id", "message_id", "ordinal"],
+  };
+  for (const [table, columns] of Object.entries(requiredColumns)) {
+    const existing = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name));
+    const missingColumns = columns.filter((column) => !existing.has(column));
+    if (missingColumns.length > 0) {
+      throw new Error(
+        `LCM database table ${table} is missing required columns: ${missingColumns.join(", ")}. Run lossless-claw migrations before using Lossless Codex.`,
+      );
+    }
   }
 }
 
@@ -137,8 +179,7 @@ function buildScope(params, alias = "") {
   const where = [];
   const args = [];
   if (params.conversationId != null) {
-    const id = Number(params.conversationId);
-    if (!Number.isInteger(id) || id <= 0) throw new Error("conversationId must be a positive integer.");
+    const id = readPositiveInt(params.conversationId, "conversationId");
     where.push(`${prefix}conversation_id = ?`);
     args.push(id);
   }
@@ -167,6 +208,15 @@ function normalizeSort(sort) {
   return sort === "relevance" || sort === "hybrid" || sort === "oldest" ? sort : "recency";
 }
 
+function compileSafeRegex(pattern, caseSensitive) {
+  if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) return undefined;
+  try {
+    return new RegExp(pattern, caseSensitive === true ? "" : "i");
+  } catch {
+    return undefined;
+  }
+}
+
 function searchMessages(db, params) {
   const query = readString(params.pattern ?? params.query);
   if (!query) throw new Error("pattern is required.");
@@ -174,37 +224,43 @@ function searchMessages(db, params) {
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
   const sort = normalizeSort(params.sort);
   const scope = buildScope(params, "m");
+  const regex = mode === "regex" ? compileSafeRegex(query, params.caseSensitive) : undefined;
+  if (mode === "regex" && !regex) return [];
 
   if (mode === "full_text" && tableExists(db, "messages_fts")) {
-    const where = ["messages_fts MATCH ?", ...scope.where];
-    const args = [sanitizeFts5Query(query), ...scope.args];
-    if (scope.since) {
-      where.push("julianday(m.created_at) >= julianday(?)");
-      args.push(scope.since);
+    try {
+      const where = ["messages_fts MATCH ?", ...scope.where];
+      const args = [sanitizeFts5Query(query), ...scope.args];
+      if (scope.since) {
+        where.push("julianday(m.created_at) >= julianday(?)");
+        args.push(scope.since);
+      }
+      if (scope.before) {
+        where.push("julianday(m.created_at) < julianday(?)");
+        args.push(scope.before);
+      }
+      args.push(limit);
+      return db
+        .prepare(
+          `SELECT
+             'message:' || m.message_id AS id,
+             m.message_id,
+             m.conversation_id,
+             m.role AS kind,
+             snippet(messages_fts, 0, '', '', '...', 32) AS snippet,
+             m.created_at,
+             rank
+           FROM messages_fts
+           JOIN messages m ON m.message_id = messages_fts.rowid
+           WHERE ${where.join(" AND ")}
+           ORDER BY ${orderBy(sort, "m.created_at")}
+           LIMIT ?`,
+        )
+        .all(...args)
+        .map((row) => ({ type: "message", ...row }));
+    } catch {
+      // Stale or malformed copied FTS tables should not make read-only recall unusable.
     }
-    if (scope.before) {
-      where.push("julianday(m.created_at) < julianday(?)");
-      args.push(scope.before);
-    }
-    args.push(limit);
-    return db
-      .prepare(
-        `SELECT
-           'message:' || m.message_id AS id,
-           m.message_id,
-           m.conversation_id,
-           m.role AS kind,
-           snippet(messages_fts, 0, '', '', '...', 32) AS snippet,
-           m.created_at,
-           rank
-         FROM messages_fts
-         JOIN messages m ON m.message_id = messages_fts.rowid
-         WHERE ${where.join(" AND ")}
-         ORDER BY ${orderBy(sort, "m.created_at")}
-         LIMIT ?`,
-      )
-      .all(...args)
-      .map((row) => ({ type: "message", ...row }));
   }
 
   const terms = mode === "full_text" ? likeTerms(query) : [];
@@ -240,7 +296,6 @@ function searchMessages(db, params) {
        LIMIT ?`,
     )
     .all(...args);
-  const regex = mode === "regex" ? new RegExp(query, params.caseSensitive === true ? "" : "i") : undefined;
   return rows
     .filter((row) => (regex ? regex.test(String(row.content ?? "")) : true))
     .slice(0, limit)
@@ -263,37 +318,43 @@ function searchSummaries(db, params) {
   const sort = normalizeSort(params.sort);
   const scope = buildScope(params, "s");
   const timeExpr = "COALESCE(s.latest_at, s.created_at)";
+  const regex = mode === "regex" ? compileSafeRegex(query, params.caseSensitive) : undefined;
+  if (mode === "regex" && !regex) return [];
 
   if (mode === "full_text" && tableExists(db, "summaries_fts")) {
-    const where = ["summaries_fts MATCH ?", ...scope.where];
-    const args = [sanitizeFts5Query(query), ...scope.args];
-    if (scope.since) {
-      where.push(`julianday(${timeExpr}) >= julianday(?)`);
-      args.push(scope.since);
+    try {
+      const where = ["summaries_fts MATCH ?", ...scope.where];
+      const args = [sanitizeFts5Query(query), ...scope.args];
+      if (scope.since) {
+        where.push(`julianday(${timeExpr}) >= julianday(?)`);
+        args.push(scope.since);
+      }
+      if (scope.before) {
+        where.push(`julianday(${timeExpr}) < julianday(?)`);
+        args.push(scope.before);
+      }
+      args.push(limit);
+      return db
+        .prepare(
+          `SELECT
+             s.summary_id AS id,
+             s.summary_id,
+             s.conversation_id,
+             s.kind,
+             snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
+             ${timeExpr} AS created_at,
+             rank
+           FROM summaries_fts
+           JOIN summaries s ON s.summary_id = summaries_fts.summary_id
+           WHERE ${where.join(" AND ")}
+           ORDER BY ${orderBy(sort, timeExpr)}
+           LIMIT ?`,
+        )
+        .all(...args)
+        .map((row) => ({ type: "summary", ...row }));
+    } catch {
+      // Stale or malformed copied FTS tables should fall back to escaped LIKE search.
     }
-    if (scope.before) {
-      where.push(`julianday(${timeExpr}) < julianday(?)`);
-      args.push(scope.before);
-    }
-    args.push(limit);
-    return db
-      .prepare(
-        `SELECT
-           s.summary_id AS id,
-           s.summary_id,
-           s.conversation_id,
-           s.kind,
-           snippet(summaries_fts, 1, '', '', '...', 32) AS snippet,
-           ${timeExpr} AS created_at,
-           rank
-         FROM summaries_fts
-         JOIN summaries s ON s.summary_id = summaries_fts.summary_id
-         WHERE ${where.join(" AND ")}
-         ORDER BY ${orderBy(sort, timeExpr)}
-         LIMIT ?`,
-      )
-      .all(...args)
-      .map((row) => ({ type: "summary", ...row }));
   }
 
   const terms = mode === "full_text" ? likeTerms(query) : [];
@@ -329,7 +390,6 @@ function searchSummaries(db, params) {
        LIMIT ?`,
     )
     .all(...args);
-  const regex = mode === "regex" ? new RegExp(query, params.caseSensitive === true ? "" : "i") : undefined;
   return rows
     .filter((row) => (regex ? regex.test(String(row.content ?? "")) : true))
     .slice(0, limit)
@@ -432,6 +492,7 @@ function describeMessage(db, rawId) {
 function lcmDescribe(db, params) {
   const id = readString(params.id);
   if (!id) throw new Error("id is required.");
+  const maxChars = clampInt(params.maxChars, DEFAULT_DESCRIBE_CHARS, 1_000, MAX_DESCRIBE_CHARS);
   const result =
     id.startsWith("file_")
       ? describeFile(db, id)
@@ -452,9 +513,19 @@ function lcmDescribe(db, params) {
       hint: "The ID exists outside the requested conversation or does not exist.",
     });
   }
+  const bounded = { ...result };
+  for (const field of ["content", "exploration_summary"]) {
+    if (typeof bounded[field] === "string") {
+      const truncated = truncateChars(bounded[field], maxChars);
+      bounded[field] = truncated.text;
+      bounded[`${field}_truncated`] = truncated.truncated;
+      bounded[`${field}_original_length`] = truncated.originalLength;
+    }
+  }
   return jsonTextResult({
     tool: "lcm_describe",
-    item: result,
+    maxChars,
+    item: bounded,
     note:
       result.type === "message"
         ? "This is a source message. Use linked summary IDs for broader context."
@@ -472,19 +543,31 @@ function truncateTokens(text, maxTokens) {
   return value.length <= maxChars ? value : `${value.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n...(truncated)`;
 }
 
+function truncateChars(text, maxChars) {
+  const value = String(text ?? "");
+  if (value.length <= maxChars) return { text: value, truncated: false, originalLength: value.length };
+  return {
+    text: `${value.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n...(truncated)`,
+    truncated: true,
+    originalLength: value.length,
+  };
+}
+
 function expandSummary(db, summaryId, options = {}) {
   const maxDepth = clampInt(options.maxDepth, 4, 0, 24);
+  const maxNodes = clampInt(options.maxNodes, DEFAULT_MAX_EXPAND_NODES, 1, MAX_EXPAND_NODES);
+  const conversationId = readPositiveInt(options.conversationId, "conversationId");
   const rows = db
     .prepare(
       `WITH RECURSIVE subtree(summary_id, parent_summary_id, depth_from_root, path) AS (
          SELECT ?, NULL, 0, ''
          UNION ALL
-         SELECT sp.summary_id, sp.parent_summary_id, subtree.depth_from_root + 1,
+         SELECT sp.parent_summary_id, sp.summary_id, subtree.depth_from_root + 1,
                 CASE WHEN subtree.path = '' THEN printf('%04d', sp.ordinal)
                      ELSE subtree.path || '.' || printf('%04d', sp.ordinal)
                 END
          FROM summary_parents sp
-         JOIN subtree ON sp.parent_summary_id = subtree.summary_id
+         JOIN subtree ON sp.summary_id = subtree.summary_id
          WHERE subtree.depth_from_root < ?
        )
        SELECT s.summary_id, s.conversation_id, s.kind, s.depth, s.content, s.token_count,
@@ -492,10 +575,37 @@ function expandSummary(db, summaryId, options = {}) {
               subtree.parent_summary_id, subtree.path
        FROM subtree
        JOIN summaries s ON s.summary_id = subtree.summary_id
-       ORDER BY subtree.depth_from_root ASC, subtree.path ASC, s.created_at ASC`,
+       WHERE (? IS NULL OR s.conversation_id = ?)
+       ORDER BY subtree.depth_from_root ASC, subtree.path ASC, s.created_at ASC
+       LIMIT ?`,
     )
-    .all(summaryId, maxDepth);
+    .all(summaryId, maxDepth, conversationId ?? null, conversationId ?? null, maxNodes);
   return rows;
+}
+
+function getSummaryConversationId(db, summaryId) {
+  const row = db.prepare("SELECT conversation_id FROM summaries WHERE summary_id = ?").get(summaryId);
+  return row?.conversation_id;
+}
+
+function getSummaryIdsForMessageHits(db, messageHits, conversationId, limit) {
+  const messageIds = messageHits
+    .map((row) => row.message_id)
+    .filter((id) => Number.isInteger(id) && id > 0);
+  if (messageIds.length === 0) return [];
+  const placeholders = messageIds.map(() => "?").join(", ");
+  return db
+    .prepare(
+      `SELECT DISTINCT sm.summary_id, s.created_at
+       FROM summary_messages sm
+       JOIN summaries s ON s.summary_id = sm.summary_id
+       WHERE s.conversation_id = ?
+         AND sm.message_id IN (${placeholders})
+       ORDER BY s.created_at DESC
+       LIMIT ?`,
+    )
+    .all(conversationId, ...messageIds, limit)
+    .map((row) => row.summary_id);
 }
 
 function lcmExpand(db, params) {
@@ -504,12 +614,25 @@ function lcmExpand(db, params) {
     : readString(params.summaryId)
       ? [readString(params.summaryId)]
       : [];
-  const summaryIds = rawIds.filter((id) => typeof id === "string" && id.trim()).map((id) => id.trim());
+  const summaryIds = rawIds
+    .filter((id) => typeof id === "string" && id.trim())
+    .map((id) => id.trim())
+    .slice(0, MAX_SUMMARY_IDS);
   if (summaryIds.length === 0) throw new Error("summaryId or summaryIds is required.");
   const tokenCap = clampInt(params.tokenCap, 24_000, 1_000, MAX_EXPAND_TOKENS);
+  const conversationId = readPositiveInt(params.conversationId, "conversationId");
   const expanded = [];
   let rendered = "";
   for (const id of summaryIds) {
+    const rootConversationId = getSummaryConversationId(db, id);
+    if (rootConversationId == null) {
+      expanded.push({ summaryId: id, error: "not found" });
+      continue;
+    }
+    if (conversationId != null && rootConversationId !== conversationId) {
+      expanded.push({ summaryId: id, error: `not found in conversation ${conversationId}` });
+      continue;
+    }
     const rows = expandSummary(db, id, params);
     if (rows.length === 0) {
       expanded.push({ summaryId: id, error: "not found" });
@@ -521,7 +644,7 @@ function lcmExpand(db, params) {
       const block = `${header}\n${row.content ?? ""}`.trim();
       if (estimateTokens(`${rendered}\n\n${block}`) > tokenCap) {
         items.push({ summaryId: row.summary_id, omitted: true, reason: "tokenCap" });
-        continue;
+        break;
       }
       rendered += `${rendered ? "\n\n" : ""}${block}`;
       items.push(row);
@@ -532,6 +655,7 @@ function lcmExpand(db, params) {
     tool: "lcm_expand",
     summaryIds,
     tokenCap,
+    maxNodes: clampInt(params.maxNodes, DEFAULT_MAX_EXPAND_NODES, 1, MAX_EXPAND_NODES),
     text: truncateTokens(rendered, tokenCap),
     expanded,
     note: "Read-only Codex expansion. Use the returned source IDs as evidence anchors.",
@@ -553,6 +677,20 @@ function lcmExpandQuery(db, params) {
       limit: clampInt(params.seedLimit, 12, 1, 50),
     });
     summaryIds = matches.map((row) => row.summary_id).filter(Boolean);
+    if (summaryIds.length === 0 && params.conversationId != null) {
+      const messageHits = searchMessages(db, {
+        ...params,
+        pattern: query,
+        mode: params.mode === "regex" ? "regex" : "full_text",
+        limit: clampInt(params.seedLimit, 12, 1, 50),
+      });
+      summaryIds = getSummaryIdsForMessageHits(
+        db,
+        messageHits,
+        readPositiveInt(params.conversationId, "conversationId"),
+        clampInt(params.seedLimit, 12, 1, 50),
+      );
+    }
   }
   if (summaryIds.length === 0) {
     return jsonTextResult({ tool: "lcm_expand_query", prompt, query, summaryIds: [], text: "", note: "No seed summaries matched." });
@@ -600,6 +738,7 @@ const currentTools = [
       properties: {
         id: { type: "string" },
         conversationId: { type: "number" },
+        maxChars: { type: "number", default: DEFAULT_DESCRIBE_CHARS },
       },
       required: ["id"],
       additionalProperties: true,
@@ -615,6 +754,7 @@ const currentTools = [
         summaryId: { type: "string" },
         summaryIds: { type: "array", items: { type: "string" } },
         maxDepth: { type: "number", default: 4 },
+        maxNodes: { type: "number", default: DEFAULT_MAX_EXPAND_NODES },
         tokenCap: { type: "number", default: 24000 },
       },
       additionalProperties: true,
@@ -632,6 +772,7 @@ const currentTools = [
         summaryIds: { type: "array", items: { type: "string" } },
         seedLimit: { type: "number", default: 12 },
         tokenCap: { type: "number", default: 24000 },
+        maxNodes: { type: "number", default: DEFAULT_MAX_EXPAND_NODES },
         conversationId: { type: "number" },
       },
       additionalProperties: true,

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -163,15 +163,16 @@ function orderBy(sort, createdExpr, rankExpr = "rank") {
   }
 }
 
+function normalizeSort(sort) {
+  return sort === "relevance" || sort === "hybrid" || sort === "oldest" ? sort : "recency";
+}
+
 function searchMessages(db, params) {
   const query = readString(params.pattern ?? params.query);
   if (!query) throw new Error("pattern is required.");
   const mode = params.mode === "full_text" ? "full_text" : "regex";
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  const sort =
-    params.sort === "relevance" || params.sort === "hybrid" || params.sort === "oldest"
-      ? params.sort
-      : "recency";
+  const sort = normalizeSort(params.sort);
   const scope = buildScope(params, "m");
 
   if (mode === "full_text" && tableExists(db, "messages_fts")) {
@@ -259,10 +260,7 @@ function searchSummaries(db, params) {
   if (!query) throw new Error("pattern is required.");
   const mode = params.mode === "full_text" ? "full_text" : "regex";
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  const sort =
-    params.sort === "relevance" || params.sort === "hybrid" || params.sort === "oldest"
-      ? params.sort
-      : "recency";
+  const sort = normalizeSort(params.sort);
   const scope = buildScope(params, "s");
   const timeExpr = "COALESCE(s.latest_at, s.created_at)";
 
@@ -346,22 +344,30 @@ function searchSummaries(db, params) {
     }));
 }
 
-function lcmGrep(db, params) {
+function lcmGrep(db, params, context = {}) {
   const scope = params.scope === "messages" || params.scope === "summaries" ? params.scope : "both";
+  const requestedSort = normalizeSort(params.sort);
+  const effectiveSort =
+    scope === "both" && (requestedSort === "relevance" || requestedSort === "hybrid")
+      ? "recency"
+      : requestedSort;
+  const searchParams = effectiveSort === requestedSort ? params : { ...params, sort: effectiveSort };
   const results = [];
-  if (scope === "messages" || scope === "both") results.push(...searchMessages(db, params));
-  if (scope === "summaries" || scope === "both") results.push(...searchSummaries(db, params));
+  if (scope === "messages" || scope === "both") results.push(...searchMessages(db, searchParams));
+  if (scope === "summaries" || scope === "both") results.push(...searchSummaries(db, searchParams));
   const limit = clampInt(params.limit, DEFAULT_LIMIT, 1, MAX_LIMIT);
-  if (params.sort === "oldest") {
+  if (effectiveSort === "oldest") {
     results.sort((a, b) => String(a.created_at ?? "").localeCompare(String(b.created_at ?? "")));
-  } else {
+  } else if (effectiveSort === "recency" || scope === "both") {
     results.sort((a, b) => String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")));
   }
   return jsonTextResult({
     tool: "lcm_grep",
-    databasePath: resolveDatabasePath(),
+    databasePath: context.databasePath ?? resolveDatabasePath(),
     mode: params.mode === "full_text" ? "full_text" : "regex",
     scope,
+    requestedSort,
+    sort: effectiveSort,
     count: Math.min(results.length, limit),
     results: results.slice(0, limit),
     note: "Codex LCM Reader is read-only and bounded. Expand IDs before treating snippets as proof.",
@@ -432,9 +438,19 @@ function lcmDescribe(db, params) {
       : id.startsWith("message:") || /^\d+$/.test(id)
         ? describeMessage(db, id)
         : describeSummary(db, id);
-  if (!result) return jsonTextResult({ error: `Not found: ${id}` });
+  if (!result) {
+    return jsonTextResult({
+      tool: "lcm_describe",
+      error: `Not found: ${id}`,
+      hint: "Expected a summary ID like sum_..., a message:<id> or numeric message ID, or a file_... ID.",
+    });
+  }
   if (params.conversationId != null && result.conversation_id !== Number(params.conversationId)) {
-    return jsonTextResult({ error: `Not found in conversation ${params.conversationId}: ${id}` });
+    return jsonTextResult({
+      tool: "lcm_describe",
+      error: `Not found in conversation ${params.conversationId}: ${id}`,
+      hint: "The ID exists outside the requested conversation or does not exist.",
+    });
   }
   return jsonTextResult({
     tool: "lcm_describe",
@@ -631,11 +647,12 @@ export function createTools() {
 export async function callTool(name, args, options = {}) {
   const tool = createTools().find((entry) => entry.name === name);
   if (!tool) throw new Error(`Unknown tool: ${name}`);
-  const db = options.db ?? openReadOnlyDatabase(options.dbPath);
+  const databasePath = options.dbPath ? resolve(options.dbPath) : resolveDatabasePath();
+  const db = options.db ?? openReadOnlyDatabase(databasePath);
   const shouldClose = !options.db;
   try {
     requiredSchema(db);
-    return await tool.handler(db, args ?? {});
+    return await tool.handler(db, args ?? {}, { databasePath });
   } finally {
     if (shouldClose) db.close();
   }

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 
 const SERVER_NAME = "codex-lcm-reader";
@@ -678,7 +678,15 @@ class McpServer {
   }
 }
 
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
-if (isMain) {
+function isEntrypoint() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+  }
+}
+
+if (isEntrypoint()) {
   new McpServer().start();
 }

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -209,7 +209,13 @@ function normalizeSort(sort) {
 }
 
 function compileSafeRegex(pattern, caseSensitive) {
-  if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) return undefined;
+  if (
+    pattern.length > 500 ||
+    /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern) ||
+    /\([^)]*\|[^)]*\)(\+|\*|\{\d)/.test(pattern)
+  ) {
+    return undefined;
+  }
   try {
     return new RegExp(pattern, caseSensitive === true ? "" : "i");
   } catch {
@@ -226,6 +232,8 @@ function searchMessages(db, params) {
   const scope = buildScope(params, "m");
   const regex = mode === "regex" ? compileSafeRegex(query, params.caseSensitive) : undefined;
   if (mode === "regex" && !regex) return [];
+  const terms = mode === "full_text" ? likeTerms(query) : [];
+  if (mode === "full_text" && terms.length === 0) return [];
 
   if (mode === "full_text" && tableExists(db, "messages_fts")) {
     try {
@@ -263,7 +271,6 @@ function searchMessages(db, params) {
     }
   }
 
-  const terms = mode === "full_text" ? likeTerms(query) : [];
   const where = [...scope.where];
   const args = [...scope.args];
   if (scope.since) {
@@ -320,6 +327,8 @@ function searchSummaries(db, params) {
   const timeExpr = "COALESCE(s.latest_at, s.created_at)";
   const regex = mode === "regex" ? compileSafeRegex(query, params.caseSensitive) : undefined;
   if (mode === "regex" && !regex) return [];
+  const terms = mode === "full_text" ? likeTerms(query) : [];
+  if (mode === "full_text" && terms.length === 0) return [];
 
   if (mode === "full_text" && tableExists(db, "summaries_fts")) {
     try {
@@ -357,7 +366,6 @@ function searchSummaries(db, params) {
     }
   }
 
-  const terms = mode === "full_text" ? likeTerms(query) : [];
   const where = [...scope.where];
   const args = [...scope.args];
   if (scope.since) {

--- a/plugins/codex-lcm-reader/scripts/mcp-server.mjs
+++ b/plugins/codex-lcm-reader/scripts/mcp-server.mjs
@@ -85,6 +85,18 @@ function tableExists(db, tableName) {
   return !!row;
 }
 
+function ftsTableUsable(db, tableName) {
+  if (!tableExists(db, tableName)) return false;
+  try {
+    db.prepare(`SELECT rowid FROM ${tableName} WHERE ${tableName} MATCH ? LIMIT 1`).all(
+      '"__lossless_codex_probe_no_hit__"',
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function requiredSchema(db) {
   const required = ["conversations", "messages", "summaries", "summary_parents", "summary_messages"];
   const missing = required.filter((name) => !tableExists(db, name));
@@ -415,8 +427,14 @@ function searchSummaries(db, params) {
 function lcmGrep(db, params, context = {}) {
   const scope = params.scope === "messages" || params.scope === "summaries" ? params.scope : "both";
   const requestedSort = normalizeSort(params.sort);
+  const mode = params.mode === "full_text" ? "full_text" : "regex";
+  const rankedScopeAvailable =
+    mode === "full_text" &&
+    scope !== "both" &&
+    ((scope === "messages" && ftsTableUsable(db, "messages_fts")) ||
+      (scope === "summaries" && ftsTableUsable(db, "summaries_fts")));
   const effectiveSort =
-    scope === "both" && (requestedSort === "relevance" || requestedSort === "hybrid")
+    (requestedSort === "relevance" || requestedSort === "hybrid") && !rankedScopeAvailable
       ? "recency"
       : requestedSort;
   const searchParams = effectiveSort === requestedSort ? params : { ...params, sort: effectiveSort };
@@ -432,7 +450,7 @@ function lcmGrep(db, params, context = {}) {
   return jsonTextResult({
     tool: "lcm_grep",
     databasePath: context.databasePath ?? resolveDatabasePath(),
-    mode: params.mode === "full_text" ? "full_text" : "regex",
+    mode,
     scope,
     requestedSort,
     sort: effectiveSort,
@@ -514,10 +532,11 @@ function lcmDescribe(db, params) {
       hint: "Expected a summary ID like sum_..., a message:<id> or numeric message ID, or a file_... ID.",
     });
   }
-  if (params.conversationId != null && result.conversation_id !== Number(params.conversationId)) {
+  const conversationId = readPositiveInt(params.conversationId, "conversationId");
+  if (conversationId != null && result.conversation_id !== conversationId) {
     return jsonTextResult({
       tool: "lcm_describe",
-      error: `Not found in conversation ${params.conversationId}: ${id}`,
+      error: `Not found in conversation ${conversationId}: ${id}`,
       hint: "The ID exists outside the requested conversation or does not exist.",
     });
   }
@@ -703,6 +722,7 @@ function lcmExpandQuery(db, params) {
   if (summaryIds.length === 0) {
     return jsonTextResult({ tool: "lcm_expand_query", prompt, query, summaryIds: [], text: "", note: "No seed summaries matched." });
   }
+  summaryIds = summaryIds.slice(0, MAX_SUMMARY_IDS);
   const expansion = lcmExpand(db, { ...params, summaryIds });
   const details = expansion.structuredContent;
   return jsonTextResult({
@@ -814,7 +834,7 @@ class McpServer {
 
   start() {
     process.stdin.on("data", (chunk) => this.onData(chunk));
-    process.stdin.on("end", () => process.exit(0));
+    process.stdin.resume();
   }
 
   onData(chunk) {

--- a/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
+++ b/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: codex-lcm-reader
+description: Use when Codex should inspect local OpenClaw/lossless-claw LCM memory through read-only tools. Search and expand evidence from the local SQLite database without mutating OpenClaw state.
+---
+
+# Codex LCM Reader
+
+Use this plugin when a task needs prior OpenClaw conversation context stored in the local lossless-claw LCM database.
+
+The tools are read-only and bounded. They do not run LCM maintenance, write rollups, mutate OpenClaw task state, or write Cortex memory.
+
+## Tool Routing
+
+- Use `lcm_grep` for keyword, phrase, topic, path, error, PR number, or identifier discovery.
+- Use `lcm_describe` when you already have a `sum_...` or `file_...` ID and need cheap inspection.
+- Use `lcm_expand` to expand a known summary subtree into source evidence.
+- Use `lcm_expand_query` when you have either summary IDs or a short query and want an evidence bundle to answer from.
+
+## Proof Rule
+
+LCM output is evidence, not authority. Verify exact claims such as commands, SHAs, file paths, timestamps, root cause, and shipped status against source evidence or the relevant external authority before asserting them.
+
+## Database Path
+
+The MCP server reads `LCM_CODEX_DB_PATH` first, then `LCM_DATABASE_PATH`, then defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`.
+
+Prefer pointing `LCM_CODEX_DB_PATH` at a copied database for production rehearsal or destructive experiments. The server opens SQLite in read-only mode and sets `PRAGMA query_only = ON`.

--- a/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
+++ b/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
@@ -11,8 +11,8 @@ The tools are read-only and bounded. They do not run LCM maintenance, write roll
 
 ## Tool Routing
 
-- Use `lcm_grep` for keyword, phrase, topic, path, error, PR number, or identifier discovery.
-- Use `lcm_describe` when you already have a `sum_...` or `file_...` ID and need cheap inspection.
+- Use `lcm_grep` for keyword, phrase, topic, path, error, PR number, or identifier discovery. Use `sort: "oldest"` when the user asks when something first appeared.
+- Use `lcm_describe` when you already have a `sum_...`, `message:<id>`, numeric message ID, or `file_...` ID and need cheap inspection.
 - Use `lcm_expand` to expand a known summary subtree into source evidence.
 - Use `lcm_expand_query` when you have either summary IDs or a short query and want an evidence bundle to answer from.
 

--- a/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
+++ b/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
@@ -3,9 +3,9 @@ name: codex-lcm-reader
 description: Use when Codex should inspect local OpenClaw/lossless-claw LCM memory through read-only tools. Search and expand evidence from the local SQLite database without mutating OpenClaw state.
 ---
 
-# Codex LCM Reader
+# Lossless Codex
 
-Use this plugin when a task needs prior OpenClaw conversation context stored in the local lossless-claw LCM database.
+Use this plugin when a task needs prior OpenClaw conversation context stored in the local lossless-claw LCM database. The user-facing plugin name is Lossless Codex; the package folder remains `codex-lcm-reader`.
 
 The tools are read-only and bounded. They do not run LCM maintenance, write rollups, mutate OpenClaw task state, or write Cortex memory.
 
@@ -22,6 +22,6 @@ LCM output is evidence, not authority. Verify exact claims such as commands, SHA
 
 ## Database Path
 
-The MCP server reads `LCM_CODEX_DB_PATH` first, then `LCM_DATABASE_PATH`, then defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`.
+The MCP server reads `LCM_CODEX_DB_PATH` first, then `LCM_DATABASE_PATH`, then `LOSSLESS_CLAW_DB_PATH`, then `OPENCLAW_LCM_DB_PATH`, and finally defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`.
 
 Prefer pointing `LCM_CODEX_DB_PATH` at a copied database for production rehearsal or destructive experiments. The server opens SQLite in read-only mode and sets `PRAGMA query_only = ON`.

--- a/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
+++ b/plugins/codex-lcm-reader/skills/codex-lcm-reader/SKILL.md
@@ -5,9 +5,11 @@ description: Use when Codex should inspect local OpenClaw/lossless-claw LCM memo
 
 # Lossless Codex
 
-Use this plugin when a task needs prior OpenClaw conversation context stored in the local lossless-claw LCM database. The user-facing plugin name is Lossless Codex; the package folder remains `codex-lcm-reader`.
+Use this plugin when a task needs prior OpenClaw conversation context stored in the local lossless-claw LCM database and the user has asked for memory/previous-context recall or clearly consented to using local memory. The user-facing plugin name is Lossless Codex; the package folder remains `codex-lcm-reader`.
 
 The tools are read-only and bounded. They do not run LCM maintenance, write rollups, mutate OpenClaw task state, or write Cortex memory.
+
+Do not search all local LCM memory for unrelated repo/path/error questions by default. Prefer repo, time, keyword, or `conversationId` filters when the user gives them, and say when a broad all-conversation search was needed.
 
 ## Tool Routing
 

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -179,9 +179,25 @@ describe("Codex LCM Reader plugin", () => {
     );
 
     expect(result.structuredContent?.tool).toBe("lcm_grep");
+    expect(result.structuredContent?.databasePath).toBe(fixture.dbPath);
     const results = result.structuredContent?.results as Array<{ type: string; id: string }>;
     expect(results.some((row) => row.type === "message")).toBe(true);
     expect(results.some((row) => row.type === "summary")).toBe(true);
+  });
+
+  it("reports effective sort when merged message and summary relevance cannot be compared", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "Lexar", mode: "full_text", scope: "both", sort: "relevance", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.requestedSort).toBe("relevance");
+    expect(result.structuredContent?.sort).toBe("recency");
   });
 
   it("can sort grep results oldest-first for first-occurrence discovery", async () => {
@@ -248,6 +264,22 @@ describe("Codex LCM Reader plugin", () => {
     expect(item.message_id).toBe(fixture.firstMessageId);
     expect(item.content).toContain("Lexar drive");
     expect(item.summaryIds).toEqual(["sum_codex_reader_child"]);
+  });
+
+  it("returns structured describe errors with tool and ID-format hints", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_describe",
+      { id: "sum_missing" },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.tool).toBe("lcm_describe");
+    expect(result.structuredContent?.error).toContain("sum_missing");
+    expect(result.structuredContent?.hint).toContain("message:<id>");
   });
 
   it("expands a summary subtree without mutating state", async () => {

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -49,7 +49,7 @@ async function createLcmFixture() {
       conversationId: conversation.conversationId,
       seq: 0,
       role: "user",
-      content: "We recovered the Lexar drive and audited the LCM plugin idea.",
+      content: `We recovered the Lexar drive and audited the LCM plugin idea. ${"x".repeat(1500)}`,
       tokenCount: 16,
     },
     {
@@ -87,9 +87,7 @@ async function createLcmFixture() {
     firstMessage.messageId,
     secondMessage.messageId,
   ]);
-  await summaryStore.linkSummaryToParents("sum_codex_reader_child", [
-    "sum_codex_reader_parent",
-  ]);
+  await summaryStore.linkSummaryToParents("sum_codex_reader_parent", ["sum_codex_reader_child"]);
   db.prepare("UPDATE messages SET created_at = ? WHERE message_id = ?").run(
     "2026-04-29T10:00:00.000Z",
     firstMessage.messageId,
@@ -107,6 +105,31 @@ async function createLcmFixture() {
     firstMessageId: firstMessage.messageId,
     secondMessageId: secondMessage.messageId,
   };
+}
+
+async function createLegacyLcmFixture() {
+  const tempDir = mkdtempSync(join(tmpdir(), "codex-lcm-reader-legacy-"));
+  const dbPath = join(tempDir, "lcm.db");
+  const db = createLcmDatabaseConnection(dbPath);
+  db.exec(`
+    CREATE TABLE conversations (conversation_id INTEGER PRIMARY KEY, session_id TEXT);
+    CREATE TABLE messages (
+      message_id INTEGER PRIMARY KEY,
+      conversation_id INTEGER,
+      content TEXT,
+      created_at TEXT
+    );
+    CREATE TABLE summaries (
+      summary_id TEXT PRIMARY KEY,
+      conversation_id INTEGER,
+      content TEXT,
+      created_at TEXT
+    );
+    CREATE TABLE summary_parents (summary_id TEXT, parent_summary_id TEXT);
+    CREATE TABLE summary_messages (summary_id TEXT, message_id INTEGER);
+  `);
+  closeLcmConnection(dbPath);
+  return { tempDir, dbPath };
 }
 
 function encodeMcp(payload: unknown): string {
@@ -231,16 +254,16 @@ describe("Codex LCM Reader plugin", () => {
 
     const result = await plugin.callTool(
       "lcm_describe",
-      { id: "sum_codex_reader_child" },
+      { id: "sum_codex_reader_parent" },
       { dbPath: fixture.dbPath },
     );
 
     const item = result.structuredContent?.item as {
       parentIds: string[];
-      messageIds: number[];
+      childIds: string[];
     };
-    expect(item.parentIds).toEqual(["sum_codex_reader_parent"]);
-    expect(item.messageIds).toHaveLength(2);
+    expect(item.parentIds).toEqual(["sum_codex_reader_child"]);
+    expect(item.childIds).toEqual([]);
   });
 
   it("describes source messages and linked summaries", async () => {
@@ -264,6 +287,27 @@ describe("Codex LCM Reader plugin", () => {
     expect(item.message_id).toBe(fixture.firstMessageId);
     expect(item.content).toContain("Lexar drive");
     expect(item.summaryIds).toEqual(["sum_codex_reader_child"]);
+  });
+
+  it("bounds lcm_describe source content by maxChars", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_describe",
+      { id: `message:${fixture.firstMessageId}`, maxChars: 1000 },
+      { dbPath: fixture.dbPath },
+    );
+
+    const item = result.structuredContent?.item as {
+      content: string;
+      content_truncated: boolean;
+      content_original_length: number;
+    };
+    expect(item.content.length).toBeLessThanOrEqual(1020);
+    expect(item.content_truncated).toBe(true);
+    expect(item.content_original_length).toBeGreaterThan(1000);
   });
 
   it("returns structured describe errors with tool and ID-format hints", async () => {
@@ -295,6 +339,89 @@ describe("Codex LCM Reader plugin", () => {
 
     expect(result.structuredContent?.text).toContain("read-only plugin");
     expect(result.structuredContent?.text).toContain("expand-query work");
+  });
+
+  it("does not expand explicit summary IDs outside the requested conversation", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_expand_query",
+      {
+        summaryIds: ["sum_codex_reader_parent"],
+        conversationId: fixture.conversationId + 1,
+        prompt: "Should not cross conversations",
+      },
+      { dbPath: fixture.dbPath },
+    );
+
+    const expanded = result.structuredContent?.expanded as Array<{ error: string }>;
+    expect(expanded[0].error).toContain(`conversation ${fixture.conversationId + 1}`);
+    expect(result.structuredContent?.text).toBe("");
+  });
+
+  it("falls back from message hits to linked summaries for expand-query seeds", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_expand_query",
+      {
+        query: "read-only SQLite access",
+        prompt: "What was the safe plan?",
+        conversationId: fixture.conversationId,
+        tokenCap: 4000,
+      },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.summaryIds).toEqual(["sum_codex_reader_child"]);
+    expect(result.structuredContent?.text).toContain("expand-query work");
+  });
+
+  it("rejects unsafe regex patterns without throwing", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "(a+)+$", mode: "regex", scope: "messages", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBe(0);
+    expect(result.structuredContent?.results).toEqual([]);
+  });
+
+  it("falls back to LIKE when copied FTS tables are malformed", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const db = createLcmDatabaseConnection(fixture.dbPath);
+    db.exec("DROP TABLE IF EXISTS messages_fts");
+    db.exec("CREATE TABLE messages_fts(content TEXT)");
+    closeLcmConnection(fixture.dbPath);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "Lexar", mode: "full_text", scope: "messages", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBeGreaterThan(0);
+  });
+
+  it("rejects legacy databases with missing required columns before raw SQL failures", async () => {
+    const fixture = await createLegacyLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    await expect(
+      plugin.callTool("lcm_describe", { id: "sum_legacy" }, { dbPath: fixture.dbPath }),
+    ).rejects.toThrow("missing required columns");
   });
 
   it("finds seed summaries for expand-query and returns evidence for Codex to synthesize", async () => {
@@ -376,6 +503,56 @@ describe("Codex LCM Reader plugin", () => {
     expect(messages.map((message) => message.id)).toEqual([1, 2, 3]);
     expect(JSON.stringify(messages[1])).toContain("lcm_expand_query");
     expect(JSON.stringify(messages[2])).toContain("Lexar");
+  });
+
+  it("starts over MCP stdio using the checked-in .mcp.json command", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const pluginRoot = join(process.cwd(), "plugins/codex-lcm-reader");
+    const mcpConfig = JSON.parse(
+      readFileSync(join(pluginRoot, ".mcp.json"), "utf8"),
+    ) as {
+      mcpServers: Record<string, { command: string; args: string[]; cwd: string }>;
+    };
+    const server = mcpConfig.mcpServers["codex-lcm-reader"];
+
+    const child = spawn(server.command, server.args, {
+      cwd: join(pluginRoot, server.cwd),
+      env: { ...process.env, LCM_CODEX_DB_PATH: fixture.dbPath },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.stdin.write(encodeMcp({ jsonrpc: "2.0", id: 1, method: "tools/list" }));
+    child.stdin.end();
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`MCP config server timed out. stderr=${stderr}`));
+      }, 5_000);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        if (code === 0) resolve();
+        else reject(new Error(`MCP config server exited ${code}. stderr=${stderr}`));
+      });
+    });
+
+    const messages = decodeMcp(stdout);
+    expect(messages).toHaveLength(1);
+    expect(JSON.stringify(messages[0])).toContain("lcm_expand_query");
   });
 
   it("starts over MCP stdio when invoked through an installed symlink path", async () => {

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -439,6 +439,32 @@ describe("Codex LCM Reader plugin", () => {
     expect(result.structuredContent?.sort).toBe("recency");
   });
 
+  it("downgrades relevance sort when summaries FTS lacks required join columns", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const db = createLcmDatabaseConnection(fixture.dbPath);
+    db.exec("DROP TABLE IF EXISTS summaries_fts");
+    db.exec("CREATE VIRTUAL TABLE summaries_fts USING fts5(content)");
+    closeLcmConnection(fixture.dbPath);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      {
+        pattern: "Lexar",
+        mode: "full_text",
+        scope: "summaries",
+        sort: "relevance",
+        limit: 10,
+      },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBeGreaterThan(0);
+    expect(result.structuredContent?.requestedSort).toBe("relevance");
+    expect(result.structuredContent?.sort).toBe("recency");
+  });
+
   it("reports recency as the effective sort when regex cannot rank relevance", async () => {
     const fixture = await createLcmFixture();
     tempDirs.add(fixture.tempDir);

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -1,0 +1,287 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { SummaryStore } from "../src/store/summary-store.js";
+
+const pluginModulePath = "../plugins/codex-lcm-reader/scripts/mcp-server.mjs";
+
+type PluginModule = {
+  createTools: () => Array<{ name: string }>;
+  callTool: (
+    name: string,
+    args?: Record<string, unknown>,
+    options?: { dbPath?: string },
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    structuredContent?: Record<string, unknown>;
+  }>;
+  openReadOnlyDatabase: (dbPath: string) => {
+    close: () => void;
+    prepare: (sql: string) => { run: (...args: unknown[]) => unknown };
+  };
+};
+
+async function loadPlugin(): Promise<PluginModule> {
+  return (await import(pluginModulePath)) as PluginModule;
+}
+
+async function createLcmFixture() {
+  const tempDir = mkdtempSync(join(tmpdir(), "codex-lcm-reader-"));
+  const dbPath = join(tempDir, "lcm.db");
+  const db = createLcmDatabaseConnection(dbPath);
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+
+  const conversationStore = new ConversationStore(db, { fts5Available });
+  const summaryStore = new SummaryStore(db, { fts5Available });
+  const conversation = await conversationStore.createConversation({
+    sessionId: "codex-lcm-reader-session",
+    title: "Codex LCM Reader fixture",
+  });
+  const [firstMessage, secondMessage] = await conversationStore.createMessagesBulk([
+    {
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "We recovered the Lexar drive and audited the LCM plugin idea.",
+      tokenCount: 16,
+    },
+    {
+      conversationId: conversation.conversationId,
+      seq: 1,
+      role: "assistant",
+      content: "The safe plan is read-only SQLite access from Codex Desktop.",
+      tokenCount: 14,
+    },
+  ]);
+
+  await summaryStore.insertSummary({
+    summaryId: "sum_codex_reader_parent",
+    conversationId: conversation.conversationId,
+    kind: "condensed",
+    depth: 1,
+    content: "Codex Desktop should inspect local LCM memory through a read-only plugin.",
+    tokenCount: 22,
+    sourceMessageTokenCount: 30,
+    earliestAt: new Date("2026-04-29T10:00:00.000Z"),
+    latestAt: new Date("2026-04-29T10:05:00.000Z"),
+  });
+  await summaryStore.insertSummary({
+    summaryId: "sum_codex_reader_child",
+    conversationId: conversation.conversationId,
+    kind: "leaf",
+    depth: 0,
+    content: "The Lexar test fixture proves grep, describe, expand, and expand-query work.",
+    tokenCount: 18,
+    sourceMessageTokenCount: 30,
+    earliestAt: new Date("2026-04-29T10:00:00.000Z"),
+    latestAt: new Date("2026-04-29T10:05:00.000Z"),
+  });
+  await summaryStore.linkSummaryToMessages("sum_codex_reader_child", [
+    firstMessage.messageId,
+    secondMessage.messageId,
+  ]);
+  await summaryStore.linkSummaryToParents("sum_codex_reader_child", [
+    "sum_codex_reader_parent",
+  ]);
+
+  closeLcmConnection(dbPath);
+  return { tempDir, dbPath, conversationId: conversation.conversationId };
+}
+
+function encodeMcp(payload: unknown): string {
+  const body = JSON.stringify(payload);
+  return `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`;
+}
+
+function decodeMcp(buffer: string): Array<Record<string, unknown>> {
+  const messages: Array<Record<string, unknown>> = [];
+  let rest = buffer;
+  while (rest.length > 0) {
+    const headerEnd = rest.indexOf("\r\n\r\n");
+    if (headerEnd < 0) break;
+    const header = rest.slice(0, headerEnd);
+    const match = /Content-Length:\s*(\d+)/i.exec(header);
+    if (!match) break;
+    const length = Number(match[1]);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    if (rest.length < bodyEnd) break;
+    messages.push(JSON.parse(rest.slice(bodyStart, bodyEnd)) as Record<string, unknown>);
+    rest = rest.slice(bodyEnd);
+  }
+  return messages;
+}
+
+describe("Codex LCM Reader plugin", () => {
+  const tempDirs = new Set<string>();
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.clear();
+  });
+
+  it("exposes only the current read-only LCM tools", async () => {
+    const plugin = await loadPlugin();
+    expect(plugin.createTools().map((tool) => tool.name)).toEqual([
+      "lcm_grep",
+      "lcm_describe",
+      "lcm_expand",
+      "lcm_expand_query",
+    ]);
+  });
+
+  it("opens the LCM database read-only", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+    const db = plugin.openReadOnlyDatabase(fixture.dbPath);
+    try {
+      expect(() =>
+        db.prepare("INSERT INTO conversations (session_id) VALUES (?)").run("should-not-write"),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("searches messages and summaries from a migrated LCM database", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "Lexar", mode: "full_text", scope: "both", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.tool).toBe("lcm_grep");
+    const results = result.structuredContent?.results as Array<{ type: string; id: string }>;
+    expect(results.some((row) => row.type === "message")).toBe(true);
+    expect(results.some((row) => row.type === "summary")).toBe(true);
+  });
+
+  it("describes known summaries with lineage and source messages", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_describe",
+      { id: "sum_codex_reader_child" },
+      { dbPath: fixture.dbPath },
+    );
+
+    const item = result.structuredContent?.item as {
+      parentIds: string[];
+      messageIds: number[];
+    };
+    expect(item.parentIds).toEqual(["sum_codex_reader_parent"]);
+    expect(item.messageIds).toHaveLength(2);
+  });
+
+  it("expands a summary subtree without mutating state", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_expand",
+      { summaryId: "sum_codex_reader_parent", maxDepth: 2 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.text).toContain("read-only plugin");
+    expect(result.structuredContent?.text).toContain("expand-query work");
+  });
+
+  it("finds seed summaries for expand-query and returns evidence for Codex to synthesize", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_expand_query",
+      { query: "Lexar", prompt: "What did the plugin prove?", tokenCap: 4000 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.tool).toBe("lcm_expand_query");
+    expect(result.structuredContent?.text).toContain("Lexar test fixture");
+    expect(result.structuredContent?.note).toContain("does not spawn an OpenClaw sub-agent");
+  });
+
+  it("responds to initialize, tools/list, and tools/call over MCP stdio", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const scriptPath = join(process.cwd(), "plugins/codex-lcm-reader/scripts/mcp-server.mjs");
+    expect(existsSync(scriptPath)).toBe(true);
+
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, LCM_CODEX_DB_PATH: fixture.dbPath },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.stdin.write(
+      encodeMcp({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05" },
+      }),
+    );
+    child.stdin.write(encodeMcp({ jsonrpc: "2.0", id: 2, method: "tools/list" }));
+    child.stdin.write(
+      encodeMcp({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "lcm_grep",
+          arguments: { pattern: "Lexar", mode: "full_text", scope: "both", limit: 5 },
+        },
+      }),
+    );
+    child.stdin.end();
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`MCP server timed out. stderr=${stderr}`));
+      }, 5_000);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        if (code === 0) resolve();
+        else reject(new Error(`MCP server exited ${code}. stderr=${stderr}`));
+      });
+    });
+
+    const messages = decodeMcp(stdout);
+    expect(messages.map((message) => message.id)).toEqual([1, 2, 3]);
+    expect(JSON.stringify(messages[1])).toContain("lcm_expand_query");
+    expect(JSON.stringify(messages[2])).toContain("Lexar");
+  });
+});

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -516,6 +516,27 @@ describe("Codex LCM Reader plugin", () => {
     expect((result.structuredContent?.expanded as unknown[])).toHaveLength(20);
   });
 
+  it("bounds lcm_expand_query echoed prompt/query inputs", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+    const prompt = "p".repeat(10_000);
+    const query = "Lexar " + "q".repeat(10_000);
+
+    const result = await plugin.callTool(
+      "lcm_expand_query",
+      { query, prompt, tokenCap: 4000 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(String(result.structuredContent?.prompt).length).toBeLessThanOrEqual(1_020);
+    expect(result.structuredContent?.prompt_truncated).toBe(true);
+    expect(result.structuredContent?.prompt_original_length).toBe(prompt.length);
+    expect(String(result.structuredContent?.query).length).toBeLessThanOrEqual(1_020);
+    expect(result.structuredContent?.query_truncated).toBe(true);
+    expect(result.structuredContent?.query_original_length).toBe(query.length);
+  });
+
   it("decodes MCP frames by byte length for non-ASCII payloads", () => {
     const first = { jsonrpc: "2.0", id: 1, result: { text: "Eva 🖤" } };
     const second = { jsonrpc: "2.0", id: 2, result: { text: "ok" } };

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -90,9 +90,23 @@ async function createLcmFixture() {
   await summaryStore.linkSummaryToParents("sum_codex_reader_child", [
     "sum_codex_reader_parent",
   ]);
+  db.prepare("UPDATE messages SET created_at = ? WHERE message_id = ?").run(
+    "2026-04-29T10:00:00.000Z",
+    firstMessage.messageId,
+  );
+  db.prepare("UPDATE messages SET created_at = ? WHERE message_id = ?").run(
+    "2026-04-29T10:05:00.000Z",
+    secondMessage.messageId,
+  );
 
   closeLcmConnection(dbPath);
-  return { tempDir, dbPath, conversationId: conversation.conversationId };
+  return {
+    tempDir,
+    dbPath,
+    conversationId: conversation.conversationId,
+    firstMessageId: firstMessage.messageId,
+    secondMessageId: secondMessage.messageId,
+  };
 }
 
 function encodeMcp(payload: unknown): string {
@@ -170,6 +184,30 @@ describe("Codex LCM Reader plugin", () => {
     expect(results.some((row) => row.type === "summary")).toBe(true);
   });
 
+  it("can sort grep results oldest-first for first-occurrence discovery", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      {
+        pattern: "Lexar|read-only",
+        mode: "regex",
+        scope: "messages",
+        sort: "oldest",
+        limit: 2,
+      },
+      { dbPath: fixture.dbPath },
+    );
+
+    const results = result.structuredContent?.results as Array<{ id: string }>;
+    expect(results.map((row) => row.id)).toEqual([
+      `message:${fixture.firstMessageId}`,
+      `message:${fixture.secondMessageId}`,
+    ]);
+  });
+
   it("describes known summaries with lineage and source messages", async () => {
     const fixture = await createLcmFixture();
     tempDirs.add(fixture.tempDir);
@@ -187,6 +225,29 @@ describe("Codex LCM Reader plugin", () => {
     };
     expect(item.parentIds).toEqual(["sum_codex_reader_parent"]);
     expect(item.messageIds).toHaveLength(2);
+  });
+
+  it("describes source messages and linked summaries", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_describe",
+      { id: `message:${fixture.firstMessageId}` },
+      { dbPath: fixture.dbPath },
+    );
+
+    const item = result.structuredContent?.item as {
+      type: string;
+      message_id: number;
+      content: string;
+      summaryIds: string[];
+    };
+    expect(item.type).toBe("message");
+    expect(item.message_id).toBe(fixture.firstMessageId);
+    expect(item.content).toContain("Lexar drive");
+    expect(item.summaryIds).toEqual(["sum_codex_reader_child"]);
   });
 
   it("expands a summary subtree without mutating state", async () => {

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -465,6 +465,44 @@ describe("Codex LCM Reader plugin", () => {
     expect(result.structuredContent?.sort).toBe("recency");
   });
 
+  it("downgrades relevance sort when summaries FTS lacks searchable content", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const db = createLcmDatabaseConnection(fixture.dbPath);
+    db.exec("DROP TABLE IF EXISTS summaries_fts");
+    db.exec("CREATE VIRTUAL TABLE summaries_fts USING fts5(summary_id UNINDEXED)");
+    db.prepare("INSERT INTO summaries_fts(rowid, summary_id) VALUES (?, ?)").run(1, "sum_codex_reader_child");
+    closeLcmConnection(fixture.dbPath);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      {
+        pattern: "Lexar",
+        mode: "full_text",
+        scope: "summaries",
+        sort: "relevance",
+        limit: 10,
+      },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBeGreaterThan(0);
+    expect(result.structuredContent?.requestedSort).toBe("relevance");
+    expect(result.structuredContent?.sort).toBe("recency");
+  });
+
+  it("exposes supported MCP tool parameters in schemas", async () => {
+    const plugin = await loadPlugin();
+    const grepTool = plugin.createTools().find((tool: { name: string }) => tool.name === "lcm_grep");
+    expect(grepTool?.inputSchema.properties).toHaveProperty("caseSensitive");
+    const expandTool = plugin.createTools().find((tool: { name: string }) => tool.name === "lcm_expand");
+    expect(expandTool?.inputSchema.properties).toHaveProperty("conversationId");
+    const expandQueryTool = plugin.createTools().find((tool: { name: string }) => tool.name === "lcm_expand_query");
+    expect(expandQueryTool?.inputSchema.properties).toHaveProperty("mode");
+    expect(expandQueryTool?.inputSchema.properties).toHaveProperty("maxDepth");
+  });
+
   it("reports recency as the effective sort when regex cannot rank relevance", async () => {
     const fixture = await createLcmFixture();
     tempDirs.add(fixture.tempDir);

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -137,21 +137,22 @@ function encodeMcp(payload: unknown): string {
   return `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`;
 }
 
-function decodeMcp(buffer: string): Array<Record<string, unknown>> {
+function decodeMcp(buffer: string | Buffer): Array<Record<string, unknown>> {
   const messages: Array<Record<string, unknown>> = [];
-  let rest = buffer;
+  let rest = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer, "utf8");
+  const separator = Buffer.from("\r\n\r\n");
   while (rest.length > 0) {
-    const headerEnd = rest.indexOf("\r\n\r\n");
+    const headerEnd = rest.indexOf(separator);
     if (headerEnd < 0) break;
-    const header = rest.slice(0, headerEnd);
+    const header = rest.subarray(0, headerEnd).toString("utf8");
     const match = /Content-Length:\s*(\d+)/i.exec(header);
     if (!match) break;
     const length = Number(match[1]);
     const bodyStart = headerEnd + 4;
     const bodyEnd = bodyStart + length;
     if (rest.length < bodyEnd) break;
-    messages.push(JSON.parse(rest.slice(bodyStart, bodyEnd)) as Record<string, unknown>);
-    rest = rest.slice(bodyEnd);
+    messages.push(JSON.parse(rest.subarray(bodyStart, bodyEnd).toString("utf8")) as Record<string, unknown>);
+    rest = rest.subarray(bodyEnd);
   }
   return messages;
 }
@@ -264,6 +265,20 @@ describe("Codex LCM Reader plugin", () => {
     };
     expect(item.parentIds).toEqual(["sum_codex_reader_child"]);
     expect(item.childIds).toEqual([]);
+  });
+
+  it("rejects invalid describe conversationId values clearly", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    await expect(
+      plugin.callTool(
+        "lcm_describe",
+        { id: "sum_codex_reader_parent", conversationId: "not-a-number" },
+        { dbPath: fixture.dbPath },
+      ),
+    ).rejects.toThrow("conversationId must be a positive integer");
   });
 
   it("describes source messages and linked summaries", async () => {
@@ -415,11 +430,28 @@ describe("Codex LCM Reader plugin", () => {
 
     const result = await plugin.callTool(
       "lcm_grep",
-      { pattern: "Lexar", mode: "full_text", scope: "messages", limit: 10 },
+      { pattern: "Lexar", mode: "full_text", scope: "messages", sort: "relevance", limit: 10 },
       { dbPath: fixture.dbPath },
     );
 
     expect(result.structuredContent?.count).toBeGreaterThan(0);
+    expect(result.structuredContent?.requestedSort).toBe("relevance");
+    expect(result.structuredContent?.sort).toBe("recency");
+  });
+
+  it("reports recency as the effective sort when regex cannot rank relevance", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "Lexar", mode: "regex", scope: "messages", sort: "hybrid", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.requestedSort).toBe("hybrid");
+    expect(result.structuredContent?.sort).toBe("recency");
   });
 
   it("does not turn punctuation-only full-text fallback into an unfiltered scan", async () => {
@@ -464,6 +496,34 @@ describe("Codex LCM Reader plugin", () => {
     expect(result.structuredContent?.tool).toBe("lcm_expand_query");
     expect(result.structuredContent?.text).toContain("Lexar test fixture");
     expect(result.structuredContent?.note).toContain("does not spawn an OpenClaw sub-agent");
+  });
+
+  it("reports only summary IDs that were actually expanded by expand-query", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const plugin = await loadPlugin();
+    const summaryIds = Array.from({ length: 25 }, (_, index) => `sum_missing_${index}`);
+    summaryIds[0] = "sum_codex_reader_child";
+    summaryIds[1] = "sum_codex_reader_parent";
+
+    const result = await plugin.callTool(
+      "lcm_expand_query",
+      { summaryIds, prompt: "Expand capped IDs", tokenCap: 4000 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.summaryIds).toEqual(summaryIds.slice(0, 20));
+    expect((result.structuredContent?.expanded as unknown[])).toHaveLength(20);
+  });
+
+  it("decodes MCP frames by byte length for non-ASCII payloads", () => {
+    const first = { jsonrpc: "2.0", id: 1, result: { text: "Eva 🖤" } };
+    const second = { jsonrpc: "2.0", id: 2, result: { text: "ok" } };
+
+    expect(decodeMcp(Buffer.from(`${encodeMcp(first)}${encodeMcp(second)}`, "utf8"))).toEqual([
+      first,
+      second,
+    ]);
   });
 
   it("responds to initialize, tools/list, and tools/call over MCP stdio", async () => {

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -472,6 +472,26 @@ describe("Codex LCM Reader plugin", () => {
     expect(result.structuredContent?.results).toEqual([]);
   });
 
+  it("bounds full-text LIKE fallback term count for very large pasted queries", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const db = createLcmDatabaseConnection(fixture.dbPath);
+    db.exec("DROP TABLE IF EXISTS messages_fts");
+    db.exec("DROP TABLE IF EXISTS summaries_fts");
+    closeLcmConnection(fixture.dbPath);
+    const plugin = await loadPlugin();
+    const query = Array.from({ length: 2_000 }, (_, index) => `term${index}`).join(" ");
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: query, mode: "full_text", scope: "both", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBe(0);
+    expect(result.structuredContent?.results).toEqual([]);
+  });
+
   it("rejects legacy databases with missing required columns before raw SQL failures", async () => {
     const fixture = await createLegacyLcmFixture();
     tempDirs.add(fixture.tempDir);

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -394,6 +394,14 @@ describe("Codex LCM Reader plugin", () => {
 
     expect(result.structuredContent?.count).toBe(0);
     expect(result.structuredContent?.results).toEqual([]);
+
+    const alternationResult = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "(a|aa)+$", mode: "regex", scope: "messages", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+    expect(alternationResult.structuredContent?.count).toBe(0);
+    expect(alternationResult.structuredContent?.results).toEqual([]);
   });
 
   it("falls back to LIKE when copied FTS tables are malformed", async () => {
@@ -412,6 +420,24 @@ describe("Codex LCM Reader plugin", () => {
     );
 
     expect(result.structuredContent?.count).toBeGreaterThan(0);
+  });
+
+  it("does not turn punctuation-only full-text fallback into an unfiltered scan", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const db = createLcmDatabaseConnection(fixture.dbPath);
+    db.exec("DROP TABLE IF EXISTS messages_fts");
+    closeLcmConnection(fixture.dbPath);
+    const plugin = await loadPlugin();
+
+    const result = await plugin.callTool(
+      "lcm_grep",
+      { pattern: "!!!", mode: "full_text", scope: "messages", limit: 10 },
+      { dbPath: fixture.dbPath },
+    );
+
+    expect(result.structuredContent?.count).toBe(0);
+    expect(result.structuredContent?.results).toEqual([]);
   });
 
   it("rejects legacy databases with missing required columns before raw SQL failures", async () => {

--- a/test/codex-lcm-reader-plugin.test.ts
+++ b/test/codex-lcm-reader-plugin.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -283,5 +283,53 @@ describe("Codex LCM Reader plugin", () => {
     expect(messages.map((message) => message.id)).toEqual([1, 2, 3]);
     expect(JSON.stringify(messages[1])).toContain("lcm_expand_query");
     expect(JSON.stringify(messages[2])).toContain("Lexar");
+  });
+
+  it("starts over MCP stdio when invoked through an installed symlink path", async () => {
+    const fixture = await createLcmFixture();
+    tempDirs.add(fixture.tempDir);
+    const installDir = mkdtempSync(join(tmpdir(), "codex-lcm-reader-install-"));
+    tempDirs.add(installDir);
+    const symlinkedPlugin = join(installDir, "codex-lcm-reader");
+    symlinkSync(join(process.cwd(), "plugins/codex-lcm-reader"), symlinkedPlugin, "dir");
+    const scriptPath = join(symlinkedPlugin, "scripts/mcp-server.mjs");
+
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: symlinkedPlugin,
+      env: { ...process.env, LCM_CODEX_DB_PATH: fixture.dbPath },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.stdin.write(encodeMcp({ jsonrpc: "2.0", id: 1, method: "tools/list" }));
+    child.stdin.end();
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`MCP symlink server timed out. stderr=${stderr}`));
+      }, 5_000);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        if (code === 0) resolve();
+        else reject(new Error(`MCP symlink server exited ${code}. stderr=${stderr}`));
+      });
+    });
+
+    const messages = decodeMcp(stdout);
+    expect(messages).toHaveLength(1);
+    expect(JSON.stringify(messages[0])).toContain("lcm_grep");
   });
 });


### PR DESCRIPTION
# Lossless Codex: read-only OpenClaw LCM memory in Codex Desktop

## Launch Summary

This PR ships the first production slice of **Lossless Codex**: a Codex Desktop plugin that lets Codex search and inspect an existing local OpenClaw/lossless-claw LCM database without writing to it.

This is the safe bridge from Codex into the memory OpenClaw already has. It is intentionally read-only and limited to the LCM tools available on current `main`:

- `lcm_grep`
- `lcm_describe`
- `lcm_expand`
- `lcm_expand_query`

Current state: **ready to review/merge**. Head `3e0b093` is `MERGEABLE`, GitHub CI is green, and review threads are resolved.

## Stack Map

| PR | Product slice | Current state | Why it exists |
|---|---|---:|---|
| #550 | Codex reads existing OpenClaw LCM | **Merge-ready** | Gives Codex current LCM recall immediately. |
| #589 | Codex gets its own coding-work memory sidecar | Feature-complete draft/save-state | Adds Codex-native memory after this reader exists. |
| #590 | Lossless Claw `lcm_recent` displays Codex work hints | Future adapter draft/reference | Lets OpenClaw see compact Codex worklog hints after #516/#589. |

```mermaid
flowchart LR
  C["Codex Desktop"] --> P["#550 codex-lcm-reader plugin"]
  P --> M["MCP stdio server"]
  M --> R["SQLite read-only handle"]
  R --> L[("existing OpenClaw lcm.db")]
  L --> S["summaries + lineage"]
  L --> G["messages"]
  S --> E["bounded evidence bundle"]
  G --> E
  E --> C
```

## What Ships In This PR

This PR is **Codex-only plugin surface**. It does not change the LCM schema or OpenClaw runtime.

| Area | Files | Added LOC | Notes |
|---|---:|---:|---|
| Functional plugin code | 1 | 964 | MCP stdio server, DB path resolution, read-only SQLite access, search/describe/expand tools, bounded output. |
| Tests | 1 | 758 | Plugin contract, read-only guard, MCP smoke, malformed FTS fallback, schema/error/search/expand hardening. |
| Docs/skill/metadata/assets/package | 8 | 217 | Codex plugin manifest, MCP config, marketplace entry, README, skill, icon, changeset, package inclusion. |

Total visible diff: **1,939 added lines across 10 files**.

## User Scenarios

- A Codex agent needs prior OpenClaw context for a repo: call `lcm_grep`, then `lcm_describe` or `lcm_expand`.
- A user asks when something first appeared: use `lcm_grep` with `sort: "oldest"`, then inspect `message:<id>` or the linked summaries.
- A user asks for proof behind a claim: use `lcm_describe` and `lcm_expand` to drill from recap into source evidence.
- A user wants Codex to benefit from OpenClaw memory without corrupting it: all access is read-only, query-only SQLite.

```mermaid
sequenceDiagram
  participant U as User
  participant C as Codex Desktop
  participant P as Lossless Codex reader
  participant DB as local lcm.db

  U->>C: "What did we decide about LCM?"
  C->>P: lcm_grep(query)
  P->>DB: bounded read-only search
  DB-->>P: summary/message hits
  C->>P: lcm_expand_query(query)
  P->>DB: bounded lineage expansion
  P-->>C: evidence bundle + caveats
  C-->>U: answer with source IDs, not silent authority
```

## Install From This PR

Repo-local review install:

```bash
gh pr checkout 550 --repo Martian-Engineering/lossless-claw
node -e "import('node:sqlite').then(() => console.log('node:sqlite ok'))"
npm install
npm test -- --run test/codex-lcm-reader-plugin.test.ts
```

Home-local Codex Desktop install from the checked-out PR:

```bash
mkdir -p ~/plugins ~/.agents/plugins
rm -rf ~/plugins/codex-lcm-reader
cp -R plugins/codex-lcm-reader ~/plugins/codex-lcm-reader
```

Then add or merge this local plugin entry into `~/.agents/plugins/marketplace.json`:

```json
{
  "name": "lossless-codex-local",
  "interface": { "displayName": "Lossless Codex Local" },
  "plugins": [
    {
      "name": "codex-lcm-reader",
      "source": { "source": "local", "path": "./plugins/codex-lcm-reader" },
      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
      "category": "Engineering"
    }
  ]
}
```

Restart Codex Desktop. Point it at a non-default LCM database with `LCM_CODEX_DB_PATH=/absolute/path/to/lcm.db` if needed.

## Safety Model

```mermaid
flowchart TD
  A["Tool call"] --> B["resolve DB path"]
  B --> C["open SQLite readOnly=true"]
  C --> D["PRAGMA query_only = ON"]
  D --> E["bounded SELECTs only"]
  E --> F["return evidence"]
  F -. "no writes" .-> G["no tasks / Cortex / rollups / compaction"]
```

The plugin does not:

- write to LCM,
- run compaction,
- build rollups,
- write Cortex memory,
- create/update/close OpenClaw tasks,
- expose future tools that are not on current `main`.

## Validation

- GitHub CI: `test` and `smoke-latest-openclaw` passed on `3e0b093`.
- Mergeability: `MERGEABLE`.
- Review threads: 0 unresolved.
- Local checks run during hardening: focused plugin tests, full suite, build, diff-check, package dry-run.

## Detailed Notes / Earlier Review Context


## Reviewer Top Note

This PR adds **Lossless Codex**, a Codex Desktop plugin for read-only access to local lossless-claw LCM memory. The package/folder remains `codex-lcm-reader` for stable plugin IDs and branch history.

It is intentionally limited to the LCM tools available on current `main`:

- `lcm_grep`
- `lcm_describe`
- `lcm_expand`
- `lcm_expand_query`

A stacked follow-up will add the newer temporal/observed-work tools (`lcm_recent`, `lcm_rollup_debug`, `lcm_work_density`, `lcm_event_search`) after those schemas/tools exist on the base stack.

### LOC Breakdown

Total diff: **1,744 added lines**.

| Area | Files | Added LOC | Notes |
|---|---:|---:|---|
| Functional plugin code | 1 | 896 | Self-contained read-only MCP stdio server over local SQLite. Includes current tools, message drilldown, bounded describe, safe regex, FTS fallback, scoped expansion, node caps, effective-sort reporting, and oldest-first search. |
| Tests | 1 | 631 | Migrated and legacy LCM fixtures, tool calls, read-only guard, MCP protocol/config/symlink smoke, message describe, structured errors, database path reporting, malformed FTS fallback, punctuation-only full-text guard, regex/ReDoS guards, scoped expansion, message-hit fallback, package-facing behavior. |
| Docs/skill/metadata/assets/package | 8 | 217 | Codex plugin manifest, MCP config, marketplace entry, README install instructions, skill, icon, changeset, package `files` inclusion. |

### Local Install Smoke

This was also installed as a **home-local Codex plugin** at `~/plugins/codex-lcm-reader` with the marketplace entry in `~/.agents/plugins/marketplace.json`. The installed copy was tested against a real local LCM database using only read-only calls.

Live/local hardening found and fixed before merge:

- `message:<id>` inspection for grep hits.
- `sort: "oldest"` for first-occurrence style discovery.
- Accurate `databasePath` reporting for explicit DB paths.
- Effective-sort reporting when `scope="both"` cannot compare FTS ranks across tables.
- Structured describe errors with ID-format hints.
- Bounded `lcm_describe` output via `maxChars`.
- Correct summary expansion direction through `summary_parents`.
- `conversationId` scoping for explicit expansion IDs.
- Message-hit fallback for `lcm_expand_query` when summary text misses a raw-message phrase.
- Malformed/stale FTS fallback to escaped `LIKE`.
- Regex safety guard for invalid or ReDoS-shaped patterns, including quantified alternation.
- Package inclusion so release artifacts contain the plugin.
- Copy-pasteable home-local install docs and Node/`node:sqlite` prerequisites.

## What This Solves

Codex Desktop can inspect the local OpenClaw/lossless-claw LCM database without running OpenClaw itself, mutating memory, or competing for write locks. This gives Codex access to the same local evidence layer the OpenClaw agent uses while preserving the LCM authority boundary: LCM is evidence, not proof or task authority.

```mermaid
flowchart LR
  A["Codex Desktop"] --> B["Lossless Codex plugin"]
  B --> C["MCP stdio server"]
  C --> D[("Local lcm.db")]
  D --> E["messages"]
  D --> F["summaries + DAG lineage"]
  C --> G["Read-only evidence bundle"]
  G --> A
```

## How Users Install It

Repo-local development install:

1. Keep the plugin directory at `plugins/codex-lcm-reader`.
2. Keep `.agents/plugins/marketplace.json` with the `codex-lcm-reader` local plugin entry.
3. Restart Codex Desktop or refresh its plugin registry.
4. Set `LCM_CODEX_DB_PATH=/absolute/path/to/lcm.db` if the desired DB is not the default `~/.openclaw/lcm.db`.

Home-local install:

1. Copy `plugins/codex-lcm-reader` to `~/plugins/codex-lcm-reader`.
2. Add the README's complete marketplace JSON to `~/.agents/plugins/marketplace.json`, or merge the `codex-lcm-reader` entry into an existing marketplace file.
3. Restart Codex Desktop.

Prerequisite: Codex Desktop must be able to launch `node`, and `node` must support `node:sqlite`.

Codex should then expose the plugin as **Lossless Codex** with read-only LCM tools.

## How It Works

The plugin registers an MCP stdio server through `.mcp.json`. The server opens SQLite with `readOnly: true`, sets `PRAGMA query_only = ON`, and uses bounded reads only.

Database path resolution:

1. `LCM_CODEX_DB_PATH`
2. `LCM_DATABASE_PATH`
3. `LOSSLESS_CLAW_DB_PATH`
4. `OPENCLAW_LCM_DB_PATH`
5. `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`

Tool routing:

```mermaid
flowchart TD
  Q["Need prior OpenClaw context"] --> G["lcm_grep: find keywords / IDs"]
  G --> D["lcm_describe: inspect known summary/message/file ID"]
  D --> X["lcm_expand: expand known summary DAG"]
  G --> EQ["lcm_expand_query: query seeds + expand evidence"]
  X --> P["Codex synthesizes answer with caveats"]
  EQ --> P
```

## Safety / Non-Goals

This PR does **not**:

- write to the LCM database,
- run compaction or rollup maintenance,
- build temporal rollups,
- write Cortex memory,
- create/update/close OpenClaw tasks,
- expose the newer temporal or observed-work tools.

`lcm_expand_query` is a Codex-local adapter here: it returns expanded evidence for Codex to synthesize from. It does not spawn an OpenClaw sub-agent.

## Scenario Coverage

- “Find prior context for this repo” → `lcm_grep` over summaries/messages, then `lcm_describe` or `lcm_expand`.
- “When did this first appear?” → `lcm_grep` with `sort: "oldest"`, then `lcm_describe` on `message:<id>` or `lcm_expand` on linked summaries.
- “What did we decide about X?” → `lcm_expand_query` returns bounded evidence; Codex answers with source IDs and caveats.
- “Show me the source behind this claim” → `lcm_describe` supports summaries, source messages, and files; `lcm_expand` handles summary subtrees.
- “Use my live OpenClaw memory without changing it” → SQLite is opened read-only and query-only.

## Proof Rule

LCM output is evidence, not authority. Exact commands, SHAs, file paths, timestamps, root cause, shipped status, and external state still require source or live-system verification.

## Validation

Ran locally from `/Volumes/LEXAR/Codex/worktrees/lossless-claw-codex-lcm-reader`:

```bash
node --check plugins/codex-lcm-reader/scripts/mcp-server.mjs
npm test -- --run test/codex-lcm-reader-plugin.test.ts
npm test
npm run build
git diff --check
npm pack --dry-run --json
```

Results:

- Focused plugin tests: 20 passed.
- Full test suite: 45 files, 833 tests passed.
- Build: passed.
- Node syntax check: passed.
- Diff check: passed.
- Package dry run: passed; release artifact includes `plugins/codex-lcm-reader/**` and `.agents/plugins/marketplace.json`.
- Home-local install smoke: passed against `~/plugins/codex-lcm-reader` and local read-only LCM DB.


