### PR TITLE
fix: prevent afterTurn replay of compacted instructions

### DIFF
--- a/.changeset/fix-afterturn-transcript-reconcile.md
+++ b/.changeset/fix-afterturn-transcript-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Reconcile foreground transcript turns before post-turn ingestion so assistant replies cannot be stored without their user prompt.

--- a/.changeset/fix-summary-overlap-dedup.md
+++ b/.changeset/fix-summary-overlap-dedup.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip afterTurn messages whose content is already covered by an auto-compaction summary, preventing safeguard-mode summary re-injection from duplicating user instructions in LCM context.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1073,8 +1073,24 @@ function toDbRole(role: string): "user" | "assistant" | "system" | "tool" {
   if (role === "assistant") {
     return "assistant";
   }
-  // Unknown roles are preserved via message_parts metadata and treated as assistant.
+  // Direct callers should filter unknown roles before storage. Preserve the
+  // historical fallback for typed AgentMessage values that reach this helper.
   return "assistant";
+}
+
+function hasPersistableMessageRole(message: AgentMessage): boolean {
+  const role = (message as { role?: unknown }).role;
+  return (
+    role === "user" ||
+    role === "assistant" ||
+    role === "system" ||
+    role === "tool" ||
+    role === "toolResult"
+  );
+}
+
+function filterPersistableMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.filter(hasPersistableMessageRole);
 }
 
 type StoredMessage = {
@@ -4496,6 +4512,105 @@ export class LcmContextEngine implements ContextEngine {
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
   }
 
+  private async reconcileTranscriptTailForAfterTurn(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<void> {
+    const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
+    await this.withSessionQueue(
+      queueKey,
+      async () => {
+        const conversation = await this.conversationStore.getConversationForSession({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+        });
+        if (!conversation) {
+          return;
+        }
+
+        // OpenClaw can submit the foreground prompt outside the mutable
+        // messages array passed to afterTurn. The transcript has the complete
+        // turn by this point, so reconcile it before accepting assistant-only
+        // deltas from the runtime snapshot.
+        const checkpoint = await this.summaryStore.getConversationBootstrapState(
+          conversation.conversationId,
+        );
+        if (
+          checkpoint &&
+          checkpoint.sessionFilePath === params.sessionFile &&
+          checkpoint.lastProcessedOffset >= 0
+        ) {
+          const appended = await readAppendedLeafPathMessages({
+            sessionFile: params.sessionFile,
+            offset: checkpoint.lastProcessedOffset,
+          });
+          if (appended.canUseAppendOnly) {
+            let importedMessages = 0;
+            for (const message of appended.messages) {
+              const result = await this.ingestSingle({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                message,
+              });
+              if (result.ingested) {
+                importedMessages += 1;
+              }
+            }
+            if (importedMessages > 0) {
+              this.clearStableOrphanStrippingOrdinal(conversation.conversationId);
+              this.recordRecentBootstrapImport(
+                conversation.conversationId,
+                importedMessages,
+                "reconciled missing session messages",
+              );
+              await this.refreshBootstrapState({
+                conversationId: conversation.conversationId,
+                sessionFile: params.sessionFile,
+              });
+            }
+            return;
+          }
+        }
+
+        const historicalMessages = await readLeafPathMessages(params.sessionFile);
+        if (historicalMessages.length === 0) {
+          return;
+        }
+        const reconcile = await this.reconcileSessionTail({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          conversationId: conversation.conversationId,
+          historicalMessages,
+        });
+        if (reconcile.blockedByImportCap) {
+          return;
+        }
+        if (reconcile.importedMessages > 0) {
+          this.clearStableOrphanStrippingOrdinal(conversation.conversationId);
+          this.recordRecentBootstrapImport(
+            conversation.conversationId,
+            reconcile.importedMessages,
+            "reconciled missing session messages",
+          );
+        }
+        if (reconcile.importedMessages > 0) {
+          await this.refreshBootstrapState({
+            conversationId: conversation.conversationId,
+            sessionFile: params.sessionFile,
+          });
+        }
+      },
+      {
+        operationName: "afterTurnTranscriptReconcile",
+        context: [
+          `session=${params.sessionId}`,
+          ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+        ].join(" "),
+      },
+    );
+  }
+
   /**
    * Persist bootstrap checkpoint metadata anchored to the current DB frontier.
    *
@@ -5413,6 +5528,9 @@ export class LcmContextEngine implements ContextEngine {
     if (isHeartbeat) {
       return { ingested: false };
     }
+    if (!hasPersistableMessageRole(message)) {
+      return { ingested: false };
+    }
 
     // Skip assistant messages that failed with an error and have no useful content.
     // These occur when an API call returns a 500 or similar transient error.
@@ -5736,7 +5854,20 @@ export class LcmContextEngine implements ContextEngine {
     // Dedup guard: prevent duplicate ingestion when gateway restart replays
     // full history. Run on newMessages BEFORE prepending autoCompactionSummary
     // so synthetic summaries cannot interfere with replay detection.
-    const newMessages = params.messages.slice(params.prePromptMessageCount);
+    const newMessages = filterPersistableMessages(
+      params.messages.slice(params.prePromptMessageCount),
+    );
+    try {
+      await this.reconcileTranscriptTailForAfterTurn({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
+      );
+    }
     const dedupedNewMessages = await this.deduplicateAfterTurnBatch(
       params.sessionId,
       params.sessionKey,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1648,6 +1648,22 @@ function messageIdentity(role: string, content: string): string {
   return `${role}\u0000${content}`;
 }
 
+function normalizeSummaryOverlapText(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function messageContentCoveredBySummary(params: {
+  message: AgentMessage;
+  summary: string;
+}): boolean {
+  const content = normalizeSummaryOverlapText(toStoredMessage(params.message).content);
+  if (content.length < 24) {
+    return false;
+  }
+  const summary = normalizeSummaryOverlapText(params.summary);
+  return summary.includes(content);
+}
+
 // ── LcmContextEngine ────────────────────────────────────────────────────────
 
 export class LcmContextEngine implements ContextEngine {
@@ -5873,6 +5889,29 @@ export class LcmContextEngine implements ContextEngine {
       params.sessionKey,
       newMessages,
     );
+    const summaryCoveredMessages: AgentMessage[] = [];
+    const summaryDedupedNewMessages: AgentMessage[] = [];
+    if (params.autoCompactionSummary) {
+      for (const message of dedupedNewMessages) {
+        if (
+          messageContentCoveredBySummary({
+            message,
+            summary: params.autoCompactionSummary,
+          })
+        ) {
+          summaryCoveredMessages.push(message);
+        } else {
+          summaryDedupedNewMessages.push(message);
+        }
+      }
+    } else {
+      summaryDedupedNewMessages.push(...dedupedNewMessages);
+    }
+    if (summaryCoveredMessages.length > 0) {
+      this.deps.log.info(
+        `[lcm] afterTurn: skipped ${summaryCoveredMessages.length} messages already covered by autoCompactionSummary ${sessionLabel}`,
+      );
+    }
 
     const ingestBatch: AgentMessage[] = [];
     if (params.autoCompactionSummary) {
@@ -5882,7 +5921,7 @@ export class LcmContextEngine implements ContextEngine {
       } as AgentMessage);
     }
 
-    ingestBatch.push(...dedupedNewMessages);
+    ingestBatch.push(...summaryDedupedNewMessages);
     if (ingestBatch.length === 0) {
       this.deps.log.info(
         `[lcm] afterTurn: nothing to ingest ${sessionLabel} newMessages=${newMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3725,6 +3725,58 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(reconcileSpy).not.toHaveBeenCalled();
   });
 
+  it("reconciles foreground transcript messages before assistant-only afterTurn deltas", async () => {
+    const sessionFile = createSessionFilePath("after-turn-foreground-transcript-reconcile");
+    const sm = SessionManager.open(sessionFile);
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "kick off workers" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "same status reply" }],
+    } as AgentMessage);
+
+    const engine = createEngine();
+    const sessionId = "after-turn-foreground-transcript-reconcile";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    sm.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "You set up a monitor too right?" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "same status reply" }],
+    } as AgentMessage);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "same status reply" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "kick off workers",
+      "same status reply",
+      "You set up a monitor too right?",
+      "same status reply",
+    ]);
+
+    const sessionFileStats = statSync(sessionFile);
+    const bootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(bootstrapState?.lastProcessedOffset).toBe(sessionFileStats.size);
+  });
+
   it("falls back to full reconciliation when append-only checkpoint validation mismatches", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
@@ -5796,22 +5848,18 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(toolResult.content?.[0]?.output).toEqual({ cwd: "/tmp" });
   });
 
-  it("maps unknown roles to assistant instead of silently coercing to user", async () => {
+  it("skips unknown roles instead of storing them as assistant messages", async () => {
     const engine = createEngine();
     const sessionId = randomUUID();
 
-    await engine.ingest({
+    const result = await engine.ingest({
       sessionId,
       message: makeMessage({ role: "custom-event", content: "opaque payload" }),
     });
 
+    expect(result.ingested).toBe(false);
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
-    expect(conversation).not.toBeNull();
-    const storedMessages = await engine
-      .getConversationStore()
-      .getMessages(conversation!.conversationId);
-    expect(storedMessages).toHaveLength(1);
-    expect(storedMessages[0].role).toBe("assistant");
+    expect(conversation).toBeNull();
   });
 
   it("uses explicit compact tokenBudget over legacy tokenBudget", async () => {
@@ -9249,6 +9297,31 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(conversation).not.toBeNull();
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((m) => m.content)).toEqual(["hello", "hi there"]);
+  });
+
+  it("does not persist custom transcript context as assistant messages", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-custom-context";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-custom-context"),
+      messages: [
+        {
+          type: "custom_message",
+          customType: "openclaw.runtime-context",
+          content: "Conversation info (untrusted metadata)",
+        } as unknown as AgentMessage,
+        makeMessage({ role: "assistant", content: "real reply" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["real reply"]);
   });
 
   it("ingests all genuinely new messages (normal afterTurn, no restart)", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6035,6 +6035,61 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ]);
   });
 
+  it("afterTurn skips new-message content already covered by auto-compaction summary", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-overlap";
+    const repeatedInstruction =
+      "kick off workers to review all of these pull requests and report back";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-overlap"),
+      messages: [
+        makeMessage({ role: "user", content: repeatedInstruction }),
+        makeMessage({ role: "assistant", content: "Workers are running now." }),
+      ],
+      prePromptMessageCount: 0,
+      autoCompactionSummary: `Summary of compacted context: the user said "${repeatedInstruction}" and the assistant began coordinating the work.`,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      `Summary of compacted context: the user said "${repeatedInstruction}" and the assistant began coordinating the work.`,
+      "Workers are running now.",
+    ]);
+  });
+
+  it("afterTurn does not drop short messages just because they appear in auto-compaction summary", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-short-overlap";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-short-overlap"),
+      messages: [
+        makeMessage({ role: "user", content: "yes" }),
+        makeMessage({ role: "assistant", content: "Proceeding." }),
+      ],
+      prePromptMessageCount: 0,
+      autoCompactionSummary: "Summary: the user previously said yes to the plan.",
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Summary: the user previously said yes to the plan.",
+      "yes",
+      "Proceeding.",
+    ]);
+  });
+
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {
     const engine = createEngineWithConfig({
       proactiveThresholdCompactionMode: "inline",


### PR DESCRIPTION
## Summary

Fixes lossless-claw's afterTurn ingestion path so compacted/safeguard context cannot replay old user instructions back into stored LCM context.

This was prompted by openclaw/openclaw#75972. The issue was closed as not actionable in OpenClaw core, but the failure mode was real in lossless-claw's external context-engine integration.

## What changed

- Reconcile the session transcript tail before assistant-only afterTurn ingestion, so foreground user messages that OpenClaw writes outside the mutable afterTurn message array are not skipped/misaligned and later treated as new.
- Ignore non-persistable/custom runtime-context messages instead of storing unknown roles as assistant messages.
- When `autoCompactionSummary` is present, skip ingesting `dedupedNewMessages` whose normalized content is already covered by that summary.
- Add regression tests for transcript reconciliation and summary/new-message overlap dedupe.

## Validation

- `npm run build`
- `pnpm vitest run test/engine.test.ts -t 'auto-compaction summary|summary-overlap|summary-short-overlap'`
- `npm test` — 817 passed / 44 files

References openclaw/openclaw#75972.
