### PR TITLE
fix(manifest): declare contracts.tools so the plugin loads on OpenClaw 2026.5.2

### DIFF
--- a/.changeset/declare-contracts-tools.md
+++ b/.changeset/declare-contracts-tools.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare `contracts.tools` in `openclaw.plugin.json` so OpenClaw 2026.5.2's stricter loader accepts the plugin's `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query` registrations. Without this declaration the loader emits `plugin must declare contracts.tools before registering agent tools` and the plugin fails to register, which silently disables compaction (the engine still loads but no tools are wired up).

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,14 @@
   "skills": [
     "skills/lossless-claw"
   ],
+  "contracts": {
+    "tools": [
+      "lcm_grep",
+      "lcm_describe",
+      "lcm_expand",
+      "lcm_expand_query"
+    ]
+  },
   "uiHints": {
     "enabled": {
       "label": "Enabled",


### PR DESCRIPTION
OpenClaw 2026.5.2 tightened plugin validation in `loader-CiaemmFD.js`'s `registerTool`: every tool name a plugin registers must appear in `contracts.tools` of `openclaw.plugin.json`. Without it the loader emits

    plugin must declare contracts.tools before registering agent tools

and rejects all four `lcm_*` registrations. The engine itself still initializes (logs `[lcm] Plugin loaded ... Engine initialized`), but because none of the agent tools wire up, compaction never runs end to end — sessions silently grow until they hit context limits.

Declaring the four tools the plugin actually registers (`lcm_grep`, `lcm_describe`, `lcm_expand`, `lcm_expand_query`) restores normal loading. After applying this on a 2026.5.2 install:

    $ openclaw plugins doctor
    No plugin issues detected.