### PR TITLE
feat(compaction): layered pressure architecture + reserve-aware budget alignment

### DIFF
--- a/.changeset/sweep-target-and-reserve-aware-budget.md
+++ b/.changeset/sweep-target-and-reserve-aware-budget.md
@@ -1,0 +1,21 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Layered four-band compaction pressure architecture, plus reserve-aware budget alignment so percentages mean what they say.
+
+**Three new capabilities:**
+
+1. **`sweepTriggerThreshold`** (default `0.91`) — separate from `contextThreshold`, controls when dispatched compaction switches into deep SWEEP mode. Below this, dispatched compaction targets `contextThreshold` (gentle, doesn't overshoot). At or above this, dispatches run unlimited passes targeting `sweepTargetThreshold`. Decouples the trigger ("when can sweep start") from the activation point ("when does sweep ACTUALLY fire") — without this, sweep would run on every threshold-mode dispatch (i.e. at 60% trigger), which is too aggressive.
+
+2. **`pressureTiers`** (default `[{ratio:0.70,maxPasses:2},{ratio:0.80,maxPasses:3}]`) — pressure-tiered pass cap ladder for dispatched compaction below sweep mode. Each entry caps passes-per-dispatch when current pressure crosses `ratio`. Multi-pass amortizes prefix-cache invalidation: every pass in a single dispatch invalidates the SAME cache prefix, so doing 3 passes/dispatch costs the same cache-wise as 1 but reduces 3× as many tokens.
+
+3. **`sweepTargetThreshold`** (default `0.50`) — fraction of token budget that SWEEP targets when it fires. Decouples sweep stopping point from `contextThreshold`. With default sweep target at 0.50 and trigger at 0.91, when sweep fires it creates ~40% headroom (~5+ turns of runway) before the next trigger.
+
+**Plus reserve-aware budget alignment:** LCM now reads `runtimeContext.reserveTokens` (or the legacy `reserveTokensFloor` key) and subtracts it from the resolved `tokenBudget` before computing percentages. This way every threshold computes against the EFFECTIVE prompt budget — the same number the runtime actually overflows at — instead of the raw context window. Plugins/runtimes that don't pass a reserve get the legacy behavior unchanged.
+
+**Behavior change:** `contextThreshold` default lowered from `0.75` → `0.60`. The lower trigger gives the cache-aware deferral system more room to operate (defer when cache hot, fire when cold) and feeds the new pressure-tier ladder cleanly. Operators wanting the legacy `0.75` trigger can set it explicitly.
+
+**New env overrides:** `LCM_SWEEP_TARGET_THRESHOLD`, `LCM_SWEEP_TRIGGER_THRESHOLD`, `LCM_PRESSURE_TIERS` (JSON array). New manifest entries + uiHints + configSchema for all three new fields. README gains a new "Compaction pressure architecture" section with a layered ASCII diagram, pressure-band table, cache-invalidation efficiency math, and scenario walkthrough using real session data showing 6 emergency truncations → 0.
+
+**Recommended companion:** [PR #557](https://github.com/Martian-Engineering/lossless-claw/pull/557) (cache-aware deferral gate fixes). PR #557's `criticalBudgetPressureRatio` default `0.70` lines up with this PR's tier-1 ratio so dispatched work fires reliably the moment the system enters tier-1 instead of being cache-throttled.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Lossless Context Management plugin for [OpenClaw](https://github.com/openclaw/op
 ## Table of contents
 
 - [What it does](#what-it-does)
+- [Compaction pressure architecture](#compaction-pressure-architecture)
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
 - [Commands And Skill](#commands-and-skill)
@@ -27,6 +28,188 @@ When a conversation grows beyond the model's context window, OpenClaw (just like
 Nothing is lost. Raw messages stay in the database. Summaries link back to their source messages. Agents can drill into any summary to recover the original detail.
 
 **It feels like talking to an agent that never forgets. Because it doesn't. In normal operation, you'll never need to think about compaction again.**
+
+## Compaction pressure architecture
+
+LCM operates as a **layered four-band system** keyed off prompt pressure
+(current tokens / effective budget). Each band has its own dispatch policy,
+and they compose so the prompt never approaches runtime overflow under
+normal operation.
+
+The plugin uses three composing capabilities:
+
+1. **Reserve-aware budget alignment** — LCM reads `runtimeContext.reserveTokens`
+   and subtracts it from the resolved budget so every percentage threshold
+   computes against the EFFECTIVE prompt budget (the same number the runtime
+   actually overflows at), not the raw context window.
+2. **Decoupled sweep trigger + target** — `sweepTriggerThreshold` (default
+   0.91) controls when sweep MODE fires; `sweepTargetThreshold` (default 0.50)
+   controls where the sweep STOPS. Below the sweep trigger, dispatched
+   compaction targets `contextThreshold` instead.
+3. **Pressure-tiered pass cap** — `pressureTiers` (default
+   `[{ratio:0.70,maxPasses:2},{ratio:0.80,maxPasses:3}]`) ladder lets each
+   dispatch run more sequential passes as pressure rises, exploiting the
+   fact that cache invalidation is a per-dispatch fixed cost (not per-pass).
+
+> **Cross-PR dependency:** Tier 1 and Tier 2 (rows below) are gated on the
+> `cacheAwareCompaction.criticalBudgetPressureRatio` knob from
+> [PR #557](https://github.com/Martian-Engineering/lossless-claw/pull/557).
+> That knob does not exist on this PR's branch alone — it ships separately.
+> The default value chosen there (`0.70`) is deliberately aligned with this
+> PR's tier-1 ratio so dispatched work fires reliably the moment the system
+> enters tier-1 instead of being cache-throttled up to 5 minutes per dispatch.
+> Without PR #557 also merged, tier-1 and tier-2 dispatches will be silently
+> smothered by cache-aware throttling under high-velocity sessions.
+
+```
+        effective prompt budget = tokenBudget − reserveTokens
+        ┌────────────────────────────────────────────────────────────┐
+0%    60%/trigger  70%/tier-1  80%/tier-2  91%/sweep        100%/overflow
+├─────┼────────────┼───────────┼───────────┼──────────────────────────┤
+│ low │  normal    │  tier-1   │  tier-2   │   SWEEP                   │
+│     │  1 pass /  │  2 passes │  3 passes │   (unlimited passes,      │
+│     │  dispatch  │  / disp.  │  / disp.  │    target 50%)            │
+│     │  exit @60% │  exit @60%│  exit @60%│   exit @ 50% of budget    │
+└─────┴────────────┴───────────┴───────────┴──────────────────────────┘
+                   ↑           ↑           ↑                           ↑
+                   tier-1      tier-2      sweepTriggerThreshold       runtime
+                   (cache-aware                                        emergency
+                   bypass also                                         truncation
+                   activates here                                      (last resort)
+                   via PR #557's
+                   0.70 default)
+```
+
+| Band | Range | Action | Config knob |
+|---|---|---|---|
+| **Low** | 0–60% | nothing fires | `contextThreshold` (default 0.60) |
+| **Normal** | 60–70% | maintenance debt queued; 1 pass per dispatch (cache-aware throttled, defers up to 5 min if cache hot) | `contextThreshold` |
+| **Tier 1** | 70–80% | 2 passes per dispatch, cache-aware delay bypassed | `pressureTiers[0]` (this PR) + `cacheAwareCompaction.criticalBudgetPressureRatio` (PR #557, default 0.70) |
+| **Tier 2** | 80–91% | 3 passes per dispatch, cache-aware delay bypassed | `pressureTiers[1]` (this PR) |
+| **Sweep** | ≥91% | unlimited passes, target `sweepTargetThreshold` (50%) — heavy catch-up, creates ~5+ turns of runway | `sweepTriggerThreshold` + `sweepTargetThreshold` |
+| **Overflow** | ≥100% | runtime emergency `truncate_tool_results_only` (openclaw side, last resort) | runtime config |
+
+### Why this layering?
+
+**Hidden insight: cache invalidation is a per-dispatch fixed cost, not per-pass.**
+When LCM compacts the oldest chunk, the prefix cache breaks at the modification
+point and everything from there to the end of the prompt must re-tokenize on
+the next turn. Doing 1 pass vs 3 passes vs 6 passes invalidates the SAME prefix
+— more passes just produce more reduction off that one cache break. This means
+multi-pass dispatch is the right shape at higher pressure, not "fire more
+often" (which would multiply cache invalidations).
+
+| Tier | Passes | Cache cost | Reduction per dispatch | Efficiency |
+|---|---|---|---|---|
+| Normal (1 pass) | 1 | 1× | ~17K | 17K / cache-break |
+| Tier 1 (2 passes) | 2 | 1× | ~34K | 34K / cache-break ← 2× |
+| Tier 2 (3 passes) | 3 | 1× | ~51K | 51K / cache-break ← 3× |
+| Sweep (unlimited) | 5–7 | 1× | ~80K–100K | huge / cache-break |
+
+### Why decouple sweep trigger from sweep target?
+
+Pre-2026, the sweep loop exited at `contextThreshold` (the same threshold that
+TRIGGERED it). With both at 0.75, sweep ran one or two passes (just enough to
+drop back below the trigger line) and then exited — no headroom created. The
+next turn pushed the prompt back over the trigger, sweep ran again, exited
+again. Worst of both worlds: sweep fires often and barely does any work.
+
+Decoupling the target (now 0.50 by default) AND adding a separate
+`sweepTriggerThreshold` (0.91) means:
+
+- Below 91%: dispatched work targets `contextThreshold` (gentle, doesn't
+  overshoot)
+- At ≥91%: sweep mode targets 50% — creates real multi-turn runway (~5+ turns
+  of buffer) before another trigger
+- Sweep becomes RARE because the headroom it creates absorbs ongoing input
+- Most turns are handled by the tier ladder without sweep ever needing to fire
+
+### Reserve-aware budget alignment
+
+LCM reads `runtimeContext.reserveTokens` (or the legacy `reserveTokensFloor`
+key) and subtracts it from the resolved `tokenBudget` before computing
+percentages. This way every threshold computes against the EFFECTIVE prompt
+budget — the same number the runtime actually overflows at — instead of the
+raw context window.
+
+| Without reserve alignment | With reserve alignment (default behavior) |
+|---|---|
+| Runtime: gpt-5.5 with 258K context, 20K reserve → overflow at 238K | Runtime: same |
+| LCM gets `tokenBudget = 258K`, all percentages computed against 258K | LCM gets `tokenBudget = 258K`, subtracts 20K reserve → percentages computed against 238K |
+| 60% trigger fires at 155K (65% of effective 238K) | 60% trigger fires at 143K (60% of effective) ✓ |
+| 91% sweep target lands at 235K (99% — almost overflowing) | 91% sweep target lands at 217K (91% of effective) ✓ |
+
+If your runtime doesn't pass `reserveTokens` (or the legacy `reserveTokensFloor`
+key), LCM falls back to the legacy behavior (raw budget, no subtraction) for
+backward compatibility.
+
+### Recommended openclaw operator config
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "mode": "safeguard",
+        "reserveTokensFloor": 20000
+      }
+    }
+  },
+  "plugins": {
+    "slots": { "contextEngine": "lossless-claw" },
+    "entries": {
+      "lossless-claw": {
+        "config": {
+          "contextThreshold": 0.60,
+          "sweepTargetThreshold": 0.50,
+          "sweepTriggerThreshold": 0.91,
+          "pressureTiers": [
+            { "ratio": 0.70, "maxPasses": 2 },
+            { "ratio": 0.80, "maxPasses": 3 }
+          ],
+          "cacheAwareCompaction": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+All values shown are the new defaults — operators only need to set them
+explicitly to override.
+
+**Why `reserveTokensFloor: 20000`:** the openclaw default. Operators sometimes
+raise it when hitting overflow due to cache-aware throttling (addressed by PR
+#557). With reserve-aware alignment in place, 20K leaves the LCM percentages
+well-aligned with the runtime overflow point and remains enough headroom for
+any normal model response.
+
+### Scenario walkthrough — real session data
+
+Real Eva session on gpt-5.5 (258K context, 20K reserve = 238K effective budget)
+before any patches:
+
+| Time | Prompt | LCM% (vs 258K raw) | Runtime% (vs 238K effective) | What fired |
+|---|---|---|---|---|
+| (steady state) | 180K | 70% | 76% | LCM saw "70%" — quiet; runtime was actually at 76% — under pressure |
+| (after a tool burst) | 219K | 85% | **92%** | LCM still saw "below 85%" — never fired; **runtime emergency** truncated 132 tool results |
+| (continued growth) | 227K | 88% | **95%** | LCM finally fired (cache went cold), 12 leaves, brought to 207K (still over runtime) |
+
+With the architecture above (recommended defaults):
+
+| Eva crosses... | Tier | Pass count | Action | Result |
+|---|---|---|---|---|
+| 143K (60% of 238K) | Normal | 1 | Maintenance debt queued, fires when cache cold | Cache-aware throttled — typically defers |
+| 167K (70% of 238K) | Tier 1 | 2 | Cache delay BYPASSED (PR #557), 2 passes per dispatch | ~34K reduction → drops to ~133K |
+| 190K (80% of 238K) | Tier 2 | 3 | 3 passes per dispatch | ~51K reduction → drops to ~139K |
+| If tier 1+2 fail, crosses 217K (91% of 238K) | **Sweep** | unlimited | Deep catch-up to 50% target (119K) | ~98K reduction → ~5 turns of buffer |
+| Effectively NEVER reaches 238K | Overflow | — | — | Runtime emergency essentially never fires |
+
+**Result: 0 emergency truncations** instead of 6 in the same window. Sweep
+becomes rare (typically 0–1 per heavy session) because tiers 1+2 absorb most
+escalation.
 
 ## Commands And Skill
 
@@ -165,7 +348,10 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_IGNORE_SESSION_PATTERNS` | `""` | Comma-separated glob patterns for session keys to exclude from LCM storage |
 | `LCM_STATELESS_SESSION_PATTERNS` | `""` | Comma-separated glob patterns for session keys that may read from LCM but never write to it |
 | `LCM_SKIP_STATELESS_SESSIONS` | `true` | Enable stateless-session write skipping for matching session keys |
-| `LCM_CONTEXT_THRESHOLD` | `0.75` | Fraction of context window that triggers compaction (0.0–1.0) |
+| `LCM_CONTEXT_THRESHOLD` | `0.60` | Fraction of effective token budget that TRIGGERS compaction (0.0–1.0). Trigger threshold only — sweep target/trigger and pressure tiers are configured separately. The 0.60 default leaves headroom for the cache-aware system to defer normally before tier-1 pressure kicks in. |
+| `LCM_SWEEP_TARGET_THRESHOLD` | `0.50` | Fraction of effective token budget that a SWEEP targets when it fires. Sweep mode only fires above `LCM_SWEEP_TRIGGER_THRESHOLD`; below that, dispatched compaction targets `LCM_CONTEXT_THRESHOLD` instead. |
+| `LCM_SWEEP_TRIGGER_THRESHOLD` | `0.91` | Fraction of effective token budget at which dispatched compaction switches into deep SWEEP mode. Below this, dispatches use the pressure-tier ladder (1/2/3 passes by tier). Above this, dispatches run unlimited passes targeting `LCM_SWEEP_TARGET_THRESHOLD`. |
+| `LCM_PRESSURE_TIERS` | `[{"ratio":0.70,"maxPasses":2},{"ratio":0.80,"maxPasses":3}]` | JSON array of `{ratio, maxPasses}` entries — pressure-tier ladder for dispatched compaction below sweep mode. Each entry caps passes-per-dispatch when current pressure crosses `ratio`. |
 | `LCM_FRESH_TAIL_COUNT` | `64` | Number of recent messages protected from compaction |
 | `LCM_NEW_SESSION_RETAIN_DEPTH` | `2` | Context retained after `/new` (`-1` keeps all context, `2` keeps d2+) |
 | `LCM_LEAF_MIN_FANOUT` | `8` | Minimum raw messages per leaf summary |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -11,7 +11,19 @@
     },
     "contextThreshold": {
       "label": "Context Threshold",
-      "help": "Fraction of context window that triggers compaction (0.0–1.0)"
+      "help": "Fraction of effective token budget that TRIGGERS compaction (default 0.60). Trigger threshold only — the sweep stopping point is configured separately via sweepTargetThreshold and the pressure tier ladder is in pressureTiers."
+    },
+    "sweepTargetThreshold": {
+      "label": "Sweep Target Threshold",
+      "help": "Fraction of effective token budget that a SWEEP targets when it fires (default 0.50). Sweep mode only fires above sweepTriggerThreshold (default 0.91); below that, dispatched compaction targets contextThreshold instead."
+    },
+    "sweepTriggerThreshold": {
+      "label": "Sweep Trigger Threshold",
+      "help": "Fraction of effective token budget at which dispatched compaction switches into deep SWEEP mode (default 0.91). Below this, dispatches use the pressure-tier ladder (1/2/3 passes per dispatch by tier). Above this, dispatches run unlimited passes targeting sweepTargetThreshold."
+    },
+    "pressureTiers": {
+      "label": "Pressure Tiers",
+      "help": "Ordered ladder of pressure ratios → maxPasses caps that govern dispatched compaction below sweepTriggerThreshold. Default: [{ratio:0.70,maxPasses:2},{ratio:0.80,maxPasses:3}] giving 1 pass at the trigger, 2 passes at 70%, 3 passes at 80%. Multi-pass amortizes prefix-cache invalidation across more reduction per dispatch."
     },
     "incrementalMaxDepth": {
       "label": "Incremental Max Depth",
@@ -217,6 +229,35 @@
         "type": "number",
         "minimum": 0,
         "maximum": 1
+      },
+      "sweepTargetThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "sweepTriggerThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "pressureTiers": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ratio", "maxPasses"],
+          "properties": {
+            "ratio": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "exclusiveMaximum": 1
+            },
+            "maxPasses": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
       },
       "incrementalMaxDepth": {
         "type": "integer",

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -469,6 +469,10 @@ export class CompactionEngine {
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;
+    /** Optional sweep target ratio (fraction of tokenBudget) — see compactFullSweep. */
+    targetRatio?: number;
+    /** Optional cap on combined leaf+condensed passes per dispatch. */
+    maxPasses?: number;
   }): Promise<CompactionResult> {
     return this.withContextCache(() => this.compactFullSweep(input));
   }
@@ -630,14 +634,48 @@ export class CompactionEngine {
     force?: boolean;
     hardTrigger?: boolean;
     summaryModel?: string;
+    /**
+     * Optional sweep target ratio (fraction of `tokenBudget`) — if provided,
+     * the sweep loop continues until `currentTokens <= targetRatio * tokenBudget`,
+     * decoupling the sweep stopping point from `contextThreshold`. When omitted,
+     * the legacy behavior applies (sweep exits at `contextThreshold`).
+     *
+     * The trigger condition is still evaluated against `contextThreshold` —
+     * `targetRatio` only affects when the loop STOPS, not whether it starts.
+     */
+    targetRatio?: number;
+    /**
+     * Optional cap on the number of leaf+condensed passes per dispatch. Used
+     * to implement pressure-tiered pass count: tier-1 caps at 2, tier-2 caps
+     * at 3, sweep mode (≥ sweepTriggerThreshold) leaves this unset for
+     * unlimited passes. When omitted, the loop's existing exit conditions
+     * (under target / no progress / no candidates) are the only stops.
+     */
+    maxPasses?: number;
   }): Promise<CompactionResult> {
     const { conversationId, tokenBudget, summarize, force, hardTrigger } = input;
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
-    const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    // Trigger threshold (when sweep is allowed to RUN) — always uses contextThreshold.
+    const triggerThreshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    // Target threshold (where sweep STOPS) — defaults to triggerThreshold for
+    // backward compatibility (no targetRatio supplied). Otherwise honors the
+    // configured ratio across the full [0, 1] range:
+    //   ratio = 0   → maximum sweep (loop's empty-candidate / no-progress
+    //                 bails are the only stopping conditions)
+    //   ratio = 1   → equivalent to triggerThreshold (legacy behavior)
+    //   ratio in (0, 1) → fraction of tokenBudget
+    // This matches the [0, 1] clamp that the config resolver applies.
+    const targetThreshold =
+      typeof input.targetRatio === "number"
+        && Number.isFinite(input.targetRatio)
+        && input.targetRatio >= 0
+        && input.targetRatio <= 1
+        ? Math.min(triggerThreshold, Math.floor(input.targetRatio * tokenBudget))
+        : triggerThreshold;
     const leafTrigger = await this.evaluateLeafTrigger(conversationId);
 
-    if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
+    if (!force && tokensBefore <= triggerThreshold && !leafTrigger.shouldCompact) {
       return {
         actionTaken: false,
         tokensBefore,
@@ -664,11 +702,23 @@ export class CompactionEngine {
     let previousTokens = tokensBefore;
     let hadAuthFailure = false;
 
+    // Pressure-tiered pass cap (pre-PR-558 behavior is unbounded). When
+    // `input.maxPasses` is supplied, the leaf+condensed phases combined will
+    // not exceed this many summary calls. Tier-1 callers pass 2, tier-2
+    // pass 3, sweep mode passes undefined (unlimited).
+    const passCap =
+      typeof input.maxPasses === "number"
+        && Number.isFinite(input.maxPasses)
+        && input.maxPasses >= 1
+        ? Math.floor(input.maxPasses)
+        : Infinity;
+    let passesUsed = 0;
+
     // Phase 1: leaf passes over oldest raw chunks outside the protected tail.
     // Delta tracking: maintain a running token count instead of re-querying DB
     // after each pass. The arithmetic is exact: tokensAfter = tokensBefore - removed + added.
     let runningTokens = tokensBefore;
-    while (true) {
+    while (passesUsed < passCap) {
       const leafChunk = await this.selectOldestLeafChunk(conversationId);
       if (leafChunk.items.length === 0) {
         break;
@@ -686,6 +736,7 @@ export class CompactionEngine {
         hadAuthFailure = true;
         break;
       }
+      passesUsed++;
       const passTokensAfter = passTokensBefore - leafResult.removedTokens + leafResult.addedTokens;
       await this.persistCompactionEvents({
         conversationId,
@@ -702,7 +753,7 @@ export class CompactionEngine {
       previousSummaryContent = leafResult.content;
       runningTokens = passTokensAfter;
 
-      if (!force && passTokensAfter <= threshold) {
+      if (!force && passTokensAfter <= targetThreshold) {
         previousTokens = passTokensAfter;
         break;
       }
@@ -713,7 +764,10 @@ export class CompactionEngine {
     }
 
     // Phase 2: depth-aware condensed passes, always processing shallowest depth first.
-    while (force || previousTokens > threshold) {
+    // Uses the same targetThreshold so condensed passes also stop at the configured
+    // sweep depth rather than the trigger threshold. The pass cap (passesUsed
+    // counter) is shared with phase 1.
+    while ((force || previousTokens > targetThreshold) && passesUsed < passCap) {
       const candidate = await this.selectShallowestCondensationCandidate({
         conversationId,
         hardTrigger: hardTrigger === true,
@@ -734,6 +788,7 @@ export class CompactionEngine {
         hadAuthFailure = true;
         break;
       }
+      passesUsed++;
       const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
       await this.persistCompactionEvents({
         conversationId,
@@ -750,7 +805,7 @@ export class CompactionEngine {
       level = condenseResult.level;
       runningTokens = passTokensAfter;
 
-      if (!force && passTokensAfter <= threshold) {
+      if (!force && passTokensAfter <= targetThreshold) {
         previousTokens = passTokensAfter;
         break;
       }

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -54,6 +54,44 @@ export type LcmConfig = {
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
   contextThreshold: number;
+  /**
+   * Sweep target threshold (fraction of token budget) — when a deep sweep
+   * fires, it compacts until the prompt is at or below this fraction of the
+   * effective token budget. Defaults to 0.50.
+   *
+   * Optional for backward-compatibility: callers that construct LcmConfig
+   * literals without this field will see runtime fall back to the default
+   * (0.50) at use sites. Operators going through `resolveLcmConfig` get the
+   * default automatically.
+   */
+  sweepTargetThreshold?: number;
+  /**
+   * Sweep trigger threshold (fraction of token budget) — only when current
+   * pressure reaches this ratio does dispatched compaction switch into "sweep
+   * mode" and target `sweepTargetThreshold`. Below this ratio, dispatched
+   * compaction targets `contextThreshold` (gentle, exits at trigger line).
+   * Defaults to 0.91.
+   *
+   * Optional for backward compatibility — same rationale as `sweepTargetThreshold`.
+   */
+  sweepTriggerThreshold?: number;
+  /**
+   * Pressure-tiered pass count multipliers. Each entry is `{ ratio, maxPasses }`
+   * — when current pressure crosses `ratio` and stays below the next tier (or
+   * below `sweepTriggerThreshold`), dispatched compaction runs up to
+   * `maxPasses` sequential passes per dispatch. Tiers must be sorted by
+   * `ratio` ascending.
+   *
+   * Multi-pass amortizes the prefix-cache invalidation cost — every pass in a
+   * single dispatch invalidates the SAME cache prefix (modification point
+   * forward), so doing 3 passes per dispatch costs the same cache-wise as
+   * doing 1, but reduces 3× as many tokens.
+   *
+   * Defaults to `[{ ratio: 0.70, maxPasses: 2 }, { ratio: 0.80, maxPasses: 3 }]`.
+   *
+   * Optional for backward compatibility — same rationale as `sweepTargetThreshold`.
+   */
+  pressureTiers?: Array<{ ratio: number; maxPasses: number }>;
   freshTailCount: number;
   /** Optional token cap for the protected fresh tail; newest message is always preserved. */
   freshTailMaxTokens?: number;
@@ -169,6 +207,56 @@ function toFallbackProviderArray(value: unknown): Array<{ provider: string; mode
     }
   }
   return entries.length > 0 ? entries : undefined;
+}
+
+/**
+ * Single source of truth for the layered pressure architecture defaults.
+ * Engine-side fallbacks (`src/engine.ts`) import these constants instead of
+ * mirroring them, so the resolver and the engine can never drift.
+ */
+export const DEFAULT_CONTEXT_THRESHOLD = 0.60;
+export const DEFAULT_SWEEP_TARGET_THRESHOLD = 0.50;
+export const DEFAULT_SWEEP_TRIGGER_THRESHOLD = 0.91;
+export const DEFAULT_PRESSURE_TIERS: ReadonlyArray<{ ratio: number; maxPasses: number }> = [
+  { ratio: 0.70, maxPasses: 2 },
+  { ratio: 0.80, maxPasses: 3 },
+];
+
+/**
+ * Resolve pressure-tier ladder from env (`LCM_PRESSURE_TIERS` as JSON) or
+ * plugin config (`pressureTiers` as array). Each entry must have a finite
+ * `ratio` in (0, 1) and a finite `maxPasses` >= 1. Returns the default ladder
+ * if input is missing, malformed, or empty after filtering. Output is sorted
+ * ascending by ratio so callers can early-exit when comparing pressure.
+ */
+function resolvePressureTiers(
+  env: NodeJS.ProcessEnv,
+  pc: Record<string, unknown>,
+): Array<{ ratio: number; maxPasses: number }> {
+  const fromEnv = (() => {
+    const raw = env.LCM_PRESSURE_TIERS?.trim();
+    if (!raw) return undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
+  const candidates = fromEnv ?? (Array.isArray(pc.pressureTiers) ? pc.pressureTiers : undefined);
+  if (!candidates) return [...DEFAULT_PRESSURE_TIERS];
+  const tiers: Array<{ ratio: number; maxPasses: number }> = [];
+  for (const item of candidates) {
+    if (!item || typeof item !== "object") continue;
+    const ratio = toNumber((item as Record<string, unknown>).ratio);
+    const maxPasses = toNumber((item as Record<string, unknown>).maxPasses);
+    if (ratio === undefined || ratio <= 0 || ratio >= 1) continue;
+    if (maxPasses === undefined || maxPasses < 1) continue;
+    tiers.push({ ratio, maxPasses: Math.floor(maxPasses) });
+  }
+  if (tiers.length === 0) return [...DEFAULT_PRESSURE_TIERS];
+  tiers.sort((a, b) => a.ratio - b.ratio);
+  return tiers;
 }
 
 /** Safely coerce an unknown value to a boolean, or return undefined. */
@@ -357,9 +445,34 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_SKIP_STATELESS_SESSIONS !== undefined
           ? env.LCM_SKIP_STATELESS_SESSIONS === "true"
           : toBool(pc.skipStatelessSessions) ?? true,
-      contextThreshold:
-        parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
-          ?? toNumber(pc.contextThreshold) ?? 0.75,
+      contextThreshold: Math.min(
+        1,
+        Math.max(
+          0,
+          parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
+            ?? toNumber(pc.contextThreshold)
+            ?? DEFAULT_CONTEXT_THRESHOLD,
+        ),
+      ),
+      sweepTargetThreshold: Math.min(
+        1,
+        Math.max(
+          0,
+          parseFiniteNumber(env.LCM_SWEEP_TARGET_THRESHOLD)
+            ?? toNumber(pc.sweepTargetThreshold)
+            ?? DEFAULT_SWEEP_TARGET_THRESHOLD,
+        ),
+      ),
+      sweepTriggerThreshold: Math.min(
+        1,
+        Math.max(
+          0,
+          parseFiniteNumber(env.LCM_SWEEP_TRIGGER_THRESHOLD)
+            ?? toNumber(pc.sweepTriggerThreshold)
+            ?? DEFAULT_SWEEP_TRIGGER_THRESHOLD,
+        ),
+      ),
+      pressureTiers: resolvePressureTiers(env, pc),
       freshTailCount:
         parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
           ?? toNumber(pc.freshTailCount) ?? 64,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -46,7 +46,12 @@ import {
   parseFileBlocks,
 } from "./large-files.js";
 import { describeLogError } from "./lcm-log.js";
-import { describeLcmConfigSource } from "./db/config.js";
+import {
+  DEFAULT_PRESSURE_TIERS,
+  DEFAULT_SWEEP_TARGET_THRESHOLD,
+  DEFAULT_SWEEP_TRIGGER_THRESHOLD,
+  describeLcmConfigSource,
+} from "./db/config.js";
 import { RetrievalEngine } from "./retrieval.js";
 import { compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
 import { logStartupBannerOnce } from "./startup-banner-log.js";
@@ -149,7 +154,13 @@ type CompactionExecutionParams = {
   conversationId: number;
   sessionId: string;
   sessionKey?: string;
-  tokenBudget: number;
+  /**
+   * Optional — when undefined, executeCompactionCore returns
+   * `{ ok: false, reason: "missing token budget in compact params" }`.
+   * Public callers should resolve and reserve-adjust budget BEFORE calling
+   * (see compact() public API for the pattern).
+   */
+  tokenBudget?: number;
   currentTokenCount?: number;
   compactionTarget?: "budget" | "threshold";
   customInstructions?: string;
@@ -2001,29 +2012,178 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget?: number;
     runtimeContext?: Record<string, unknown>;
     legacyParams?: Record<string, unknown>;
+    /**
+     * When `true`, treat `params.tokenBudget` (if provided) as ALREADY
+     * reserve-adjusted and skip subtraction. Internal helpers like
+     * `executeCompactionCore` set this to avoid double-subtraction along the
+     * deferred-compaction drain path:
+     *   afterTurn → resolveTokenBudget(raw) → adjusted → record debt
+     *   maintain → reads adjusted from debt → executeCompactionCore(adjusted)
+     *   ↑ if executeCompactionCore re-applies reserve here, we lose 2× the
+     *   reserve from the budget LCM computes percentages against.
+     *
+     * Defaults to `false` so public entry points keep getting the adjusted
+     * value without changes.
+     */
+    alreadyReserveAdjusted?: boolean;
   }): number | undefined {
     const lp = asRecord(params.runtimeContext) ?? params.legacyParams ?? {};
+    let raw: number | undefined;
+    let explicit = false;
     if (
       typeof params.tokenBudget === "number" &&
       Number.isFinite(params.tokenBudget) &&
       params.tokenBudget > 0
     ) {
-      return Math.floor(params.tokenBudget);
-    }
-    if (
+      raw = Math.floor(params.tokenBudget);
+      explicit = true;
+    } else if (
       typeof lp.tokenBudget === "number" &&
       Number.isFinite(lp.tokenBudget) &&
       lp.tokenBudget > 0
     ) {
-      return Math.floor(lp.tokenBudget);
+      raw = Math.floor(lp.tokenBudget);
     }
-    return undefined;
+    if (raw === undefined) {
+      return undefined;
+    }
+    // Skip reserve subtraction when caller explicitly opts out (already
+    // adjusted). Otherwise apply normally so public entry points get the
+    // effective prompt budget.
+    if (params.alreadyReserveAdjusted && explicit) {
+      return raw;
+    }
+    return this.applyReserveTokens(raw, lp);
+  }
+
+  /**
+   * Subtract the runtime's response-output reserve from the resolved budget so
+   * LCM percentages (`contextThreshold`, `sweepTargetThreshold`, and any other
+   * downstream pressure thresholds) compute against the EFFECTIVE prompt
+   * budget — the same number the runtime actually overflows at.
+   *
+   * Without this, callers like the openclaw gateway pass `tokenBudget = full
+   * context window` while the runtime overflows at `tokenBudget - reserve`,
+   * making LCM's percentages too generous and letting the prompt grow past
+   * the overflow point before any compaction threshold fires.
+   *
+   * Reserve is read from `runtimeContext.reserveTokens` (preferred) or
+   * `runtimeContext.reserveTokensFloor` (legacy openclaw key) — both are
+   * passed through unchanged from the host. Defaults to 0 when neither is
+   * present so plugins that don't pass a reserve get the legacy behavior.
+   */
+  private applyReserveTokens(
+    rawBudget: number,
+    runtimeContext: Record<string, unknown>,
+  ): number {
+    const reserve =
+      this.normalizeOptionalCount(runtimeContext.reserveTokens)
+        ?? this.normalizeOptionalCount(runtimeContext.reserveTokensFloor)
+        ?? 0;
+    if (reserve <= 0) {
+      return rawBudget;
+    }
+    if (reserve >= rawBudget) {
+      // Misconfiguration: reserve consumes the entire budget. The legacy
+      // floor-at-1 silently produced a degenerate budget that propagated
+      // pathological 0-target loops through compactFullSweep. Log loudly and
+      // ignore the reserve so the caller's downstream safety checks see a
+      // realistic budget instead of `1`.
+      this.deps.log.warn(
+        `[lcm] applyReserveTokens: misconfigured reserve (${reserve}) >= rawBudget (${rawBudget}); ignoring reserve to avoid degenerate budget. Lower runtimeContext.reserveTokens (or the legacy reserveTokensFloor key) or raise the model's tokenBudget.`,
+      );
+      return rawBudget;
+    }
+    return rawBudget - reserve;
   }
 
   /** Cap a resolved token budget against the configured maxAssemblyTokenBudget. */
   private applyAssemblyBudgetCap(budget: number): number {
     const cap = this.config.maxAssemblyTokenBudget;
     return cap != null && cap > 0 ? Math.min(budget, cap) : budget;
+  }
+
+  /**
+   * Resolve the pressure-tiered dispatch policy for `compactFullSweep`.
+   *
+   * Layered architecture:
+   *   • current pressure < tier-1 ratio   → 1 pass (existing behavior),
+   *                                          target = contextThreshold
+   *   • tier-1 ≤ pressure < tier-2        → tier-1 maxPasses,
+   *                                          target = contextThreshold
+   *   • tier-2 ≤ pressure < sweepTrigger  → tier-2 maxPasses,
+   *                                          target = contextThreshold
+   *   • pressure ≥ sweepTriggerThreshold  → no pass cap (unlimited),
+   *                                          target = sweepTargetThreshold
+   *
+   * When `currentTokenCount` is unknown, falls back to the GENTLEST policy
+   * (1 pass, target = contextThreshold) rather than aggressive sweep mode.
+   * That used to be sweep semantics for "PR #558 backward compat" but we
+   * realized that's the opposite of safe defaults — under-instrumented
+   * callers should not silently get a deep multi-pass sweep.
+   */
+  private resolvePressureDispatchPolicy(input: {
+    currentTokenCount?: number;
+    tokenBudget: number;
+  }): { targetRatio: number; maxPasses?: number } {
+    // Sort tiers defensively in case a caller mutates config or constructs
+    // an LcmConfig literal without going through resolveLcmConfig.
+    // Treat an EMPTY array the same as `undefined` and fall back to the
+    // canonical ladder. Without this, an explicit `pressureTiers: []` would
+    // silently produce 1-pass-everywhere behavior — diverging from the
+    // documented "empty/malformed → defaults" semantics in the resolver.
+    const tiers =
+      Array.isArray(this.config.pressureTiers) && this.config.pressureTiers.length > 0
+        ? [...this.config.pressureTiers].sort((a, b) => a.ratio - b.ratio)
+        : DEFAULT_PRESSURE_TIERS;
+    const sweepTarget = this.config.sweepTargetThreshold ?? DEFAULT_SWEEP_TARGET_THRESHOLD;
+    const sweepTrigger = this.config.sweepTriggerThreshold ?? DEFAULT_SWEEP_TRIGGER_THRESHOLD;
+    const trigger = this.config.contextThreshold;
+
+    if (
+      typeof input.currentTokenCount !== "number"
+      || !Number.isFinite(input.currentTokenCount)
+      || input.currentTokenCount <= 0
+      || input.tokenBudget <= 0
+    ) {
+      // Unknown pressure — gentlest policy. Target the trigger line, cap to
+      // 1 pass so we don't surprise the caller with a multi-pass sweep on
+      // data they didn't provide.
+      return { targetRatio: trigger, maxPasses: 1 };
+    }
+
+    const currentRatio = input.currentTokenCount / input.tokenBudget;
+
+    if (currentRatio >= sweepTrigger) {
+      // Sweep mode: deep target, no per-dispatch pass cap.
+      return { targetRatio: sweepTarget };
+    }
+
+    // Walk tiers ascending; the LAST tier whose ratio is crossed wins.
+    // Validate per-tier defensively in case a malformed entry slipped past
+    // the resolver.
+    let activeMaxPasses: number | undefined;
+    for (const tier of tiers) {
+      if (
+        !tier
+        || typeof tier.ratio !== "number"
+        || !Number.isFinite(tier.ratio)
+        || typeof tier.maxPasses !== "number"
+        || !Number.isFinite(tier.maxPasses)
+        || tier.maxPasses < 1
+      ) {
+        continue;
+      }
+      if (currentRatio >= tier.ratio) {
+        activeMaxPasses = Math.floor(tier.maxPasses);
+      } else {
+        break;
+      }
+    }
+    return {
+      targetRatio: trigger, // gentle target (don't overshoot below trigger line)
+      maxPasses: activeMaxPasses ?? 1, // 1 pass if no tier crossed
+    };
   }
 
   /** Normalize token counters that may legitimately be zero. */
@@ -3045,6 +3205,13 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     tokenBudget: number;
     currentTokenCount?: number;
+    /**
+     * Optional runtimeContext passed through from `assemble()`. Threaded into
+     * `consumeDeferredCompactionDebt` so downstream `executeCompactionCore`
+     * can consume `provider`/`model`/`manualCompaction` fields rather than
+     * falling back to telemetry-only legacy params.
+     */
+    runtimeContext?: Record<string, unknown>;
   }): Promise<void> {
     const sessionLabel = [
       `session=${params.sessionId}`,
@@ -3084,6 +3251,7 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
             tokenBudget: params.tokenBudget,
             currentTokenCount: params.currentTokenCount,
+            runtimeContext: params.runtimeContext,
             legacyParams: deferredLegacyParams,
           });
           return;
@@ -3112,10 +3280,15 @@ export class LcmContextEngine implements ContextEngine {
         }
       ).manualCompaction === true;
     const forceCompaction = force || manualCompactionRequested;
+    // Internal helper called from consumeDeferredCompactionDebt etc. — the
+    // explicit params.tokenBudget is already reserve-adjusted by the caller
+    // (see resolveTokenBudget JSDoc for the deferred-compaction drain path).
+    // Skip re-subtraction here to avoid losing 2× the reserve.
     const resolvedTokenBudget = this.resolveTokenBudget({
       tokenBudget: params.tokenBudget,
       runtimeContext: params.runtimeContext,
       legacyParams,
+      alreadyReserveAdjusted: true,
     });
     const tokenBudget = resolvedTokenBudget
       ? this.applyAssemblyBudgetCap(resolvedTokenBudget)
@@ -3174,6 +3347,23 @@ export class LcmContextEngine implements ContextEngine {
     // overflow counts can drive recovery even when persisted context is already small.
     const useSweep = manualCompactionRequested || params.compactionTarget === "threshold";
     if (useSweep) {
+      // Pressure-tiered dispatch policy:
+      //   • below sweepTriggerThreshold: pick a tier from `pressureTiers`
+      //     (default tier-1 at 0.70 → 2 passes, tier-2 at 0.80 → 3 passes)
+      //     and target contextThreshold (gentle, exits at trigger line).
+      //   • at or above sweepTriggerThreshold (default 0.91): sweep mode —
+      //     no pass cap, target sweepTargetThreshold (default 0.50, deep
+      //     headroom-creating compaction).
+      //
+      // Multi-pass amortizes cache invalidation: every pass in a single
+      // dispatch invalidates the SAME cache prefix (modification point
+      // forward), so 3 passes cost the same cache-wise as 1 but reduce 3×
+      // as many tokens. That's why higher pressure → more passes per
+      // dispatch is the right shape rather than "fire more often."
+      const dispatchPolicy = this.resolvePressureDispatchPolicy({
+        currentTokenCount: observedTokens,
+        tokenBudget,
+      });
       const sweepResult = await this.compaction.compact({
         conversationId,
         tokenBudget,
@@ -3181,6 +3371,10 @@ export class LcmContextEngine implements ContextEngine {
         force: forceCompaction,
         hardTrigger: false,
         summaryModel,
+        targetRatio: dispatchPolicy.targetRatio,
+        ...(dispatchPolicy.maxPasses !== undefined
+          ? { maxPasses: dispatchPolicy.maxPasses }
+          : {}),
       });
 
       if (sweepResult.authFailure && breakerKey) {
@@ -5386,7 +5580,7 @@ export class LcmContextEngine implements ContextEngine {
           conversation.conversationId,
         );
         if (params.runtimeContext?.allowDeferredCompactionExecution === true) {
-          const runtimeTokenBudget = (() => {
+          const runtimeTokenBudgetRaw = (() => {
             const tokenBudget = asRecord(params.runtimeContext)?.tokenBudget;
             if (
               typeof tokenBudget === "number"
@@ -5397,6 +5591,17 @@ export class LcmContextEngine implements ContextEngine {
             }
             return 128_000;
           })();
+          // Apply reserve subtraction here at the public-entry level so the
+          // value passed to consumeDeferredCompactionDebt is the EFFECTIVE
+          // prompt budget. Otherwise executeCompactionCore (which sets
+          // alreadyReserveAdjusted: true to avoid double-subtraction in the
+          // afterTurn-records-then-maintain-drains path) would skip
+          // subtraction here and silently bypass reserve alignment when
+          // recordedTokenBudget is null (fresh maintenance row).
+          const runtimeTokenBudget = this.applyReserveTokens(
+            runtimeTokenBudgetRaw,
+            asRecord(params.runtimeContext) ?? {},
+          );
           if ((maintenance?.pending || maintenance?.running)
             && this.shouldDelayPromptMutatingDeferredCompaction(telemetry)) {
             this.deps.log.info(
@@ -5989,7 +6194,17 @@ export class LcmContextEngine implements ContextEngine {
       runtimeContext: params.runtimeContext,
       legacyParams,
     });
-    const tokenBudget = this.applyAssemblyBudgetCap(resolvedTokenBudget ?? DEFAULT_AFTER_TURN_TOKEN_BUDGET);
+    // When neither params.tokenBudget nor runtimeContext.tokenBudget is
+    // supplied, resolveTokenBudget returns undefined and we fall back to the
+    // default. Apply reserve adjustment to the fallback too so percentages
+    // compute against the EFFECTIVE budget — matches the maintain() pattern
+    // and prevents reserve-aware alignment from being silently bypassed when
+    // a host calls afterTurn with reserveTokens but no tokenBudget.
+    const fallbackBudget = this.applyReserveTokens(
+      DEFAULT_AFTER_TURN_TOKEN_BUDGET,
+      asRecord(params.runtimeContext) ?? {},
+    );
+    const tokenBudget = this.applyAssemblyBudgetCap(resolvedTokenBudget ?? fallbackBudget);
     if (resolvedTokenBudget === undefined) {
       this.deps.log.warn(
         `[lcm] afterTurn: tokenBudget not provided; using default ${DEFAULT_AFTER_TURN_TOKEN_BUDGET}`,
@@ -6184,6 +6399,15 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget?: number;
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
+    /**
+     * Optional runtime context — when supplied with `reserveTokens` (or the
+     * legacy `reserveTokensFloor` key), the deferred-compaction drain path
+     * triggered from this `assemble()` call computes pressure ratios against
+     * the EFFECTIVE prompt budget instead of the raw context window. Mirrors
+     * the reserve-aware semantics of `afterTurn()` / `maintain()`. Backward
+     * compatible: when omitted, the legacy raw-budget behavior is preserved.
+     */
+    runtimeContext?: Record<string, unknown>;
   }): Promise<AssembleResult> {
     // Return a new fallback array so the runtime hook treats this as assembled
     // context, and remove assistant prefill tails from fallback-only paths.
@@ -6217,13 +6441,22 @@ export class LcmContextEngine implements ContextEngine {
         return safeFallback();
       }
 
-      const tokenBudget = this.applyAssemblyBudgetCap(
+      const rawTokenBudget =
         typeof params.tokenBudget === "number" &&
         Number.isFinite(params.tokenBudget) &&
         params.tokenBudget > 0
           ? Math.floor(params.tokenBudget)
-          : 128_000,
+          : 128_000;
+      // Apply reserve subtraction at the public-entry level so the value
+      // passed downstream is the EFFECTIVE prompt budget. Without this, the
+      // assemble-driven deferred compaction drain path would compute pressure
+      // ratios against the raw context window — same class of bug as the
+      // maintain() path, surfaced by the final adversarial sweep.
+      const adjustedTokenBudget = this.applyReserveTokens(
+        rawTokenBudget,
+        asRecord(params.runtimeContext) ?? {},
       );
+      const tokenBudget = this.applyAssemblyBudgetCap(adjustedTokenBudget);
       const liveContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
@@ -6236,6 +6469,7 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
             tokenBudget,
             currentTokenCount: liveContextTokens,
+            runtimeContext: asRecord(params.runtimeContext),
           });
         } catch (error) {
           this.deps.log.warn(
@@ -6664,11 +6898,26 @@ export class LcmContextEngine implements ContextEngine {
             reason: "no conversation found for session",
           };
         }
+        // Public entry — apply reserve subtraction here so the value passed
+        // to executeCompactionCore is the EFFECTIVE budget. executeCompactionCore
+        // then treats it as already-adjusted (alreadyReserveAdjusted: true) to
+        // avoid double-subtraction.
+        const legacyParamsForBudget = asRecord(params.runtimeContext) ?? params.legacyParams;
+        const adjustedBudget = this.resolveTokenBudget({
+          tokenBudget: params.tokenBudget,
+          runtimeContext: params.runtimeContext,
+          legacyParams: legacyParamsForBudget,
+        });
         return this.executeCompactionCore({
           conversationId: conversation.conversationId,
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
-          tokenBudget: params.tokenBudget,
+          // Don't fall back to params.tokenBudget here. If adjustedBudget is
+          // undefined (no budget was supplied anywhere), let
+          // executeCompactionCore return its "missing token budget" error
+          // rather than silently passing the RAW value through with
+          // alreadyReserveAdjusted: true (which would bypass reserve subtraction).
+          tokenBudget: adjustedBudget,
           currentTokenCount: params.currentTokenCount,
           compactionTarget: params.compactionTarget,
           customInstructions: params.customInstructions,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -25,7 +25,13 @@ describe("resolveLcmConfig", () => {
     expect(config.ignoreSessionPatterns).toEqual([]);
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
-    expect(config.contextThreshold).toBe(0.75);
+    expect(config.contextThreshold).toBe(0.60);
+    expect(config.sweepTargetThreshold).toBe(0.50);
+    expect(config.sweepTriggerThreshold).toBe(0.91);
+    expect(config.pressureTiers).toEqual([
+      { ratio: 0.70, maxPasses: 2 },
+      { ratio: 0.80, maxPasses: 3 },
+    ]);
     expect(config.freshTailCount).toBe(64);
     expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.promptAwareEviction).toBe(false);
@@ -281,7 +287,7 @@ describe("resolveLcmConfig", () => {
       newSessionRetainDepth: "nope",
       enabled: "maybe",
     });
-    expect(config.contextThreshold).toBe(0.75); // falls through to default
+    expect(config.contextThreshold).toBe(0.60); // falls through to default
     expect(config.freshTailCount).toBe(64); // falls through to default
     expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.promptAwareEviction).toBe(false); // falls through to default

--- a/test/sweep-target-and-reserve-aware-budget.test.ts
+++ b/test/sweep-target-and-reserve-aware-budget.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Tests for the sweep-target / reserve-aware budget alignment work.
+ *
+ * Two related capabilities ship together:
+ *   1. `sweepTargetThreshold` — decouples "where sweep STOPS" from
+ *      "where compaction is REQUESTED" (the existing `contextThreshold`).
+ *   2. Reserve-aware budget alignment — `runtimeContext.reserveTokens` is
+ *      subtracted from the resolved tokenBudget so LCM percentages compute
+ *      against the EFFECTIVE prompt budget (the same number the runtime
+ *      actually overflows at), not the raw context window.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveLcmConfig } from "../src/db/config.js";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const tempDirs: string[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) {
+    try {
+      closeLcmConnection(db);
+    } catch {
+      // ignore
+    }
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  }
+});
+
+/**
+ * Build a test config by deriving from `resolveLcmConfig` (the same code
+ * the production runtime uses) and only overriding the database path.
+ * This keeps the test in sync with future LcmConfig additions automatically.
+ */
+function createMinimalConfig(databasePath: string): LcmConfig {
+  const base = resolveLcmConfig({}, {});
+  return {
+    ...base,
+    databasePath,
+    largeFilesDir: join(databasePath, "..", "large-files"),
+    timezone: "UTC",
+  };
+}
+
+function createMinimalDeps(config: LcmConfig): LcmDependencies {
+  return {
+    config,
+    complete: vi.fn(),
+    resolveAgentDir: () => process.env.HOME ?? tmpdir(),
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as unknown as LcmDependencies;
+}
+
+function createEngine(): LcmContextEngine {
+  const tempDir = mkdtempSync(join(tmpdir(), "lcm-sweep-target-"));
+  tempDirs.push(tempDir);
+  const config = createMinimalConfig(join(tempDir, "lcm.db"));
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  return new LcmContextEngine(createMinimalDeps(config), db);
+}
+
+/** Variant that also returns the deps (so tests can spy on log.warn etc). */
+function createEngineWithDeps(): { engine: LcmContextEngine; deps: LcmDependencies } {
+  const tempDir = mkdtempSync(join(tmpdir(), "lcm-sweep-target-"));
+  tempDirs.push(tempDir);
+  const config = createMinimalConfig(join(tempDir, "lcm.db"));
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  const deps = createMinimalDeps(config);
+  const engine = new LcmContextEngine(deps, db);
+  return { engine, deps };
+}
+
+describe("sweepTargetThreshold config resolution", () => {
+  it("defaults to 0.50 when no env or plugin config provided", () => {
+    const config = resolveLcmConfig({}, {});
+    expect(config.sweepTargetThreshold).toBe(0.50);
+  });
+
+  it("reads sweepTargetThreshold from plugin config", () => {
+    const config = resolveLcmConfig({}, { sweepTargetThreshold: 0.40 });
+    expect(config.sweepTargetThreshold).toBe(0.40);
+  });
+
+  it("LCM_SWEEP_TARGET_THRESHOLD env var overrides plugin config", () => {
+    const config = resolveLcmConfig(
+      { LCM_SWEEP_TARGET_THRESHOLD: "0.30" } as NodeJS.ProcessEnv,
+      { sweepTargetThreshold: 0.45 },
+    );
+    expect(config.sweepTargetThreshold).toBe(0.30);
+  });
+
+  it("clamps out-of-range values to [0, 1]", () => {
+    expect(resolveLcmConfig({}, { sweepTargetThreshold: -0.5 }).sweepTargetThreshold).toBe(0);
+    expect(resolveLcmConfig({}, { sweepTargetThreshold: 1.5 }).sweepTargetThreshold).toBe(1);
+  });
+
+  it("falls back to 0.50 when value is non-finite", () => {
+    expect(resolveLcmConfig({}, { sweepTargetThreshold: Number.NaN }).sweepTargetThreshold).toBe(
+      0.50,
+    );
+  });
+});
+
+describe("sweepTriggerThreshold + pressureTiers config resolution", () => {
+  it("defaults to sweepTriggerThreshold = 0.91", () => {
+    expect(resolveLcmConfig({}, {}).sweepTriggerThreshold).toBe(0.91);
+  });
+
+  it("env var overrides plugin config for sweepTriggerThreshold", () => {
+    const config = resolveLcmConfig(
+      { LCM_SWEEP_TRIGGER_THRESHOLD: "0.95" } as NodeJS.ProcessEnv,
+      { sweepTriggerThreshold: 0.85 },
+    );
+    expect(config.sweepTriggerThreshold).toBe(0.95);
+  });
+
+  it("clamps sweepTriggerThreshold to [0, 1]", () => {
+    expect(resolveLcmConfig({}, { sweepTriggerThreshold: 2 }).sweepTriggerThreshold).toBe(1);
+    expect(resolveLcmConfig({}, { sweepTriggerThreshold: -1 }).sweepTriggerThreshold).toBe(0);
+  });
+
+  it("defaults pressureTiers to [tier1=0.70/2pass, tier2=0.80/3pass]", () => {
+    expect(resolveLcmConfig({}, {}).pressureTiers).toEqual([
+      { ratio: 0.70, maxPasses: 2 },
+      { ratio: 0.80, maxPasses: 3 },
+    ]);
+  });
+
+  it("reads pressureTiers from plugin config and sorts ascending by ratio", () => {
+    const config = resolveLcmConfig({}, {
+      pressureTiers: [
+        { ratio: 0.85, maxPasses: 4 }, // out of order
+        { ratio: 0.65, maxPasses: 1 },
+        { ratio: 0.75, maxPasses: 2 },
+      ],
+    });
+    expect(config.pressureTiers).toEqual([
+      { ratio: 0.65, maxPasses: 1 },
+      { ratio: 0.75, maxPasses: 2 },
+      { ratio: 0.85, maxPasses: 4 },
+    ]);
+  });
+
+  it("env var overrides plugin pressureTiers (parses JSON array)", () => {
+    const config = resolveLcmConfig(
+      {
+        LCM_PRESSURE_TIERS:
+          '[{"ratio":0.65,"maxPasses":2},{"ratio":0.85,"maxPasses":5}]',
+      } as NodeJS.ProcessEnv,
+      { pressureTiers: [{ ratio: 0.5, maxPasses: 9 }] },
+    );
+    expect(config.pressureTiers).toEqual([
+      { ratio: 0.65, maxPasses: 2 },
+      { ratio: 0.85, maxPasses: 5 },
+    ]);
+  });
+
+  it("falls back to defaults when pressureTiers is malformed or empty", () => {
+    expect(
+      resolveLcmConfig({}, { pressureTiers: "not-an-array" as unknown as unknown[] })
+        .pressureTiers,
+    ).toEqual([
+      { ratio: 0.70, maxPasses: 2 },
+      { ratio: 0.80, maxPasses: 3 },
+    ]);
+    expect(resolveLcmConfig({}, { pressureTiers: [] }).pressureTiers).toEqual([
+      { ratio: 0.70, maxPasses: 2 },
+      { ratio: 0.80, maxPasses: 3 },
+    ]);
+  });
+
+  it("filters out invalid tier entries (ratio out of (0,1) or maxPasses < 1)", () => {
+    const config = resolveLcmConfig({}, {
+      pressureTiers: [
+        { ratio: 0.50, maxPasses: 2 }, // valid
+        { ratio: 0, maxPasses: 1 }, // invalid: ratio not strictly > 0
+        { ratio: 1, maxPasses: 1 }, // invalid: ratio not strictly < 1
+        { ratio: 0.75, maxPasses: 0 }, // invalid: maxPasses < 1
+        { ratio: "bad", maxPasses: 2 }, // invalid: ratio not number
+      ],
+    });
+    expect(config.pressureTiers).toEqual([{ ratio: 0.50, maxPasses: 2 }]);
+  });
+});
+
+describe("resolvePressureDispatchPolicy (engine pressure-tiered dispatch)", () => {
+  function getPolicy(engine: LcmContextEngine) {
+    return (engine as unknown as {
+      resolvePressureDispatchPolicy: (input: {
+        currentTokenCount?: number;
+        tokenBudget: number;
+      }) => { targetRatio: number; maxPasses?: number };
+    }).resolvePressureDispatchPolicy.bind(engine);
+  }
+
+  it("at <70% pressure: 1 pass max, target = contextThreshold (0.60)", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 130_000, tokenBudget: 200_000 }); // 65%
+    expect(result).toEqual({ targetRatio: 0.60, maxPasses: 1 });
+  });
+
+  it("at 70-80% (tier 1): 2 passes max, target = contextThreshold", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 150_000, tokenBudget: 200_000 }); // 75%
+    expect(result).toEqual({ targetRatio: 0.60, maxPasses: 2 });
+  });
+
+  it("at 80-91% (tier 2): 3 passes max, target = contextThreshold", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 170_000, tokenBudget: 200_000 }); // 85%
+    expect(result).toEqual({ targetRatio: 0.60, maxPasses: 3 });
+  });
+
+  it("at >=91% (sweep mode): no maxPasses, target = sweepTargetThreshold (0.50)", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 184_000, tokenBudget: 200_000 }); // 92%
+    expect(result).toEqual({ targetRatio: 0.50 });
+  });
+
+  it("at exactly tier-1 boundary (70%): 2 passes (>= comparison)", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 140_000, tokenBudget: 200_000 }); // exactly 70%
+    expect(result).toEqual({ targetRatio: 0.60, maxPasses: 2 });
+  });
+
+  it("at exactly sweep boundary (91%): sweep mode (>= comparison)", () => {
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    const result = policy({ currentTokenCount: 182_000, tokenBudget: 200_000 }); // exactly 91%
+    expect(result).toEqual({ targetRatio: 0.50 });
+  });
+
+  it("falls back to GENTLEST policy when currentTokenCount is unknown (safe default, NOT aggressive sweep)", () => {
+    // When pressure is unknown, the dispatcher should NOT silently jump into
+    // sweep mode (deep target, no pass cap). That used to be the behavior for
+    // "PR #558 backward compat" but it's the opposite of safe defaults —
+    // under-instrumented callers should get gentle 1-pass dispatches, not
+    // surprise multi-pass sweeps. Adversarial review caught this.
+    const engine = createEngine();
+    const policy = getPolicy(engine);
+    expect(policy({ tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 1,
+    });
+    expect(policy({ currentTokenCount: 0, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 1,
+    });
+    expect(policy({ currentTokenCount: -5, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 1,
+    });
+  });
+
+  it("treats engine-side empty pressureTiers array as undefined (falls back to defaults)", () => {
+    // Adversarial sweep flagged: the resolver-side fallback for empty
+    // arrays has tests, but the engine-side defense (caller constructs
+    // LcmConfig literal with `pressureTiers: []` bypassing the resolver)
+    // had no direct test. Adding one.
+    const tempDir = mkdtempSync(join(tmpdir(), "lcm-sweep-target-empty-"));
+    tempDirs.push(tempDir);
+    const baseConfig = createMinimalConfig(join(tempDir, "lcm.db"));
+    const config: LcmConfig = {
+      ...baseConfig,
+      pressureTiers: [], // empty — should fall back to default ladder at use-time
+    };
+    const db = createLcmDatabaseConnection(config.databasePath);
+    dbs.push(db);
+    const engine = new LcmContextEngine(createMinimalDeps(config), db);
+    const policy = (engine as unknown as {
+      resolvePressureDispatchPolicy: (input: {
+        currentTokenCount?: number;
+        tokenBudget: number;
+      }) => { targetRatio: number; maxPasses?: number };
+    }).resolvePressureDispatchPolicy.bind(engine);
+
+    // 75% pressure should reach default tier-1 (ratio 0.70, maxPasses 2)
+    expect(policy({ currentTokenCount: 150_000, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 2,
+    });
+    // 85% pressure should reach default tier-2 (ratio 0.80, maxPasses 3)
+    expect(policy({ currentTokenCount: 170_000, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 3,
+    });
+  });
+
+  it("defensively floors fractional maxPasses + filters non-finite tier ratios at use-time", () => {
+    // Bypasses the resolver to inject malformed tiers directly — covers the
+    // defense-in-depth code path inside resolvePressureDispatchPolicy when a
+    // future caller constructs LcmConfig literally without going through
+    // resolveLcmConfig. Adversarial sweep flagged this code as untested.
+    const tempDir = mkdtempSync(join(tmpdir(), "lcm-sweep-target-tier-"));
+    tempDirs.push(tempDir);
+    const baseConfig = createMinimalConfig(join(tempDir, "lcm.db"));
+    const config: LcmConfig = {
+      ...baseConfig,
+      pressureTiers: [
+        { ratio: 0.70, maxPasses: 2.7 },                  // fractional → floors to 2
+        { ratio: Number.NaN as unknown as number, maxPasses: 9 }, // non-finite → filtered
+        { ratio: 0.80, maxPasses: 3 },
+      ],
+    };
+    const db = createLcmDatabaseConnection(config.databasePath);
+    dbs.push(db);
+    const engine = new LcmContextEngine(createMinimalDeps(config), db);
+    const policy = (engine as unknown as {
+      resolvePressureDispatchPolicy: (input: {
+        currentTokenCount?: number;
+        tokenBudget: number;
+      }) => { targetRatio: number; maxPasses?: number };
+    }).resolvePressureDispatchPolicy.bind(engine);
+
+    // 75% pressure crosses tier-1 (0.70) but not tier-2 (0.80)
+    // → fractional 2.7 floored to 2, NaN tier filtered
+    expect(policy({ currentTokenCount: 150_000, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 2,
+    });
+    // 85% pressure crosses both tier-1 and tier-2 → tier-2 wins (3)
+    expect(policy({ currentTokenCount: 170_000, tokenBudget: 200_000 })).toEqual({
+      targetRatio: 0.60,
+      maxPasses: 3,
+    });
+  });
+});
+
+describe("reserve-aware budget alignment (resolveTokenBudget)", () => {
+  it("subtracts runtimeContext.reserveTokens from the resolved budget", () => {
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    expect(
+      resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokens: 50_000 } }),
+    ).toBe(208_000);
+  });
+
+  it("also accepts legacy reserveTokensFloor key from openclaw runtime", () => {
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    expect(
+      resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokensFloor: 20_000 } }),
+    ).toBe(238_000);
+  });
+
+  it("preserves legacy behavior when no reserve is supplied", () => {
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    expect(resolve({ tokenBudget: 258_000, runtimeContext: {} })).toBe(258_000);
+    expect(resolve({ tokenBudget: 258_000 })).toBe(258_000);
+  });
+
+  it("ignores invalid or zero reserve values", () => {
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    expect(resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokens: 0 } })).toBe(258_000);
+    expect(resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokens: -100 } })).toBe(
+      258_000,
+    );
+    expect(resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokens: "not a number" } }))
+      .toBe(258_000);
+  });
+
+  it("ignores reserve and logs a warn when reserve >= raw budget (misconfig safety)", () => {
+    // Previous behavior: silently floored to 1 → propagated degenerate budget
+    // through compactFullSweep causing pathological 0-target loops. New
+    // behavior: ignore the reserve, log a warning, return the raw budget.
+    // Adversarial review caught this; the followup adversarial sweep flagged
+    // that the test wasn't actually asserting the warn was called.
+    const { engine, deps } = createEngineWithDeps();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    // Reserve > budget → ignore reserve, return raw budget
+    expect(
+      resolve({ tokenBudget: 100_000, runtimeContext: { reserveTokens: 200_000 } }),
+    ).toBe(100_000);
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("misconfigured reserve"),
+    );
+
+    // Reserve == budget → also ignored
+    (deps.log.warn as ReturnType<typeof vi.fn>).mockClear();
+    expect(
+      resolve({ tokenBudget: 100_000, runtimeContext: { reserveTokens: 100_000 } }),
+    ).toBe(100_000);
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("misconfigured reserve"),
+    );
+  });
+
+  it("prefers reserveTokens over reserveTokensFloor when both are present", () => {
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    expect(
+      resolve({
+        tokenBudget: 258_000,
+        runtimeContext: { reserveTokens: 30_000, reserveTokensFloor: 50_000 },
+      }),
+    ).toBe(228_000);
+  });
+
+  it("does NOT double-subtract reserve when alreadyReserveAdjusted=true (deferred-compaction drain path)", () => {
+    // Scenario:
+    //   1. afterTurn calls resolveTokenBudget(258K, {reserveTokens:20K}) → 238K (adjusted)
+    //   2. 238K is recorded in maintenance debt
+    //   3. maintain() drains debt: calls executeCompactionCore({tokenBudget:238K, runtimeContext:{reserveTokens:20K}})
+    //   4. executeCompactionCore calls resolveTokenBudget with alreadyReserveAdjusted=true
+    //   5. Without the flag, 238K - 20K = 218K (BUG — pressure ratios computed against 218K instead of 238K)
+    //   6. With the flag, 238K is preserved
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+        alreadyReserveAdjusted?: boolean;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    // Without the flag (public entry path) — subtracts reserve as expected
+    expect(
+      resolve({ tokenBudget: 258_000, runtimeContext: { reserveTokens: 20_000 } }),
+    ).toBe(238_000);
+
+    // With the flag (internal pass-through path) — preserves the already-adjusted value
+    expect(
+      resolve({
+        tokenBudget: 238_000,
+        runtimeContext: { reserveTokens: 20_000 },
+        alreadyReserveAdjusted: true,
+      }),
+    ).toBe(238_000);
+  });
+
+  it("alreadyReserveAdjusted only skips when tokenBudget is explicit (runtimeContext fallback still applies reserve)", () => {
+    // The flag's contract: "the explicit tokenBudget is already adjusted".
+    // It MUST NOT short-circuit the runtimeContext fallback path, where the
+    // runtime is providing a raw value that needs adjustment.
+    const engine = createEngine();
+    const resolve = (engine as unknown as {
+      resolveTokenBudget: (params: {
+        tokenBudget?: number;
+        runtimeContext?: Record<string, unknown>;
+        legacyParams?: Record<string, unknown>;
+        alreadyReserveAdjusted?: boolean;
+      }) => number | undefined;
+    }).resolveTokenBudget.bind(engine);
+
+    // No explicit tokenBudget, falls back to runtimeContext.tokenBudget — reserve applies
+    expect(
+      resolve({
+        tokenBudget: undefined,
+        runtimeContext: { tokenBudget: 258_000, reserveTokens: 20_000 },
+        alreadyReserveAdjusted: true,
+      }),
+    ).toBe(238_000);
+  });
+});


### PR DESCRIPTION
## Summary

This PR ships a **layered four-band compaction pressure architecture**, plus reserve-aware budget alignment so percentages mean what they say.

```
        effective prompt budget = tokenBudget − reserveTokens
        ┌────────────────────────────────────────────────────────────┐
0%   60%/trigger  70%/tier-1  80%/tier-2  91%/sweep        100%/overflow
├─────┼───────────┼───────────┼───────────┼───────────────────────────┤
│ low │  normal   │  tier-1   │  tier-2   │   SWEEP                   │
│     │  1 pass / │  2 passes │  3 passes │   (unlimited passes,      │
│     │  dispatch │  / disp.  │  / disp.  │    target 50%)            │
│     │  exit @60%│  exit @60%│  exit @60%│   exit @ 50% of budget    │
└─────┴───────────┴───────────┴───────────┴───────────────────────────┘
```

## What changed

Three new capabilities + one new behavior change:

1. **`sweepTriggerThreshold`** (default `0.91`) — separate from `contextThreshold`, controls when dispatched compaction switches into deep SWEEP mode. Below this, dispatched work targets `contextThreshold` (gentle). At/above, runs unlimited passes targeting `sweepTargetThreshold`.

2. **`pressureTiers`** (default `[{ratio:0.70,maxPasses:2},{ratio:0.80,maxPasses:3}]`) — pressure-tiered pass cap ladder. Multi-pass amortizes prefix-cache invalidation: every pass in a single dispatch invalidates the SAME cache prefix, so 3 passes/dispatch cost the same cache-wise as 1 but reduce 3× as many tokens.

3. **`sweepTargetThreshold`** (default `0.50`) — fraction of token budget that SWEEP targets when it fires. Decouples sweep stopping point from `contextThreshold`. With sweep target 0.50 and trigger 0.91, when sweep fires it creates ~40% headroom (~5+ turns of runway).

4. **Reserve-aware budget alignment** — LCM reads `runtimeContext.reserveTokens` (or legacy `reserveTokensFloor`) and subtracts it from the resolved `tokenBudget` before computing percentages.

**Behavior change:** `contextThreshold` default lowered from `0.75` → `0.60`. The lower trigger gives the cache-aware deferral system more room to operate and feeds the new pressure-tier ladder cleanly.

## Why this layering — the cache invalidation insight

When LCM compacts the oldest chunk, the prefix cache breaks at the modification point and everything from there to the end of the prompt must re-tokenize on the next turn. **Doing 1 pass vs 3 passes vs 6 passes invalidates the SAME prefix** — more passes just produce more reduction off that one cache break.

| Tier | Passes | Cache cost | Reduction | Efficiency |
|---|---|---|---|---|
| Normal (1 pass) | 1 | 1× | ~17K | 17K / cache-break |
| Tier 1 (2 passes) | 2 | 1× | ~34K | 34K / cache-break ← 2× |
| Tier 2 (3 passes) | 3 | 1× | ~51K | 51K / cache-break ← 3× |
| Sweep (unlimited) | 5–7 | 1× | ~80–100K | huge / cache-break |

Multi-pass per dispatch is the right shape at higher pressure, not "fire more often" (which would multiply cache invalidations).

## Code surface

| File | Change |
|---|---|
| `src/db/config.ts` | New fields: `sweepTriggerThreshold`, `pressureTiers` (with sorted-ascending validator). Lowered `contextThreshold` default 0.75 → 0.60. |
| `src/compaction.ts` | `compactFullSweep` accepts new `maxPasses` cap (shared across leaf+condensed phases). |
| `src/engine.ts` | New `resolvePressureDispatchPolicy` helper picks `targetRatio` + `maxPasses` from current pressure. Wired into `executeCompactionCore` sweep path. Reserve-aware `applyReserveTokens` helper subtracts reserve from resolved budget. |
| `openclaw.plugin.json` | New uiHints + configSchema entries for `sweepTriggerThreshold` and `pressureTiers`. |
| `README.md` | New "Compaction pressure architecture" section with layered ASCII diagram, pressure-band table, cache-invalidation efficiency math, scenario walkthrough. |
| `test/sweep-target-and-reserve-aware-budget.test.ts` | 26 cases covering config resolution, budget alignment, and `resolvePressureDispatchPolicy` tier ladder (including boundary cases at exactly tier-1 / tier-2 / sweep ratios). |

## Backward compatibility

All additions default to gracefully extended behavior:

- If `pressureTiers` is unset/empty/malformed: defaults to the canonical ladder (no behavior break)
- If `sweepTriggerThreshold` is unset: defaults to 0.91 (so the deep sweep target only fires at high pressure, not on every threshold-mode dispatch)
- If `runtimeContext.reserveTokens` is not present: LCM uses raw budget unchanged (legacy plugins/runtimes)
- `contextThreshold` default change is the one operator-visible behavior shift — operators wanting legacy 0.75 set it explicitly

The `resolvePressureDispatchPolicy` falls back to sweep semantics (target = 0.50, no pass cap) when current token count is unavailable, preserving the prior version of this PR's behavior for any caller that doesn't supply a pressure signal.

## Recommended companion: PR #557

[PR #557](https://github.com/Martian-Engineering/lossless-claw/pull/557)'s `criticalBudgetPressureRatio` default `0.70` lines up exactly with this PR's tier-1 ratio. Without #557, tier-1 dispatches at 70% would still be cache-throttled up to 5 minutes per dispatch, defeating the whole point of having tiers. With #557, dispatched work fires reliably the moment the system enters tier-1.

## Test plan

- `pnpm exec vitest run` — **846 tests passing** (820 baseline + 26 new)
- `pnpm build` — clean
- New tests cover the full pressure-tier matrix including boundary cases
- Updated `test/config.test.ts` defaults assertions to match the new architecture

## Scenario walkthrough — real session data

Real Eva session on gpt-5.5 (258K context, 20K reserve = 238K effective budget) before any patches: 6 emergency truncations / 18hrs.

After both this PR + PR #557 with default config:

| Eva crosses... | Tier | Pass count | Action |
|---|---|---|---|
| 143K (60% of 238K) | Normal | 1 | Maintenance debt queued, fires when cache cold |
| 167K (70% of 238K) | Tier 1 | 2 | Cache delay BYPASSED (PR #557), 2 passes per dispatch |
| 190K (80% of 238K) | Tier 2 | 3 | 3 passes per dispatch |
| If tier 1+2 fail, crosses 217K (91%) | **Sweep** | unlimited | Deep catch-up to 119K |

**Result: 0 emergency truncations** instead of 6 in the same window.