### PR TITLE
[hotfix] v0.9.3 prefill safety net + Codex/Ollama silent redirects (A/8)

### DIFF
--- a/.changeset/hotfix-v093-prefill-providers.md
+++ b/.changeset/hotfix-v093-prefill-providers.md
@@ -2,7 +2,7 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Fix three v0.9.3 regressions affecting prefill safety and provider routing:
+Fix v0.9.3 regressions affecting prefill safety and provider routing:
 
 - Restore the reference-inequality contract on the no-user-turn assemble fallback. PR #502's guard returned `params.messages` by reference, defeating the `installContextEngineLoopHook` `assembled.messages !== sourceMessages` check installed by PR #504; the guard now uses the same `safeFallback()` helper as the other fallback paths so the gateway treats the result as assembled context.
 - Strip assistant messages whose only blocks are blank text (`[{type:"text", text:""}]`) during assembly, complementing the existing thinking-only filter so Bedrock no longer rejects with `The text field in the ContentBlock object at messages.N.content.0 is blank`.

--- a/.changeset/hotfix-v093-prefill-providers.md
+++ b/.changeset/hotfix-v093-prefill-providers.md
@@ -1,0 +1,10 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix three v0.9.3 regressions affecting prefill safety and provider routing:
+
+- Restore the reference-inequality contract on the no-user-turn assemble fallback. PR #502's guard returned `params.messages` by reference, defeating the `installContextEngineLoopHook` `assembled.messages !== sourceMessages` check installed by PR #504; the guard now uses the same `safeFallback()` helper as the other fallback paths so the gateway treats the result as assembled context.
+- Strip assistant messages whose only blocks are blank text (`[{type:"text", text:""}]`) during assembly, complementing the existing thinking-only filter so Bedrock no longer rejects with `The text field in the ContentBlock object at messages.N.content.0 is blank`.
+- Stop redirecting paid OpenAI API-key Codex users from `https://api.openai.com/v1` to `https://chatgpt.com/backend-api/codex`. `shouldUseNativeCodexBaseUrl` now respects an explicitly-configured baseUrl; the rewrite still applies when baseUrl is empty or already a ChatGPT Codex variant.
+- Remove the silent `http://localhost:11434` ollama fallback in `inferBaseUrlFromProvider` so cloud-only ollama configs (`https://ollama.com`) and self-hosted setups must be explicit; the prior default would silently route cloud configs to localhost.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -104,6 +104,15 @@ function isThinkingOnlyContent(content: unknown[]): boolean {
   );
 }
 
+/** Returns true when a content block is a blank or whitespace-only text block. */
+function isBlankTextBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") return false;
+  const record = block as Record<string, unknown>;
+  if (record.type !== "text") return false;
+  if (typeof record.text !== "string") return false;
+  return record.text.trim() === "";
+}
+
 /** Returns true when every block in the content array is a text block whose
  *  text is empty or whitespace-only. Bedrock rejects messages whose content
  *  is a `[{type:"text", text:""}]` shape with `The text field in the
@@ -111,13 +120,7 @@ function isThinkingOnlyContent(content: unknown[]): boolean {
  *  filtered before the cleaned tail is handed to the provider. */
 function isBlankContent(content: unknown[]): boolean {
   if (content.length === 0) return false;
-  return content.every((block) => {
-    if (!block || typeof block !== "object") return false;
-    const record = block as Record<string, unknown>;
-    if (record.type !== "text") return false;
-    if (typeof record.text !== "string") return false;
-    return record.text.trim() === "";
-  });
+  return content.every(isBlankTextBlock);
 }
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -1254,6 +1257,18 @@ export class ContextAssembler {
             content: [{ type: "text", text: msg.content }] as unknown as typeof msg.content,
           } as AgentMessage,
         };
+      }
+      if (msg?.role === "assistant" && Array.isArray(msg.content)) {
+        const content = msg.content.filter((block) => !isBlankTextBlock(block));
+        if (content.length !== msg.content.length) {
+          return {
+            ...entry,
+            message: {
+              ...msg,
+              content: content as unknown as typeof msg.content,
+            } as AgentMessage,
+          };
+        }
       }
       return entry;
     });

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -104,6 +104,22 @@ function isThinkingOnlyContent(content: unknown[]): boolean {
   );
 }
 
+/** Returns true when every block in the content array is a text block whose
+ *  text is empty or whitespace-only. Bedrock rejects messages whose content
+ *  is a `[{type:"text", text:""}]` shape with `The text field in the
+ *  ContentBlock object at messages.N.content.0 is blank`, so they must be
+ *  filtered before the cleaned tail is handed to the provider. */
+function isBlankContent(content: unknown[]): boolean {
+  if (content.length === 0) return false;
+  return content.every((block) => {
+    if (!block || typeof block !== "object") return false;
+    const record = block as Record<string, unknown>;
+    if (record.type !== "text") return false;
+    if (typeof record.text !== "string") return false;
+    return record.text.trim() === "";
+  });
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface AssembleContextInput {
@@ -1242,20 +1258,22 @@ export class ContextAssembler {
       return entry;
     });
 
-    // Filter out assistant messages with empty or thinking-only content —
-    // these can occur when tool-use-only turns are stored with content=""
-    // and zero message_parts, when filterNonFreshAssistantToolCalls strips
-    // all tool_use blocks, or when a turn contains only thinking/reasoning
-    // blocks that will be stripped by the provider layer, leaving an empty
-    // content array. Anthropic/Bedrock reject empty content arrays/strings.
+    // Filter out assistant messages with empty, blank, or thinking-only
+    // content — these can occur when tool-use-only turns are stored with
+    // content="" and zero message_parts, when filterNonFreshAssistantToolCalls
+    // strips all tool_use blocks, when a turn contains only thinking/reasoning
+    // blocks that will be stripped by the provider layer, or when the stored
+    // content is a `[{type:"text", text:""}]` blank-text shape. Anthropic and
+    // Bedrock reject any of these as empty.
     const cleanedEntries = normalizedEntries.filter(
       (entry) =>
         !(
           entry.message?.role === "assistant" &&
           (Array.isArray(entry.message.content)
             ? entry.message.content.length === 0 ||
-              isThinkingOnlyContent(entry.message.content)
-            : !entry.message.content)
+              isThinkingOnlyContent(entry.message.content) ||
+              isBlankContent(entry.message.content)
+            : !entry.message.content || entry.message.content.trim() === "")
         ),
     );
     const cleaned = cleanedEntries.map((entry) => entry.message);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6464,10 +6464,12 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.info(
           `[lcm] assemble: assembled context has no user turns, falling back to live context to prevent prefill errors conversation=${conversation.conversationId} ${sessionLabel} assembledMessages=${assembled.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
-        return {
-          messages: params.messages,
-          estimatedTokens: 0,
-        };
+        // Use safeFallback() so the result is a *new* array; otherwise the
+        // gateway's `assembled.messages !== sourceMessages` reference-equality
+        // check falls through to raw sourceMessages (still ending in assistant)
+        // and re-introduces the prefill-rejection bug fixed by safeFallback in
+        // the other early-return paths.
+        return safeFallback();
       }
 
       this.deps.log.info(

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -791,7 +791,10 @@ export function shouldOmitTemperatureForApi(api: string | undefined): boolean {
  *  and self-hosted setups both rely on explicit baseUrl configuration; a
  *  silent `http://localhost:11434` fallback would silently route cloud
  *  configs to localhost and produce confusing connection errors. Returning
- *  undefined here forces an explicit baseUrl. */
+ *  undefined here drops the inferred default — `resolveProviderModelBaseUrl`
+ *  still passes `""` through to the dispatcher when no other source yields
+ *  a baseUrl, which surfaces a clearer downstream error than a silent
+ *  wrong-target connect. */
 function inferBaseUrlFromProvider(provider: string): string | undefined {
   const normalized = normalizeProviderId(provider);
   const map: Record<string, string> = {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -683,6 +683,12 @@ function shouldUseNativeCodexBaseUrl(params: {
   provider: string;
   api: string | undefined;
   baseUrl: string | undefined;
+  /** True when the user explicitly set baseUrl via runtime config. When
+   *  explicit, do not rewrite `https://api.openai.com/v1` to the ChatGPT
+   *  Codex backend — that breaks paid OpenAI API-key users who chose that
+   *  endpoint deliberately. The native rewrite still applies when the
+   *  baseUrl is empty (default) or already a ChatGPT Codex variant. */
+  isExplicitlyConfigured?: boolean;
 }): boolean {
   if (!isOpenAICodexProvider(params.provider) || !isOpenAICodexResponsesApi(params.api)) {
     return false;
@@ -694,6 +700,9 @@ function shouldUseNativeCodexBaseUrl(params: {
   }
 
   const normalized = normalizeBaseUrl(baseUrl);
+  if (params.isExplicitlyConfigured && normalized === OPENAI_API_BASE_URL) {
+    return false;
+  }
   return normalized === OPENAI_API_BASE_URL || OPENAI_CODEX_NATIVE_BASE_URLS.has(normalized);
 }
 
@@ -709,7 +718,12 @@ function resolveProviderModelBaseUrl(params: {
     typeof params.fallbackBaseUrl === "string" ? params.fallbackBaseUrl : undefined;
   const baseUrl =
     configuredBaseUrl ?? fallbackBaseUrl ?? inferBaseUrlFromProvider(params.provider) ?? "";
-  return shouldUseNativeCodexBaseUrl({ provider: params.provider, api: params.api, baseUrl })
+  return shouldUseNativeCodexBaseUrl({
+    provider: params.provider,
+    api: params.api,
+    baseUrl,
+    isExplicitlyConfigured: configuredBaseUrl !== undefined,
+  })
     ? OPENAI_CODEX_RESPONSES_BASE_URL
     : baseUrl;
 }
@@ -771,7 +785,13 @@ export function shouldOmitTemperatureForApi(api: string | undefined): boolean {
   return isOpenAICodexResponsesApi(api);
 }
 
-/** Resolve known provider base URLs when model lookup misses. */
+/** Resolve known provider base URLs when model lookup misses.
+ *
+ *  Note: ollama is intentionally absent. Cloud Ollama (`https://ollama.com`)
+ *  and self-hosted setups both rely on explicit baseUrl configuration; a
+ *  silent `http://localhost:11434` fallback would silently route cloud
+ *  configs to localhost and produce confusing connection errors. Returning
+ *  undefined here forces an explicit baseUrl. */
 function inferBaseUrlFromProvider(provider: string): string | undefined {
   const normalized = normalizeProviderId(provider);
   const map: Record<string, string> = {
@@ -784,7 +804,6 @@ function inferBaseUrlFromProvider(provider: string): string | undefined {
     mistral: "https://api.mistral.ai",
     together: "https://api.together.xyz",
     openrouter: "https://openrouter.ai/api/v1",
-    ollama: "http://localhost:11434",
   };
   return map[normalized];
 }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4636,8 +4636,13 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 10_000,
     });
 
-    // Should fall back to live context, not return the assistant-only DB context
-    expect(result.messages).toBe(liveMessages);
+    // Should fall back to live context, not return the assistant-only DB context.
+    // The fallback must be a *new* array so the gateway hook's reference-equality
+    // check (`assembled.messages !== sourceMessages`) treats it as assembled —
+    // returning the same reference falls through to raw sourceMessages and
+    // re-introduces the prefill-rejection bug fixed by safeFallback.
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
   });
 
@@ -5247,6 +5252,57 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages[1]?.role).toBe("toolResult");
     expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("fc_1");
     expect(result.messages[2]?.role).toBe("user");
+  });
+
+  it("filters assistant messages with blank-text content during assembly", async () => {
+    // Regression: v0.9.3's #506 added an isThinkingOnlyContent filter for the
+    // Bedrock empty-content rejection, but did not handle the
+    // [{type:"text", text:""}] blank-text shape — Bedrock still rejects with
+    // "The text field in the ContentBlock object at messages.N.content.0 is
+    // blank". The cleanedEntries filter must also strip these.
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "Question?" }),
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "   \n\t  " }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Real answer." }],
+      } as AgentMessage,
+    });
+
+    const assembled = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+
+    expect(assembled.messages).toHaveLength(2);
+    expect(assembled.messages[0]?.role).toBe("user");
+    const assistant = assembled.messages[1] as {
+      role: string;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content?.[0]?.text).toBe("Real answer.");
   });
 
   it("filters thinking-only assistant messages during assembly", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5259,7 +5259,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
     // Bedrock empty-content rejection, but did not handle the
     // [{type:"text", text:""}] blank-text shape — Bedrock still rejects with
     // "The text field in the ContentBlock object at messages.N.content.0 is
-    // blank". The cleanedEntries filter must also strip these.
+    // blank". The cleanedEntries filter must strip all-blank messages and blank
+    // blocks inside otherwise valid assistant messages.
     const engine = createEngine();
     const sessionId = randomUUID();
 
@@ -5285,7 +5286,10 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId,
       message: {
         role: "assistant",
-        content: [{ type: "text", text: "Real answer." }],
+        content: [
+          { type: "text", text: "" },
+          { type: "text", text: "Real answer." },
+        ],
       } as AgentMessage,
     });
 
@@ -5302,6 +5306,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       content?: Array<{ type?: string; text?: string }>;
     };
     expect(assistant.role).toBe("assistant");
+    expect(assistant.content).toHaveLength(1);
     expect(assistant.content?.[0]?.text).toBe("Real answer.");
   });
 

--- a/test/index-complete-provider-config.test.ts
+++ b/test/index-complete-provider-config.test.ts
@@ -324,6 +324,41 @@ describe("createLcmDependencies.complete provider config resolution", () => {
     );
   });
 
+  it("preserves an explicit api.openai.com/v1 baseUrl for paid OpenAI API-key Codex users", async () => {
+    // Regression: v0.9.3's #549 added OPENAI_CODEX_NATIVE_BASE_URLS which would
+    // rewrite an explicitly-configured `https://api.openai.com/v1` to
+    // `chatgpt.com/backend-api/codex` whenever api was `openai-codex-responses`.
+    // That broke users on a paid OpenAI API key who set baseUrl deliberately.
+    // shouldUseNativeCodexBaseUrl now respects an explicit configured baseUrl.
+    const runtimeConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.openai.com/v1",
+          },
+        },
+      },
+    };
+
+    await callComplete({
+      loadConfigResult: runtimeConfig,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      runtimeConfig,
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("keeps custom Codex proxy baseUrl when openai-codex uses native transport", async () => {
     const runtimeConfig = {
       models: {
@@ -488,12 +523,46 @@ describe("createLcmDependencies.complete provider config resolution", () => {
       runtimeConfig: {},
     });
 
+    // ollama is intentionally absent from inferBaseUrlFromProvider — cloud
+    // ollama (`https://ollama.com`) and self-hosted setups both rely on
+    // explicit baseUrl. A silent localhost fallback would route cloud
+    // configs to localhost and produce confusing connection errors.
     expect(piAiMock.completeSimple).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "kimi-k2.5:cloud",
         provider: "ollama",
         api: "openai-completions",
-        baseUrl: "http://localhost:11434",
+        baseUrl: "",
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("preserves a user-configured ollama cloud baseUrl instead of overriding to localhost", async () => {
+    const runtimeConfig = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "https://ollama.com",
+          },
+        },
+      },
+    };
+
+    await callComplete({
+      loadConfigResult: runtimeConfig,
+      provider: "ollama",
+      model: "kimi-k2.5:cloud",
+      runtimeConfig,
+    });
+
+    expect(piAiMock.completeSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "kimi-k2.5:cloud",
+        provider: "ollama",
+        api: "openai-completions",
+        baseUrl: "https://ollama.com",
       }),
       expect.any(Object),
       expect.any(Object),


### PR DESCRIPTION
Closes #559, closes #560.

Three regressions introduced inside v0.9.3 itself, each a self-contained hunk. All four sub-fixes ship together because they share a single hotfix-shaped theme — silent breakage from changes that landed in v0.9.3 — and a reviewer should look at all of them at once to confirm the scope is regression-only.

(Sub-fix A4 from #561 — the bootstrap raw-hash anchor — was deferred from this PR. The original audit recommendation conflicts with the heartbeat-prune append-only fast path because the same `lastProcessedEntryHash` field serves two roles: DB-tail integrity check (post-prune, post-externalization) and raw-transcript checkpoint. Doing it right needs the dedup work in a follow-up.)

## Sub-fixes

### `[assembly]` reference-inequality contract on no-user-turn fallback (#559 A1)

PR #502's no-user-turn guard returned `{ messages: params.messages, estimatedTokens: 0 }` by reference. PR #504 (merged ~3 hours apart) added the contract that all fallback paths must return a *new* array via `safeFallback()`, so `installContextEngineLoopHook`'s `assembled.messages !== sourceMessages` check treats the result as assembled context. #502's guard violated that contract — when it fired, the gateway hook fell through to raw `sourceMessages` (still ending with assistant), re-introducing exactly the prefill-rejection bug fixed by #504 (#499, #505).

Fix: replace `return { messages: params.messages, estimatedTokens: 0 }` with `return safeFallback();` (helper already in scope).

### `[assembly]` blank-text-block survival in `cleanedEntries` (#559 B5)

PR #506 added `isThinkingOnlyContent` to the assembler's `cleanedEntries` filter to fix Bedrock empty-content rejection from thinking-only messages (#519, #509). Blank text blocks `[{type:"text", text:""}]` aren't thinking-only, so they pass the filter — and Bedrock still rejects them with `The text field in the ContentBlock object at messages.N.content.0 is blank`.

Fix: new `isBlankContent` helper mirroring the `isThinkingOnlyContent` shape; added to the `cleanedEntries` filter and the non-array-content check (which now also rejects whitespace-only strings).

### `[provider]` paid OpenAI API-key Codex redirect (#560 A2)

PR #549's `OPENAI_CODEX_NATIVE_BASE_URLS` rewrites baseUrls to `https://chatgpt.com/backend-api/codex` whenever api is `openai-codex-responses`. The native-rewrite list includes `https://api.openai.com/v1` — so users on a paid OpenAI API key who configured `models.providers.openai-codex.baseUrl: https://api.openai.com/v1` get silently redirected to the ChatGPT backend, which their API key cannot authenticate against. This is exactly the audience PR #500 (Truck0ff) targeted with per-model api overrides.

Fix: `shouldUseNativeCodexBaseUrl` now accepts an `isExplicitlyConfigured` flag; `resolveProviderModelBaseUrl` sets it when `configuredBaseUrl` is non-undefined. When explicit AND normalized baseUrl equals `OPENAI_API_BASE_URL`, return false (don't rewrite). The native rewrite still applies when baseUrl is empty (default) or already a ChatGPT Codex variant.

### `[provider]` ollama localhost fallback breaks cloud configs (#560 A3)

PR #546 added `ollama: http://localhost:11434` to `inferBaseUrlFromProvider`. Cloud-only ollama users (`https://ollama.com`, per #480) without a model-catalog entry now get rewritten to localhost — guaranteed connection refused.

Fix: remove the ollama entry from `inferBaseUrlFromProvider`. Cloud and self-hosted setups both rely on explicit baseUrl; an empty baseUrl produces a clearer error than a silent localhost connect. Local users typically already configure baseUrl explicitly, but if not, a missing-baseUrl error is a far better failure mode than a silent wrong-target connection.

## Tests

- `test/engine.test.ts`: existing `cold-cache new session` test rewritten to assert reference-inequality (`not.toBe(liveMessages)` + `toStrictEqual(liveMessages)`); new test `filters assistant messages with blank-text content during assembly` covering A1's blank-text gap; one regression test per sub-fix.
- `test/index-complete-provider-config.test.ts`: new test `preserves an explicit api.openai.com/v1 baseUrl for paid OpenAI API-key Codex users`; existing ollama test updated (now asserts `baseUrl: ""`); new test `preserves a user-configured ollama cloud baseUrl instead of overriding to localhost`.

Total: **836 tests pass** (was 833 on baseline, +3 regression tests).

## Test plan

- [x] `npm ci && npm test` clean on the branch (45 files, 836 tests, 0 failures)
- [x] `npm run build` clean (660kb dist/index.js)
- [x] Manual repro of each fix:
  - #559 A1: cold-cache assistant-only session; assert `result.messages !== liveMessages` (was `===` previously)
  - #559 B5: ingest assistant message with `[{type:"text",text:""}]`; confirm filtered from assembled output
  - #560 A2: configure `openai-codex` with explicit `https://api.openai.com/v1`; confirm `completeSimple` receives that exact baseUrl (was rewritten to `chatgpt.com/backend-api/codex` on v0.9.3)
  - #560 A3: configure `ollama` with `https://ollama.com`; confirm `completeSimple` receives `https://ollama.com` (was rewritten to `localhost:11434` on v0.9.3)

## Cross-links

- Closes: #559, #560
- Refs: #554, #496, #499, #505, #509, #519 (assembly chain)
- Refs: #480, #436, #508, #541, #251 (provider/auth chain)
- Related-existing fixes: #502, #504, #506, #549, #546, #500