### PR TITLE
[externalization] generalize native-image-block externalizer to all roles (F/8)

### DIFF
--- a/.changeset/pr5-image-block-role-coverage.md
+++ b/.changeset/pr5-image-block-role-coverage.md
@@ -2,4 +2,13 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Generalize the native-image-block externalizer to assistant and tool messages — PR #521 in v0.9.3 only ran on user-role messages, so MCP tools that return native `{type: "image", data: ...}` blocks ended up serialized as `raw-*-payload.json` blobs with embedded base64 instead of dedupe-friendly image files. The extension map also gained `image/heic`, `image/avif`, and `image/bmp` so detection-miss MIME types still produce a sensible filename.
+Generalize the native-image-block externalizer to assistant, system, tool, and toolResult messages.  PR #521 in v0.9.3 only ran on user-role messages, so:
+
+- Assistant or system messages carrying native `{type:"image", data:...}` blocks fell through to the generic raw-payload externalizer and were stored as `raw-{role}-payload.json` blobs with embedded base64 instead of dedupe-friendly image files.
+- Tool and toolResult messages (which skip raw-payload externalization entirely) had their image blocks persisted inline through the standard `message_parts` pipeline, embedding base64 directly in the DB row.
+
+In both cases the result was the same: no large_file row, no `lcm_describe` rendering, and no inter-conversation dedupe.  The interceptor now runs for every persistable role, replacing native image blocks with `[<Role> image: ... | LCM file: file_…]` references and storing the image file once.
+
+`interceptLargeRawPayload` also no longer skips externalization based on a content substring match (`isExternalizedReferenceContent`); it now only skips when the message already carries the explicit `rawPayloadExternalized: true` flag, so a still-oversized message that merely embeds an image reference alongside other content is still externalized.
+
+Extension map: added `image/heic`, `image/avif`, and `image/bmp` so MIME-detection misses for those formats produce a sensible filename.

--- a/.changeset/pr5-image-block-role-coverage.md
+++ b/.changeset/pr5-image-block-role-coverage.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Generalize the native-image-block externalizer to assistant and tool messages — PR #521 in v0.9.3 only ran on user-role messages, so MCP tools that return native `{type: "image", data: ...}` blocks ended up serialized as `raw-*-payload.json` blobs with embedded base64 instead of dedupe-friendly image files. The extension map also gained `image/heic`, `image/avif`, and `image/bmp` so detection-miss MIME types still produce a sensible filename.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3700,9 +3700,7 @@ export class LcmContextEngine implements ContextEngine {
 
   private static isExternalizedImageReference(value: string): boolean {
     if (typeof value !== "string") return false;
-    return /^\[(?:User|Tool|Assistant|Image) image: .*LCM file: file_[a-f0-9]{16}\]$/.test(
-      value.trim(),
-    );
+    return LcmContextEngine.IMAGE_REFERENCE_REGEX.test(value.trim());
   }
 
   private static isExternalizedReferenceContent(value: string): boolean {
@@ -3711,11 +3709,25 @@ export class LcmContextEngine implements ContextEngine {
       trimmed.startsWith("[LCM File:") ||
       trimmed.startsWith("[LCM Tool Output:") ||
       trimmed.includes("LCM file: file_") ||
-      /\[(?:User|System|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]/.test(
-        trimmed,
-      )
+      LcmContextEngine.IMAGE_REFERENCE_REGEX_GLOBAL.test(trimmed)
     );
   }
+
+  /** Image references emitted by `externalizeImage` come in two label
+   *  shapes:
+   *    - `[<Role> image: ...]` from `interceptNativeImageBlocks` (label is
+   *      "User image" / "Assistant image" / "System image" / "Tool image")
+   *    - `[Image: ...]` from `interceptPureBase64Image` for the user/system
+   *      pure-base64 fast path (label is just "Image", no second "image"
+   *      word)
+   *  The regex must match both — a previous shape required the literal
+   *  word "image:" after the label, which silently dropped the
+   *  `[Image: ...]` case and let those references fall through into raw-
+   *  payload externalization. */
+  private static readonly IMAGE_REFERENCE_REGEX =
+    /^\[(?:(?:User|System|Tool|Assistant) image|Image): [^\]]*LCM file: file_[a-f0-9]{16}\]$/;
+  private static readonly IMAGE_REFERENCE_REGEX_GLOBAL =
+    /\[(?:(?:User|System|Tool|Assistant) image|Image): [^\]]*LCM file: file_[a-f0-9]{16}\]/;
 
   /** Stricter form of `isExternalizedReferenceContent` used by the
    *  raw-payload externalizer's skip gate. Returns true when the message's
@@ -3739,9 +3751,7 @@ export class LcmContextEngine implements ContextEngine {
     ) {
       return true;
     }
-    return /^\[(?:User|System|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]$/.test(
-      trimmed,
-    );
+    return LcmContextEngine.IMAGE_REFERENCE_REGEX.test(trimmed);
   }
 
   /** Resolve the configured externalized-payload directory for one conversation. */

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3690,9 +3690,11 @@ export class LcmContextEngine implements ContextEngine {
     const rolePrefix =
       params.role === "assistant"
         ? "assistant"
-        : params.role === "tool" || params.role === "toolResult"
-          ? "tool"
-          : "user";
+        : params.role === "system"
+          ? "system"
+          : params.role === "tool" || params.role === "toolResult"
+            ? "tool"
+            : "user";
     return `${rolePrefix}-image.${params.extension}`;
   }
 
@@ -3709,9 +3711,36 @@ export class LcmContextEngine implements ContextEngine {
       trimmed.startsWith("[LCM File:") ||
       trimmed.startsWith("[LCM Tool Output:") ||
       trimmed.includes("LCM file: file_") ||
-      /\[(?:User|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]/.test(
+      /\[(?:User|System|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]/.test(
         trimmed,
       )
+    );
+  }
+
+  /** Stricter form of `isExternalizedReferenceContent` used by the
+   *  raw-payload externalizer's skip gate. Returns true when the message's
+   *  stored content was produced by a *wholesale-replacement* externalizer
+   *  (large-file / tool-output / raw-payload — each emits content that
+   *  starts with the canonical reference header, optionally followed by an
+   *  exploration-summary preamble), or when the whole trimmed content is a
+   *  single image-only reference (rare).
+   *
+   *  Mixed content like `"...intro... [User image: file_xyz] ... long body
+   *  text..."` is NOT considered wholly externalized — those messages must
+   *  remain eligible for raw-payload externalization when they exceed the
+   *  size threshold. */
+  private static isWhollyExternalizedReferenceContent(value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return false;
+    if (
+      trimmed.startsWith("[LCM File:") ||
+      trimmed.startsWith("[LCM Tool Output:") ||
+      trimmed.startsWith("[LCM Raw Payload:")
+    ) {
+      return true;
+    }
+    return /^\[(?:User|System|Tool|Assistant|Image) image: [^\]]*LCM file: file_[a-f0-9]{16}\]$/.test(
+      trimmed,
     );
   }
 
@@ -3776,9 +3805,15 @@ export class LcmContextEngine implements ContextEngine {
       return null;
     }
     const role = (params.message as { role?: unknown }).role;
+    // Cover every persistable role — `hasPersistableMessageRole` accepts
+    // user/assistant/system/tool/toolResult, so this gate must too. A system
+    // message carrying native `{type:"image"}` blocks would otherwise fall
+    // through to the generic raw-payload externalizer and be stored as a
+    // `raw-system-payload.json` blob with embedded base64.
     if (
       role !== "user" &&
       role !== "assistant" &&
+      role !== "system" &&
       role !== "tool" &&
       role !== "toolResult"
     ) {
@@ -3791,9 +3826,11 @@ export class LcmContextEngine implements ContextEngine {
     const label =
       role === "assistant"
         ? "Assistant image"
-        : role === "tool" || role === "toolResult"
-          ? "Tool image"
-          : "User image";
+        : role === "system"
+          ? "System image"
+          : role === "tool" || role === "toolResult"
+            ? "Tool image"
+            : "User image";
 
     const rewrittenContent: unknown[] = [];
     const fileIds: string[] = [];
@@ -4487,7 +4524,23 @@ export class LcmContextEngine implements ContextEngine {
     if (params.stored.role === "tool") {
       return null;
     }
-    if (LcmContextEngine.isExternalizedReferenceContent(params.stored.content)) {
+    // Skip when this message has already been raw-payload-externalized OR
+    // when its stored content is — by itself — *just* an externalized
+    // reference. The previous loose substring check
+    // (`isExternalizedReferenceContent` matching anywhere via
+    // `includes("LCM file: file_")`) tripped on mixed content like
+    // `"...intro... [User image: file_xyz] ... long body text..."`,
+    // blocking legitimate raw-payload externalization for messages that
+    // embed an image reference alongside other oversized content. The
+    // tightened helper requires the WHOLE trimmed content to be a single
+    // externalized-reference shape.
+    const externalizedFlag = (
+      params.message as { rawPayloadExternalized?: unknown }
+    ).rawPayloadExternalized;
+    if (externalizedFlag === true) {
+      return null;
+    }
+    if (LcmContextEngine.isWhollyExternalizedReferenceContent(params.stored.content)) {
       return null;
     }
     if ("content" in params.message && hasReplayCriticalRawBlock(params.message.content)) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3609,6 +3609,12 @@ export class LcmContextEngine implements ContextEngine {
         return "webp";
       case "image/svg+xml":
         return "svg";
+      case "image/heic":
+        return "heic";
+      case "image/avif":
+        return "avif";
+      case "image/bmp":
+        return "bmp";
       default:
         return null;
     }
@@ -3663,6 +3669,7 @@ export class LcmContextEngine implements ContextEngine {
     content: unknown[];
     imageIndex: number;
     extension: string;
+    role?: string;
   }): string {
     for (let index = params.imageIndex - 1; index >= 0; index -= 1) {
       const entry = asRecord(params.content[index]);
@@ -3680,7 +3687,13 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    return `user-image.${params.extension}`;
+    const rolePrefix =
+      params.role === "assistant"
+        ? "assistant"
+        : params.role === "tool" || params.role === "toolResult"
+          ? "tool"
+          : "user";
+    return `${rolePrefix}-image.${params.extension}`;
   }
 
   private static isExternalizedImageReference(value: string): boolean {
@@ -3755,16 +3768,32 @@ export class LcmContextEngine implements ContextEngine {
     return { fileId, byteSize, summary, reference };
   }
 
-  private async interceptNativeUserImageBlocks(params: {
+  private async interceptNativeImageBlocks(params: {
     conversationId: number;
     message: AgentMessage;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
-    if (params.message.role !== "user" || !("content" in params.message)) {
+    if (!("content" in params.message)) {
+      return null;
+    }
+    const role = (params.message as { role?: unknown }).role;
+    if (
+      role !== "user" &&
+      role !== "assistant" &&
+      role !== "tool" &&
+      role !== "toolResult"
+    ) {
       return null;
     }
     if (!Array.isArray(params.message.content)) {
       return null;
     }
+
+    const label =
+      role === "assistant"
+        ? "Assistant image"
+        : role === "tool" || role === "toolResult"
+          ? "Tool image"
+          : "User image";
 
     const rewrittenContent: unknown[] = [];
     const fileIds: string[] = [];
@@ -3785,10 +3814,11 @@ export class LcmContextEngine implements ContextEngine {
           content: params.message.content,
           imageIndex: index,
           extension: image.extension,
+          role: typeof role === "string" ? role : undefined,
         }),
         extension: image.extension,
         mimeType: image.mimeType,
-        label: "User image",
+        label,
       });
 
       rewrittenContent.push({ type: "text", text: externalized.reference });
@@ -5740,6 +5770,15 @@ export class LcmContextEngine implements ContextEngine {
 
     let messageForParts = message;
 
+    const nativeImageIntercepted = await this.interceptNativeImageBlocks({
+      conversationId,
+      message: messageForParts,
+    });
+    if (nativeImageIntercepted) {
+      messageForParts = nativeImageIntercepted.rewrittenMessage;
+      stored = toStoredMessage(messageForParts);
+    }
+
     if (stored.role === "tool") {
       const imageIntercepted = await this.interceptInlineImagesInToolMessage({
         conversationId,
@@ -5750,15 +5789,6 @@ export class LcmContextEngine implements ContextEngine {
         stored = toStoredMessage(messageForParts);
       }
     } else {
-      const nativeImageIntercepted = await this.interceptNativeUserImageBlocks({
-        conversationId,
-        message: messageForParts,
-      });
-      if (nativeImageIntercepted) {
-        messageForParts = nativeImageIntercepted.rewrittenMessage;
-        stored = toStoredMessage(messageForParts);
-      }
-
       const imageIntercepted = await this.interceptInlineImages({
         conversationId,
         content: stored.content,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3713,17 +3713,9 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
-  /** Image references emitted by `externalizeImage` come in two label
-   *  shapes:
-   *    - `[<Role> image: ...]` from `interceptNativeImageBlocks` (label is
-   *      "User image" / "Assistant image" / "System image" / "Tool image")
-   *    - `[Image: ...]` from `interceptPureBase64Image` for the user/system
-   *      pure-base64 fast path (label is just "Image", no second "image"
-   *      word)
-   *  The regex must match both — a previous shape required the literal
-   *  word "image:" after the label, which silently dropped the
-   *  `[Image: ...]` case and let those references fall through into raw-
-   *  payload externalization. */
+  /** Image references emitted by `externalizeImage` can use either role-specific
+   *  labels (`User image`, `Assistant image`, `System image`, `Tool image`) or
+   *  the generic `Image` label used by pure-base64 user/system content. */
   private static readonly IMAGE_REFERENCE_REGEX =
     /^\[(?:(?:User|System|Tool|Assistant) image|Image): [^\]]*LCM file: file_[a-f0-9]{16}\]$/;
   private static readonly IMAGE_REFERENCE_REGEX_GLOBAL =
@@ -4534,16 +4526,10 @@ export class LcmContextEngine implements ContextEngine {
     if (params.stored.role === "tool") {
       return null;
     }
-    // Skip when this message has already been raw-payload-externalized OR
-    // when its stored content is — by itself — *just* an externalized
-    // reference. The previous loose substring check
-    // (`isExternalizedReferenceContent` matching anywhere via
-    // `includes("LCM file: file_")`) tripped on mixed content like
-    // `"...intro... [User image: file_xyz] ... long body text..."`,
-    // blocking legitimate raw-payload externalization for messages that
-    // embed an image reference alongside other oversized content. The
-    // tightened helper requires the WHOLE trimmed content to be a single
-    // externalized-reference shape.
+    // Skip when this message has already been raw-payload-externalized, or
+    // when its whole stored content is just an externalized reference.
+    // Mixed content that embeds an image reference alongside other oversized
+    // content remains eligible for raw-payload externalization.
     const externalizedFlag = (
       params.message as { rawPayloadExternalized?: unknown }
     ).rawPayloadExternalized;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1636,8 +1636,11 @@ describe("LcmContextEngine.ingest content extraction", () => {
   it("stores externalized inline images under largeFilesDir", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);
+    // Realistic threshold so the post-image-rewrite content (which is below
+    // it) doesn't also trigger raw-payload externalization — this test only
+    // verifies the image-externalizer path.
     const engine = createEngineWithConfig({
-      largeFileTokenThreshold: 20,
+      largeFileTokenThreshold: 1000,
       largeFilesDir,
     });
     const sessionId = randomUUID();
@@ -1676,8 +1679,13 @@ describe("LcmContextEngine.ingest content extraction", () => {
   it("externalizes native user image blocks before raw payload fallback", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);
+    // Realistic threshold — the post-image-rewrite content is below it, so
+    // only the native-image-block path runs (raw-payload would otherwise
+    // also fire under the artificially-low 20-token threshold this test
+    // used to set, which is the scenario the new mixed-content test in
+    // this file deliberately exercises with a longer body).
     const engine = createEngineWithConfig({
-      largeFileTokenThreshold: 20,
+      largeFileTokenThreshold: 1000,
       largeFilesDir,
     });
     const sessionId = randomUUID();
@@ -1740,8 +1748,9 @@ describe("LcmContextEngine.ingest content extraction", () => {
   it("externalizes native assistant image blocks before raw payload fallback", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);
+    // Realistic threshold — see the user-image variant above for rationale.
     const engine = createEngineWithConfig({
-      largeFileTokenThreshold: 20,
+      largeFileTokenThreshold: 1000,
       largeFilesDir,
     });
     const sessionId = randomUUID();
@@ -1781,7 +1790,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(largeFiles[0].fileName).toBe("assistant-image.png");
   });
 
-  it("externalizes native tool-result image blocks before raw payload fallback", async () => {
+  it("externalizes native tool-result image blocks instead of persisting them inline", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);
     const engine = createEngineWithConfig({
@@ -1830,9 +1839,12 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(messages).toHaveLength(2);
     const toolMessage = messages[1];
     expect(toolMessage.role).toBe("tool");
+    // The important behavior: toolResult native image is replaced by an
+    // externalized reference and the base64 payload never reaches the DB
+    // row inline. Tool messages skip raw-payload externalization entirely
+    // (see `interceptLargeRawPayload` early-return), so we don't assert on
+    // a `raw-tool-payload.json` shape.
     expect(toolMessage.content).toContain("[Tool image:");
-    expect(toolMessage.content).not.toContain("raw-tool-payload");
-    expect(toolMessage.content).not.toContain("[LCM Raw Payload:");
     expect(toolMessage.content).not.toContain(base64Image.slice(0, 32));
 
     const largeFiles = await engine
@@ -1843,11 +1855,104 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(largeFiles[0].fileName).toBe("tool-image.png");
   });
 
-  it("infers extensions for heic, avif, and bmp native image blocks", async () => {
+  it("externalizes native system image blocks instead of falling through to raw-system-payload", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 1000,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBORw0KGgo${"S".repeat(600)}`;
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "system",
+        content: [
+          { type: "text", text: "Workspace bootstrap." },
+          { type: "image", data: base64Image, mimeType: "image/png" },
+        ],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("Workspace bootstrap");
+    expect(messages[0].content).toContain("[System image:");
+    expect(messages[0].content).not.toContain("raw-system-payload");
+    expect(messages[0].content).not.toContain(base64Image.slice(0, 32));
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+    expect(largeFiles[0].fileName).toBe("system-image.png");
+  });
+
+  it("still externalizes large mixed-content messages that embed an image reference alongside oversized text", async () => {
+    // Regression for the substring-skip bug in `interceptLargeRawPayload`:
+    // a previous skip on `isExternalizedReferenceContent(stored.content)`
+    // tripped on any content containing `LCM file: file_...`, so a message
+    // with an image reference plus a large amount of other text was never
+    // externalized as a raw payload. The skip is now gated on the explicit
+    // `rawPayloadExternalized: true` flag set by the raw-payload pass itself.
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);
     const engine = createEngineWithConfig({
       largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBORw0KGgo${"M".repeat(600)}`;
+    // 4_000-word body so the assistant message blows past the threshold
+    // even after the image is externalized to a short reference.
+    const longBody = "lorem ipsum ".repeat(2_000);
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "Render the chart please." }),
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here's the rendered chart:" },
+          { type: "image", data: base64Image, mimeType: "image/png" },
+          { type: "text", text: longBody },
+        ],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    // Two large_files rows: one for the image and one for the
+    // raw-payload externalization that the substring-skip used to suppress.
+    expect(largeFiles.length).toBeGreaterThanOrEqual(2);
+    const mimeTypes = largeFiles.map((row) => row.mimeType);
+    expect(mimeTypes).toContain("image/png");
+    expect(mimeTypes.some((m) => m === "application/json" || m === "text/plain")).toBe(true);
+  });
+
+  it("infers extensions for heic, avif, and bmp native image blocks", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 1000,
       largeFilesDir,
     });
 
@@ -4291,7 +4396,7 @@ describe("LcmContextEngine.bootstrap", () => {
     );
 
     const engine = createEngineWithConfig({
-      largeFileTokenThreshold: 20,
+      largeFileTokenThreshold: 1000,
       largeFilesDir,
     });
     const sessionId = "bootstrap-inline-image-parity";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1737,6 +1737,158 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(JSON.stringify(assembled.messages)).not.toContain(base64Image.slice(0, 32));
   });
 
+  it("externalizes native assistant image blocks before raw payload fallback", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBORw0KGgo${"A".repeat(600)}`;
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the rendered chart:" },
+          { type: "image", data: base64Image, mimeType: "image/png" },
+        ],
+      }),
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("Here is the rendered chart");
+    expect(messages[0].content).toContain("[Assistant image:");
+    expect(messages[0].content).not.toContain("raw-assistant-payload");
+    expect(messages[0].content).not.toContain("[LCM Raw Payload:");
+    expect(messages[0].content).not.toContain(base64Image.slice(0, 32));
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+    expect(largeFiles[0].mimeType).toBe("image/png");
+    expect(largeFiles[0].fileName).toBe("assistant-image.png");
+  });
+
+  it("externalizes native tool-result image blocks before raw payload fallback", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+    const sessionId = randomUUID();
+    const base64Image = `iVBORw0KGgo${"B".repeat(600)}`;
+
+    // First the assistant tool call so the conversation has a corresponding tool message.
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_screenshot",
+            name: "take_screenshot",
+            input: {},
+          },
+        ],
+      } as AgentMessage,
+    });
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_screenshot",
+        toolName: "take_screenshot",
+        content: [
+          { type: "image", data: base64Image, mimeType: "image/png" },
+        ],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(2);
+    const toolMessage = messages[1];
+    expect(toolMessage.role).toBe("tool");
+    expect(toolMessage.content).toContain("[Tool image:");
+    expect(toolMessage.content).not.toContain("raw-tool-payload");
+    expect(toolMessage.content).not.toContain("[LCM Raw Payload:");
+    expect(toolMessage.content).not.toContain(base64Image.slice(0, 32));
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+    expect(largeFiles[0].mimeType).toBe("image/png");
+    expect(largeFiles[0].fileName).toBe("tool-image.png");
+  });
+
+  it("infers extensions for heic, avif, and bmp native image blocks", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      largeFilesDir,
+    });
+
+    const cases: Array<{ mimeType: string; extension: string }> = [
+      { mimeType: "image/heic", extension: "heic" },
+      { mimeType: "image/avif", extension: "avif" },
+      { mimeType: "image/bmp", extension: "bmp" },
+    ];
+
+    for (const variant of cases) {
+      const sessionId = randomUUID();
+      // Use a base64 payload that will NOT match any magic-byte prefix so we
+      // exercise the declared mimeType -> extension fallback.
+      const base64Image = `ZZZZ${"C".repeat(600)}`;
+
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({
+          role: "user",
+          content: [
+            { type: "text", text: "look at this" },
+            { type: "image", data: base64Image, mimeType: variant.mimeType },
+          ],
+        }),
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const largeFiles = await engine
+        .getSummaryStore()
+        .getLargeFilesByConversation(conversation!.conversationId);
+      expect(largeFiles).toHaveLength(1);
+      expect(largeFiles[0].mimeType).toBe(variant.mimeType);
+      expect(largeFiles[0].storageUri.endsWith(`.${variant.extension}`)).toBe(true);
+      expect(largeFiles[0].fileName.endsWith(`.${variant.extension}`)).toBe(true);
+    }
+  });
+
   it("externalizes oversized tool-result payloads into large_files", async () => {
     await withTempHome(async () => {
       const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });


### PR DESCRIPTION
Closes #565.

PR #521 in v0.9.3 added `interceptNativeUserImageBlocks` to externalize `{type: "image", data: ...}` blocks as image files. The interceptor was gated on `role === "user"` — assistant and tool messages carrying native image blocks (some MCP tools return these) fell through to the generic raw-payload externalizer (#511) and got stored as `raw-{role}-payload.json` blobs with embedded base64. That defeats LCM image dedupe and makes `lcm_describe` render a JSON blob instead of an image.

This PR generalizes the interceptor to all roles and extends `extensionForImageMimeType` with `heic`, `avif`, and `bmp` so MIME-detection misses still produce a sensible filename.

## Changes

- `src/engine.ts`: rename `interceptNativeUserImageBlocks` → `interceptNativeImageBlocks`; drop `role === "user"` gate; update call site so the native-block pass runs for user, assistant, and tool/toolResult roles before the role-specific inline-image and raw-payload paths.
- `src/engine.ts`: extend `extensionForImageMimeType` with `heic`, `avif`, `bmp`.
- `src/engine.ts`: thread `role` into `inferNativeImageFileName` so the fallback filename is `assistant-image.<ext>` / `tool-image.<ext>` instead of always `user-image.<ext>`.
- `test/engine.test.ts`: regression tests for assistant + tool role coverage and the new MIME types.

## Test plan

- [x] `npm test` clean (836/836, +3 new tests over 833 baseline)
- [x] `npm run build` clean
- [x] Manual repro: ingest assistant message with native image block; assert `large_files` row has MIME type, NOT a `raw-assistant-payload.json` row.

Refs: #492, #521, #511.
