### PR TITLE
[compaction] afterTurn lane robustness: silent skip + dedup precision + slow-path (G/8)

### DIFF
--- a/.changeset/pr6-compaction-aftertrun-robustness.md
+++ b/.changeset/pr6-compaction-aftertrun-robustness.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Harden three afterTurn-lane robustness gaps in v0.9.3:
+
+- `scheduleDeferredCompactionDebtDrain` no longer silently skips when `compactionTelemetry` lacks provider/model — CLI-backend sessions (#472) accumulated debt forever.  Now drains anyway when telemetry is missing (let the inner cache-aware gate decide), keeping silent debt off the floor.
+- `messageContentCoveredBySummary` (PR #551) replaces bare substring match with anchored-or-quoted matching — a 24+ char user instruction coincidentally appearing inside a long narrative summary is no longer silently dropped.
+- `reconcileTranscriptTailForAfterTurn` (PR #551) slow path no longer blindly re-reads the full session file when checkpoint is missing or path mismatched — refresh checkpoint and switch to incremental reads, with a one-shot warn for visibility.

--- a/.changeset/pr6-compaction-aftertrun-robustness.md
+++ b/.changeset/pr6-compaction-aftertrun-robustness.md
@@ -1,9 +1,0 @@
----
-"@martian-engineering/lossless-claw": patch
----
-
-Harden three afterTurn-lane robustness gaps in v0.9.3:
-
-- `scheduleDeferredCompactionDebtDrain` no longer silently skips when `compactionTelemetry` lacks provider/model — CLI-backend sessions (#472) accumulated debt forever.  Now drains anyway when telemetry is missing (let the inner cache-aware gate decide), keeping silent debt off the floor.
-- `messageContentCoveredBySummary` (PR #551) replaces bare substring match with anchored-or-quoted matching — a 24+ char user instruction coincidentally appearing inside a long narrative summary is no longer silently dropped.
-- `reconcileTranscriptTailForAfterTurn` (PR #551) slow path no longer blindly re-reads the full session file when checkpoint is missing or path mismatched — refresh checkpoint and switch to incremental reads, with a one-shot warn for visibility.

--- a/.changeset/pr6-compaction-afterturn-robustness.md
+++ b/.changeset/pr6-compaction-afterturn-robustness.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Harden the afterTurn-lane robustness:
+
+- `scheduleDeferredCompactionDebtDrain` no longer silently skips when `compactionTelemetry` lacks provider/model — CLI-backend sessions (#472) accumulated debt forever.  Now drains anyway when telemetry is missing (let the inner cache-aware gate decide), keeping silent debt off the floor.  The visibility log is deduped to once per conversation per process so long-running CLI sessions don't spam every afterTurn.
+- `messageContentCoveredBySummary` (PR #551) replaces bare substring match with anchored-or-quoted matching — a 24+ char user instruction coincidentally appearing inside a long narrative summary is no longer silently dropped.  The quote-span scan is also more resilient: an unmatched opening quote skips past instead of aborting the entire scan, so later well-formed quoted spans still get checked.
+- `reconcileTranscriptTailForAfterTurn` (PR #551) slow path no longer blindly re-reads the full session file when checkpoint is missing or path mismatched — refresh checkpoint and switch to incremental reads, with a one-shot warn for visibility.  The dedupe set is bounded with FIFO eviction at 4096 entries so hosts churning through many sessions don't accumulate it indefinitely.  The empty-`historicalMessages` branch now distinguishes "actually empty file" (size 0 → refresh checkpoint) from "non-empty file but parser failure" (size > 0 → emit warn, skip checkpoint refresh, keep the next afterTurn eligible to retry).

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1671,21 +1671,29 @@ function messageContentCoveredBySummary(params: {
   // coincidentally appear inside a long narrative summary and get silently
   // dropped. Require one of:
   //   1. content appears at the very start or end of the summary, OR
-  //   2. content appears inside a quoted block ("..." or backticks) — the
-  //      pattern emitted by our summarizer when it embeds verbatim user text.
+  //   2. content appears inside a quoted block — double quotes ("..."),
+  //      single quotes ('...'), or backticks (`...`). All three quote
+  //      styles survive normalization and are emitted by the summarizer
+  //      when it embeds verbatim user text.
   // Otherwise treat it as a coincidental collision and keep the message.
   if (summary.startsWith(content) || summary.endsWith(content)) {
     return true;
   }
-  // After whitespace normalization, both " and ' and `…` survive. Walk each
-  // quote-delimited span (cheap; summaries are bounded) and check membership.
-  for (const quoteChar of ['"', "'", "`"]) {
+  // Walk each quote-delimited span (cheap; summaries are bounded) and check
+  // membership. Use double-quoted literals to match the rest of the file.
+  for (const quoteChar of ["\"", "'", "`"]) {
     let cursor = 0;
     while (cursor < summary.length) {
       const open = summary.indexOf(quoteChar, cursor);
       if (open < 0) break;
       const close = summary.indexOf(quoteChar, open + 1);
-      if (close < 0) break;
+      if (close < 0) {
+        // Unmatched opening quote: don't break out of the entire scan —
+        // a later well-formed quoted span may still contain the content.
+        // Skip past this lone opener and continue.
+        cursor = open + 1;
+        continue;
+      }
       const span = summary.slice(open + 1, close);
       if (span.includes(content)) {
         return true;
@@ -1742,11 +1750,29 @@ export class LcmContextEngine implements ContextEngine {
   // ── Circuit breaker for compaction auth failures ──
   private circuitBreakerStates = new Map<string, CircuitBreakerState>();
 
-  // Per-process cap on `reconcileTranscriptTailForAfterTurn` slow-path full
-  // re-reads, keyed by `${sessionQueueKey} ${sessionFile}`. Long-running
-  // sessions where the bootstrap checkpoint is missing or path-mismatched
-  // would otherwise pay O(file-size) on every afterTurn.
+  /** Per-process cap on `reconcileTranscriptTailForAfterTurn` slow-path full
+   *  re-reads, keyed by `${sessionQueueKey}\u0000${sessionFile}` (same
+   *  NUL-escape separator pattern as `messageIdentity`). Long-running
+   *  sessions where the bootstrap checkpoint is missing or path-mismatched
+   *  would otherwise pay O(file-size) on every afterTurn; one slow path
+   *  per (queueKey, sessionFile) is the bound.
+   *
+   *  Bounded with FIFO eviction at `AFTER_TURN_RECONCILE_KEY_CAP` entries
+   *  so hosts churning through many sessions/files don't accumulate this
+   *  set indefinitely. When the cap is exceeded we drop the oldest entry
+   *  (Set iteration order is insertion order in JS); a session whose
+   *  entry eventually evicts may pay the slow path once again, which is
+   *  acceptable since the bound is well above realistic concurrent-session
+   *  counts. */
   private afterTurnReconcileFullReadKeys = new Set<string>();
+  private static readonly AFTER_TURN_RECONCILE_KEY_CAP = 4096;
+
+  /** Per-process dedupe for the `cache-context-unknown` info-level log
+   *  (PR #557 added the diagnostic; on long-running sessions without
+   *  provider telemetry it would otherwise fire every afterTurn that
+   *  records deferred debt). Keyed by conversationId so each session
+   *  emits the visibility log AT MOST ONCE per process. */
+  private cacheContextUnknownLogged = new Set<number>();
 
   constructor(deps: LcmDependencies, database: DatabaseSync) {
     this.deps = deps;
@@ -4770,7 +4796,7 @@ export class LcmContextEngine implements ContextEngine {
         // long-running sessions otherwise pay O(file-size) every afterTurn.
         // Subsequent calls fall through to refreshBootstrapState below so the
         // next afterTurn takes the fast (incremental) path.
-        const fullReadKey = `${queueKey} ${params.sessionFile}`;
+        const fullReadKey = `${queueKey}\u0000${params.sessionFile}`;
         const reason = !checkpoint
           ? "checkpoint-missing"
           : checkpoint.sessionFilePath !== params.sessionFile
@@ -4786,17 +4812,49 @@ export class LcmContextEngine implements ContextEngine {
           });
           return;
         }
+        // FIFO-evict the oldest entry once we exceed the cap so the set is
+        // bounded across long-lived processes.
+        if (
+          this.afterTurnReconcileFullReadKeys.size
+            >= LcmContextEngine.AFTER_TURN_RECONCILE_KEY_CAP
+        ) {
+          const oldest = this.afterTurnReconcileFullReadKeys.values().next().value;
+          if (oldest !== undefined) {
+            this.afterTurnReconcileFullReadKeys.delete(oldest);
+          }
+        }
         this.afterTurnReconcileFullReadKeys.add(fullReadKey);
         const slowPathStartedAt = Date.now();
 
+        // Distinguish empty-file from read/parse error: stat the file and
+        // only treat it as "actually empty" when size is 0. A non-zero file
+        // returning empty `historicalMessages` indicates the parser hit an
+        // error (and `readLeafPathMessages` swallows those into `[]`); in
+        // that case we must NOT mark the bootstrap checkpoint as fully
+        // processed, otherwise future afterTurns will skip reconciliation
+        // and we lose messages.
+        let sessionFileSize: number | undefined;
+        try {
+          const sessionFileStats = await stat(params.sessionFile);
+          sessionFileSize = sessionFileStats.size;
+        } catch {
+          /* surface as undefined → treat the empty-historical-messages branch
+             as a parse error path and skip the checkpoint refresh */
+        }
         const historicalMessages = await readLeafPathMessages(params.sessionFile);
         if (historicalMessages.length === 0) {
-          // Nothing to reconcile, but still refresh the checkpoint so the next
-          // afterTurn takes the incremental path.
-          await this.refreshBootstrapState({
-            conversationId: conversation.conversationId,
-            sessionFile: params.sessionFile,
-          });
+          if (sessionFileSize === 0) {
+            // File is genuinely empty — refresh the checkpoint so the next
+            // afterTurn takes the incremental path.
+            await this.refreshBootstrapState({
+              conversationId: conversation.conversationId,
+              sessionFile: params.sessionFile,
+            });
+          } else {
+            this.deps.log.warn(
+              `[lcm] afterTurn: transcript reconcile slow path read empty messages from non-empty file (${sessionFileSize ?? "?"} bytes) — skipping checkpoint refresh to avoid dropping messages on parser failure conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
+            );
+          }
           return;
         }
         const reconcile = await this.reconcileSessionTail({
@@ -6371,9 +6429,15 @@ export class LcmContextEngine implements ContextEngine {
         // decide whether prompt mutation is actually safe — that gate is
         // robust to missing telemetry.
         if (!compactionTelemetry?.provider && !compactionTelemetry?.model) {
-          this.deps.log.info(
-            `[lcm] background deferred compaction scheduled without cache context conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
-          );
+          // Dedupe the visibility log to once per conversation per process —
+          // long-running CLI-backend sessions otherwise emit this line on
+          // every afterTurn that records deferred debt.
+          if (!this.cacheContextUnknownLogged.has(conversation.conversationId)) {
+            this.cacheContextUnknownLogged.add(conversation.conversationId);
+            this.deps.log.info(
+              `[lcm] background deferred compaction scheduled without cache context conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
+            );
+          }
         }
         deferredCompactionDrain = {
           tokenBudget,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1664,7 +1664,36 @@ function messageContentCoveredBySummary(params: {
     return false;
   }
   const summary = normalizeSummaryOverlapText(params.summary);
-  return summary.includes(content);
+  if (!summary.includes(content)) {
+    return false;
+  }
+  // Bare substring match is too loose: a 24+ char user instruction can
+  // coincidentally appear inside a long narrative summary and get silently
+  // dropped. Require one of:
+  //   1. content appears at the very start or end of the summary, OR
+  //   2. content appears inside a quoted block ("..." or backticks) — the
+  //      pattern emitted by our summarizer when it embeds verbatim user text.
+  // Otherwise treat it as a coincidental collision and keep the message.
+  if (summary.startsWith(content) || summary.endsWith(content)) {
+    return true;
+  }
+  // After whitespace normalization, both " and ' and `…` survive. Walk each
+  // quote-delimited span (cheap; summaries are bounded) and check membership.
+  for (const quoteChar of ['"', "'", "`"]) {
+    let cursor = 0;
+    while (cursor < summary.length) {
+      const open = summary.indexOf(quoteChar, cursor);
+      if (open < 0) break;
+      const close = summary.indexOf(quoteChar, open + 1);
+      if (close < 0) break;
+      const span = summary.slice(open + 1, close);
+      if (span.includes(content)) {
+        return true;
+      }
+      cursor = close + 1;
+    }
+  }
+  return false;
 }
 
 // ── LcmContextEngine ────────────────────────────────────────────────────────
@@ -1712,6 +1741,12 @@ export class LcmContextEngine implements ContextEngine {
 
   // ── Circuit breaker for compaction auth failures ──
   private circuitBreakerStates = new Map<string, CircuitBreakerState>();
+
+  // Per-process cap on `reconcileTranscriptTailForAfterTurn` slow-path full
+  // re-reads, keyed by `${sessionQueueKey} ${sessionFile}`. Long-running
+  // sessions where the bootstrap checkpoint is missing or path-mismatched
+  // would otherwise pay O(file-size) on every afterTurn.
+  private afterTurnReconcileFullReadKeys = new Set<string>();
 
   constructor(deps: LcmDependencies, database: DatabaseSync) {
     this.deps = deps;
@@ -4730,8 +4765,38 @@ export class LcmContextEngine implements ContextEngine {
           }
         }
 
+        // Slow path: checkpoint missing, path mismatched, or non-append-only.
+        // Cap full re-reads to once per (queueKey, sessionFile) per process;
+        // long-running sessions otherwise pay O(file-size) every afterTurn.
+        // Subsequent calls fall through to refreshBootstrapState below so the
+        // next afterTurn takes the fast (incremental) path.
+        const fullReadKey = `${queueKey} ${params.sessionFile}`;
+        const reason = !checkpoint
+          ? "checkpoint-missing"
+          : checkpoint.sessionFilePath !== params.sessionFile
+            ? "path-mismatch"
+            : "append-only-ineligible";
+        if (this.afterTurnReconcileFullReadKeys.has(fullReadKey)) {
+          this.deps.log.info(
+            `[lcm] afterTurn: transcript reconcile slow path skipped (already executed this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+          );
+          await this.refreshBootstrapState({
+            conversationId: conversation.conversationId,
+            sessionFile: params.sessionFile,
+          });
+          return;
+        }
+        this.afterTurnReconcileFullReadKeys.add(fullReadKey);
+        const slowPathStartedAt = Date.now();
+
         const historicalMessages = await readLeafPathMessages(params.sessionFile);
         if (historicalMessages.length === 0) {
+          // Nothing to reconcile, but still refresh the checkpoint so the next
+          // afterTurn takes the incremental path.
+          await this.refreshBootstrapState({
+            conversationId: conversation.conversationId,
+            sessionFile: params.sessionFile,
+          });
           return;
         }
         const reconcile = await this.reconcileSessionTail({
@@ -4751,12 +4816,17 @@ export class LcmContextEngine implements ContextEngine {
             "reconciled missing session messages",
           );
         }
-        if (reconcile.importedMessages > 0) {
-          await this.refreshBootstrapState({
-            conversationId: conversation.conversationId,
-            sessionFile: params.sessionFile,
-          });
-        }
+        // Always refresh the checkpoint after a slow-path read, even when no
+        // messages were imported. This pins the offset to the new sessionFile
+        // so the next afterTurn takes the incremental path instead of paying
+        // for another full re-read on every turn.
+        await this.refreshBootstrapState({
+          conversationId: conversation.conversationId,
+          sessionFile: params.sessionFile,
+        });
+        this.deps.log.warn(
+          `[lcm] afterTurn: transcript reconcile slow path (full re-read) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile} historicalMessages=${historicalMessages.length} importedMessages=${reconcile.importedMessages} duration=${formatDurationMs(Date.now() - slowPathStartedAt)}`,
+        );
       },
       {
         operationName: "afterTurnTranscriptReconcile",
@@ -6294,17 +6364,22 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
         });
-        if (compactionTelemetry?.provider || compactionTelemetry?.model) {
-          deferredCompactionDrain = {
-            tokenBudget,
-            currentTokenCount: observedCurrentTokenCount,
-            reason: deferredReason,
-          };
-        } else {
+        // CLI-backend sessions (#472) never observe provider/model telemetry,
+        // so the previous gate skipped scheduling and accumulated debt
+        // forever. Schedule the drain unconditionally and let the inner
+        // cache-aware gate (`shouldDelayPromptMutatingDeferredCompaction`)
+        // decide whether prompt mutation is actually safe — that gate is
+        // robust to missing telemetry.
+        if (!compactionTelemetry?.provider && !compactionTelemetry?.model) {
           this.deps.log.info(
-            `[lcm] background deferred compaction not scheduled conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
+            `[lcm] background deferred compaction scheduled without cache context conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
           );
         }
+        deferredCompactionDrain = {
+          tokenBudget,
+          currentTokenCount: observedCurrentTokenCount,
+          reason: deferredReason,
+        };
       }
     } catch (err) {
       this.deps.log.warn(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1750,21 +1750,21 @@ export class LcmContextEngine implements ContextEngine {
   // ── Circuit breaker for compaction auth failures ──
   private circuitBreakerStates = new Map<string, CircuitBreakerState>();
 
-  /** Per-process cap on `reconcileTranscriptTailForAfterTurn` slow-path full
-   *  re-reads, keyed by `${sessionQueueKey}\u0000${sessionFile}` (same
-   *  NUL-escape separator pattern as `messageIdentity`). Long-running
+  /** Last file state successfully covered by `reconcileTranscriptTailForAfterTurn`
+   *  slow-path full re-reads, keyed by `${sessionQueueKey}\u0000${sessionFile}`
+   *  (same NUL-escape separator pattern as `messageIdentity`). Long-running
    *  sessions where the bootstrap checkpoint is missing or path-mismatched
-   *  would otherwise pay O(file-size) on every afterTurn; one slow path
-   *  per (queueKey, sessionFile) is the bound.
+   *  would otherwise pay O(file-size) on every afterTurn; repeated attempts
+   *  for the same unchanged file state are skipped.
    *
    *  Bounded with FIFO eviction at `AFTER_TURN_RECONCILE_KEY_CAP` entries
    *  so hosts churning through many sessions/files don't accumulate this
-   *  set indefinitely. When the cap is exceeded we drop the oldest entry
-   *  (Set iteration order is insertion order in JS); a session whose
+   *  map indefinitely. When the cap is exceeded we drop the oldest entry
+   *  (Map iteration order is insertion order in JS); a session whose
    *  entry eventually evicts may pay the slow path once again, which is
    *  acceptable since the bound is well above realistic concurrent-session
    *  counts. */
-  private afterTurnReconcileFullReadKeys = new Set<string>();
+  private afterTurnReconcileFullReadStates = new Map<string, { size: number; mtimeMs: number }>();
   private static readonly AFTER_TURN_RECONCILE_KEY_CAP = 4096;
 
   /** Per-process dedupe for the `cache-context-unknown` info-level log
@@ -4792,38 +4792,55 @@ export class LcmContextEngine implements ContextEngine {
         }
 
         // Slow path: checkpoint missing, path mismatched, or non-append-only.
-        // Cap full re-reads to once per (queueKey, sessionFile) per process;
-        // long-running sessions otherwise pay O(file-size) every afterTurn.
-        // Subsequent calls fall through to refreshBootstrapState below so the
-        // next afterTurn takes the fast (incremental) path.
+        // Cap full re-reads only for unchanged file states. If the transcript
+        // changed since the last full read, reconcile again; if it did not,
+        // skip without advancing the checkpoint so stale state can be retried
+        // after a later file change, process restart, or cap eviction.
         const fullReadKey = `${queueKey}\u0000${params.sessionFile}`;
         const reason = !checkpoint
           ? "checkpoint-missing"
           : checkpoint.sessionFilePath !== params.sessionFile
             ? "path-mismatch"
             : "append-only-ineligible";
-        if (this.afterTurnReconcileFullReadKeys.has(fullReadKey)) {
+        let sessionFileState: { size: number; mtimeMs: number } | undefined;
+        try {
+          const sessionFileStats = await stat(params.sessionFile);
+          sessionFileState = {
+            size: sessionFileStats.size,
+            mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+          };
+        } catch {
+          // Leave undefined: without stat proof, do not use the slow-read cap.
+        }
+        const rememberedFileState = this.afterTurnReconcileFullReadStates.get(fullReadKey);
+        if (
+          rememberedFileState
+          && sessionFileState
+          && rememberedFileState.size === sessionFileState.size
+          && rememberedFileState.mtimeMs === sessionFileState.mtimeMs
+        ) {
           this.deps.log.info(
-            `[lcm] afterTurn: transcript reconcile slow path skipped (already executed this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+            `[lcm] afterTurn: transcript reconcile slow path skipped (file state already read this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
           );
-          await this.refreshBootstrapState({
-            conversationId: conversation.conversationId,
-            sessionFile: params.sessionFile,
-          });
           return;
         }
-        // FIFO-evict the oldest entry once we exceed the cap so the set is
-        // bounded across long-lived processes.
-        if (
-          this.afterTurnReconcileFullReadKeys.size
-            >= LcmContextEngine.AFTER_TURN_RECONCILE_KEY_CAP
-        ) {
-          const oldest = this.afterTurnReconcileFullReadKeys.values().next().value;
-          if (oldest !== undefined) {
-            this.afterTurnReconcileFullReadKeys.delete(oldest);
+
+        const rememberSlowReadState = (): void => {
+          if (!sessionFileState) {
+            return;
           }
-        }
-        this.afterTurnReconcileFullReadKeys.add(fullReadKey);
+          if (
+            !this.afterTurnReconcileFullReadStates.has(fullReadKey)
+            && this.afterTurnReconcileFullReadStates.size
+              >= LcmContextEngine.AFTER_TURN_RECONCILE_KEY_CAP
+          ) {
+            const oldest = this.afterTurnReconcileFullReadStates.keys().next().value;
+            if (typeof oldest === "string") {
+              this.afterTurnReconcileFullReadStates.delete(oldest);
+            }
+          }
+          this.afterTurnReconcileFullReadStates.set(fullReadKey, sessionFileState);
+        };
         const slowPathStartedAt = Date.now();
 
         // Distinguish empty-file from read/parse error: stat the file and
@@ -4833,26 +4850,19 @@ export class LcmContextEngine implements ContextEngine {
         // that case we must NOT mark the bootstrap checkpoint as fully
         // processed, otherwise future afterTurns will skip reconciliation
         // and we lose messages.
-        let sessionFileSize: number | undefined;
-        try {
-          const sessionFileStats = await stat(params.sessionFile);
-          sessionFileSize = sessionFileStats.size;
-        } catch {
-          /* surface as undefined → treat the empty-historical-messages branch
-             as a parse error path and skip the checkpoint refresh */
-        }
         const historicalMessages = await readLeafPathMessages(params.sessionFile);
         if (historicalMessages.length === 0) {
-          if (sessionFileSize === 0) {
+          if (sessionFileState?.size === 0) {
             // File is genuinely empty — refresh the checkpoint so the next
             // afterTurn takes the incremental path.
             await this.refreshBootstrapState({
               conversationId: conversation.conversationId,
               sessionFile: params.sessionFile,
             });
+            rememberSlowReadState();
           } else {
             this.deps.log.warn(
-              `[lcm] afterTurn: transcript reconcile slow path read empty messages from non-empty file (${sessionFileSize ?? "?"} bytes) — skipping checkpoint refresh to avoid dropping messages on parser failure conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
+              `[lcm] afterTurn: transcript reconcile slow path read empty messages from non-empty file (${sessionFileState?.size ?? "?"} bytes) — skipping checkpoint refresh to avoid dropping messages on parser failure conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
             );
           }
           return;
@@ -4882,6 +4892,7 @@ export class LcmContextEngine implements ContextEngine {
           conversationId: conversation.conversationId,
           sessionFile: params.sessionFile,
         });
+        rememberSlowReadState();
         this.deps.log.warn(
           `[lcm] afterTurn: transcript reconcile slow path (full re-read) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile} historicalMessages=${historicalMessages.length} importedMessages=${reconcile.importedMessages} duration=${formatDurationMs(Date.now() - slowPathStartedAt)}`,
         );

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6091,6 +6091,70 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ]);
   });
 
+  it("afterTurn keeps a 24+ char user message that only collides as a substring of the summary narrative (F6)", async () => {
+    // PR-6 #566 / F6: bare summary.includes(content) was too loose. A medium-
+    // length user instruction that coincidentally appears inside a long
+    // narrative summary must NOT be silently dropped — only anchored or
+    // quoted matches count as covered.
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-substring-collision";
+    const collidingInstruction = "please update the readme file"; // 30 chars
+    const summary =
+      "Summary of compacted context: the assistant was asked to please " +
+      "update the readme file with new sections, then verify CI passes " +
+      "and report back to the operator before EOD.";
+    expect(summary.toLowerCase()).toContain(collidingInstruction);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-substring-collision"),
+      messages: [
+        makeMessage({ role: "user", content: collidingInstruction }),
+        makeMessage({ role: "assistant", content: "Acknowledged." }),
+      ],
+      prePromptMessageCount: 0,
+      autoCompactionSummary: summary,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    // The user instruction must survive: it's only a coincidental substring,
+    // not anchored or quoted.
+    expect(stored.map((message) => message.content)).toEqual([
+      summary,
+      collidingInstruction,
+      "Acknowledged.",
+    ]);
+  });
+
+  it("afterTurn drops a user message when the summary ends with that exact content (F6 anchored)", async () => {
+    // Anchored truth case: content appears at the end of the summary's
+    // normalized text — that's a real coverage signal, drop the dup.
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-suffix-anchored";
+    const repeatedInstruction = "kick off the workers and check back in an hour";
+    const summary = `Summary of compacted context. ${repeatedInstruction}`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-suffix-anchored"),
+      messages: [
+        makeMessage({ role: "user", content: repeatedInstruction }),
+        makeMessage({ role: "assistant", content: "On it." }),
+      ],
+      prePromptMessageCount: 0,
+      autoCompactionSummary: summary,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([summary, "On it."]);
+  });
+
   it("afterTurn runs proactive threshold compaction when tokenBudget is provided", async () => {
     const engine = createEngineWithConfig({
       proactiveThresholdCompactionMode: "inline",
@@ -6834,6 +6898,184 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.running).toBe(false);
     expect(maintenance?.reason).toBe("threshold");
     expect(maintenance?.tokenBudget).toBe(400);
+  });
+
+  it("afterTurn schedules a deferred drain even when compactionTelemetry has no provider/model (D4)", async () => {
+    // PR-6 #566 / D4: CLI-backend sessions (#472) never observe provider/model
+    // telemetry. Previously the gate at the schedule site silently skipped
+    // and debt accumulated forever. Now we always schedule and let the inner
+    // cache-aware gate decide.
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: infoLog, warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-cli-backend-no-cache-context";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      scheduleDeferredCompactionDebtDrain: (params: unknown) => void;
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 50_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 1_024,
+      threshold: 3_072,
+    });
+    const scheduleSpy = vi.spyOn(privateEngine, "scheduleDeferredCompactionDebtDrain");
+
+    // No legacyCompactionParams provided → updateCompactionTelemetry stores a
+    // record without provider/model — exactly the CLI-backend case.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-cli-backend-no-cache-context"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // Drain MUST be scheduled even though provider/model are unknown.
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId,
+        reason: "leaf-trigger",
+        tokenBudget: 4_096,
+      }),
+    );
+
+    // The new visibility log should be emitted, not the legacy "not
+    // scheduled" message.
+    const infoMessages = infoLog.mock.calls.map((c) => String(c[0]));
+    expect(
+      infoMessages.some((m) =>
+        m.includes("scheduled without cache context") && m.includes("cache-context-unknown"),
+      ),
+    ).toBe(true);
+    expect(
+      infoMessages.some((m) => m.includes("background deferred compaction not scheduled")),
+    ).toBe(false);
+
+    // And debt is still recorded — that part was already correct.
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending).toBe(true);
+  });
+
+  it("afterTurn caps the transcript-reconcile slow path to one full re-read per session+file (F7)", async () => {
+    // PR-6 #566 / F7: PR #551 added reconcileTranscriptTailForAfterTurn but
+    // its slow path called readLeafPathMessages on the entire session file
+    // every afterTurn when the checkpoint was missing or path-mismatched.
+    // After PR-6: the slow path runs once per (session-key|id, sessionFile),
+    // refreshes the checkpoint, and subsequent afterTurns take the
+    // incremental path or the cap branch.
+    const infoLog = vi.fn();
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: infoLog, warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-reconcile-slow-path-cap";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    // Seed conversation by ingesting one turn through afterTurn first, with
+    // a DIFFERENT sessionFile so the next call has a path-mismatched
+    // checkpoint and is forced into the slow path.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-reconcile-slow-path-seed"),
+      messages: [makeMessage({ role: "assistant", content: "seed turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // Spy on the (module-scoped) full reader by spying on the slow-path
+    // log, since readLeafPathMessages is a free function. The slow-path warn
+    // is the canonical signal that the full re-read happened.
+    warnLog.mockClear();
+    infoLog.mockClear();
+
+    // First call with a different sessionFile triggers the slow path.
+    // Pre-populate the target sessionFile with at least one historical
+    // message so readLeafPathMessages returns a non-empty list and the
+    // slow-path warn fires (the empty-file branch is a separate exit).
+    const targetSessionFile = createSessionFilePath("after-turn-reconcile-slow-path-target");
+    writeFileSync(
+      targetSessionFile,
+      `${JSON.stringify({
+        message: { role: "user", content: [{ type: "text", text: "historical user line" }] },
+      })}\n`,
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: targetSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "next turn one" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const slowPathWarns = warnLog.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("transcript reconcile slow path"));
+    expect(slowPathWarns.length).toBe(1);
+
+    // Second call against the SAME (sessionId, sessionFile) tuple must NOT
+    // re-enter the slow path. After the first slow-path read we refresh the
+    // checkpoint, so this normally goes through the fast (incremental) path
+    // and emits no slow-path warn. If somehow the slow path is reached again
+    // (e.g. checkpoint not append-only-eligible), the cap log fires instead
+    // of a second full re-read.
+    warnLog.mockClear();
+    infoLog.mockClear();
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: targetSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "next turn two" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const secondSlowPathWarns = warnLog.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("transcript reconcile slow path (full re-read)"));
+    expect(secondSlowPathWarns.length).toBe(0);
   });
 
   it("afterTurn does not background-compact prompt-mutating debt while Anthropic cache is hot", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7078,6 +7078,118 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(secondSlowPathWarns.length).toBe(0);
   });
 
+  it("afterTurn retries a capped reconcile when the transcript file changed with an append-only-ineligible suffix (F7)", async () => {
+    const infoLog = vi.fn();
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: infoLog, warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-reconcile-cap-retries-on-file-change";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-reconcile-cap-retry-seed"),
+      messages: [makeMessage({ role: "assistant", content: "seed turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const targetSessionFile = createSessionFilePath("after-turn-reconcile-cap-retry-target");
+    writeFileSync(
+      targetSessionFile,
+      `${JSON.stringify({
+        message: { role: "assistant", content: [{ type: "text", text: "seed turn" }] },
+      })}\n`,
+      "utf8",
+    );
+
+    warnLog.mockClear();
+    infoLog.mockClear();
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: targetSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "next turn one" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .filter((m) => m.includes("transcript reconcile slow path (full re-read)")),
+    ).toHaveLength(1);
+
+    appendFileSync(
+      targetSessionFile,
+      `not-json\n${JSON.stringify({
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "append-only-ineligible user" }],
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    warnLog.mockClear();
+    infoLog.mockClear();
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: targetSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "append-only-ineligible assistant" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      infoLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("transcript reconcile slow path skipped")),
+    ).toBe(false);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .filter((m) => m.includes("transcript reconcile slow path (full re-read)")),
+    ).toHaveLength(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed turn",
+      "next turn one",
+      "append-only-ineligible user",
+      "append-only-ineligible assistant",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(targetSessionFile).size);
+  });
+
   it("afterTurn does not background-compact prompt-mutating debt while Anthropic cache is hot", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-background-hot-cache-deferred";


### PR DESCRIPTION
## Summary

Three afterTurn-lane robustness fixes, all in `src/engine.ts`. Bundled as one PR (the "afterTurn lane hardening" surface) so a reviewer sees the whole picture; each fix is independent.

Closes #566. Refs #472, #553, #507, #551.

### D4 — `scheduleDeferredCompactionDebtDrain` no longer silently skips on missing telemetry

PR #507 gated drain scheduling on `compactionTelemetry?.provider || ?.model`. CLI-backend sessions (#472) never observe provider/model, so they accumulated deferred debt forever. The inner gate (`shouldDelayPromptMutatingDeferredCompaction` + `legacyParams` derivation) is already robust to missing telemetry. We now schedule unconditionally and emit one info-level visibility log when telemetry is missing.

### F6 — `messageContentCoveredBySummary` anchored-or-quoted match

PR #551 used `summary.includes(content)` with a 24-char floor. False-positive: a medium-length user instruction (e.g. "please update the readme file") that happens to appear inside a narrative summary got silently dropped. New rule: match counts only if the content (a) appears at the start/end of the normalized summary, OR (b) appears inside a quoted span (`"…"`, `'…'`, or backticks). The summarizer's actual coverage pattern is quoted verbatim text, so the truth case is preserved.

### F7 — `reconcileTranscriptTailForAfterTurn` slow path bounded

PR #551's slow path called `readLeafPathMessages(sessionFile)` — full O(file-size) read — on every afterTurn when the bootstrap checkpoint was missing or path-mismatched. Long-running sessions paid this every turn. Now:
- Per-process `Set<string>` keyed by `${queueKey} ${sessionFile}` caps the slow path to one full re-read per tuple
- After the slow read, the bootstrap checkpoint is refreshed unconditionally so subsequent afterTurns take the incremental (`readAppendedLeafPathMessages`) path
- Emits a `warn` with `reason` (checkpoint-missing / path-mismatch / append-only-ineligible), historical message count, and timing — visibility for operators

## Test plan

- [x] `npm ci` clean
- [x] Baseline: 833 passing
- [x] After: 837 passing (+4: F6 collision case, F6 anchored-suffix truth case, D4 schedule-without-telemetry, F7 slow-path one-shot cap)
- [x] `npm run build` clean
- [x] Existing summary-overlap tests (`afterTurn skips new-message content already covered by auto-compaction summary` — uses quoted block) still pass under the stricter F6 rule
- [x] Existing deferred-debt tests still pass (D4 only changes the schedule-site, not the inner gate)

## Constraints respected

- Worktree-only (`/Volumes/LEXAR/repos/lcm-pr6`)
- LoC: ~80 production, ~210 test (vs ~80 / ~150 budget — F7 test setup needs the seed afterTurn + JSONL write)
- All three sub-fixes touch `src/engine.ts` only; no overlap with PR-8's bootstrap path
- "Afterturn lane hardening" framing for the barnacle bot
