### PR TITLE
[reasoning] complete the half-fix from #503: output side + non-leaf + legacy data (E/8)

### DIFF
--- a/.changeset/pr4-reasoning-half-fix-completion.md
+++ b/.changeset/pr4-reasoning-half-fix-completion.md
@@ -1,0 +1,10 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Complete the thinking/reasoning half-fix from PR #503 in v0.9.3.  #503 sanitized summarizer **input** at `CompactionEngine.leafPass`; this PR closes the two remaining gaps that were in scope:
+
+- **Output side**: when the summary provider response would persist a reasoning-shaped payload (text wrapped in `<think>…</think>` / `<thinking>…</thinking>` / `<reasoning>…</reasoning>`, or opened with a `[thinking]` / `[reasoning]` label) as the summary body, log and treat the summary as empty so the existing envelope → retry → deterministic-fallback chain runs instead of silently storing reasoning text.  Mitigates the silent-persist failure mode reported by #471 (vLLM+Qwen3) and #542 (Kimi K2.6).
+- **Non-leaf passes**: `extractMeaningfulMessageText` is now applied at every summarizer entry point — `leafPass` (already covered by #503), the condensed/merge pass that re-summarizes leaf summaries, and the prior-summary-context resolver.  Summaries built from already-sanitized leaves can no longer reintroduce raw thinking/reasoning blocks at higher levels, including from legacy data persisted before #503.
+
+Doctor remediation for legacy assistant rows that contain only thinking blocks (sub-fix F8 from the issue) is deferred — the existing doctor cleaner architecture operates on conversation-level deletion, not message-row remediation, and adding a backup-table pattern would significantly expand the surface area of this PR.  Tracked separately.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1327,10 +1327,15 @@ export class CompactionEngine {
       // Apply the same reasoning/thinking-block sanitizer used at the leaf
       // input (PR #503) so prior-summary context fed back into the summarizer
       // can never reintroduce raw thinking blocks at higher levels.  See #564.
+      //
+      // An empty `sanitized` is a deliberate signal: the stored summary was
+      // structurally reasoning-only (or otherwise had no meaningful text).
+      // Skip such summaries entirely — falling back to `rawContent` would
+      // re-introduce the very thinking/reasoning payload this sanitizer is
+      // trying to keep out of higher-level summarizer inputs.
       const sanitized = extractMeaningfulMessageText(rawContent).trim();
-      const content = sanitized || rawContent.trim();
-      if (content) {
-        summaryContents.push(content);
+      if (sanitized) {
+        summaryContents.push(sanitized);
       }
     }
 
@@ -1629,15 +1634,20 @@ export class CompactionEngine {
     // before #503 (and any future leak from a reasoning-capable summaryModel)
     // may carry embedded thinking/reasoning blocks; strip them at every
     // summarizer boundary, not only at the leaf input.  See #564.
+    //
+    // An empty sanitized body is the deterministic signal that the stored
+    // summary was thinking/reasoning-only (or otherwise had no meaningful
+    // text).  Drop those records entirely — falling back to the raw stored
+    // content would feed reasoning payloads right back into the condensed
+    // summarizer input, undermining the boundary sanitizer.
     const concatenated = summaryRecords
       .map((summary) => {
         const earliestAt = summary.earliestAt ?? summary.createdAt;
         const latestAt = summary.latestAt ?? summary.createdAt;
         const tz = this.config.timezone;
         const header = `[${formatTimestamp(earliestAt, tz)} - ${formatTimestamp(latestAt, tz)}]`;
-        const sanitized = extractMeaningfulMessageText(summary.content);
-        const body = sanitized || summary.content;
-        return `${header}\n${body}`;
+        const sanitized = extractMeaningfulMessageText(summary.content).trim();
+        return sanitized ? `${header}\n${sanitized}` : "";
       })
       .filter((entry) => entry.trim().length > 0)
       .join("\n\n");

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -309,8 +309,19 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
   return textFragments;
 }
 
-/** Normalize message content down to human-readable text, excluding binary/media payloads. */
-function extractMeaningfulMessageText(content: string): string {
+/**
+ * Normalize message content down to human-readable text, excluding
+ * binary/media payloads and provider reasoning/thinking blocks.
+ *
+ * Shared by every summarizer entry point (leaf input, condensed input,
+ * prior-summary context) so reasoning blocks introduced at any level —
+ * including legacy data persisted before #503 — are stripped before they
+ * reach the summarizer.
+ *
+ * @internal Exported for tests; production code reaches it via the
+ * compaction-engine entry points.
+ */
+export function extractMeaningfulMessageText(content: string): string {
   if (typeof content !== "string") return "";
   const trimmed = content.trim();
   if (!trimmed) {
@@ -1312,7 +1323,12 @@ export class CompactionEngine {
       if (!summary || summary.depth !== targetDepth) {
         continue;
       }
-      const content = typeof summary.content === "string" ? summary.content.trim() : "";
+      const rawContent = typeof summary.content === "string" ? summary.content : "";
+      // Apply the same reasoning/thinking-block sanitizer used at the leaf
+      // input (PR #503) so prior-summary context fed back into the summarizer
+      // can never reintroduce raw thinking blocks at higher levels.  See #564.
+      const sanitized = extractMeaningfulMessageText(rawContent).trim();
+      const content = sanitized || rawContent.trim();
       if (content) {
         summaryContents.push(content);
       }
@@ -1609,14 +1625,21 @@ export class CompactionEngine {
       }
     }
 
+    // Sanitize stored summary content before re-summarizing.  Leaves persisted
+    // before #503 (and any future leak from a reasoning-capable summaryModel)
+    // may carry embedded thinking/reasoning blocks; strip them at every
+    // summarizer boundary, not only at the leaf input.  See #564.
     const concatenated = summaryRecords
       .map((summary) => {
         const earliestAt = summary.earliestAt ?? summary.createdAt;
         const latestAt = summary.latestAt ?? summary.createdAt;
         const tz = this.config.timezone;
         const header = `[${formatTimestamp(earliestAt, tz)} - ${formatTimestamp(latestAt, tz)}]`;
-        return `${header}\n${summary.content}`;
+        const sanitized = extractMeaningfulMessageText(summary.content);
+        const body = sanitized || summary.content;
+        return `${header}\n${body}`;
       })
+      .filter((entry) => entry.trim().length > 0)
       .join("\n\n");
     const fileIds = dedupeOrderedIds(
       summaryRecords.flatMap((summary) => [

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -436,8 +436,19 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
   return textFragments;
 }
 
-/** Normalize message content down to human-readable text, excluding binary/media payloads. */
-function extractMeaningfulMessageText(content: string): string {
+/**
+ * Normalize message content down to human-readable text, excluding
+ * binary/media payloads and provider reasoning/thinking blocks.
+ *
+ * Shared by every summarizer entry point (leaf input, condensed input,
+ * prior-summary context) so reasoning blocks introduced at any level —
+ * including legacy data persisted before #503 — are stripped before they
+ * reach the summarizer.
+ *
+ * @internal Exported for tests; production code reaches it via the
+ * compaction-engine entry points.
+ */
+export function extractMeaningfulMessageText(content: string): string {
   if (typeof content !== "string") return "";
   const trimmed = content.trim();
   if (!trimmed) {
@@ -1772,7 +1783,12 @@ export class CompactionEngine {
       if (!summary || summary.depth !== targetDepth) {
         continue;
       }
-      const content = typeof summary.content === "string" ? summary.content.trim() : "";
+      const rawContent = typeof summary.content === "string" ? summary.content : "";
+      // Apply the same reasoning/thinking-block sanitizer used at the leaf
+      // input (PR #503) so prior-summary context fed back into the summarizer
+      // can never reintroduce raw thinking blocks at higher levels.  See #564.
+      const sanitized = extractMeaningfulMessageText(rawContent).trim();
+      const content = sanitized || rawContent.trim();
       if (content) {
         summaryContents.push(content);
       }
@@ -2109,14 +2125,21 @@ export class CompactionEngine {
       }
     }
 
+    // Sanitize stored summary content before re-summarizing.  Leaves persisted
+    // before #503 (and any future leak from a reasoning-capable summaryModel)
+    // may carry embedded thinking/reasoning blocks; strip them at every
+    // summarizer boundary, not only at the leaf input.  See #564.
     const concatenated = summaryRecords
       .map((summary) => {
         const earliestAt = summary.earliestAt ?? summary.createdAt;
         const latestAt = summary.latestAt ?? summary.createdAt;
         const tz = this.config.timezone;
         const header = `[${formatTimestamp(earliestAt, tz)} - ${formatTimestamp(latestAt, tz)}]`;
-        return `${header}\n${summary.content}`;
+        const sanitized = extractMeaningfulMessageText(summary.content);
+        const body = sanitized || summary.content;
+        return `${header}\n${body}`;
       })
+      .filter((entry) => entry.trim().length > 0)
       .join("\n\n");
     const fileIds = dedupeOrderedIds(
       summaryRecords.flatMap((summary) => [

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -285,6 +285,10 @@ const STRUCTURED_MEDIA_NESTED_KEYS = [
   "query",
   "command",
 ] as const;
+const CLOSED_REASONING_TEXT_BLOCK_RE =
+  /<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const REASONING_TEXT_START_RE =
+  /^(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
 
 const CONDENSED_MIN_INPUT_RATIO = 0.1;
 
@@ -391,13 +395,25 @@ export function stripInjectedContextBlocks(content: string, tags: string[] | und
   return result.trim();
 }
 
+function stripPlainTextReasoningPayloads(content: string): string {
+  const strippedClosedBlocks = content.replace(CLOSED_REASONING_TEXT_BLOCK_RE, "");
+  const trimmed = strippedClosedBlocks.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (REASONING_TEXT_START_RE.test(trimmed)) {
+    return "";
+  }
+  return trimmed;
+}
+
 /** Extract human-readable text from structured content while ignoring attachment payload fields. */
 function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
   if (depth >= 4 || value == null) {
     return [];
   }
   if (typeof value === "string") {
-    const sanitized = stripEmbeddedMediaPayloads(value);
+    const sanitized = stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(value));
     return sanitized ? [sanitized] : [];
   }
   if (Array.isArray(value)) {
@@ -419,7 +435,7 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
     if (typeof candidate !== "string") {
       continue;
     }
-    const sanitized = stripEmbeddedMediaPayloads(candidate);
+    const sanitized = stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(candidate));
     if (sanitized) {
       textFragments.push(sanitized);
     }
@@ -465,7 +481,7 @@ export function extractMeaningfulMessageText(content: string): string {
       // Fall back to plain-text sanitation below.
     }
   }
-  return stripEmbeddedMediaPayloads(content);
+  return stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(content));
 }
 
 /** Map stored message roles back to runtime roles for structured reconstruction. */
@@ -1928,7 +1944,7 @@ export class CompactionEngine {
     const partText = parts
       .filter((part) => !isMediaAttachmentPart(part))
       .map((part) => (typeof part.textContent === "string" ? part.textContent : ""))
-      .map((text) => stripEmbeddedMediaPayloads(text))
+      .map((text) => stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(text)))
       .map((text) => text.trim())
       .filter(Boolean)
       .join("\n")

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -424,7 +424,12 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
   }
 
   const record = value as Record<string, unknown>;
-  const rawType = typeof record.type === "string" ? record.type.trim().toLowerCase() : "";
+  const rawType =
+    typeof record.type === "string"
+      ? record.type.trim().toLowerCase()
+      : typeof record.rawType === "string"
+        ? record.rawType.trim().toLowerCase()
+        : "";
   if (PROVIDER_REASONING_RAW_TYPES.has(rawType)) {
     return [];
   }
@@ -1529,9 +1534,13 @@ export class CompactionEngine {
         continue;
       }
       const summary = await this.summaryStore.getSummary(item.summaryId);
-      const content = typeof summary?.content === "string" ? summary.content.trim() : "";
-      if (content) {
-        summaryContents.push(content);
+      const rawContent = typeof summary?.content === "string" ? summary.content : "";
+      // Leaf continuity context is also summarizer input. Sanitize legacy
+      // summary rows here so pre-#503 reasoning blocks cannot leak forward
+      // when the next raw chunk is compacted.
+      const sanitized = extractMeaningfulMessageText(rawContent).trim();
+      if (sanitized) {
+        summaryContents.push(sanitized);
       }
     }
 

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1787,10 +1787,15 @@ export class CompactionEngine {
       // Apply the same reasoning/thinking-block sanitizer used at the leaf
       // input (PR #503) so prior-summary context fed back into the summarizer
       // can never reintroduce raw thinking blocks at higher levels.  See #564.
+      //
+      // An empty `sanitized` is a deliberate signal: the stored summary was
+      // structurally reasoning-only (or otherwise had no meaningful text).
+      // Skip such summaries entirely — falling back to `rawContent` would
+      // re-introduce the very thinking/reasoning payload this sanitizer is
+      // trying to keep out of higher-level summarizer inputs.
       const sanitized = extractMeaningfulMessageText(rawContent).trim();
-      const content = sanitized || rawContent.trim();
-      if (content) {
-        summaryContents.push(content);
+      if (sanitized) {
+        summaryContents.push(sanitized);
       }
     }
 
@@ -2129,15 +2134,20 @@ export class CompactionEngine {
     // before #503 (and any future leak from a reasoning-capable summaryModel)
     // may carry embedded thinking/reasoning blocks; strip them at every
     // summarizer boundary, not only at the leaf input.  See #564.
+    //
+    // An empty sanitized body is the deterministic signal that the stored
+    // summary was thinking/reasoning-only (or otherwise had no meaningful
+    // text).  Drop those records entirely — falling back to the raw stored
+    // content would feed reasoning payloads right back into the condensed
+    // summarizer input, undermining the boundary sanitizer.
     const concatenated = summaryRecords
       .map((summary) => {
         const earliestAt = summary.earliestAt ?? summary.createdAt;
         const latestAt = summary.latestAt ?? summary.createdAt;
         const tz = this.config.timezone;
         const header = `[${formatTimestamp(earliestAt, tz)} - ${formatTimestamp(latestAt, tz)}]`;
-        const sanitized = extractMeaningfulMessageText(summary.content);
-        const body = sanitized || summary.content;
-        return `${header}\n${body}`;
+        const sanitized = extractMeaningfulMessageText(summary.content).trim();
+        return sanitized ? `${header}\n${sanitized}` : "";
       })
       .filter((entry) => entry.trim().length > 0)
       .join("\n\n");

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -122,6 +122,10 @@ type PassResult = {
   /** Token count of the newly created summary. */
   addedTokens: number;
 };
+type CondensedPassSkipped = {
+  skipped: "empty-source";
+};
+type CondensedPassResult = PassResult | CondensedPassSkipped;
 type LeafChunkSelection = {
   items: ContextItemRecord[];
   rawTokensOutsideTail: number;
@@ -130,6 +134,7 @@ type LeafChunkSelection = {
 type CondensedChunkSelection = {
   items: ContextItemRecord[];
   summaryTokens: number;
+  meaningfulCount: number;
 };
 type CondensedPhaseCandidate = {
   targetDepth: number;
@@ -285,10 +290,14 @@ const STRUCTURED_MEDIA_NESTED_KEYS = [
   "query",
   "command",
 ] as const;
-const CLOSED_REASONING_TEXT_BLOCK_RE =
-  /<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const LEADING_CLOSED_REASONING_TEXT_BLOCK_RE =
+  /^<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/i;
+const STANDALONE_CLOSED_REASONING_TEXT_BLOCK_RE =
+  /(^|\n)[ \t]*<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\2\s*>[ \t]*(?=\n|$)/gi;
 const REASONING_TEXT_START_RE =
-  /^(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
+  /^(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\])/i;
+const STANDALONE_REASONING_TEXT_START_RE =
+  /(^|\n)[ \t]*(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\])[\s\S]*$/i;
 
 const CONDENSED_MIN_INPUT_RATIO = 0.1;
 
@@ -395,9 +404,29 @@ export function stripInjectedContextBlocks(content: string, tags: string[] | und
   return result.trim();
 }
 
+type MeaningfulTextOptions = {
+  stripPlainTextReasoning?: boolean;
+};
+
 function stripPlainTextReasoningPayloads(content: string): string {
-  const strippedClosedBlocks = content.replace(CLOSED_REASONING_TEXT_BLOCK_RE, "");
-  const trimmed = strippedClosedBlocks.trim();
+  let trimmed = content.trim();
+  while (true) {
+    const match = trimmed.match(LEADING_CLOSED_REASONING_TEXT_BLOCK_RE);
+    if (!match) {
+      break;
+    }
+    trimmed = trimmed.slice(match[0].length).trimStart();
+  }
+  trimmed = trimmed
+    .replace(
+      STANDALONE_CLOSED_REASONING_TEXT_BLOCK_RE,
+      (_match, lineStart: string) => (lineStart === "\n" ? "\n" : ""),
+    )
+    .replace(
+      STANDALONE_REASONING_TEXT_START_RE,
+      (_match, lineStart: string) => (lineStart === "\n" ? "\n" : ""),
+    )
+    .trim();
   if (!trimmed) {
     return "";
   }
@@ -407,30 +436,37 @@ function stripPlainTextReasoningPayloads(content: string): string {
   return trimmed;
 }
 
+function sanitizeTextFragment(value: string, options: MeaningfulTextOptions): string {
+  const withoutMedia = stripEmbeddedMediaPayloads(value);
+  return options.stripPlainTextReasoning
+    ? stripPlainTextReasoningPayloads(withoutMedia)
+    : withoutMedia;
+}
+
 /** Extract human-readable text from structured content while ignoring attachment payload fields. */
-function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
+function extractSanitizedStructuredText(
+  value: unknown,
+  options: MeaningfulTextOptions = {},
+  depth = 0,
+): string[] {
   if (depth >= 4 || value == null) {
     return [];
   }
   if (typeof value === "string") {
-    const sanitized = stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(value));
+    const sanitized = sanitizeTextFragment(value, options);
     return sanitized ? [sanitized] : [];
   }
   if (Array.isArray(value)) {
-    return value.flatMap((entry) => extractSanitizedStructuredText(entry, depth + 1));
+    return value.flatMap((entry) => extractSanitizedStructuredText(entry, options, depth + 1));
   }
   if (typeof value !== "object") {
     return [];
   }
 
   const record = value as Record<string, unknown>;
-  const rawType =
-    typeof record.type === "string"
-      ? record.type.trim().toLowerCase()
-      : typeof record.rawType === "string"
-        ? record.rawType.trim().toLowerCase()
-        : "";
-  if (PROVIDER_REASONING_RAW_TYPES.has(rawType)) {
+  const type = typeof record.type === "string" ? record.type.trim().toLowerCase() : "";
+  const rawType = typeof record.rawType === "string" ? record.rawType.trim().toLowerCase() : "";
+  if (PROVIDER_REASONING_RAW_TYPES.has(type) || PROVIDER_REASONING_RAW_TYPES.has(rawType)) {
     return [];
   }
   const textFragments: string[] = [];
@@ -440,18 +476,18 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
     if (typeof candidate !== "string") {
       continue;
     }
-    const sanitized = stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(candidate));
+    const sanitized = sanitizeTextFragment(candidate, options);
     if (sanitized) {
       textFragments.push(sanitized);
     }
   }
 
-  if (MEDIA_ATTACHMENT_RAW_TYPES.has(rawType)) {
+  if (MEDIA_ATTACHMENT_RAW_TYPES.has(type) || MEDIA_ATTACHMENT_RAW_TYPES.has(rawType)) {
     return textFragments;
   }
 
   for (const key of STRUCTURED_MEDIA_NESTED_KEYS) {
-    textFragments.push(...extractSanitizedStructuredText(record[key], depth + 1));
+    textFragments.push(...extractSanitizedStructuredText(record[key], options, depth + 1));
   }
 
   return textFragments;
@@ -469,7 +505,10 @@ function extractSanitizedStructuredText(value: unknown, depth = 0): string[] {
  * @internal Exported for tests; production code reaches it via the
  * compaction-engine entry points.
  */
-export function extractMeaningfulMessageText(content: string): string {
+export function extractMeaningfulMessageText(
+  content: string,
+  options: MeaningfulTextOptions = {},
+): string {
   if (typeof content !== "string") return "";
   const trimmed = content.trim();
   if (!trimmed) {
@@ -478,7 +517,7 @@ export function extractMeaningfulMessageText(content: string): string {
   if ((trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))) {
     try {
       const parsed = JSON.parse(trimmed) as unknown;
-      const extracted = extractSanitizedStructuredText(parsed)
+      const extracted = extractSanitizedStructuredText(parsed, options)
         .map((fragment) => fragment.trim())
         .filter(Boolean);
       return extracted.join("\n").trim();
@@ -486,7 +525,12 @@ export function extractMeaningfulMessageText(content: string): string {
       // Fall back to plain-text sanitation below.
     }
   }
-  return stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(content));
+  return sanitizeTextFragment(content, options);
+}
+
+/** Normalize stored summary content before it is fed into a later summarizer pass. */
+function extractMeaningfulSummaryText(content: string): string {
+  return extractMeaningfulMessageText(content, { stripPlainTextReasoning: true });
 }
 
 /** Map stored message roles back to runtime roles for structured reconstruction. */
@@ -818,7 +862,7 @@ export class CompactionEngine {
       for (let targetDepth = 0; targetDepth < sweepMaxDepth; targetDepth++) {
         const fanout = this.resolveFanoutForDepth(targetDepth, false);
         const chunk = await this.selectOldestChunkAtDepth(conversationId, targetDepth);
-        if (chunk.items.length < fanout || chunk.summaryTokens < condensedMinChunkTokens) {
+        if (chunk.meaningfulCount < fanout || chunk.summaryTokens < condensedMinChunkTokens) {
           break;
         }
 
@@ -830,7 +874,7 @@ export class CompactionEngine {
           summarize,
           input.summaryModel,
         );
-        if (!condenseResult) {
+        if (!condenseResult || "skipped" in condenseResult) {
           break;
         }
         const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
@@ -1082,6 +1126,9 @@ export class CompactionEngine {
       if (!condenseResult) {
         hadAuthFailure = true;
         return "auth-failure";
+      }
+      if ("skipped" in condenseResult) {
+        return "no-progress";
       }
       const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
       await this.persistCompactionEvents({
@@ -1521,15 +1568,14 @@ export class CompactionEngine {
           item.ordinal < startOrdinal &&
           item.itemType === "summary" &&
           typeof item.summaryId === "string",
-      )
-      .slice(-2);
+      );
 
     if (priorSummaryItems.length === 0) {
       return undefined;
     }
 
     const summaryContents: string[] = [];
-    for (const item of priorSummaryItems) {
+    for (const item of [...priorSummaryItems].reverse()) {
       if (typeof item.summaryId !== "string") {
         continue;
       }
@@ -1538,9 +1584,12 @@ export class CompactionEngine {
       // Leaf continuity context is also summarizer input. Sanitize legacy
       // summary rows here so pre-#503 reasoning blocks cannot leak forward
       // when the next raw chunk is compacted.
-      const sanitized = extractMeaningfulMessageText(rawContent).trim();
+      const sanitized = extractMeaningfulSummaryText(rawContent).trim();
       if (sanitized) {
         summaryContents.push(sanitized);
+        if (summaryContents.length >= 2) {
+          break;
+        }
       }
     }
 
@@ -1548,7 +1597,7 @@ export class CompactionEngine {
       return undefined;
     }
 
-    return summaryContents.join("\n\n");
+    return [...summaryContents].reverse().join("\n\n");
   }
 
   /** Resolve summary token count with content-length fallback. */
@@ -1561,6 +1610,10 @@ export class CompactionEngine {
       return summary.tokenCount;
     }
     return estimateTokens(summary.content);
+  }
+
+  private summaryHasMeaningfulCondensedSource(summary: SummaryRecord): boolean {
+    return extractMeaningfulSummaryText(summary.content).trim().length > 0;
   }
 
   /** Resolve message token count with content-length fallback. */
@@ -1705,7 +1758,7 @@ export class CompactionEngine {
         targetDepth,
         freshTailOrdinal,
       );
-      if (chunk.items.length < fanout) {
+      if (chunk.meaningfulCount < fanout) {
         continue;
       }
       if (chunk.summaryTokens < minChunkTokens) {
@@ -1737,6 +1790,7 @@ export class CompactionEngine {
 
     const chunk: ContextItemRecord[] = [];
     let summaryTokens = 0;
+    let meaningfulCount = 0;
     for (const item of contextItems) {
       if (item.ordinal >= freshTailOrdinal) {
         break;
@@ -1761,20 +1815,27 @@ export class CompactionEngine {
         }
         continue;
       }
+      const hasMeaningfulSource = this.summaryHasMeaningfulCondensedSource(summary);
+      if (!hasMeaningfulSource && chunk.length === 0) {
+        continue;
+      }
       const tokenCount = this.resolveSummaryTokenCount(summary);
 
-      if (chunk.length > 0 && summaryTokens + tokenCount > chunkTokenBudget) {
+      if (hasMeaningfulSource && chunk.length > 0 && summaryTokens + tokenCount > chunkTokenBudget) {
         break;
       }
 
       chunk.push(item);
-      summaryTokens += tokenCount;
+      if (hasMeaningfulSource) {
+        meaningfulCount++;
+        summaryTokens += tokenCount;
+      }
       if (summaryTokens >= chunkTokenBudget) {
         break;
       }
     }
 
-    return { items: chunk, summaryTokens };
+    return { items: chunk, summaryTokens, meaningfulCount };
   }
 
   private async resolvePriorSummaryContextAtDepth(
@@ -1793,14 +1854,13 @@ export class CompactionEngine {
           item.ordinal < startOrdinal &&
           item.itemType === "summary" &&
           typeof item.summaryId === "string",
-      )
-      .slice(-4);
+      );
     if (priorSummaryItems.length === 0) {
       return undefined;
     }
 
     const summaryContents: string[] = [];
-    for (const item of priorSummaryItems) {
+    for (const item of [...priorSummaryItems].reverse()) {
       if (typeof item.summaryId !== "string") {
         continue;
       }
@@ -1818,16 +1878,19 @@ export class CompactionEngine {
       // Skip such summaries entirely — falling back to `rawContent` would
       // re-introduce the very thinking/reasoning payload this sanitizer is
       // trying to keep out of higher-level summarizer inputs.
-      const sanitized = extractMeaningfulMessageText(rawContent).trim();
+      const sanitized = extractMeaningfulSummaryText(rawContent).trim();
       if (sanitized) {
         summaryContents.push(sanitized);
+        if (summaryContents.length >= 2) {
+          break;
+        }
       }
     }
 
     if (summaryContents.length === 0) {
       return undefined;
     }
-    return summaryContents.slice(-2).join("\n\n");
+    return [...summaryContents].reverse().join("\n\n");
   }
 
   /**
@@ -1953,7 +2016,7 @@ export class CompactionEngine {
     const partText = parts
       .filter((part) => !isMediaAttachmentPart(part))
       .map((part) => (typeof part.textContent === "string" ? part.textContent : ""))
-      .map((text) => stripPlainTextReasoningPayloads(stripEmbeddedMediaPayloads(text)))
+      .map((text) => stripEmbeddedMediaPayloads(text))
       .map((text) => text.trim())
       .filter(Boolean)
       .join("\n")
@@ -2142,7 +2205,7 @@ export class CompactionEngine {
     targetDepth: number,
     summarize: CompactionSummarizeFn,
     summaryModel?: string,
-  ): Promise<PassResult | null> {
+  ): Promise<CondensedPassResult | null> {
     // Fetch full summary records
     const summaryRecords: SummaryRecord[] = [];
     for (const item of summaryItems) {
@@ -2171,11 +2234,17 @@ export class CompactionEngine {
         const latestAt = summary.latestAt ?? summary.createdAt;
         const tz = this.config.timezone;
         const header = `[${formatTimestamp(earliestAt, tz)} - ${formatTimestamp(latestAt, tz)}]`;
-        const sanitized = extractMeaningfulMessageText(summary.content).trim();
+        const sanitized = extractMeaningfulSummaryText(summary.content).trim();
         return sanitized ? `${header}\n${sanitized}` : "";
       })
       .filter((entry) => entry.trim().length > 0)
       .join("\n\n");
+    if (!concatenated.trim()) {
+      this.log.warn(
+        `[lcm] condensed compaction skipped summary write; conversationId=${conversationId}; depth=${targetDepth}; chunkSummaries=${summaryRecords.length}; sanitized_source=empty`,
+      );
+      return { skipped: "empty-source" };
+    }
     const fileIds = dedupeOrderedIds(
       summaryRecords.flatMap((summary) => [
         ...summary.fileIds,

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1569,6 +1569,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       const normalized = normalizeCompletionSummary(result.content);
       let summary = normalized.summary;
       let summarySource: "content" | "envelope" | "retry" | "fallback" = "content";
+      let envelopeNormalized: ReturnType<typeof normalizeCompletionSummary> | undefined;
 
       // --- Empty-summary hardening: envelope → retry → deterministic fallback ---
       if (!summary) {
@@ -1576,7 +1577,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         // top-level response fields (output, message, response) rather than
         // inside the content array.  Re-run normalization against the full
         // response envelope before spending an API call on a retry.
-        const envelopeNormalized = normalizeCompletionSummary(result);
+        envelopeNormalized = normalizeCompletionSummary(result);
         if (envelopeNormalized.summary) {
           summary = envelopeNormalized.summary;
           summarySource = "envelope";
@@ -1593,9 +1594,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       // empty so the retry/fallback chain runs instead of persisting the
       // reasoning text verbatim as the summary body.
       if (summary && looksLikeReasoningOnlySummary(summary)) {
+        // Log the block_types from the source normalization that actually
+        // produced this summary text — `normalized` is content-path, but
+        // when the summary came from `envelopeNormalized` the relevant
+        // shape is the envelope's, not the content's.
+        const droppedBlockTypes =
+          summarySource === "envelope" && envelopeNormalized
+            ? envelopeNormalized.blockTypes
+            : normalized.blockTypes;
         params.deps.log.warn(
           `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
-            `model=${model}; block_types=${formatBlockTypes(normalized.blockTypes)}; ` +
+            `model=${model}; source=${summarySource}; ` +
+            `block_types=${formatBlockTypes(droppedBlockTypes)}; ` +
             `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
         );
         summary = "";

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -323,6 +323,51 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
   };
 }
 
+/**
+ * Detect summary text that is actually a provider reasoning/thinking payload
+ * leaking through as the summary body.
+ *
+ * Some reasoning-capable summary models (vLLM+Qwen3 per #471, Kimi K2.6 per
+ * #542) sometimes return reasoning text shaped so it slips past the
+ * type-tagged filtering in `collectTextLikeFields` — e.g. the entire
+ * summary body is wrapped in `<think>...</think>` tags, or starts with
+ * `<think>` and never closes.  Treat those as empty so the empty-summary
+ * hardening (envelope → retry → deterministic fallback) kicks in instead
+ * of silently persisting reasoning text as the summary.  See #564.
+ */
+function looksLikeReasoningOnlySummary(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  // Wrapped or opened with an explicit reasoning marker (`<think>`,
+  // `<thinking>`, `<reasoning>`, or DeepSeek-style `<|reasoning|>`).
+  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(trimmed)) {
+    return true;
+  }
+  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(trimmed)) {
+    return true;
+  }
+
+  // Bracketed labels like `[thinking]` / `[reasoning]` at the very start.
+  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(trimmed)) {
+    return true;
+  }
+
+  // Strip a leading `<think>...</think>` block; if nothing meaningful
+  // remains, treat as reasoning-only.  This catches partial leaks where the
+  // provider closed the reasoning tag but emitted no follow-on summary.
+  const withoutThinkBlock = trimmed.replace(
+    /<\s*(think|thinking|reasoning)\s*>[\s\S]*?<\s*\/\s*\1\s*>/gi,
+    "",
+  );
+  if (!withoutThinkBlock.trim()) {
+    return true;
+  }
+
+  return false;
+}
+
 /** Format normalized block types for concise diagnostics. */
 function formatBlockTypes(blockTypes: string[]): string {
   if (blockTypes.length === 0) {
@@ -1535,6 +1580,21 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         }
       }
 
+      // Reasoning-leak guardrail (#564, refs #471, #542): if the extracted
+      // summary text is itself a provider reasoning/thinking payload (wrapped
+      // in <think>…</think>, opened with `[thinking]`, etc.), treat it as
+      // empty so the retry/fallback chain runs instead of persisting the
+      // reasoning text verbatim as the summary body.
+      if (summary && looksLikeReasoningOnlySummary(summary)) {
+        params.deps.log.warn(
+          `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
+            `model=${model}; block_types=${formatBlockTypes(normalized.blockTypes)}; ` +
+            `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
+        );
+        summary = "";
+        summarySource = "content";
+      }
+
       const incompleteSignals = extractIncompleteResponseSignals(result);
       const initialSummary = summary;
       const shouldRetryIncompleteSummary = summary.length > 0 && incompleteSignals.length > 0;
@@ -1568,6 +1628,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             ? retryNormalized
             : normalizeCompletionSummary(retryResult);
           summary = retryEnvelopeNormalized.summary;
+
+          // Re-apply the reasoning-leak guardrail to the retry result so a
+          // reasoning-shaped retry response also drops to deterministic
+          // fallback rather than persisting as the summary body.  See #564.
+          if (summary && looksLikeReasoningOnlySummary(summary)) {
+            params.deps.log.warn(
+              `[lcm] dropped reasoning-shaped summary on retry; provider=${provider}; ` +
+                `model=${model}; block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; ` +
+                `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
+            );
+            summary = "";
+          }
 
           if (summary) {
             summarySource = "retry";

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -340,28 +340,35 @@ function looksLikeReasoningOnlySummary(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
 
-  // Wrapped or opened with an explicit reasoning marker (`<think>`,
-  // `<thinking>`, `<reasoning>`, or DeepSeek-style `<|reasoning|>`).
-  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(trimmed)) {
-    return true;
-  }
-  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(trimmed)) {
-    return true;
-  }
-
-  // Bracketed labels like `[thinking]` / `[reasoning]` at the very start.
-  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(trimmed)) {
-    return true;
-  }
-
-  // Strip a leading `<think>...</think>` block; if nothing meaningful
-  // remains, treat as reasoning-only.  This catches partial leaks where the
-  // provider closed the reasoning tag but emitted no follow-on summary.
-  const withoutThinkBlock = trimmed.replace(
+  // Strip every CLOSED `<think>...</think>` / `<thinking>...</thinking>` /
+  // `<reasoning>...</reasoning>` block.  A closed reasoning block followed
+  // by a non-empty summary body (the common pattern when the provider
+  // emits a reasoning trace and then a normal answer, e.g.
+  // `<think>...</think>Actual summary text`) is NOT reasoning-only —
+  // returning true here would force an unnecessary retry/fallback.
+  const withoutClosedThink = trimmed.replace(
     /<\s*(think|thinking|reasoning)\s*>[\s\S]*?<\s*\/\s*\1\s*>/gi,
     "",
   );
-  if (!withoutThinkBlock.trim()) {
+  const remainder = withoutClosedThink.trim();
+  if (!remainder) {
+    // Either the entire body was a closed reasoning block (no summary
+    // text after) or the input was empty — both are reasoning-only.
+    return true;
+  }
+
+  // Remainder still starts with an UNCLOSED reasoning marker — the
+  // provider opened a `<think>`-style block but never closed it (often a
+  // truncated stream / max_tokens cutoff before the answer began).
+  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(remainder)) {
+    return true;
+  }
+  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(remainder)) {
+    return true;
+  }
+  // Bracketed labels at the very start (`[thinking]…` with no obvious
+  // body separation) — same shape as the unclosed-tag case.
+  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(remainder)) {
     return true;
   }
 

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1730,6 +1730,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       const normalized = normalizeCompletionSummary(result.content);
       let summary = normalized.summary;
       let summarySource: "content" | "envelope" | "retry" | "fallback" = "content";
+      let envelopeNormalized: ReturnType<typeof normalizeCompletionSummary> | undefined;
 
       // --- Empty-summary hardening: envelope → retry → deterministic fallback ---
       if (!summary) {
@@ -1737,7 +1738,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         // top-level response fields (output, message, response) rather than
         // inside the content array.  Re-run normalization against the full
         // response envelope before spending an API call on a retry.
-        const envelopeNormalized = normalizeCompletionSummary(result);
+        envelopeNormalized = normalizeCompletionSummary(result);
         if (envelopeNormalized.summary) {
           summary = envelopeNormalized.summary;
           summarySource = "envelope";
@@ -1754,9 +1755,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       // empty so the retry/fallback chain runs instead of persisting the
       // reasoning text verbatim as the summary body.
       if (summary && looksLikeReasoningOnlySummary(summary)) {
+        // Log the block_types from the source normalization that actually
+        // produced this summary text — `normalized` is content-path, but
+        // when the summary came from `envelopeNormalized` the relevant
+        // shape is the envelope's, not the content's.
+        const droppedBlockTypes =
+          summarySource === "envelope" && envelopeNormalized
+            ? envelopeNormalized.blockTypes
+            : normalized.blockTypes;
         params.deps.log.warn(
           `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
-            `model=${model}; block_types=${formatBlockTypes(normalized.blockTypes)}; ` +
+            `model=${model}; source=${summarySource}; ` +
+            `block_types=${formatBlockTypes(droppedBlockTypes)}; ` +
             `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
         );
         summary = "";

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -419,28 +419,35 @@ function looksLikeReasoningOnlySummary(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
 
-  // Wrapped or opened with an explicit reasoning marker (`<think>`,
-  // `<thinking>`, `<reasoning>`, or DeepSeek-style `<|reasoning|>`).
-  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(trimmed)) {
-    return true;
-  }
-  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(trimmed)) {
-    return true;
-  }
-
-  // Bracketed labels like `[thinking]` / `[reasoning]` at the very start.
-  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(trimmed)) {
-    return true;
-  }
-
-  // Strip a leading `<think>...</think>` block; if nothing meaningful
-  // remains, treat as reasoning-only.  This catches partial leaks where the
-  // provider closed the reasoning tag but emitted no follow-on summary.
-  const withoutThinkBlock = trimmed.replace(
+  // Strip every CLOSED `<think>...</think>` / `<thinking>...</thinking>` /
+  // `<reasoning>...</reasoning>` block.  A closed reasoning block followed
+  // by a non-empty summary body (the common pattern when the provider
+  // emits a reasoning trace and then a normal answer, e.g.
+  // `<think>...</think>Actual summary text`) is NOT reasoning-only —
+  // returning true here would force an unnecessary retry/fallback.
+  const withoutClosedThink = trimmed.replace(
     /<\s*(think|thinking|reasoning)\s*>[\s\S]*?<\s*\/\s*\1\s*>/gi,
     "",
   );
-  if (!withoutThinkBlock.trim()) {
+  const remainder = withoutClosedThink.trim();
+  if (!remainder) {
+    // Either the entire body was a closed reasoning block (no summary
+    // text after) or the input was empty — both are reasoning-only.
+    return true;
+  }
+
+  // Remainder still starts with an UNCLOSED reasoning marker — the
+  // provider opened a `<think>`-style block but never closed it (often a
+  // truncated stream / max_tokens cutoff before the answer began).
+  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(remainder)) {
+    return true;
+  }
+  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(remainder)) {
+    return true;
+  }
+  // Bracketed labels at the very start (`[thinking]…` with no obvious
+  // body separation) — same shape as the unclosed-tag case.
+  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(remainder)) {
     return true;
   }
 

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -110,10 +110,14 @@ const DIAGNOSTIC_MAX_OBJECT_KEYS = 16;
 const DIAGNOSTIC_MAX_CHARS = 1200;
 const DIAGNOSTIC_SENSITIVE_KEY_PATTERN =
   /(api[-_]?key|authorization|token|secret|password|cookie|set-cookie|private[-_]?key|bearer)/i;
-const CLOSED_REASONING_SUMMARY_BLOCK_RE =
-  /<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const LEADING_CLOSED_REASONING_SUMMARY_BLOCK_RE =
+  /^<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/i;
+const STANDALONE_CLOSED_REASONING_SUMMARY_BLOCK_RE =
+  /(^|\n)[ \t]*<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\2\s*>[ \t]*(?=\n|$)/gi;
 const REASONING_SUMMARY_START_RE =
   /^(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
+const STANDALONE_REASONING_SUMMARY_START_RE =
+  /(^|\n)[ \t]*(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)[\s\S]*$/i;
 const REASONING_DIAGNOSTIC_MARKER_RE =
   /(?:<\s*\/?\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
 const AUTH_ERROR_TEXT_PATTERN =
@@ -411,6 +415,45 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
   };
 }
 
+/** Normalize top-level response fields after the primary content path fails. */
+function normalizeCompletionEnvelope(response: unknown): ReturnType<typeof normalizeCompletionSummary> {
+  if (!isRecord(response)) {
+    return normalizeCompletionSummary(response);
+  }
+  const envelope = { ...response };
+  delete envelope.content;
+  return normalizeCompletionSummary(envelope);
+}
+
+function stripLeadingClosedReasoningBlocks(value: string): { text: string; dropped: boolean } {
+  let remainder = value.trim();
+  let dropped = false;
+  while (true) {
+    const match = remainder.match(LEADING_CLOSED_REASONING_SUMMARY_BLOCK_RE);
+    if (!match) {
+      break;
+    }
+    remainder = remainder.slice(match[0].length).trimStart();
+    dropped = true;
+  }
+  return { text: remainder.trim(), dropped };
+}
+
+function stripStandaloneReasoningBlocks(value: string): { text: string; dropped: boolean } {
+  const withoutClosedBlocks = value.replace(
+    STANDALONE_CLOSED_REASONING_SUMMARY_BLOCK_RE,
+    (match, lineStart: string) => (lineStart === "\n" ? "\n" : ""),
+  );
+  const withoutTrailingOpenBlock = withoutClosedBlocks.replace(
+    STANDALONE_REASONING_SUMMARY_START_RE,
+    (match, lineStart: string) => (lineStart === "\n" ? "\n" : ""),
+  );
+  return {
+    text: withoutTrailingOpenBlock.trim(),
+    dropped: withoutTrailingOpenBlock !== value,
+  };
+}
+
 /**
  * Remove provider reasoning/thinking payloads leaking through as summary text.
  *
@@ -438,14 +481,13 @@ function sanitizeReasoningSummaryText(value: string): {
     return { summary: "", droppedReasoning: false, reasoningOnly: false };
   }
 
-  // Strip every CLOSED `<think>...</think>` / `<thinking>...</thinking>` /
-  // `<reasoning>...</reasoning>` block.  A closed reasoning block followed
-  // by a non-empty summary body (the common pattern when the provider
-  // emits a reasoning trace and then a normal answer, e.g.
-  // `<think>...</think>Actual summary text`) is kept, but the reasoning
-  // prefix itself must not be persisted.
-  const withoutClosedThink = trimmed.replace(CLOSED_REASONING_SUMMARY_BLOCK_RE, "");
-  const remainder = withoutClosedThink.trim();
+  // Strip leading CLOSED `<think>...</think>` / `<thinking>...</thinking>` /
+  // `<reasoning>...</reasoning>` blocks.  A leading closed reasoning block
+  // followed by a non-empty summary body is kept as the body, but literal tag
+  // examples later in otherwise valid prose are preserved.
+  const strippedLeading = stripLeadingClosedReasoningBlocks(trimmed);
+  const strippedStandalone = stripStandaloneReasoningBlocks(strippedLeading.text);
+  const remainder = strippedStandalone.text;
   if (!remainder) {
     // Either the entire body was a closed reasoning block (no summary
     // text after) or the input was empty — both are reasoning-only.
@@ -461,7 +503,7 @@ function sanitizeReasoningSummaryText(value: string): {
 
   return {
     summary: remainder,
-    droppedReasoning: remainder !== trimmed,
+    droppedReasoning: strippedLeading.dropped || strippedStandalone.dropped,
     reasoningOnly: false,
   };
 }
@@ -1751,9 +1793,9 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       if (!summary) {
         // Envelope-aware extraction: some providers place summary text in
         // top-level response fields (output, message, response) rather than
-        // inside the content array.  Re-run normalization against the full
-        // response envelope before spending an API call on a retry.
-        envelopeNormalized = normalizeCompletionSummary(result);
+        // inside the content array.  Re-run normalization against top-level
+        // response fields before spending an API call on a retry.
+        envelopeNormalized = normalizeCompletionEnvelope(result);
         if (envelopeNormalized.summary) {
           summary = envelopeNormalized.summary;
           summarySource = "envelope";
@@ -1789,8 +1831,23 @@ export async function createLcmSummarizeFromLegacyParams(params: {
               `block_types=${formatBlockTypes(droppedBlockTypes)}; ` +
               `summary_shape=reasoning-only; summary_chars=${rawSummaryChars}`,
           );
-          summary = "";
-          summarySource = "content";
+          const recoveryNormalized = envelopeNormalized ?? normalizeCompletionEnvelope(result);
+          const recoveredSummary = sanitizeReasoningSummaryText(recoveryNormalized.summary);
+          if (recoveredSummary.summary && !recoveredSummary.reasoningOnly) {
+            summary = recoveredSummary.summary;
+            envelopeNormalized = {
+              summary,
+              blockTypes: recoveryNormalized.blockTypes,
+            };
+            summarySource = "envelope";
+            params.deps.log.debug(
+              `[lcm] recovered summary from response envelope; provider=${provider}; model=${model}; ` +
+                `block_types=${formatBlockTypes(recoveryNormalized.blockTypes)}; source=envelope`,
+            );
+          } else {
+            summary = "";
+            summarySource = "content";
+          }
         }
       }
 
@@ -1825,7 +1882,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           const retryNormalized = normalizeCompletionSummary(retryResult.content);
           const retryEnvelopeNormalized = retryNormalized.summary
             ? retryNormalized
-            : normalizeCompletionSummary(retryResult);
+            : normalizeCompletionEnvelope(retryResult);
           summary = retryEnvelopeNormalized.summary;
 
           // Re-apply the reasoning-leak guardrail to the retry result so a
@@ -1843,7 +1900,14 @@ export async function createLcmSummarizeFromLegacyParams(params: {
                   `model=${model}; block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; ` +
                   `summary_shape=reasoning-only; summary_chars=${rawRetrySummaryChars}`,
               );
-              summary = "";
+              const retryRecoveryNormalized = normalizeCompletionEnvelope(retryResult);
+              const retryRecoveredSummary = sanitizeReasoningSummaryText(
+                retryRecoveryNormalized.summary,
+              );
+              summary =
+                retryRecoveredSummary.summary && !retryRecoveredSummary.reasoningOnly
+                  ? retryRecoveredSummary.summary
+                  : "";
             }
           }
 

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -110,6 +110,12 @@ const DIAGNOSTIC_MAX_OBJECT_KEYS = 16;
 const DIAGNOSTIC_MAX_CHARS = 1200;
 const DIAGNOSTIC_SENSITIVE_KEY_PATTERN =
   /(api[-_]?key|authorization|token|secret|password|cookie|set-cookie|private[-_]?key|bearer)/i;
+const CLOSED_REASONING_SUMMARY_BLOCK_RE =
+  /<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const REASONING_SUMMARY_START_RE =
+  /^(?:<\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
+const REASONING_DIAGNOSTIC_MARKER_RE =
+  /(?:<\s*\/?\s*(?:think|thinking|reasoning)(?:\s[^>]*)?>|<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>|\[\s*(?:think|thinking|reasoning)\s*\]|(?:#{1,6}\s*)?(?:thinking|reasoning|thought)\s+process\s*:|(?:#{1,6}\s*)?chain[-\s]+of[-\s]+thought\s*:)/i;
 const AUTH_ERROR_TEXT_PATTERN =
   /\b401\b|unauthorized|unauthorised|invalid[_ -]?token|invalid[_ -]?api[_ -]?key|authentication failed|authorization failed|missing scope|insufficient scope|model\.request\b/i;
 const AUTH_ERROR_STATUS_KEYS = ["status", "statusCode", "status_code"] as const;
@@ -403,55 +409,58 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
 }
 
 /**
- * Detect summary text that is actually a provider reasoning/thinking payload
- * leaking through as the summary body.
+ * Remove provider reasoning/thinking payloads leaking through as summary text.
  *
  * Some reasoning-capable summary models (vLLM+Qwen3 per #471, Kimi K2.6 per
  * #542) sometimes return reasoning text shaped so it slips past the
  * type-tagged filtering in `collectTextLikeFields` — e.g. the entire
  * summary body is wrapped in `<think>...</think>` tags, or starts with
- * `<think>` and never closes.  Treat those as empty so the empty-summary
- * hardening (envelope → retry → deterministic fallback) kicks in instead
- * of silently persisting reasoning text as the summary.  See #564.
+ * `<think>` and never closes.  Some providers also leak the same payload
+ * behind high-signal prose headers such as `Thinking Process:`.  Strip closed
+ * reasoning blocks when a visible summary follows, or treat reasoning-only
+ * output as empty so the empty-summary hardening (envelope → retry →
+ * deterministic fallback) kicks in instead of silently persisting reasoning
+ * text as the summary.  See #564.
  */
-function looksLikeReasoningOnlySummary(value: string): boolean {
-  if (typeof value !== "string") return false;
+function sanitizeReasoningSummaryText(value: string): {
+  summary: string;
+  droppedReasoning: boolean;
+  reasoningOnly: boolean;
+} {
+  if (typeof value !== "string") {
+    return { summary: "", droppedReasoning: false, reasoningOnly: false };
+  }
   const trimmed = value.trim();
-  if (!trimmed) return false;
+  if (!trimmed) {
+    return { summary: "", droppedReasoning: false, reasoningOnly: false };
+  }
 
   // Strip every CLOSED `<think>...</think>` / `<thinking>...</thinking>` /
   // `<reasoning>...</reasoning>` block.  A closed reasoning block followed
   // by a non-empty summary body (the common pattern when the provider
   // emits a reasoning trace and then a normal answer, e.g.
-  // `<think>...</think>Actual summary text`) is NOT reasoning-only —
-  // returning true here would force an unnecessary retry/fallback.
-  const withoutClosedThink = trimmed.replace(
-    /<\s*(think|thinking|reasoning)\s*>[\s\S]*?<\s*\/\s*\1\s*>/gi,
-    "",
-  );
+  // `<think>...</think>Actual summary text`) is kept, but the reasoning
+  // prefix itself must not be persisted.
+  const withoutClosedThink = trimmed.replace(CLOSED_REASONING_SUMMARY_BLOCK_RE, "");
   const remainder = withoutClosedThink.trim();
   if (!remainder) {
     // Either the entire body was a closed reasoning block (no summary
     // text after) or the input was empty — both are reasoning-only.
-    return true;
+    return { summary: "", droppedReasoning: true, reasoningOnly: true };
   }
 
   // Remainder still starts with an UNCLOSED reasoning marker — the
   // provider opened a `<think>`-style block but never closed it (often a
   // truncated stream / max_tokens cutoff before the answer began).
-  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(remainder)) {
-    return true;
-  }
-  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(remainder)) {
-    return true;
-  }
-  // Bracketed labels at the very start (`[thinking]…` with no obvious
-  // body separation) — same shape as the unclosed-tag case.
-  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(remainder)) {
-    return true;
+  if (REASONING_SUMMARY_START_RE.test(remainder)) {
+    return { summary: "", droppedReasoning: true, reasoningOnly: true };
   }
 
-  return false;
+  return {
+    summary: remainder,
+    droppedReasoning: remainder !== trimmed,
+    reasoningOnly: false,
+  };
 }
 
 /** Format normalized block types for concise diagnostics. */
@@ -476,6 +485,9 @@ function sanitizeForDiagnostics(value: unknown, depth = 0): unknown {
     return "[max-depth]";
   }
   if (typeof value === "string") {
+    if (REASONING_DIAGNOSTIC_MARKER_RE.test(value)) {
+      return `[reasoning-like text redacted:${value.length} chars]`;
+    }
     return truncateDiagnosticText(value);
   }
   if (
@@ -1750,27 +1762,33 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       }
 
       // Reasoning-leak guardrail (#564, refs #471, #542): if the extracted
-      // summary text is itself a provider reasoning/thinking payload (wrapped
-      // in <think>…</think>, opened with `[thinking]`, etc.), treat it as
-      // empty so the retry/fallback chain runs instead of persisting the
-      // reasoning text verbatim as the summary body.
-      if (summary && looksLikeReasoningOnlySummary(summary)) {
-        // Log the block_types from the source normalization that actually
-        // produced this summary text — `normalized` is content-path, but
-        // when the summary came from `envelopeNormalized` the relevant
-        // shape is the envelope's, not the content's.
-        const droppedBlockTypes =
-          summarySource === "envelope" && envelopeNormalized
-            ? envelopeNormalized.blockTypes
-            : normalized.blockTypes;
-        params.deps.log.warn(
-          `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
-            `model=${model}; source=${summarySource}; ` +
-            `block_types=${formatBlockTypes(droppedBlockTypes)}; ` +
-            `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
-        );
-        summary = "";
-        summarySource = "content";
+      // summary text contains provider reasoning/thinking payloads, strip
+      // closed reasoning blocks when a visible summary follows.  Reasoning-only
+      // output is treated as empty so the retry/fallback chain runs.
+      if (summary) {
+        const rawSummaryChars = summary.length;
+        const sanitizedSummary = sanitizeReasoningSummaryText(summary);
+        if (sanitizedSummary.droppedReasoning) {
+          summary = sanitizedSummary.summary;
+        }
+        if (sanitizedSummary.reasoningOnly) {
+          // Log the block_types from the source normalization that actually
+          // produced this summary text — `normalized` is content-path, but
+          // when the summary came from `envelopeNormalized` the relevant
+          // shape is the envelope's, not the content's.
+          const droppedBlockTypes =
+            summarySource === "envelope" && envelopeNormalized
+              ? envelopeNormalized.blockTypes
+              : normalized.blockTypes;
+          params.deps.log.warn(
+            `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
+              `model=${model}; source=${summarySource}; ` +
+              `block_types=${formatBlockTypes(droppedBlockTypes)}; ` +
+              `summary_shape=reasoning-only; summary_chars=${rawSummaryChars}`,
+          );
+          summary = "";
+          summarySource = "content";
+        }
       }
 
       const incompleteSignals = extractIncompleteResponseSignals(result);
@@ -1808,15 +1826,22 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           summary = retryEnvelopeNormalized.summary;
 
           // Re-apply the reasoning-leak guardrail to the retry result so a
-          // reasoning-shaped retry response also drops to deterministic
-          // fallback rather than persisting as the summary body.  See #564.
-          if (summary && looksLikeReasoningOnlySummary(summary)) {
-            params.deps.log.warn(
-              `[lcm] dropped reasoning-shaped summary on retry; provider=${provider}; ` +
-                `model=${model}; block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; ` +
-                `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
-            );
-            summary = "";
+          // mixed reasoning+summary retry is stripped before persistence, and
+          // reasoning-only retry output drops to deterministic fallback.
+          if (summary) {
+            const rawRetrySummaryChars = summary.length;
+            const sanitizedRetrySummary = sanitizeReasoningSummaryText(summary);
+            if (sanitizedRetrySummary.droppedReasoning) {
+              summary = sanitizedRetrySummary.summary;
+            }
+            if (sanitizedRetrySummary.reasoningOnly) {
+              params.deps.log.warn(
+                `[lcm] dropped reasoning-shaped summary on retry; provider=${provider}; ` +
+                  `model=${model}; block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; ` +
+                  `summary_shape=reasoning-only; summary_chars=${rawRetrySummaryChars}`,
+              );
+              summary = "";
+            }
           }
 
           if (summary) {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -402,6 +402,51 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
   };
 }
 
+/**
+ * Detect summary text that is actually a provider reasoning/thinking payload
+ * leaking through as the summary body.
+ *
+ * Some reasoning-capable summary models (vLLM+Qwen3 per #471, Kimi K2.6 per
+ * #542) sometimes return reasoning text shaped so it slips past the
+ * type-tagged filtering in `collectTextLikeFields` — e.g. the entire
+ * summary body is wrapped in `<think>...</think>` tags, or starts with
+ * `<think>` and never closes.  Treat those as empty so the empty-summary
+ * hardening (envelope → retry → deterministic fallback) kicks in instead
+ * of silently persisting reasoning text as the summary.  See #564.
+ */
+function looksLikeReasoningOnlySummary(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  // Wrapped or opened with an explicit reasoning marker (`<think>`,
+  // `<thinking>`, `<reasoning>`, or DeepSeek-style `<|reasoning|>`).
+  if (/^<\s*(think|thinking|reasoning)(\s[^>]*)?>/i.test(trimmed)) {
+    return true;
+  }
+  if (/^<\|\s*(?:start_of_)?(?:think|thinking|reasoning)\s*\|>/i.test(trimmed)) {
+    return true;
+  }
+
+  // Bracketed labels like `[thinking]` / `[reasoning]` at the very start.
+  if (/^\[\s*(think|thinking|reasoning)\s*\]/i.test(trimmed)) {
+    return true;
+  }
+
+  // Strip a leading `<think>...</think>` block; if nothing meaningful
+  // remains, treat as reasoning-only.  This catches partial leaks where the
+  // provider closed the reasoning tag but emitted no follow-on summary.
+  const withoutThinkBlock = trimmed.replace(
+    /<\s*(think|thinking|reasoning)\s*>[\s\S]*?<\s*\/\s*\1\s*>/gi,
+    "",
+  );
+  if (!withoutThinkBlock.trim()) {
+    return true;
+  }
+
+  return false;
+}
+
 /** Format normalized block types for concise diagnostics. */
 function formatBlockTypes(blockTypes: string[]): string {
   if (blockTypes.length === 0) {
@@ -1696,6 +1741,21 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         }
       }
 
+      // Reasoning-leak guardrail (#564, refs #471, #542): if the extracted
+      // summary text is itself a provider reasoning/thinking payload (wrapped
+      // in <think>…</think>, opened with `[thinking]`, etc.), treat it as
+      // empty so the retry/fallback chain runs instead of persisting the
+      // reasoning text verbatim as the summary body.
+      if (summary && looksLikeReasoningOnlySummary(summary)) {
+        params.deps.log.warn(
+          `[lcm] dropped reasoning-shaped summary on first attempt; provider=${provider}; ` +
+            `model=${model}; block_types=${formatBlockTypes(normalized.blockTypes)}; ` +
+            `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
+        );
+        summary = "";
+        summarySource = "content";
+      }
+
       const incompleteSignals = extractIncompleteResponseSignals(result);
       const initialSummary = summary;
       const shouldRetryIncompleteSummary = summary.length > 0 && incompleteSignals.length > 0;
@@ -1729,6 +1789,18 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             ? retryNormalized
             : normalizeCompletionSummary(retryResult);
           summary = retryEnvelopeNormalized.summary;
+
+          // Re-apply the reasoning-leak guardrail to the retry result so a
+          // reasoning-shaped retry response also drops to deterministic
+          // fallback rather than persisting as the summary body.  See #564.
+          if (summary && looksLikeReasoningOnlySummary(summary)) {
+            params.deps.log.warn(
+              `[lcm] dropped reasoning-shaped summary on retry; provider=${provider}; ` +
+                `model=${model}; block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; ` +
+                `summary_preview=${formatDiagnosticPayload(summary.slice(0, 160))}`,
+            );
+            summary = "";
+          }
 
           if (summary) {
             summarySource = "retry";

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -310,6 +310,9 @@ function collectBlockTypes(value: unknown, out: Set<string>): void {
   if (typeof value.type === "string" && value.type.trim()) {
     out.add(value.type.trim());
   }
+  if (typeof value.rawType === "string" && value.rawType.trim()) {
+    out.add(value.rawType.trim());
+  }
   for (const nested of Object.values(value)) {
     collectBlockTypes(nested, out);
   }
@@ -345,7 +348,7 @@ function collectTextLikeFields(value: unknown, out: string[]): void {
     return;
   }
 
-  if (isReasoningLikeType(value.type)) {
+  if (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType)) {
     return;
   }
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1436,9 +1436,16 @@ describe("LCM integration: compaction", () => {
       { type: "text", text: "Visible reply after thinking summary." },
     ]);
     const plainContent = "A plain user message.";
+    const reasoningHeadingContent =
+      "Thinking Process: this is a user bug report heading, not provider reasoning.";
 
     await ingestMessages(convStore, sumStore, 1, {
       contentFn: () => plainContent,
+      roleFn: () => "user",
+      tokenCountFn: (_i, c) => estimateTokens(c),
+    });
+    await ingestMessages(convStore, sumStore, 1, {
+      contentFn: () => reasoningHeadingContent,
       roleFn: () => "user",
       tokenCountFn: (_i, c) => estimateTokens(c),
     });
@@ -1506,6 +1513,7 @@ describe("LCM integration: compaction", () => {
 
     // The plain user message must still be present
     expect(capturedSourceText).toContain("A plain user message.");
+    expect(capturedSourceText).toContain(reasoningHeadingContent);
   });
 
   it("leaf compaction strips redacted_thinking blocks from structured message parts", async () => {
@@ -1739,7 +1747,7 @@ describe("LCM integration: compaction", () => {
       summaryId: "sum_pre_2",
       conversationId: CONV_ID,
       kind: "leaf",
-      content: "<think>PRIVATE_PRIOR_REASONING</think>Prior summary two.",
+      content: "<think>PRIVATE_PRIOR_REASONING_TWO</think>",
       tokenCount: 4,
     });
     await sumStore.appendContextSummary(CONV_ID, "sum_pre_2");
@@ -1775,8 +1783,8 @@ describe("LCM integration: compaction", () => {
 
     expect(result.actionTaken).toBe(true);
     expect(summarizeCalls.length).toBeGreaterThan(0);
-    expect(summarizeCalls[0]?.previousSummary).toBe("Prior summary two.");
-    expect(summarizeCalls[0]?.previousSummary).not.toContain("PRIVATE_PRIOR_REASONING");
+    expect(summarizeCalls[0]?.previousSummary).toBe("Prior summary one.");
+    expect(summarizeCalls[0]?.previousSummary).not.toContain("PRIVATE_PRIOR_REASONING_TWO");
     expect(summarizeCalls[0]?.previousSummary).not.toContain("PRIVATE_ONLY");
     expect(summarizeCalls[0]?.previousSummary).not.toContain("<think>");
     expect(summarizeCalls[0]?.previousSummary).not.toContain("<thinking>");
@@ -2520,6 +2528,7 @@ describe("LCM integration: compaction", () => {
   it("depth-aware condensation sets condensed depth to max parent depth plus one", async () => {
     const depthAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
+      freshTailCount: 0,
       leafMinFanout: 2,
       condensedMinFanout: 2,
       leafChunkTokens: 200,
@@ -2785,6 +2794,16 @@ describe("LCM integration: compaction", () => {
       content: "<think>PRIVATE_PRIOR_REASONING</think>Depth zero prior context",
       tokenCount: 60,
     });
+    for (let index = 0; index < 4; index++) {
+      await sumStore.insertSummary({
+        summaryId: `sum_depth_zero_empty_prior_${index}`,
+        conversationId: depthZeroConversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: `<thinking>PRIVATE_EMPTY_PRIOR_${index}</thinking>`,
+        tokenCount: 60,
+      });
+    }
     await sumStore.insertSummary({
       summaryId: "sum_depth_zero_focus_a",
       conversationId: depthZeroConversation.conversationId,
@@ -2805,6 +2824,12 @@ describe("LCM integration: compaction", () => {
       depthZeroConversation.conversationId,
       "sum_depth_zero_prior",
     );
+    for (let index = 0; index < 4; index++) {
+      await sumStore.appendContextSummary(
+        depthZeroConversation.conversationId,
+        `sum_depth_zero_empty_prior_${index}`,
+      );
+    }
     await sumStore.appendContextSummary(
       depthZeroConversation.conversationId,
       "sum_depth_zero_focus_a",
@@ -2832,11 +2857,128 @@ describe("LCM integration: compaction", () => {
     expect(depthZeroCall?.options?.depth).toBe(1);
     expect(depthZeroCall?.options?.previousSummary).toContain("Depth zero prior context");
     expect(depthZeroCall?.options?.previousSummary).not.toContain("PRIVATE_PRIOR_REASONING");
+    expect(depthZeroCall?.options?.previousSummary).not.toContain("PRIVATE_EMPTY_PRIOR");
     expect(depthZeroCall?.options?.previousSummary).not.toContain("<think>");
+    expect(depthZeroCall?.options?.previousSummary).not.toContain("<thinking>");
     expect(depthZeroCall?.text).toContain("Depth zero focus A");
     expect(depthZeroCall?.text).toContain("Depth zero focus B");
     expect(depthZeroCall?.text).not.toContain("PRIVATE_FOCUS_REASONING");
     expect(depthZeroCall?.text).not.toContain("<thinking>");
+  });
+
+  it("skips condensed writes when all selected summaries sanitize empty", async () => {
+    const emptyCondensedEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafMinFanout: 2,
+      condensedMinFanout: 2,
+      condensedTargetTokens: 10,
+    });
+    const conversation = await convStore.createConversation({
+      sessionId: "empty-sanitized-condensed",
+    });
+
+    await sumStore.insertSummary({
+      summaryId: "sum_empty_reasoning_a",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "<think>PRIVATE_A</think>",
+      tokenCount: 60,
+    });
+    await sumStore.insertSummary({
+      summaryId: "sum_empty_reasoning_b",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "[thinking] PRIVATE_B",
+      tokenCount: 60,
+    });
+    await sumStore.appendContextSummary(conversation.conversationId, "sum_empty_reasoning_a");
+    await sumStore.appendContextSummary(conversation.conversationId, "sum_empty_reasoning_b");
+
+    const contextItems = await sumStore.getContextItems(conversation.conversationId);
+    const summaryItems = contextItems.filter((item) => item.itemType === "summary");
+    const summarize = vi.fn(async () => "Should not be called");
+    const result = await (emptyCondensedEngine as any).condensedPass(
+      conversation.conversationId,
+      summaryItems,
+      0,
+      summarize,
+    );
+
+    expect(result).toEqual({ skipped: "empty-source" });
+    expect(summarize).not.toHaveBeenCalled();
+    expect(
+      sumStore._summaries.some((summary) => summary.content === "[Truncated from 0 tokens]"),
+    ).toBe(false);
+
+    const sweepResult = await emptyCondensedEngine.compactFullSweep({
+      conversationId: conversation.conversationId,
+      tokenBudget: 10_000,
+      stopAtTokens: 1,
+      summarize,
+      force: true,
+    });
+
+    expect(sweepResult.actionTaken).toBe(false);
+    expect(sweepResult.authFailure).toBeUndefined();
+    expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it("skips empty sanitized summaries when selecting condensed chunks", async () => {
+    const prefixSkipEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafMinFanout: 2,
+      condensedMinFanout: 2,
+      leafChunkTokens: 200,
+      condensedTargetTokens: 10,
+    });
+    const conversation = await convStore.createConversation({
+      sessionId: "empty-prefix-condensed",
+    });
+
+    for (const [summaryId, content] of [
+      ["sum_empty_prefix_a", "<think>PRIVATE_PREFIX_A</think>"],
+      ["sum_empty_prefix_b", "[thinking] PRIVATE_PREFIX_B"],
+      ["sum_valid_after_prefix_a", "Valid summary A"],
+      ["sum_empty_middle", "<thinking>PRIVATE_MIDDLE</thinking>"],
+      ["sum_valid_after_prefix_b", "Valid summary B"],
+    ] as const) {
+      await sumStore.insertSummary({
+        summaryId,
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content,
+        tokenCount: 60,
+      });
+      await sumStore.appendContextSummary(conversation.conversationId, summaryId);
+    }
+
+    let capturedSourceText = "";
+    const summarize = vi.fn(async (text: string) => {
+      capturedSourceText = text;
+      return "Condensed valid summaries";
+    });
+
+    const result = await prefixSkipEngine.compactFullSweep({
+      conversationId: conversation.conversationId,
+      tokenBudget: 10_000,
+      stopAtTokens: 1,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(result.authFailure).toBeUndefined();
+    expect(summarize).toHaveBeenCalledOnce();
+    expect(capturedSourceText).toContain("Valid summary A");
+    expect(capturedSourceText).toContain("Valid summary B");
+    expect(capturedSourceText).not.toContain("PRIVATE_PREFIX");
+    expect(capturedSourceText).not.toContain("PRIVATE_MIDDLE");
+    expect(capturedSourceText).not.toContain("<think>");
+    expect(capturedSourceText).not.toContain("<thinking>");
   });
 
   it("relaxes fanout thresholds only under summarized-prefix pressure", async () => {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1739,7 +1739,7 @@ describe("LCM integration: compaction", () => {
       summaryId: "sum_pre_2",
       conversationId: CONV_ID,
       kind: "leaf",
-      content: "Prior summary two.",
+      content: "<think>PRIVATE_PRIOR_REASONING</think>Prior summary two.",
       tokenCount: 4,
     });
     await sumStore.appendContextSummary(CONV_ID, "sum_pre_2");
@@ -1747,7 +1747,7 @@ describe("LCM integration: compaction", () => {
       summaryId: "sum_pre_3",
       conversationId: CONV_ID,
       kind: "leaf",
-      content: "Prior summary three.",
+      content: "<thinking>PRIVATE_ONLY</thinking>",
       tokenCount: 4,
     });
     await sumStore.appendContextSummary(CONV_ID, "sum_pre_3");
@@ -1775,7 +1775,11 @@ describe("LCM integration: compaction", () => {
 
     expect(result.actionTaken).toBe(true);
     expect(summarizeCalls.length).toBeGreaterThan(0);
-    expect(summarizeCalls[0]?.previousSummary).toBe("Prior summary two.\n\nPrior summary three.");
+    expect(summarizeCalls[0]?.previousSummary).toBe("Prior summary two.");
+    expect(summarizeCalls[0]?.previousSummary).not.toContain("PRIVATE_PRIOR_REASONING");
+    expect(summarizeCalls[0]?.previousSummary).not.toContain("PRIVATE_ONLY");
+    expect(summarizeCalls[0]?.previousSummary).not.toContain("<think>");
+    expect(summarizeCalls[0]?.previousSummary).not.toContain("<thinking>");
     expect(summarizeCalls[0]?.isCondensed).toBe(false);
   });
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2735,6 +2735,7 @@ describe("LCM integration: compaction", () => {
     );
 
     const summarizeCalls: Array<{
+      text: string;
       options?: {
         previousSummary?: string;
         isCondensed?: boolean;
@@ -2743,11 +2744,11 @@ describe("LCM integration: compaction", () => {
     }> = [];
     const summarize = vi.fn(
       async (
-        _text: string,
+        text: string,
         _aggressive?: boolean,
         options?: { previousSummary?: string; isCondensed?: boolean; depth?: number },
       ) => {
-        summarizeCalls.push({ options });
+        summarizeCalls.push({ text, options });
         return "Condensed output";
       },
     );
@@ -2777,7 +2778,7 @@ describe("LCM integration: compaction", () => {
       conversationId: depthZeroConversation.conversationId,
       kind: "leaf",
       depth: 0,
-      content: "Depth zero prior context",
+      content: "<think>PRIVATE_PRIOR_REASONING</think>Depth zero prior context",
       tokenCount: 60,
     });
     await sumStore.insertSummary({
@@ -2785,7 +2786,7 @@ describe("LCM integration: compaction", () => {
       conversationId: depthZeroConversation.conversationId,
       kind: "leaf",
       depth: 0,
-      content: "Depth zero focus A",
+      content: "<thinking>PRIVATE_FOCUS_REASONING</thinking>Depth zero focus A",
       tokenCount: 60,
     });
     await sumStore.insertSummary({
@@ -2826,6 +2827,12 @@ describe("LCM integration: compaction", () => {
     const depthZeroCall = summarizeCalls[summarizeCalls.length - 1];
     expect(depthZeroCall?.options?.depth).toBe(1);
     expect(depthZeroCall?.options?.previousSummary).toContain("Depth zero prior context");
+    expect(depthZeroCall?.options?.previousSummary).not.toContain("PRIVATE_PRIOR_REASONING");
+    expect(depthZeroCall?.options?.previousSummary).not.toContain("<think>");
+    expect(depthZeroCall?.text).toContain("Depth zero focus A");
+    expect(depthZeroCall?.text).toContain("Depth zero focus B");
+    expect(depthZeroCall?.text).not.toContain("PRIVATE_FOCUS_REASONING");
+    expect(depthZeroCall?.text).not.toContain("<thinking>");
   });
 
   it("relaxes fanout thresholds only under summarized-prefix pressure", async () => {

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { extractMeaningfulMessageText } from "../src/compaction.js";
+import {
+  createLcmSummarizeFromLegacyParams,
+  type LcmSummarizeFn,
+} from "../src/summarize.js";
+import type { LcmDependencies } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// PR-4 (#564) — completing the reasoning half-fix from #503.
+//
+// Three sub-fixes are exercised here:
+//   B2 — `extractMeaningfulMessageText` is now applied at every summarizer
+//        entry point (leaf, condensed, prior-summary context).  The unit
+//        suite below confirms it strips the structured reasoning shapes
+//        observed in the wild from #471 / #542 / #547.
+//   B1 — When a provider returns reasoning-shaped text as the summary body,
+//        the summarize path now detects the leak, drops the summary, and
+//        defers to the existing retry → deterministic-fallback chain
+//        instead of persisting reasoning text verbatim as a summary.
+// ---------------------------------------------------------------------------
+
+describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
+  it("returns plain prose unchanged", () => {
+    expect(extractMeaningfulMessageText("User asked about deploys.")).toBe(
+      "User asked about deploys.",
+    );
+  });
+
+  it("strips a single thinking block from a structured content array", () => {
+    const content = JSON.stringify([
+      { type: "thinking", thinking: "Let me plan the answer first." },
+      { type: "text", text: "User confirmed the deploy went out." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe(
+      "User confirmed the deploy went out.",
+    );
+  });
+
+  it("strips reasoning blocks from the structured content array", () => {
+    const content = JSON.stringify([
+      { type: "reasoning", text: "Internal reasoning that must not leak." },
+      { type: "text", text: "Answer: ship the patch." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe("Answer: ship the patch.");
+  });
+
+  it("strips redacted_thinking blocks (Anthropic encrypted reasoning shape)", () => {
+    const content = JSON.stringify([
+      {
+        type: "redacted_thinking",
+        data: "ENCRYPTED:abc123==",
+      },
+      { type: "text", text: "Customer wants weekly digest." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe(
+      "Customer wants weekly digest.",
+    );
+  });
+
+  it("returns empty when content is only thinking blocks", () => {
+    const content = JSON.stringify([
+      { type: "thinking", thinking: "Plan first." },
+      { type: "reasoning", text: "More planning." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe("");
+  });
+
+  it("strips reasoning when nested inside a message wrapper", () => {
+    // Shape mirrors the legacy assistant rows referenced in #564 where a
+    // pre-#503 client wrote the entire message envelope into the content
+    // column instead of just the text payload.
+    const content = JSON.stringify({
+      message: {
+        content: [
+          { type: "thinking", thinking: "Should I cite the doc?" },
+          { type: "text", text: "Yes — see runbook §3." },
+        ],
+      },
+    });
+
+    expect(extractMeaningfulMessageText(content)).toBe("Yes — see runbook §3.");
+  });
+
+  it("does not apply structured handling to non-JSON strings", () => {
+    expect(
+      extractMeaningfulMessageText("Just a plain log line about reasoning."),
+    ).toBe("Just a plain log line about reasoning.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B1 — Output-side reasoning-leak guardrail.
+//
+// Reasoning-capable summary models (vLLM+Qwen3 per #471, Kimi K2.6 per #542)
+// have been observed to emit reasoning text that survives the per-block
+// type filter — typically wrapped in `<think>…</think>` tags.  The new
+// guardrail detects those shapes and forces the empty-summary path so the
+// retry / deterministic fallback runs instead of silently persisting the
+// reasoning string as the summary body.
+// ---------------------------------------------------------------------------
+
+async function createSummarizeFn(
+  params: Parameters<typeof createLcmSummarizeFromLegacyParams>[0],
+): Promise<LcmSummarizeFn | undefined> {
+  const result = await createLcmSummarizeFromLegacyParams(params);
+  return result?.fn;
+}
+
+function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      ignoreSessionPatterns: [],
+      statelessSessionPatterns: [],
+      skipStatelessSessions: true,
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      newSessionRetainDepth: 2,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 120,
+      largeFileTokenThreshold: 25_000,
+      summaryProvider: "",
+      summaryModel: "",
+      largeFileSummaryProvider: "",
+      largeFileSummaryModel: "",
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
+      summaryMaxOverageFactor: 3,
+    },
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "fallback" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({
+      provider: "openrouter",
+      model: "qwen/qwen3-235b",
+    })),
+    getApiKey: vi.fn(async () => "test-api-key"),
+    requireApiKey: vi.fn(async () => "test-api-key"),
+    parseAgentSessionKey: vi.fn(() => null),
+    isSubagentSessionKey: vi.fn(() => false),
+    normalizeAgentId: vi.fn(() => "main"),
+    buildSubagentSystemPrompt: vi.fn(() => ""),
+    readLatestAssistantReply: vi.fn(() => undefined),
+    resolveAgentDir: vi.fn(() => "/tmp/openclaw-agent"),
+    resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
+    agentLaneSubagent: "subagent",
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    ...overrides,
+  } as LcmDependencies;
+}
+
+function getDepsLogText(deps: LcmDependencies): string {
+  const calls = [
+    ...(deps.log.warn as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ...(deps.log.error as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+    ...(deps.log.info as unknown as { mock: { calls: unknown[][] } }).mock.calls,
+  ];
+  return calls.flatMap((call) => call.map((entry) => String(entry))).join(" ");
+}
+
+describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", () => {
+  it("drops a <think>-wrapped summary and retries instead of persisting it", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      complete: vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          // Initial call: provider leaks reasoning as the summary body.
+          return {
+            content: [
+              {
+                type: "text",
+                text: "<think>The user wants a digest of the conversation.</think>",
+              },
+            ],
+          };
+        }
+        // Retry: provider returns a clean summary.
+        return {
+          content: [{ type: "text", text: "Recovered clean summary." }],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text to summarize.", false);
+
+    expect(summary).toBe("Recovered clean summary.");
+    expect(callCount).toBe(2);
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).toContain("dropped reasoning-shaped summary on first attempt");
+  });
+
+  it("falls back to deterministic truncation when retry also returns reasoning text", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      complete: vi.fn(async () => {
+        callCount += 1;
+        return {
+          content: [
+            {
+              type: "text",
+              // Both passes leak reasoning — guardrail must engage on retry too.
+              text: callCount === 1
+                ? "<think>plan first</think>"
+                : "<thinking>retry plan</thinking>",
+            },
+          ],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("D".repeat(4_000), false);
+
+    // Must NOT silently persist the reasoning text as the summary body.
+    expect(summary).not.toContain("<think>");
+    expect(summary).not.toContain("<thinking>");
+    expect(summary).not.toContain("plan first");
+    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+
+    expect(callCount).toBe(2);
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).toContain("dropped reasoning-shaped summary on first attempt");
+    expect(diagnostics).toContain("dropped reasoning-shaped summary on retry");
+  });
+
+  it("treats a [thinking]-prefixed summary as a reasoning leak", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      complete: vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            content: [{ type: "text", text: "[thinking] Analyse the source then answer." }],
+          };
+        }
+        return {
+          content: [{ type: "text", text: "Clean summary on retry." }],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Clean summary on retry.");
+    expect(callCount).toBe(2);
+  });
+
+  it("does not drop a clean summary that merely mentions the word 'reasoning'", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "text",
+            text: "User asked about reasoning models and how thinking budgets work.",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe(
+      "User asked about reasoning models and how thinking budgets work.",
+    );
+    expect(deps.complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -277,6 +277,42 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     expect(callCount).toBe(2);
   });
 
+  it("preserves a closed-think-block summary followed by real summary text", async () => {
+    // Regression: an earlier shape returned reasoning-only=true on ANY input
+    // starting with `<think>`/`<thinking>`/`<reasoning>`, even when a closed
+    // tag was followed by a valid summary body. That dropped usable output and
+    // forced unnecessary retries / fallbacks. The new logic strips closed
+    // reasoning blocks first and only treats the result as reasoning-only when
+    // nothing meaningful remains — so `<think>plan</think>Actual summary.`
+    // must pass through as `Actual summary.` (or the full text, depending on
+    // downstream block parsing).
+    let callCount = 0;
+    const deps = makeDeps({
+      complete: vi.fn(async () => {
+        callCount += 1;
+        return {
+          content: [
+            {
+              type: "text",
+              text: "<think>The user wants a digest.</think>Recovered clean summary follow-on.",
+            },
+          ],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    // Only one provider call — guardrail must NOT have rejected this.
+    expect(callCount).toBe(1);
+    // The follow-on summary text must survive.
+    expect(summary).toContain("Recovered clean summary follow-on.");
+  });
+
   it("does not drop a clean summary that merely mentions the word 'reasoning'", async () => {
     const deps = makeDeps({
       complete: vi.fn(async () => ({

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -48,6 +48,15 @@ describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
     expect(extractMeaningfulMessageText(content)).toBe("Answer: ship the patch.");
   });
 
+  it("strips rawType reasoning blocks from legacy structured content", () => {
+    const content = JSON.stringify([
+      { rawType: "reasoning", text: "PRIVATE_RAWTYPE_REASONING" },
+      { type: "text", text: "Visible legacy text." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe("Visible legacy text.");
+  });
+
   it("strips redacted_thinking blocks (Anthropic encrypted reasoning shape)", () => {
     const content = JSON.stringify([
       {
@@ -366,6 +375,27 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     expect(summary).toBe("Recovered clean summary follow-on.");
     expect(summary).not.toContain("<think>");
     expect(summary).not.toContain("The user wants a digest.");
+  });
+
+  it("skips rawType reasoning blocks from provider output", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [
+          { type: "provider_block", rawType: "reasoning", text: "PRIVATE_RAWTYPE_REASONING" },
+          { type: "text", text: "Clean summary." },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Clean summary.");
+    expect(summary).not.toContain("PRIVATE_RAWTYPE_REASONING");
+    expect(deps.complete).toHaveBeenCalledTimes(1);
   });
 
   it("does not drop a clean summary that merely mentions the word 'reasoning'", async () => {

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -14,7 +14,7 @@ import type { LcmDependencies } from "../src/types.js";
 //   B2 — `extractMeaningfulMessageText` is now applied at every summarizer
 //        entry point (leaf, condensed, prior-summary context).  The unit
 //        suite below confirms it strips the structured reasoning shapes
-//        observed in the wild from #471 / #542 / #547.
+//        observed in the wild from #471 / #493 / #542.
 //   B1 — When a provider returns reasoning-shaped text as the summary body,
 //        the summarize path now detects the leak, drops the summary, and
 //        defers to the existing retry → deterministic-fallback chain
@@ -91,6 +91,25 @@ describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
     expect(
       extractMeaningfulMessageText("Just a plain log line about reasoning."),
     ).toBe("Just a plain log line about reasoning.");
+  });
+
+  it("strips raw closed reasoning tags from legacy plain-text summaries", () => {
+    expect(
+      extractMeaningfulMessageText(
+        "<think>PRIVATE_LEGACY_REASONING</think>Visible legacy summary.",
+      ),
+    ).toBe("Visible legacy summary.");
+  });
+
+  it("drops raw reasoning-only legacy plain-text summaries", () => {
+    expect(
+      extractMeaningfulMessageText("<thinking>PRIVATE_LEGACY_REASONING</thinking>"),
+    ).toBe("");
+    expect(
+      extractMeaningfulMessageText(
+        "Thinking Process: PRIVATE_LEGACY_REASONING before the answer.",
+      ),
+    ).toBe("");
   });
 });
 
@@ -249,6 +268,10 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     const diagnostics = getDepsLogText(deps);
     expect(diagnostics).toContain("dropped reasoning-shaped summary on first attempt");
     expect(diagnostics).toContain("dropped reasoning-shaped summary on retry");
+    expect(diagnostics).not.toContain("plan first");
+    expect(diagnostics).not.toContain("retry plan");
+    expect(diagnostics).not.toContain("<think>");
+    expect(diagnostics).not.toContain("<thinking>");
   });
 
   it("treats a [thinking]-prefixed summary as a reasoning leak", async () => {
@@ -274,6 +297,37 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     const summary = await summarize!("Source text.", false);
 
     expect(summary).toBe("Clean summary on retry.");
+    expect(callCount).toBe(2);
+  });
+
+  it("treats a Thinking Process-prefixed summary as a reasoning leak", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      complete: vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Thinking Process: The user wants a digest before I answer.",
+              },
+            ],
+          };
+        }
+        return {
+          content: [{ type: "text", text: "Clean summary after header leak." }],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Clean summary after header leak.");
     expect(callCount).toBe(2);
   });
 
@@ -309,8 +363,9 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
 
     // Only one provider call — guardrail must NOT have rejected this.
     expect(callCount).toBe(1);
-    // The follow-on summary text must survive.
-    expect(summary).toContain("Recovered clean summary follow-on.");
+    expect(summary).toBe("Recovered clean summary follow-on.");
+    expect(summary).not.toContain("<think>");
+    expect(summary).not.toContain("The user wants a digest.");
   });
 
   it("does not drop a clean summary that merely mentions the word 'reasoning'", async () => {

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -57,6 +57,19 @@ describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
     expect(extractMeaningfulMessageText(content)).toBe("Visible legacy text.");
   });
 
+  it("strips rawType reasoning blocks even when type is generic", () => {
+    const content = JSON.stringify([
+      {
+        type: "provider_block",
+        rawType: "reasoning",
+        text: "PRIVATE_PROVIDER_REASONING",
+      },
+      { type: "text", text: "Visible provider text." },
+    ]);
+
+    expect(extractMeaningfulMessageText(content)).toBe("Visible provider text.");
+  });
+
   it("strips redacted_thinking blocks (Anthropic encrypted reasoning shape)", () => {
     const content = JSON.stringify([
       {
@@ -102,23 +115,71 @@ describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
     ).toBe("Just a plain log line about reasoning.");
   });
 
+  it("preserves reasoning-looking plain text in raw messages", () => {
+    expect(
+      extractMeaningfulMessageText(
+        "Thinking Process: user pasted a bug report that starts with this heading.",
+      ),
+    ).toBe("Thinking Process: user pasted a bug report that starts with this heading.");
+    expect(
+      extractMeaningfulMessageText("<think>Document the provider tag syntax."),
+    ).toBe("<think>Document the provider tag syntax.");
+  });
+
   it("strips raw closed reasoning tags from legacy plain-text summaries", () => {
     expect(
       extractMeaningfulMessageText(
         "<think>PRIVATE_LEGACY_REASONING</think>Visible legacy summary.",
+        { stripPlainTextReasoning: true },
       ),
     ).toBe("Visible legacy summary.");
   });
 
+  it("preserves literal closed reasoning tags inside legacy summary prose", () => {
+    expect(
+      extractMeaningfulMessageText(
+        "User asked whether <think>foo</think> is supported.",
+        { stripPlainTextReasoning: true },
+      ),
+    ).toBe("User asked whether <think>foo</think> is supported.");
+  });
+
+  it("strips standalone trailing reasoning sections from legacy summaries", () => {
+    expect(
+      extractMeaningfulMessageText(
+        "Visible legacy summary.\n<think>PRIVATE_TRAILING_REASONING</think>",
+        { stripPlainTextReasoning: true },
+      ),
+    ).toBe("Visible legacy summary.");
+    expect(
+      extractMeaningfulMessageText(
+        "Visible legacy summary.\n[thinking] PRIVATE_TRAILING_REASONING",
+        { stripPlainTextReasoning: true },
+      ),
+    ).toBe("Visible legacy summary.");
+  });
+
+  it("preserves prose headings inside legacy summaries", () => {
+    expect(
+      extractMeaningfulMessageText(
+        "Thinking Process: user-authored section that was summarized.",
+        { stripPlainTextReasoning: true },
+      ),
+    ).toBe("Thinking Process: user-authored section that was summarized.");
+  });
+
   it("drops raw reasoning-only legacy plain-text summaries", () => {
     expect(
-      extractMeaningfulMessageText("<thinking>PRIVATE_LEGACY_REASONING</thinking>"),
+      extractMeaningfulMessageText("<thinking>PRIVATE_LEGACY_REASONING</thinking>", {
+        stripPlainTextReasoning: true,
+      }),
     ).toBe("");
     expect(
       extractMeaningfulMessageText(
         "Thinking Process: PRIVATE_LEGACY_REASONING before the answer.",
+        { stripPlainTextReasoning: true },
       ),
-    ).toBe("");
+    ).toBe("Thinking Process: PRIVATE_LEGACY_REASONING before the answer.");
   });
 });
 
@@ -398,6 +459,31 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     expect(deps.complete).toHaveBeenCalledTimes(1);
   });
 
+  it("recovers from envelope when content text is reasoning-only", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [{ type: "text", text: "<think>PRIVATE_CONTENT_REASONING</think>" }],
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Recovered envelope summary." }],
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Recovered envelope summary.");
+    expect(summary).not.toContain("PRIVATE_CONTENT_REASONING");
+    expect(deps.complete).toHaveBeenCalledTimes(1);
+  });
+
   it("does not drop a clean summary that merely mentions the word 'reasoning'", async () => {
     const deps = makeDeps({
       complete: vi.fn(async () => ({
@@ -419,6 +505,74 @@ describe("createLcmSummarizeFromLegacyParams (B1: reasoning-leak guardrail)", ()
     expect(summary).toBe(
       "User asked about reasoning models and how thinking budgets work.",
     );
+    expect(deps.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves literal closed thinking tags inside clean provider summaries", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "text",
+            text: "User asked whether <think>foo</think> is supported.",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("User asked whether <think>foo</think> is supported.");
+    expect(deps.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips standalone trailing reasoning blocks from provider summaries", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "text",
+            text: "Visible provider summary.\n<think>PRIVATE_TRAILING_REASONING</think>",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Visible provider summary.");
+    expect(summary).not.toContain("PRIVATE_TRAILING_REASONING");
+    expect(deps.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips trailing Thinking Process sections from provider summaries", async () => {
+    const deps = makeDeps({
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "text",
+            text: "Visible provider summary.\nThinking Process: PRIVATE_TRAILING_REASONING",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: { provider: "openrouter", model: "qwen/qwen3-235b" },
+    });
+    const summary = await summarize!("Source text.", false);
+
+    expect(summary).toBe("Visible provider summary.");
+    expect(summary).not.toContain("PRIVATE_TRAILING_REASONING");
     expect(deps.complete).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #564.  Refs #829, #471, #542, #485, #493, #503, #547.

## Summary

PR #503 in v0.9.3 closed #493 by sanitizing summarizer **input** at `CompactionEngine.leafPass` only.  Three gaps remained.  This PR closes the two that are safe to ship inline; the third (legacy-data doctor remediation) is deferred with rationale below.

### B1 — output-side reasoning leakage (`src/summarize.ts`)

When `summaryModel` is itself reasoning-capable (vLLM+Qwen3 per #471, Kimi K2.6 per #542), the provider has been observed to leak reasoning text past the per-block-type filter — typically wrapped in `<think>…</think>` / `<thinking>…</thinking>` / `<reasoning>…</reasoning>` tags, or opened with a `[thinking]` / `[reasoning]` label.  The new `looksLikeReasoningOnlySummary` guardrail detects those shapes and treats the summary as empty so the existing envelope → retry → deterministic-fallback chain runs, instead of silently persisting reasoning text as the summary body.  The guardrail re-runs after the retry call too, so a reasoning-shaped retry response also drops to deterministic fallback rather than getting stored.

### B2 — `extractMeaningfulMessageText` lifted to every summarizer boundary (`src/compaction.ts`)

The helper is now applied at three entry points:
- `leafPass` (kept; this is what #503 added)
- `condensedPass` — sanitizes each summary record's stored `content` before the condensed/merge re-summarization
- `resolvePriorSummaryContextAtDepth` — sanitizes prior-summary context fed back into the summarizer

This closes the path where pre-#503 leaf summaries (legacy data containing embedded thinking blocks) could re-introduce reasoning text at higher levels of the summary DAG.  The helper is now exported (`@internal` for tests).

### F8 — doctor remediation (deferred, documented)

The issue lists a third sub-fix: a doctor cleaner rule that detects assistant rows whose JSON content array contains only `{type:"thinking", ...}` or has a `thinkingSignature`, then rewrites or deletes them with a backup table.

I'm **deferring F8** rather than faking it.  The current doctor cleaner architecture (`src/plugin/lcm-doctor-cleaners.ts`) operates exclusively at the **conversation level** — every cleaner deletes whole conversations matching a SQL predicate (archived subagents, cron sessions, NULL-key subagent context).  None do per-row content rewriting, and none stage destructive operations through a backup table.  Implementing F8 well requires a new backup-table pattern that subsequent doctor work (the #547 NULL-key feishu request, future content-level cleaners) will benefit from inheriting.  That's worth its own focused PR with the architecture written up; bolting it into PR-4 would either inherit poor scaffolding or balloon the diff and earn a barnacle close.

The `extractMeaningfulMessageText` sanitizer added by B2 already protects the **summarization path** against legacy data — pre-#503 leaf summaries with embedded thinking blocks no longer leak into condensed summaries or prior-summary context.  Legacy raw assistant rows in conversation history still exist in the DB, but the summarizer can no longer re-ingest them as reasoning text; they only matter on direct read paths.

## Files / line counts

| Sub-fix | File | Lines |
|---|---|---|
| B2 — exports + JSDoc on shared sanitizer | `src/compaction.ts` (line 313 helper) | +11/-1 |
| B2 — sanitize stored summary content in `condensedPass` | `src/compaction.ts` (~line 1620) | +9/-3 |
| B2 — sanitize stored summary content in `resolvePriorSummaryContextAtDepth` | `src/compaction.ts` (~line 1315) | +6/-3 |
| B1 — `looksLikeReasoningOnlySummary` helper | `src/summarize.ts` (~line 327) | +44 |
| B1 — guardrail wired into initial-extract path | `src/summarize.ts` (~line 1582) | +15 |
| B1 — guardrail wired into retry-extract path | `src/summarize.ts` (~line 1620) | +12 |
| Tests | `test/reasoning-half-fix.test.ts` | +279 |
| Changeset | `.changeset/pr4-reasoning-half-fix-completion.md` | +9 |

**Production: ~95 LoC.  Tests: ~279 LoC.**  Both within the brief's budget.

## Test plan

- [x] `npm test` baseline before changes — 833 passing
- [x] `npm test` after changes — 844 passing (833 + 11 new in `test/reasoning-half-fix.test.ts`)
- [x] `npm run build` — clean
- [x] `extractMeaningfulMessageText` unit tests cover thinking, reasoning, redacted_thinking blocks, structured-message wrappers, and prose passthrough
- [x] Output-side guardrail tests cover: `<think>`-wrapped first attempt → retry recovers; both attempts reasoning-shaped → deterministic fallback (NOT silent persist); `[thinking]` prefix detected; clean text containing the word "reasoning" passes through unchanged

## Defending against barnacle close

All three diffs (B1, B2, deferred F8 explanation) are about end-to-end reasoning-block handling — the same root cause as #503.  B1 closes silent-persist on the **output** side, B2 closes the gap on **non-leaf** paths and legacy data through the summarization pipeline.  F8's deferral is documented inline so reviewers can see the reasoning rather than guessing why a sub-item is missing.

