### PR TITLE
fix(afterTurn): fail closed on oversized no-overlap dedup

### DIFF
--- a/.changeset/afterturn-oversized-no-overlap-fail-closed.md
+++ b/.changeset/afterturn-oversized-no-overlap-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fail closed when oversized afterTurn dedup batches have no overlap with the stored LCM tail, preventing short stale runtime snapshots from being imported as fresh duplicate rows.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5365,13 +5365,18 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    // Fall back to suffix matching.
+    // Fall back to suffix matching. If the DB is already longer than the
+    // incoming afterTurn batch and no suffix overlap exists, fail closed:
+    // importing the whole short batch as new would duplicate/pollute LCM with
+    // stale runtime tail snapshots. The transcript reconcile path runs before
+    // this and is responsible for importing genuine missing JSONL tail turns.
     return this.deduplicateSuffixFallback(
       conversationId,
       batch,
       storedBatch,
       storedMessageCount,
       "oversized",
+      { onNoOverlap: "skip" },
     );
   }
 
@@ -5386,6 +5391,7 @@ export class LcmContextEngine implements ContextEngine {
     storedBatch: ReturnType<typeof toStoredMessage>[],
     storedMessageCount: number,
     context: string,
+    options?: { onNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
     const allStored = await this.conversationStore.getMessages(conversationId, {
       limit: storedMessageCount,
@@ -5430,6 +5436,14 @@ export class LcmContextEngine implements ContextEngine {
         );
         return newSlice;
       }
+    }
+
+    if (options?.onNoOverlap === "skip") {
+      this.deps.log.warn(
+        `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
+          `no overlap found — fail-closed skipping full batch`,
+      );
+      return [];
     }
 
     this.deps.log.warn(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9803,6 +9803,54 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(stored.map((m) => m.content)).toEqual(["hello", "world"]);
   });
 
+  it("fails closed for oversized no-overlap afterTurn batches", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "dedup-oversized-no-overlap-fail-closed";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-fail-closed"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "assistant", content: "old B" }),
+        makeMessage({ role: "tool", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // Simulates a short afterTurn runtime snapshot that has no overlap with
+    // the longer stored LCM conversation. Before this guard, LCM imported the
+    // whole batch as fresh rows and polluted context; the transcript reconcile
+    // path is responsible for genuine missing JSONL tail imports before this
+    // dedup check runs.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-fail-closed-2"),
+      messages: [
+        makeMessage({ role: "user", content: "unanchored user" }),
+        makeMessage({ role: "assistant", content: "unanchored assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["old A", "old B", "old C"]);
+    expect(warnLog).toHaveBeenCalledWith(
+      `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — fail-closed skipping full batch`,
+    );
+  });
+
   it("preserves a legitimate repeated first new message", async () => {
     const engine = createEngine();
     const sessionId = "dedup-repeated-first-new-message";


### PR DESCRIPTION
## Summary

Fixes the hazardous afterTurn dedup fallback for the `storedMessageCount > batch.length` path.

When LCM already has more stored messages than the incoming afterTurn batch, and the short incoming batch has no suffix overlap with the DB tail, the previous behavior was to import the entire batch as fresh content:

```text
[lcm] dedup: oversized, storedCount=<n> batchLen=<n>, no overlap found — ingesting full batch
```

That is the exact failure mode observed in #566: stale/short runtime tail snapshots can be repeatedly inserted as new LCM rows, creating duplicate `messages` and duplicate selected `context_items`.

This PR changes only the oversized/no-overlap path to fail closed instead of importing the ambiguous batch.

## Why this is safe

For genuine missing transcript tail messages, `afterTurn` already runs transcript reconciliation before afterTurn batch dedup. The oversized/no-overlap afterTurn batch is therefore not a safe source of truth when it cannot be anchored to stored LCM history.

Normal append/replay behavior is unchanged:

- aligned tails still skip duplicates
- suffix-overlap replay still imports only new suffix content
- non-oversized no-overlap behavior still preserves the existing fallback
- terminal one-message matches are still not treated as full replays

## Changes

- Add `onNoOverlap: "skip"` behavior to `deduplicateSuffixFallback`
- Use that fail-closed behavior only from `deduplicateOversizedBatch`
- Log a distinct warning:
  - `no overlap found — fail-closed skipping full batch`
- Add regression coverage for oversized/no-overlap afterTurn batches
- Add changeset

## Tests

```bash
npm test -- --run test/engine.test.ts -t "afterTurn dedup guard"
npm test -- --run test/engine.test.ts
npm run build
npm test
```

Results:

- afterTurn dedup guard: 14 passed
- engine.test.ts: 214 passed
- full test suite: 837 passed
- build: passed

Closes #566.
