### PR TITLE
fix: activate context engine on startup

### DIFF
--- a/.changeset/startup-activation-context-engine.md
+++ b/.changeset/startup-activation-context-engine.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare startup activation in the OpenClaw plugin manifest so OpenClaw 2026.5.2-era startup/runtime plugin planning loads Lossless Claw before resolving the configured context engine.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "lossless-claw",
   "kind": "context-engine",
+  "activation": {
+    "onStartup": true
+  },
   "skills": [
     "skills/lossless-claw"
   ],

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -95,10 +95,8 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
     expect(declared).toEqual(expected);
   });
 
-  // Note: `manifest.kind === "context-engine"` is asserted in
-  // `test/config.test.ts` ("declares context-engine kind so OpenClaw core
-  // binds the contextEngine slot on install"). That assertion also covers
-  // the Windows-installer hook-pack-detector concern from #451 since the
-  // `kind` field is the same discriminator in both cases — no duplicate
-  // assertion needed here.
+  it("declares startup activation until OpenClaw always loads selected context-engine plugins", () => {
+    expect(manifest.kind).toBe("context-engine");
+    expect(manifest.activation?.onStartup).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `activation.onStartup: true` to the Lossless Claw OpenClaw manifest.

This is a compatibility mitigation for OpenClaw 2026.5.2-era startup/runtime plugin planning where an installed/enabled/selected external context-engine plugin can be omitted from the scoped runtime plugin set unless it declares startup activation. In that state OpenClaw can later resolve `plugins.slots.contextEngine = "lossless-claw"`, find no registered engine, and fall back to `legacy`.

## Why

Refs openclaw/openclaw#76576. The durable upstream fix should still be for OpenClaw core to always load the selected non-legacy `plugins.slots.contextEngine` plugin as a required runtime dependency. This PR makes Lossless resilient on affected installs in the meantime.

## Changes

- Declare `activation.onStartup: true` in `openclaw.plugin.json`
- Add a manifest regression test asserting context-engine kind + startup activation
- Add a patch changeset

## Testing

- `npx vitest run test/manifest.test.ts test/config.test.ts`
- `npm run build`
- `git diff --check`
