### PR TITLE
fix(assembler): drop empty content for user/toolResult roles, not only assistant

### DIFF
--- a/.changeset/drop-empty-content-all-roles.md
+++ b/.changeset/drop-empty-content-all-roles.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix Bedrock `messages.0 is empty` validation rejection by extending the assemble pass's empty-content filter to cover `user` and `toolResult` roles, not only `assistant`. Previously an empty content array briefly produced upstream during incremental compaction could survive the cleaned-tail filter and be sent to Bedrock Converse, which rejects it with `The content field in the Message object at messages.N is empty. Add a ContentBlock object to the content field and try again.` The new unified `isEmptyMessageContent` helper drops empty-array, empty-string, null, and undefined content for any role while preserving the existing assistant-only thinking-only / blank-text guards.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -123,6 +123,50 @@ function isBlankContent(content: unknown[]): boolean {
   return content.every(isBlankTextBlock);
 }
 
+/** Returns true when a message's `content` is an empty/blank shape that the
+ *  Bedrock Converse API (and other strict providers) will reject.
+ *
+ *  Specifically guards against:
+ *  - `content === undefined` or `content === null`
+ *  - `content === ""` or whitespace-only string
+ *  - `content === []` (empty array) for **any** role
+ *  - For `assistant`: arrays that are thinking-only or blank-text-only,
+ *    since the provider layer strips reasoning blocks and forwards a
+ *    `[{type:"text", text:""}]` shape, both of which Bedrock rejects.
+ *
+ *  Bedrock Converse rejects empty `user` and `toolResult` content arrays
+ *  with the literal wording:
+ *    `The content field in the Message object at messages.N is empty.
+ *     Add a ContentBlock object to the content field and try again.`
+ *  This wording is reproducible only when `content === []`; bare strings or
+ *  non-empty arrays produce different validation errors. The pre-existing
+ *  filter only protected the assistant role, leaving an asymmetric gap that
+ *  fires during incremental compaction when an empty user/toolResult shape
+ *  can be momentarily produced upstream.
+ *
+ * @internal Exported for testing only.
+ */
+export function isEmptyMessageContent(message: {
+  role?: unknown;
+  content?: unknown;
+}): boolean {
+  if (!message) return true;
+  const content = message.content;
+  if (content === undefined || content === null) return true;
+  if (Array.isArray(content)) {
+    if (content.length === 0) return true;
+    if (message.role === "assistant") {
+      if (isThinkingOnlyContent(content)) return true;
+      if (isBlankContent(content)) return true;
+    }
+    return false;
+  }
+  if (typeof content === "string") {
+    return content.trim() === "";
+  }
+  return false;
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface AssembleContextInput {
@@ -1273,23 +1317,22 @@ export class ContextAssembler {
       return entry;
     });
 
-    // Filter out assistant messages with empty, blank, or thinking-only
-    // content — these can occur when tool-use-only turns are stored with
-    // content="" and zero message_parts, when filterNonFreshAssistantToolCalls
-    // strips all tool_use blocks, when a turn contains only thinking/reasoning
-    // blocks that will be stripped by the provider layer, or when the stored
-    // content is a `[{type:"text", text:""}]` blank-text shape. Anthropic and
-    // Bedrock reject any of these as empty.
+    // Filter messages whose content normalises to no content — these can occur
+    // when tool-use-only turns are stored with content="" and zero
+    // message_parts, when filterNonFreshAssistantToolCalls strips all tool_use
+    // blocks, when an assistant turn contains only thinking/reasoning blocks
+    // that will be stripped by the provider layer, when the stored content is
+    // a `[{type:"text", text:""}]` blank-text shape, or when an upstream layer
+    // momentarily produces an empty `user` or `toolResult` content array
+    // during incremental compaction. Anthropic and Bedrock reject any of these
+    // as empty; Bedrock's specific wording for `content === []` is
+    // `The content field in the Message object at messages.N is empty.
+    //  Add a ContentBlock object to the content field and try again.`
+    // Dropping a `toolResult` here is safe — sanitizeToolUseResultPairing runs
+    // immediately below and re-pairs missing results with a synthetic
+    // `[lossless-claw] missing tool result …` placeholder.
     const cleanedEntries = normalizedEntries.filter(
-      (entry) =>
-        !(
-          entry.message?.role === "assistant" &&
-          (Array.isArray(entry.message.content)
-            ? entry.message.content.length === 0 ||
-              isThinkingOnlyContent(entry.message.content) ||
-              isBlankContent(entry.message.content)
-            : !entry.message.content || entry.message.content.trim() === "")
-        ),
+      (entry) => !isEmptyMessageContent(entry.message),
     );
     const cleaned = cleanedEntries.map((entry) => entry.message);
     const preSanitizeEvictableMessages = cleanedEntries

--- a/test/assembler-empty-content.test.ts
+++ b/test/assembler-empty-content.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { isEmptyMessageContent } from "../src/assembler.js";
+
+/**
+ * Regression coverage for the asymmetric empty-content filter.
+ *
+ * Before the fix `cleanedEntries` only dropped empty content for `assistant`
+ * messages, so an empty-array `user` or `toolResult` produced upstream during
+ * incremental compaction would survive the assemble pass and hit Bedrock's
+ * Converse validator with the literal wording:
+ *
+ *   `The content field in the Message object at messages.0 is empty.
+ *    Add a ContentBlock object to the content field and try again.`
+ *
+ * The unified helper now drops empty-content for any role, while preserving
+ * the existing assistant-only thinking-only / blank-text guards.
+ */
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// isEmptyMessageContent — shared empty / null / undefined handling
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("isEmptyMessageContent — universal empties", () => {
+  it("returns true when message is null-like", () => {
+    expect(isEmptyMessageContent(null as unknown as { content?: unknown })).toBe(true);
+    expect(isEmptyMessageContent(undefined as unknown as { content?: unknown })).toBe(true);
+  });
+
+  it.each(["user", "assistant", "toolResult"])(
+    "returns true for role=%s with content === undefined",
+    (role) => {
+      expect(isEmptyMessageContent({ role, content: undefined })).toBe(true);
+    },
+  );
+
+  it.each(["user", "assistant", "toolResult"])(
+    "returns true for role=%s with content === null",
+    (role) => {
+      expect(isEmptyMessageContent({ role, content: null })).toBe(true);
+    },
+  );
+
+  it.each(["user", "assistant", "toolResult"])(
+    "returns true for role=%s with content === [] (the production failure shape)",
+    (role) => {
+      expect(isEmptyMessageContent({ role, content: [] })).toBe(true);
+    },
+  );
+
+  it.each(["user", "assistant", "toolResult"])(
+    "returns true for role=%s with content === '' (empty string)",
+    (role) => {
+      expect(isEmptyMessageContent({ role, content: "" })).toBe(true);
+    },
+  );
+
+  it.each(["user", "assistant", "toolResult"])(
+    "returns true for role=%s with whitespace-only string content",
+    (role) => {
+      expect(isEmptyMessageContent({ role, content: "   \n\t  " })).toBe(true);
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// isEmptyMessageContent — non-empty shapes are preserved across roles
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("isEmptyMessageContent — non-empty shapes", () => {
+  it.each(["user", "assistant", "toolResult"])(
+    "returns false for role=%s with a single non-empty text block",
+    (role) => {
+      expect(
+        isEmptyMessageContent({
+          role,
+          content: [{ type: "text", text: "hello" }],
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("returns false for user role with non-empty string content", () => {
+    expect(isEmptyMessageContent({ role: "user", content: "ping" })).toBe(false);
+  });
+
+  it("returns false for assistant role with a tool_use block", () => {
+    expect(
+      isEmptyMessageContent({
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "x" } }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for toolResult with the synthetic transcript-repair placeholder shape", () => {
+    expect(
+      isEmptyMessageContent({
+        role: "toolResult",
+        content: [
+          {
+            type: "text",
+            text: "[lossless-claw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// isEmptyMessageContent — assistant-specific guards remain in place
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("isEmptyMessageContent — assistant-only guards", () => {
+  it("returns true for assistant content that is thinking-only", () => {
+    expect(
+      isEmptyMessageContent({
+        role: "assistant",
+        content: [
+          { type: "thinking", text: "internal reasoning" },
+          { type: "redacted_thinking", text: "[redacted]" },
+          { type: "reasoning", text: "more reasoning" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for assistant content that is blank-text-only", () => {
+    expect(
+      isEmptyMessageContent({
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "text", text: "   " },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for user content that happens to look like a thinking block", () => {
+    // The thinking-only / blank-text guards are deliberately scoped to the
+    // assistant role: thinking blocks are stripped downstream only on the
+    // assistant side. User-authored content that mentions "thinking" should
+    // never be treated as empty.
+    expect(
+      isEmptyMessageContent({
+        role: "user",
+        content: [{ type: "thinking", text: "user-supplied raw text" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for assistant content that mixes thinking and a real text block", () => {
+    expect(
+      isEmptyMessageContent({
+        role: "assistant",
+        content: [
+          { type: "thinking", text: "internal" },
+          { type: "text", text: "Here is the answer." },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Regression: the exact production failure shape
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Bedrock 'messages.0 is empty' regression", () => {
+  it("drops a user message with content === [] when run through a filter that uses isEmptyMessageContent", () => {
+    const messages = [
+      { role: "user", content: [] },
+      { role: "user", content: [{ type: "text", text: "real question" }] },
+    ];
+
+    const cleaned = messages.filter((m) => !isEmptyMessageContent(m));
+
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "real question" }],
+    });
+  });
+
+  it("drops a toolResult with content === [] (sanitize will re-pair with a synthetic result)", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "x" } }],
+      },
+      { role: "toolResult", toolCallId: "call_1", content: [] },
+    ];
+
+    const cleaned = messages.filter((m) => !isEmptyMessageContent(m));
+
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0]?.role).toBe("assistant");
+  });
+});


### PR DESCRIPTION
## Summary

Fix Bedrock `messages.N is empty` validation rejection by extending the assemble pass's empty-content filter to cover `user` and `toolResult` roles, not only `assistant`.

The pre-existing `cleanedEntries` filter at `src/assembler.ts` only guarded the `assistant` role. An empty content array produced upstream for a `user` or `toolResult` message during incremental compaction could survive the cleaned-tail pass and reach Bedrock Converse, which rejects it with the literal wording:

> `Validation error: The content field in the Message object at messages.0 is empty. Add a ContentBlock object to the content field and try again.`

A direct probe against `eu.anthropic.claude-haiku-4-5-20251001-v1:0` via `ConverseCommand` confirms this exact wording is reproducible only when `content === []` (empty array); bare strings produce a different `SerializationException` error, so the production wording is specific to the empty-array shape.

The asymmetry between the assistant guard and the missing user/toolResult guard explains why the v0.9.3 prefill safety net (#572) and the v0.9.4 blank-text guard did not fully close the validation surface.

## Production reproduction signal

Observed in a long-running OpenClaw session against `eu.anthropic.claude-opus-4-6-v1` via `bedrock-converse-stream`. The failed turn was recorded as:

```json
{
  "type": "message",
  "timestamp": "2026-05-01T07:50:52.195Z",
  "message": {
    "role": "assistant",
    "content": [{"type":"text","text":"[assistant turn failed before producing content]"}],
    "api": "bedrock-converse-stream",
    "provider": "amazon-bedrock",
    "model": "eu.anthropic.claude-opus-4-6-v1",
    "stopReason": "error",
    "errorMessage": "Validation error: The content field in the Message object at messages.0 is empty. Add a ContentBlock object to the content field and try again."
  }
}
```

Timeline (the LCM `conversations` row for this session at the time of failure):

| UTC time | Event |
|---|---|
| 07:29:24 | First leaf summary `sum_14ac9f3745cdfa00` created |
| 07:32:50–07:33:12 | Active turns (subagent calls + tool results) |
| **07:50:51** | **New leaf summary `sum_91b1ebdf4c1bb243` committed** |
| **07:50:52** | **Assistant turn fails with `messages.0 is empty`** (≤1 s after the summary) |
| 07:58:21 | Third leaf summary created on retry |
| 07:58:32 | Fourth leaf summary + second identical failure |

The ≤1 s delta between summary commit and failure points to a transient mid-compaction state rather than a persisted shape — replaying the same conversation's stored `lcm.db` state today through the assemble pipeline produces zero empty-array messages, so the empty array is produced and consumed within the compaction window.

## What changed

1. **New helper `isEmptyMessageContent(message)`** in `src/assembler.ts` (exported with `@internal` JSDoc, matching the existing `toolCallBlockFromPart` / `toolResultBlockFromPart` / `blockFromPart` / `contentFromParts` convention). It returns `true` when content is:
   - `undefined` or `null`
   - empty string `""` or whitespace-only string
   - empty array `[]` for **any** role
   - thinking-only or blank-text-only content for the `assistant` role specifically (preserves the existing v0.9.3 / v0.9.4 guards)

2. **Replace the `cleanedEntries` filter** to use the new helper. The filter now drops empty content for any role.

3. **Extended comment** on the filter explains the new compaction-window failure mode and notes that dropping a `toolResult` is safe because `sanitizeToolUseResultPairing` runs immediately afterwards and re-pairs missing results with the existing synthetic `[lossless-claw] missing tool result …` placeholder.

4. **Regression test** `test/assembler-empty-content.test.ts` (28 cases):
   - universal empty handling across `user`/`assistant`/`toolResult`
   - non-empty preservation across the same three roles
   - assistant-only thinking-only / blank-text guards remain in place
   - the exact production failure shape (empty-array `user` and `toolResult`)

5. **Changeset** (`patch` bump per `AGENTS.md` guidance for fixes / compatibility work).

## Risk and compatibility

- The helper preserves all pre-existing behaviour for the `assistant` role (thinking-only and blank-text-only guards still fire).
- New filtering is strictly additive — empty content arrays for user/toolResult were always rejected by the downstream provider; we now drop them earlier rather than producing an unrecoverable rejection.
- Downstream `sanitizeToolUseResultPairing` already handles missing tool results via synthetic placeholders, so a dropped empty `toolResult` is recoverable.
- No public API change.

## Test plan

- [x] `npm test` — 879 / 886 tests pass on Windows. The 7 failures are pre-existing Windows-specific path/HOME issues (backslashes vs forward slashes, `HOME` env handling) unrelated to this change. Will run green on CI's `ubuntu-latest`.
- [x] `npm test -- test/assembler-empty-content.test.ts test/assembler-blocks.test.ts test/transcript-repair.test.ts` — 75 / 75 green.
- [x] `npm run build` — bundle builds cleanly (688.4 KB).
- [ ] CI green (will run on push).

## Related

- v0.9.3 hotfix #572 (prefill safety net + blank-text guard) — sibling fix, addresses the `text field … is blank` wording for assistant content
- The pre-existing `isThinkingOnlyContent` / `isBlankContent` helpers (lines 97–124) — the new `isEmptyMessageContent` helper builds on them and keeps their assistant-specific scope intact

Happy to iterate on naming, helper placement, or the changeset wording — and to extend the filter to additional empty shapes if maintainers know of other transient post-compaction states that produce them.

Made with [Cursor](https://cursor.com)