### PR TITLE
feat(compaction): opt-in hard-floor for incremental compaction below contextThreshold

### DIFF
--- a/.changeset/compaction-eval-on-empty-ingest.md
+++ b/.changeset/compaction-eval-on-empty-ingest.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix `afterTurn` skipping compaction evaluation when `ingestBatch` is empty. When `deduplicateAfterTurnBatch` removed every new message (e.g. because `afterTurnTranscriptReconcile` or per-message `engine.ingest` calls had already imported them), `afterTurn` would early-return before reaching the compaction policy block. Long-running conversations could accumulate well beyond `contextThreshold` without ever triggering an incremental leaf pass, deferred-compaction debt record, or budget-trigger run — leaving the host's emergency overflow truncation as the only safety net. The early-return is now replaced with a fall-through: when `ingestBatch` is empty the actual `ingestBatch` call is skipped, but token-budget resolution, conversation lookup, and the existing compaction evaluation flow still run. This is observable in the `[lcm] afterTurn: nothing to ingest …` log line, which now ends with `(continuing to compaction evaluation; transcript reconcile may have already ingested)`.

--- a/.changeset/respect-threshold-as-hard-floor.md
+++ b/.changeset/respect-threshold-as-hard-floor.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add opt-in `respectThresholdAsHardFloor` config flag (default `false`). When enabled, `evaluateIncrementalCompaction` short-circuits with `reason="below-context-threshold-floor"` whenever `currentTokenCount < contextThreshold * tokenBudget`, regardless of cache state, leaf trigger, or activity band. Prevents cold-cache catch-up passes from compacting context away during idle gaps for users who want a strict "never compact below X%" policy. Configurable via env var `LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR=true`.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,6 +24,10 @@
       "label": "Context Threshold",
       "help": "Fraction of context window that triggers compaction (0.0–1.0)"
     },
+    "respectThresholdAsHardFloor": {
+      "label": "Respect Threshold as Hard Floor",
+      "help": "When enabled, never run incremental compaction below contextThreshold of the budget — including cold-cache catch-up. Prevents bleed during idle gaps. Default off (no behavior change)."
+    },
     "incrementalMaxDepth": {
       "label": "Incremental Max Depth",
       "help": "How deep incremental compaction goes (0 = leaf only, -1 = unlimited)"
@@ -248,6 +252,9 @@
         "type": "number",
         "minimum": 0,
         "maximum": 1
+      },
+      "respectThresholdAsHardFloor": {
+        "type": "boolean"
       },
       "incrementalMaxDepth": {
         "type": "integer",

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -34,6 +34,12 @@ export interface CompactionResult {
 export interface CompactionConfig {
   /** Context threshold as fraction of budget (default 0.75) */
   contextThreshold: number;
+  /**
+   * PR #619 follow-up — when true, treat `contextThreshold` as a hard
+   * floor for ALL compaction paths (leaf-trigger, condensed-trigger,
+   * incremental, full sweep). Default false preserves existing behavior.
+   */
+  respectThresholdAsHardFloor?: boolean;
   /** Number of fresh tail turns to protect (default 8) */
   freshTailCount: number;
   /** Optional token cap for the protected fresh tail; newest message is always preserved. */
@@ -506,6 +512,30 @@ export class CompactionEngine {
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
     const leafTrigger = await this.evaluateLeafTrigger(conversationId, input.leafChunkTokens);
 
+    // PR #619 follow-up — hard-floor short-circuit for the leaf-trigger path.
+    // The original PR gated `evaluateIncrementalCompaction` and the afterTurn
+    // deferred-debt recording, but NOT `_compactLeafImpl` or its inner
+    // condensed passes. As a result, leaf-trigger (raw-frontier accumulation)
+    // and condensed-trigger (depth-1 fan-out) still fired below the floor.
+    // This produced ~616K source tokens worth of lossy compactions on a
+    // single conversation overnight (2026-05-11 23:32 → 05-12 04:31), all
+    // while the operator believed the floor was holding. Honor the same
+    // semantics the commit message promised: never compact when current
+    // tokens are below `contextThreshold * tokenBudget`, *regardless* of
+    // leaf trigger, cache state, or activity band.
+    if (
+      !force
+      && this.config.respectThresholdAsHardFloor
+      && tokensBefore < threshold
+    ) {
+      return {
+        actionTaken: false,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        condensed: false,
+      };
+    }
+
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {
         actionTaken: false,
@@ -567,6 +597,18 @@ export class CompactionEngine {
     let runningTokens = tokensAfterLeaf;
     if (incrementalMaxDepth > 0 && input.allowCondensedPasses !== false) {
       for (let targetDepth = 0; targetDepth < incrementalMaxDepth; targetDepth++) {
+        // PR #619 follow-up — re-check the hard-floor between condensed
+        // passes. The outer leaf pass may have legitimately fired (we
+        // started above the threshold), but its token-reduction could
+        // push runningTokens below the floor. From that point onward,
+        // subsequent condensed passes must respect the floor too.
+        if (
+          !force
+          && this.config.respectThresholdAsHardFloor
+          && runningTokens < threshold
+        ) {
+          break;
+        }
         const fanout = this.resolveFanoutForDepth(targetDepth, false);
         const chunk = await this.selectOldestChunkAtDepth(conversationId, targetDepth);
         if (chunk.items.length < fanout || chunk.summaryTokens < condensedMinChunkTokens) {
@@ -636,6 +678,23 @@ export class CompactionEngine {
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
     const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+
+    // PR #619 follow-up — hard-floor short-circuit for compactFullSweep,
+    // same semantics as _compactLeafImpl. Without this, a full sweep
+    // triggered while the conversation was below the floor would still
+    // chew through raw frontier via leaf-trigger.
+    if (
+      !force
+      && this.config.respectThresholdAsHardFloor
+      && tokensBefore < threshold
+    ) {
+      return {
+        actionTaken: false,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        condensed: false,
+      };
+    }
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
       return {

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -91,6 +91,14 @@ export type LcmConfig = {
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
   contextThreshold: number;
+  /**
+   * When true, treat `contextThreshold` as a hard floor for incremental
+   * compaction: never propose a compaction pass while currentTokenCount is
+   * below `contextThreshold * tokenBudget`, regardless of cache state, leaf
+   * trigger, or activity band. Prevents cold-cache catch-up passes from
+   * bleeding context away during idle gaps. Default false (no behavior change).
+   */
+  respectThresholdAsHardFloor: boolean;
   freshTailCount: number;
   /** Optional token cap for the protected fresh tail; newest message is always preserved. */
   freshTailMaxTokens?: number;
@@ -432,6 +440,10 @@ export function resolveLcmConfigWithDiagnostics(
       contextThreshold:
         parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
           ?? toNumber(pc.contextThreshold) ?? 0.75,
+      respectThresholdAsHardFloor:
+        env.LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR !== undefined
+          ? env.LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR === "true"
+          : toBool(pc.respectThresholdAsHardFloor) ?? false,
       freshTailCount:
         parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
           ?? toNumber(pc.freshTailCount) ?? 64,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1899,6 +1899,11 @@ export class LcmContextEngine implements ContextEngine {
 
     const compactionConfig: CompactionConfig = {
       contextThreshold: this.config.contextThreshold,
+      // PR #619 follow-up — plumb hard-floor flag into the compaction
+      // engine so leaf-trigger / condensed paths respect it (was only
+      // gated in engine-level evaluateIncrementalCompaction + afterTurn
+      // deferred-debt recording before this).
+      respectThresholdAsHardFloor: this.config.respectThresholdAsHardFloor,
       freshTailCount: this.config.freshTailCount,
       freshTailMaxTokens: this.config.freshTailMaxTokens,
       leafMinFanout: this.config.leafMinFanout,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6546,6 +6546,23 @@ export class LcmContextEngine implements ContextEngine {
           }
         }
       } else if (thresholdDecision.shouldCompact || rawLeafTrigger?.shouldCompact) {
+        // Hard-floor: in deferred mode, `thresholdDecision` and `rawLeafTrigger`
+        // come from `compaction.evaluate` / `evaluateLeafTrigger` directly and do
+        // not consult `respectThresholdAsHardFloor`. Without this guard, debt
+        // would accumulate from below-floor leaf-trigger fires and later drain
+        // via paths that do not re-check the floor — leaking the hard-floor
+        // semantics. Skip debt recording entirely when below floor.
+        if (
+          this.config.respectThresholdAsHardFloor
+          && typeof observedCurrentTokenCount === "number"
+          && Number.isFinite(observedCurrentTokenCount)
+          && observedCurrentTokenCount
+            < Math.floor(this.config.contextThreshold * tokenBudget)
+        ) {
+          this.deps.log.info(
+            `[lcm] afterTurn: skipping deferred compaction debt below context-threshold floor conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${observedCurrentTokenCount} threshold=${Math.floor(this.config.contextThreshold * tokenBudget)}`,
+          );
+        } else {
         const deferredReason = thresholdDecision.shouldCompact
           ? "threshold"
           : leafDecision.shouldCompact
@@ -6579,6 +6596,7 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
           reason: deferredReason,
         };
+        }
       }
     } catch (err) {
       this.deps.log.warn(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6326,38 +6326,43 @@ export class LcmContextEngine implements ContextEngine {
 
     ingestBatch.push(...summaryDedupedNewMessages);
     if (ingestBatch.length === 0) {
+      // Nothing to ingest in *this* afterTurn call — but the conversation may
+      // still be over threshold from prior turns, especially when the host
+      // path (e.g. afterTurnTranscriptReconcile, or external `engine.ingest`
+      // calls during the turn) already imported the new messages before
+      // afterTurn's dedup ran. Log and fall through to compaction evaluation
+      // rather than early-returning, otherwise compaction would never fire
+      // once dedup begins consistently swallowing new turn deltas.
       this.deps.log.info(
-        `[lcm] afterTurn: nothing to ingest ${sessionLabel} newMessages=${newMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
+        `[lcm] afterTurn: nothing to ingest ${sessionLabel} newMessages=${newMessages.length} (continuing to compaction evaluation; transcript reconcile may have already ingested) duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
-      await runRuntimeAutoRotate();
-      return;
-    }
-
-    try {
-      await this.ingestBatch({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        messages: ingestBatch,
-        isHeartbeat: params.isHeartbeat === true,
-      });
-    } catch (err) {
-      // Never compact a stale or partially ingested frontier.
-      this.deps.log.error(
-        `[lcm] afterTurn: ingest failed, skipping compaction: ${describeLogError(err)}`,
-      );
-      this.logAutoRotateSessionFileDecision({
-        phase: "runtime",
-        action: "skip",
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        thresholdBytes: this.config.autoRotateSessionFiles.sizeBytes,
-        durationMs: 0,
-        reason: "ingest-failed",
-        error: describeLogError(err),
-        level: "warn",
-      });
-      return;
+    } else {
+      try {
+        await this.ingestBatch({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          messages: ingestBatch,
+          isHeartbeat: params.isHeartbeat === true,
+        });
+      } catch (err) {
+        // Never compact a stale or partially ingested frontier.
+        this.deps.log.error(
+          `[lcm] afterTurn: ingest failed, skipping compaction: ${describeLogError(err)}`,
+        );
+        this.logAutoRotateSessionFileDecision({
+          phase: "runtime",
+          action: "skip",
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          thresholdBytes: this.config.autoRotateSessionFiles.sizeBytes,
+          durationMs: 0,
+          reason: "ingest-failed",
+          error: describeLogError(err),
+          level: "warn",
+        });
+        return;
+      }
     }
 
     if (batchLooksLikeHeartbeatAckTurn(ingestBatch)) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2819,6 +2819,40 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget: number;
     currentTokenCount?: number;
   }): Promise<IncrementalCompactionDecision> {
+    // Hard-floor short-circuit: when respectThresholdAsHardFloor is enabled,
+    // never propose compaction below contextThreshold of the token budget,
+    // regardless of cache state, leaf trigger, or activity band. This prevents
+    // cold-cache catch-up passes from compacting away context during idle gaps.
+    // Opt-in: default false preserves existing behavior.
+    if (this.config.respectThresholdAsHardFloor) {
+      const minTokenFloor = Math.floor(this.config.contextThreshold * params.tokenBudget);
+      if (
+        typeof params.currentTokenCount === "number"
+        && Number.isFinite(params.currentTokenCount)
+        && params.currentTokenCount < minTokenFloor
+      ) {
+        return this.logIncrementalCompactionDecision({
+          conversationId: params.conversationId,
+          cacheState: "unknown",
+          activityBand: "low",
+          tokenBudget: params.tokenBudget,
+          currentTokenCount: params.currentTokenCount,
+          cacheRead: null,
+          cacheWrite: null,
+          cachePromptTokenCount: null,
+          triggerLeafChunkTokens: 0,
+          preferredLeafChunkTokens: 0,
+          fallbackLeafChunkTokens: [],
+          rawTokensOutsideTail: 0,
+          threshold: minTokenFloor,
+          shouldCompact: false,
+          maxPasses: 1,
+          allowCondensedPasses: false,
+          reason: "below-context-threshold-floor",
+        });
+      }
+    }
+
     const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
       params.conversationId,
     );

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -28,6 +28,7 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
     expect(config.contextThreshold).toBe(0.75);
+    expect(config.respectThresholdAsHardFloor).toBe(false);
     expect(config.freshTailCount).toBe(64);
     expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.promptAwareEviction).toBe(false);
@@ -67,6 +68,7 @@ describe("resolveLcmConfig", () => {
   it("reads values from plugin config", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: 0.5,
+      respectThresholdAsHardFloor: true,
       freshTailCount: 16,
       freshTailMaxTokens: 12000,
       promptAwareEviction: false,
@@ -109,6 +111,7 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual(["agent:*:ephemeral:**"]);
     expect(config.skipStatelessSessions).toBe(false);
     expect(config.contextThreshold).toBe(0.5);
+    expect(config.respectThresholdAsHardFloor).toBe(true);
     expect(config.freshTailCount).toBe(16);
     expect(config.freshTailMaxTokens).toBe(12000);
     expect(config.promptAwareEviction).toBe(false);
@@ -144,6 +147,7 @@ describe("resolveLcmConfig", () => {
   it("env vars override plugin config", () => {
     const env = {
       LCM_CONTEXT_THRESHOLD: "0.9",
+      LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR: "true",
       LCM_FRESH_TAIL_COUNT: "64",
       LCM_FRESH_TAIL_MAX_TOKENS: "32000",
       LCM_PROMPT_AWARE_EVICTION_ENABLED: "false",
@@ -219,6 +223,7 @@ describe("resolveLcmConfig", () => {
       runtime: "off",
     });
     expect(config.contextThreshold).toBe(0.9); // env wins
+    expect(config.respectThresholdAsHardFloor).toBe(true); // env wins
     expect(config.freshTailCount).toBe(64); // env wins
     expect(config.freshTailMaxTokens).toBe(32000); // env wins
     expect(config.promptAwareEviction).toBe(false); // env wins

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9321,6 +9321,151 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.shouldCompact).toBe(false);
   });
 
+  it("evaluateIncrementalCompaction allows existing logic at exact floor boundary even with hard-floor enabled", async () => {
+    const engine = createEngineWithDeps({
+      respectThresholdAsHardFloor: true,
+      contextThreshold: 0.7,
+    });
+    const sessionId = "incremental-hard-floor-boundary";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{ shouldCompact: boolean; reason: string }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+
+    // The check uses strict `<`; at exact equality, existing logic runs.
+    const leafTriggerSpy = vi
+      .spyOn(privateEngine.compaction, "evaluateLeafTrigger")
+      .mockResolvedValue({
+        shouldCompact: false,
+        rawTokensOutsideTail: 5_000,
+        threshold: 20_000,
+      });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 200_000,
+      currentTokenCount: 140_000, // exactly 0.7 * 200_000 = floor.
+    });
+
+    expect(leafTriggerSpy).toHaveBeenCalled();
+    expect(decision.reason).toBe("below-leaf-trigger");
+  });
+
+  it("evaluateIncrementalCompaction falls through to existing logic when currentTokenCount is undefined even with hard-floor enabled", async () => {
+    const engine = createEngineWithDeps({
+      respectThresholdAsHardFloor: true,
+      contextThreshold: 0.7,
+    });
+    const sessionId = "incremental-hard-floor-undefined-current";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{ shouldCompact: boolean; reason: string }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+
+    const leafTriggerSpy = vi
+      .spyOn(privateEngine.compaction, "evaluateLeafTrigger")
+      .mockResolvedValue({
+        shouldCompact: false,
+        rawTokensOutsideTail: 5_000,
+        threshold: 20_000,
+      });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 200_000,
+      // currentTokenCount intentionally omitted.
+    });
+
+    expect(leafTriggerSpy).toHaveBeenCalled();
+    expect(decision.reason).toBe("below-leaf-trigger");
+  });
+
+  it("afterTurn in deferred mode skips deferred-debt recording when below contextThreshold floor", async () => {
+    const engine = createEngineWithDeps({
+      respectThresholdAsHardFloor: true,
+      contextThreshold: 0.7,
+      proactiveThresholdCompactionMode: "deferred",
+    });
+    const sessionId = "after-turn-hard-floor-deferred";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (
+          conversationId: number,
+          leafChunkTokens?: number,
+        ) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+
+    // Both `compaction.evaluate` and `evaluateLeafTrigger` would say "compact"
+    // if asked — but the after-turn floor guard should suppress debt recording.
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 50_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 50_000,
+      threshold: 140_000,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-hard-floor-deferred"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 200_000,
+      runtimeContext: { currentTokenCount: 50_000 }, // 25% — well below 0.7 floor.
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending ?? false).toBe(false);
+  });
+
   it("evaluateIncrementalCompaction treats low cache-read share as cold even when telemetry says hot", async () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7367,6 +7367,140 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.requestedAt).toBeInstanceOf(Date);
   });
 
+  it("afterTurn evaluates compaction when ingestBatch is empty (dedup swallowed everything but conversation may still be over threshold)", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-empty-ingest-still-evaluates-compaction";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (conversationId: number, tokenBudget: number, observed?: number) => Promise<unknown>;
+      };
+      deduplicateAfterTurnBatch: (
+        sessionId: string,
+        sessionKey: string | undefined,
+        messages: AgentMessage[],
+        opts: unknown,
+      ) => Promise<AgentMessage[]>;
+    };
+
+    // Pre-create the conversation via a real ingest so afterTurn's later
+    // conversation lookup succeeds (mirrors a long-running session that has
+    // already had messages stored from prior turns).
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed message" }),
+    });
+
+    // Force every new message to dedup as already-stored — simulates the
+    // afterTurnTranscriptReconcile / per-message ingest race in modern
+    // OpenClaw hosts.
+    vi.spyOn(privateEngine, "deduplicateAfterTurnBatch").mockResolvedValue([]);
+
+    // Conversation IS already over threshold from prior turns.
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 50_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 200_000,
+      threshold: 180_000,
+    });
+
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-empty-ingest-still-evaluates-compaction"),
+      messages: [
+        makeMessage({ role: "user", content: "already-stored user message" }),
+        makeMessage({ role: "assistant", content: "already-stored assistant reply" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 258_000,
+      runtimeContext: { currentTokenCount: 200_000 },
+    });
+
+    // Conversation should exist (created by afterTurn even with empty ingest).
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    // The defining behavior: deferred-mode default records compaction debt
+    // even though ingestBatch was empty. Pre-fix, afterTurn would early-return
+    // and no maintenance row would exist.
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.reason).toBe("threshold");
+
+    // Inline-execution paths should not have fired in deferred mode.
+    expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("afterTurn skips compaction work when ingestBatch is empty AND conversation is below threshold", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-empty-ingest-below-threshold-noop";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (conversationId: number, tokenBudget: number, observed?: number) => Promise<unknown>;
+      };
+      deduplicateAfterTurnBatch: (
+        sessionId: string,
+        sessionKey: string | undefined,
+        messages: AgentMessage[],
+        opts: unknown,
+      ) => Promise<AgentMessage[]>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed message" }),
+    });
+
+    vi.spyOn(privateEngine, "deduplicateAfterTurnBatch").mockResolvedValue([]);
+
+    // Below threshold — leaf trigger off and budget evaluator says no.
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 5_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 30_000,
+      threshold: 180_000,
+    });
+
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-empty-ingest-below-threshold-noop"),
+      messages: [makeMessage({ role: "assistant", content: "already-stored" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 258_000,
+      runtimeContext: { currentTokenCount: 30_000 },
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending ?? false).toBe(false);
+    expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
+    expect(compactSpy).not.toHaveBeenCalled();
+  });
+
   it("afterTurn records deferred leaf debt even when cache heuristics defer execution", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-hot-cache-deferred-leaf-debt";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -31,6 +31,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
     contextThreshold: 0.75,
+    respectThresholdAsHardFloor: false,
     freshTailCount: 8,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
@@ -9145,6 +9146,179 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(infoLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheReadSharePct=20.5%"),
     );
+  });
+
+  it("evaluateIncrementalCompaction short-circuits below contextThreshold when respectThresholdAsHardFloor is enabled", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      { respectThresholdAsHardFloor: true, contextThreshold: 0.7 },
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-hard-floor-below";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{ shouldCompact: boolean; reason: string; threshold: number; cacheState: string }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    // Spies must NOT be invoked when the hard-floor short-circuit fires.
+    const leafTriggerSpy = vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger");
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate");
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 200_000,
+      currentTokenCount: 100_000, // 50% of budget — below 0.7 floor (140k).
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.reason).toBe("below-context-threshold-floor");
+    expect(decision.threshold).toBe(140_000);
+    expect(leafTriggerSpy).not.toHaveBeenCalled();
+    expect(evaluateSpy).not.toHaveBeenCalled();
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=below-context-threshold-floor"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction allows existing compaction logic at/above contextThreshold even when hard-floor is enabled", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      { respectThresholdAsHardFloor: true, contextThreshold: 0.7 },
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-hard-floor-above";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{ shouldCompact: boolean; reason: string }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 60_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 150_000,
+      threshold: 140_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 200_000,
+      currentTokenCount: 150_000, // 75% of budget — above 0.7 floor (140k).
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.reason).toBe("budget-trigger");
+  });
+
+  it("evaluateIncrementalCompaction preserves default behavior when respectThresholdAsHardFloor is disabled", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      { respectThresholdAsHardFloor: false, contextThreshold: 0.7 },
+      {
+        log: {
+          info: infoLog,
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const sessionId = "incremental-hard-floor-disabled";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{ shouldCompact: boolean; reason: string }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    // Without the hard-floor flag, the existing path must run regardless of currentTokenCount.
+    const leafTriggerSpy = vi
+      .spyOn(privateEngine.compaction, "evaluateLeafTrigger")
+      .mockResolvedValue({
+        shouldCompact: false,
+        rawTokensOutsideTail: 5_000,
+        threshold: 20_000,
+      });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 200_000,
+      currentTokenCount: 100_000, // 50% — below 0.7 floor, but flag disabled so logic runs.
+    });
+
+    expect(leafTriggerSpy).toHaveBeenCalled();
+    expect(decision.reason).toBe("below-leaf-trigger");
+    expect(decision.shouldCompact).toBe(false);
   });
 
   it("evaluateIncrementalCompaction treats low cache-read share as cold even when telemetry says hot", async () => {


### PR DESCRIPTION
## TL;DR
**Adds an opt-in config flag `respectThresholdAsHardFloor` (default `false`, no behavior change for existing users).** When enabled, `evaluateIncrementalCompaction` short-circuits with `reason="below-context-threshold-floor"` whenever `currentTokenCount < contextThreshold * tokenBudget`, regardless of cache state, leaf-trigger fires, or activity-band heuristics. The deferred-mode debt-recording path at `engine.ts:6548` is gated under the same predicate to prevent silent leakage of the floor through the deferred drain.

This is a **policy enhancement**, not a bug fix. The default behavior continues to allow cold-cache catch-up passes to fire below threshold (the existing design that some users want). Users who instead want strict "never compact below X%" semantics — typically because of bursty/idle conversation patterns where step-away gaps cause cold-mode firing to bleed context — can now opt in with one flag.

## The problem this addresses, visualized

```
Without the flag (existing behavior):
   ┌─────────────────────────────────────────────────────────────────┐
   │  step-away 20 min  →  cache cold  →  next turn               │
   │      ↓                                                        │
   │  cold-mode catch-up fires (maxColdCacheCatchupPasses leaf passes) │
   │      ↓                                                        │
   │  context drops by ~2× chunkSize even though %-used was low    │
   │      ↓                                                        │
   │  step-away 5 more min  →  cache cold again  →  fires again    │
   │      ↓                                                        │
   │  pattern repeats; context drains during idle gaps             │
   └─────────────────────────────────────────────────────────────────┘

With respectThresholdAsHardFloor=true:
   ┌─────────────────────────────────────────────────────────────────┐
   │  evaluateIncrementalCompaction first checks:                  │
   │    currentTokenCount  vs  floor (= contextThreshold × budget) │
   │      │                                                        │
   │      ├── below floor → return shouldCompact=false             │
   │      │                  reason="below-context-threshold-floor"│
   │      │                  (cache-aware/leaf-trigger gates skipped)│
   │      │                                                        │
   │      └── at/above floor → existing logic runs unchanged       │
   │                            (budget-trigger, hot-cache gates,  │
   │                             cold catch-up, etc.)              │
   └─────────────────────────────────────────────────────────────────┘
```

## Behavior matrix

| Flag | currentTokenCount | Decision |
|---|---|---|
| `false` (default) | any | **existing logic** — all gates and triggers behave as before |
| `true` | undefined | falls through to existing logic (no floor enforced when count is unknown) |
| `true` | < `contextThreshold × tokenBudget` | short-circuit: `shouldCompact=false reason="below-context-threshold-floor"` |
| `true` | ≥ `contextThreshold × tokenBudget` | falls through to existing logic |
| `true` (deferred mode) | < floor | also skips `recordDeferredCompactionDebt` (prevents drain leak) |
| `true` (deferred mode) | ≥ floor | existing deferred-debt recording behavior |

## Diff overview

3 commits:
- **`1c99131`** `feat(compaction): add opt-in respectThresholdAsHardFloor flag`
  - `src/db/config.ts`: add `respectThresholdAsHardFloor: boolean` to `LcmConfig`, parser entry with env-var support (`LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR`), default `false`.
  - `src/engine.ts`: 30-line guard at the top of `evaluateIncrementalCompaction`, returns through the existing `logIncrementalCompactionDecision` so the new `reason` shows up in standard telemetry.
  - Tests in `test/engine.test.ts` and `test/config.test.ts`.

- **`434eb28`** `fix(compaction): plug deferred-mode hard-floor leak; add boundary tests`
  - In deferred mode (`engine.ts:6548-6603`), debt is recorded based on `thresholdDecision.shouldCompact || rawLeafTrigger?.shouldCompact` — both use unguarded `compaction.evaluate` / `evaluateLeafTrigger`. Without this fix, debt would accumulate from below-floor leaf-trigger fires and later drain via paths that don't re-check the floor.
  - Adds the same predicate guard around `recordDeferredCompactionDebt` and the deferred-drain scheduling, with an explanatory log line: `[lcm] afterTurn: skipping deferred compaction debt below context-threshold floor …`.
  - Adds boundary tests: exact equality at floor, undefined `currentTokenCount` with flag enabled, and an integration test for the deferred-mode skip.

- **`8cc4e63`** `feat(manifest): expose respectThresholdAsHardFloor in plugin config schema and uiHints`
  - `openclaw.plugin.json`: adds `respectThresholdAsHardFloor: { type: "boolean" }` to `configSchema.properties` (required so OpenClaw's host-side validator with `additionalProperties: false` accepts the new field). Adds a `uiHints` entry with label and help text so the field shows up in the OpenClaw plugin settings UI.

## Naming conventions

- Flag: `respectThresholdAsHardFloor` — follows the existing pattern of compound-clause boolean flags.
- Env var: `LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR` — matches the existing `LCM_*` env pattern for plugin config overrides.
- Reason string: `"below-context-threshold-floor"` — follows the hyphenated convention of `"budget-trigger"`, `"hot-cache-defer"`, `"hot-cache-budget-headroom"`, `"below-leaf-trigger"`.
- Telemetry: routed through the existing `logIncrementalCompactionDecision` so the new reason appears in the same `[lcm] incremental compaction decision: …` lines operators already grep.

## What is intentionally NOT changed

- `compactFullSweep` and `compactUntilUnder` are not affected. Forced compaction (`manualCompaction: true`, overflow recovery, explicit `compact({force: true})`) bypasses `evaluateIncrementalCompaction` entirely and continues to work above the soft floor as before. This matters for emergency overflow recovery, which should always be allowed.
- Default behavior is preserved exactly — when the flag is `false` (the default), zero lines of pre-existing logic execute differently. Verified via the regression test `evaluateIncrementalCompaction preserves default behavior when respectThresholdAsHardFloor is disabled`.

## Tests

- **`test/engine.test.ts`** — 5 new tests:
  - `evaluateIncrementalCompaction short-circuits below contextThreshold when respectThresholdAsHardFloor is enabled` — verifies short-circuit and that `evaluateLeafTrigger`/`evaluate` are NOT called.
  - `evaluateIncrementalCompaction allows existing compaction logic at/above contextThreshold even when hard-floor is enabled` — verifies budget-trigger still fires above floor.
  - `evaluateIncrementalCompaction preserves default behavior when respectThresholdAsHardFloor is disabled` — regression guard for the default path.
  - `evaluateIncrementalCompaction allows existing logic at exact floor boundary even with hard-floor enabled` — boundary test for `currentTokenCount === minTokenFloor` (uses `<` not `<=`, so the boundary admits compaction).
  - `evaluateIncrementalCompaction falls through to existing logic when currentTokenCount is undefined even with hard-floor enabled` — verifies the type-guard fall-through case.
  - `afterTurn in deferred mode skips deferred-debt recording when below contextThreshold floor` — integration test for the deferred-mode leak fix (commit `434eb28`).

- **`test/config.test.ts`** — 3 path coverages:
  - Default `false` in the hardcoded-defaults test.
  - Plugin-config override path.
  - Env-var override path (`LCM_RESPECT_THRESHOLD_AS_HARD_FLOOR=true`).

Full suite: **860/860 passing.**

## Independence

PR #619 is independent of PR #621. They address different concerns:
- **#619** (this PR): policy enhancement — opt-in hard-floor for incremental compaction.
- **#621**: bug fix — `afterTurn` early-return on empty `ingestBatch` skips compaction evaluation entirely (different code path).

No merge-order dependency. Either PR can land first.

## Test plan

- [x] `npm run build` — bundles cleanly (689kb).
- [x] `npm test` — 860/860 passing.
- [x] Default-false preserves existing behavior across all 855 pre-existing tests (zero regressions).
- [x] Adversarial review (3 reviewers, separately checking flag interaction, regression risk, and mechanism) — all cleared.
- [x] Manifest schema accepts the new field; verified with the host's config validator (`additionalProperties: false`).