### PR TITLE
fix: reduce routine LCM log noise

### DIFF
--- a/.changeset/reduce-routine-log-noise.md
+++ b/.changeset/reduce-routine-log-noise.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Reduce routine LCM log noise by moving debugging-oriented diagnostics to debug level.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1832,7 +1832,7 @@ export class LcmContextEngine implements ContextEngine {
         );
       } else {
         migrationOk = true;
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] Migration run completed during engine init: duration=${formatDurationMs(Date.now() - migrationStartedAt)} fts5=${this.fts5Available}`,
         );
         this.deps.log.debug(
@@ -2021,12 +2021,12 @@ export class LcmContextEngine implements ContextEngine {
       return;
     }
     const migrationStartedAt = Date.now();
-    this.deps.log.info("[lcm] ensureMigrated: running migrations lazily");
+    this.deps.log.debug("[lcm] ensureMigrated: running migrations lazily");
     runLcmMigrations(this.db, {
       log: this.deps.log,
     });
     this.migrated = true;
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] ensureMigrated: completed in ${formatDurationMs(Date.now() - migrationStartedAt)}`,
     );
   }
@@ -2061,7 +2061,7 @@ export class LcmContextEngine implements ContextEngine {
     const waitMs = Date.now() - waitStartedAt;
     if (options?.operationName) {
       const detail = options.context ? ` ${options.context}` : "";
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] ${options.operationName}: session queue acquired queueKey=${queueKey} queuedAhead=${queuedAhead} wait=${formatDurationMs(waitMs)}${detail}`,
       );
     }
@@ -2826,7 +2826,7 @@ export class LcmContextEngine implements ContextEngine {
       && params.cachePromptTokenCount > 0
         ? `${((params.cacheRead / params.cachePromptTokenCount) * 100).toFixed(1)}%`
         : "null";
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] incremental compaction decision: conversation=${params.conversationId} cacheState=${params.cacheState} activityBand=${params.activityBand} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"} cacheRead=${params.cacheRead ?? "null"} cacheWrite=${params.cacheWrite ?? "null"} cachePromptTokenCount=${params.cachePromptTokenCount ?? "null"} cacheReadSharePct=${cacheReadSharePct} triggerLeafChunkTokens=${params.triggerLeafChunkTokens} preferredLeafChunkTokens=${params.preferredLeafChunkTokens} fallbackLeafChunkTokens=${params.fallbackLeafChunkTokens.join(",")} rawTokensOutsideTail=${params.rawTokensOutsideTail} threshold=${params.threshold} shouldCompact=${params.shouldCompact} maxPasses=${params.maxPasses} allowCondensedPasses=${params.allowCondensedPasses} reason=${params.reason}`,
     );
     return {
@@ -3036,7 +3036,7 @@ export class LcmContextEngine implements ContextEngine {
       tokenBudget: params.tokenBudget,
       currentTokenCount: params.currentTokenCount ?? null,
     });
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"}`,
     );
   }
@@ -3069,7 +3069,7 @@ export class LcmContextEngine implements ContextEngine {
       ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
     ].join(" ");
     if (this.sessionOperationQueues.has(params.queueKey)) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=session-queue-busy debtReason=${params.reason}`,
       );
       return;
@@ -3083,7 +3083,7 @@ export class LcmContextEngine implements ContextEngine {
             params.conversationId,
           );
         if (!maintenance?.pending && !maintenance?.running) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=no-pending-debt debtReason=${params.reason}`,
           );
           return;
@@ -3111,7 +3111,7 @@ export class LcmContextEngine implements ContextEngine {
             debtReason: maintenance.reason ?? params.reason,
           })
         ) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=hot-cache retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"} debtReason=${maintenance.reason ?? params.reason}`,
           );
           return;
@@ -3133,7 +3133,7 @@ export class LcmContextEngine implements ContextEngine {
           legacyParams,
         });
         if (result) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] background deferred compaction done conversation=${params.conversationId} ${sessionLabel} changed=${result.changed} reason=${result.reason ?? "none"} debtReason=${maintenance.reason ?? params.reason}`,
           );
         }
@@ -3230,7 +3230,7 @@ export class LcmContextEngine implements ContextEngine {
                       : "deferred compaction no longer needed",
                   };
                 }
-                this.deps.log.info(
+                this.deps.log.debug(
                   `[lcm] maintain: deferred prompt-cache leaf debt ignoring effective hot-cache state after TTL expiry conversation=${params.conversationId} ${sessionLabel} reason=${leafDecision.reason} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
                 );
               }
@@ -3255,7 +3255,7 @@ export class LcmContextEngine implements ContextEngine {
         failureSummary: result.ok ? null : result.reason ?? "deferred compaction failed",
         keepPending: !result.ok || result.reason === DEFERRED_COMPACTION_STILL_NEEDED_REASON,
       });
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"}`,
       );
       return {
@@ -3354,7 +3354,7 @@ export class LcmContextEngine implements ContextEngine {
           return;
         }
 
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: deferred compaction still cache-hot for conversation=${params.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
         );
       },
@@ -4653,7 +4653,7 @@ export class LcmContextEngine implements ContextEngine {
       sessionKey: params.sessionKey,
     });
     if (historicalMessages.length === 0) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] reconcileSessionTail: skipped for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=0 reason=empty-history`,
       );
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
@@ -4661,7 +4661,7 @@ export class LcmContextEngine implements ContextEngine {
 
     const latestDbMessage = await this.conversationStore.getLastMessage(conversationId);
     if (!latestDbMessage) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] reconcileSessionTail: skipped for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} reason=no-db-tail`,
       );
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
@@ -4685,7 +4685,7 @@ export class LcmContextEngine implements ContextEngine {
         }
       }
       if (dbOccurrences === historicalOccurrences) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] reconcileSessionTail: fast path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=true`,
         );
         return { blockedByImportCap: false, importedMessages: 0, hasOverlap: true };
@@ -4753,14 +4753,14 @@ export class LcmContextEngine implements ContextEngine {
       }
 
       if (anchorIndex < 0) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] reconcileSessionTail: no anchor for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=false`,
         );
         return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
       }
     }
     if (anchorIndex >= historicalMessages.length - 1) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] reconcileSessionTail: anchor at tip for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=true`,
       );
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: true };
@@ -4773,7 +4773,7 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.warn(
         `[lcm] reconcileSessionTail: import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${existingDbCount}). Aborting to prevent flood.`,
       );
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] reconcileSessionTail: blocked for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} missingTail=${missingTail.length} existingDbCount=${existingDbCount}`,
       );
       return { blockedByImportCap: true, importedMessages: 0, hasOverlap: true };
@@ -4787,7 +4787,7 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] reconcileSessionTail: slow path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages}`,
     );
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
@@ -4882,7 +4882,7 @@ export class LcmContextEngine implements ContextEngine {
           && rememberedFileState.size === sessionFileState.size
           && rememberedFileState.mtimeMs === sessionFileState.mtimeMs
         ) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] afterTurn: transcript reconcile slow path skipped (file state already read this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
           );
           return { importedMessages: 0, blockedByImportCap: false };
@@ -5141,7 +5141,7 @@ export class LcmContextEngine implements ContextEngine {
             if (!conversation.bootstrappedAt) {
               await this.conversationStore.markConversationBootstrapped(conversationId);
             }
-            this.deps.log.info(
+            this.deps.log.debug(
               `[lcm] bootstrap: checkpoint hit conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} duration=${formatDurationMs(Date.now() - startedAt)}`,
             );
             return {
@@ -5218,7 +5218,7 @@ export class LcmContextEngine implements ContextEngine {
                 if (importedMessages > 0) {
                   this.clearStableOrphanStrippingOrdinal(conversationId);
                 }
-                this.deps.log.info(
+                this.deps.log.debug(
                   `[lcm] bootstrap: append-only conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} appendedMessages=${appended.messages.length} importedMessages=${importedMessages} duration=${formatDurationMs(Date.now() - startedAt)}`,
                 );
 
@@ -5250,7 +5250,7 @@ export class LcmContextEngine implements ContextEngine {
               cached.mtimeMs === sessionFileMtimeMs
             ) {
               await persistBootstrapState(conversationId);
-              this.deps.log.info(
+              this.deps.log.debug(
                 `[lcm] bootstrap: skipped full read (file unchanged) conversation=${conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
               );
               return {
@@ -5262,7 +5262,7 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           const historicalMessages = await readLeafPathMessages(params.sessionFile);
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] bootstrap: full transcript read conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} historicalMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
 
@@ -5320,7 +5320,7 @@ export class LcmContextEngine implements ContextEngine {
             if (importedMessages > 0) {
               this.clearStableOrphanStrippingOrdinal(conversationId);
             }
-            this.deps.log.info(
+            this.deps.log.debug(
               `[lcm] bootstrap: initial import conversation=${conversationId} ${sessionLabel} importedMessages=${importedMessages} sourceMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
             );
 
@@ -5339,7 +5339,7 @@ export class LcmContextEngine implements ContextEngine {
             historicalMessages,
             checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
           });
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
 
@@ -5428,7 +5428,7 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
 
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] bootstrap: done ${sessionLabel} bootstrapped=${result.bootstrapped} importedMessages=${result.importedMessages} reason=${result.reason ?? "none"} duration=${formatDurationMs(Date.now() - startedAt)}`,
     );
     return result;
@@ -5562,7 +5562,7 @@ export class LcmContextEngine implements ContextEngine {
           }
         }
         if (tailMatch) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] dedup: tail-match detected, batch already fully stored ` +
               `(storedCount=${storedMessageCount} batchLen=${batch.length}), skipping entire batch`,
           );
@@ -5635,7 +5635,7 @@ export class LcmContextEngine implements ContextEngine {
       }
       const newSlice = batch.slice(k + 1);
       if (suffixMatch && (newSlice.length > 0 || matchLen > 1)) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] dedup: ${context} suffix-match at batch[${k}], ` +
             `returning ${newSlice.length} new messages ` +
             `(storedCount=${storedMessageCount} batchLen=${batch.length})`,
@@ -5788,7 +5788,7 @@ export class LcmContextEngine implements ContextEngine {
               tokenBudget: cappedTokenBudget,
               debtReason: maintenance.reason,
             })) {
-            this.deps.log.info(
+            this.deps.log.debug(
               `[lcm] maintain: deferred compaction debt still hot-cache deferred conversation=${conversation.conversationId} ${sessionLabel} retention=${telemetry?.retention ?? "null"} lastCacheTouchAt=${telemetry?.lastCacheTouchAt?.toISOString() ?? "null"}`,
             );
           } else {
@@ -5803,7 +5803,7 @@ export class LcmContextEngine implements ContextEngine {
             });
           }
         } else if (maintenance?.pending || maintenance?.running) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] maintain: deferred compaction debt pending conversation=${conversation.conversationId} ${sessionLabel} but host runtimeContext.allowDeferredCompactionExecution is disabled`,
           );
         }
@@ -5836,7 +5836,7 @@ export class LcmContextEngine implements ContextEngine {
           { limit: TRANSCRIPT_GC_BATCH_SIZE },
         );
         if (candidates.length === 0) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] maintain: no transcript GC candidates conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
           return deferredCompactionResult ?? {
@@ -5874,7 +5874,7 @@ export class LcmContextEngine implements ContextEngine {
         }
 
         if (replacements.length === 0) {
-          this.deps.log.info(
+          this.deps.log.debug(
             `[lcm] maintain: no matching transcript entries conversation=${conversation.conversationId} ${sessionLabel} candidates=${candidates.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
           return deferredCompactionResult ?? {
@@ -5912,7 +5912,7 @@ export class LcmContextEngine implements ContextEngine {
             }
           : result;
 
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] maintain: done conversation=${conversation.conversationId} ${sessionLabel} candidates=${candidates.length} replacements=${replacements.length} changed=${combinedResult.changed} rewrittenEntries=${combinedResult.rewrittenEntries} bytesFreed=${combinedResult.bytesFreed} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return combinedResult;
@@ -6310,7 +6310,7 @@ export class LcmContextEngine implements ContextEngine {
       summaryDedupedNewMessages.push(...dedupedNewMessages);
     }
     if (summaryCoveredMessages.length > 0) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] afterTurn: skipped ${summaryCoveredMessages.length} messages already covered by autoCompactionSummary ${sessionLabel}`,
       );
     }
@@ -6332,7 +6332,7 @@ export class LcmContextEngine implements ContextEngine {
       // afterTurn's dedup ran. Log and fall through to compaction evaluation
       // rather than early-returning, otherwise compaction would never fire
       // once dedup begins consistently swallowing new turn deltas.
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] afterTurn: nothing to ingest ${sessionLabel} newMessages=${newMessages.length} (continuing to compaction evaluation; transcript reconcile may have already ingested) duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
     } else {
@@ -6438,7 +6438,7 @@ export class LcmContextEngine implements ContextEngine {
       sessionKey: params.sessionKey,
     });
     if (!conversation) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] afterTurn: conversation lookup missed ${sessionLabel} ingestBatch=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
       await runRuntimeAutoRotate();
@@ -6573,7 +6573,7 @@ export class LcmContextEngine implements ContextEngine {
           // every afterTurn that records deferred debt.
           if (!this.cacheContextUnknownLogged.has(conversation.conversationId)) {
             this.cacheContextUnknownLogged.add(conversation.conversationId);
-            this.deps.log.info(
+            this.deps.log.debug(
               `[lcm] background deferred compaction scheduled without cache context conversation=${conversation.conversationId} ${sessionLabel} reason=cache-context-unknown debtReason=${deferredReason}`,
             );
           }
@@ -6605,7 +6605,7 @@ export class LcmContextEngine implements ContextEngine {
       });
     }
 
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] afterTurn: done conversation=${conversation.conversationId} ${sessionLabel} newMessages=${newMessages.length} dedupedMessages=${dedupedNewMessages.length} ingestedMessages=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
     );
     await runRuntimeAutoRotate();
@@ -6645,7 +6645,7 @@ export class LcmContextEngine implements ContextEngine {
         sessionKey: params.sessionKey,
       });
       if (!conversation) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: conversation lookup missed ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return safeFallback();
@@ -6691,7 +6691,7 @@ export class LcmContextEngine implements ContextEngine {
 
       const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
       if (contextItems.length === 0) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: no context items conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return safeFallback();
@@ -6702,7 +6702,7 @@ export class LcmContextEngine implements ContextEngine {
       // the live path to avoid dropping prompt context.
       const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
       if (!hasSummaryItems && contextItems.length < params.messages.length) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return safeFallback();
@@ -6727,7 +6727,7 @@ export class LcmContextEngine implements ContextEngine {
       // If assembly produced no messages for a non-empty live session,
       // fail safe to the live context.
       if (assembled.messages.length === 0 && params.messages.length > 0) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: empty assembled output, using live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         return safeFallback();
@@ -6740,7 +6740,7 @@ export class LcmContextEngine implements ContextEngine {
       // every stored message is role "assistant" or "toolResult".
       const assembledHasUserTurn = assembled.messages.some((m) => m.role === "user");
       if (!assembledHasUserTurn && params.messages.length > 0) {
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble: assembled context has no user turns, falling back to live context to prevent prefill errors conversation=${conversation.conversationId} ${sessionLabel} assembledMessages=${assembled.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
         // Use safeFallback() so the result is a *new* array; otherwise the
@@ -6751,7 +6751,7 @@ export class LcmContextEngine implements ContextEngine {
         return safeFallback();
       }
 
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] assemble: done conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} hasSummaryItems=${hasSummaryItems} inputMessages=${params.messages.length} outputMessages=${assembled.messages.length} tokenBudget=${tokenBudget} estimatedTokens=${assembled.estimatedTokens} duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
       const prefixChange = describeAssembledPrefixChange(
@@ -6779,7 +6779,7 @@ export class LcmContextEngine implements ContextEngine {
               ),
             })}`
           : "";
-        this.deps.log.info(
+        this.deps.log.debug(
           `[lcm] assemble-debug conversation=${conversation.conversationId} ${sessionLabel} cacheAwareState=${cacheAwareState} messagesHash=${assembled.debug.finalMessagesHash} preSanitizeHash=${assembled.debug.preSanitizeMessagesHash} previousAssembledCount=${prefixChange.previousCount} commonPrefixCount=${prefixChange.commonPrefixCount} commonPrefixHash=${prefixChange.commonPrefixHash} previousWasPrefix=${prefixChange.previousWasPrefix} firstDivergenceIndex=${prefixChange.firstDivergenceIndex} previousDivergenceMessage=${prefixChange.previousDivergenceMessage} currentDivergenceMessage=${prefixChange.currentDivergenceMessage} evictableCount=${assembled.debug.preSanitizeEvictableCount} evictableHash=${assembled.debug.preSanitizeEvictableHash} freshTailSegmentCount=${assembled.debug.preSanitizeFreshTailCount} freshTailSegmentHash=${assembled.debug.preSanitizeFreshTailHash} selectionMode=${assembled.debug.selectionMode} freshTailOrdinal=${assembled.debug.freshTailOrdinal} orphanStrippingOrdinal=${assembled.debug.orphanStrippingOrdinal} baseFreshTailCount=${assembled.debug.baseFreshTailCount} freshTailCount=${assembled.debug.freshTailCount} tailTokens=${assembled.debug.tailTokens} remainingBudget=${assembled.debug.remainingBudget} evictableTotalTokens=${assembled.debug.evictableTotalTokens} promotedToolResults=${assembled.debug.promotedToolResultCount} promotedOrdinals=${promotedOrdinals} removedToolUseBlocks=${assembled.debug.removedToolUseBlockCount} touchedAssistantMessages=${assembled.debug.touchedAssistantMessageCount}${overflowDiagnostics}`,
         );
       }
@@ -6790,7 +6790,7 @@ export class LcmContextEngine implements ContextEngine {
       };
       return result;
     } catch (err) {
-      this.deps.log.info(
+      this.deps.log.debug(
         `[lcm] assemble: failed for session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} error=${describeLogError(err)}`,
       );
       return safeFallback();
@@ -6884,7 +6884,7 @@ export class LcmContextEngine implements ContextEngine {
         && params.leafChunkTokens > 0
         ? Math.floor(params.leafChunkTokens)
         : fallbackLeafChunkTokens[0];
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] compactLeafAsync start: conversation=${params.conversationId} session=${params.sessionId} leafChunkTokens=${activeLeafChunkTokens ?? "null"} fallbackLeafChunkTokens=${fallbackLeafChunkTokens.join(",")} maxPasses=${maxPasses} activityBand=${params.activityBand ?? "unknown"} allowCondensedPasses=${params.allowCondensedPasses !== false}`,
     );
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -2420,7 +2420,7 @@ const lcmPlugin = {
     // when the same DB path is already initialized.
     const existingInit = getSharedInit(normalizedDbPath);
     if (existingInit && !existingInit.stopped) {
-      deps.log.info(`[lcm] Reusing shared engine init for db=${normalizedDbPath}`);
+      deps.log.debug(`[lcm] Reusing shared engine init for db=${normalizedDbPath}`);
       wirePluginHandlers(api, deps, existingInit);
       return;
     }

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1401,7 +1401,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
               failure: directResponseFailure,
             });
           }
-          params.deps.log.info(
+          params.deps.log.debug(
             `[lcm] summarizer auth retry succeeded; provider=${provider}; model=${model}; source=direct-credentials`,
           );
           return directResult;
@@ -1528,7 +1528,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         if (envelopeNormalized.summary) {
           summary = envelopeNormalized.summary;
           summarySource = "envelope";
-          params.deps.log.info(
+          params.deps.log.debug(
             `[lcm] recovered summary from response envelope; provider=${provider}; model=${model}; ` +
               `block_types=${formatBlockTypes(envelopeNormalized.blockTypes)}; source=envelope`,
           );
@@ -1571,7 +1571,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
 
           if (summary) {
             summarySource = "retry";
-            params.deps.log.info(
+            params.deps.log.debug(
               `[lcm] retry succeeded; provider=${provider}; model=${model}; ` +
                 `block_types=${formatBlockTypes(retryEnvelopeNormalized.blockTypes)}; source=retry`,
             );
@@ -1647,7 +1647,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       }
 
       if (summarySource !== "content") {
-        params.deps.log.info(
+        params.deps.log.debug(
           `[lcm] summary resolved via non-content path; provider=${provider}; model=${model}; source=${summarySource}`,
         );
       }

--- a/src/tools/lcm-expansion-recursion-guard.ts
+++ b/src/tools/lcm-expansion-recursion-guard.ts
@@ -332,7 +332,7 @@ export function recordExpansionDelegationTelemetry(params: {
   };
   const line = `[lcm][expansion_delegation] ${JSON.stringify(payload)}`;
   if (params.event === "start" || params.event === "success") {
-    params.deps.log.info(line);
+    params.deps.log.debug(line);
     return;
   }
   params.deps.log.warn(line);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4855,6 +4855,7 @@ describe("LcmContextEngine.bootstrap", () => {
 
   it("skips full read when file is unchanged and conversation is already bootstrapped", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
     const dbPath = join(tempDir, "lcm.db");
@@ -4877,7 +4878,7 @@ describe("LcmContextEngine.bootstrap", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       }),
       db,
@@ -4919,14 +4920,14 @@ describe("LcmContextEngine.bootstrap", () => {
     });
 
     // Verify the cache guard fired (skipped full read)
-    const cacheGuardLogs = infoLog.mock.calls.filter(
+    const cacheGuardLogs = debugLog.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("skipped full read (file unchanged)"),
     );
     expect(cacheGuardLogs).toHaveLength(1);
 
     // Verify only one full transcript read occurred (the first bootstrap)
-    const fullReadLogs = infoLog.mock.calls.filter(
+    const fullReadLogs = debugLog.mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && call[0].includes("full transcript read"),
     );
     expect(fullReadLogs).toHaveLength(1);
@@ -4934,6 +4935,7 @@ describe("LcmContextEngine.bootstrap", () => {
 
   it("file-level cache guard allows full read when file changes", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
     const dbPath = join(tempDir, "lcm.db");
@@ -4955,7 +4957,7 @@ describe("LcmContextEngine.bootstrap", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       }),
       db,
@@ -4991,13 +4993,13 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(second.importedMessages).toBeGreaterThanOrEqual(1);
 
     // Two full reads should have occurred
-    const fullReadLogs = infoLog.mock.calls.filter(
+    const fullReadLogs = debugLog.mock.calls.filter(
       (call: unknown[]) => typeof call[0] === "string" && call[0].includes("full transcript read"),
     );
     expect(fullReadLogs).toHaveLength(2);
 
     // And the cache guard must not have fired after the file grew
-    const skippedLogs = infoLog.mock.calls.filter(
+    const skippedLogs = debugLog.mock.calls.filter(
       (call: unknown[]) =>
         typeof call[0] === "string" && call[0].includes("skipped full read (file unchanged)"),
     );
@@ -5576,13 +5578,13 @@ describe("LcmContextEngine.assemble canonical path", () => {
   });
 
   it("logs previous and current divergence message summaries when assembled prefixes change", async () => {
-    const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
-        info: infoLog,
+        info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
-        debug: vi.fn(),
+        debug: debugLog,
       },
     });
     const sessionId = "session-prefix-divergence-debug";
@@ -5614,7 +5616,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 10_000,
     });
 
-    const assembleDebugLog = infoLog.mock.calls
+    const assembleDebugLog = debugLog.mock.calls
       .map((call: unknown[]) => call[0])
       .find(
         (entry: unknown) =>
@@ -5631,13 +5633,13 @@ describe("LcmContextEngine.assemble canonical path", () => {
   });
 
   it("adds compact overflow diagnostics to stressed assemble debug logs", async () => {
-    const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
-        info: infoLog,
+        info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
-        debug: vi.fn(),
+        debug: debugLog,
       },
     });
     const sessionId = "session-overflow-diagnostics";
@@ -5680,7 +5682,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       tokenBudget: 100,
     });
 
-    const assembleDebugLog = infoLog.mock.calls
+    const assembleDebugLog = debugLog.mock.calls
       .map((call: unknown[]) => call[0])
       .find(
         (entry: unknown) =>
@@ -7624,10 +7626,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // and debt accumulated forever. Now we always schedule and let the inner
     // cache-aware gate decide.
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
-        log: { info: infoLog, warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        log: { info: infoLog, warn: vi.fn(), error: vi.fn(), debug: debugLog },
       },
     );
     const sessionId = "after-turn-cli-backend-no-cache-context";
@@ -7677,14 +7680,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     // The new visibility log should be emitted, not the legacy "not
     // scheduled" message.
-    const infoMessages = infoLog.mock.calls.map((c) => String(c[0]));
+    const debugMessages = debugLog.mock.calls.map((c) => String(c[0]));
     expect(
-      infoMessages.some((m) =>
+      debugMessages.some((m) =>
         m.includes("scheduled without cache context") && m.includes("cache-context-unknown"),
       ),
     ).toBe(true);
     expect(
-      infoMessages.some((m) => m.includes("background deferred compaction not scheduled")),
+      debugMessages.some((m) => m.includes("background deferred compaction not scheduled")),
     ).toBe(false);
 
     // And debt is still recorded — that part was already correct.
@@ -7704,6 +7707,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // refreshes the checkpoint, and subsequent afterTurns take the
     // incremental path or the cap branch.
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
@@ -7749,7 +7753,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // log, since readLeafPathMessages is a free function. The slow-path warn
     // is the canonical signal that the full re-read happened.
     warnLog.mockClear();
-    infoLog.mockClear();
+    debugLog.mockClear();
 
     // First call with a different sessionFile triggers the slow path.
     // Pre-populate the target sessionFile with at least one historical
@@ -7782,7 +7786,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // (e.g. checkpoint not append-only-eligible), the cap log fires instead
     // of a second full re-read.
     warnLog.mockClear();
-    infoLog.mockClear();
+    debugLog.mockClear();
     await engine.afterTurn({
       sessionId,
       sessionFile: targetSessionFile,
@@ -7798,6 +7802,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn retries a capped reconcile when the transcript file changed with an append-only-ineligible suffix (F7)", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
@@ -7846,7 +7851,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
 
     warnLog.mockClear();
-    infoLog.mockClear();
+    debugLog.mockClear();
     await engine.afterTurn({
       sessionId,
       sessionFile: targetSessionFile,
@@ -7872,7 +7877,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
 
     warnLog.mockClear();
-    infoLog.mockClear();
+    debugLog.mockClear();
     await engine.afterTurn({
       sessionId,
       sessionFile: targetSessionFile,
@@ -9423,6 +9428,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("evaluateIncrementalCompaction skips hot-cache maintenance when real budget headroom is comfortable", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9430,7 +9436,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9494,31 +9500,32 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.shouldCompact).toBe(false);
     expect(decision.cacheState).toBe("hot");
     expect(decision.leafChunkTokens).toBe(40_000);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("tokenBudget=100000"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("currentTokenCount=10000"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheRead=2048"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheWrite=null"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cachePromptTokenCount=10000"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheReadSharePct=20.5%"),
     );
   });
 
   it("evaluateIncrementalCompaction treats low cache-read share as cold even when telemetry says hot", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9526,7 +9533,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9593,16 +9600,17 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.cacheState).toBe("cold");
     expect(decision.maxPasses).toBe(2);
     expect(decision.allowCondensedPasses).toBe(true);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=cold-cache-catchup"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheReadSharePct=15.0%"),
     );
   });
 
   it("evaluateIncrementalCompaction keeps cache-write-only telemetry hot", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9610,7 +9618,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9676,19 +9684,20 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.shouldCompact).toBe(false);
     expect(decision.cacheState).toBe("hot");
     expect(decision.allowCondensedPasses).toBe(false);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheReadSharePct=0.0%"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("cacheWrite=8000"),
     );
   });
 
   it("evaluateIncrementalCompaction scales budget-trigger passes by prompt overage", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9696,7 +9705,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9763,16 +9772,17 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.leafChunkTokens).toBe(40_000);
     expect(decision.maxPasses).toBe(4);
     expect(decision.allowCondensedPasses).toBe(true);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=budget-trigger"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("maxPasses=4"),
     );
   });
 
   it("evaluateIncrementalCompaction keeps hot-cache hysteresis for a recent cache hit", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9780,7 +9790,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9843,13 +9853,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     expect(decision.shouldCompact).toBe(false);
     expect(decision.cacheState).toBe("hot");
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
     );
   });
 
   it("evaluateIncrementalCompaction lets low cache-read share override hot-cache hysteresis", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9857,7 +9868,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -9923,13 +9934,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.shouldCompact).toBe(true);
     expect(decision.cacheState).toBe("cold");
     expect(decision.maxPasses).toBe(2);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=cold-cache-catchup"),
     );
   });
 
   it("evaluateIncrementalCompaction treats a single cold reading as non-authoritative when the session was previously hot", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -9937,7 +9949,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -10000,13 +10012,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     expect(decision.shouldCompact).toBe(false);
     expect(decision.cacheState).toBe("hot");
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
     );
   });
 
   it("evaluateIncrementalCompaction eventually treats repeated cold readings as authoritative", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -10014,7 +10027,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -10079,13 +10092,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.shouldCompact).toBe(true);
     expect(decision.cacheState).toBe("cold");
     expect(decision.maxPasses).toBe(2);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=cold-cache-catchup"),
     );
   });
 
   it("evaluateIncrementalCompaction keeps hot-cache protection for unknown observations without an explicit break", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -10093,7 +10107,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -10156,7 +10170,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     expect(decision.shouldCompact).toBe(false);
     expect(decision.cacheState).toBe("hot");
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
     );
   });
@@ -10244,6 +10258,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn increases the working leaf chunk target for busy sessions when dynamic sizing is enabled", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {
         proactiveThresholdCompactionMode: "inline",
@@ -10257,7 +10272,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -10319,10 +10334,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
         }),
       );
     });
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("activityBand=high"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("preferredLeafChunkTokens=40000"),
     );
   });
@@ -10583,12 +10598,13 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("afterTurn prunes heartbeat-shaped ACK turns before compaction even without the heartbeat flag", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
         info: infoLog,
         warn: vi.fn(),
         error: vi.fn(),
-        debug: vi.fn(),
+        debug: debugLog,
       },
     });
     const sessionId = "after-turn-heartbeat-prune";
@@ -11140,6 +11156,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 describe("LcmContextEngine compaction telemetry", () => {
   it("does not append synthetic system messages for compaction passes", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
     const config = createTestConfig(join(tempDir, "lcm.db"));
@@ -11158,7 +11175,7 @@ describe("LcmContextEngine compaction telemetry", () => {
             info: infoLog,
             warn: vi.fn(),
             error: vi.fn(),
-            debug: vi.fn(),
+            debug: debugLog,
           },
         },
       ),
@@ -11255,8 +11272,9 @@ describe("LcmContextEngine compaction telemetry", () => {
     expect(compactLeafSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("compactLeafAsync logs cache-aware start details at info", async () => {
+  it("compactLeafAsync logs cache-aware start details at debug", async () => {
     const infoLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
@@ -11264,7 +11282,7 @@ describe("LcmContextEngine compaction telemetry", () => {
           info: infoLog,
           warn: vi.fn(),
           error: vi.fn(),
-          debug: vi.fn(),
+          debug: debugLog,
         },
       },
     );
@@ -11301,16 +11319,16 @@ describe("LcmContextEngine compaction telemetry", () => {
     });
 
     expect(result.compacted).toBe(true);
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("[lcm] compactLeafAsync start:"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("leafChunkTokens=40000"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("fallbackLeafChunkTokens=40000,30000,20000"),
     );
-    expect(infoLog).toHaveBeenCalledWith(
+    expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("activityBand=medium"),
     );
   });

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -84,7 +84,7 @@ function getMockLogText(mockFn: unknown): string {
 
 function getDepsLogText(
   deps: LcmDependencies,
-  levels: Array<keyof LcmDependencies["log"]> = ["warn", "error", "info"],
+  levels: Array<keyof LcmDependencies["log"]> = ["warn", "error", "info", "debug"],
 ): string {
   return levels
     .map((level) => getMockLogText(deps.log[level]))


### PR DESCRIPTION
## What
Moves routine/debugging-oriented LCM diagnostics from info logging to debug logging.

## Why
Issue #630 reports that normal `openclaw logs --follow` output is dominated by long routine LCM diagnostic lines. These details are useful when debugging cache, bootstrap, compaction, summarizer, and expansion behavior, but they are not operator-facing info logs.

## Changes
- Demote verbose assembly diagnostics, including `[lcm] assemble-debug`, to debug
- Demote routine compaction decision/debt/drain diagnostics to debug
- Demote bootstrap/reconcile/dedup/afterTurn/maintain success-path diagnostics to debug
- Demote summarizer retry/envelope diagnostics to debug
- Demote delegated expansion start/success telemetry to debug
- Keep startup banners, lifecycle events, manual rotate, compaction pass records, warnings, and errors at their existing levels
- Add patch changeset

## Testing
- `npm test -- test/engine.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`

Closes #630.