### PR TITLE
fix: register explicit lcm tool runtime names

### DIFF
--- a/.changeset/plugin-tool-runtime-names.md
+++ b/.changeset/plugin-tool-runtime-names.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Register explicit plugin tool runtime names so cached tool descriptors can execute every lcm_* tool on newer OpenClaw releases.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -2364,22 +2364,27 @@ function wirePluginHandlers(
 
   api.registerContextEngine("lossless-claw", () => shared.getCachedEngine() ?? shared.waitForEngine());
 
-  api.registerTool((ctx) =>
-    createLcmGrepTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+  api.registerTool(
+    (ctx) => createLcmGrepTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    { name: "lcm_grep" },
   );
-  api.registerTool((ctx) =>
-    createLcmDescribeTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+  api.registerTool(
+    (ctx) => createLcmDescribeTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    { name: "lcm_describe" },
   );
-  api.registerTool((ctx) =>
-    createLcmExpandTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+  api.registerTool(
+    (ctx) => createLcmExpandTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    { name: "lcm_expand" },
   );
-  api.registerTool((ctx) =>
-    createLcmExpandQueryTool({
-      deps,
-      getLcm: shared.waitForEngine,
-      sessionKey: ctx.sessionKey,
-      requesterSessionKey: ctx.sessionKey,
-    }),
+  api.registerTool(
+    (ctx) =>
+      createLcmExpandQueryTool({
+        deps,
+        getLcm: shared.waitForEngine,
+        sessionKey: ctx.sessionKey,
+        requesterSessionKey: ctx.sessionKey,
+      }),
+    { name: "lcm_expand_query" },
   );
 
   api.registerCommand(

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -54,21 +54,49 @@ function extractToolNames(): string[] {
   return [...names].sort();
 }
 
-function extractRegisterToolFactoryCallSites(): string[] {
-  const src = readFileSync(PLUGIN_INDEX, "utf8");
-  // Find each `api.registerTool(...)` call and capture the inner factory
-  // identifier (e.g. createLcmGrepTool). Tolerates both expression-body and
-  // block-body arrow forms, optional async, and any whitespace/newlines:
-  //
-  //   api.registerTool((ctx) => createLcmGrepTool(...))
-  //   api.registerTool((ctx) => { return createLcmGrepTool(...) })
-  //   api.registerTool(async (ctx) => createLcmGrepTool(...))
-  const pattern =
-    /api\.registerTool\s*\(\s*(?:async\s+)?\([^)]*\)\s*=>\s*\{?\s*(?:return\s+)?(create[A-Za-z]+Tool)\b/g;
-  const matches = src.matchAll(pattern);
-  return [...matches].map((m) => m[1]).sort();
-}
+type RegisterToolFactoryCallSite = {
+  factory: string;
+  runtimeName?: string;
+};
 
+function extractRegisterToolFactoryCallSites(): RegisterToolFactoryCallSite[] {
+  const src = readFileSync(PLUGIN_INDEX, "utf8");
+  const sites: RegisterToolFactoryCallSite[] = [];
+  const marker = "api.registerTool(";
+  let searchFrom = 0;
+
+  while (true) {
+    const start = src.indexOf(marker, searchFrom);
+    if (start === -1) {
+      break;
+    }
+    let depth = 0;
+    let end = start;
+    for (; end < src.length; end += 1) {
+      const char = src[end];
+      if (char === "(") {
+        depth += 1;
+      } else if (char === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          end += 1;
+          break;
+        }
+      }
+    }
+    const call = src.slice(start, end);
+    const factory = call.match(/\b(create[A-Za-z]+Tool)\b/)?.[1];
+    if (factory) {
+      sites.push({
+        factory,
+        runtimeName: call.match(/\{\s*name\s*:\s*["'](lcm_[a-z_]+)["']\s*\}/)?.[1],
+      });
+    }
+    searchFrom = end;
+  }
+
+  return sites.sort((a, b) => a.factory.localeCompare(b.factory));
+}
 describe("openclaw.plugin.json manifest drift guard (#570)", () => {
   it("contracts.tools matches the canonical name fields in src/tools/*", () => {
     const declared = [...manifest.contracts.tools].sort();
@@ -77,11 +105,11 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
   });
 
   it("contracts.tools enumerates one entry per registerTool call site", () => {
-    const factories = extractRegisterToolFactoryCallSites();
+    const callSites = extractRegisterToolFactoryCallSites();
     // Each createLcm*Tool factory must correspond to exactly one declared
     // contract. If a registerTool call is added without a manifest update,
-    // factories.length grows and this assertion fails.
-    expect(factories.length).toBe(manifest.contracts.tools.length);
+    // callSites.length grows and this assertion fails.
+    expect(callSites.length).toBe(manifest.contracts.tools.length);
     // Each factory name should map 1:1 to a declared tool (createLcmGrepTool
     // -> lcm_grep, createLcmExpandQueryTool -> lcm_expand_query, etc.).
     const factoryToName = (s: string): string =>
@@ -90,9 +118,16 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
         .replace(/Tool$/, "")
         .replace(/([a-z])([A-Z])/g, "$1_$2")
         .toLowerCase();
-    const expected = factories.map(factoryToName).sort();
+    const expected = callSites.map((site) => factoryToName(site.factory)).sort();
     const declared = [...manifest.contracts.tools].sort();
     expect(declared).toEqual(expected);
+  });
+
+  it("registers explicit runtime names for factory-owned tools", () => {
+    const callSites = extractRegisterToolFactoryCallSites();
+    const runtimeNames = callSites.map((site) => site.runtimeName).sort();
+    const declared = [...manifest.contracts.tools].sort();
+    expect(runtimeNames).toEqual(declared);
   });
 
   it("declares startup activation until OpenClaw always loads selected context-engine plugins", () => {


### PR DESCRIPTION
## What
Registers explicit runtime names for all factory-owned LCM tools.

## Why
Issue #623 reports that newer OpenClaw versions can expose cached descriptors for all four `lcm_*` tools while the plugin runtime lookup only matches the unnamed factory registration entry. That makes `lcm_grep` work but causes `lcm_describe`, `lcm_expand`, and `lcm_expand_query` execution to fail with `plugin tool runtime missing (lossless-claw): <toolName>`.

The registration already returns the right tool objects, but OpenClaw's cached-descriptor executor needs factory registrations to advertise the names they can produce.

## Changes
- Pass `{ name: "..." }` to each `api.registerTool` factory registration
- Extend the manifest drift guard to require explicit runtime names for factory-owned tools
- Add patch changeset

## Testing
- `npm test -- test/manifest.test.ts test/lcm-tools.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`

Closes #623.