### PR TITLE
fix: move @mariozechner/pi-* from optional peer-deps to runtime dependencies

### DIFF
--- a/.changeset/move-pi-deps-to-dependencies.md
+++ b/.changeset/move-pi-deps-to-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Move `@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, and `@mariozechner/pi-coding-agent` from `peerDependencies` (with `peerDependenciesMeta.optional: true`) to runtime `dependencies`. The plugin's bundled `dist/index.js` imports these unconditionally (build externalizes `@mariozechner/*`), so absence becomes a hard `ERR_MODULE_NOT_FOUND` at module load — `optional: true` was not honored at runtime. Treating them as runtime dependencies makes the plugin self-contained on `npm install` and removes the host-symlink workaround currently required on fresh OpenClaw installs.
+
+Fixes #636.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,28 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
+        "@mariozechner/pi-agent-core": ">=0.66 <1",
+        "@mariozechner/pi-ai": ">=0.66 <1",
+        "@mariozechner/pi-coding-agent": ">=0.66 <1",
         "@sinclair/typebox": "0.34.48"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
-        "@mariozechner/pi-agent-core": "0.66.1",
-        "@mariozechner/pi-ai": "0.66.1",
-        "@mariozechner/pi-coding-agent": "0.66.1",
         "esbuild": "^0.28.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-agent-core": "*",
-        "@mariozechner/pi-ai": "*",
-        "@mariozechner/pi-coding-agent": "*",
-        "openclaw": "*"
-      },
-      "peerDependenciesMeta": {
-        "@mariozechner/pi-agent-core": {
-          "optional": true
-        },
-        "@mariozechner/pi-ai": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        }
+        "openclaw": ">=2026.2.17 <2026.6.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -2992,7 +2978,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3006,7 +2991,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
       "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,7 +3007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3040,7 +3023,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3057,7 +3039,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,7 +3055,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,7 +3071,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3108,7 +3087,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3125,7 +3103,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3142,7 +3119,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3169,7 +3145,6 @@
       "version": "0.66.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.66.1.tgz",
       "integrity": "sha512-Nj54A7SuB/EQi8r3Gs+glFOr9wz/a9uxYFf0pCLf2DE7VmzA9O7WSejrvArna17K6auftLSdNyRRe2bIO0qezg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.66.1"
@@ -3182,7 +3157,6 @@
       "version": "0.66.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.66.1.tgz",
       "integrity": "sha512-7IZHvpsFdKEBkTmjNrdVL7JLUJVIpha6bwTr12cZ5XyDrxij06wP6Ncpnf4HT5BXAzD5w2JnoqTOSbMEIZj3dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -3210,7 +3184,6 @@
       "version": "0.66.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.66.1.tgz",
       "integrity": "sha512-cNmatT+5HvYzQ78cRhRih00wCeUTH/fFx9ecJh5AbN7axgWU+bwiZYy0cjrTsGVgMGF4xMYlPRn/Nze9JEB+/w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
@@ -3248,7 +3221,6 @@
       "version": "0.66.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.66.1.tgz",
       "integrity": "sha512-hNFN42ebjwtfGooqoUwM+QaPR1XCyqPuueuP3aLOWS1bZ2nZP/jq8MBuGNrmMw1cgiDcotvOlSNj3BatzEOGsw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -3268,7 +3240,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3278,7 +3249,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -3340,7 +3310,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
       "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
-      "dev": true,
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
@@ -5859,7 +5828,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6450,7 +6418,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -7351,7 +7318,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -7718,7 +7684,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -7823,7 +7788,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -8267,7 +8231,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -10059,7 +10022,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
       "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -10741,7 +10703,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -11067,7 +11028,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -13734,7 +13694,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -31,34 +31,20 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@mariozechner/pi-agent-core": ">=0.66 <1",
+    "@mariozechner/pi-ai": ">=0.66 <1",
+    "@mariozechner/pi-coding-agent": ">=0.66 <1",
     "@sinclair/typebox": "0.34.48"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
-    "@mariozechner/pi-agent-core": "0.66.1",
-    "@mariozechner/pi-ai": "0.66.1",
-    "@mariozechner/pi-coding-agent": "0.66.1",
     "esbuild": "^0.28.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-agent-core": ">=0.66 <1",
-    "@mariozechner/pi-ai": ">=0.66 <1",
-    "@mariozechner/pi-coding-agent": ">=0.66 <1",
     "openclaw": ">=2026.2.17 <2026.6.0"
-  },
-  "peerDependenciesMeta": {
-    "@mariozechner/pi-agent-core": {
-      "optional": true
-    },
-    "@mariozechner/pi-ai": {
-      "optional": true
-    },
-    "@mariozechner/pi-coding-agent": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Moves `@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, and `@mariozechner/pi-coding-agent` from `peerDependencies` (with `peerDependenciesMeta.optional: true`) to runtime `dependencies`.

The plugin's bundled `dist/index.js` imports these unconditionally — the build script has `--external:"@mariozechner/*"`, so they must be resolvable from the plugin's module-resolution chain at runtime. The `optional: true` flag is therefore not honored: when these packages aren't present, the plugin fails to load with `ERR_MODULE_NOT_FOUND` instead of degrading gracefully.

Treating them as runtime `dependencies` makes the plugin self-contained on `npm install` and removes the host-symlink workaround that fresh OpenClaw installs currently need.

Fixes #636.

## Why this approach (vs. honoring `optional` via dynamic imports)

The simplest and safest fix is to make the `package.json` reflect what the runtime already does (hard-require these). Honoring `optional: true` in code would require splitting the imports into dynamic `await import()` calls with try/catch and feature-gating the dependent code paths — a larger change with semantic implications about which features should still work without the pi-* deps. If you'd prefer that direction instead, happy to close this PR and rework — let me know.

## Trade-offs

- **Pro:** Self-contained `npm install`. No host-bundling assumption. Works on any `openclaw` install path or version, not just ones that ship `@mariozechner/*` bundled.
- **Pro:** Removes the now-orphan `peerDependenciesMeta` entries (only `@mariozechner/*` were listed; `openclaw` peer-dep stays).
- **Con:** ~minor disk overlap with OpenClaw's bundled copies of the same packages on installs where both are present. Bounded by `>=0.66 <1` range and the existing pinned bundled version.

## Verification

Locally on macOS / Node 22.22.1, after applying:

```bash
$ rm -rf node_modules/@mariozechner/  # simulate fresh install with no host-symlink
$ npm install --omit=dev
added 685 packages in 12s
$ ls node_modules/@mariozechner/
pi-agent-core  pi-ai  pi-coding-agent
```

After running the plugin under OpenClaw 2026.5.7:
- `openclaw plugins inspect lossless-claw` → `Status: loaded` (was: `failed to load`)
- Context engine slot binds correctly; sessions use lossless-claw, not legacy fallback
- No `ERR_MODULE_NOT_FOUND` in logs

## Diff scope

- `package.json`: 3 entries moved (deps), 3 entries removed (peerDeps), `peerDependenciesMeta` removed
- `package-lock.json`: regenerated via `npm install --omit=dev` (smaller, since pi-* are no longer duplicated as devDeps)
- `.changeset/move-pi-deps-to-dependencies.md`: patch-level changeset describing the fix

## Notes

- I dropped `@mariozechner/pi-*` from `devDependencies` since they're now installed via `dependencies` regardless. If you'd rather keep them pinned in devDeps for reproducible test/build (the original had them at `0.66.1` exact), happy to add back — just say the word.
- Used `>=0.66 <1` for the dependency range to mirror the original peer-dep range; tightening to e.g. `^0.66.1` would also be reasonable.