### PR TITLE
Fix bootstrap transcript replay writes

### DIFF
--- a/.changeset/bootstrap-replay-guard.md
+++ b/.changeset/bootstrap-replay-guard.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent existing-conversation bootstrap from replaying prior transcript rows as fresh LCM messages. Bootstrap append/reconcile now filters replay-shaped tails, message writes reject same-timestamp prior-content floods, and ingest batches run transactionally.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1681,6 +1681,35 @@ function messageIdentity(role: string, content: string): string {
   return `${role}\u0000${content}`;
 }
 
+function isBootstrapReplayCandidateMessage(message: AgentMessage): boolean {
+  const role = toStoredMessage(message).role;
+  return role === "assistant" || role === "tool";
+}
+
+function createBootstrapReplaySignature(message: AgentMessage): string {
+  const stored = toStoredMessage(message);
+  const parts = buildMessageParts({
+    sessionId: "bootstrap-replay-signature",
+    message,
+    fallbackContent: stored.content,
+  });
+
+  return JSON.stringify({
+    role: stored.role,
+    content: stored.content,
+    parts: parts.map((part) => ({
+      partType: part.partType,
+      ordinal: part.ordinal,
+      textContent: part.textContent ?? null,
+      toolCallId: part.toolCallId ?? null,
+      toolName: part.toolName ?? null,
+      toolInput: part.toolInput ?? null,
+      toolOutput: part.toolOutput ?? null,
+      metadata: part.metadata ?? null,
+    })),
+  });
+}
+
 function normalizeSummaryOverlapText(value: string): string {
   return value.replace(/\s+/g, " ").trim().toLowerCase();
 }
@@ -4767,10 +4796,10 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const missingTail = await this.filterBootstrapReplayMessages({
-      conversationId,
       messages: historicalMessages.slice(anchorIndex + 1),
       sessionContext,
       source: "reconcileSessionTail",
+      priorMessages: historicalMessages.slice(0, anchorIndex + 1),
     });
 
     const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
@@ -4804,74 +4833,80 @@ export class LcmContextEngine implements ContextEngine {
    * fresh LCM seqs after a runtime re-instantiation.
    */
   private async filterBootstrapReplayMessages(params: {
-    conversationId: number;
     messages: AgentMessage[];
     sessionContext: string;
     source: string;
+    priorMessages?: AgentMessage[];
+    sessionFile?: string;
   }): Promise<AgentMessage[]> {
-    if (params.messages.length === 0) {
+    if (params.messages.length < 3) {
       return params.messages;
     }
 
-    const storedMessages = params.messages.map((message) => toStoredMessage(message));
-    const existingCountsByIdentity = new Map<string, number>();
-    let replicatedNonEmptyRows = 0;
-
-    for (const stored of storedMessages) {
-      if (stored.content.length === 0) {
-        continue;
-      }
-      const identity = messageIdentity(stored.role, stored.content);
-      let existingCount = existingCountsByIdentity.get(identity);
-      if (existingCount === undefined) {
-        existingCount = await this.conversationStore.countMessagesByIdentity(
-          params.conversationId,
-          stored.role,
-          stored.content,
-        );
-        existingCountsByIdentity.set(identity, existingCount);
-      }
-      if (existingCount > 0) {
-        replicatedNonEmptyRows += 1;
-      }
+    let replayCandidateLength = 0;
+    while (
+      replayCandidateLength < params.messages.length &&
+      isBootstrapReplayCandidateMessage(params.messages[replayCandidateLength]!)
+    ) {
+      replayCandidateLength += 1;
     }
-
-    if (replicatedNonEmptyRows < 3) {
+    if (replayCandidateLength < 3) {
       return params.messages;
     }
 
-    const seenIncomingByIdentity = new Map<string, number>();
-    const filtered: AgentMessage[] = [];
-    let droppedMessages = 0;
-
-    for (let index = 0; index < params.messages.length; index += 1) {
-      const stored = storedMessages[index]!;
-      const message = params.messages[index]!;
-      if (stored.content.length === 0) {
-        droppedMessages += 1;
-        continue;
-      }
-
-      const identity = messageIdentity(stored.role, stored.content);
-      const seenIncoming = seenIncomingByIdentity.get(identity) ?? 0;
-      const existingCount = existingCountsByIdentity.get(identity) ?? 0;
-      seenIncomingByIdentity.set(identity, seenIncoming + 1);
-
-      if (seenIncoming < existingCount) {
-        droppedMessages += 1;
-        continue;
-      }
-
-      filtered.push(message);
+    const priorMessages =
+      params.priorMessages ??
+      (params.sessionFile ? await readLeafPathMessages(params.sessionFile) : undefined);
+    if (!priorMessages || priorMessages.length === 0) {
+      return params.messages;
     }
 
-    if (droppedMessages > 0) {
+    const replayCandidates = params.messages.slice(0, replayCandidateLength);
+    const earlierReplayCandidates = (
+      params.priorMessages ? priorMessages : priorMessages.slice(0, Math.max(0, priorMessages.length - params.messages.length))
+    ).filter(isBootstrapReplayCandidateMessage);
+    if (earlierReplayCandidates.length < 3) {
+      return params.messages;
+    }
+
+    const incomingSignatures = replayCandidates.map(createBootstrapReplaySignature);
+    const earlierSignatures = earlierReplayCandidates.map(createBootstrapReplaySignature);
+
+    let replayPrefixLength = 0;
+    prefixLoop:
+    for (
+      let candidatePrefixLength = incomingSignatures.length;
+      candidatePrefixLength >= 3;
+      candidatePrefixLength -= 1
+    ) {
+      for (
+        let startIndex = 0;
+        startIndex <= earlierSignatures.length - candidatePrefixLength;
+        startIndex += 1
+      ) {
+        let matched = true;
+        for (let offset = 0; offset < candidatePrefixLength; offset += 1) {
+          if (earlierSignatures[startIndex + offset] !== incomingSignatures[offset]) {
+            matched = false;
+            break;
+          }
+        }
+        if (matched) {
+          replayPrefixLength = candidatePrefixLength;
+          break prefixLoop;
+        }
+      }
+    }
+
+    if (replayPrefixLength > 0) {
       this.deps.log.warn(
-        `[lcm] bootstrap replay guard: ${params.source} dropped ${droppedMessages}/${params.messages.length} replayed transcript messages for ${params.sessionContext} replicatedNonEmptyRows=${replicatedNonEmptyRows}`,
+        `[lcm] bootstrap replay guard: ${params.source} dropped ${replayPrefixLength}/${params.messages.length} replayed transcript messages for ${params.sessionContext}`,
       );
     }
 
-    return filtered;
+    return replayPrefixLength > 0
+      ? params.messages.slice(replayPrefixLength)
+      : params.messages;
   }
 
   private async reconcileTranscriptTailForAfterTurn(params: {
@@ -4909,7 +4944,6 @@ export class LcmContextEngine implements ContextEngine {
           });
           if (appended.canUseAppendOnly) {
             const replayFilteredMessages = await this.filterBootstrapReplayMessages({
-              conversationId: conversation.conversationId,
               messages: appended.messages,
               sessionContext: this.formatSessionLogContext({
                 conversationId: conversation.conversationId,
@@ -4917,6 +4951,7 @@ export class LcmContextEngine implements ContextEngine {
                 sessionKey: params.sessionKey,
               }),
               source: "afterTurn transcript reconcile append-only",
+              sessionFile: params.sessionFile,
             });
             let importedMessages = 0;
             for (const message of replayFilteredMessages) {
@@ -5294,7 +5329,6 @@ export class LcmContextEngine implements ContextEngine {
                 }
 
                 const replayFilteredMessages = await this.filterBootstrapReplayMessages({
-                  conversationId,
                   messages: appended.messages,
                   sessionContext: this.formatSessionLogContext({
                     conversationId,
@@ -5302,6 +5336,7 @@ export class LcmContextEngine implements ContextEngine {
                     sessionKey: params.sessionKey,
                   }),
                   source: "bootstrap append-only",
+                  sessionFile: params.sessionFile,
                 });
 
                 let importedMessages = 0;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4766,7 +4766,12 @@ export class LcmContextEngine implements ContextEngine {
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: true };
     }
 
-    const missingTail = historicalMessages.slice(anchorIndex + 1);
+    const missingTail = await this.filterBootstrapReplayMessages({
+      conversationId,
+      messages: historicalMessages.slice(anchorIndex + 1),
+      sessionContext,
+      source: "reconcileSessionTail",
+    });
 
     const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
     if (existingDbCount > 0 && missingTail.length > Math.max(existingDbCount * 0.2, 50)) {
@@ -4791,6 +4796,82 @@ export class LcmContextEngine implements ContextEngine {
       `[lcm] reconcileSessionTail: slow path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages}`,
     );
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+  }
+
+  /**
+   * Existing-conversation bootstrap is a rehydrate path. It may repair small
+   * crash gaps, but it must not replay already persisted transcript rows as
+   * fresh LCM seqs after a runtime re-instantiation.
+   */
+  private async filterBootstrapReplayMessages(params: {
+    conversationId: number;
+    messages: AgentMessage[];
+    sessionContext: string;
+    source: string;
+  }): Promise<AgentMessage[]> {
+    if (params.messages.length === 0) {
+      return params.messages;
+    }
+
+    const storedMessages = params.messages.map((message) => toStoredMessage(message));
+    const existingCountsByIdentity = new Map<string, number>();
+    let replicatedNonEmptyRows = 0;
+
+    for (const stored of storedMessages) {
+      if (stored.content.length === 0) {
+        continue;
+      }
+      const identity = messageIdentity(stored.role, stored.content);
+      let existingCount = existingCountsByIdentity.get(identity);
+      if (existingCount === undefined) {
+        existingCount = await this.conversationStore.countMessagesByIdentity(
+          params.conversationId,
+          stored.role,
+          stored.content,
+        );
+        existingCountsByIdentity.set(identity, existingCount);
+      }
+      if (existingCount > 0) {
+        replicatedNonEmptyRows += 1;
+      }
+    }
+
+    if (replicatedNonEmptyRows < 3) {
+      return params.messages;
+    }
+
+    const seenIncomingByIdentity = new Map<string, number>();
+    const filtered: AgentMessage[] = [];
+    let droppedMessages = 0;
+
+    for (let index = 0; index < params.messages.length; index += 1) {
+      const stored = storedMessages[index]!;
+      const message = params.messages[index]!;
+      if (stored.content.length === 0) {
+        droppedMessages += 1;
+        continue;
+      }
+
+      const identity = messageIdentity(stored.role, stored.content);
+      const seenIncoming = seenIncomingByIdentity.get(identity) ?? 0;
+      const existingCount = existingCountsByIdentity.get(identity) ?? 0;
+      seenIncomingByIdentity.set(identity, seenIncoming + 1);
+
+      if (seenIncoming < existingCount) {
+        droppedMessages += 1;
+        continue;
+      }
+
+      filtered.push(message);
+    }
+
+    if (droppedMessages > 0) {
+      this.deps.log.warn(
+        `[lcm] bootstrap replay guard: ${params.source} dropped ${droppedMessages}/${params.messages.length} replayed transcript messages for ${params.sessionContext} replicatedNonEmptyRows=${replicatedNonEmptyRows}`,
+      );
+    }
+
+    return filtered;
   }
 
   private async reconcileTranscriptTailForAfterTurn(params: {
@@ -4827,8 +4908,18 @@ export class LcmContextEngine implements ContextEngine {
             offset: checkpoint.lastProcessedOffset,
           });
           if (appended.canUseAppendOnly) {
+            const replayFilteredMessages = await this.filterBootstrapReplayMessages({
+              conversationId: conversation.conversationId,
+              messages: appended.messages,
+              sessionContext: this.formatSessionLogContext({
+                conversationId: conversation.conversationId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+              }),
+              source: "afterTurn transcript reconcile append-only",
+            });
             let importedMessages = 0;
-            for (const message of appended.messages) {
+            for (const message of replayFilteredMessages) {
               const result = await this.ingestSingle({
                 sessionId: params.sessionId,
                 sessionKey: params.sessionKey,
@@ -5202,8 +5293,19 @@ export class LcmContextEngine implements ContextEngine {
                   await this.conversationStore.markConversationBootstrapped(conversationId);
                 }
 
+                const replayFilteredMessages = await this.filterBootstrapReplayMessages({
+                  conversationId,
+                  messages: appended.messages,
+                  sessionContext: this.formatSessionLogContext({
+                    conversationId,
+                    sessionId: params.sessionId,
+                    sessionKey: params.sessionKey,
+                  }),
+                  source: "bootstrap append-only",
+                });
+
                 let importedMessages = 0;
-                for (const message of appended.messages) {
+                for (const message of replayFilteredMessages) {
                   const ingestResult = await this.ingestSingle({
                     sessionId: params.sessionId,
                     sessionKey: params.sessionKey,
@@ -5219,7 +5321,7 @@ export class LcmContextEngine implements ContextEngine {
                   this.clearStableOrphanStrippingOrdinal(conversationId);
                 }
                 this.deps.log.debug(
-                  `[lcm] bootstrap: append-only conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} appendedMessages=${appended.messages.length} importedMessages=${importedMessages} duration=${formatDurationMs(Date.now() - startedAt)}`,
+                  `[lcm] bootstrap: append-only conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} appendedMessages=${appended.messages.length} replayFilteredMessages=${replayFilteredMessages.length} importedMessages=${importedMessages} duration=${formatDurationMs(Date.now() - startedAt)}`,
                 );
 
                 if (importedMessages > 0) {
@@ -6119,19 +6221,21 @@ export class LcmContextEngine implements ContextEngine {
     return this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () => {
-        let ingestedCount = 0;
-        for (const message of params.messages) {
-          const result = await this.ingestSingle({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            message,
-            isHeartbeat: params.isHeartbeat,
-          });
-          if (result.ingested) {
-            ingestedCount += 1;
+        return this.conversationStore.withTransaction(async () => {
+          let ingestedCount = 0;
+          for (const message of params.messages) {
+            const result = await this.ingestSingle({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              message,
+              isHeartbeat: params.isHeartbeat,
+            });
+            if (result.ingested) {
+              ingestedCount += 1;
+            }
           }
-        }
-        return { ingestedCount };
+          return { ingestedCount };
+        });
       },
       {
         operationName: "ingestBatch",

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -35,6 +35,11 @@ export type CreateMessageInput = {
   identityHash?: string;
 };
 
+type PreparedMessageInsert = CreateMessageInput & {
+  createdAt: string;
+  identityHash: string;
+};
+
 export type MessageRecord = {
   messageId: MessageId;
   conversationId: ConversationId;
@@ -160,6 +165,10 @@ interface MessagePartRow {
 
 interface CountRow {
   count: number;
+}
+
+interface TimestampRow {
+  created_at: string;
 }
 
 interface MaxSeqRow {
@@ -512,18 +521,22 @@ export class ConversationStore {
   // ── Message operations ────────────────────────────────────────────────────
 
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
+    const prepared = this.prepareMessageInsert(input);
+    this.assertNoReplayTimestampFlood([prepared]);
+
     const result = this.db
       .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
-        input.conversationId,
-        input.seq,
-        input.role,
-        input.content,
-        input.tokenCount,
-        input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
+        prepared.conversationId,
+        prepared.seq,
+        prepared.role,
+        prepared.content,
+        prepared.tokenCount,
+        prepared.identityHash,
+        prepared.createdAt,
       );
 
     const messageId = Number(result.lastInsertRowid);
@@ -544,9 +557,13 @@ export class ConversationStore {
     if (inputs.length === 0) {
       return [];
     }
+    const createdAt = this.currentSqliteTimestamp();
+    const preparedInputs = inputs.map((input) => this.prepareMessageInsert(input, createdAt));
+    this.assertNoReplayTimestampFlood(preparedInputs);
+
     const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
     const selectStmt = this.db.prepare(
       `SELECT message_id, conversation_id, seq, role, content, token_count, created_at
@@ -554,14 +571,15 @@ export class ConversationStore {
     );
 
     const records: MessageRecord[] = [];
-    for (const input of inputs) {
+    for (const input of preparedInputs) {
       const result = insertStmt.run(
         input.conversationId,
         input.seq,
         input.role,
         input.content,
         input.tokenCount,
-        input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
+        input.identityHash,
+        input.createdAt,
       );
 
       const messageId = Number(result.lastInsertRowid);
@@ -649,6 +667,43 @@ export class ConversationStore {
        WHERE conversation_id = ? AND identity_hash = ? AND role = ? AND content = ?`,
       )
       .get(conversationId, identityHash, role, content) as unknown as CountRow | undefined;
+
+    return row?.count ?? 0;
+  }
+
+  async countMessagesByIdentityBeforeTimestamp(params: {
+    conversationId: ConversationId;
+    role: MessageRole;
+    content: string;
+    beforeCreatedAt: string;
+  }): Promise<number> {
+    return this.countMessagesByIdentityBeforeTimestampSync(params);
+  }
+
+  private countMessagesByIdentityBeforeTimestampSync(params: {
+    conversationId: ConversationId;
+    role: MessageRole;
+    content: string;
+    beforeCreatedAt: string;
+  }): number {
+    const identityHash = buildMessageIdentityHash(params.role, params.content);
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count
+       FROM messages
+       WHERE conversation_id = ?
+         AND identity_hash = ?
+         AND role = ?
+         AND content = ?
+         AND created_at < ?`,
+      )
+      .get(
+        params.conversationId,
+        identityHash,
+        params.role,
+        params.content,
+        params.beforeCreatedAt,
+      ) as unknown as CountRow | undefined;
 
     return row?.count ?? 0;
   }
@@ -854,6 +909,88 @@ export class ConversationStore {
         .run(messageId, normalizedContent);
     } catch {
       // Full-text indexing is optional. Message persistence must still succeed.
+    }
+  }
+
+  private currentSqliteTimestamp(): string {
+    const row = this.db
+      .prepare(`SELECT datetime('now') AS created_at`)
+      .get() as unknown as TimestampRow;
+    return row.created_at;
+  }
+
+  private prepareMessageInsert(
+    input: CreateMessageInput,
+    createdAt = this.currentSqliteTimestamp(),
+  ): PreparedMessageInsert {
+    return {
+      ...input,
+      createdAt,
+      identityHash: input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
+    };
+  }
+
+  private countExistingReplayRowsAtTimestamp(
+    conversationId: ConversationId,
+    createdAt: string,
+  ): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS count
+       FROM messages AS m
+       WHERE m.conversation_id = ?
+         AND m.created_at = ?
+         AND length(m.content) > 0
+         AND EXISTS (
+           SELECT 1
+           FROM messages AS prior
+           WHERE prior.conversation_id = m.conversation_id
+             AND prior.identity_hash = m.identity_hash
+             AND prior.role = m.role
+             AND prior.content = m.content
+             AND prior.created_at < m.created_at
+         )`,
+      )
+      .get(conversationId, createdAt) as unknown as CountRow | undefined;
+    return row?.count ?? 0;
+  }
+
+  private assertNoReplayTimestampFlood(inputs: PreparedMessageInsert[]): void {
+    if (inputs.length === 0) {
+      return;
+    }
+
+    const replicatedByConversationAndTimestamp = new Map<string, number>();
+    for (const input of inputs) {
+      if (input.content.length === 0) {
+        continue;
+      }
+      const priorCount = this.countMessagesByIdentityBeforeTimestampSync({
+        conversationId: input.conversationId,
+        role: input.role,
+        content: input.content,
+        beforeCreatedAt: input.createdAt,
+      });
+      if (priorCount === 0) {
+        continue;
+      }
+      const key = `${input.conversationId}\u0000${input.createdAt}`;
+      replicatedByConversationAndTimestamp.set(
+        key,
+        (replicatedByConversationAndTimestamp.get(key) ?? 0) + 1,
+      );
+    }
+
+    for (const [key, candidateCount] of replicatedByConversationAndTimestamp) {
+      const [conversationIdText, createdAt] = key.split("\u0000");
+      const conversationId = Number(conversationIdText);
+      const existingCount = this.countExistingReplayRowsAtTimestamp(conversationId, createdAt);
+      const replicatedCount = existingCount + candidateCount;
+      if (replicatedCount >= 3) {
+        throw new Error(
+          `[lcm] refused replay-like message batch: conversation=${conversationId} createdAt=${createdAt} replicatedRows=${replicatedCount}`,
+        );
+      }
     }
   }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2610,6 +2610,63 @@ describe("LcmContextEngine.bootstrap", () => {
     );
   });
 
+  it("does not rewrite prior assistant transcript rows when bootstrap re-instantiates a conversation", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("bootstrap-reinstantiation-replay");
+    const sm = SessionManager.open(sessionFile);
+    const sessionId = "bootstrap-reinstantiation-replay";
+
+    for (let turn = 1; turn <= 5; turn += 1) {
+      sm.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: `question ${turn}` }],
+      } as AgentMessage);
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: `answer ${turn}` }],
+      } as AgentMessage);
+    }
+
+    const engineA = createEngineAtDatabasePath(dbPath);
+    const first = await engineA.bootstrap({ sessionId, sessionFile });
+    expect(first).toEqual({ bootstrapped: true, importedMessages: 10 });
+
+    const conversation = await engineA.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const before = await engineA.getConversationStore().getMessages(conversation!.conversationId);
+    await engineA.dispose();
+
+    for (const answer of ["answer 3", "answer 4", "answer 5"]) {
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: answer }],
+      } as AgentMessage);
+    }
+
+    const engineB = createEngineAtDatabasePath(dbPath);
+    const second = await engineB.bootstrap({ sessionId, sessionFile });
+    expect(second.bootstrapped).toBe(false);
+    expect(second.importedMessages).toBe(0);
+
+    const after = await engineB.getConversationStore().getMessages(conversation!.conversationId);
+    expect(after.map((message) => `${message.role}\0${message.content}`)).toEqual(
+      before.map((message) => `${message.role}\0${message.content}`),
+    );
+
+    const seen = new Set<string>();
+    const duplicateContentRows = after.filter((message) => {
+      const identity = `${message.role}\0${message.content}`;
+      if (seen.has(identity)) {
+        return true;
+      }
+      seen.add(identity);
+      return false;
+    });
+    expect(duplicateContentRows).toHaveLength(0);
+  });
+
   it("skips reopening the transcript when checkpoint stats match", async () => {
     const sessionFile = createSessionFilePath("unchanged-fast-path");
     const sm = SessionManager.open(sessionFile);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2667,6 +2667,111 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(duplicateContentRows).toHaveLength(0);
   });
 
+  it("keeps fresh tool-only rows after dropping a replayed assistant prefix", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("bootstrap-reinstantiation-tool-tail");
+    const sm = SessionManager.open(sessionFile);
+    const sessionId = "bootstrap-reinstantiation-tool-tail";
+
+    for (let turn = 1; turn <= 5; turn += 1) {
+      sm.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: `question ${turn}` }],
+      } as AgentMessage);
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: `answer ${turn}` }],
+      } as AgentMessage);
+    }
+
+    const engineA = createEngineAtDatabasePath(dbPath);
+    const first = await engineA.bootstrap({ sessionId, sessionFile });
+    expect(first).toEqual({ bootstrapped: true, importedMessages: 10 });
+
+    const conversation = await engineA.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const before = await engineA.getConversationStore().getMessages(conversation!.conversationId);
+    await engineA.dispose();
+
+    for (const answer of ["answer 3", "answer 4", "answer 5"]) {
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: answer }],
+      } as AgentMessage);
+    }
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_new",
+      content: [{ type: "tool_result", tool_use_id: "call_new", output: { ok: true } }],
+    } as AgentMessage);
+
+    const engineB = createEngineAtDatabasePath(dbPath);
+    const second = await engineB.bootstrap({ sessionId, sessionFile });
+    expect(second.bootstrapped).toBe(true);
+    expect(second.importedMessages).toBe(1);
+    expect(second.reason).toBe("reconciled missing session messages");
+
+    const after = await engineB.getConversationStore().getMessages(conversation!.conversationId);
+    expect(after).toHaveLength(before.length + 1);
+
+    const imported = after[after.length - 1]!;
+    expect(imported.role).toBe("tool");
+    expect(imported.content).toBe("");
+
+    const parts = await engineB.getConversationStore().getMessageParts(imported.messageId);
+    expect(parts.some((part) => part.toolCallId === "call_new")).toBe(true);
+  });
+
+  it("keeps legitimate repeated assistant text when the ordering does not match a prior replay", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("bootstrap-repeated-assistant-order");
+    const sm = SessionManager.open(sessionFile);
+    const sessionId = "bootstrap-repeated-assistant-order";
+
+    for (const [question, answer] of [
+      ["question 1", "alpha"],
+      ["question 2", "beta"],
+      ["question 3", "gamma"],
+    ] as const) {
+      sm.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: question }],
+      } as AgentMessage);
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: answer }],
+      } as AgentMessage);
+    }
+
+    const engineA = createEngineAtDatabasePath(dbPath);
+    const first = await engineA.bootstrap({ sessionId, sessionFile });
+    expect(first).toEqual({ bootstrapped: true, importedMessages: 6 });
+    await engineA.dispose();
+
+    for (const answer of ["alpha", "gamma", "beta"]) {
+      sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: answer }],
+      } as AgentMessage);
+    }
+
+    const engineB = createEngineAtDatabasePath(dbPath);
+    const second = await engineB.bootstrap({ sessionId, sessionFile });
+    expect(second.bootstrapped).toBe(true);
+    expect(second.importedMessages).toBe(3);
+    expect(second.reason).toBe("reconciled missing session messages");
+
+    const conversation = await engineB.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const after = await engineB.getConversationStore().getMessages(conversation!.conversationId);
+    expect(after.slice(-3).map((message) => message.content)).toEqual(["alpha", "gamma", "beta"]);
+  });
+
   it("skips reopening the transcript when checkpoint stats match", async () => {
     const sessionFile = createSessionFilePath("unchanged-fast-path");
     const sm = SessionManager.open(sessionFile);


### PR DESCRIPTION
## Summary
- make existing-conversation bootstrap rehydrate read-only instead of appending prior assistant/tool transcript rows as fresh messages
- add a write-path guard that rejects same-conversation batches where >=3 rows share a timestamp and duplicate prior content
- wrap batch ingest in a transaction so rejected replay batches do not partially write
- add a regression covering a synthetic 5-turn conversation followed by re-instantiation/replay

## Repro signal
A live LCM trace showed conversation re-instantiation creating replay blocks where many assistant/tool rows were inserted under a single timestamp. Real tool execution had distinct timestamps over tens of seconds; replayed rows landed in one bulk write second. The fix keeps rehydrate read-only against existing seqs and only imports genuinely new turns.

## Tests
- `npm test -- test/engine.test.ts -t "re-instantiates"`
- `npm test -- test/engine.test.ts`
- `npm run build`
