### PR TITLE
feat: add SQLite-aware bootstrap frontier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"
@@ -22,10 +22,10 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-agent-core": "*",
-        "@mariozechner/pi-ai": "*",
-        "@mariozechner/pi-coding-agent": "*",
-        "openclaw": "*"
+        "@mariozechner/pi-agent-core": ">=0.66 <1",
+        "@mariozechner/pi-ai": ">=0.66 <1",
+        "@mariozechner/pi-coding-agent": ">=0.66 <1",
+        "openclaw": ">=2026.2.17 <2026.6.0"
       },
       "peerDependenciesMeta": {
         "@mariozechner/pi-agent-core": {
@@ -2992,7 +2992,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3006,7 +3005,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
       "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,7 +3021,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3040,7 +3037,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3057,7 +3053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,7 +3069,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,7 +3085,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3108,7 +3101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3125,7 +3117,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3142,7 +3133,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -168,6 +168,54 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
 }
 
+function ensureBootstrapStateColumns(db: DatabaseSync): void {
+  const bootstrapColumns = db.prepare(`PRAGMA table_info(conversation_bootstrap_state)`).all() as SummaryColumnInfo[];
+  const hasTranscriptSourceKind = bootstrapColumns.some((col) => col.name === "transcript_source_kind");
+  const hasTranscriptSourceIdentity = bootstrapColumns.some(
+    (col) => col.name === "transcript_source_identity",
+  );
+  const hasTranscriptUpdatedAt = bootstrapColumns.some((col) => col.name === "transcript_updated_at");
+  const hasTranscriptEventCount = bootstrapColumns.some((col) => col.name === "transcript_event_count");
+  const hasTranscriptLastSeq = bootstrapColumns.some((col) => col.name === "transcript_last_seq");
+  const hasTranscriptBaseCreatedAt = bootstrapColumns.some(
+    (col) => col.name === "transcript_base_created_at",
+  );
+
+  if (!hasTranscriptSourceKind) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_source_kind TEXT`);
+  }
+  if (!hasTranscriptSourceIdentity) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_source_identity TEXT`);
+  }
+  if (!hasTranscriptUpdatedAt) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_updated_at INTEGER`);
+  }
+  if (!hasTranscriptEventCount) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_event_count INTEGER`);
+  }
+  if (!hasTranscriptLastSeq) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_last_seq INTEGER`);
+  }
+  if (!hasTranscriptBaseCreatedAt) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN transcript_base_created_at INTEGER`);
+  }
+
+  db.exec(`
+    UPDATE conversation_bootstrap_state
+    SET transcript_source_kind = COALESCE(NULLIF(transcript_source_kind, ''), 'jsonl'),
+        transcript_source_identity = COALESCE(NULLIF(transcript_source_identity, ''), session_file_path),
+        transcript_updated_at = COALESCE(transcript_updated_at, last_seen_mtime_ms),
+        transcript_event_count = COALESCE(transcript_event_count, 0),
+        transcript_last_seq = COALESCE(transcript_last_seq, -1),
+        transcript_base_created_at = COALESCE(transcript_base_created_at, 0)
+  `);
+  db.exec(`DROP INDEX IF EXISTS bootstrap_state_path_idx`);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS bootstrap_state_source_idx
+    ON conversation_bootstrap_state (transcript_source_kind, transcript_source_identity, updated_at)
+  `);
+}
+
 /**
  * Belt-and-suspenders guard: create `message_parts` if it does not yet exist.
  *
@@ -937,6 +985,13 @@ export function runLcmMigrations(
       last_seen_mtime_ms INTEGER NOT NULL,
       last_processed_offset INTEGER NOT NULL,
       last_processed_entry_hash TEXT,
+      transcript_source_kind TEXT NOT NULL DEFAULT 'jsonl'
+        CHECK (transcript_source_kind IN ('jsonl', 'sqlite')),
+      transcript_source_identity TEXT,
+      transcript_updated_at INTEGER,
+      transcript_event_count INTEGER,
+      transcript_last_seq INTEGER,
+      transcript_base_created_at INTEGER,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -993,8 +1048,8 @@ export function runLcmMigrations(
     CREATE INDEX IF NOT EXISTS message_parts_type_idx ON message_parts (part_type);
     CREATE INDEX IF NOT EXISTS context_items_conv_idx ON context_items (conversation_id, ordinal);
     CREATE INDEX IF NOT EXISTS large_files_conv_idx ON large_files (conversation_id, created_at);
-    CREATE INDEX IF NOT EXISTS bootstrap_state_path_idx
-      ON conversation_bootstrap_state (session_file_path, updated_at);
+    CREATE INDEX IF NOT EXISTS bootstrap_state_source_idx
+      ON conversation_bootstrap_state (transcript_source_kind, transcript_source_identity, updated_at);
     CREATE INDEX IF NOT EXISTS compaction_telemetry_state_idx
       ON conversation_compaction_telemetry (cache_state, updated_at);
 
@@ -1046,6 +1101,7 @@ export function runLcmMigrations(
       ensureSummaryMetadataColumns(db),
     );
     runMigrationStep("ensureSummaryModelColumn", log, () => ensureSummaryModelColumn(db));
+    runMigrationStep("ensureBootstrapStateColumns", log, () => ensureBootstrapStateColumns(db));
     runMigrationStep("ensureMessageIdentityHashColumn", log, () =>
       ensureMessageIdentityHashColumn(db),
     );

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -71,7 +71,15 @@ import {
 } from "./store/conversation-store.js";
 import { SummaryStore } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "./summarize.js";
-import type { LcmDependencies, StartupSessionFileCandidate } from "./types.js";
+import type {
+  LcmDependencies,
+  SqliteSessionTranscriptCursor,
+  SqliteSessionTranscriptDelta,
+  SqliteSessionTranscriptEvent,
+  SqliteSessionTranscriptFrontier,
+  SqliteSessionTranscriptScope,
+  StartupSessionFileCandidate,
+} from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 import { createLcmDatabaseBackup } from "./plugin/lcm-db-backup.js";
 import {
@@ -1675,6 +1683,19 @@ function readBootstrapMessageFromJsonLine(line: string | null): AgentMessage | n
   } catch {
     return null;
   }
+}
+
+function bootstrapMessagesFromSqliteTranscriptEvents(
+  events: SqliteSessionTranscriptEvent[],
+): AgentMessage[] {
+  const messages: AgentMessage[] = [];
+  for (const entry of events) {
+    const candidate = extractBootstrapMessageCandidate(entry.event);
+    if (candidate) {
+      messages.push(candidate);
+    }
+  }
+  return messages;
 }
 
 function messageIdentity(role: string, content: string): string {
@@ -4939,6 +4960,321 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  private resolveSqliteTranscriptScope(params: {
+    sessionId: string;
+    sessionKey?: string;
+  }): SqliteSessionTranscriptScope | null {
+    if (
+      !this.deps.getSqliteSessionTranscriptFrontier
+      || !this.deps.loadSqliteSessionTranscriptDelta
+    ) {
+      return null;
+    }
+    const sessionId = params.sessionId.trim();
+    if (!sessionId) {
+      return null;
+    }
+    const parsed = params.sessionKey?.trim()
+      ? this.deps.parseAgentSessionKey(params.sessionKey.trim())
+      : null;
+    return {
+      agentId: this.deps.normalizeAgentId(parsed?.agentId),
+      sessionId,
+    };
+  }
+
+  private async bootstrapFromHistoricalMessages(params: {
+    conversation: ConversationRecord;
+    existingCount: number;
+    historicalMessages: AgentMessage[];
+    sessionId: string;
+    sessionKey?: string;
+    sessionLabel: string;
+    startedAt: number;
+    checkpointEntryHash?: string | null;
+    persistBootstrapState: (lastProcessedEntryHash?: string | null) => Promise<void>;
+  }): Promise<BootstrapResult> {
+    const conversationId = params.conversation.conversationId;
+
+    if (params.existingCount === 0) {
+      const bootstrapMessages = trimBootstrapMessagesToBudget(
+        params.historicalMessages,
+        resolveBootstrapMaxTokens(this.config),
+      );
+
+      if (bootstrapMessages.length === 0) {
+        await this.conversationStore.markConversationBootstrapped(conversationId);
+        await params.persistBootstrapState();
+        return {
+          bootstrapped: false,
+          importedMessages: 0,
+          reason: "no leaf-path messages in session",
+        };
+      }
+
+      let importedMessages = 0;
+      for (const message of bootstrapMessages) {
+        const result = await this.ingestSingle({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          message,
+        });
+        if (result.ingested) {
+          importedMessages += 1;
+        }
+      }
+      await this.conversationStore.markConversationBootstrapped(conversationId);
+
+      let prunedMessages = 0;
+      if (this.config.pruneHeartbeatOk) {
+        const pruned = await this.pruneHeartbeatOkTurns(conversationId);
+        prunedMessages = pruned;
+        if (pruned > 0) {
+          this.clearStableOrphanStrippingOrdinal(conversationId);
+          this.deps.log.info(
+            `[lcm] bootstrap: pruned ${pruned} HEARTBEAT_OK messages from conversation ${conversationId}`,
+          );
+        }
+      }
+
+      const lastImportedHash =
+        prunedMessages === 0 && bootstrapMessages.length > 0
+          ? createBootstrapEntryHash(toStoredMessage(bootstrapMessages[bootstrapMessages.length - 1]))
+          : undefined;
+      await params.persistBootstrapState(lastImportedHash);
+      if (importedMessages > 0) {
+        this.clearStableOrphanStrippingOrdinal(conversationId);
+      }
+      this.deps.log.info(
+        `[lcm] bootstrap: initial import conversation=${conversationId} ${params.sessionLabel} importedMessages=${importedMessages} sourceMessages=${params.historicalMessages.length} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+      );
+
+      return {
+        bootstrapped: true,
+        importedMessages,
+      };
+    }
+
+    const reconcile = await this.reconcileSessionTail({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      conversationId,
+      historicalMessages: params.historicalMessages,
+      checkpointEntryHash: params.checkpointEntryHash,
+    });
+    this.deps.log.info(
+      `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${params.sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+    );
+
+    if (reconcile.blockedByImportCap) {
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "reconcile import capped",
+      };
+    }
+
+    if (!params.conversation.bootstrappedAt) {
+      await this.conversationStore.markConversationBootstrapped(conversationId);
+    }
+
+    if (reconcile.importedMessages > 0) {
+      this.clearStableOrphanStrippingOrdinal(conversationId);
+      await params.persistBootstrapState();
+      return {
+        bootstrapped: true,
+        importedMessages: reconcile.importedMessages,
+        reason: "reconciled missing session messages",
+      };
+    }
+
+    if (reconcile.hasOverlap) {
+      await params.persistBootstrapState();
+    }
+
+    if (params.conversation.bootstrappedAt) {
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "already bootstrapped",
+      };
+    }
+
+    return {
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: reconcile.hasOverlap
+        ? "conversation already up to date"
+        : "conversation already has messages",
+    };
+  }
+
+  private async bootstrapFromSqliteTranscript(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    sessionLabel: string;
+    startedAt: number;
+    sqliteScope: SqliteSessionTranscriptScope;
+  }): Promise<BootstrapResult> {
+    const getFrontier = this.deps.getSqliteSessionTranscriptFrontier;
+    const loadDelta = this.deps.loadSqliteSessionTranscriptDelta;
+    if (!getFrontier || !loadDelta) {
+      throw new Error("SQLite transcript bootstrap requested without SQLite transcript dependencies.");
+    }
+
+    return this.withSessionQueue(
+      this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+      async () =>
+        this.conversationStore.withTransaction(async () => {
+          const conversation = await this.conversationStore.getOrCreateConversation(params.sessionId, {
+            sessionKey: params.sessionKey,
+          });
+          const conversationId = conversation.conversationId;
+          const existingCount = await this.conversationStore.getMessageCount(conversationId);
+          const bootstrapState = await this.summaryStore.getConversationBootstrapState(conversationId);
+          const sourceIdentity = `${params.sqliteScope.agentId}:${params.sqliteScope.sessionId}`;
+          const frontier = await getFrontier(params.sqliteScope);
+
+          if (!frontier) {
+            if (!conversation.bootstrappedAt) {
+              await this.conversationStore.markConversationBootstrapped(conversationId);
+            }
+            return {
+              bootstrapped: false,
+              importedMessages: 0,
+              reason: "no sqlite transcript events",
+            };
+          }
+
+          const persistBootstrapState = async (
+            lastProcessedEntryHash?: string | null,
+            nextFrontier: SqliteSessionTranscriptFrontier = frontier,
+          ): Promise<void> => {
+            await this.refreshBootstrapState({
+              conversationId,
+              sessionFile: params.sessionFile,
+              lastProcessedEntryHash,
+              sqliteScope: params.sqliteScope,
+              sqliteFrontier: nextFrontier,
+            });
+          };
+
+          if (
+            bootstrapState?.transcriptSourceKind === "sqlite"
+            && bootstrapState.transcriptSourceIdentity === sourceIdentity
+            && bootstrapState.transcriptEventCount === frontier.eventCount
+            && bootstrapState.transcriptLastSeq === frontier.lastSeq
+            && bootstrapState.transcriptBaseCreatedAt === frontier.baseCreatedAt
+          ) {
+            if (!conversation.bootstrappedAt) {
+              await this.conversationStore.markConversationBootstrapped(conversationId);
+            }
+            this.deps.log.info(
+              `[lcm] bootstrap: sqlite checkpoint hit conversation=${conversationId} ${params.sessionLabel} existingCount=${existingCount} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+            );
+            return {
+              bootstrapped: false,
+              importedMessages: 0,
+              reason: conversation.bootstrappedAt
+                ? "already bootstrapped"
+                : "conversation already up to date",
+            };
+          }
+
+          const cursor: SqliteSessionTranscriptCursor | undefined =
+            bootstrapState?.transcriptSourceKind === "sqlite"
+            && bootstrapState.transcriptSourceIdentity === sourceIdentity
+            && bootstrapState.transcriptEventCount !== null
+            && bootstrapState.transcriptLastSeq !== null
+            && bootstrapState.transcriptBaseCreatedAt !== null
+              ? {
+                  eventCount: bootstrapState.transcriptEventCount,
+                  lastSeq: bootstrapState.transcriptLastSeq,
+                  baseCreatedAt: bootstrapState.transcriptBaseCreatedAt,
+                }
+              : undefined;
+          const delta: SqliteSessionTranscriptDelta = await loadDelta({
+            ...params.sqliteScope,
+            ...(cursor ? { cursor } : {}),
+          });
+
+          if (delta.mode === "missing" || !delta.frontier) {
+            if (!conversation.bootstrappedAt) {
+              await this.conversationStore.markConversationBootstrapped(conversationId);
+            }
+            return {
+              bootstrapped: false,
+              importedMessages: 0,
+              reason: "no sqlite transcript events",
+            };
+          }
+
+          if (delta.mode === "append" && cursor) {
+            if (!conversation.bootstrappedAt) {
+              await this.conversationStore.markConversationBootstrapped(conversationId);
+            }
+
+            let importedMessages = 0;
+            const appendMessages = bootstrapMessagesFromSqliteTranscriptEvents(delta.events);
+            for (const message of appendMessages) {
+              const ingestResult = await this.ingestSingle({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                message,
+              });
+              if (ingestResult.ingested) {
+                importedMessages += 1;
+              }
+            }
+
+            await persistBootstrapState(undefined, delta.frontier);
+            if (importedMessages > 0) {
+              this.clearStableOrphanStrippingOrdinal(conversationId);
+            }
+            this.deps.log.info(
+              `[lcm] bootstrap: sqlite append conversation=${conversationId} ${params.sessionLabel} existingCount=${existingCount} appendedMessages=${appendMessages.length} importedMessages=${importedMessages} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+            );
+
+            if (importedMessages > 0) {
+              return {
+                bootstrapped: true,
+                importedMessages,
+                reason: "reconciled missing session messages",
+              };
+            }
+
+            return {
+              bootstrapped: false,
+              importedMessages: 0,
+              reason: conversation.bootstrappedAt
+                ? "already bootstrapped"
+                : "conversation already up to date",
+            };
+          }
+
+          const historicalMessages = bootstrapMessagesFromSqliteTranscriptEvents(delta.events);
+          this.deps.log.info(
+            `[lcm] bootstrap: sqlite transcript read conversation=${conversationId} ${params.sessionLabel} existingCount=${existingCount} historicalMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+          );
+
+          return this.bootstrapFromHistoricalMessages({
+            conversation,
+            existingCount,
+            historicalMessages,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionLabel: params.sessionLabel,
+            startedAt: params.startedAt,
+            checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
+            persistBootstrapState: async (lastProcessedEntryHash?: string | null) =>
+              persistBootstrapState(lastProcessedEntryHash, delta.frontier),
+          });
+        }),
+      { operationName: "bootstrap", context: params.sessionLabel },
+    );
+  }
+
   /**
    * Persist bootstrap checkpoint metadata anchored to the current DB frontier.
    *
@@ -4951,9 +5287,16 @@ export class LcmContextEngine implements ContextEngine {
     sessionFile: string;
     fileStats?: { size: number; mtimeMs: number };
     lastProcessedEntryHash?: string | null;
+    sqliteScope?: SqliteSessionTranscriptScope;
+    sqliteFrontier?: SqliteSessionTranscriptFrontier;
   }): Promise<void> {
     const latestDbMessage = await this.conversationStore.getLastMessage(params.conversationId);
-    const fileStats = params.fileStats ?? (await stat(params.sessionFile));
+    const fileStats = params.sqliteFrontier
+      ? {
+          size: 0,
+          mtimeMs: params.sqliteFrontier.updatedAt,
+        }
+      : params.fileStats ?? (await stat(params.sessionFile));
     await this.summaryStore.upsertConversationBootstrapState({
       conversationId: params.conversationId,
       sessionFilePath: params.sessionFile,
@@ -4970,6 +5313,16 @@ export class LcmContextEngine implements ContextEngine {
                 tokenCount: latestDbMessage.tokenCount,
               })
             : null,
+      transcriptSourceKind: params.sqliteFrontier ? "sqlite" : "jsonl",
+      transcriptSourceIdentity: params.sqliteScope
+        ? `${params.sqliteScope.agentId}:${params.sqliteScope.sessionId}`
+        : params.sessionFile,
+      transcriptUpdatedAt: params.sqliteFrontier
+        ? params.sqliteFrontier.updatedAt
+        : Math.trunc(fileStats.mtimeMs),
+      transcriptEventCount: params.sqliteFrontier?.eventCount ?? null,
+      transcriptLastSeq: params.sqliteFrontier?.lastSeq ?? null,
+      transcriptBaseCreatedAt: params.sqliteFrontier?.baseCreatedAt ?? null,
     });
   }
 
@@ -4998,6 +5351,51 @@ export class LcmContextEngine implements ContextEngine {
       `session=${params.sessionId}`,
       ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
     ].join(" ");
+    const sqliteScope = this.resolveSqliteTranscriptScope(params);
+    if (sqliteScope) {
+      const result = await this.bootstrapFromSqliteTranscript({
+        ...params,
+        sessionLabel,
+        startedAt,
+        sqliteScope,
+      });
+
+      if (this.config.pruneHeartbeatOk && result.bootstrapped === false) {
+        try {
+          const conversation = await this.conversationStore.getConversationForSession({
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          });
+          if (conversation) {
+            const pruned = await this.pruneHeartbeatOkTurns(conversation.conversationId);
+            if (pruned > 0) {
+              this.clearStableOrphanStrippingOrdinal(conversation.conversationId);
+              const frontier = await this.deps.getSqliteSessionTranscriptFrontier?.(sqliteScope);
+              if (frontier) {
+                await this.refreshBootstrapState({
+                  conversationId: conversation.conversationId,
+                  sessionFile: params.sessionFile,
+                  sqliteScope,
+                  sqliteFrontier: frontier,
+                });
+              }
+              this.deps.log.info(
+                `[lcm] bootstrap: retroactively pruned ${pruned} HEARTBEAT_OK messages from conversation ${conversation.conversationId}`,
+              );
+            }
+          }
+        } catch (err) {
+          this.deps.log.warn(
+            `[lcm] bootstrap: heartbeat pruning failed: ${describeLogError(err)}`,
+          );
+        }
+      }
+
+      this.deps.log.info(
+        `[lcm] bootstrap: done ${sessionLabel} bootstrapped=${result.bootstrapped} importedMessages=${result.importedMessages} reason=${result.reason ?? "none"} duration=${formatDurationMs(Date.now() - startedAt)}`,
+      );
+      return result;
+    }
     const sessionFileStats = await stat(params.sessionFile);
     const sessionFileSize = sessionFileStats.size;
     const sessionFileMtimeMs = Math.trunc(sessionFileStats.mtimeMs);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -20,7 +20,14 @@ import { createLcmExpandQueryTool } from "../tools/lcm-expand-query-tool.js";
 import { createLcmExpandTool } from "../tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
 import { createLcmCommand } from "./lcm-command.js";
-import type { LcmDependencies, StartupSessionFileCandidate } from "../types.js";
+import type {
+  LcmDependencies,
+  SqliteSessionTranscriptCursor,
+  SqliteSessionTranscriptDelta,
+  SqliteSessionTranscriptFrontier,
+  SqliteSessionTranscriptScope,
+  StartupSessionFileCandidate,
+} from "../types.js";
 
 /** Parse `agent:<agentId>:<suffix...>` session keys. */
 function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
@@ -61,6 +68,31 @@ type RuntimeAgentSessionApi = {
   ) => string;
 };
 type RuntimeAgentSessionApiCandidate = Partial<RuntimeAgentSessionApi>;
+
+type SessionStoreRuntimeModule = {
+  getSqliteSessionTranscriptFrontier?: (scope: {
+    env?: NodeJS.ProcessEnv;
+    agentId: string;
+    sessionId: string;
+  }) => Promise<SqliteSessionTranscriptFrontier | null> | SqliteSessionTranscriptFrontier | null;
+  loadSqliteSessionTranscriptDelta?: (params: {
+    env?: NodeJS.ProcessEnv;
+    agentId: string;
+    sessionId: string;
+    cursor?: SqliteSessionTranscriptCursor;
+  }) => Promise<SqliteSessionTranscriptDelta> | SqliteSessionTranscriptDelta;
+};
+
+let sessionStoreRuntimeModulePromise: Promise<SessionStoreRuntimeModule | null> | null = null;
+
+async function loadSessionStoreRuntimeModule(): Promise<SessionStoreRuntimeModule | null> {
+  if (!sessionStoreRuntimeModulePromise) {
+    sessionStoreRuntimeModulePromise = import("openclaw/plugin-sdk/session-store-runtime")
+      .then((mod) => mod as SessionStoreRuntimeModule)
+      .catch(() => null);
+  }
+  return sessionStoreRuntimeModulePromise;
+}
 
 /** Return the runtime session registry API when the host exposes it. */
 function getRuntimeAgentSessionApi(api: OpenClawPluginApi): RuntimeAgentSessionApi | undefined {
@@ -2253,6 +2285,49 @@ function createLcmDependencies(
         return transcriptPath.trim() || undefined;
       } catch {
         return undefined;
+      }
+    },
+    getSqliteSessionTranscriptFrontier: async (scope: SqliteSessionTranscriptScope) => {
+      const runtime = await loadSessionStoreRuntimeModule();
+      if (!runtime?.getSqliteSessionTranscriptFrontier) {
+        return null;
+      }
+      try {
+        return (
+          (await runtime.getSqliteSessionTranscriptFrontier({
+            env: process.env,
+            agentId: scope.agentId,
+            sessionId: scope.sessionId,
+          })) ?? null
+        );
+      } catch {
+        return null;
+      }
+    },
+    loadSqliteSessionTranscriptDelta: async (
+      params: SqliteSessionTranscriptScope & { cursor?: SqliteSessionTranscriptCursor },
+    ) => {
+      const runtime = await loadSessionStoreRuntimeModule();
+      if (!runtime?.loadSqliteSessionTranscriptDelta) {
+        return {
+          mode: "missing",
+          frontier: null,
+          events: [],
+        } satisfies SqliteSessionTranscriptDelta;
+      }
+      try {
+        return await runtime.loadSqliteSessionTranscriptDelta({
+          env: process.env,
+          agentId: params.agentId,
+          sessionId: params.sessionId,
+          ...(params.cursor ? { cursor: params.cursor } : {}),
+        });
+      } catch {
+        return {
+          mode: "missing",
+          frontier: null,
+          events: [],
+        } satisfies SqliteSessionTranscriptDelta;
       }
     },
     listStartupSessionFileCandidates: async () => {

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -112,6 +112,12 @@ export type UpsertConversationBootstrapStateInput = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash?: string | null;
+  transcriptSourceKind?: "jsonl" | "sqlite";
+  transcriptSourceIdentity?: string | null;
+  transcriptUpdatedAt?: number | null;
+  transcriptEventCount?: number | null;
+  transcriptLastSeq?: number | null;
+  transcriptBaseCreatedAt?: number | null;
 };
 
 export type ConversationBootstrapStateRecord = {
@@ -121,6 +127,12 @@ export type ConversationBootstrapStateRecord = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash: string | null;
+  transcriptSourceKind: "jsonl" | "sqlite";
+  transcriptSourceIdentity: string;
+  transcriptUpdatedAt: number | null;
+  transcriptEventCount: number | null;
+  transcriptLastSeq: number | null;
+  transcriptBaseCreatedAt: number | null;
   updatedAt: Date;
 };
 
@@ -224,6 +236,12 @@ interface ConversationBootstrapStateRow {
   last_seen_mtime_ms: number;
   last_processed_offset: number;
   last_processed_entry_hash: string | null;
+  transcript_source_kind: string | null;
+  transcript_source_identity: string | null;
+  transcript_updated_at: number | null;
+  transcript_event_count: number | null;
+  transcript_last_seq: number | null;
+  transcript_base_created_at: number | null;
   updated_at: string;
 }
 
@@ -318,6 +336,7 @@ function toLargeFileRecord(row: LargeFileRow): LargeFileRecord {
 function toConversationBootstrapStateRecord(
   row: ConversationBootstrapStateRow,
 ): ConversationBootstrapStateRecord {
+  const transcriptSourceKind = row.transcript_source_kind === "sqlite" ? "sqlite" : "jsonl";
   return {
     conversationId: row.conversation_id,
     sessionFilePath: row.session_file_path,
@@ -325,6 +344,27 @@ function toConversationBootstrapStateRecord(
     lastSeenMtimeMs: row.last_seen_mtime_ms,
     lastProcessedOffset: row.last_processed_offset,
     lastProcessedEntryHash: row.last_processed_entry_hash,
+    transcriptSourceKind,
+    transcriptSourceIdentity:
+      row.transcript_source_identity ??
+      (row.session_file_path && row.session_file_path.length > 0 ? row.session_file_path : ""),
+    transcriptUpdatedAt:
+      typeof row.transcript_updated_at === "number" && Number.isFinite(row.transcript_updated_at)
+        ? row.transcript_updated_at
+        : null,
+    transcriptEventCount:
+      typeof row.transcript_event_count === "number" && Number.isFinite(row.transcript_event_count)
+        ? row.transcript_event_count
+        : null,
+    transcriptLastSeq:
+      typeof row.transcript_last_seq === "number" && Number.isFinite(row.transcript_last_seq)
+        ? row.transcript_last_seq
+        : null,
+    transcriptBaseCreatedAt:
+      typeof row.transcript_base_created_at === "number" &&
+      Number.isFinite(row.transcript_base_created_at)
+        ? row.transcript_base_created_at
+        : null,
     updatedAt: parseUtcTimestamp(row.updated_at),
   };
 }
@@ -1516,7 +1556,9 @@ export class SummaryStore {
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
+                last_processed_offset, last_processed_entry_hash, transcript_source_kind,
+                transcript_source_identity, transcript_updated_at, transcript_event_count,
+                transcript_last_seq, transcript_base_created_at, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )
@@ -1535,15 +1577,27 @@ export class SummaryStore {
            last_seen_size,
            last_seen_mtime_ms,
            last_processed_offset,
-           last_processed_entry_hash
+           last_processed_entry_hash,
+           transcript_source_kind,
+           transcript_source_identity,
+           transcript_updated_at,
+           transcript_event_count,
+           transcript_last_seq,
+           transcript_base_created_at
          )
-         VALUES (?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (conversation_id) DO UPDATE SET
            session_file_path = excluded.session_file_path,
            last_seen_size = excluded.last_seen_size,
            last_seen_mtime_ms = excluded.last_seen_mtime_ms,
            last_processed_offset = excluded.last_processed_offset,
            last_processed_entry_hash = excluded.last_processed_entry_hash,
+           transcript_source_kind = excluded.transcript_source_kind,
+           transcript_source_identity = excluded.transcript_source_identity,
+           transcript_updated_at = excluded.transcript_updated_at,
+           transcript_event_count = excluded.transcript_event_count,
+           transcript_last_seq = excluded.transcript_last_seq,
+           transcript_base_created_at = excluded.transcript_base_created_at,
            updated_at = datetime('now')`,
       )
       .run(
@@ -1553,12 +1607,20 @@ export class SummaryStore {
         Math.max(0, Math.floor(input.lastSeenMtimeMs)),
         Math.max(0, Math.floor(input.lastProcessedOffset)),
         input.lastProcessedEntryHash ?? null,
+        input.transcriptSourceKind ?? "jsonl",
+        input.transcriptSourceIdentity ?? input.sessionFilePath,
+        input.transcriptUpdatedAt ?? input.lastSeenMtimeMs,
+        input.transcriptEventCount ?? null,
+        input.transcriptLastSeq ?? null,
+        input.transcriptBaseCreatedAt ?? null,
       );
 
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, updated_at
+                last_processed_offset, last_processed_entry_hash, transcript_source_kind,
+                transcript_source_identity, transcript_updated_at, transcript_event_count,
+                transcript_last_seq, transcript_base_created_at, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,42 @@ export type ParseAgentSessionKeyFn = (sessionKey: string) => {
 
 export type IsSubagentSessionKeyFn = (sessionKey: string) => boolean;
 
+export type SqliteSessionTranscriptScope = {
+  agentId: string;
+  sessionId: string;
+};
+
+export type SqliteSessionTranscriptFrontier = {
+  sessionId: string;
+  updatedAt: number;
+  eventCount: number;
+  lastSeq: number;
+  baseCreatedAt: number;
+};
+
+export type SqliteSessionTranscriptCursor = Pick<
+  SqliteSessionTranscriptFrontier,
+  "eventCount" | "lastSeq" | "baseCreatedAt"
+>;
+
+export type SqliteSessionTranscriptEvent = {
+  seq: number;
+  createdAt: number;
+  event: unknown;
+};
+
+export type SqliteSessionTranscriptDelta =
+  | {
+      mode: "missing";
+      frontier: null;
+      events: [];
+    }
+  | {
+      mode: "append" | "reset";
+      frontier: SqliteSessionTranscriptFrontier;
+      events: SqliteSessionTranscriptEvent[];
+    };
+
 export type StartupSessionFileCandidate = {
   sessionId: string;
   sessionKey: string;
@@ -170,6 +206,16 @@ export interface LcmDependencies {
     sessionId: string;
     sessionKey?: string;
   }) => Promise<string | undefined>;
+
+  /** Optional SQLite-native transcript frontier seam from newer OpenClaw runtimes. */
+  getSqliteSessionTranscriptFrontier?: (
+    scope: SqliteSessionTranscriptScope,
+  ) => Promise<SqliteSessionTranscriptFrontier | null>;
+
+  /** Optional SQLite-native transcript delta seam from newer OpenClaw runtimes. */
+  loadSqliteSessionTranscriptDelta?: (
+    params: SqliteSessionTranscriptScope & { cursor?: SqliteSessionTranscriptCursor },
+  ) => Promise<SqliteSessionTranscriptDelta>;
 
   /** List OpenClaw-indexed session files that startup recovery may enumerate. */
   listStartupSessionFileCandidates?: () => Promise<StartupSessionFileCandidate[]>;

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -111,6 +111,71 @@ function createSessionFilePath(name: string): string {
   return join(tempDir, `${name}.jsonl`);
 }
 
+type MockSqliteTranscriptFrontier = {
+  sessionId: string;
+  updatedAt: number;
+  eventCount: number;
+  lastSeq: number;
+  baseCreatedAt: number;
+};
+
+type MockSqliteTranscriptEvent = {
+  seq: number;
+  createdAt: number;
+  event: unknown;
+};
+
+function createSqliteTranscriptEventsFromMessages(params: {
+  sessionId: string;
+  messages: AgentMessage[];
+  startedAt?: number;
+}): MockSqliteTranscriptEvent[] {
+  const startedAt = params.startedAt ?? Date.parse("2026-05-10T00:00:00Z");
+  const events: MockSqliteTranscriptEvent[] = [
+    {
+      seq: 0,
+      createdAt: startedAt,
+      event: {
+        type: "session",
+        version: 3,
+        id: params.sessionId,
+        timestamp: new Date(startedAt).toISOString(),
+        cwd: "/tmp/lcm-sqlite-flood",
+      },
+    },
+  ];
+
+  params.messages.forEach((message, index) => {
+    const id = `msg-${index + 1}`;
+    events.push({
+      seq: index + 1,
+      createdAt: startedAt + (index + 1) * 1_000,
+      event: {
+        type: "message",
+        id,
+        parentId: index === 0 ? null : `msg-${index}`,
+        timestamp: new Date(startedAt + (index + 1) * 1_000).toISOString(),
+        message,
+      },
+    });
+  });
+
+  return events;
+}
+
+function createSqliteTranscriptFrontier(
+  sessionId: string,
+  events: MockSqliteTranscriptEvent[],
+): MockSqliteTranscriptFrontier {
+  return {
+    sessionId,
+    updatedAt: events.at(-1)?.createdAt ?? 0,
+    eventCount: events.length,
+    lastSeq: events.at(-1)?.seq ?? -1,
+    baseCreatedAt: events[0]?.createdAt ?? 0,
+  };
+}
+
 /**
  * Build a JSONL session with `pairCount` user/assistant message pairs.
  * Every 5th pair uses identical "ping"/"pong" content to stress
@@ -445,5 +510,88 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
       finalCount,
       "DB message count should be unchanged after capped flood attempt",
     ).toBe(dbCountAfterBoot);
+  });
+
+  it("reconciles a SQLite reset replay with repeated content without duplicate flood", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lcm-flood-skills-"));
+    tempDirs.push(tempDir);
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const db = createLcmDatabaseConnection(config.databasePath);
+    const deps = createTestDeps(config) as LcmDependencies & {
+      getSqliteSessionTranscriptFrontier: ReturnType<typeof vi.fn>;
+      loadSqliteSessionTranscriptDelta: ReturnType<typeof vi.fn>;
+    };
+    const engine = new LcmContextEngine(deps, db);
+    const sessionId = randomUUID();
+    const sessionKey = "agent:main:sqlite-flood";
+
+    const initialMessages: AgentMessage[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      initialMessages.push({
+        role: "user",
+        content: [{ type: "text", text: i % 2 === 0 ? "ping" : `Question ${i}` }],
+      } as AgentMessage);
+      initialMessages.push({
+        role: "assistant",
+        content: [{ type: "text", text: i % 2 === 0 ? "pong" : `Answer ${i}` }],
+      } as AgentMessage);
+    }
+    const initialEvents = createSqliteTranscriptEventsFromMessages({
+      sessionId,
+      messages: initialMessages,
+    });
+    const initialFrontier = createSqliteTranscriptFrontier(sessionId, initialEvents);
+    const resetMessages = [
+      ...initialMessages,
+      { role: "user", content: [{ type: "text", text: "ping" }] } as AgentMessage,
+      { role: "assistant", content: [{ type: "text", text: "pong" }] } as AgentMessage,
+    ];
+    const resetEvents = createSqliteTranscriptEventsFromMessages({
+      sessionId,
+      messages: resetMessages,
+      startedAt: Date.parse("2026-05-10T01:00:00Z"),
+    });
+    const resetFrontier = createSqliteTranscriptFrontier(sessionId, resetEvents);
+
+    deps.getSqliteSessionTranscriptFrontier = vi
+      .fn()
+      .mockResolvedValueOnce(initialFrontier)
+      .mockResolvedValueOnce(resetFrontier);
+    deps.loadSqliteSessionTranscriptDelta = vi
+      .fn()
+      .mockResolvedValueOnce({
+        mode: "reset",
+        frontier: initialFrontier,
+        events: initialEvents,
+      })
+      .mockResolvedValueOnce({
+        mode: "reset",
+        frontier: resetFrontier,
+        events: resetEvents,
+      });
+
+    const first = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: "/tmp/sqlite-flood-first.jsonl",
+    });
+    const second = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: "/tmp/sqlite-flood-second.jsonl",
+    });
+
+    expect(first.importedMessages).toBe(initialMessages.length);
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(resetMessages.length);
   });
 });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -173,6 +173,83 @@ function createSessionFilePath(name: string): string {
   return join(tempDir, `${name}.jsonl`);
 }
 
+type MockSqliteTranscriptFrontier = {
+  sessionId: string;
+  updatedAt: number;
+  eventCount: number;
+  lastSeq: number;
+  baseCreatedAt: number;
+};
+
+type MockSqliteTranscriptEvent = {
+  seq: number;
+  createdAt: number;
+  event: unknown;
+};
+
+type MockSqliteTranscriptDelta =
+  | {
+      mode: "missing";
+      frontier: null;
+      events: [];
+    }
+  | {
+      mode: "append" | "reset";
+      frontier: MockSqliteTranscriptFrontier;
+      events: MockSqliteTranscriptEvent[];
+    };
+
+function createSqliteTranscriptMessageEvents(params: {
+  sessionId: string;
+  messages: Array<{ role: string; content: unknown }>;
+  startedAt?: number;
+}): MockSqliteTranscriptEvent[] {
+  const startedAt = params.startedAt ?? Date.parse("2026-05-10T00:00:00Z");
+  const events: MockSqliteTranscriptEvent[] = [
+    {
+      seq: 0,
+      createdAt: startedAt,
+      event: {
+        type: "session",
+        version: 3,
+        id: params.sessionId,
+        timestamp: new Date(startedAt).toISOString(),
+        cwd: "/tmp/lcm-sqlite-bootstrap",
+      },
+    },
+  ];
+
+  params.messages.forEach((message, index) => {
+    const id = `msg-${index + 1}`;
+    events.push({
+      seq: index + 1,
+      createdAt: startedAt + (index + 1) * 1_000,
+      event: {
+        type: "message",
+        id,
+        parentId: index === 0 ? null : `msg-${index}`,
+        timestamp: new Date(startedAt + (index + 1) * 1_000).toISOString(),
+        message,
+      },
+    });
+  });
+
+  return events;
+}
+
+function createSqliteTranscriptFrontier(
+  sessionId: string,
+  events: MockSqliteTranscriptEvent[],
+): MockSqliteTranscriptFrontier {
+  return {
+    sessionId,
+    updatedAt: events.at(-1)?.createdAt ?? 0,
+    eventCount: events.length,
+    lastSeq: events.at(-1)?.seq ?? -1,
+    baseCreatedAt: events[0]?.createdAt ?? 0,
+  };
+}
+
 function createEngineWithConfig(overrides: Partial<LcmConfig>): LcmContextEngine {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
   tempDirs.push(tempDir);
@@ -5002,6 +5079,165 @@ describe("LcmContextEngine.bootstrap", () => {
         typeof call[0] === "string" && call[0].includes("skipped full read (file unchanged)"),
     );
     expect(skippedLogs).toHaveLength(0);
+  });
+
+  it("bootstraps from a SQLite transcript delta without requiring a transcript file", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const db = createLcmDatabaseConnection(config.databasePath);
+    const sessionId = "sqlite-bootstrap";
+    const sessionKey = "agent:main:sqlite-bootstrap";
+    const events = createSqliteTranscriptMessageEvents({
+      sessionId,
+      messages: [
+        { role: "user", content: "hello from sqlite" },
+        { role: "assistant", content: "reply from sqlite" },
+      ],
+    });
+    const frontier = createSqliteTranscriptFrontier(sessionId, events);
+    const deps = createTestDeps(config) as LcmDependencies & {
+      getSqliteSessionTranscriptFrontier: ReturnType<typeof vi.fn>;
+      loadSqliteSessionTranscriptDelta: ReturnType<typeof vi.fn>;
+    };
+    deps.getSqliteSessionTranscriptFrontier = vi.fn(async () => frontier);
+    deps.loadSqliteSessionTranscriptDelta = vi.fn(
+      async (): Promise<MockSqliteTranscriptDelta> => ({
+        mode: "reset",
+        frontier,
+        events,
+      }),
+    );
+    const engine = new LcmContextEngine(deps, db);
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: "/tmp/does-not-exist.jsonl",
+    });
+
+    expect(result).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "hello from sqlite",
+      "reply from sqlite",
+    ]);
+
+    const bootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(bootstrapState).not.toBeNull();
+    expect(bootstrapState?.transcriptSourceKind).toBe("sqlite");
+    expect(bootstrapState?.transcriptSourceIdentity).toBe("main:sqlite-bootstrap");
+    expect(bootstrapState?.transcriptEventCount).toBe(frontier.eventCount);
+    expect(bootstrapState?.transcriptLastSeq).toBe(frontier.lastSeq);
+    expect(bootstrapState?.transcriptBaseCreatedAt).toBe(frontier.baseCreatedAt);
+  });
+
+  it("resumes from a stored SQLite cursor and ingests only appended transcript messages", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const db = createLcmDatabaseConnection(config.databasePath);
+    const sessionId = "sqlite-append";
+    const sessionKey = "agent:main:sqlite-append";
+    const initialEvents = createSqliteTranscriptMessageEvents({
+      sessionId,
+      messages: [
+        { role: "user", content: "turn one" },
+        { role: "assistant", content: "turn two" },
+      ],
+    });
+    const initialFrontier = createSqliteTranscriptFrontier(sessionId, initialEvents);
+    const appendedEvents: MockSqliteTranscriptEvent[] = [
+      {
+        seq: 3,
+        createdAt: initialFrontier.updatedAt + 1_000,
+        event: {
+          type: "message",
+          id: "msg-3",
+          parentId: "msg-2",
+          timestamp: new Date(initialFrontier.updatedAt + 1_000).toISOString(),
+          message: { role: "user", content: "turn three" },
+        },
+      },
+      {
+        seq: 4,
+        createdAt: initialFrontier.updatedAt + 2_000,
+        event: {
+          type: "message",
+          id: "msg-4",
+          parentId: "msg-3",
+          timestamp: new Date(initialFrontier.updatedAt + 2_000).toISOString(),
+          message: { role: "assistant", content: "turn four" },
+        },
+      },
+    ];
+    const appendedFrontier = createSqliteTranscriptFrontier(sessionId, [
+      ...initialEvents,
+      ...appendedEvents,
+    ]);
+    const deps = createTestDeps(config) as LcmDependencies & {
+      getSqliteSessionTranscriptFrontier: ReturnType<typeof vi.fn>;
+      loadSqliteSessionTranscriptDelta: ReturnType<typeof vi.fn>;
+    };
+    deps.getSqliteSessionTranscriptFrontier = vi
+      .fn()
+      .mockResolvedValueOnce(initialFrontier)
+      .mockResolvedValueOnce(appendedFrontier);
+    deps.loadSqliteSessionTranscriptDelta = vi
+      .fn()
+      .mockResolvedValueOnce({
+        mode: "reset",
+        frontier: initialFrontier,
+        events: initialEvents,
+      } satisfies MockSqliteTranscriptDelta)
+      .mockResolvedValueOnce({
+        mode: "append",
+        frontier: appendedFrontier,
+        events: appendedEvents,
+      } satisfies MockSqliteTranscriptDelta);
+    const engine = new LcmContextEngine(deps, db);
+
+    const first = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: "/tmp/missing-first.jsonl",
+    });
+    const second = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: "/tmp/missing-second.jsonl",
+    });
+
+    expect(first.importedMessages).toBe(2);
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "turn one",
+      "turn two",
+      "turn three",
+      "turn four",
+    ]);
   });
 });
 

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -799,6 +799,12 @@ describe("runLcmMigrations summary depth backfill", () => {
       "last_seen_mtime_ms",
       "last_processed_offset",
       "last_processed_entry_hash",
+      "transcript_source_kind",
+      "transcript_source_identity",
+      "transcript_updated_at",
+      "transcript_event_count",
+      "transcript_last_seq",
+      "transcript_base_created_at",
       "updated_at",
     ]);
   });


### PR DESCRIPTION
## Summary

This starts the LCM-side SQLite migration by making bootstrap frontier state source-aware and SQLite-capable, while keeping JSONL compatibility as a fallback.

The immediate goal is not to solve the full Lossless Claw migration in one PR. The goal here is narrower:
- stop hard-depending on file `mtime` / `size` / `offset` for the canonical bootstrap frontier
- allow LCM to bootstrap and resume from an OpenClaw SQLite transcript cursor when the newer session-store seam is available
- preserve current JSONL behavior on older OpenClaw runtimes

This is the first implementation slice for #645 and part of the vNext umbrella in #641.

## Why this is better

OpenClaw is moving toward SQLite-backed session/transcript state. LCM's current bootstrap checkpoint model is still file-era:
- `session_file_path`
- `last_seen_size`
- `last_seen_mtime_ms`
- `last_processed_offset`

That works for append-only JSONL recovery, but it does not map cleanly onto:
- same-session transcript rewrites
- full transcript replacement
- runtimes where the transcript file is no longer the canonical operational source

This PR gives LCM a real SQLite replay frontier without forcing the rest of the migration into the same slice.

## What changed

### Core bootstrap frontier
- adds SQLite-aware bootstrap metadata to `conversation_bootstrap_state`
- stores source kind/identity plus SQLite frontier fields alongside the legacy JSONL fields
- migrates existing rows forward as `jsonl` source records

### Engine replay path
- adds an optional SQLite bootstrap path in `LcmContextEngine.bootstrap(...)`
- uses OpenClaw SQLite frontier + delta reads when the host exposes them
- avoids `stat(sessionFile)` as the first truth source on SQLite-capable hosts
- keeps the existing JSONL fast paths untouched as the compatibility fallback

### Runtime adapter
- wires an optional adapter in `src/plugin/index.ts`
- dynamically loads `openclaw/plugin-sdk/session-store-runtime` when available
- consumes the `#79904`-style frontier/delta seam without hard-breaking older OpenClaw installs

### Regression coverage
- adds engine coverage for:
  - fileless SQLite bootstrap
  - SQLite cursor append-resume
- adds flood-regression coverage for:
  - SQLite reset replay against repeated-content history
- updates migration coverage for the new bootstrap-state schema

## Non-goals

This PR does **not** attempt to solve:
- session-family / segment / runtime-session continuity policy from #642
- `message_parts` reconstruction and richer transcript semantic mapping from #643
- rotate/checkpoint/GC maintenance remapping from #644

It is intentionally the narrow frontier/replay slice.

## Validation

```bash
cd /Volumes/LEXAR/repos/lossless-claw-645-sqlite-frontier
npm test -- test/engine.test.ts test/bootstrap-flood-regression.test.ts test/migration.test.ts
npm run build
```

Results on this branch:
- `250/250` targeted tests passed
- build passed

## Stack placement

This PR is the first downstream Lossless Claw implementation slice that consumes the OpenClaw SQLite migration work.

Related stack:
- LCM umbrella: [Martian-Engineering/lossless-claw#641](https://github.com/Martian-Engineering/lossless-claw/issues/641)
- tracked issue: [Martian-Engineering/lossless-claw#645](https://github.com/Martian-Engineering/lossless-claw/issues/645)
- upstream dependency seam: [openclaw/openclaw#79972](https://github.com/openclaw/openclaw/pull/79972)
- upstream refactor context: [openclaw/openclaw#78595](https://github.com/openclaw/openclaw/pull/78595)
- later downstream slices: [Martian-Engineering/lossless-claw#642](https://github.com/Martian-Engineering/lossless-claw/issues/642), [Martian-Engineering/lossless-claw#643](https://github.com/Martian-Engineering/lossless-claw/issues/643), [Martian-Engineering/lossless-claw#644](https://github.com/Martian-Engineering/lossless-claw/issues/644)

Why this is separate:
- frontier correctness is the narrowest and safest migration step
- identity, message-parts, and maintenance remapping stay gated until the upstream seam contracts settle

## Related

- Closes / implements the first code slice for #645
- Umbrella: #641
- Upstream seam dependency: openclaw/openclaw#79904
