### PR TITLE
Fix transcript epoch reconciliation after runtime transcript rollover

### DIFF
--- a/.changeset/transcript-epoch-reconcile.md
+++ b/.changeset/transcript-epoch-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve continuity when OpenClaw switches to a new transcript file for an existing session key. LCM now treats a bounded, path-mismatched transcript with no old anchor as a new transcript epoch, imports its recoverable messages, and avoids advancing checkpoints for no-anchor reads that imported nothing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,8 @@ LCM handles crash recovery through **bootstrap reconciliation**:
 2. Compare against the LCM database.
 3. Find the most recent message that exists in both (the "anchor").
 4. Import any messages after the anchor that are in JSONL but not in LCM.
+5. If an existing session key moves to a different transcript file and no anchor exists, treat the new file as a bounded transcript epoch and import its recoverable messages. The same flood cap used for tail reconciliation prevents large unrelated transcripts from being appended automatically.
+6. Advance the bootstrap checkpoint only after an overlap is found or a bounded epoch import succeeds. No-anchor reads that import nothing leave the old checkpoint in place so a later turn can retry.
 
 This handles the case where OpenClaw wrote messages to the session file but crashed before LCM could persist them.
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1736,6 +1736,12 @@ function messageContentCoveredBySummary(params: {
 
 // ── LcmContextEngine ────────────────────────────────────────────────────────
 
+type TranscriptReconcileResult = {
+  blockedByImportCap: boolean;
+  importedMessages: number;
+  hasOverlap: boolean;
+};
+
 export class LcmContextEngine implements ContextEngine {
   readonly info: ContextEngineInfo;
 
@@ -4664,11 +4670,9 @@ export class LcmContextEngine implements ContextEngine {
     conversationId: number;
     historicalMessages: AgentMessage[];
     checkpointEntryHash?: string | null;
-  }): Promise<{
-    blockedByImportCap: boolean;
-    importedMessages: number;
-    hasOverlap: boolean;
-  }> {
+    allowNoAnchorImport?: boolean;
+    noAnchorImportReason?: string;
+  }): Promise<TranscriptReconcileResult> {
     const { sessionId, conversationId, historicalMessages } = params;
     const startedAt = Date.now();
     const sessionContext = this.formatSessionLogContext({
@@ -4690,6 +4694,7 @@ export class LcmContextEngine implements ContextEngine {
       );
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
     }
+    const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
 
     const storedHistoricalMessages = historicalMessages.map((message) => toStoredMessage(message));
 
@@ -4777,6 +4782,30 @@ export class LcmContextEngine implements ContextEngine {
       }
 
       if (anchorIndex < 0) {
+        if (params.allowNoAnchorImport) {
+          const importCap = Math.max(Math.floor(existingDbCount * 0.2), 50);
+          if (historicalMessages.length > importCap) {
+            this.deps.log.warn(
+              `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${historicalMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,
+            );
+            this.deps.log.debug(
+              `[lcm] reconcileSessionTail: blocked no-anchor import for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} existingDbCount=${existingDbCount} cap=${importCap} overlap=false`,
+            );
+            return { blockedByImportCap: true, importedMessages: 0, hasOverlap: false };
+          }
+
+          let importedMessages = 0;
+          for (const message of historicalMessages) {
+            const result = await this.ingestSingle({ sessionId, sessionKey: params.sessionKey, message });
+            if (result.ingested) {
+              importedMessages += 1;
+            }
+          }
+          this.deps.log.warn(
+            `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=${importedMessages} overlap=false`,
+          );
+          return { blockedByImportCap: false, importedMessages, hasOverlap: false };
+        }
         this.deps.log.debug(
           `[lcm] reconcileSessionTail: no anchor for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=false`,
         );
@@ -4792,7 +4821,6 @@ export class LcmContextEngine implements ContextEngine {
 
     const missingTail = historicalMessages.slice(anchorIndex + 1);
 
-    const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
     if (existingDbCount > 0 && missingTail.length > Math.max(existingDbCount * 0.2, 50)) {
       this.deps.log.warn(
         `[lcm] reconcileSessionTail: import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${existingDbCount}). Aborting to prevent flood.`,
@@ -4821,7 +4849,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionId: string;
     sessionKey?: string;
     sessionFile: string;
-  }): Promise<{ importedMessages: number; blockedByImportCap: boolean }> {
+  }): Promise<TranscriptReconcileResult> {
     const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     return await this.withSessionQueue(
       queueKey,
@@ -4831,7 +4859,10 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
         });
         if (!conversation) {
-          return { importedMessages: 0, blockedByImportCap: false };
+          // No persisted conversation exists yet; afterTurn's own ingest batch
+          // will create the initial frontier, so refreshing after that ingest is
+          // safe and preserves the normal first-turn checkpoint behavior.
+          return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
         }
 
         // OpenClaw can submit the foreground prompt outside the mutable
@@ -4874,7 +4905,7 @@ export class LcmContextEngine implements ContextEngine {
                 sessionFile: params.sessionFile,
               });
             }
-            return { importedMessages, blockedByImportCap: false };
+            return { importedMessages, blockedByImportCap: false, hasOverlap: true };
           }
         }
 
@@ -4909,7 +4940,7 @@ export class LcmContextEngine implements ContextEngine {
           this.deps.log.debug(
             `[lcm] afterTurn: transcript reconcile slow path skipped (file state already read this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
           );
-          return { importedMessages: 0, blockedByImportCap: false };
+          return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
         }
 
         const rememberSlowReadState = (): void => {
@@ -4939,7 +4970,17 @@ export class LcmContextEngine implements ContextEngine {
         // and we lose messages.
         const historicalMessages = await readLeafPathMessages(params.sessionFile);
         if (historicalMessages.length === 0) {
-          if (sessionFileState?.size === 0) {
+          if (!sessionFileState) {
+            this.deps.log.warn(
+              `[lcm] afterTurn: transcript reconcile slow path could not stat/read transcript; allowing live afterTurn persistence without checkpoint refresh conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
+            );
+            return {
+              importedMessages: 0,
+              blockedByImportCap: false,
+              hasOverlap: true,
+            };
+          }
+          if (sessionFileState.size === 0) {
             // File is genuinely empty — refresh the checkpoint so the next
             // afterTurn takes the incremental path.
             await this.refreshBootstrapState({
@@ -4952,16 +4993,22 @@ export class LcmContextEngine implements ContextEngine {
               `[lcm] afterTurn: transcript reconcile slow path read empty messages from non-empty file (${sessionFileState?.size ?? "?"} bytes) — skipping checkpoint refresh to avoid dropping messages on parser failure conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
             );
           }
-          return { importedMessages: 0, blockedByImportCap: false };
+          return {
+            importedMessages: 0,
+            blockedByImportCap: false,
+            hasOverlap: sessionFileState.size === 0,
+          };
         }
         const reconcile = await this.reconcileSessionTail({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           conversationId: conversation.conversationId,
           historicalMessages,
+          allowNoAnchorImport: reason === "path-mismatch",
+          noAnchorImportReason: reason,
         });
         if (reconcile.blockedByImportCap) {
-          return { importedMessages: 0, blockedByImportCap: true };
+          return { importedMessages: 0, blockedByImportCap: true, hasOverlap: reconcile.hasOverlap };
         }
         if (reconcile.importedMessages > 0) {
           this.clearStableOrphanStrippingOrdinal(conversation.conversationId);
@@ -4971,10 +5018,15 @@ export class LcmContextEngine implements ContextEngine {
             "reconciled missing session messages",
           );
         }
-        // Always refresh the checkpoint after a slow-path read, even when no
-        // messages were imported. This pins the offset to the new sessionFile
-        // so the next afterTurn takes the incremental path instead of paying
-        // for another full re-read on every turn.
+        if (!reconcile.hasOverlap && reconcile.importedMessages === 0) {
+          this.deps.log.warn(
+            `[lcm] afterTurn: transcript reconcile found no anchor and imported 0 messages; skipping checkpoint refresh conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile} historicalMessages=${historicalMessages.length}`,
+          );
+          return { importedMessages: 0, blockedByImportCap: false, hasOverlap: false };
+        }
+        // Refresh only after the slow-path read either found an overlap or
+        // imported the bounded no-anchor epoch. A no-overlap/no-import result
+        // leaves the checkpoint stale on purpose so future turns can retry.
         await this.refreshBootstrapState({
           conversationId: conversation.conversationId,
           sessionFile: params.sessionFile,
@@ -4983,7 +5035,11 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.warn(
           `[lcm] afterTurn: transcript reconcile slow path (full re-read) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile} historicalMessages=${historicalMessages.length} importedMessages=${reconcile.importedMessages} duration=${formatDurationMs(Date.now() - slowPathStartedAt)}`,
         );
-        return { importedMessages: reconcile.importedMessages, blockedByImportCap: false };
+        return {
+          importedMessages: reconcile.importedMessages,
+          blockedByImportCap: false,
+          hasOverlap: reconcile.hasOverlap,
+        };
       },
       {
         operationName: "afterTurnTranscriptReconcile",
@@ -5136,11 +5192,13 @@ export class LcmContextEngine implements ContextEngine {
           const conversationId = conversation.conversationId;
           let existingCount = await this.conversationStore.getMessageCount(conversationId);
           let bootstrapState = await this.summaryStore.getConversationBootstrapState(conversationId);
+          let transcriptEpochRotated = false;
 
           if (
             bootstrapState &&
             bootstrapState.sessionFilePath !== params.sessionFile
           ) {
+            transcriptEpochRotated = true;
             this.deps.log.warn(
               `[lcm] bootstrap: session file rotated conversation=${conversationId} ${sessionLabel} oldFile=${bootstrapState.sessionFilePath} newFile=${params.sessionFile}`,
             );
@@ -5362,6 +5420,8 @@ export class LcmContextEngine implements ContextEngine {
             conversationId,
             historicalMessages,
             checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
+            allowNoAnchorImport: transcriptEpochRotated,
+            noAnchorImportReason: transcriptEpochRotated ? "path-mismatch" : undefined,
           });
           this.deps.log.debug(
             `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -6295,7 +6355,11 @@ export class LcmContextEngine implements ContextEngine {
     const newMessages = filterPersistableMessages(
       params.messages.slice(params.prePromptMessageCount),
     );
-    let transcriptReconcileResult = { importedMessages: 0, blockedByImportCap: false };
+    let transcriptReconcileResult: TranscriptReconcileResult = {
+      importedMessages: 0,
+      blockedByImportCap: false,
+      hasOverlap: true,
+    };
     try {
       transcriptReconcileResult = await this.reconcileTranscriptTailForAfterTurn({
         sessionId: params.sessionId,
@@ -6307,14 +6371,26 @@ export class LcmContextEngine implements ContextEngine {
         `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
       );
     }
-    const dedupedNewMessages = await this.deduplicateAfterTurnBatch(
-      params.sessionId,
-      params.sessionKey,
-      newMessages,
-      {
-        oversizedNoOverlap: transcriptReconcileResult.importedMessages > 0 ? "ingest" : "skip",
-      },
-    );
+    const transcriptReconcileUnsafeToAdvance =
+      transcriptReconcileResult.blockedByImportCap ||
+      (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
+    let dedupedNewMessages: AgentMessage[] = [];
+    if (transcriptReconcileUnsafeToAdvance) {
+      if (newMessages.length > 0 || params.autoCompactionSummary) {
+        this.deps.log.warn(
+          `[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`,
+        );
+      }
+    } else {
+      dedupedNewMessages = await this.deduplicateAfterTurnBatch(
+        params.sessionId,
+        params.sessionKey,
+        newMessages,
+        {
+          oversizedNoOverlap: transcriptReconcileResult.importedMessages > 0 ? "ingest" : "skip",
+        },
+      );
+    }
     const summaryCoveredMessages: AgentMessage[] = [];
     const summaryDedupedNewMessages: AgentMessage[] = [];
     if (params.autoCompactionSummary) {
@@ -6340,7 +6416,7 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const ingestBatch: AgentMessage[] = [];
-    if (params.autoCompactionSummary) {
+    if (!transcriptReconcileUnsafeToAdvance && params.autoCompactionSummary) {
       ingestBatch.push({
         role: "user",
         content: params.autoCompactionSummary,
@@ -6494,7 +6570,9 @@ export class LcmContextEngine implements ContextEngine {
         );
       }
     };
-    let shouldRefreshBootstrapState = true;
+    let shouldRefreshBootstrapState =
+      !transcriptReconcileResult.blockedByImportCap &&
+      (transcriptReconcileResult.hasOverlap || transcriptReconcileResult.importedMessages > 0);
     let deferredCompactionDrain:
       | {
           reason: string;
@@ -6553,8 +6631,6 @@ export class LcmContextEngine implements ContextEngine {
             leafDecision,
             sessionLabel,
           });
-        } else {
-          shouldRefreshBootstrapState = true;
         }
 
         if (!leafCompactionScheduled) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -172,6 +172,26 @@ function createSessionFilePath(name: string): string {
   return join(tempDir, `${name}.jsonl`);
 }
 
+function writeLeafTranscript(
+  sessionFile: string,
+  entries: Array<{ role: AgentMessage["role"]; content: string }>,
+): void {
+  writeFileSync(
+    sessionFile,
+    entries
+      .map((entry) =>
+        JSON.stringify({
+          message: {
+            role: entry.role,
+            content: [{ type: "text", text: entry.content }],
+          },
+        }),
+      )
+      .join("\n") + "\n",
+    "utf8",
+  );
+}
+
 function createEngineWithConfig(overrides: Partial<LcmConfig>): LcmContextEngine {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
   tempDirs.push(tempDir);
@@ -7756,9 +7776,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // Seed conversation by ingesting one turn through afterTurn first, with
     // a DIFFERENT sessionFile so the next call has a path-mismatched
     // checkpoint and is forced into the slow path.
+    const seedSessionFile = createSessionFilePath("after-turn-reconcile-slow-path-seed");
+    writeLeafTranscript(seedSessionFile, [{ role: "assistant", content: "seed turn" }]);
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("after-turn-reconcile-slow-path-seed"),
+      sessionFile: seedSessionFile,
       messages: [makeMessage({ role: "assistant", content: "seed turn" })],
       prePromptMessageCount: 0,
       tokenBudget: 4_096,
@@ -7772,16 +7794,10 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     // First call with a different sessionFile triggers the slow path.
     // Pre-populate the target sessionFile with at least one historical
-    // message so readLeafPathMessages returns a non-empty list and the
-    // slow-path warn fires (the empty-file branch is a separate exit).
+    // overlapping message so readLeafPathMessages returns a successful
+    // same-frontier full read and the slow-path cap can be remembered.
     const targetSessionFile = createSessionFilePath("after-turn-reconcile-slow-path-target");
-    writeFileSync(
-      targetSessionFile,
-      `${JSON.stringify({
-        message: { role: "user", content: [{ type: "text", text: "historical user line" }] },
-      })}\n`,
-      "utf8",
-    );
+    writeLeafTranscript(targetSessionFile, [{ role: "assistant", content: "seed turn" }]);
     await engine.afterTurn({
       sessionId,
       sessionFile: targetSessionFile,
@@ -7813,6 +7829,390 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .map((c) => String(c[0]))
       .filter((m) => m.includes("transcript reconcile slow path (full re-read)"));
     expect(secondSlowPathWarns.length).toBe(0);
+  });
+
+  it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
+    const engine = createEngine();
+    const sessionId = "bootstrap-transcript-epoch-no-anchor";
+    const sessionKey = "agent:main:test:direct:transcript-epoch";
+
+    const oldSessionFile = createSessionFilePath("bootstrap-transcript-epoch-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old runtime question" },
+      { role: "assistant", content: "old runtime answer" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old runtime question" }),
+        makeMessage({ role: "assistant", content: "old runtime answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const newSessionFile = createSessionFilePath("bootstrap-transcript-epoch-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "current codex user report" },
+      { role: "assistant", content: "current codex assistant reply" },
+    ]);
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(2);
+    expect(result.reason).toBe("reconciled missing session messages");
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old runtime question",
+      "old runtime answer",
+      "current codex user report",
+      "current codex assistant reply",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.sessionFilePath).toBe(newSessionFile);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
+  });
+
+  it("afterTurn reconciles a path-mismatched no-anchor transcript before oversized delta dedup", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-transcript-epoch-no-anchor";
+    const sessionKey = "agent:main:test:direct:transcript-epoch";
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const oldSessionFile = createSessionFilePath("after-turn-transcript-epoch-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old turn user 1" },
+      { role: "assistant", content: "old turn assistant 1" },
+      { role: "user", content: "old turn user 2" },
+      { role: "assistant", content: "old turn assistant 2" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old turn user 1" }),
+        makeMessage({ role: "assistant", content: "old turn assistant 1" }),
+        makeMessage({ role: "user", content: "old turn user 2" }),
+        makeMessage({ role: "assistant", content: "old turn assistant 2" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const newSessionFile = createSessionFilePath("after-turn-transcript-epoch-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new codex user prompt" },
+      { role: "assistant", content: "new codex assistant delta" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "new codex assistant delta" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old turn user 1",
+      "old turn assistant 1",
+      "old turn user 2",
+      "old turn assistant 2",
+      "new codex user prompt",
+      "new codex assistant delta",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.sessionFilePath).toBe(newSessionFile);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
+  });
+
+  it("afterTurn skips persistence when full reread finds no anchor and imports nothing", async () => {
+    const engine = createEngineWithDeps({}, {
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    });
+    const sessionId = "after-turn-no-anchor-no-import";
+    const sessionKey = "agent:main:test:direct:no-anchor-no-import";
+
+    const privateEngine = engine as unknown as {
+      config: LcmConfig;
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const sessionFile = createSessionFilePath("after-turn-no-anchor-no-import");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "old no-anchor user" },
+      { role: "assistant", content: "old no-anchor assistant" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old no-anchor user" }),
+        makeMessage({ role: "assistant", content: "old no-anchor assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(sessionFile);
+
+    const rawDb = createLcmDatabaseConnection(privateEngine.config.databasePath);
+    try {
+      rawDb
+        .prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`)
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "rewritten missing prefix user" },
+      { role: "assistant", content: "rewritten missing prefix assistant" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "live no-anchor user" }),
+        makeMessage({ role: "assistant", content: "live no-anchor assistant" }),
+        makeMessage({ role: "user", content: "live no-anchor follow-up" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const checkpointAfterNoImport = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpointAfterNoImport).toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old no-anchor user",
+      "old no-anchor assistant",
+    ]);
+  });
+
+  it("afterTurn keeps the old checkpoint when a path-mismatched no-anchor import is capped", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      { proactiveThresholdCompactionMode: "inline" },
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-transcript-epoch-no-anchor-capped";
+    const sessionKey = "agent:main:test:direct:transcript-epoch";
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const oldSessionFile = createSessionFilePath("after-turn-transcript-epoch-capped-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old capped user" },
+      { role: "assistant", content: "old capped assistant" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old capped user" }),
+        makeMessage({ role: "assistant", content: "old capped assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(oldSessionFile);
+
+    const newSessionFile = createSessionFilePath("after-turn-transcript-epoch-capped-new");
+    writeLeafTranscript(
+      newSessionFile,
+      Array.from({ length: 60 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `oversized no-anchor epoch ${index}`,
+      })),
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "live after capped epoch user" }),
+        makeMessage({ role: "assistant", content: "live after capped epoch assistant" }),
+        makeMessage({ role: "user", content: "live after capped epoch follow-up" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("no anchor import cap exceeded")),
+    ).toBe(true);
+
+    const checkpointAfterCap = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpointAfterCap).toEqual(oldCheckpoint);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old capped user",
+      "old capped assistant",
+    ]);
+
+    appendFileSync(
+      newSessionFile,
+      `${JSON.stringify({
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "live after capped epoch assistant" }],
+        },
+      })}\n${JSON.stringify({
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "second live after capped epoch user" }],
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    warnLog.mockClear();
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [
+        makeMessage({ role: "assistant", content: "live after capped epoch assistant" }),
+        makeMessage({ role: "user", content: "second live after capped epoch user" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("no anchor import cap exceeded")),
+    ).toBe(true);
+    const checkpointAfterRetry = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpointAfterRetry).toEqual(oldCheckpoint);
+
+    const storedAfterRetry = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(storedAfterRetry.map((message) => message.content)).toEqual([
+      "old capped user",
+      "old capped assistant",
+    ]);
   });
 
   it("afterTurn retries a capped reconcile when the transcript file changed with an append-only-ineligible suffix (F7)", async () => {


### PR DESCRIPTION
## Summary

- Treat runtime transcript path changes as bounded transcript epochs instead of advancing the checkpoint after importing zero messages.
- Skip afterTurn persistence when reconciliation is unsafe to advance, so LCM does not create a future anchor past unreconciled transcript history.
- Add regression coverage for path-mismatch epoch import, import-cap blocking, checkpoint freshness, and inline compaction safety.
- Document the transcript reconciliation invariant in the architecture notes.

## Root Cause

LCM could refresh `conversation_bootstrap_state` to a new runtime transcript file after a path mismatch even when the new transcript had no overlap with the persisted DB frontier and imported zero messages. That made future turns look reconciled while the prompt-visible frontier stayed stale, especially after runtime transcript rollover / model-switch session changes.

## Validation

- `npm run build`
- `npm test -- test/engine.test.ts`
- `npm test`
- `git diff --check`
- `codex review --base main`

Co-Authored-By: Cha <cha@jetd.one> via OpenClaw
