### PR TITLE
Fix transcript repair across display-only assistant turns

### DIFF
--- a/.changeset/transcript-repair-display-turns.md
+++ b/.changeset/transcript-repair-display-turns.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Repair delayed tool-result pairing when display-only assistant progress turns appear between the original assistant tool call and its result, and avoid replay-guard false positives while bootstrapping legitimate repeated transcript messages.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4825,7 +4825,12 @@ export class LcmContextEngine implements ContextEngine {
 
           let importedMessages = 0;
           for (const message of historicalMessages) {
-            const result = await this.ingestSingle({ sessionId, sessionKey: params.sessionKey, message });
+            const result = await this.ingestSingle({
+              sessionId,
+              sessionKey: params.sessionKey,
+              message,
+              skipReplayTimestampFloodGuard: true,
+            });
             if (result.ingested) {
               importedMessages += 1;
             }
@@ -5509,6 +5514,7 @@ export class LcmContextEngine implements ContextEngine {
                 sessionId: params.sessionId,
                 sessionKey: params.sessionKey,
                 message,
+                skipReplayTimestampFloodGuard: true,
               });
               if (result.ingested) {
                 importedMessages += 1;
@@ -6148,8 +6154,9 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     message: AgentMessage;
     isHeartbeat?: boolean;
+    skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult> {
-    const { sessionId, sessionKey, message, isHeartbeat } = params;
+    const { sessionId, sessionKey, message, isHeartbeat, skipReplayTimestampFloodGuard } = params;
     if (isHeartbeat) {
       return { ingested: false };
     }
@@ -6279,6 +6286,7 @@ export class LcmContextEngine implements ContextEngine {
       role: stored.role,
       content: stored.content,
       tokenCount: stored.tokenCount,
+      skipReplayTimestampFloodGuard,
     });
     await this.conversationStore.createMessageParts(
       msgRecord.messageId,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -33,6 +33,8 @@ export type CreateMessageInput = {
   content: string;
   tokenCount: number;
   identityHash?: string;
+  // Use only when the caller is intentionally importing a fresh transcript epoch.
+  skipReplayTimestampFloodGuard?: boolean;
 };
 
 type PreparedMessageInsert = CreateMessageInput & {
@@ -522,7 +524,9 @@ export class ConversationStore {
 
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
     const prepared = this.prepareMessageInsert(input);
-    this.assertNoReplayTimestampFlood([prepared]);
+    if (!prepared.skipReplayTimestampFloodGuard) {
+      this.assertNoReplayTimestampFlood([prepared]);
+    }
 
     const result = this.db
       .prepare(
@@ -559,7 +563,9 @@ export class ConversationStore {
     }
     const createdAt = this.currentSqliteTimestamp();
     const preparedInputs = inputs.map((input) => this.prepareMessageInsert(input, createdAt));
-    this.assertNoReplayTimestampFlood(preparedInputs);
+    this.assertNoReplayTimestampFlood(
+      preparedInputs.filter((input) => !input.skipReplayTimestampFloodGuard),
+    );
 
     const insertStmt = this.db.prepare(
       `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -37,7 +37,10 @@ const TOOL_CALL_TYPES = new Set([
 ]);
 const OPENAI_FUNCTION_CALL_TYPES = new Set(["functionCall", "function_call"]);
 
-function extractToolCallId(block: { id?: unknown; call_id?: unknown }): string | null {
+function extractToolCallId(block: {
+  id?: unknown;
+  call_id?: unknown;
+}): string | null {
   if (typeof block.id === "string" && block.id) {
     return block.id;
   }
@@ -47,7 +50,9 @@ function extractToolCallId(block: { id?: unknown; call_id?: unknown }): string |
   return null;
 }
 
-function normalizeAssistantReasoningBlocks<T extends AgentMessageLike>(message: T): T {
+function normalizeAssistantReasoningBlocks<T extends AgentMessageLike>(
+  message: T
+): T {
   if (!Array.isArray(message.content)) {
     return message;
   }
@@ -113,7 +118,12 @@ function extractToolCallsFromAssistant(msg: AgentMessageLike): ToolCallLike[] {
     if (!block || typeof block !== "object") {
       continue;
     }
-    const rec = block as { type?: unknown; id?: unknown; call_id?: unknown; name?: unknown };
+    const rec = block as {
+      type?: unknown;
+      id?: unknown;
+      call_id?: unknown;
+      name?: unknown;
+    };
     const id = extractToolCallId(rec);
     if (!id) {
       continue;
@@ -168,7 +178,9 @@ function makeMissingToolResult(params: {
  * - Drops duplicate toolResults for the same ID
  * - Drops orphaned toolResults with no matching tool call
  */
-export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(messages: T[]): T[] {
+export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
+  messages: T[]
+): T[] {
   const out: T[] = [];
   const seenToolResultIds = new Set<string>();
   let droppedDuplicateCount = 0;
@@ -242,7 +254,14 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(message
 
       const nextRole = next.role;
       if (nextRole === "assistant") {
-        break;
+        const nextToolCalls = extractToolCallsFromAssistant(
+          normalizeAssistantReasoningBlocks(next)
+        );
+        if (nextToolCalls.length > 0) {
+          break;
+        }
+        remainder.push(next);
+        continue;
       }
 
       if (nextRole === "toolResult") {

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -7,14 +7,22 @@ describe("sanitizeToolUseResultPairing", () => {
       {
         role: "assistant",
         content: [
-          { type: "function_call", call_id: "fc_1", name: "bash", arguments: '{"cmd":"pwd"}' },
+          {
+            type: "function_call",
+            call_id: "fc_1",
+            name: "bash",
+            arguments: '{"cmd":"pwd"}',
+          },
           { type: "reasoning", text: "Need tool output first." },
         ],
       },
     ]);
 
     const assistant = repaired[0] as { content?: Array<{ type?: string }> };
-    expect(assistant.content?.map((block) => block.type)).toEqual(["reasoning", "function_call"]);
+    expect(assistant.content?.map((block) => block.type)).toEqual([
+      "reasoning",
+      "function_call",
+    ]);
   });
 
   it("preserves interleaved reasoning when an assistant turn has multiple function calls", () => {
@@ -22,9 +30,19 @@ describe("sanitizeToolUseResultPairing", () => {
       {
         role: "assistant",
         content: [
-          { type: "function_call", call_id: "fc_1", name: "bash", arguments: '{"cmd":"pwd"}' },
+          {
+            type: "function_call",
+            call_id: "fc_1",
+            name: "bash",
+            arguments: '{"cmd":"pwd"}',
+          },
           { type: "reasoning", text: "Reasoning for the second call." },
-          { type: "function_call", call_id: "fc_2", name: "bash", arguments: '{"cmd":"ls"}' },
+          {
+            type: "function_call",
+            call_id: "fc_2",
+            name: "bash",
+            arguments: '{"cmd":"ls"}',
+          },
         ],
       },
     ]);
@@ -33,9 +51,19 @@ describe("sanitizeToolUseResultPairing", () => {
       content?: Array<{ type?: string; call_id?: string; text?: string }>;
     };
     expect(assistant.content).toEqual([
-      { type: "function_call", call_id: "fc_1", name: "bash", arguments: '{"cmd":"pwd"}' },
+      {
+        type: "function_call",
+        call_id: "fc_1",
+        name: "bash",
+        arguments: '{"cmd":"pwd"}',
+      },
       { type: "reasoning", text: "Reasoning for the second call." },
-      { type: "function_call", call_id: "fc_2", name: "bash", arguments: '{"cmd":"ls"}' },
+      {
+        type: "function_call",
+        call_id: "fc_2",
+        name: "bash",
+        arguments: '{"cmd":"ls"}',
+      },
     ]);
   });
 
@@ -43,7 +71,14 @@ describe("sanitizeToolUseResultPairing", () => {
     const messages = [
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "call_missing", name: "update_plan", input: { step: "x" } }],
+        content: [
+          {
+            type: "toolCall",
+            id: "call_missing",
+            name: "update_plan",
+            input: { step: "x" },
+          },
+        ],
       },
     ];
 
@@ -63,5 +98,37 @@ describe("sanitizeToolUseResultPairing", () => {
       ],
       isError: true,
     });
+  });
+
+  it("looks past display-only assistant turns for delayed tool results", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bridge",
+            name: "tool_search_code",
+            input: { code: "run" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "tool progress" }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bridge",
+        toolName: "tool_search_code",
+        content: [{ type: "text", text: "real result" }],
+      },
+    ];
+
+    expect(sanitizeToolUseResultPairing(messages)).toEqual([
+      messages[0],
+      messages[2],
+      messages[1],
+    ]);
   });
 });


### PR DESCRIPTION
## What
Fix transcript repair so delayed tool results remain paired when display-only assistant progress turns appear between the original assistant tool call and the matching tool result.

## Why
Bridge/tool-search progress can create assistant turns that contain display text but no real tool calls. Treating those turns as hard pairing boundaries causes transcript repair to synthesize a missing tool result and leave the real result orphaned. While validating the PR, CI also exposed a replay-guard false positive during first-time bootstrap of legitimate repeated transcript messages.

## Changes
- Skip display-only assistant pairing boundaries
- Preserve progress turns after paired results
- Keep new tool-call turns as boundaries
- Add delayed-result regression coverage
- Skip replay guard for fresh bootstrap imports
- Add patch changeset

## Testing
- `npm test -- test/transcript-repair.test.ts`
- `npm test -- test/bootstrap-flood-regression.test.ts`
- `npm test`
- `npm run build`
