### PR TITLE
chore: clean stub-tier filenames

### DIFF
--- a/architecture/stub-tier-stratification.md
+++ b/architecture/stub-tier-stratification.md
@@ -1,4 +1,4 @@
-# LCM v4.2 — Stub-Tier Stratification
+# LCM Stub-Tier Stratification
 
 **Status:** Architecture proposal · pre-adversarial review
 **Base:** `pr-613-newest` (= PR #613 v4.1 omnibus)
@@ -21,7 +21,7 @@ BEFORE (v4.1):
     - tool result bodies — often 10k-50k tokens each
   assemble() inlines all of these.
 
-AFTER (v4.2 proposal):
+AFTER (stub-tier proposal):
   messages.content holds:
     - text messages (user, assistant) — unchanged
     - tool calls (the request) — unchanged, naturally small
@@ -45,7 +45,7 @@ AFTER (v4.2 proposal):
 ### 2.1 Goals
 
 1. **G1 — Reduce per-turn assembled context cost by ≥40% on a real LCM with mature history**, measured against the v4.1 agent-harness DB (3,855 leaves, ~13M token corpus), without losing information.
-2. **G2 — Lossless storage invariant preserved.** Every byte that v4.1 stores is still recoverable in v4.2; only its location and access pattern differ.
+2. **G2 — Lossless storage invariant preserved.** Every byte that v4.1 stores is still recoverable after migration; only its location and access pattern differ.
 3. **G3 — Backward-compatible schema migration.** Existing rows continue to work without conversion. Operator can run a one-shot migration tool to convert historical tool messages to stubs at their convenience, on a schedule, or never.
 4. **G4 — No new agent tools required.** Drill-down works via existing `lcm_describe(message_id, expandMessages=true)` and `lcm_grep --mode verbatim`. Both already exist in v4.1.
 5. **G5 — Cache-stable.** Stub representation does not change between consecutive turns for the same message — prompt cache invalidations only happen when a message itself changes.
@@ -320,12 +320,12 @@ Option A is implementation-cheap and preserves v4.1's existing FTS semantics. Do
 | Goal | How verified |
 |---|---|
 | G1 — ≥40% per-turn assembled cost reduction | Run `scripts/v41-qa-runner.mjs --suite full --measure-tokens` against migrated DB; compare to v4.1 baseline |
-| G2 — Lossless invariant | Round-trip: for every migrated message, drill down via `lcm_describe expandMessages=true` and verify exact byte match against pre-migration content. New regression test: `test/v42-blob-tier-roundtrip.test.ts` |
+| G2 — Lossless invariant | Round-trip: for every migrated message, drill down via `lcm_describe expandMessages=true` and verify exact byte match against pre-migration content. New regression test: `test/stub-tier-roundtrip.test.ts` |
 | G3 — Backward-compat schema | Run v4.1 test suite (1533 tests) against migrated DB without any code changes; all must pass. New tests added on top. |
 | G4 — No new tools | Verify by code review: no new entries in `openclaw.plugin.json contracts.tools`. |
-| G5 — Cache stability | Snapshot the assembled prompt for a fixed `currentTokenCount` across two consecutive afterTurn calls; verify the prefix is byte-identical (no spurious stub differences). New regression test: `test/v42-blob-tier-cache-stability.test.ts` |
-| G6 — Refcount correctness | Test: insert 10 messages referencing same blob; refcount=10. Delete 5; refcount=5. Update 1 to point at different blob; old refcount=4, new=1. Run trigger-based and application-code paths separately. New tests: `test/v42-blob-tier-refcount.test.ts` |
-| G7 — Migration idempotency | Run migration tool 3x on same DB; row counts and blob counts must match after each run. New test: `test/v42-blob-tier-migration.test.ts` |
+| G5 — Cache stability | Snapshot the assembled prompt for a fixed `currentTokenCount` across two consecutive afterTurn calls; verify the prefix is byte-identical (no spurious stub differences). New regression test: `test/stub-tier-cache-stability.test.ts` |
+| G6 — Refcount correctness | Test: insert 10 messages referencing same blob; refcount=10. Delete 5; refcount=5. Update 1 to point at different blob; old refcount=4, new=1. Run trigger-based and application-code paths separately. New tests: `test/stub-tier-refcount.test.ts` |
+| G7 — Migration idempotency | Run migration tool 3x on same DB; row counts and blob counts must match after each run. New test: `test/stub-tier-migration.test.ts` |
 | G8 — Test parity | `scripts/v41-qa-runner.mjs --suite full` on migrated DB returns 30/30 (same as v4.1 baseline) |
 
 ### 4.12 Implementation phases
@@ -388,7 +388,7 @@ Final integration test: run `scripts/v41-qa-runner.mjs --suite full --measure-to
 2. **Should user/assistant messages ever be migrated?** Currently `--role tool` only. Some assistant messages contain large code blocks. But assistant content is more semantically valuable; stubbing it would break in-context recall.
 3. **What about `text/thinking` blocks within assistant messages?** v4.1 already strips them in some paths via `removedToolUseBlocks`. Should thinking content go to blobs? Probably not — thinking is the model's reasoning process, structurally part of the assistant turn.
 4. **Garbage collection cadence** — should there be an opt-in `--gc-after` option that auto-purges orphans after each migration run? Current proposal: never auto-GC; always operator-controlled.
-5. **Inline window granularity** — currently uses the same `freshTailCount`/`freshTailMaxTokens` as v4.1. Should there be a separate `inlineToolWindow` config that's independently tunable? Proposal: not for v4.2; revisit in v4.3 if usage patterns demand it.
+5. **Inline window granularity** — currently uses the same `freshTailCount`/`freshTailMaxTokens` as v4.1. Should there be a separate `inlineToolWindow` config that's independently tunable? Proposal: not for the initial stub-tier implementation; revisit later if usage patterns demand it.
 6. **What if a tool result's content varies between calls** (e.g., `date` returns different content each time)? Each call produces a new blob with its own hash. Refcount = 1. Free; no special handling.
 
 ---
@@ -417,7 +417,7 @@ Final integration test: run `scripts/v41-qa-runner.mjs --suite full --measure-to
 
 ## 10. Acceptance criteria for merge
 
-A v4.2 PR can be merged when:
+The stub-tier PR can be merged when:
 
 1. Architecture review (this document) passes adversarial review with no blocking findings.
 2. All 1533 v4.1 tests still pass.

--- a/audit/stub-tier-bench/DECISION-mitigations.md
+++ b/audit/stub-tier-bench/DECISION-mitigations.md
@@ -1,8 +1,8 @@
-# Decision: v4.2 stub-tier mitigations
+# Decision: stub-tier mitigations
 
 ## Context
 
-After the Opus subagent A/B comparison of v4.1 baseline (333 blocks) vs v4.2-stubs (689 blocks at full migration; 421 in our partial-migration test) at the same 258K-token budget, four mitigations were recommended to address moderate-risk findings (stale-info, cognitive load, stub legibility):
+After the Opus subagent A/B comparison of v4.1 baseline (333 blocks) vs stub-tier (689 blocks at full migration; 421 in our partial-migration test) at the same 258K-token budget, four mitigations were recommended to address moderate-risk findings (stale-info, cognitive load, stub legibility):
 
 1. Recency cue `[t-NNm]` on turn headers
 2. Semantic stub wrapping `<lcm-stub …>` XML tags
@@ -13,15 +13,15 @@ We applied the first-principles-architectural-decision skill (Step 1: research, 
 
 ## Decision
 
-**REJECT ALL FOUR.** Stay with v4.2 as currently shipped (Options C + D + F at commit `e309bed`).
+**REJECT ALL FOUR.** Stay with the stub-tier implementation as currently shipped (Options C + D + F at commit `e309bed`).
 
 ## Rationale
 
 ### #1 — Recency cue `[t-NNm]` — REJECT
 
-**Empirical finding (Step 1):** User messages already carry absolute timestamps in prefix form: `[Thu 2026-04-09 01:38 GMT+7]`. Counted 55 in baseline, 71 in v4.2 (one per user turn). The agent already has the recency signal it needs.
+**Empirical finding (Step 1):** User messages already carry absolute timestamps in prefix form: `[Thu 2026-04-09 01:38 GMT+7]`. Counted 55 in baseline, 71 in the stub-tier variant (one per user turn). The agent already has the recency signal it needs.
 
-**Architectural failure (Step 2 diagram):** A `[t-NNm]` tag is a function of `now()` at assemble time. The same conversation prefix produces a different rendered string on every assembly. This invalidates the Anthropic prompt cache prefix all the way back to the first turn, on every single request. v4.2's whole value proposition (689 items at same budget) is amortized via prefix caching. Burning the cache to add information already present in the prefix is strictly negative ROI.
+**Architectural failure (Step 2 diagram):** A `[t-NNm]` tag is a function of `now()` at assemble time. The same conversation prefix produces a different rendered string on every assembly. This invalidates the Anthropic prompt cache prefix all the way back to the first turn, on every single request. The stub-tier implementation's whole value proposition (689 items at same budget) is amortized via prefix caching. Burning the cache to add information already present in the prefix is strictly negative ROI.
 
 **Adversarial verdict:** FOR position 85% confidence ("low-cost insurance against unobserved failure mode"). AGAINST position ≥95% confidence (cache thrashing + redundant data). AGAINST wins decisively.
 
@@ -35,7 +35,7 @@ We applied the first-principles-architectural-decision skill (Step 1: research, 
 
 ### #3 — Empty-assistant collapsing — REJECT
 
-**Empirical finding (Step 1):** ~39-40% of assistant turns are empty after stripping the rendered ` ```tool_use``` ` fences (177 → 71 in baseline; 249 → 98 in v4.2; ~identical proportion). Statistically significant.
+**Empirical finding (Step 1):** ~39-40% of assistant turns are empty after stripping the rendered ` ```tool_use``` ` fences (177 → 71 in baseline; 249 → 98 in the stub-tier variant; ~identical proportion). Statistically significant.
 
 **Architectural failure (Step 2 diagram):** The wire-format contract requires `tool_use` blocks to live in assistant turns; `tool_result` blocks pair to them by `toolCallId`. The Anthropic / OpenAI API will reject a `tool_result` whose preceding assistant turn doesn't carry the matching `tool_use`. The "empty" rendering in our dump is a display artifact — the assembler emits content arrays containing tool_use blocks; the dump renderer chose to elide them visually but they exist in the API payload.
 
@@ -87,14 +87,14 @@ Rejecting these mitigations is fully reversible:
 
 - If stale-info actually fires in production, build a cache-stable recency signal (e.g., turn-relative `[turn -47]` instead of clock-relative `[t-12m]`) — that's a different mitigation than #1.
 - If a future model fails to recognize the bracket format, ship Option G (LLM-generated exploration summaries instead of tool_input disambiguators) which gives the agent semantic content rather than format recognition.
-- Empty-assistant work can be revisited as a v4.1 cleanup PR (separate from v4.2, addresses both variants equally).
+- Empty-assistant work can be revisited as a v4.1 cleanup PR (separate from stub-tier, addresses both variants equally).
 - Resolution markers can be revisited if/when explicit user annotations become a workflow primitive elsewhere in OpenClaw.
 
-None of these would compete with the v4.2 work that's shipped.
+None of these would compete with the stub-tier work that's shipped.
 
 ## Conclusion
 
-The current v4.2 (Options C + D + F at commit `e309bed`) is the right shipping shape. Each proposed mitigation either:
+The current stub-tier implementation (Options C + D + F at commit `e309bed`) is the right shipping shape. Each proposed mitigation either:
 - Adds cost without observed benefit (#1 cache thrash; #2 novel format)
 - Conflates rendered transcript with API payload (#3 wire-contract)
 - Has no reliable trigger condition (#4 detection)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,7 +41,7 @@
       "help": "When enabled, budget-constrained assembly keeps older context by prompt relevance instead of pure chronology. This can improve recall under tight budgets, but it can also reduce provider prompt-cache hit rates because the preserved prefix changes as prompts change."
     },
     "stubLargeToolPayloads": {
-      "label": "Stub Large Tool Payloads (v4.2)",
+      "label": "Stub Large Tool Payloads",
       "help": "When enabled, evictable tool-result rows whose payload was externalized via lcm-blob-migrate are replaced with a [LCM Tool Output: file_xxx | …] reference at assemble time. Fresh tail is never stubbed. The agent recovers the original output via lcm_describe(id=file_xxx, expandFile=true). Default off; requires running scripts/lcm-blob-migrate.mjs first to populate messages.large_content."
     },
     "leafChunkTokens": {

--- a/scripts/lcm-blob-migrate.mjs
+++ b/scripts/lcm-blob-migrate.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * v4.2 §B blob-migrate (Option C) — externalize large tool-result payloads
+ * Stub-tier blob migration — externalize large tool-result payloads
  * to the v4.1 `large_files` storage model.
  *
  * For each `role='tool'` row whose `messages.content` exceeds the byte

--- a/scripts/stub-tier-assemble-bench.mjs
+++ b/scripts/stub-tier-assemble-bench.mjs
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 /**
- * v4.2 assemble-bench — measure assembled context cost on a snapshot DB.
+ * stub-tier assemble bench — measure assembled context cost on a snapshot DB.
  *
  * Calls engine.assemble() for the most-active session and captures token
  * counts, item composition (summaries vs raw vs fresh-tail), and segment
- * breakdowns. Used to compare baseline v4.1 vs proposed v4.2 variants.
+ * breakdowns. Used to compare baseline v4.1 vs stub-tier variants.
  *
  * USAGE:
  *   VOYAGE_API_KEY=$(cat ~/.openclaw/credentials/voyage-api-key) \
  *   LCM_TEST_VEC0_PATH=$HOME/.openclaw/extensions/node_modules/sqlite-vec-darwin-arm64/vec0.dylib \
- *     node scripts/v42-assemble-bench.mjs --db <path>
+ *     node scripts/stub-tier-assemble-bench.mjs --db <path>
  *
  * NEVER touches the live DB; pass an explicit --db.
  *
@@ -39,7 +39,7 @@ const jsonOut = getArg("json-out");
 const verbose = hasFlag("verbose");
 
 if (!dbPath) {
-  console.error("Usage: v42-assemble-bench.mjs --db <path> [--variant LABEL] [--budget N] [--session-id ID]");
+  console.error("Usage: stub-tier-assemble-bench.mjs --db <path> [--variant LABEL] [--budget N] [--session-id ID]");
   process.exit(1);
 }
 if (!existsSync(dbPath)) {
@@ -112,9 +112,9 @@ const config = {
     coldCacheObservationThreshold: 3, criticalBudgetPressureRatio: 0.7,
   },
   dynamicLeafChunkTokens: { enabled: true, max: 40000 },
-  // v4.2 §B — picked up by engine.assemble() via the cast; on for the
-  // "v42-stubs" variant, off for "baseline".
-  stubLargeToolPayloads: variantLabel === "v42-stubs",
+  // stub-tier flag picked up by engine.assemble() via the cast; on for the
+  // "stub-tier" variant, off for "baseline".
+  stubLargeToolPayloads: variantLabel === "stub-tier",
 };
 
 const noopLog = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
@@ -198,7 +198,7 @@ try {
     freshTailCount: config.freshTailCount,
     freshTailMaxTokens: config.freshTailMaxTokens,
     promptAwareEviction: config.promptAwareEviction,
-    stubLargeToolPayloads: variantLabel === "v42-stubs",
+    stubLargeToolPayloads: variantLabel === "stub-tier",
   });
 } catch (err) {
   error = String(err?.stack ?? err);
@@ -226,7 +226,7 @@ for (const item of result.messages ?? []) {
   totalMessageTokens += Math.ceil(text.length / 4);
 }
 
-// v4.2 §B — pull stub diagnostics out of the assembled debug bag.
+// Pull stub-tier diagnostics out of the assembled debug bag.
 const stubStats = result.debug?.stubStats ?? null;
 
 // ── Output ──
@@ -261,7 +261,7 @@ const report = {
       JOIN conversations c ON c.conversation_id = s.conversation_id
       WHERE c.session_id = ?
     `).get(sessionToBench).n,
-    // v4.2 §B — surface stratification state of the DB so the bench
+    // stub-tier stratification state of the DB so the bench
     // report makes it obvious whether large_content was populated for
     // this run.
     messagesWithLargeContent: (() => {

--- a/scripts/stub-tier-drilldown-harness.mjs
+++ b/scripts/stub-tier-drilldown-harness.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * v4.2 §B drilldown harness — empirically validate that a real LLM,
- * presented with the v4.2 stub format (`[LCM Tool Output: file_xxx | …]`),
+ * stub-tier drilldown harness — empirically validate that a real LLM,
+ * presented with the stub-tier format (`[LCM Tool Output: file_xxx | …]`),
  * actually invokes `lcm_describe(id="file_xxx")` when it needs the
  * elided tool-result content.
  *
@@ -11,7 +11,7 @@
  * verify the agent reaches for the drilldown when needed.
  *
  * What it does:
- *   1. Opens the migrated DB (--db, default audit/v42-bench/lcm-v42-optionc.db)
+ *   1. Opens the migrated DB (--db, default audit/stub-tier-bench/lcm-stub-tier-optionc.db)
  *   2. Calls ContextAssembler.assemble(...stubLargeToolPayloads=true) for the
  *      target session, capturing the assembled prompt (which contains stubs)
  *   3. For each of N stub-bearing tool_results in the prompt, constructs
@@ -30,7 +30,7 @@
  *   OPENROUTER_API_KEY=$(grep OPENROUTER_API_KEY ~/.openclaw/service-env/ai.openclaw.gateway.env | sed 's/.*=//') \
  *   VOYAGE_API_KEY=$(cat ~/.openclaw/credentials/voyage-api-key) \
  *   LCM_TEST_VEC0_PATH=$HOME/.openclaw/extensions/node_modules/sqlite-vec-darwin-arm64/vec0.dylib \
- *     node scripts/v42-drilldown-harness.mjs --db audit/v42-bench/lcm-v42-optionc.db \
+ *     node scripts/stub-tier-drilldown-harness.mjs --db audit/stub-tier-bench/lcm-stub-tier-optionc.db \
  *       --session-id 0cb8928b-f925-4be1-a995-a30f30938cf4 \
  *       --scenarios 5 --model openai/gpt-4o-mini
  *
@@ -65,7 +65,7 @@ const getArg = (n) => {
   return i >= 0 && i < args.length - 1 ? args[i + 1] : undefined;
 };
 
-const dbPath = getArg("db") ?? "/Volumes/LEXAR/repos/lossless-claw/audit/v42-bench/lcm-v42-optionc.db";
+const dbPath = getArg("db") ?? "/Volumes/LEXAR/repos/lossless-claw/audit/stub-tier-bench/lcm-stub-tier-optionc.db";
 const sessionId = getArg("session-id") ?? "0cb8928b-f925-4be1-a995-a30f30938cf4";
 const sessionKey = getArg("session-key") ?? "agent:main:main";
 const tokenBudget = Number(getArg("budget") ?? 258000);
@@ -112,7 +112,7 @@ const conversationStore = new ConversationStore(db);
 const summaryStore = new SummaryStore(db);
 const assembler = new ContextAssembler(conversationStore, summaryStore, "UTC");
 
-// --no-stubs lets us compare baseline (v4.1) vs v4.2 with the SAME prompt,
+// --no-stubs lets us compare baseline (v4.1) vs stub-tier with the SAME prompt,
 // so we can read the agent's answer side-by-side and judge confabulation.
 const stubsOn = !args.includes("--no-stubs");
 const assembled = await assembler.assemble({
@@ -371,7 +371,7 @@ async function llmCall(messages, opts = {}) {
     headers: {
       "Authorization": `Bearer ${apiKey}`,
       "Content-Type": "application/json",
-      "X-Title": "v4.2 drilldown harness",
+      "X-Title": "stub-tier drilldown harness",
     },
     body: JSON.stringify(body),
   });

--- a/scripts/stub-tier-live-watcher.mjs
+++ b/scripts/stub-tier-live-watcher.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * v4.2 §B live watcher — tails the gateway log + LCM DB to surface
+ * stub-tier live watcher — tails the gateway log + LCM DB to surface
  * stub-tier telemetry in real time during a live session.
  *
  * What it surfaces (every event hits stdout as one line):
@@ -14,7 +14,7 @@
  *   [DB stubbedRows=… diskUsageMB=…]             periodic DB-state snapshot (every 30s)
  *
  * USAGE:
- *   node scripts/v42-live-watcher.mjs
+ *   node scripts/stub-tier-live-watcher.mjs
  *     [--log PATH]           default ~/.openclaw/logs/gateway.log
  *     [--db PATH]            default ~/.openclaw/lcm.db
  *     [--snapshot-secs N]    default 30
@@ -198,7 +198,7 @@ function snapshotDb() {
         .prepare(`SELECT COUNT(*) AS n FROM messages WHERE large_content IS NOT NULL`)
         .get();
     } catch {
-      schemaState = "pre-v4.2-migration";
+      schemaState = "pre-stub-tier-migration";
     }
     try {
       filesRow = db

--- a/test/stub-tier.test.ts
+++ b/test/stub-tier.test.ts
@@ -15,7 +15,7 @@ const BLOB_MIGRATE_SCRIPT = fileURLToPath(
 );
 
 /**
- * v4.2 §B (Option C) — stub-tier stratification end-to-end behavior tests.
+ * stub-tier stratification end-to-end behavior tests.
  *
  * Option C reuses the v4.1 `large_files` storage model:
  *  - `messages.large_content` stores the externalized `file_xxx` id
@@ -157,12 +157,12 @@ function bigPayload(prefix: string, kb: number): string {
 function setupDb(): { db: DatabaseSync; storageDir: string } {
   const db = new DatabaseSync(":memory:");
   runLcmMigrations(db, { fts5Available: false });
-  const storageDir = mkdtempSync(join(tmpdir(), "v42-stub-storage-"));
+  const storageDir = mkdtempSync(join(tmpdir(), "stub-tier-storage-"));
   return { db, storageDir };
 }
 
 function setupScriptDb(): { db: DatabaseSync; dbPath: string; storageDir: string; stateDir: string } {
-  const stateDir = mkdtempSync(join(tmpdir(), "v42-script-state-"));
+  const stateDir = mkdtempSync(join(tmpdir(), "stub-tier-script-state-"));
   const storageDir = join(stateDir, "lcm-files");
   mkdirSync(storageDir, { recursive: true });
   const dbPath = join(stateDir, "lcm.db");
@@ -171,7 +171,7 @@ function setupScriptDb(): { db: DatabaseSync; dbPath: string; storageDir: string
   return { db, dbPath, storageDir, stateDir };
 }
 
-describe("v4.2 §B (Option C) stub-tier stratification", () => {
+describe("stub-tier stratification", () => {
   it("emits stubs only for evictable externalized tool messages", async () => {
     const { db, storageDir } = setupDb();
 
@@ -221,7 +221,7 @@ describe("v4.2 §B (Option C) stub-tier stratification", () => {
       })
       .filter((t) => t.includes("[LCM Tool Output:"));
     expect(stubTexts.length).toBeGreaterThan(0);
-    // Each stub references a file_xxx id and includes the v4.2 hint
+    // Each stub references a file_xxx id and includes the stub-tier hint
     // pointing at lcm_describe with expandFile=true (the path that
     // actually returns content from disk).
     for (const t of stubTexts) {
@@ -384,7 +384,7 @@ describe("v4.2 §B (Option C) stub-tier stratification", () => {
  * asserts the bytes match the original tool-result payload.
  */
 import { readFileSync } from "node:fs";
-describe("v4.2 §B (Option C) drilldown round-trip", () => {
+describe("stub-tier drilldown round-trip", () => {
   it("agent can recover the full payload via the file_xxx referenced in the stub", async () => {
     const { db, storageDir } = setupDb();
     const originalPayload = bigPayload("END-TO-END", 20);
@@ -482,7 +482,7 @@ describe("v4.2 §B (Option C) drilldown round-trip", () => {
   });
 });
 
-describe("v4.2 §B blob-migrate script", () => {
+describe("stub-tier blob-migrate script", () => {
   it("uses the runtime large-files root derived from OPENCLAW_STATE_DIR", () => {
     const { db, dbPath, stateDir } = setupScriptDb();
     db.close();


### PR DESCRIPTION
## What
Renames the temporary v42/v4.2 stub-tier files, scripts, audit directory, and test file to durable feature-oriented names.

## Why
The merged stub-tier work still exposed implementation-phase v42 naming in durable paths and operator-facing script text.

## Changes
- Rename stub-tier architecture doc
- Rename stub-tier audit directory
- Rename bench and watcher scripts
- Rename stub-tier regression test
- Remove v4.2 manifest label
- Update script/docs/test references

## Testing
- `npx vitest run test/stub-tier.test.ts test/lcm-integration.test.ts` passed: 85 tests
- `npm run build` passed

Changeset: not included; this is a mechanical naming cleanup with no runtime behavior change.