### PR TITLE
fix: preserve LCM continuity across gateway lifecycle

### DIFF
--- a/.changeset/restart-shutdown-continuity.md
+++ b/.changeset/restart-shutdown-continuity.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve active conversation history when OpenClaw emits `session_end` for gateway `restart` or `shutdown` lifecycle events.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7619,7 +7619,13 @@ export class LcmContextEngine implements ContextEngine {
     nextSessionKey?: string;
   }): Promise<void> {
     const reason = params.reason?.trim();
-    if (!reason || reason === "new" || reason === "unknown") {
+    if (
+      !reason ||
+      reason === "new" ||
+      reason === "unknown" ||
+      reason === "restart" ||
+      reason === "shutdown"
+    ) {
       return;
     }
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1217,6 +1217,40 @@ describe("LcmContextEngine session_end lifecycle", () => {
     expect(active?.active).toBe(true);
   });
 
+  for (const reason of ["restart", "shutdown"] as const) {
+    it(`ignores session_end ${reason} so gateway lifecycle does not orphan conversation history`, async () => {
+      const engine = createEngine();
+      (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+      const store = engine.getConversationStore();
+
+      const original = await store.getOrCreateConversation("uuid-1", {
+        sessionKey: "agent:main:main",
+      });
+      await store.createMessage({
+        conversationId: original.conversationId,
+        seq: 1,
+        role: "user",
+        content: "seed",
+        tokenCount: 5,
+      });
+
+      await engine.handleSessionEnd({
+        reason,
+        sessionId: "uuid-1",
+        sessionKey: "agent:main:main",
+        nextSessionId: "uuid-2",
+      });
+
+      const active = await store.getConversationBySessionKey("agent:main:main");
+      const originalAfterLifecycle = await store.getConversation(original.conversationId);
+
+      expect(active?.conversationId).toBe(original.conversationId);
+      expect(active?.active).toBe(true);
+      expect(originalAfterLifecycle?.active).toBe(true);
+      expect(originalAfterLifecycle?.archivedAt).toBeNull();
+    });
+  }
+
   it("archives the prior active conversation and creates a fresh active row on idle rollover", async () => {
     const engine = createEngine();
     (engine as unknown as { ensureMigrated(): void }).ensureMigrated();


### PR DESCRIPTION
## What
Treat OpenClaw `session_end` events with `restart` or `shutdown` reasons as process lifecycle notifications instead of Lossless conversation rollover events.

## Why
OpenClaw now emits typed `session_end` events for active sessions during gateway restart and shutdown. Lossless was treating those as conversation replacement events, which could archive the active conversation and orphan its summarized context from the stable session key.

## Changes
- Ignore restart/shutdown session_end
- Preserve active conversation history
- Add regression coverage
- Add patch changeset

## Testing
- `npm test -- engine.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`
