### PR TITLE
fix: recover same-path transcript shrink epochs

### DIFF
--- a/.changeset/same-path-transcript-shrink.md
+++ b/.changeset/same-path-transcript-shrink.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Recover bounded transcript epochs when OpenClaw rewrites a session JSONL in place and the stored bootstrap checkpoint points past the new file end. LCM now treats same-path transcript shrink as an epoch rollover instead of accepting an empty append-only read as fully covered.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -137,6 +137,10 @@ type TranscriptRewriteReplacement = {
 type TranscriptRewriteRequest = {
   replacements: TranscriptRewriteReplacement[];
 };
+type BootstrapCheckpointFileState = {
+  lastProcessedOffset: number;
+  lastSeenSize: number;
+};
 type RotateTranscriptRewriteResult = {
   checkpointSize: number;
   bytesRemoved: number;
@@ -179,6 +183,16 @@ type DeferredCompactionDebtDrainParams = {
   currentTokenCount?: number;
   reason: string;
 };
+
+function checkpointIsPastTranscriptEof(
+  checkpoint: BootstrapCheckpointFileState | null | undefined,
+  fileSize: number,
+): boolean {
+  if (!checkpoint) {
+    return false;
+  }
+  return checkpoint.lastProcessedOffset > fileSize || checkpoint.lastSeenSize > fileSize;
+}
 
 function getErrorCode(error: unknown): string | undefined {
   if (!(error instanceof Error)) {
@@ -4711,6 +4725,7 @@ export class LcmContextEngine implements ContextEngine {
     conversationId: number;
     historicalMessages: AgentMessage[];
     checkpointEntryHash?: string | null;
+    skipContentAnchorScan?: boolean;
     allowNoAnchorImport?: boolean;
     noAnchorImportReason?: string;
   }): Promise<TranscriptReconcileResult> {
@@ -4742,7 +4757,10 @@ export class LcmContextEngine implements ContextEngine {
     // Fast path: one tail comparison for the common in-sync case.
     const latestHistorical = storedHistoricalMessages[storedHistoricalMessages.length - 1];
     const latestIdentity = messageIdentity(latestDbMessage.role, latestDbMessage.content);
-    if (latestIdentity === messageIdentity(latestHistorical.role, latestHistorical.content)) {
+    if (
+      !params.skipContentAnchorScan &&
+      latestIdentity === messageIdentity(latestHistorical.role, latestHistorical.content)
+    ) {
       const dbOccurrences = await this.conversationStore.countMessagesByIdentity(
         conversationId,
         latestDbMessage.role,
@@ -4771,42 +4789,44 @@ export class LcmContextEngine implements ContextEngine {
       historicalIdentityTotals.set(identity, (historicalIdentityTotals.get(identity) ?? 0) + 1);
     }
 
-    const historicalIdentityCountsAfterIndex = new Map<string, number>();
-    const dbIdentityCounts = new Map<string, number>();
-    for (let index = storedHistoricalMessages.length - 1; index >= 0; index--) {
-      const stored = storedHistoricalMessages[index];
-      const identity = messageIdentity(stored.role, stored.content);
-      const seenAfter = historicalIdentityCountsAfterIndex.get(identity) ?? 0;
-      const total = historicalIdentityTotals.get(identity) ?? 0;
-      const occurrencesThroughIndex = total - seenAfter;
-      const exists = await this.conversationStore.hasMessage(
-        conversationId,
-        stored.role,
-        stored.content,
-      );
-      historicalIdentityCountsAfterIndex.set(identity, seenAfter + 1);
-      if (!exists) {
-        continue;
-      }
-
-      let dbCountForIdentity = dbIdentityCounts.get(identity);
-      if (dbCountForIdentity === undefined) {
-        dbCountForIdentity = await this.conversationStore.countMessagesByIdentity(
+    if (!params.skipContentAnchorScan) {
+      const historicalIdentityCountsAfterIndex = new Map<string, number>();
+      const dbIdentityCounts = new Map<string, number>();
+      for (let index = storedHistoricalMessages.length - 1; index >= 0; index--) {
+        const stored = storedHistoricalMessages[index];
+        const identity = messageIdentity(stored.role, stored.content);
+        const seenAfter = historicalIdentityCountsAfterIndex.get(identity) ?? 0;
+        const total = historicalIdentityTotals.get(identity) ?? 0;
+        const occurrencesThroughIndex = total - seenAfter;
+        const exists = await this.conversationStore.hasMessage(
           conversationId,
           stored.role,
           stored.content,
         );
-        dbIdentityCounts.set(identity, dbCountForIdentity);
-      }
+        historicalIdentityCountsAfterIndex.set(identity, seenAfter + 1);
+        if (!exists) {
+          continue;
+        }
 
-      // Match the same occurrence index as the DB tail so repeated empty
-      // tool messages do not anchor against a later, still-missing entry.
-      if (dbCountForIdentity !== occurrencesThroughIndex) {
-        continue;
-      }
+        let dbCountForIdentity = dbIdentityCounts.get(identity);
+        if (dbCountForIdentity === undefined) {
+          dbCountForIdentity = await this.conversationStore.countMessagesByIdentity(
+            conversationId,
+            stored.role,
+            stored.content,
+          );
+          dbIdentityCounts.set(identity, dbCountForIdentity);
+        }
 
-      anchorIndex = index;
-      break;
+        // Match the same occurrence index as the DB tail so repeated empty
+        // tool messages do not anchor against a later, still-missing entry.
+        if (dbCountForIdentity !== occurrencesThroughIndex) {
+          continue;
+        }
+
+        anchorIndex = index;
+        break;
+      }
     }
 
     if (anchorIndex < 0) {
@@ -5005,10 +5025,25 @@ export class LcmContextEngine implements ContextEngine {
         const checkpoint = await this.summaryStore.getConversationBootstrapState(
           conversation.conversationId,
         );
+        let sessionFileState: { size: number; mtimeMs: number } | undefined;
+        try {
+          const sessionFileStats = await stat(params.sessionFile);
+          sessionFileState = {
+            size: sessionFileStats.size,
+            mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+          };
+        } catch {
+          // Leave undefined: without stat proof, do not use append-only guards or slow-read caps.
+        }
+        const transcriptEpochShrank = checkpointIsPastTranscriptEof(
+          checkpoint,
+          sessionFileState?.size ?? Number.POSITIVE_INFINITY,
+        );
         if (
           checkpoint &&
           checkpoint.sessionFilePath === params.sessionFile &&
-          checkpoint.lastProcessedOffset >= 0
+          checkpoint.lastProcessedOffset >= 0 &&
+          !transcriptEpochShrank
         ) {
           const appended = await readAppendedLeafPathMessages({
             sessionFile: params.sessionFile,
@@ -5062,16 +5097,11 @@ export class LcmContextEngine implements ContextEngine {
           ? "checkpoint-missing"
           : checkpoint.sessionFilePath !== params.sessionFile
             ? "path-mismatch"
-            : "append-only-ineligible";
-        let sessionFileState: { size: number; mtimeMs: number } | undefined;
-        try {
-          const sessionFileStats = await stat(params.sessionFile);
-          sessionFileState = {
-            size: sessionFileStats.size,
-            mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
-          };
-        } catch {
-          // Leave undefined: without stat proof, do not use the slow-read cap.
+            : transcriptEpochShrank
+              ? "same-path-shrink"
+              : "append-only-ineligible";
+        if (reason === "same-path-shrink") {
+          this.afterTurnReconcileFullReadStates.delete(fullReadKey);
         }
         const rememberedFileState = this.afterTurnReconcileFullReadStates.get(fullReadKey);
         if (
@@ -5147,7 +5177,8 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
           conversationId: conversation.conversationId,
           historicalMessages,
-          allowNoAnchorImport: reason === "path-mismatch",
+          skipContentAnchorScan: reason === "same-path-shrink",
+          allowNoAnchorImport: reason === "path-mismatch" || reason === "same-path-shrink",
           noAnchorImportReason: reason,
         });
         if (reconcile.blockedByImportCap) {
@@ -5336,12 +5367,14 @@ export class LcmContextEngine implements ContextEngine {
           let existingCount = await this.conversationStore.getMessageCount(conversationId);
           let bootstrapState = await this.summaryStore.getConversationBootstrapState(conversationId);
           let transcriptEpochRotated = false;
+          let transcriptEpochReason: string | undefined;
 
           if (
             bootstrapState &&
             bootstrapState.sessionFilePath !== params.sessionFile
           ) {
             transcriptEpochRotated = true;
+            transcriptEpochReason = "path-mismatch";
             this.deps.log.warn(
               `[lcm] bootstrap: session file rotated conversation=${conversationId} ${sessionLabel} oldFile=${bootstrapState.sessionFilePath} newFile=${params.sessionFile}`,
             );
@@ -5350,6 +5383,20 @@ export class LcmContextEngine implements ContextEngine {
             // in-memory file-level guard, and any counters derived from the
             // old file's messages. Clear them all in one place so subsequent
             // reads treat this conversation as unbootstrapped.
+            this.lastFullReadFileState.delete(conversationId);
+            this.clearStableOrphanStrippingOrdinal(conversationId);
+            bootstrapState = null;
+          }
+          if (
+            bootstrapState &&
+            bootstrapState.sessionFilePath === params.sessionFile &&
+            checkpointIsPastTranscriptEof(bootstrapState, sessionFileSize)
+          ) {
+            transcriptEpochRotated = true;
+            transcriptEpochReason = "same-path-shrink";
+            this.deps.log.warn(
+              `[lcm] bootstrap: session file shrank past checkpoint conversation=${conversationId} ${sessionLabel} file=${params.sessionFile} checkpointOffset=${bootstrapState.lastProcessedOffset} checkpointSize=${bootstrapState.lastSeenSize} currentSize=${sessionFileSize}`,
+            );
             this.lastFullReadFileState.delete(conversationId);
             this.clearStableOrphanStrippingOrdinal(conversationId);
             bootstrapState = null;
@@ -5574,9 +5621,13 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
             conversationId,
             historicalMessages,
-            checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
+            checkpointEntryHash:
+              transcriptEpochReason === "same-path-shrink"
+                ? undefined
+                : bootstrapState?.lastProcessedEntryHash,
+            skipContentAnchorScan: transcriptEpochReason === "same-path-shrink",
             allowNoAnchorImport: transcriptEpochRotated,
-            noAnchorImportReason: transcriptEpochRotated ? "path-mismatch" : undefined,
+            noAnchorImportReason: transcriptEpochReason,
           });
           this.deps.log.debug(
             `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4608,6 +4608,183 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(stored[5].content).toBe("");
   });
 
+  it("bootstraps a bounded same-path transcript epoch after the file shrinks", async () => {
+    const warnLog = vi.fn();
+    const sessionFile = createSessionFilePath("bootstrap-same-path-shrink");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "old bootstrap shrink user" },
+      { role: "assistant", content: "old bootstrap shrink assistant" },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "bootstrap-same-path-shrink";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+    expect(first.importedMessages).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(sessionFile);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "missed bootstrap shrink user" },
+      { role: "assistant", content: "missed bootstrap shrink assistant" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("same-path-shrink")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old bootstrap shrink user",
+      "old bootstrap shrink assistant",
+      "missed bootstrap shrink user",
+      "missed bootstrap shrink assistant",
+    ]);
+
+    const newCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(newCheckpoint?.sessionFilePath).toBe(sessionFile);
+    expect(newCheckpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("imports the full bounded same-path shrink epoch instead of trusting a stale externalized frontier", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-same-path-shrink-externalized");
+    const rawFrontier = "externalized raw shrink frontier";
+    writeLeafTranscript(sessionFile, [
+      { role: "assistant", content: rawFrontier },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-same-path-shrink-externalized";
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+    expect(first.importedMessages).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const firstStored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(firstStored).toHaveLength(1);
+
+    const rawDb = createLcmDatabaseConnection(engine.config.databasePath);
+    try {
+      rawDb
+        .prepare(`UPDATE messages SET content = ?, token_count = ? WHERE message_id = ?`)
+        .run(
+          "[LCM externalized payload reference]",
+          estimateTokens("[LCM externalized payload reference]"),
+          firstStored[0].messageId,
+        );
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.lastProcessedEntryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "assistant", content: rawFrontier },
+      { role: "user", content: "tail after externalized shrink" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "[LCM externalized payload reference]",
+      rawFrontier,
+      "tail after externalized shrink",
+    ]);
+  });
+
+  it("imports a full same-path shrink epoch when new content repeats an old frontier message", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-same-path-shrink-duplicate-frontier");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "old duplicate frontier user" },
+      { role: "assistant", content: "OK" },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-same-path-shrink-duplicate-frontier";
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+    expect(first.importedMessages).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "new duplicate frontier user" },
+      { role: "assistant", content: "OK" },
+      { role: "user", content: "new duplicate frontier tail" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 3,
+      reason: "reconciled missing session messages",
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old duplicate frontier user",
+      "OK",
+      "new duplicate frontier user",
+      "OK",
+      "new duplicate frontier tail",
+    ]);
+  });
+
   it("does not append JSONL when no overlapping anchor exists in LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-no-overlap");
     const sm = SessionManager.open(sessionFile);
@@ -8229,6 +8406,304 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "old no-anchor user",
       "old no-anchor assistant",
+    ]);
+  });
+
+  it("afterTurn imports a bounded same-path transcript epoch after the file shrinks", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-same-path-shrink";
+    const sessionKey = "agent:main:test:direct:same-path-shrink";
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const sessionFile = createSessionFilePath("after-turn-same-path-shrink");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "old shrink user" },
+      { role: "assistant", content: "old shrink assistant" },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old shrink user" }),
+        makeMessage({ role: "assistant", content: "old shrink assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(sessionFile);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "missed shrink prefix user" },
+      { role: "assistant", content: "missed shrink prefix assistant" },
+      { role: "user", content: "live shrink user" },
+      { role: "assistant", content: "live shrink assistant" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+    const shrinkStats = statSync(sessionFile);
+    (
+      engine as unknown as {
+        afterTurnReconcileFullReadStates: Map<string, { size: number; mtimeMs: number }>;
+      }
+    ).afterTurnReconcileFullReadStates.set(`${sessionKey}\u0000${sessionFile}`, {
+      size: shrinkStats.size,
+      mtimeMs: Math.trunc(shrinkStats.mtimeMs),
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "live shrink user" }),
+        makeMessage({ role: "assistant", content: "live shrink assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("same-path-shrink")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old shrink user",
+      "old shrink assistant",
+      "missed shrink prefix user",
+      "missed shrink prefix assistant",
+      "live shrink user",
+      "live shrink assistant",
+    ]);
+
+    const newCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(newCheckpoint?.sessionFilePath).toBe(sessionFile);
+    expect(newCheckpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn imports the full bounded same-path shrink epoch instead of trusting a stale externalized frontier", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-same-path-shrink-externalized";
+    const sessionKey = "agent:main:test:direct:same-path-shrink-externalized";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const sessionFile = createSessionFilePath("after-turn-same-path-shrink-externalized");
+    const rawFrontier = "afterTurn externalized raw shrink frontier";
+    writeLeafTranscript(sessionFile, [
+      { role: "assistant", content: rawFrontier },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: rawFrontier })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const firstStored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(firstStored).toHaveLength(1);
+
+    const rawDb = createLcmDatabaseConnection(engine.config.databasePath);
+    try {
+      rawDb
+        .prepare(`UPDATE messages SET content = ?, token_count = ? WHERE message_id = ?`)
+        .run(
+          "[LCM afterTurn externalized payload reference]",
+          estimateTokens("[LCM afterTurn externalized payload reference]"),
+          firstStored[0].messageId,
+        );
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.lastProcessedEntryHash).toMatch(/^[a-f0-9]{64}$/);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "assistant", content: rawFrontier },
+      { role: "user", content: "afterTurn tail after externalized shrink" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "user", content: "afterTurn tail after externalized shrink" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "[LCM afterTurn externalized payload reference]",
+      rawFrontier,
+      "afterTurn tail after externalized shrink",
+    ]);
+  });
+
+  it("afterTurn imports a full same-path shrink epoch when new content repeats an old frontier message", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-same-path-shrink-duplicate-frontier";
+    const sessionKey = "agent:main:test:direct:same-path-shrink-duplicate-frontier";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const sessionFile = createSessionFilePath("after-turn-same-path-shrink-duplicate-frontier");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "old afterTurn duplicate frontier user" },
+      { role: "assistant", content: "OK" },
+    ]);
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "old afterTurn duplicate frontier user" }),
+        makeMessage({ role: "assistant", content: "OK" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "new afterTurn duplicate frontier user" },
+      { role: "assistant", content: "OK" },
+      { role: "user", content: "new afterTurn duplicate frontier tail" },
+    ]);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(sessionFile).size);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "user", content: "new afterTurn duplicate frontier tail" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old afterTurn duplicate frontier user",
+      "OK",
+      "new afterTurn duplicate frontier user",
+      "OK",
+      "new afterTurn duplicate frontier tail",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Detect same-path transcript shrink when the stored bootstrap checkpoint points past the current JSONL EOF.
- Recover those shrink cases as bounded transcript epochs instead of accepting an empty append-only read as covered.
- Avoid stale content anchors for same-path shrink epochs and add bootstrap/afterTurn regressions for externalized and duplicate-frontier cases.

## Tests

- `npm test -- --run test/engine.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`
- `codex review --commit HEAD`

Co-Authored-By: Cha <cha@jetd.one> via OpenClaw