### PR TITLE
fix: avoid plugin runtime llm agent override

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1043,6 +1043,7 @@ function createLcmDependencies(
       const modelId = model.trim();
       const modelRef = runtimeModelOverride?.modelRef.trim();
       const runtimeLlm = runtimeLlmComplete ?? getRuntimeLlm(api)?.complete;
+      const isBoundRuntimeLlm = !!runtimeLlmComplete;
       const requestMetadata = {
         request_provider: providerId ?? "(runtime)",
         request_model: modelId || "(runtime)",
@@ -1075,7 +1076,10 @@ function createLcmDependencies(
             : {}),
           ...(typeof system === "string" && system.trim() ? { systemPrompt: system.trim() } : {}),
           purpose: "lossless-claw compaction summarization",
-          ...(agentId?.trim() ? { agentId: agentId.trim() } : {}),
+          // Only context-engine supplied runtime LLM capabilities may carry an explicit
+          // agentId. Plugin-wide api.runtime.llm.complete is gateway-scoped and rejects
+          // target-agent overrides unless OpenClaw is explicitly configured otherwise.
+          ...(isBoundRuntimeLlm && agentId?.trim() ? { agentId: agentId.trim() } : {}),
         });
         const text = typeof result.text === "string" ? result.text : "";
         return {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1292,6 +1292,10 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       : undefined;
   const agentId = explicitAgentId || sessionAgentId;
   const runtimeLlmComplete = readRuntimeLlmComplete(params.legacyParams);
+  // OpenClaw only permits agentId override on host-bound/context-engine runtime LLM
+  // capabilities. Plugin-wide api.runtime.llm.complete is already scoped by the
+  // gateway and rejects unbound agentId overrides.
+  const shouldPassAgentId = !!runtimeLlmComplete && !!agentId;
 
   const condensedTargetTokens =
     Number.isFinite(params.deps.config.condensedTargetTokens) &&
@@ -1363,7 +1367,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           model,
           ...(runtimeModelOverride ? { runtimeModelOverride } : {}),
           ...(runtimeLlmComplete ? { runtimeLlmComplete } : {}),
-          ...(agentId ? { agentId } : {}),
+          ...(shouldPassAgentId ? { agentId } : {}),
           system: LCM_SUMMARIZER_SYSTEM_PROMPT,
           messages: [
             {

--- a/test/index-runtime-llm-complete.test.ts
+++ b/test/index-runtime-llm-complete.test.ts
@@ -117,7 +117,7 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
     vi.clearAllMocks();
   });
 
-  it("delegates model dispatch and auth to api.runtime.llm.complete", async () => {
+  it("delegates model dispatch and auth to api.runtime.llm.complete without target-agent override", async () => {
     const runtimeLlmComplete = vi.fn(async () => ({
       text: "summary output",
       provider: "openai-codex",
@@ -154,7 +154,6 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         temperature: 0.2,
         systemPrompt: "System summary policy.",
         purpose: "lossless-claw compaction summarization",
-        agentId: "research-agent",
       });
       expect(result).toMatchObject({
         content: [{ type: "text", text: "summary output" }],
@@ -163,6 +162,34 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         agentId: "research-agent",
         request_api: "runtime.llm",
       });
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  });
+
+
+  it("omits agentId for plugin-wide runtime llm even when deps.complete receives one", async () => {
+    const runtimeLlmComplete = vi.fn(async () => ({
+      text: "summary output",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      agentId: "main",
+    }));
+    const { api, getFactory, dbPath } = buildApi({ runtimeLlmComplete });
+    const engine = getRegisteredEngine(api, getFactory);
+
+    try {
+      await engine.deps.complete({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        agentId: "research-agent",
+        messages: [{ role: "user", content: "Summarize this." }],
+        maxTokens: 256,
+      });
+
+      expect(runtimeLlmComplete).toHaveBeenCalledWith(
+        expect.not.objectContaining({ agentId: expect.any(String) }),
+      );
     } finally {
       closeLcmConnection(dbPath);
     }
@@ -189,12 +216,16 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
         runtimeLlmComplete: boundRuntimeLlmComplete,
+        agentId: "research",
         messages: [{ role: "user", content: "Summarize this." }],
         maxTokens: 256,
       });
 
       expect(boundRuntimeLlmComplete).toHaveBeenCalledTimes(1);
       expect(pluginRuntimeLlmComplete).not.toHaveBeenCalled();
+      expect(boundRuntimeLlmComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "research" }),
+      );
       expect(result).toMatchObject({
         content: [{ type: "text", text: "bound summary" }],
         agentId: "research",

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -493,6 +493,31 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(Object.prototype.hasOwnProperty.call(completeArgs, "authProfileId")).toBe(false);
   });
 
+
+  it("does not derive agentId for plugin-wide runtime completion from sessionKey", async () => {
+    const deps = makeDeps({
+      parseAgentSessionKey: vi.fn(() => ({
+        agentId: "research",
+        suffix: "session:abc",
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        sessionKey: "agent:research:session:abc",
+      },
+    });
+
+    await summarize!("Summary input");
+
+    expect(vi.mocked(deps.complete).mock.calls[0]?.[0]).not.toMatchObject({
+      agentId: expect.any(String),
+    });
+  });
+
   it("passes host-bound runtime llm completion from context engine params", async () => {
     const runtimeLlmComplete = vi.fn(async () => ({
       text: "bound summary",


### PR DESCRIPTION
## Summary
- stop passing agentId from plugin-wide Lossless summarization calls to api.runtime.llm.complete
- preserve explicit agentId only for host-bound/context-engine runtime LLM completions
- add regressions for plugin-wide omission, sessionKey-derived agent omission, and bound completion preservation

## Why
OpenClaw treats agentId on plugin-wide runtime.llm.complete as a target-agent override. Lossless was deriving it from the session and forwarding it, so compaction summarization could be rejected with "Plugin LLM completion cannot override the target agent", forcing deterministic fallback summaries.

## Test plan
- npm test -- --run test/index-runtime-llm-complete.test.ts test/summarize.test.ts
- git diff --check
- npm run build
