### PR TITLE
fix: preserve hot prompt cache deferral

### DIFF
--- a/.changeset/cache-aware-gpt-defaults.md
+++ b/.changeset/cache-aware-gpt-defaults.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve hot prompt-cache deferral for direct OpenAI GPT models and raise the default critical budget pressure ratio to 0.90 so normal threshold compaction does not immediately bypass cache protection.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ Most installations only need to override a handful of keys. If you want a comple
     "hotCachePressureFactor": 4,
     "hotCacheBudgetHeadroomRatio": 0.2,
     "coldCacheObservationThreshold": 3,
-    "criticalBudgetPressureRatio": 0.70
+    "criticalBudgetPressureRatio": 0.90
   },
   "dynamicLeafChunkTokens": {
     "enabled": true,
@@ -196,7 +196,7 @@ Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capabil
 | `cacheAwareCompaction.hotCachePressureFactor` | `number` | `4` | `LCM_HOT_CACHE_PRESSURE_FACTOR` | Multiplier applied to the hot-cache leaf trigger before raw-history pressure overrides cache preservation. |
 | `cacheAwareCompaction.hotCacheBudgetHeadroomRatio` | `number` | `0.2` | `LCM_HOT_CACHE_BUDGET_HEADROOM_RATIO` | Minimum fraction of the real token budget that must remain free before hot-cache incremental compaction is skipped entirely. |
 | `cacheAwareCompaction.coldCacheObservationThreshold` | `integer` | `3` | `LCM_COLD_CACHE_OBSERVATION_THRESHOLD` | Consecutive cold observations required before non-explicit cache misses are treated as truly cold. This dampens one-off routing noise and provider failover blips. |
-| `cacheAwareCompaction.criticalBudgetPressureRatio` | `number` | `0.70` | `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | Fraction of the token budget at which deferred compaction bypasses hot-cache delay so prompt-mutating debt can run before overflow. Set to `1` to disable this bypass. |
+| `cacheAwareCompaction.criticalBudgetPressureRatio` | `number` | `0.90` | `LCM_CRITICAL_BUDGET_PRESSURE_RATIO` | Fraction of the token budget at which deferred compaction bypasses hot-cache delay so prompt-mutating debt can run before overflow. Set to `1` to disable this bypass. |
 
 #### `dynamicLeafChunkTokens`
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -194,7 +194,7 @@
     },
     "cacheAwareCompaction.criticalBudgetPressureRatio": {
       "label": "Critical Budget Pressure Ratio",
-      "help": "Fraction of token budget at which deferred compaction fires regardless of prompt-cache state. Defaults to 0.70 — set to 1 to disable the override and let cache-aware throttling fully control deferral."
+      "help": "Fraction of token budget at which deferred compaction fires regardless of prompt-cache state. Defaults to 0.90 — set to 1 to disable the override and let cache-aware throttling fully control deferral."
     },
     "dynamicLeafChunkTokens.enabled": {
       "label": "Dynamic Leaf Chunk Tokens",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -118,7 +118,7 @@ Good defaults:
 - `hotCachePressureFactor: 4`
 - `hotCacheBudgetHeadroomRatio: 0.2`
 - `coldCacheObservationThreshold: 3`
-- `criticalBudgetPressureRatio: 0.70`
+- `criticalBudgetPressureRatio: 0.90`
 
 Operationally:
 
@@ -501,7 +501,7 @@ Why it matters:
 
 Default:
 
-- `0.70`
+- `0.90`
 
 Env override:
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -23,7 +23,7 @@ export function resolveOpenclawStateDir(env: NodeJS.ProcessEnv = process.env): s
  * value. Mirrored to `src/engine.ts`'s `?? DEFAULT_CRITICAL_BUDGET_PRESSURE_RATIO`
  * usage.
  */
-export const DEFAULT_CRITICAL_BUDGET_PRESSURE_RATIO = 0.70;
+export const DEFAULT_CRITICAL_BUDGET_PRESSURE_RATIO = 0.90;
 export const DEFAULT_AUTO_ROTATE_SESSION_FILE_SIZE_BYTES = 2 * 1024 * 1024;
 
 export type CacheAwareCompactionConfig = {
@@ -35,21 +35,17 @@ export type CacheAwareCompactionConfig = {
   coldCacheObservationThreshold: number;
   /**
    * Token-budget ratio that bypasses cache-aware deferral when the prompt is
-   * critically full. Defaults to 0.70 — once `currentTokenCount >= 0.70 *
+   * critically full. Defaults to 0.90 — once `currentTokenCount >= 0.90 *
    * tokenBudget`, deferred compaction fires regardless of prompt-cache
    * temperature so the runtime never has to fall back to emergency overflow
    * truncation.
    *
-   * The 0.70 default leaves a 30% headroom band (0–70%) where cache-aware
-   * throttling can defer up to the configured cache TTL window per dispatch
-   * (default 5 minutes via `cacheTTLSeconds: 300`).
-   * Above 70%, the bypass fires every turn regardless of cache state — that
-   * 30% buffer is enough room for a heavily-deferred backlog to drain before
-   * the runtime emergency overflow handler is needed. Set to `>= 1` to
-   * disable the bypass entirely (cache-aware throttling fully controls
-   * deferral).
+   * The 0.90 default leaves the normal 0.75 context threshold inside the
+   * cache-protected band while still preserving a final 10% escape hatch for
+   * overflow avoidance. Set to `>= 1` to disable the bypass entirely
+   * (cache-aware throttling fully controls deferral).
    *
-   * Optional for backward compatibility — runtime defaults to 0.70 when this
+   * Optional for backward compatibility — runtime defaults to 0.90 when this
    * field is absent.
    */
   criticalBudgetPressureRatio?: number;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2273,6 +2273,12 @@ export class LcmContextEngine implements ContextEngine {
   ): boolean {
     const provider = telemetry?.provider?.trim().toLowerCase() ?? "";
     const model = telemetry?.model?.trim().toLowerCase() ?? "";
+    const modelUsesOpenAiPromptCache =
+      model.startsWith("gpt-")
+      || /^o[1-9](?:-|$)/.test(model);
+    if (modelUsesOpenAiPromptCache) {
+      return true;
+    }
     const identifiers = [provider, model];
     return identifiers.some((identifier) =>
       identifier.includes("anthropic")
@@ -2349,12 +2355,10 @@ export class LcmContextEngine implements ContextEngine {
    *    high-velocity sessions can livelock the dispatcher: each turn refreshes
    *    `lastCacheTouchAt`, the TTL window never expires, deferred work never
    *    fires, and the runtime emergency overflow handler is left to do all
-   *    the work. The default 0.70 threshold (configurable via
-   *    `cacheAwareCompaction.criticalBudgetPressureRatio`) leaves a ~30%
-   *    headroom band (0–70%) where cache-aware throttling still applies;
-   *    above that band the cache hold is broken so deferred compaction can
-   *    drag the prompt back down before the runtime emergency overflow
-   *    handler is needed.
+   *    the work. The default 0.90 threshold (configurable via
+   *    `cacheAwareCompaction.criticalBudgetPressureRatio`) keeps ordinary
+   *    threshold compaction inside the cache-protected band while preserving
+   *    a final overflow-avoidance escape hatch.
    */
   private shouldDelayPromptMutatingDeferredCompaction(
     telemetry: ConversationCompactionTelemetryRecord | null,

--- a/test/cache-aware-deferral-gate.test.ts
+++ b/test/cache-aware-deferral-gate.test.ts
@@ -170,7 +170,7 @@ describe("shouldDelayPromptMutatingDeferredCompaction (cache-aware deferral gate
     }
   });
 
-  it("does NOT defer when prompt is at or above the critical pressure ratio (0.70 default)", () => {
+  it("defers at the default compaction threshold while hot cache is still protected", () => {
     const engine = createEngine();
     const gate = (engine as unknown as {
       shouldDelayPromptMutatingDeferredCompaction: (
@@ -181,12 +181,27 @@ describe("shouldDelayPromptMutatingDeferredCompaction (cache-aware deferral gate
       ) => boolean;
     }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
 
-    // 140,001 / 200,000 = 0.700005 — above the 0.70 ratio
-    expect(gate(makeHotCodexTelemetry(), new Date(), 140_001, 200_000)).toBe(false);
-    // 140,000 / 200,000 = 0.70 exactly — at the ratio (>= comparison)
-    expect(gate(makeHotCodexTelemetry(), new Date(), 140_000, 200_000)).toBe(false);
-    // 139,999 / 200,000 = 0.699995 — below the ratio
-    expect(gate(makeHotCodexTelemetry(), new Date(), 139_999, 200_000)).toBe(true);
+    // 150,000 / 200,000 = 0.75, matching the default contextThreshold.
+    expect(gate(makeHotCodexTelemetry(), new Date(), 150_000, 200_000)).toBe(true);
+  });
+
+  it("does NOT defer when prompt is at or above the critical pressure ratio (0.90 default)", () => {
+    const engine = createEngine();
+    const gate = (engine as unknown as {
+      shouldDelayPromptMutatingDeferredCompaction: (
+        telemetry: ConversationCompactionTelemetryRecord | null,
+        now?: Date,
+        currentTokenCount?: number,
+        tokenBudget?: number,
+      ) => boolean;
+    }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
+
+    // 180,001 / 200,000 = 0.900005 — above the 0.90 ratio
+    expect(gate(makeHotCodexTelemetry(), new Date(), 180_001, 200_000)).toBe(false);
+    // 180,000 / 200,000 = 0.90 exactly — at the ratio (>= comparison)
+    expect(gate(makeHotCodexTelemetry(), new Date(), 180_000, 200_000)).toBe(false);
+    // 179,999 / 200,000 = 0.899995 — below the ratio
+    expect(gate(makeHotCodexTelemetry(), new Date(), 179_999, 200_000)).toBe(true);
   });
 
   it("respects a custom criticalBudgetPressureRatio override", () => {
@@ -251,7 +266,7 @@ describe("shouldDelayPromptMutatingDeferredCompaction (cache-aware deferral gate
     expect(gate(makeHotCodexTelemetry(), new Date(), 100_000, 0)).toBe(true);
   });
 
-  it("does not defer when provider is not mutation-sensitive (e.g. plain openai)", () => {
+  it("defers for direct OpenAI GPT models while the cache is hot", () => {
     const engine = createEngine();
     const gate = (engine as unknown as {
       shouldDelayPromptMutatingDeferredCompaction: (
@@ -265,6 +280,27 @@ describe("shouldDelayPromptMutatingDeferredCompaction (cache-aware deferral gate
     expect(
       gate(
         makeHotCodexTelemetry({ provider: "openai", model: "gpt-4o" }),
+        new Date(),
+        100_000,
+        200_000,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not defer when provider and model are not mutation-sensitive", () => {
+    const engine = createEngine();
+    const gate = (engine as unknown as {
+      shouldDelayPromptMutatingDeferredCompaction: (
+        telemetry: ConversationCompactionTelemetryRecord | null,
+        now?: Date,
+        currentTokenCount?: number,
+        tokenBudget?: number,
+      ) => boolean;
+    }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
+
+    expect(
+      gate(
+        makeHotCodexTelemetry({ provider: "local", model: "llama-4" }),
         new Date(),
         100_000,
         200_000,

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -66,7 +66,7 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
       coldCacheObservationThreshold: 3,
-      criticalBudgetPressureRatio: 0.70,
+      criticalBudgetPressureRatio: 0.90,
     },
     dynamicLeafChunkTokens: {
       enabled: true,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -73,7 +73,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
       coldCacheObservationThreshold: 3,
-      criticalBudgetPressureRatio: 0.70,
+      criticalBudgetPressureRatio: 0.90,
     },
     dynamicLeafChunkTokens: {
       enabled: true,
@@ -8540,7 +8540,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
       prePromptMessageCount: 0,
       // Budget chosen so observed input (8K) is far below the critical pressure
-      // ratio (0.70 default). 8K / 200K = 4% — cache-aware path is the only
+      // ratio (0.90 default). 8K / 200K = 4% — cache-aware path is the only
       // gate the test should be probing.
       tokenBudget: 200_000,
       runtimeContext: {

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -52,7 +52,7 @@ const BASE_CONFIG: LcmConfig = {
     hotCachePressureFactor: 4,
     hotCacheBudgetHeadroomRatio: 0.2,
     coldCacheObservationThreshold: 3,
-    criticalBudgetPressureRatio: 0.70,
+    criticalBudgetPressureRatio: 0.90,
   },
   dynamicLeafChunkTokens: {
     enabled: true,

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -12,6 +12,10 @@ import { resetStartupBannerLogsForTests } from "../src/startup-banner-log.js";
 type RegisteredEngineFactory = (() => unknown) | undefined;
 type HookHandler = (event: unknown, context: unknown) => unknown;
 type RegisteredContextEngine = { id: string; factory: () => unknown };
+type SessionStoreSnapshot = Record<string, {
+  totalTokens?: unknown;
+  totalTokensFresh?: unknown;
+}>;
 
 function buildApi(
   pluginConfig: unknown,
@@ -159,6 +163,18 @@ function attachSessionStoreApi(api: OpenClawPluginApi, sessionStorePath: string)
         ? entry.sessionFile
         : join(tmpdir(), `${runtimeSessionId}.jsonl`),
   };
+}
+
+/** Read a session-store snapshot, tolerating transient partial writes during async recovery. */
+function readSessionStoreSnapshot(sessionStorePath: string): SessionStoreSnapshot | undefined {
+  try {
+    return JSON.parse(readFileSync(sessionStorePath, "utf8")) as SessionStoreSnapshot;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 function defaultModelConfig(model: string): Record<string, unknown> {
@@ -996,11 +1012,8 @@ describe("lcm plugin registration", () => {
         }
       | undefined;
     for (let attempt = 0; attempt < 30; attempt += 1) {
-      const store = JSON.parse(readFileSync(sessionStorePath, "utf8")) as Record<string, {
-        totalTokens?: unknown;
-        totalTokensFresh?: unknown;
-      }>;
-      recoveredEntry = store[sessionKey];
+      const store = readSessionStoreSnapshot(sessionStorePath);
+      recoveredEntry = store?.[sessionKey];
       if (
         recoveredEntry
         && typeof recoveredEntry.totalTokens === "number"
@@ -1108,12 +1121,15 @@ describe("lcm plugin registration", () => {
     expect(secondFactory).toBeTypeOf("function");
     await Promise.resolve(secondFactory!());
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    const store = JSON.parse(readFileSync(sessionStorePath, "utf8")) as Record<string, {
-      totalTokens?: unknown;
-      totalTokensFresh?: unknown;
-    }>;
-    expect(store[sessionKey]).toMatchObject({
+    let store: SessionStoreSnapshot | undefined;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      store = readSessionStoreSnapshot(sessionStorePath);
+      if (store?.[sessionKey]?.totalTokens === 50_000) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(store?.[sessionKey]).toMatchObject({
       totalTokens: 50_000,
       totalTokensFresh: true,
     });
@@ -1254,11 +1270,8 @@ describe("lcm plugin registration", () => {
         }>
       | undefined;
     for (let attempt = 0; attempt < 30; attempt += 1) {
-      recoveredStore = JSON.parse(readFileSync(sessionStorePath, "utf8")) as Record<string, {
-        totalTokens?: unknown;
-        totalTokensFresh?: unknown;
-      }>;
-      const recoveredEntry = recoveredStore[sessionKey];
+      recoveredStore = readSessionStoreSnapshot(sessionStorePath);
+      const recoveredEntry = recoveredStore?.[sessionKey];
       if (
         recoveredEntry
         && typeof recoveredEntry.totalTokens === "number"

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -72,7 +72,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       hotCachePressureFactor: 4,
       hotCacheBudgetHeadroomRatio: 0.2,
       coldCacheObservationThreshold: 3,
-      criticalBudgetPressureRatio: 0.70,
+      criticalBudgetPressureRatio: 0.90,
     },
     dynamicLeafChunkTokens: {
       enabled: true,


### PR DESCRIPTION
## What

This PR keeps hot prompt-cache protection effective for normal threshold compaction and direct OpenAI GPT-family runs.

## Why

OpenAI prompt caching depends on stable prompt prefixes. The previous critical-pressure default bypassed hot-cache deferral at 70% of budget, below the default 75% compaction threshold, so ordinary threshold compaction could mutate the prompt while the cache was still hot. Direct `openai` GPT-family telemetry was also not classified as mutation-sensitive, allowing the same cache-breaking path for direct OpenAI routing.

## Changes

- Raise critical pressure default
- Classify direct GPT telemetry
- Add hot-cache gate regressions
- Sync config documentation
- Add patch changeset

| File | Change |
|------|--------|
| `src/db/config.ts` | Raised default to `0.90` |
| `src/engine.ts` | Treat GPT/o-series models as sensitive |
| `test/cache-aware-deferral-gate.test.ts` | Added cache-deferral regressions |
| `test/engine.test.ts` | Updated default fixture |
| `test/circuit-breaker.test.ts` | Updated default fixture |
| `test/expansion.test.ts` | Updated default fixture |
| `test/session-operation-queues.test.ts` | Updated default fixture |
| `docs/configuration.md` | Updated documented default |
| `skills/lossless-claw/references/config.md` | Updated skill reference |
| `openclaw.plugin.json` | Updated config help text |
| `.changeset/cache-aware-gpt-defaults.md` | Added patch release note |

## Testing

- `npm test -- --run test/cache-aware-deferral-gate.test.ts`
- `npm test -- --run test/config.test.ts test/plugin-config-registration.test.ts`
- `npm test`
- `npm run build`
