### PR TITLE
feat: add compaction start token floor

### DIFF
--- a/.changeset/compaction-start-tokens.md
+++ b/.changeset/compaction-start-tokens.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+feat(engine): add `compactionStartTokens` to defer optional compaction until the prompt reaches an explicit token floor
+
+`compactionStartTokens` and `LCM_COMPACTION_START_TOKENS` let operators preserve fully raw context below an absolute current-prompt token count, while still allowing critical budget pressure to compact before overflow.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
         "config": {
           "freshTailCount": 64,
           "leafChunkTokens": 80000,
+          "compactionStartTokens": 0,
           "newSessionRetainDepth": 2,
           "contextThreshold": 0.75,
           "incrementalMaxDepth": 1,
@@ -158,7 +159,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 }
 ```
 
-`leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
+`leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `compactionStartTokens` is an optional absolute prompt-token floor: set it when you want LCM to keep raw history intact until the current prompt reaches that size. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
 
 ### Environment variables
 
@@ -177,6 +178,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_CONDENSED_MIN_FANOUT_HARD` | `2` | Relaxed fanout for forced compaction sweeps |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `1` | How deep incremental compaction goes (0 = leaf only, 1 = one condensed pass, -1 = unlimited) |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Max source tokens per leaf compaction chunk |
+| `LCM_COMPACTION_START_TOKENS` | `0` | Minimum current prompt tokens before optional LCM compaction may start |
 | `LCM_LEAF_TARGET_TOKENS` | `1200` | Target token count for leaf summaries |
 | `LCM_CONDENSED_TARGET_TOKENS` | `2000` | Target token count for condensed summaries |
 | `LCM_MAX_EXPAND_TOKENS` | `4000` | Token cap for sub-agent expansion queries |
@@ -265,6 +267,7 @@ Summary calls are dispatched through OpenClaw's runtime LLM layer, so auth profi
 ```
 LCM_FRESH_TAIL_COUNT=64
 LCM_LEAF_CHUNK_TOKENS=20000
+LCM_COMPACTION_START_TOKENS=0
 LCM_INCREMENTAL_MAX_DEPTH=1
 LCM_CONTEXT_THRESHOLD=0.75
 LCM_SUMMARY_MODEL=openai/gpt-5.4-mini
@@ -273,6 +276,7 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 
 - **freshTailCount=64** protects the last 64 messages from compaction, giving the model more recent context for continuity.
 - **leafChunkTokens=20000** limits how large each leaf compaction chunk can grow before LCM summarizes it. Increase this when your summary provider is quota-limited and frequent leaf compactions are exhausting that quota.
+- **compactionStartTokens=0** leaves optional compaction available immediately. Set a positive value when you want LCM to fully preserve raw history until the current prompt reaches that absolute token count; critical budget pressure can still compact before overflow.
 - **incrementalMaxDepth=1** runs one condensed pass after each leaf compaction by default. Set to `0` for leaf-only behavior, a larger positive integer for a deeper cap, or `-1` for unlimited cascading.
 - **contextThreshold=0.75** triggers compaction when context reaches 75% of the model's window, leaving headroom for the model's response.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "condensedMinFanoutHard": 2,
   "incrementalMaxDepth": 1,
   "leafChunkTokens": 20000,
+  "compactionStartTokens": 0,
   "bootstrapMaxTokens": 6000,
   "leafTargetTokens": 2400,
   "condensedTargetTokens": 2000,
@@ -151,6 +152,7 @@ Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rot
 | `condensedMinFanoutHard` | `integer` | `2` | `LCM_CONDENSED_MIN_FANOUT_HARD` | Hard floor for condensation grouping during maintenance and repair flows. |
 | `incrementalMaxDepth` | `integer` | `1` | `LCM_INCREMENTAL_MAX_DEPTH` | Maximum automatic condensation depth after leaf compaction. Use `0` for leaf-only and `-1` for unlimited depth. |
 | `leafChunkTokens` | `integer` | `20000` | `LCM_LEAF_CHUNK_TOKENS` | Maximum source-token budget for a leaf compaction chunk. |
+| `compactionStartTokens` | `integer` | `0` | `LCM_COMPACTION_START_TOKENS` | Minimum current prompt tokens before optional LCM compaction may start. `0` disables this floor; critical budget pressure can bypass it before overflow. |
 | `bootstrapMaxTokens` | `integer` | `max(6000, floor(leafChunkTokens * 0.3))` | `LCM_BOOTSTRAP_MAX_TOKENS` | Maximum parent-history tokens imported when a new LCM conversation bootstraps. |
 | `leafTargetTokens` | `integer` | `2400` | `LCM_LEAF_TARGET_TOKENS` | Prompt target for leaf summary size. |
 | `condensedTargetTokens` | `integer` | `2000` | `LCM_CONDENSED_TARGET_TOKENS` | Prompt target for condensed summary size. |
@@ -204,6 +206,12 @@ Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capabil
 | --- | --- | --- | --- | --- |
 | `dynamicLeafChunkTokens.enabled` | `boolean` | `true` | `LCM_DYNAMIC_LEAF_CHUNK_TOKENS_ENABLED` | Enables dynamic working leaf chunk sizes for busier sessions. |
 | `dynamicLeafChunkTokens.max` | `integer` | `max(leafChunkTokens, floor(leafChunkTokens * 2))` | `LCM_DYNAMIC_LEAF_CHUNK_TOKENS_MAX` | Upper bound for the dynamic working chunk size. With the default `leafChunkTokens=20000`, this resolves to `40000`. |
+
+### Compaction start floor
+
+Set `compactionStartTokens` when you want LCM to preserve raw history until the assembled prompt reaches an explicit absolute size. For example, `compactionStartTokens: 120000` means leaf-trigger and proactive-threshold compaction stay inactive below 120k current prompt tokens, even if `leafChunkTokens` has already been exceeded.
+
+This floor only gates optional prompt-mutating compaction. Once `currentTokenCount >= cacheAwareCompaction.criticalBudgetPressureRatio * tokenBudget`, LCM may compact anyway so the prompt can stay under the model budget.
 
 ### Cache-aware incremental compaction
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -48,6 +48,10 @@
       "label": "Leaf Chunk Tokens",
       "help": "Maximum source tokens per leaf compaction chunk before summarization"
     },
+    "compactionStartTokens": {
+      "label": "Compaction Start Tokens",
+      "help": "Minimum current prompt tokens before optional LCM compaction may start. Set to 0 to disable; critical budget pressure can still compact before overflow."
+    },
     "bootstrapMaxTokens": {
       "label": "Bootstrap Max Tokens",
       "help": "Maximum raw parent-history tokens imported into a brand-new conversation bootstrap; oldest turns are dropped first"
@@ -278,6 +282,10 @@
       "leafChunkTokens": {
         "type": "integer",
         "minimum": 1
+      },
+      "compactionStartTokens": {
+        "type": "integer",
+        "minimum": 0
       },
       "bootstrapMaxTokens": {
         "type": "integer",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -101,6 +101,25 @@ Use this when:
 - Your summarizer is rate-limited or expensive.
 - You want fewer but broader leaf summaries.
 
+### `compactionStartTokens`
+
+Sets an absolute current-prompt token floor before optional compaction may start.
+
+Why it matters:
+
+- It preserves fully raw history below a known prompt size.
+- It is easier to reason about than budget-headroom ratios when the operator's goal is "do not digest before N tokens."
+- It leaves emergency budget protection intact through `cacheAwareCompaction.criticalBudgetPressureRatio`.
+
+Good default:
+
+- `0`, which disables the floor
+
+Use this when:
+
+- You run long-context models and want raw recent-session material preserved until a specific token count.
+- You want to delay both leaf-trigger and proactive-threshold compaction while the prompt is still comfortably small.
+
 ### `cacheAwareCompaction`
 
 Controls how strongly lossless-claw preserves a healthy prompt cache during incremental maintenance.
@@ -324,6 +343,10 @@ Env override:
 - `LCM_STUB_LARGE_TOOL_PAYLOADS`
 
 ### `leafChunkTokens`
+
+See high-impact settings above.
+
+### `compactionStartTokens`
 
 See high-impact settings above.
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -108,6 +108,8 @@ export type LcmConfig = {
   condensedMinFanoutHard: number;
   incrementalMaxDepth: number;
   leafChunkTokens: number;
+  /** Minimum current prompt token count before optional compaction may start. */
+  compactionStartTokens: number;
   /** Maximum raw parent-history tokens imported during first-time bootstrap. */
   bootstrapMaxTokens?: number;
   leafTargetTokens: number;
@@ -471,6 +473,14 @@ export function resolveLcmConfigWithDiagnostics(
         parseFiniteInt(env.LCM_INCREMENTAL_MAX_DEPTH)
           ?? toNumber(pc.incrementalMaxDepth) ?? 1,
       leafChunkTokens: resolvedLeafChunkTokens,
+      compactionStartTokens: Math.max(
+        0,
+        Math.floor(
+          parseFiniteInt(env.LCM_COMPACTION_START_TOKENS)
+            ?? toNumber(pc.compactionStartTokens)
+            ?? 0,
+        ),
+      ),
       bootstrapMaxTokens: resolvedBootstrapMaxTokens,
       leafTargetTokens:
         parseFiniteInt(env.LCM_LEAF_TARGET_TOKENS)

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -129,6 +129,7 @@ type DynamicLeafChunkBounds = {
   max: number;
 };
 const DEFERRED_COMPACTION_STILL_NEEDED_REASON = "deferred compaction still needed";
+const BELOW_COMPACTION_START_TOKENS_REASON = "below-compaction-start-tokens";
 const MAX_BUDGET_TRIGGER_CATCHUP_PASSES = 10;
 type TranscriptRewriteReplacement = {
   entryId: string;
@@ -2549,6 +2550,45 @@ export class LcmContextEngine implements ContextEngine {
     return params.currentTokenCount <= safeBudget;
   }
 
+  /**
+   * Keep optional compaction disabled until the assembled prompt reaches the
+   * operator's explicit start line. Critical budget pressure bypasses this so
+   * LCM can still compact before the runtime hits emergency overflow handling.
+   */
+  private isBelowCompactionStartTokens(params: {
+    currentTokenCount?: number;
+    tokenBudget: number;
+  }): boolean {
+    const startTokens = Math.max(0, Math.floor(this.config.compactionStartTokens));
+    if (startTokens <= 0) {
+      return false;
+    }
+    if (
+      typeof params.currentTokenCount !== "number"
+      || !Number.isFinite(params.currentTokenCount)
+      || params.currentTokenCount < 0
+    ) {
+      return false;
+    }
+    if (this.isUnderCriticalBudgetPressure(params)) {
+      return false;
+    }
+    return params.currentTokenCount < startTokens;
+  }
+
+  private shouldKeepDeferredLeafDebt(decision: IncrementalCompactionDecision): boolean {
+    if (decision.shouldCompact) {
+      return true;
+    }
+    if (
+      decision.reason === "hot-cache-budget-headroom"
+      || decision.reason === "hot-cache-defer"
+    ) {
+      return decision.rawTokensOutsideTail >= decision.threshold;
+    }
+    return false;
+  }
+
   /** Scale budget-trigger catch-up passes by how far the prompt exceeds threshold. */
   private resolveBudgetTriggerCatchupPasses(params: {
     currentTokens: number;
@@ -2975,6 +3015,33 @@ export class LcmContextEngine implements ContextEngine {
       });
     }
 
+    if (
+      this.isBelowCompactionStartTokens({
+        currentTokenCount: params.currentTokenCount,
+        tokenBudget: params.tokenBudget,
+      })
+    ) {
+      return this.logIncrementalCompactionDecision({
+        conversationId: params.conversationId,
+        cacheState,
+        activityBand,
+        tokenBudget: params.tokenBudget,
+        currentTokenCount: params.currentTokenCount,
+        cacheRead,
+        cacheWrite,
+        cachePromptTokenCount,
+        triggerLeafChunkTokens,
+        preferredLeafChunkTokens,
+        fallbackLeafChunkTokens,
+        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
+        threshold: leafTrigger.threshold,
+        shouldCompact: false,
+        maxPasses: 1,
+        allowCondensedPasses: false,
+        reason: BELOW_COMPACTION_START_TOKENS_REASON,
+      });
+    }
+
     const budgetDecision = await this.compaction.evaluate(
       params.conversationId,
       params.tokenBudget,
@@ -3282,10 +3349,9 @@ export class LcmContextEngine implements ContextEngine {
                   leafDecision,
                   currentTokenCount: resolvedCurrentTokenCount,
                   tokenBudget: resolvedTokenBudget,
-                });
+              });
               if (!leafDecision.shouldCompact) {
-                const deferredLeafStillNeeded =
-                  leafDecision.rawTokensOutsideTail >= leafDecision.threshold;
+                const deferredLeafStillNeeded = this.shouldKeepDeferredLeafDebt(leafDecision);
                 if (executionLeafDecision === leafDecision) {
                   return {
                     ok: true,
@@ -3457,6 +3523,27 @@ export class LcmContextEngine implements ContextEngine {
         reason: "missing token budget in compact params",
       };
     }
+    const observedTokens = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
+        (
+          lp as {
+            currentTokenCount?: unknown;
+          }
+        ).currentTokenCount,
+    );
+    if (
+      !forceCompaction
+      && this.isBelowCompactionStartTokens({
+        currentTokenCount: observedTokens,
+        tokenBudget,
+      })
+    ) {
+      return {
+        ok: true,
+        compacted: false,
+        reason: BELOW_COMPACTION_START_TOKENS_REASON,
+      };
+    }
 
     const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
       legacyParams: this.buildSummarizerLegacyParams({
@@ -3475,14 +3562,6 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const conversationId = params.conversationId;
-    const observedTokens = this.normalizeObservedTokenCount(
-      params.currentTokenCount ??
-        (
-          lp as {
-            currentTokenCount?: unknown;
-          }
-        ).currentTokenCount,
-    );
     const decision =
       observedTokens !== undefined
         ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
@@ -6829,6 +6908,12 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget,
         observedCurrentTokenCount,
       );
+      const belowCompactionStartTokens = this.isBelowCompactionStartTokens({
+        currentTokenCount: observedCurrentTokenCount,
+        tokenBudget,
+      });
+      const thresholdDebtNeeded =
+        thresholdDecision.shouldCompact && !belowCompactionStartTokens;
       if (this.config.proactiveThresholdCompactionMode === "inline") {
         let leafCompactionScheduled = false;
         if (leafDecision.shouldCompact) {
@@ -6848,27 +6933,29 @@ export class LcmContextEngine implements ContextEngine {
         }
 
         if (!leafCompactionScheduled) {
-          const compactResult = await this.compact({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            sessionFile: params.sessionFile,
-            tokenBudget,
-            currentTokenCount: observedCurrentTokenCount,
-            compactionTarget: "threshold",
-            legacyParams,
-          });
+          const compactResult = belowCompactionStartTokens
+            ? {
+                ok: true,
+                compacted: false,
+                reason: BELOW_COMPACTION_START_TOKENS_REASON,
+              }
+            : await this.compact({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                sessionFile: params.sessionFile,
+                tokenBudget,
+                currentTokenCount: observedCurrentTokenCount,
+                compactionTarget: "threshold",
+                legacyParams,
+              });
           const retryReason = thresholdDecision.shouldCompact ? "threshold" : null;
           if (!compactResult.ok && retryReason) {
             shouldRefreshBootstrapState = false;
             await recordAfterTurnCompactionRetry(retryReason);
           }
         }
-      } else if (thresholdDecision.shouldCompact || rawLeafTrigger?.shouldCompact) {
-        const deferredReason = thresholdDecision.shouldCompact
-          ? "threshold"
-          : leafDecision.shouldCompact
-            ? leafDecision.reason
-            : "leaf-trigger";
+      } else if (thresholdDebtNeeded || this.shouldKeepDeferredLeafDebt(leafDecision)) {
+        const deferredReason = thresholdDebtNeeded ? "threshold" : leafDecision.reason;
         await this.recordDeferredCompactionDebt({
           conversationId: conversation.conversationId,
           reason: deferredReason,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -34,6 +34,7 @@ describe("resolveLcmConfig", () => {
     expect(config.newSessionRetainDepth).toBe(2);
     expect(config.incrementalMaxDepth).toBe(1);
     expect(config.leafChunkTokens).toBe(20000);
+    expect(config.compactionStartTokens).toBe(0);
     expect(config.leafMinFanout).toBe(8);
     expect(config.condensedMinFanout).toBe(4);
     expect(config.condensedMinFanoutHard).toBe(2);
@@ -72,6 +73,7 @@ describe("resolveLcmConfig", () => {
       freshTailMaxTokens: 12000,
       promptAwareEviction: false,
       leafChunkTokens: 80000,
+      compactionStartTokens: 120000,
       newSessionRetainDepth: 3,
       incrementalMaxDepth: -1,
       ignoreSessionPatterns: ["agent:*:cron:*", "agent:main:subagent:**"],
@@ -116,6 +118,7 @@ describe("resolveLcmConfig", () => {
     expect(config.promptAwareEviction).toBe(false);
     expect(config.newSessionRetainDepth).toBe(3);
     expect(config.leafChunkTokens).toBe(80000);
+    expect(config.compactionStartTokens).toBe(120000);
     expect(config.incrementalMaxDepth).toBe(-1);
     expect(config.leafMinFanout).toBe(4);
     expect(config.condensedMinFanout).toBe(2);
@@ -152,6 +155,7 @@ describe("resolveLcmConfig", () => {
       LCM_PROMPT_AWARE_EVICTION_ENABLED: "false",
       LCM_NEW_SESSION_RETAIN_DEPTH: "5",
       LCM_INCREMENTAL_MAX_DEPTH: "3",
+      LCM_COMPACTION_START_TOKENS: "120000",
       LCM_ENABLED: "false",
       LCM_IGNORE_SESSION_PATTERNS: "agent:*:cron:*, agent:main:subagent:**",
       LCM_STATELESS_SESSION_PATTERNS: "agent:*:ephemeral:**, agent:main:preview:*",
@@ -178,6 +182,7 @@ describe("resolveLcmConfig", () => {
       freshTailMaxTokens: 12000,
       promptAwareEviction: true,
       incrementalMaxDepth: -1,
+      compactionStartTokens: 60000,
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
@@ -230,6 +235,7 @@ describe("resolveLcmConfig", () => {
     expect(config.promptAwareEviction).toBe(false); // env wins
     expect(config.newSessionRetainDepth).toBe(5); // env wins
     expect(config.incrementalMaxDepth).toBe(3); // env wins
+    expect(config.compactionStartTokens).toBe(120000); // env wins
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
       cacheTTLSeconds: 600,
@@ -649,6 +655,18 @@ describe("resolveLcmConfig", () => {
       type: "string",
       enum: ["deferred", "inline"],
     });
+  });
+
+  it("ships a manifest with compactionStartTokens in schema", () => {
+    expect(manifest.configSchema.properties.compactionStartTokens).toEqual({
+      type: "integer",
+      minimum: 0,
+    });
+  });
+
+  it("clamps compactionStartTokens to a non-negative integer", () => {
+    expect(resolveLcmConfig({}, { compactionStartTokens: -1 }).compactionStartTokens).toBe(0);
+    expect(resolveLcmConfig({}, { compactionStartTokens: 1234.9 }).compactionStartTokens).toBe(1234);
   });
 
   it("ships a manifest with autoRotateSessionFiles in schema", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7971,7 +7971,56 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance).not.toBeNull();
     expect(maintenance?.pending).toBe(true);
     expect(maintenance?.running).toBe(false);
-    expect(maintenance?.reason).toBe("leaf-trigger");
+    expect(maintenance?.reason).toBe("hot-cache-budget-headroom");
+  });
+
+  it("afterTurn does not record deferred compaction debt below compactionStartTokens", async () => {
+    const engine = createEngineWithConfig({ compactionStartTokens: 120_000 });
+    const sessionId = "after-turn-below-compaction-start-tokens";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (
+          conversationId: number,
+          leafChunkTokens?: number,
+        ) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 80_000,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 90_000,
+      threshold: 75_000,
+    });
+    const compactLeafAsyncSpy = vi.spyOn(engine, "compactLeafAsync");
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-below-compaction-start-tokens"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 300_000,
+      runtimeContext: { currentTokenCount: 90_000 },
+    });
+
+    expect(compactLeafAsyncSpy).not.toHaveBeenCalled();
+    expect(compactSpy).not.toHaveBeenCalled();
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending ?? false).toBe(false);
   });
 
   it("afterTurn records threshold debt even when the leaf trigger stays below threshold", async () => {
@@ -9536,6 +9585,53 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenanceResult.reason).toBe("deferred compaction still needed");
   });
 
+  it("maintain() clears deferred leaf debt when compactionStartTokens still blocks it", async () => {
+    const engine = createEngineWithConfig({ compactionStartTokens: 120_000 });
+    const privateEngine = engine as unknown as {
+      evaluateIncrementalCompaction: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "maintain-deferred-compaction-below-start";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 300_000,
+      currentTokenCount: 90_000,
+    });
+
+    vi.spyOn(privateEngine, "evaluateIncrementalCompaction").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below-compaction-start-tokens",
+      maxPasses: 1,
+      allowCondensedPasses: false,
+      activityBand: "high",
+      leafChunkTokens: 40_000,
+      fallbackLeafChunkTokens: [40_000, 30_000, 20_000],
+      rawTokensOutsideTail: 55_000,
+      threshold: 40_000,
+      cacheState: "unknown",
+    });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-below-start"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance).not.toBeNull();
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenanceResult.changed).toBe(false);
+    expect(maintenanceResult.reason).toBe("deferred compaction no longer needed");
+  });
+
   it("maintain() keeps deferred prompt-mutating debt pending while Anthropic cache is still hot", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
@@ -10510,6 +10606,117 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("using runtime prompt token count currentTokenCount=204800"),
     );
+  });
+
+  it("evaluateIncrementalCompaction skips optional compaction below compactionStartTokens", async () => {
+    const engine = createEngineWithConfig({ compactionStartTokens: 120_000 });
+    const sessionId = "incremental-below-compaction-start-tokens";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        reason: string;
+        rawTokensOutsideTail: number;
+        threshold: number;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 80_000,
+      threshold: 20_000,
+    });
+    const budgetEvaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 90_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 300_000,
+      currentTokenCount: 90_000,
+    });
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.reason).toBe("below-compaction-start-tokens");
+    expect(decision.rawTokensOutsideTail).toBe(80_000);
+    expect(decision.threshold).toBe(20_000);
+    expect(budgetEvaluateSpy).not.toHaveBeenCalled();
+  });
+
+  it("evaluateIncrementalCompaction bypasses compactionStartTokens under critical budget pressure", async () => {
+    const engine = createEngineWithConfig({ compactionStartTokens: 120_000 });
+    const sessionId = "incremental-compaction-start-critical-pressure";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        reason: string;
+        rawTokensOutsideTail: number;
+        threshold: number;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: true,
+      rawTokensOutsideTail: 80_000,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 91_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 91_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.reason).toBe("leaf-trigger");
+    expect(decision.rawTokensOutsideTail).toBe(80_000);
+    expect(decision.threshold).toBe(20_000);
   });
 
   it("evaluateIncrementalCompaction skips hot-cache maintenance when real budget headroom is comfortable", async () => {
@@ -12717,6 +12924,46 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         hardTrigger: false,
       }),
     );
+  });
+
+  it("honors compactionStartTokens in the public compact hook", async () => {
+    const engine = createEngineWithConfig({ compactionStartTokens: 120_000 });
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 90_000,
+      threshold: 75_000,
+    });
+    const compactFullSweepSpy = vi.spyOn(privateEngine.compaction, "compactFullSweep");
+
+    await engine.ingest({
+      sessionId: "compact-hook-below-compaction-start",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "compact-hook-below-compaction-start",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 300_000,
+      currentTokenCount: 90_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("below-compaction-start-tokens");
+    expect(evaluateSpy).not.toHaveBeenCalled();
+    expect(compactFullSweepSpy).not.toHaveBeenCalled();
   });
 
   it("forces one compaction round for manual compaction requests in runtimeContext", async () => {


### PR DESCRIPTION
## Summary

- Adds `compactionStartTokens` config (env: `LCM_COMPACTION_START_TOKENS`) as an absolute current-prompt token floor before optional LCM compaction may start.
- Applies the floor across incremental leaf compaction, deferred after-turn debt, inline proactive threshold compaction, maintenance debt cleanup, and the public `compact()` hook while preserving critical-pressure bypass behavior.
- Updates config schema, UI hints, README, configuration docs, bundled skill reference, tests, and Changesets release metadata.

This addresses the same wasteful early-compaction problem described in #409, using an explicit token floor instead of the ratio-based `budgetHeadroomRatio` approach from the closed #410. The absolute floor matches the operator intent more directly: keep fully raw context until the prompt reaches N tokens.

Closes #409
Refs #410

## Tests

- `npx vitest run test/engine.test.ts test/config.test.ts`
- `npm run build`
- `npm test`
- `codex review --base main`
