### PR TITLE
fix: skip adjacent duplicate ingests

### DIFF
--- a/.changeset/adjacent-ingest-dedupe.md
+++ b/.changeset/adjacent-ingest-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip adjacent duplicate ingests with the same role and content to prevent replayed turns from being persisted twice.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6342,6 +6342,16 @@ export class LcmContextEngine implements ContextEngine {
       stored = rawPayloadIntercepted.stored;
     }
 
+    const latestMessage = stored.content.length > 0
+      ? await this.conversationStore.getLastMessage(conversationId)
+      : null;
+    if (latestMessage?.role === stored.role && latestMessage.content === stored.content) {
+      this.deps.log.info(
+        `[lcm] ingestSingle: adjacent duplicate message skipped conversation=${conversationId} role=${stored.role}`,
+      );
+      return { ingested: false };
+    }
+
     // Determine next sequence number
     const maxSeq = await this.conversationStore.getMaxSeq(conversationId);
     const seq = maxSeq + 1;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -824,6 +824,40 @@ describe("LcmContextEngine stateless sessions", () => {
     ).toBe(3);
   });
 
+  it("skips duplicate ingests with the same role and content in one conversation", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+    const sessionKey = "agent:poppy:main";
+
+    const first = await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "same payload" }),
+    });
+    const duplicate = await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "same payload" }),
+    });
+    const differentRole = await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "same payload" }),
+    });
+
+    expect(first).toEqual({ ingested: true });
+    expect(duplicate).toEqual({ ingested: false });
+    expect(differentRole).toEqual({ ingested: true });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    expect(
+      await engine.getConversationStore().getMessageCount(conversation!.conversationId),
+    ).toBe(2);
+  });
+
   it("allows assemble reads for stateless session keys", async () => {
     const engine = createEngineWithConfig({
       statelessSessionPatterns: ["agent:*:subagent:worker-*"],


### PR DESCRIPTION
## Summary
- skip non-empty adjacent duplicate messages with the same role/content during ingest
- preserve legitimate repeated content separated by other turns and empty tool-result repeats
- add regression coverage and changeset

## Verification
- npm test -- test/engine.test.ts
- npm run build