### PR TITLE
fix(tui): avoid transplant context ordinal collisions

### DIFF
--- a/tui/transplant.go
+++ b/tui/transplant.go
@@ -1136,7 +1136,7 @@ func mergeTransplantedContextItems(ctx context.Context, q sqlQueryer, targetConv
 		return fmt.Errorf("temporarily shift context ordinals for conversation %d: %w", targetConversationID, err)
 	}
 
-	// Step 2: Insert transplanted summaries with temporary high ordinals.
+	// Step 2: Insert transplanted summaries into the free low-ordinal range.
 	// They'll be reordered in step 3.
 	for i, source := range sourceContext {
 		newSummaryID, ok := oldToNew[source.summaryID]
@@ -1144,7 +1144,7 @@ func mergeTransplantedContextItems(ctx context.Context, q sqlQueryer, targetConv
 			return fmt.Errorf("missing remapped summary ID for context summary %s", source.summaryID)
 		}
 
-		tempOrd := tempShift + int64(i) + 1
+		tempOrd := int64(i)
 		if _, err := q.ExecContext(ctx, `
 			INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
 			VALUES (?, ?, 'summary', ?)
@@ -1153,7 +1153,23 @@ func mergeTransplantedContextItems(ctx context.Context, q sqlQueryer, targetConv
 		}
 	}
 
-	// Step 3: Reorder all summary context items by depth DESC, then created_at ASC.
+	// Step 3: Move all summaries out of the final low-ordinal range before
+	// reordering. Otherwise a summary that should move to ordinal 0 can collide
+	// with a newly inserted temporary summary already sitting at ordinal 0.
+	maxAfterInsert := int64(len(sourceContext) - 1)
+	if maxOrdinal.Valid {
+		maxAfterInsert = tempShift + maxOrdinal.Int64
+	}
+	reorderShift := maxAfterInsert + 1
+	if _, err := q.ExecContext(ctx, `
+		UPDATE context_items
+		SET ordinal = ordinal + ?
+		WHERE conversation_id = ? AND item_type = 'summary'
+	`, reorderShift, targetConversationID); err != nil {
+		return fmt.Errorf("temporarily shift summary context ordinals for conversation %d: %w", targetConversationID, err)
+	}
+
+	// Step 4: Reorder all summary context items by depth DESC, then created_at ASC.
 	// This merges transplanted and existing summaries into the correct order.
 	if _, err := q.ExecContext(ctx, `
 		WITH ranked_summaries AS (
@@ -1175,7 +1191,7 @@ func mergeTransplantedContextItems(ctx context.Context, q sqlQueryer, targetConv
 		return fmt.Errorf("reorder summary context items for conversation %d: %w", targetConversationID, err)
 	}
 
-	// Step 4: Reorder message context items to follow after all summaries.
+	// Step 5: Reorder message context items to follow after all summaries.
 	if _, err := q.ExecContext(ctx, `
 		WITH summary_count AS (
 			SELECT COUNT(*) AS cnt

--- a/tui/transplant_test.go
+++ b/tui/transplant_test.go
@@ -61,7 +61,8 @@ func TestApplyTransplantDeepCopiesMessages(t *testing.T) {
 			item_type TEXT NOT NULL,
 			message_id INTEGER,
 			summary_id TEXT,
-			created_at TEXT
+			created_at TEXT,
+			UNIQUE (conversation_id, ordinal)
 		);
 		CREATE TABLE message_parts (
 			part_id TEXT PRIMARY KEY,
@@ -194,6 +195,88 @@ func TestApplyTransplantDeepCopiesMessages(t *testing.T) {
 		WHERE m.conversation_id = 2
 		  AND m.content IN ('source one', 'source two')
 	`, 2)
+}
+
+func TestMergeTransplantedContextItemsAvoidsShiftedOrdinalCollision(t *testing.T) {
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	mustExec(t, db, `
+		CREATE TABLE summaries (
+			summary_id TEXT PRIMARY KEY,
+			conversation_id INTEGER NOT NULL,
+			kind TEXT NOT NULL,
+			content TEXT NOT NULL,
+			token_count INTEGER NOT NULL,
+			created_at TEXT NOT NULL,
+			file_ids TEXT,
+			depth INTEGER NOT NULL
+		);
+		CREATE TABLE context_items (
+			conversation_id INTEGER NOT NULL,
+			ordinal INTEGER NOT NULL,
+			item_type TEXT NOT NULL,
+			message_id INTEGER,
+			summary_id TEXT,
+			created_at TEXT,
+			UNIQUE (conversation_id, ordinal)
+		);
+	`)
+	mustExec(t, db, `
+		INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, created_at, file_ids, depth) VALUES
+		('sum_existing', 2, 'condensed', 'existing summary', 100, '2026-01-02T00:00:00Z', '', 1),
+		('sum_new_archive', 2, 'leaf', 'new archive summary', 120, '2026-01-01T00:00:00Z', '', 0);
+	`)
+	mustExec(t, db, `
+		INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id) VALUES
+		(2, 0, 'summary', 'sum_existing');
+	`)
+	for ordinal := 1; ordinal <= 32; ordinal++ {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+			VALUES (2, ?, 'message', ?)
+		`, ordinal, int64(1000+ordinal)); err != nil {
+			t.Fatalf("insert target message context item %d: %v", ordinal, err)
+		}
+	}
+
+	err = mergeTransplantedContextItems(ctx, db, 2, []transplantContextSummary{{
+		summaryID: "sum_source_archive",
+	}}, map[string]string{
+		"sum_source_archive": "sum_new_archive",
+	})
+	if err != nil {
+		t.Fatalf("merge transplanted context items: %v", err)
+	}
+
+	assertCount(t, db, `
+		SELECT COUNT(*)
+		FROM context_items
+		WHERE conversation_id = 2
+		  AND item_type = 'summary'
+		  AND ordinal IN (0, 1)
+	`, 2)
+	assertCount(t, db, `
+		SELECT COUNT(*)
+		FROM context_items
+		WHERE conversation_id = 2
+		  AND item_type = 'message'
+		  AND ordinal BETWEEN 2 AND 33
+	`, 32)
+	assertCount(t, db, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT ordinal
+			FROM context_items
+			WHERE conversation_id = 2
+			GROUP BY ordinal
+			HAVING COUNT(*) > 1
+		)
+	`, 0)
 }
 
 func mustExec(t *testing.T, db *sql.DB, query string) {


### PR DESCRIPTION
## Summary

Fixes `lcm-tui transplant` context merge failures when the target conversation already has context items and SQLite enforces `UNIQUE (conversation_id, ordinal)`.

## Root Cause

`mergeTransplantedContextItems()` uses temporary ordinal moves before it rebuilds the final context order. Two conflict windows were possible:

1. Existing target items were shifted upward, but transplanted summaries were inserted at `tempShift + i + 1`, which can overlap the shifted rows.
2. After inserting summaries into a free range, the summary reorder update could still collide when an existing summary should move to ordinal `0` while a temporary transplanted summary was already at ordinal `0`.

Both show up as:

```text
UNIQUE constraint failed: context_items.conversation_id, context_items.ordinal
```

This was reproduced during real `lcm-tui backfill ... --transplant-to ...` runs against an existing target conversation with summary and message context items.

## Fix

- Insert transplanted summaries into the low ordinal range freed by the first shift.
- Move all summary context items out of the final low-ordinal range before assigning final summary ordinals.
- Keep the final ordering behavior unchanged:
  - summaries first, ordered by depth and creation time
  - messages after summaries

## Validation

```bash
cd tui
go test ./...
```

Result:

```text
ok  	github.com/Martian-Engineering/lossless-claw/tui	0.139s
```
