### PR TITLE
[codex] Shorten lossless command description

### DIFF
--- a/.changeset/short-lossless-command-description.md
+++ b/.changeset/short-lossless-command-description.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Shorten the `/lossless` native command description so Discord no longer truncates it during command registration.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1393,7 +1393,7 @@ export function createLcmCommand(params: {
       telegram: "Lossless Claw is working...",
     },
     description:
-      "Show Lossless Claw health, create DB backups, compact the current session transcript while preserving LCM context, inspect high-confidence junk candidates, and run scoped doctor actions.",
+      "Lossless Claw health, backups, compaction, junk review, and doctor tools.",
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);


### PR DESCRIPTION
## Summary
- shorten the `/lossless` native command description to stay below Discord's 100 character limit
- add a patch changeset for the user-visible command metadata fix

Fixes #442.

## Validation
- `npm test`
- verified the new description is 73 characters