### PR TITLE
fix: honor prompt cache expiry telemetry

### DIFF
--- a/.changeset/prompt-cache-expiry.md
+++ b/.changeset/prompt-cache-expiry.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Honor runtime prompt-cache expiry telemetry when deciding whether cache-aware compaction should defer or catch up.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,6 +212,7 @@ When cache-aware compaction is enabled:
 - hot cache stretches the incremental leaf trigger to `dynamicLeafChunkTokens.max`
 - hot cache skips incremental maintenance entirely when the assembled context is still comfortably below the real token budget
 - hot cache also gets a short hysteresis window so one ambiguous turn does not immediately discard a recently healthy cache signal
+- explicit runtime `promptCache.expiresAt` telemetry is authoritative when present; future expiry keeps mutation-sensitive deferred compaction cache-safe, and elapsed expiry lets cold-cache catch-up proceed without waiting for fallback TTL heuristics
 - cold cache still allows bounded catch-up passes via `cacheAwareCompaction.maxColdCacheCatchupPasses`
 - once `currentTokenCount >= criticalBudgetPressureRatio * tokenBudget`, deferred compaction bypasses hot-cache delay so prompt-mutating debt can run before emergency overflow handling
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -441,6 +441,7 @@ Why it matters:
 
 - lets cache-safe deferred compaction stay conservative even when the host only knows that the turn was Anthropic-family, not the exact retention tier
 - keeps prompt-mutating debt pending until the cached prefix is likely cold
+- is only a fallback: explicit runtime `promptCache.expiresAt` telemetry is preferred when the host can provide it confidently
 
 Default:
 

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -122,6 +122,7 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const hasLastActivityBand = telemetryColumns.some((col) => col.name === "last_activity_band");
   const hasLastApiCallAt = telemetryColumns.some((col) => col.name === "last_api_call_at");
   const hasLastCacheTouchAt = telemetryColumns.some((col) => col.name === "last_cache_touch_at");
+  const hasCacheExpiresAt = telemetryColumns.some((col) => col.name === "cache_expires_at");
   const hasProvider = telemetryColumns.some((col) => col.name === "provider");
   const hasModel = telemetryColumns.some((col) => col.name === "model");
   const hasLastObservedPromptTokenCount = telemetryColumns.some(
@@ -156,6 +157,9 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
   if (!hasLastCacheTouchAt) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN last_cache_touch_at TEXT`);
+  }
+  if (!hasCacheExpiresAt) {
+    db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN cache_expires_at TEXT`);
   }
   if (!hasProvider) {
     db.exec(`ALTER TABLE conversation_compaction_telemetry ADD COLUMN provider TEXT`);
@@ -985,6 +989,7 @@ export function runLcmMigrations(
         CHECK (last_activity_band IN ('low', 'medium', 'high')),
       last_api_call_at TEXT,
       last_cache_touch_at TEXT,
+      cache_expires_at TEXT,
       provider TEXT,
       model TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -107,6 +107,7 @@ type PromptCacheSnapshot = {
   retention?: string;
   sawExplicitBreak: boolean;
   lastCacheTouchAt?: Date;
+  cacheExpiresAt?: Date;
   provider?: string;
   model?: string;
 };
@@ -401,6 +402,19 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function safeBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function safeDate(value: unknown): Date | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value);
+  }
+  if (typeof value === "string") {
+    const timestamp = Date.parse(value);
+    if (Number.isFinite(timestamp)) {
+      return new Date(timestamp);
+    }
+  }
+  return undefined;
 }
 
 function extractTranscriptToolCallId(message: AgentMessage): string | undefined {
@@ -2232,9 +2246,16 @@ export class LcmContextEngine implements ContextEngine {
   /** Resolve the effective cache state the incremental compaction policy should react to. */
   private resolveCacheAwareState(
     telemetry: ConversationCompactionTelemetryRecord | null,
+    now: Date = new Date(),
   ): CacheState {
     if (!telemetry) {
       return "unknown";
+    }
+    if (this.hasFreshPromptCacheBreak(telemetry)) {
+      return "cold";
+    }
+    if (telemetry.cacheExpiresAt) {
+      return telemetry.cacheExpiresAt.getTime() > now.getTime() ? "hot" : "cold";
     }
     if (this.isObservedCacheReadShareCold(telemetry)) {
       return "cold";
@@ -2244,15 +2265,6 @@ export class LcmContextEngine implements ContextEngine {
     }
     if (this.shouldApplyHotCacheHysteresis(telemetry)) {
       return "hot";
-    }
-    if (
-      telemetry.lastObservedCacheBreakAt
-      && (
-        !telemetry.lastObservedCacheHitAt
-        || telemetry.lastObservedCacheBreakAt >= telemetry.lastObservedCacheHitAt
-      )
-    ) {
-      return "cold";
     }
     if (
       telemetry.consecutiveColdObservations
@@ -2311,6 +2323,9 @@ export class LcmContextEngine implements ContextEngine {
     telemetry: ConversationCompactionTelemetryRecord | null,
     now: Date = new Date(),
   ): boolean {
+    if (telemetry?.cacheExpiresAt) {
+      return telemetry.cacheExpiresAt.getTime() > now.getTime();
+    }
     const ttlMs = this.resolvePromptCacheTtlMs(telemetry?.retention ?? null);
     if (!ttlMs) {
       return false;
@@ -2710,11 +2725,8 @@ export class LcmContextEngine implements ContextEngine {
     })();
     const sawExplicitBreak = safeBoolean(observation?.broke) === true;
     const retention = safeString(promptCache?.retention)?.trim();
-    const lastCacheTouchAtRaw = promptCache?.lastCacheTouchAt;
-    const lastCacheTouchAt =
-      typeof lastCacheTouchAtRaw === "number" && Number.isFinite(lastCacheTouchAtRaw)
-        ? new Date(lastCacheTouchAtRaw)
-        : undefined;
+    const lastCacheTouchAt = safeDate(promptCache?.lastCacheTouchAt);
+    const cacheExpiresAt = safeDate(promptCache?.expiresAt);
     const hasUsageSignal = cacheRead !== undefined || cacheWrite !== undefined;
     const hasObservationSignal =
       typeof observation?.cacheRead === "number"
@@ -2742,6 +2754,7 @@ export class LcmContextEngine implements ContextEngine {
       ...(retention ? { retention } : {}),
       sawExplicitBreak,
       ...(lastCacheTouchAt ? { lastCacheTouchAt } : {}),
+      ...(cacheExpiresAt ? { cacheExpiresAt } : {}),
       ...(provider ? { provider } : {}),
       ...(model ? { model } : {}),
     };
@@ -2817,6 +2830,7 @@ export class LcmContextEngine implements ContextEngine {
       lastActivityBand,
       lastApiCallAt: now,
       lastCacheTouchAt: touchedPromptCache,
+      cacheExpiresAt: snapshot ? (snapshot.cacheExpiresAt ?? null) : existing?.cacheExpiresAt ?? null,
       provider: snapshot?.provider ?? existing?.provider ?? null,
       model: snapshot?.model ?? existing?.model ?? null,
     });
@@ -2825,7 +2839,7 @@ export class LcmContextEngine implements ContextEngine {
     );
     if (updated) {
       this.deps.log.debug(
-        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} coldObservationStreak=${updated.consecutiveColdObservations} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} promptTokenCount=${updated.lastObservedPromptTokenCount ?? "null"} retention=${updated.retention ?? "null"} lastApiCallAt=${updated.lastApiCallAt?.toISOString() ?? "null"} lastCacheTouchAt=${updated.lastCacheTouchAt?.toISOString() ?? "null"} provider=${updated.provider ?? "null"} model=${updated.model ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
+        `[lcm] compaction telemetry updated: conversation=${params.conversationId} cacheState=${updated.cacheState} coldObservationStreak=${updated.consecutiveColdObservations} cacheRead=${updated.lastObservedCacheRead ?? "null"} cacheWrite=${updated.lastObservedCacheWrite ?? "null"} promptTokenCount=${updated.lastObservedPromptTokenCount ?? "null"} retention=${updated.retention ?? "null"} lastApiCallAt=${updated.lastApiCallAt?.toISOString() ?? "null"} lastCacheTouchAt=${updated.lastCacheTouchAt?.toISOString() ?? "null"} cacheExpiresAt=${updated.cacheExpiresAt?.toISOString() ?? "null"} provider=${updated.provider ?? "null"} model=${updated.model ?? "null"} turnsSinceLeafCompaction=${updated.turnsSinceLeafCompaction} tokensSinceLeafCompaction=${updated.tokensAccumulatedSinceLeafCompaction} activityBand=${updated.lastActivityBand} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} tokenBudget=${params.tokenBudget ?? "null"}`,
       );
     }
     return updated;
@@ -2855,6 +2869,7 @@ export class LcmContextEngine implements ContextEngine {
       lastActivityBand: params.activityBand ?? existing?.lastActivityBand ?? "low",
       lastApiCallAt: existing?.lastApiCallAt ?? null,
       lastCacheTouchAt: existing?.lastCacheTouchAt ?? null,
+      cacheExpiresAt: existing?.cacheExpiresAt ?? null,
       provider: existing?.provider ?? null,
       model: existing?.model ?? null,
     });

--- a/src/store/compaction-telemetry-store.ts
+++ b/src/store/compaction-telemetry-store.ts
@@ -21,6 +21,7 @@ export type ConversationCompactionTelemetryRecord = {
   lastActivityBand: ActivityBand;
   lastApiCallAt: Date | null;
   lastCacheTouchAt: Date | null;
+  cacheExpiresAt: Date | null;
   provider: string | null;
   model: string | null;
   updatedAt: Date;
@@ -42,6 +43,7 @@ export type UpsertConversationCompactionTelemetryInput = {
   lastActivityBand?: ActivityBand;
   lastApiCallAt?: Date | null;
   lastCacheTouchAt?: Date | null;
+  cacheExpiresAt?: Date | null;
   provider?: string | null;
   model?: string | null;
 };
@@ -62,6 +64,7 @@ type ConversationCompactionTelemetryRow = {
   last_activity_band: ActivityBand | null;
   last_api_call_at: string | null;
   last_cache_touch_at: string | null;
+  cache_expires_at: string | null;
   provider: string | null;
   model: string | null;
   updated_at: string;
@@ -86,6 +89,7 @@ function toConversationCompactionTelemetryRecord(
     lastActivityBand: row.last_activity_band ?? "low",
     lastApiCallAt: parseUtcTimestampOrNull(row.last_api_call_at),
     lastCacheTouchAt: parseUtcTimestampOrNull(row.last_cache_touch_at),
+    cacheExpiresAt: parseUtcTimestampOrNull(row.cache_expires_at),
     provider: row.provider,
     model: row.model,
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
@@ -126,6 +130,7 @@ export class CompactionTelemetryStore {
            last_activity_band,
            last_api_call_at,
            last_cache_touch_at,
+           cache_expires_at,
            provider,
            model,
            updated_at
@@ -158,10 +163,11 @@ export class CompactionTelemetryStore {
            last_activity_band,
            last_api_call_at,
            last_cache_touch_at,
+           cache_expires_at,
            provider,
            model,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            last_observed_cache_read = excluded.last_observed_cache_read,
            last_observed_cache_write = excluded.last_observed_cache_write,
@@ -177,6 +183,7 @@ export class CompactionTelemetryStore {
            last_activity_band = excluded.last_activity_band,
            last_api_call_at = excluded.last_api_call_at,
            last_cache_touch_at = excluded.last_cache_touch_at,
+           cache_expires_at = excluded.cache_expires_at,
            provider = excluded.provider,
            model = excluded.model,
            updated_at = datetime('now')`,
@@ -197,6 +204,7 @@ export class CompactionTelemetryStore {
         input.lastActivityBand ?? "low",
         input.lastApiCallAt?.toISOString() ?? null,
         input.lastCacheTouchAt?.toISOString() ?? null,
+        input.cacheExpiresAt?.toISOString() ?? null,
         input.provider ?? null,
         input.model ?? null,
       );

--- a/test/cache-aware-deferral-gate.test.ts
+++ b/test/cache-aware-deferral-gate.test.ts
@@ -103,6 +103,7 @@ function makeHotCodexTelemetry(
     consecutiveColdObservations: 0,
     lastApiCallAt: new Date(Date.now() - 30_000),
     lastCacheTouchAt: new Date(Date.now() - 30_000),
+    cacheExpiresAt: null,
     provider: "openai-codex",
     model: "gpt-5.5",
     lastObservedPromptTokenCount: 100_000,
@@ -124,6 +125,62 @@ describe("shouldDelayPromptMutatingDeferredCompaction (cache-aware deferral gate
     }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
 
     expect(gate(makeHotCodexTelemetry(), new Date(), 100_000, 200_000)).toBe(true);
+  });
+
+  it("defers when explicit cache expiry is still in the future even if touch telemetry is stale", () => {
+    const engine = createEngine();
+    const gate = (engine as unknown as {
+      shouldDelayPromptMutatingDeferredCompaction: (
+        telemetry: ConversationCompactionTelemetryRecord | null,
+        now?: Date,
+        currentTokenCount?: number,
+        tokenBudget?: number,
+      ) => boolean;
+    }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
+    const now = new Date("2026-05-14T12:00:00.000Z");
+
+    expect(
+      gate(
+        makeHotCodexTelemetry({
+          retention: null,
+          lastObservedCacheHitAt: null,
+          lastApiCallAt: null,
+          lastCacheTouchAt: new Date(now.getTime() - 10 * 60_000),
+          cacheExpiresAt: new Date(now.getTime() + 60_000),
+        }),
+        now,
+        100_000,
+        200_000,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT defer when explicit cache expiry has elapsed despite a recent touch", () => {
+    const engine = createEngine();
+    const gate = (engine as unknown as {
+      shouldDelayPromptMutatingDeferredCompaction: (
+        telemetry: ConversationCompactionTelemetryRecord | null,
+        now?: Date,
+        currentTokenCount?: number,
+        tokenBudget?: number,
+      ) => boolean;
+    }).shouldDelayPromptMutatingDeferredCompaction.bind(engine);
+    const now = new Date("2026-05-14T12:00:00.000Z");
+
+    expect(
+      gate(
+        makeHotCodexTelemetry({
+          retention: "long",
+          lastObservedCacheHitAt: now,
+          lastApiCallAt: now,
+          lastCacheTouchAt: now,
+          cacheExpiresAt: new Date(now.getTime() - 1),
+        }),
+        now,
+        100_000,
+        200_000,
+      ),
+    ).toBe(false);
   });
 
   it("does NOT defer when cacheAwareCompaction.enabled is false (operator opt-out)", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -10420,6 +10420,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       runtimeContext: {
         promptCache: {
           retention: "long",
+          expiresAt: 1_800_000_000_000,
           lastCallUsage: {
             input: 512,
             cacheRead: 1_024,
@@ -10446,6 +10447,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       lastObservedPromptTokenCount: 1_664,
       retention: "long",
     });
+    expect(telemetry?.cacheExpiresAt).toEqual(new Date(1_800_000_000_000));
     expect(telemetry?.lastObservedCacheHitAt).toBeInstanceOf(Date);
     expect(telemetry?.lastObservedCacheBreakAt).toBeNull();
     expect(debugLog).toHaveBeenCalledWith(
@@ -11100,6 +11102,87 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(decision.cacheState).toBe("hot");
     expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("reason=hot-cache-budget-headroom"),
+    );
+  });
+
+  it("evaluateIncrementalCompaction treats elapsed explicit cache expiry as cold", async () => {
+    const debugLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: debugLog,
+        },
+      },
+    );
+    const sessionId = "incremental-explicit-expiry-cold";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number, leafChunkTokens?: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+      evaluateIncrementalCompaction: (params: {
+        conversationId: number;
+        tokenBudget: number;
+        currentTokenCount?: number;
+      }) => Promise<{
+        shouldCompact: boolean;
+        cacheState: string;
+        maxPasses: number;
+      }>;
+    };
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "seed" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "hot",
+      lastObservedCacheRead: 8_192,
+      lastObservedPromptTokenCount: 16_384,
+      lastObservedCacheHitAt: new Date(),
+      lastCacheTouchAt: new Date(),
+      cacheExpiresAt: new Date(Date.now() - 1),
+      turnsSinceLeafCompaction: 1,
+      tokensAccumulatedSinceLeafCompaction: 55_000,
+      lastActivityBand: "low",
+    });
+
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockImplementation(
+      async (_conversationId: number, leafChunkTokens?: number) => ({
+        shouldCompact: true,
+        rawTokensOutsideTail: 55_000,
+        threshold: leafChunkTokens ?? 20_000,
+      }),
+    );
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 12_000,
+      threshold: 75_000,
+    });
+
+    const decision = await privateEngine.evaluateIncrementalCompaction({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+      currentTokenCount: 12_000,
+    });
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.cacheState).toBe("cold");
+    expect(decision.maxPasses).toBe(2);
+    expect(debugLog).toHaveBeenCalledWith(
+      expect.stringContaining("reason=cold-cache-catchup"),
     );
   });
 

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -104,6 +104,39 @@ function seedLegacySummaryGraph(db: ReturnType<typeof getLcmConnection>): void {
 }
 
 describe("runLcmMigrations summary depth backfill", () => {
+  it("adds cache expiry telemetry to legacy compaction telemetry tables", () => {
+    const db = createTestDb("legacy-cache-expiry.db");
+
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE conversation_compaction_telemetry (
+        conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        last_observed_cache_read INTEGER,
+        last_observed_cache_write INTEGER,
+        last_observed_cache_hit_at TEXT,
+        last_observed_cache_break_at TEXT,
+        cache_state TEXT NOT NULL DEFAULT 'unknown'
+          CHECK (cache_state IN ('hot', 'cold', 'unknown')),
+        retention TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const telemetryColumns = db.prepare(`PRAGMA table_info(conversation_compaction_telemetry)`).all() as Array<{
+      name?: string;
+    }>;
+    expect(telemetryColumns.some((column) => column.name === "cache_expires_at")).toBe(true);
+  });
+
   it("adds depth and metadata from summary lineage", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## What
Honor runtime-provided prompt-cache expiry telemetry in Lossless Claw's cache-aware compaction policy.

## Why
Lossless previously inferred hot/cold cache state from cache touch timestamps, retention labels, and fallback TTL settings. Once OpenClaw can provide `promptCache.expiresAt`, Lossless should treat that explicit expiry as authoritative so deferred compaction preserves a known-hot cache and resumes cold-cache catch-up as soon as the known cache window has elapsed.

## Changes
- Persist cache expiry telemetry
- Migrate legacy telemetry tables
- Prefer explicit expiry over fallback TTL
- Update cache-aware docs
- Add regression coverage
- Add patch changeset

## Testing
- `npm test -- test/cache-aware-deferral-gate.test.ts test/engine.test.ts test/migration.test.ts test/config.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`

Note: `npx tsc --noEmit` still fails on existing unrelated repo-wide type errors; filtering the output for the changed expiry fields/files produced no matching errors.
