### PR TITLE
fix: account for runtime prompt overhead in threshold sweeps

### DIFF
--- a/.changeset/runtime-overhead-threshold.md
+++ b/.changeset/runtime-overhead-threshold.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Account for runtime prompt overhead when threshold compaction is triggered from an observed token count. Lossless now compares Codex's live prompt count against its persisted context count and compacts far enough to cover the observed gap instead of clearing threshold debt while the live prompt may still be over target.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -11,6 +11,10 @@ import { LcmProviderAuthError } from "./summarize.js";
 export interface CompactionDecision {
   shouldCompact: boolean;
   reason: "threshold" | "manual" | "none";
+  /** Persisted Lossless context tokens before runtime prompt overhead. */
+  storedTokens: number;
+  /** Runtime-observed prompt tokens, when supplied by the host. */
+  observedTokens?: number;
   currentTokens: number;
   threshold: number;
 }
@@ -428,6 +432,8 @@ export class CompactionEngine {
       return {
         shouldCompact: true,
         reason: "threshold",
+        storedTokens,
+        ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
         currentTokens,
         threshold,
       };
@@ -436,6 +442,8 @@ export class CompactionEngine {
     return {
       shouldCompact: false,
       reason: "none",
+      storedTokens,
+      ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
       currentTokens,
       threshold,
     };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2652,6 +2652,24 @@ export class LcmContextEngine implements ContextEngine {
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
     const liveContextStillExceedsTarget =
       observedTokens !== undefined && observedTokens >= targetTokens;
+    // Codex can report a live prompt count that includes runtime framing,
+    // tool schemas, and other overhead not present in Lossless's stored count.
+    // If that live count crosses the threshold, compact stored context far
+    // enough that stored tokens plus the observed overhead should fit.
+    const decisionStoredTokens =
+      typeof decision.storedTokens === "number"
+      && Number.isFinite(decision.storedTokens)
+      && decision.storedTokens >= 0
+        ? Math.floor(decision.storedTokens)
+        : decision.currentTokens;
+    const observedRuntimeOverhead =
+      params.compactionTarget === "threshold" && observedTokens !== undefined
+        ? Math.max(0, observedTokens - decisionStoredTokens)
+        : 0;
+    const runtimeAdjustedSweepTargetTokens =
+      observedRuntimeOverhead > 0 && observedTokens !== undefined && observedTokens > targetTokens
+        ? Math.max(1, targetTokens - observedRuntimeOverhead)
+        : undefined;
 
     if (!forceCompaction && !decision.shouldCompact) {
       return {
@@ -2672,9 +2690,12 @@ export class LcmContextEngine implements ContextEngine {
         conversationId,
         tokenBudget,
         summarize,
-        force: forceCompaction,
+        force: forceCompaction || runtimeAdjustedSweepTargetTokens !== undefined,
         hardTrigger: false,
         summaryModel,
+        ...(runtimeAdjustedSweepTargetTokens !== undefined
+          ? { stopAtTokens: runtimeAdjustedSweepTargetTokens }
+          : {}),
       });
 
       if (sweepResult.authFailure && breakerKey) {
@@ -2689,10 +2710,14 @@ export class LcmContextEngine implements ContextEngine {
         typeof sweepResult.tokensAfter === "number" && Number.isFinite(sweepResult.tokensAfter)
           ? sweepResult.tokensAfter
           : undefined;
+      const projectedTokensAfterSweep =
+        sweepTokensAfter !== undefined && runtimeAdjustedSweepTargetTokens !== undefined
+          ? sweepTokensAfter + observedRuntimeOverhead
+          : sweepTokensAfter;
       const isThresholdSweep = params.compactionTarget === "threshold";
       const isUnderTargetAfterSweep =
-        sweepTokensAfter !== undefined
-          ? sweepTokensAfter <= targetTokens
+        projectedTokensAfterSweep !== undefined
+          ? projectedTokensAfterSweep <= targetTokens
           : isThresholdSweep
             ? false
             : !liveContextStillExceedsTarget;
@@ -2723,7 +2748,13 @@ export class LcmContextEngine implements ContextEngine {
           tokensAfter: sweepResult.tokensAfter,
           details: {
             rounds: sweepResult.actionTaken ? 1 : 0,
-            targetTokens,
+            targetTokens: runtimeAdjustedSweepTargetTokens ?? targetTokens,
+            ...(runtimeAdjustedSweepTargetTokens !== undefined
+              ? {
+                  observedOverheadTokens: observedRuntimeOverhead,
+                  projectedTokensAfter: projectedTokensAfterSweep,
+                }
+              : {}),
           },
         },
       };

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9010,8 +9010,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect.objectContaining({
         conversationId: conversation.conversationId,
         tokenBudget: 4_096,
-        force: false,
+        force: true,
         hardTrigger: false,
+        stopAtTokens: 1,
       }),
     );
     expect(maintenance?.pending).toBe(true);
@@ -10481,6 +10482,126 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
+      }),
+    );
+  });
+
+  it("forces threshold sweeps to account for runtime prompt overhead", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 7_000,
+      observedTokens: 12_000,
+      currentTokens: 12_000,
+      threshold: 8_200,
+    });
+    const compactFullSweepSpy = vi
+      .spyOn(privateEngine.compaction, "compactFullSweep")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 7_000,
+        tokensAfter: 3_200,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "threshold-runtime-overhead-session",
+      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-runtime-overhead-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(compactFullSweepSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 10_000,
+        summarize: expect.any(Function),
+        force: true,
+        hardTrigger: false,
+        stopAtTokens: 3_200,
+      }),
+    );
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 3_200,
+        observedOverheadTokens: 5_000,
+        projectedTokensAfter: 8_200,
+      }),
+    );
+  });
+
+  it("does not clear threshold pressure when persisted tokens are under target but runtime tokens remain over", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 7_000,
+      observedTokens: 12_000,
+      currentTokens: 12_000,
+      threshold: 8_200,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 7_000,
+      tokensAfter: 7_000,
+      condensed: false,
+    });
+
+    await engine.ingest({
+      sessionId: "threshold-runtime-still-over-session",
+      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-runtime-still-over-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("live context still exceeds target");
+    expect(result.result?.tokensBefore).toBe(12_000);
+    expect(result.result?.tokensAfter).toBe(7_000);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 3_200,
+        observedOverheadTokens: 5_000,
+        projectedTokensAfter: 12_000,
       }),
     );
   });


### PR DESCRIPTION
## What
Account for runtime prompt overhead when threshold compaction is triggered from an observed token count. Lossless now records both persisted context tokens and runtime-observed prompt tokens, then uses the observed overhead to pick a stricter sweep target when Codex reports live context over threshold.

## Why
Codex can report a live prompt count that is above threshold even when Lossless's persisted context count is below threshold. Before this change, threshold debt could be cleared as "already under target" because the sweep only judged the stored Lossless token count, leaving the live prompt at risk of overflow.

## Changes
- Track stored and observed tokens
- Adjust threshold sweep target
- Keep live-over debt pending
- Add regression coverage
- Add patch changeset

## Testing
- `npm test -- --run test/engine.test.ts` passed
- `npm test` passed
- `npm run build` passed
- `git diff --staged --check` passed before commit