### PR TITLE
fix: preserve unpersisted volatile live input in LCM assembly

### DIFF
--- a/.changeset/assemble-live-tail.md
+++ b/.changeset/assemble-live-tail.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve unpersisted OpenClaw inter-session live input when assembling context from LCM's durable DB frontier.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -167,6 +167,20 @@ export function isEmptyMessageContent(message: {
   return false;
 }
 
+function freshTailProtectionMessageHashes(messages: AgentMessage[]): string[] {
+  const hashes: string[] = [];
+  for (const message of messages) {
+    const messageHashes = new Set<string>();
+    messageHashes.add(hashMessages([message]));
+    const repairedVariants = sanitizeToolUseResultPairing([message]) as AgentMessage[];
+    for (const repaired of repairedVariants) {
+      messageHashes.add(hashMessages([repaired]));
+    }
+    hashes.push(...messageHashes);
+  }
+  return hashes;
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface AssembleContextInput {
@@ -218,6 +232,8 @@ export interface AssembleContextResult {
     preSanitizeFreshTailCount: number;
     preSanitizeEvictableHash: string;
     preSanitizeFreshTailHash: string;
+    preSanitizeFreshTailMessageHashes: string[];
+    freshTailProtectionMessageHashes: string[];
     preSanitizeMessagesHash: string;
     finalMessagesHash: string;
     overflowDiagnostics: AssemblyOverflowDiagnostics;
@@ -1467,6 +1483,12 @@ export class ContextAssembler {
         preSanitizeFreshTailCount: preSanitizeFreshTailMessages.length,
         preSanitizeEvictableHash: hashMessages(preSanitizeEvictableMessages),
         preSanitizeFreshTailHash: hashMessages(preSanitizeFreshTailMessages),
+        preSanitizeFreshTailMessageHashes: preSanitizeFreshTailMessages.map((message) =>
+          hashMessages([message]),
+        ),
+        freshTailProtectionMessageHashes: freshTailProtectionMessageHashes(
+          preSanitizeFreshTailMessages,
+        ),
         preSanitizeMessagesHash: hashMessages(cleaned as AgentMessage[]),
         finalMessagesHash: hashMessages(repaired),
         overflowDiagnostics,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -74,6 +74,7 @@ import {
   DatabaseTransactionTimeoutError,
   withExclusiveDatabaseLock,
 } from "./transaction-mutex.js";
+import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type AssemblePrefixSnapshot = {
@@ -516,7 +517,7 @@ const STRUCTURED_ARRAY_FIELD_KEYS = [
 ];
 const STRUCTURED_NESTED_FIELD_KEYS = ["content", "output", "result", "payload", "data", "value"];
 const MAX_STRUCTURED_TEXT_DEPTH = 6;
-const TOOL_RAW_TYPES: ReadonlySet<string> = new Set([
+const TOOL_CALL_RAW_TYPES: ReadonlySet<string> = new Set([
   "tool_use",
   "toolUse",
   "tool-use",
@@ -524,10 +525,16 @@ const TOOL_RAW_TYPES: ReadonlySet<string> = new Set([
   "tool_call",
   "functionCall",
   "function_call",
+]);
+const TOOL_RESULT_RAW_TYPES: ReadonlySet<string> = new Set([
   "function_call_output",
   "tool_result",
   "toolResult",
   "tool_use_result",
+]);
+const TOOL_RAW_TYPES: ReadonlySet<string> = new Set([
+  ...TOOL_CALL_RAW_TYPES,
+  ...TOOL_RESULT_RAW_TYPES,
 ]);
 const REPLAY_CRITICAL_RAW_TYPES: ReadonlySet<string> = new Set([
   ...TOOL_RAW_TYPES,
@@ -1697,10 +1704,10 @@ function isBootstrapReplayCandidateMessage(message: AgentMessage): boolean {
   return role === "assistant" || role === "tool";
 }
 
-function createBootstrapReplaySignature(message: AgentMessage): string {
+function createLosslessMessageSignature(message: AgentMessage): string {
   const stored = toStoredMessage(message);
   const parts = buildMessageParts({
-    sessionId: "bootstrap-replay-signature",
+    sessionId: "lossless-message-signature",
     message,
     fallbackContent: stored.content,
   });
@@ -1719,6 +1726,10 @@ function createBootstrapReplaySignature(message: AgentMessage): string {
       metadata: part.metadata ?? null,
     })),
   });
+}
+
+function createBootstrapReplaySignature(message: AgentMessage): string {
+  return createLosslessMessageSignature(message);
 }
 
 function normalizeSummaryOverlapText(value: string): string {
@@ -1772,6 +1783,835 @@ function messageContentCoveredBySummary(params: {
     }
   }
   return false;
+}
+
+const INTER_SESSION_MESSAGE_MARKER = "[Inter-session message]";
+const INTERNAL_CONTEXT_BEGIN_MARKER = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_CONTEXT_END_MARKER = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_TASK_COMPLETION_EVENT_MARKER = "[Internal task completion event]";
+const NORMALIZED_INTER_SESSION_MESSAGE_MARKER = normalizeSummaryOverlapText(INTER_SESSION_MESSAGE_MARKER);
+const NORMALIZED_INTERNAL_TASK_COMPLETION_EVENT_MARKER = normalizeSummaryOverlapText(
+  INTERNAL_TASK_COMPLETION_EVENT_MARKER,
+);
+
+function hasCompleteInternalContextBlock(content: string): boolean {
+  const beginIndex = content.indexOf(INTERNAL_CONTEXT_BEGIN_MARKER);
+  if (beginIndex < 0) {
+    return false;
+  }
+  return (
+    content.indexOf(
+      INTERNAL_CONTEXT_END_MARKER,
+      beginIndex + INTERNAL_CONTEXT_BEGIN_MARKER.length,
+    ) >= 0
+  );
+}
+
+function isVolatileLiveInputContent(content: string): boolean {
+  const trimmed = content.trimStart();
+  if (!hasCompleteInternalContextBlock(trimmed)) {
+    return false;
+  }
+  const normalized = normalizeSummaryOverlapText(trimmed);
+  if (normalized.startsWith(NORMALIZED_INTER_SESSION_MESSAGE_MARKER)) {
+    return true;
+  }
+  return (
+    trimmed.startsWith(INTERNAL_CONTEXT_BEGIN_MARKER) &&
+    normalized.includes(NORMALIZED_INTERNAL_TASK_COMPLETION_EVENT_MARKER)
+  );
+}
+
+function estimateAgentMessageTokens(messages: AgentMessage[]): number {
+  return messages.reduce((total, message) => total + toStoredMessage(message).tokenCount, 0);
+}
+
+function isVolatileLiveInputMessage(message: AgentMessage): boolean {
+  const stored = toStoredMessage(message);
+  if (stored.role !== "user" && stored.role !== "system") {
+    return false;
+  }
+  if (!stored.content.trim()) {
+    return false;
+  }
+  return isVolatileLiveInputContent(stored.content);
+}
+
+function extractToolPairingIdFromRecord(record: Record<string, unknown>): string | undefined {
+  return (
+    safeString(record.toolCallId) ??
+    safeString(record.tool_call_id) ??
+    safeString(record.toolUseId) ??
+    safeString(record.tool_use_id) ??
+    safeString(record.call_id) ??
+    safeString(record.id)
+  );
+}
+
+function extractAssistantToolCallIdsForPairing(message: AgentMessage): string[] {
+  if (message.role !== "assistant" || !("content" in message) || !Array.isArray(message.content)) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const block of message.content) {
+    const record = asRecord(block);
+    if (!record || typeof record.type !== "string" || !TOOL_CALL_RAW_TYPES.has(record.type)) {
+      continue;
+    }
+    const id = extractToolPairingIdFromRecord(record);
+    if (id) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+function extractToolResultIdForPairing(message: AgentMessage): string | undefined {
+  if (message.role !== "tool" && message.role !== "toolResult") {
+    return undefined;
+  }
+  const topLevel = asRecord(message);
+  if (topLevel) {
+    const direct = extractToolPairingIdFromRecord(topLevel);
+    if (direct) {
+      return direct;
+    }
+  }
+  if (!("content" in message) || !Array.isArray(message.content)) {
+    return undefined;
+  }
+  for (const block of message.content) {
+    const record = asRecord(block);
+    if (!record || typeof record.type !== "string" || !TOOL_RESULT_RAW_TYPES.has(record.type)) {
+      continue;
+    }
+    const id = extractToolPairingIdFromRecord(record);
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+function expandProtectedToolPairIndexes(params: {
+  assembledMessages: AgentMessage[];
+  protectedAssembledIndexes: Set<number>;
+}): Set<number> {
+  const protectedIndexes = new Set(params.protectedAssembledIndexes);
+  const assistantIndexesByToolCallId = new Map<string, number[]>();
+  const toolResultIndexesByToolCallId = new Map<string, number[]>();
+
+  for (let index = 0; index < params.assembledMessages.length; index++) {
+    const message = params.assembledMessages[index] as AgentMessage;
+    for (const toolCallId of extractAssistantToolCallIdsForPairing(message)) {
+      const indexes = assistantIndexesByToolCallId.get(toolCallId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        assistantIndexesByToolCallId.set(toolCallId, [index]);
+      }
+    }
+    const toolResultId = extractToolResultIdForPairing(message);
+    if (toolResultId) {
+      const indexes = toolResultIndexesByToolCallId.get(toolResultId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        toolResultIndexesByToolCallId.set(toolResultId, [index]);
+      }
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let index = 0; index < params.assembledMessages.length; index++) {
+      if (!protectedIndexes.has(index)) {
+        continue;
+      }
+      const message = params.assembledMessages[index] as AgentMessage;
+      const relatedIndexes: number[] = [];
+      for (const toolCallId of extractAssistantToolCallIdsForPairing(message)) {
+        relatedIndexes.push(...(toolResultIndexesByToolCallId.get(toolCallId) ?? []));
+      }
+      const toolResultId = extractToolResultIdForPairing(message);
+      if (toolResultId) {
+        relatedIndexes.push(...(assistantIndexesByToolCallId.get(toolResultId) ?? []));
+      }
+      for (const relatedIndex of relatedIndexes) {
+        if (!protectedIndexes.has(relatedIndex)) {
+          protectedIndexes.add(relatedIndex);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return protectedIndexes;
+}
+
+function expandToolPairLiveSortIndexes(params: {
+  assembledMessages: AgentMessage[];
+  liveSortIndexes: Map<number, number>;
+}): Map<number, number> {
+  const liveSortIndexes = new Map(params.liveSortIndexes);
+  const assistantIndexesByToolCallId = new Map<string, number[]>();
+  const toolResultIndexesByToolCallId = new Map<string, number[]>();
+
+  for (let index = 0; index < params.assembledMessages.length; index++) {
+    const message = params.assembledMessages[index] as AgentMessage;
+    for (const toolCallId of extractAssistantToolCallIdsForPairing(message)) {
+      const indexes = assistantIndexesByToolCallId.get(toolCallId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        assistantIndexesByToolCallId.set(toolCallId, [index]);
+      }
+    }
+    const toolResultId = extractToolResultIdForPairing(message);
+    if (toolResultId) {
+      const indexes = toolResultIndexesByToolCallId.get(toolResultId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        toolResultIndexesByToolCallId.set(toolResultId, [index]);
+      }
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let index = 0; index < params.assembledMessages.length; index++) {
+      const liveIndex = liveSortIndexes.get(index);
+      if (liveIndex === undefined) {
+        continue;
+      }
+      const message = params.assembledMessages[index] as AgentMessage;
+      const relatedIndexes: number[] = [];
+      for (const toolCallId of extractAssistantToolCallIdsForPairing(message)) {
+        relatedIndexes.push(...(toolResultIndexesByToolCallId.get(toolCallId) ?? []));
+      }
+      const toolResultId = extractToolResultIdForPairing(message);
+      if (toolResultId) {
+        relatedIndexes.push(...(assistantIndexesByToolCallId.get(toolResultId) ?? []));
+      }
+      for (const relatedIndex of relatedIndexes) {
+        const existing = liveSortIndexes.get(relatedIndex);
+        if (existing === undefined || liveIndex < existing) {
+          liveSortIndexes.set(relatedIndex, liveIndex);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return liveSortIndexes;
+}
+
+function normalizeLiveMessageForAssemblyReconciliation(message: AgentMessage): AgentMessage {
+  const stored = toStoredMessage(message);
+  if (stored.role !== "system" && stored.role !== "tool") {
+    return message;
+  }
+  const runtimeRole = stored.role === "system" ? "user" : "toolResult";
+  const parts =
+    "content" in message
+      ? buildMessageParts({
+          sessionId: "live-reconciliation",
+          message,
+          fallbackContent: stored.content,
+        }).map((part) => toSyntheticMessagePartRecord(part, 0))
+      : [];
+  const content = contentFromParts(parts, runtimeRole, stored.content);
+  return {
+    ...message,
+    role: runtimeRole,
+    content,
+  } as AgentMessage;
+}
+
+function countNonOverlappingOccurrences(params: {
+  haystack: string;
+  needle: string;
+}): number {
+  if (!params.needle) {
+    return 0;
+  }
+  let count = 0;
+  let cursor = 0;
+  while (cursor <= params.haystack.length) {
+    const found = params.haystack.indexOf(params.needle, cursor);
+    if (found < 0) {
+      break;
+    }
+    count++;
+    cursor = found + params.needle.length;
+  }
+  return count;
+}
+
+function liveInputCoverageCapacity(params: {
+  assembledMessage: AgentMessage;
+  liveMessage: AgentMessage;
+  /**
+   * When true, the live message is a volatile input that was never persisted to
+   * DB. Summary substring coverage is insufficient for such messages because a
+   * summary that contains similar text is summarizing a *past* turn — it does
+   * not prove the current turn's volatile input is already represented.
+   */
+  isVolatileLiveInput?: boolean;
+}): number {
+  const assembled = toStoredMessage(params.assembledMessage);
+  const live = toStoredMessage(params.liveMessage);
+  if (messagesHaveSameLiveCoverageSignature(params.assembledMessage, params.liveMessage)) {
+    return 1;
+  }
+
+  // Volatile live inputs are never persisted to DB. A summary containing
+  // similar text covers a *past* occurrence, not the current live input.
+  // Only exact assembled message matches (handled above) can cover a
+  // volatile input — a historical summary paraphrase is insufficient.
+  if (params.isVolatileLiveInput) {
+    return 0;
+  }
+
+  // Substring coverage is only safe for LCM summary wrappers. Raw assembled
+  // turns must match exactly, otherwise normalized near-matches can hide a
+  // distinct volatile live input.
+  if (!assembled.content.includes("<summary ") || !assembled.content.includes("</summary>")) {
+    return 0;
+  }
+
+  const liveText = normalizeSummaryOverlapText(live.content);
+  if (liveText.length < 24) {
+    return 0;
+  }
+  const assembledText = normalizeSummaryOverlapText(assembled.content);
+  return countNonOverlappingOccurrences({ haystack: assembledText, needle: liveText });
+}
+
+function isSummaryWrapperContent(content: string): boolean {
+  return content.includes("<summary ") && content.includes("</summary>");
+}
+
+type VolatileLiveInputEntry = {
+  message: AgentMessage;
+  liveIndex: number;
+};
+
+type VolatileLiveInputCandidate = VolatileLiveInputEntry & {
+  liveText: string;
+};
+
+type VolatileLiveInputCoverageSlot = {
+  assembledIndex: number;
+};
+
+type RetainedAssembledEntry = {
+  message: AgentMessage;
+  index: number;
+};
+
+function materializeVolatileLiveInputEntries(entries: VolatileLiveInputEntry[]): AgentMessage[] {
+  return entries
+    .slice()
+    .sort((a, b) => a.liveIndex - b.liveIndex)
+    .map((entry) => entry.message);
+}
+
+function hashAgentMessageForAssemblyProtection(message: AgentMessage): string {
+  return createHash("sha256").update(JSON.stringify([message])).digest("hex").slice(0, 16);
+}
+
+function resolveProtectedFreshTailAssembledIndexes(params: {
+  assembledMessages: AgentMessage[];
+  freshTailMessageHashes?: string[];
+}): Set<number> {
+  const protectedIndexes = new Set<number>();
+  const usedIndexes = new Set<number>();
+  for (const hash of params.freshTailMessageHashes ?? []) {
+    for (let index = params.assembledMessages.length - 1; index >= 0; index--) {
+      if (usedIndexes.has(index)) {
+        continue;
+      }
+      const message = params.assembledMessages[index] as AgentMessage;
+      if (hashAgentMessageForAssemblyProtection(message) === hash) {
+        protectedIndexes.add(index);
+        usedIndexes.add(index);
+        break;
+      }
+    }
+  }
+  return protectedIndexes;
+}
+
+function messagesHaveSameLosslessSignature(left: AgentMessage, right: AgentMessage): boolean {
+  return createLosslessMessageSignature(left) === createLosslessMessageSignature(right);
+}
+
+function createLiveCoverageSignature(message: AgentMessage): string {
+  const stored = toStoredMessage(message);
+  if (
+    (stored.role === "user" || stored.role === "system" || stored.role === "assistant") &&
+    stored.content.length > 0 &&
+    isCanonicalTextOnlyMessage(message, stored.content)
+  ) {
+    return JSON.stringify({
+      kind: "canonical-text",
+      role: stored.role,
+      content: stored.content,
+    });
+  }
+  const canonicalToolTextSignature = createCanonicalToolTextCoverageSignature(
+    message,
+    stored.content,
+  );
+  if (canonicalToolTextSignature) {
+    return canonicalToolTextSignature;
+  }
+  return createLosslessMessageSignature(message);
+}
+
+function normalizeToolNameForCoverage(toolName: string | null | undefined): string | null {
+  // The assembler fills missing tool names with "unknown" on rehydration.
+  // Treat null/undefined/""/"unknown" as equivalent for coverage matching
+  // so live and assembled tool-result signatures still match.
+  if (!toolName || toolName === "unknown") {
+    return null;
+  }
+  return toolName;
+}
+
+function createCanonicalToolTextCoverageSignature(
+  message: AgentMessage,
+  fallbackContent: string,
+): string | undefined {
+  const stored = toStoredMessage(message);
+  if (stored.role !== "tool" || fallbackContent.length === 0) {
+    return undefined;
+  }
+  const parts = buildMessageParts({
+    sessionId: "live-tool-coverage-signature",
+    message,
+    fallbackContent,
+  });
+  if (parts.length !== 1) {
+    return undefined;
+  }
+  const part = parts[0] as CreateMessagePartInput;
+  if (
+    part.partType !== "text" ||
+    (part.textContent ?? "") !== fallbackContent ||
+    part.toolInput != null ||
+    part.toolOutput != null
+  ) {
+    return undefined;
+  }
+  return JSON.stringify({
+    kind: "canonical-tool-text",
+    role: stored.role,
+    content: fallbackContent,
+    toolCallId: part.toolCallId ?? extractToolResultIdForPairing(message) ?? null,
+    toolName: normalizeToolNameForCoverage(part.toolName),
+  });
+}
+
+function isCanonicalTextOnlyMessage(message: AgentMessage, fallbackContent: string): boolean {
+  const parts = buildMessageParts({
+    sessionId: "live-coverage-signature",
+    message,
+    fallbackContent,
+  });
+  if (parts.length !== 1) {
+    return false;
+  }
+  const part = parts[0] as CreateMessagePartInput;
+  return (
+    part.partType === "text" &&
+    (part.textContent ?? "") === fallbackContent &&
+    part.toolCallId == null &&
+    part.toolName == null &&
+    part.toolInput == null &&
+    part.toolOutput == null
+  );
+}
+
+function messagesHaveSameLiveCoverageSignature(left: AgentMessage, right: AgentMessage): boolean {
+  return createLiveCoverageSignature(left) === createLiveCoverageSignature(right);
+}
+
+function resolveExactAssembledLiveSortIndexes(params: {
+  assembledMessages: AgentMessage[];
+  liveMessages: AgentMessage[];
+}): Map<number, number> {
+  const liveSortIndexes = new Map<number, number>();
+  const usedAssembledIndexes = new Set<number>();
+  for (let liveIndex = params.liveMessages.length - 1; liveIndex >= 0; liveIndex--) {
+    const liveMessage = params.liveMessages[liveIndex] as AgentMessage;
+    for (
+      let assembledIndex = params.assembledMessages.length - 1;
+      assembledIndex >= 0;
+      assembledIndex--
+    ) {
+      if (usedAssembledIndexes.has(assembledIndex)) {
+        continue;
+      }
+      const assembledMessage = params.assembledMessages[assembledIndex] as AgentMessage;
+      if (messagesHaveSameLiveCoverageSignature(assembledMessage, liveMessage)) {
+        liveSortIndexes.set(assembledIndex, liveIndex);
+        usedAssembledIndexes.add(assembledIndex);
+        break;
+      }
+    }
+  }
+  return liveSortIndexes;
+}
+
+function mergeCoveredVolatileLiveSortIndexes(params: {
+  exactLiveSortIndexes: Map<number, number>;
+  coveredEntriesByAssembledIndex: Map<number, VolatileLiveInputEntry[]>;
+}): Map<number, number> {
+  const liveSortIndexes = new Map(params.exactLiveSortIndexes);
+  for (const [assembledIndex, entries] of params.coveredEntriesByAssembledIndex.entries()) {
+    const coveredLiveIndex = Math.min(...entries.map((entry) => entry.liveIndex));
+    const existingLiveIndex = liveSortIndexes.get(assembledIndex);
+    if (existingLiveIndex === undefined || coveredLiveIndex < existingLiveIndex) {
+      liveSortIndexes.set(assembledIndex, coveredLiveIndex);
+    }
+  }
+  return liveSortIndexes;
+}
+
+function buildVolatileLiveInputMergedOutput(params: {
+  retained: RetainedAssembledEntry[];
+  appendedEntries: VolatileLiveInputEntry[];
+  liveSortIndexes: Map<number, number>;
+}): AgentMessage[] {
+  const output: AgentMessage[] = [];
+  const appendedEntries = params.appendedEntries
+    .slice()
+    .sort((left, right) => left.liveIndex - right.liveIndex);
+  let appendedCursor = 0;
+  for (const retainedEntry of params.retained) {
+    const retainedLiveIndex = params.liveSortIndexes.get(retainedEntry.index);
+    if (retainedLiveIndex !== undefined) {
+      while (
+        appendedCursor < appendedEntries.length &&
+        (appendedEntries[appendedCursor] as VolatileLiveInputEntry).liveIndex < retainedLiveIndex
+      ) {
+        output.push((appendedEntries[appendedCursor] as VolatileLiveInputEntry).message);
+        appendedCursor++;
+      }
+    }
+    output.push(retainedEntry.message);
+  }
+  while (appendedCursor < appendedEntries.length) {
+    output.push((appendedEntries[appendedCursor] as VolatileLiveInputEntry).message);
+    appendedCursor++;
+  }
+  return sanitizeToolUseResultPairing(output) as AgentMessage[];
+}
+
+function matchVolatileLiveInputsToCoverageSlots(params: {
+  assembledMessages: AgentMessage[];
+  volatileLiveInputs: VolatileLiveInputCandidate[];
+}): Map<number, number> {
+  const entryIndexesByLiveText = new Map<string, number[]>();
+  for (let entryIndex = 0; entryIndex < params.volatileLiveInputs.length; entryIndex++) {
+    const entry = params.volatileLiveInputs[entryIndex] as VolatileLiveInputCandidate;
+    const entryIndexes = entryIndexesByLiveText.get(entry.liveText);
+    if (entryIndexes) {
+      entryIndexes.push(entryIndex);
+    } else {
+      entryIndexesByLiveText.set(entry.liveText, [entryIndex]);
+    }
+  }
+
+  const slots: VolatileLiveInputCoverageSlot[] = [];
+  const candidateSlotIndexesByEntryIndex = params.volatileLiveInputs.map(() => [] as number[]);
+  const addCandidateSlots = (entryIndexes: number[], assembledIndex: number, slotCount: number) => {
+    const slotIndexes: number[] = [];
+    for (let slotOffset = 0; slotOffset < slotCount; slotOffset++) {
+      slotIndexes.push(slots.length);
+      slots.push({ assembledIndex });
+    }
+    for (const entryIndex of entryIndexes) {
+      candidateSlotIndexesByEntryIndex[entryIndex]?.push(...slotIndexes);
+    }
+  };
+
+  for (const [liveText, entryIndexes] of entryIndexesByLiveText.entries()) {
+    for (let assembledIndex = 0; assembledIndex < params.assembledMessages.length; assembledIndex++) {
+      const assembledMessage = params.assembledMessages[assembledIndex] as AgentMessage;
+      const assembled = toStoredMessage(assembledMessage);
+      if (!isSummaryWrapperContent(assembled.content)) {
+        const exactEntryIndexes = entryIndexes.filter((entryIndex) =>
+          messagesHaveSameLiveCoverageSignature(
+            assembledMessage,
+            (params.volatileLiveInputs[entryIndex] as VolatileLiveInputCandidate).message,
+          )
+        );
+        if (exactEntryIndexes.length > 0) {
+          addCandidateSlots(exactEntryIndexes, assembledIndex, 1);
+        }
+        continue;
+      }
+
+      const representativeEntry = params.volatileLiveInputs[entryIndexes[0] as number] as VolatileLiveInputCandidate;
+      const capacity = liveInputCoverageCapacity({
+        assembledMessage,
+        liveMessage: representativeEntry.message,
+        isVolatileLiveInput: true,
+      });
+      if (capacity <= 0) {
+        continue;
+      }
+
+      const entryIndexesBySignature = new Map<string, number[]>();
+      for (const entryIndex of entryIndexes) {
+        const entry = params.volatileLiveInputs[entryIndex] as VolatileLiveInputCandidate;
+        const signature = createLiveCoverageSignature(entry.message);
+        const signatureEntryIndexes = entryIndexesBySignature.get(signature);
+        if (signatureEntryIndexes) {
+          signatureEntryIndexes.push(entryIndex);
+        } else {
+          entryIndexesBySignature.set(signature, [entryIndex]);
+        }
+      }
+
+      let exactSlotCount = 0;
+      for (const signatureEntryIndexes of entryIndexesBySignature.values()) {
+        const firstEntry = params.volatileLiveInputs[signatureEntryIndexes[0] as number] as VolatileLiveInputCandidate;
+        const liveContent = toStoredMessage(firstEntry.message).content;
+        const exactCapacity = liveContent
+          ? countNonOverlappingOccurrences({ haystack: assembled.content, needle: liveContent })
+          : 0;
+        const slotCount = Math.min(exactCapacity, signatureEntryIndexes.length);
+        if (slotCount > 0) {
+          addCandidateSlots(signatureEntryIndexes, assembledIndex, slotCount);
+          exactSlotCount += slotCount;
+        }
+      }
+
+      const genericSlotCount = Math.min(
+        Math.max(0, capacity - exactSlotCount),
+        Math.max(0, entryIndexes.length - exactSlotCount),
+      );
+      if (genericSlotCount > 0) {
+        addCandidateSlots(entryIndexes, assembledIndex, genericSlotCount);
+      }
+    }
+  }
+
+  const slotToEntryIndex = new Map<number, number>();
+  const tryAssignEntry = (entryIndex: number, visitedSlots: Set<number>): boolean => {
+    const candidateSlotIndexes = candidateSlotIndexesByEntryIndex[entryIndex] ?? [];
+    for (const slotIndex of candidateSlotIndexes) {
+      if (visitedSlots.has(slotIndex)) {
+        continue;
+      }
+      visitedSlots.add(slotIndex);
+      const currentEntryIndex = slotToEntryIndex.get(slotIndex);
+      if (
+        currentEntryIndex === undefined ||
+        tryAssignEntry(currentEntryIndex, visitedSlots)
+      ) {
+        slotToEntryIndex.set(slotIndex, entryIndex);
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (let entryIndex = 0; entryIndex < params.volatileLiveInputs.length; entryIndex++) {
+    tryAssignEntry(entryIndex, new Set<number>());
+  }
+
+  const entryToAssembledIndex = new Map<number, number>();
+  for (const [slotIndex, entryIndex] of slotToEntryIndex.entries()) {
+    const slot = slots[slotIndex] as VolatileLiveInputCoverageSlot;
+    entryToAssembledIndex.set(entryIndex, slot.assembledIndex);
+  }
+  return entryToAssembledIndex;
+}
+
+function collectUncoveredVolatileLiveInputs(params: {
+  assembledMessages: AgentMessage[];
+  liveMessages: AgentMessage[];
+}): {
+  entries: VolatileLiveInputEntry[];
+  estimatedTokens: number;
+  coveredEntriesByAssembledIndex: Map<number, VolatileLiveInputEntry[]>;
+} {
+  const volatileLiveInputs = params.liveMessages
+    .map((message, liveIndex) => ({ message, liveIndex }))
+    .filter((entry) => isVolatileLiveInputMessage(entry.message))
+    .map((entry) => ({
+      ...entry,
+      liveText: normalizeSummaryOverlapText(toStoredMessage(entry.message).content),
+    }));
+  const uncovered: VolatileLiveInputEntry[] = [];
+  const coveredEntriesByAssembledIndex = new Map<number, VolatileLiveInputEntry[]>();
+  const entryToAssembledIndex = matchVolatileLiveInputsToCoverageSlots({
+    assembledMessages: params.assembledMessages,
+    volatileLiveInputs,
+  });
+
+  for (let entryIndex = 0; entryIndex < volatileLiveInputs.length; entryIndex++) {
+    const entry = volatileLiveInputs[entryIndex] as VolatileLiveInputCandidate;
+    const assembledIndex = entryToAssembledIndex.get(entryIndex);
+    if (assembledIndex !== undefined) {
+      const coveredEntries = coveredEntriesByAssembledIndex.get(assembledIndex);
+      if (coveredEntries) {
+        coveredEntries.push(entry);
+      } else {
+        coveredEntriesByAssembledIndex.set(assembledIndex, [entry]);
+      }
+    } else {
+      uncovered.push(entry);
+    }
+  }
+
+  return {
+    entries: uncovered,
+    estimatedTokens: estimateAgentMessageTokens(materializeVolatileLiveInputEntries(uncovered)),
+    coveredEntriesByAssembledIndex,
+  };
+}
+
+function appendUncoveredVolatileLiveInputsWithinBudget(params: {
+  assembledMessages: AgentMessage[];
+  assembledEstimatedTokens: number;
+  liveMessages: AgentMessage[];
+  protectedAssembledIndexes?: Set<number>;
+  tokenBudget: number;
+}): {
+  messages: AgentMessage[];
+  estimatedTokens: number;
+  appendedMessages: number;
+  appendedTokens: number;
+  evictedMessages: number;
+  evictedTokens: number;
+  overBudget: boolean;
+} {
+  const liveMessages = params.liveMessages.map(normalizeLiveMessageForAssemblyReconciliation);
+  const protectedAssembledIndexes = expandProtectedToolPairIndexes({
+    assembledMessages: params.assembledMessages,
+    protectedAssembledIndexes: params.protectedAssembledIndexes ?? new Set<number>(),
+  });
+  const uncovered = collectUncoveredVolatileLiveInputs({
+    assembledMessages: params.assembledMessages,
+    liveMessages,
+  });
+  if (uncovered.entries.length === 0) {
+    return {
+      messages: params.assembledMessages,
+      estimatedTokens: params.assembledEstimatedTokens,
+      appendedMessages: 0,
+      appendedTokens: 0,
+      evictedMessages: 0,
+      evictedTokens: 0,
+      overBudget: params.assembledEstimatedTokens > params.tokenBudget,
+    };
+  }
+
+  const retained = params.assembledMessages.map((message, index) => ({ message, index }));
+  let appendedEntries = uncovered.entries.slice();
+  const exactLiveSortIndexes = resolveExactAssembledLiveSortIndexes({
+    assembledMessages: params.assembledMessages,
+    liveMessages,
+  });
+  const exactLiveProtectedIndexes = expandProtectedToolPairIndexes({
+    assembledMessages: params.assembledMessages,
+    protectedAssembledIndexes: new Set(exactLiveSortIndexes.keys()),
+  });
+  const liveSortIndexes = expandToolPairLiveSortIndexes({
+    assembledMessages: params.assembledMessages,
+    liveSortIndexes: mergeCoveredVolatileLiveSortIndexes({
+      exactLiveSortIndexes,
+      coveredEntriesByAssembledIndex: uncovered.coveredEntriesByAssembledIndex,
+    }),
+  });
+  let evictedMessages = 0;
+  let evictedTokens = 0;
+  let output = buildVolatileLiveInputMergedOutput({
+    retained,
+    appendedEntries,
+    liveSortIndexes,
+  });
+  let estimatedTokens = estimateAgentMessageTokens(output);
+
+  while (retained.length > 0 && estimatedTokens > params.tokenBudget) {
+    let bestCandidate:
+      | {
+          evictIndex: number;
+          output: AgentMessage[];
+          estimatedTokens: number;
+          appendedEntries: VolatileLiveInputEntry[];
+        }
+      | undefined;
+    for (let evictIndex = 0; evictIndex < retained.length; evictIndex++) {
+      const entry = retained[evictIndex] as RetainedAssembledEntry;
+      const candidateEvictsExactLiveTurn = exactLiveProtectedIndexes.has(entry.index);
+      if (candidateEvictsExactLiveTurn || protectedAssembledIndexes.has(entry.index)) {
+        continue;
+      }
+      const restoredCoveredEntries = uncovered.coveredEntriesByAssembledIndex.get(entry.index) ?? [];
+      const candidateRetained = retained.filter((_, index) => index !== evictIndex);
+      const candidateAppendedEntries =
+        restoredCoveredEntries.length > 0
+          ? [...appendedEntries, ...restoredCoveredEntries]
+          : appendedEntries;
+      const candidateOutput = buildVolatileLiveInputMergedOutput({
+        retained: candidateRetained,
+        appendedEntries: candidateAppendedEntries,
+        liveSortIndexes,
+      });
+      const candidateEstimatedTokens = estimateAgentMessageTokens(candidateOutput);
+      const candidateFits = candidateEstimatedTokens <= params.tokenBudget;
+      const bestFits =
+        bestCandidate !== undefined && bestCandidate.estimatedTokens <= params.tokenBudget;
+      if (
+        bestCandidate === undefined ||
+        (candidateFits && !bestFits) ||
+        (candidateFits &&
+          bestFits &&
+          candidateEstimatedTokens > bestCandidate.estimatedTokens) ||
+        (!candidateFits &&
+          !bestFits &&
+          candidateEstimatedTokens < bestCandidate.estimatedTokens)
+      ) {
+        bestCandidate = {
+          evictIndex,
+          output: candidateOutput,
+          estimatedTokens: candidateEstimatedTokens,
+          appendedEntries: candidateAppendedEntries,
+        };
+      }
+    }
+    if (!bestCandidate) {
+      break;
+    }
+    const [removed] = retained.splice(bestCandidate.evictIndex, 1);
+    appendedEntries = bestCandidate.appendedEntries;
+    uncovered.coveredEntriesByAssembledIndex.delete(removed.index);
+    evictedMessages += 1;
+    evictedTokens += toStoredMessage(removed.message).tokenCount;
+    output = bestCandidate.output;
+    estimatedTokens = bestCandidate.estimatedTokens;
+  }
+  const appendedMessages = materializeVolatileLiveInputEntries(appendedEntries);
+
+  return {
+    messages: output,
+    estimatedTokens,
+    appendedMessages: appendedMessages.length,
+    appendedTokens: estimateAgentMessageTokens(appendedMessages),
+    evictedMessages,
+    evictedTokens,
+    overBudget: estimatedTokens > params.tokenBudget,
+  };
 }
 
 // ── LcmContextEngine ────────────────────────────────────────────────────────
@@ -6086,6 +6926,24 @@ export class LcmContextEngine implements ContextEngine {
         return safeFallback();
       }
 
+      const volatileLiveInputAppend = appendUncoveredVolatileLiveInputsWithinBudget({
+        assembledMessages: assembled.messages,
+        assembledEstimatedTokens: assembled.estimatedTokens,
+        liveMessages: params.messages,
+        protectedAssembledIndexes: resolveProtectedFreshTailAssembledIndexes({
+          assembledMessages: assembled.messages,
+          freshTailMessageHashes:
+            assembled.debug?.freshTailProtectionMessageHashes ??
+            assembled.debug?.preSanitizeFreshTailMessageHashes,
+        }),
+        tokenBudget,
+      });
+      if (volatileLiveInputAppend.appendedMessages > 0) {
+        this.deps.log.warn(
+          `[lcm] assemble: appended unpersisted volatile live input conversation=${conversation.conversationId} ${sessionLabel} appendedMessages=${volatileLiveInputAppend.appendedMessages} appendedTokens=${volatileLiveInputAppend.appendedTokens} evictedMessages=${volatileLiveInputAppend.evictedMessages} evictedTokens=${volatileLiveInputAppend.evictedTokens} overBudget=${volatileLiveInputAppend.overBudget}`,
+        );
+      }
+
       // v4.2 §B — surface stub telemetry on the standard "assemble: done" line
       // so live watchers can grep stubbedCount/tokensSaved without needing the
       // full assemble-debug bag.
@@ -6097,12 +6955,16 @@ export class LcmContextEngine implements ContextEngine {
         contextItems,
       );
       const summaryContextItems = contextItems.filter((item) => item.itemType === "summary").length;
+      const volatileLiveInputLog = volatileLiveInputAppend.appendedMessages > 0
+        ? ` volatileLiveInputsAppended=${volatileLiveInputAppend.appendedMessages} volatileLiveInputEvicted=${volatileLiveInputAppend.evictedMessages} volatileLiveInputOverBudget=${volatileLiveInputAppend.overBudget}`
+        : "";
       this.deps.log.info(
-        `[lcm] assemble: done conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} summaryContextItems=${summaryContextItems} hasSummaryItems=${hasSummaryItems} inputMessages=${params.messages.length} outputMessages=${assembled.messages.length} tokenBudget=${tokenBudget} estimatedTokens=${assembled.estimatedTokens} contextProjectionMode=thread_bootstrap contextProjectionEpoch=${contextProjectionEpoch}${stubStatsLog} duration=${formatDurationMs(Date.now() - startedAt)}`,
+        `[lcm] assemble: done conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} summaryContextItems=${summaryContextItems} hasSummaryItems=${hasSummaryItems} inputMessages=${params.messages.length} outputMessages=${volatileLiveInputAppend.messages.length} tokenBudget=${tokenBudget} estimatedTokens=${volatileLiveInputAppend.estimatedTokens} contextProjectionMode=thread_bootstrap contextProjectionEpoch=${contextProjectionEpoch}${stubStatsLog}${volatileLiveInputLog} duration=${formatDurationMs(Date.now() - startedAt)}`,
+
       );
       const prefixChange = describeAssembledPrefixChange(
         this.getPreviousAssembledSnapshot(conversation.conversationId),
-        assembled.messages,
+        volatileLiveInputAppend.messages,
       );
       this.setPreviousAssembledSnapshot(
         conversation.conversationId,
@@ -6131,12 +6993,13 @@ export class LcmContextEngine implements ContextEngine {
       }
 
       const result: AssembleResult = {
-        messages: assembled.messages,
-        estimatedTokens: assembled.estimatedTokens,
+        messages: volatileLiveInputAppend.messages,
+        estimatedTokens: volatileLiveInputAppend.estimatedTokens,
         contextProjection: {
           mode: "thread_bootstrap",
           epoch: contextProjectionEpoch,
         },
+
       };
       return result;
     } catch (err) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1789,10 +1789,16 @@ const INTER_SESSION_MESSAGE_MARKER = "[Inter-session message]";
 const INTERNAL_CONTEXT_BEGIN_MARKER = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
 const INTERNAL_CONTEXT_END_MARKER = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
 const INTERNAL_TASK_COMPLETION_EVENT_MARKER = "[Internal task completion event]";
+const FALLBACK_RETRY_PROMPT_MARKER =
+  "[Retry after the previous model attempt failed or timed out]";
 const NORMALIZED_INTER_SESSION_MESSAGE_MARKER = normalizeSummaryOverlapText(INTER_SESSION_MESSAGE_MARKER);
 const NORMALIZED_INTERNAL_TASK_COMPLETION_EVENT_MARKER = normalizeSummaryOverlapText(
   INTERNAL_TASK_COMPLETION_EVENT_MARKER,
 );
+
+function hasFallbackRetryPromptMarker(content: string): boolean {
+  return content.split(/\r?\n/).some((line) => line.trim() === FALLBACK_RETRY_PROMPT_MARKER);
+}
 
 function hasCompleteInternalContextBlock(content: string): boolean {
   const beginIndex = content.indexOf(INTERNAL_CONTEXT_BEGIN_MARKER);
@@ -1809,6 +1815,9 @@ function hasCompleteInternalContextBlock(content: string): boolean {
 
 function isVolatileLiveInputContent(content: string): boolean {
   const trimmed = content.trimStart();
+  if (hasFallbackRetryPromptMarker(trimmed)) {
+    return true;
+  }
   if (!hasCompleteInternalContextBlock(trimmed)) {
     return false;
   }
@@ -2007,6 +2016,80 @@ function expandToolPairLiveSortIndexes(params: {
   }
 
   return liveSortIndexes;
+}
+
+function buildToolPairIndexesByAssembledIndex(
+  assembledMessages: AgentMessage[],
+): Map<number, Set<number>> {
+  const assistantIndexesByToolCallId = new Map<string, number[]>();
+  const toolResultIndexesByToolCallId = new Map<string, number[]>();
+
+  // First index both sides by tool call id so matching assistant/result turns
+  // can be treated as one eviction unit.
+  for (let index = 0; index < assembledMessages.length; index++) {
+    const message = assembledMessages[index] as AgentMessage;
+    for (const toolCallId of extractAssistantToolCallIdsForPairing(message)) {
+      const indexes = assistantIndexesByToolCallId.get(toolCallId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        assistantIndexesByToolCallId.set(toolCallId, [index]);
+      }
+    }
+    const toolResultId = extractToolResultIdForPairing(message);
+    if (toolResultId) {
+      const indexes = toolResultIndexesByToolCallId.get(toolResultId);
+      if (indexes) {
+        indexes.push(index);
+      } else {
+        toolResultIndexesByToolCallId.set(toolResultId, [index]);
+      }
+    }
+  }
+
+  const neighborsByIndex = new Map<number, Set<number>>();
+  // Link matched pairs as an undirected graph; the final groups are connected
+  // components, which handles multi-tool assistant turns and duplicate ids.
+  const linkIndexes = (left: number, right: number) => {
+    const leftNeighbors = neighborsByIndex.get(left) ?? new Set<number>([left]);
+    leftNeighbors.add(right);
+    neighborsByIndex.set(left, leftNeighbors);
+
+    const rightNeighbors = neighborsByIndex.get(right) ?? new Set<number>([right]);
+    rightNeighbors.add(left);
+    neighborsByIndex.set(right, rightNeighbors);
+  };
+
+  for (const [toolCallId, assistantIndexes] of assistantIndexesByToolCallId.entries()) {
+    const toolResultIndexes = toolResultIndexesByToolCallId.get(toolCallId) ?? [];
+    for (const assistantIndex of assistantIndexes) {
+      for (const toolResultIndex of toolResultIndexes) {
+        linkIndexes(assistantIndex, toolResultIndex);
+      }
+    }
+  }
+
+  const groupsByIndex = new Map<number, Set<number>>();
+  // Materialize every index's component so budget trimming can cheaply ask
+  // "what else must be evicted with this message?"
+  for (let index = 0; index < assembledMessages.length; index++) {
+    const group = new Set<number>();
+    const pending = [index];
+    while (pending.length > 0) {
+      const current = pending.pop() as number;
+      if (group.has(current)) {
+        continue;
+      }
+      group.add(current);
+      for (const neighbor of neighborsByIndex.get(current) ?? [current]) {
+        if (!group.has(neighbor)) {
+          pending.push(neighbor);
+        }
+      }
+    }
+    groupsByIndex.set(index, group);
+  }
+  return groupsByIndex;
 }
 
 function normalizeLiveMessageForAssemblyReconciliation(message: AgentMessage): AgentMessage {
@@ -2516,8 +2599,9 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
     };
   }
 
-  const retained = params.assembledMessages.map((message, index) => ({ message, index }));
+  let retained = params.assembledMessages.map((message, index) => ({ message, index }));
   let appendedEntries = uncovered.entries.slice();
+  const toolPairIndexesByIndex = buildToolPairIndexesByAssembledIndex(params.assembledMessages);
   const exactLiveSortIndexes = resolveExactAssembledLiveSortIndexes({
     assembledMessages: params.assembledMessages,
     liveMessages,
@@ -2545,7 +2629,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
   while (retained.length > 0 && estimatedTokens > params.tokenBudget) {
     let bestCandidate:
       | {
-          evictIndex: number;
+          evictAssembledIndexes: Set<number>;
           output: AgentMessage[];
           estimatedTokens: number;
           appendedEntries: VolatileLiveInputEntry[];
@@ -2553,12 +2637,22 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
       | undefined;
     for (let evictIndex = 0; evictIndex < retained.length; evictIndex++) {
       const entry = retained[evictIndex] as RetainedAssembledEntry;
-      const candidateEvictsExactLiveTurn = exactLiveProtectedIndexes.has(entry.index);
-      if (candidateEvictsExactLiveTurn || protectedAssembledIndexes.has(entry.index)) {
+      const evictAssembledIndexes = toolPairIndexesByIndex.get(entry.index) ?? new Set([entry.index]);
+      const candidateEvictsExactLiveTurn = Array.from(evictAssembledIndexes).some((index) =>
+        exactLiveProtectedIndexes.has(index)
+      );
+      const candidateEvictsProtectedTurn = Array.from(evictAssembledIndexes).some((index) =>
+        protectedAssembledIndexes.has(index)
+      );
+      if (candidateEvictsExactLiveTurn || candidateEvictsProtectedTurn) {
         continue;
       }
-      const restoredCoveredEntries = uncovered.coveredEntriesByAssembledIndex.get(entry.index) ?? [];
-      const candidateRetained = retained.filter((_, index) => index !== evictIndex);
+      const restoredCoveredEntries = Array.from(evictAssembledIndexes).flatMap(
+        (index) => uncovered.coveredEntriesByAssembledIndex.get(index) ?? [],
+      );
+      const candidateRetained = retained.filter(
+        (retainedEntry) => !evictAssembledIndexes.has(retainedEntry.index),
+      );
       const candidateAppendedEntries =
         restoredCoveredEntries.length > 0
           ? [...appendedEntries, ...restoredCoveredEntries]
@@ -2583,7 +2677,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
           candidateEstimatedTokens < bestCandidate.estimatedTokens)
       ) {
         bestCandidate = {
-          evictIndex,
+          evictAssembledIndexes,
           output: candidateOutput,
           estimatedTokens: candidateEstimatedTokens,
           appendedEntries: candidateAppendedEntries,
@@ -2593,11 +2687,16 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
     if (!bestCandidate) {
       break;
     }
-    const [removed] = retained.splice(bestCandidate.evictIndex, 1);
+    const removedEntries = retained.filter((entry) =>
+      bestCandidate.evictAssembledIndexes.has(entry.index),
+    );
+    retained = retained.filter((entry) => !bestCandidate.evictAssembledIndexes.has(entry.index));
     appendedEntries = bestCandidate.appendedEntries;
-    uncovered.coveredEntriesByAssembledIndex.delete(removed.index);
-    evictedMessages += 1;
-    evictedTokens += toStoredMessage(removed.message).tokenCount;
+    for (const removed of removedEntries) {
+      uncovered.coveredEntriesByAssembledIndex.delete(removed.index);
+      evictedTokens += toStoredMessage(removed.message).tokenCount;
+    }
+    evictedMessages += removedEntries.length;
     output = bestCandidate.output;
     estimatedTokens = bestCandidate.estimatedTokens;
   }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11204,4 +11204,146 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
     expect(volatileIndex).toBeLessThan(toolIndex);
   });
 
+  it("appends suppressed fallback retry prompts that lack internal context markers", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const sessionId = "session-fallback-retry-volatile";
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "Original task that persisted before retry." } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: { role: "assistant", content: "The first model attempt failed." } as AgentMessage,
+    });
+
+    const retryPrompt =
+      "Prior retry context from the session transcript.\n\n" +
+      "[Retry after the previous model attempt failed or timed out]\n\n" +
+      "Original task that persisted before retry.";
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [
+        { role: "user", content: "Original task that persisted before retry." },
+        { role: "assistant", content: "The first model attempt failed." },
+        { role: "user", content: retryPrompt },
+      ] as AgentMessage[],
+      tokenBudget: 10_000,
+    });
+
+    const rendered = result.messages.map((message) =>
+      typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+    );
+    expect(rendered.some((content) => content.includes("[Retry after the previous model attempt"))).toBe(
+      true,
+    );
+    expect(rendered.some((content) => content.includes("Prior retry context"))).toBe(true);
+  });
+
+  it("evicts historical tool-call pairs together when volatile input forces trimming", async () => {
+    const engine = createEngineWithConfig({ freshTailCount: 8 });
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const sessionId = "session-volatile-budget-tool-pair";
+    const toolCallId = "call_budget_pair";
+    const toolOutput = "large paired tool output " + "x ".repeat(900);
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "Question before tool use." } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "big.txt" } }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName: "read",
+        content: [{ type: "text", text: toolOutput }],
+      } as AgentMessage,
+    });
+    for (let index = 0; index < 8; index++) {
+      await engine.ingest({
+        sessionId,
+        message: { role: "user", content: `fresh protected tail message ${index}` } as AgentMessage,
+      });
+    }
+
+    const assembledWithoutVolatile = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+    expect(
+      assembledWithoutVolatile.messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          Array.isArray(message.content) &&
+          message.content.some(
+            (block) =>
+              block &&
+              typeof block === "object" &&
+              "id" in block &&
+              (block as { id?: unknown }).id === toolCallId,
+          ),
+      ),
+    ).toBe(true);
+    expect(
+      assembledWithoutVolatile.messages.some(
+        (message) =>
+          message.role === "toolResult" &&
+          (message as { toolCallId?: string }).toolCallId === toolCallId,
+      ),
+    ).toBe(true);
+
+    const volatileEvent =
+      "[Inter-session message] sourceSession=agent:main:subagent:budget sourceTool=subagent_announce\n" +
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+      "[Internal task completion event]\n" +
+      "Child result: volatile input should not leave a synthetic tool repair.\n" +
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [{ role: "user", content: volatileEvent }] as AgentMessage[],
+      tokenBudget: assembledWithoutVolatile.estimatedTokens + estimateTokens(volatileEvent) - 50,
+    });
+
+    const rendered = result.messages
+      .map((message) => (typeof message.content === "string" ? message.content : JSON.stringify(message.content)))
+      .join("\n");
+    expect(rendered).toContain("volatile input should not leave a synthetic tool repair");
+    expect(rendered).not.toContain(
+      "[lossless-claw] missing tool result in session history; inserted synthetic error result",
+    );
+    expect(
+      result.messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          Array.isArray(message.content) &&
+          message.content.some(
+            (block) =>
+              block &&
+              typeof block === "object" &&
+              "id" in block &&
+              (block as { id?: unknown }).id === toolCallId,
+          ),
+      ),
+    ).toBe(false);
+    expect(
+      result.messages.some(
+        (message) =>
+          message.role === "toolResult" &&
+          (message as { toolCallId?: string }).toolCallId === toolCallId,
+      ),
+    ).toBe(false);
+  });
+
 });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11076,4 +11076,132 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
   });
 
 
+
+  it("does not consume summary substring as coverage for volatile live inputs", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const sessionId = "session-volatile-not-consumed-by-summary";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {});
+    const summaryStore = engine.getSummaryStore();
+
+    // Create a summary that contains text matching a future volatile input.
+    // This simulates an older turn where a similar inter-session event was
+    // summarized — the summary is stale history, NOT the current live input.
+    const repeatedEventContent =
+      "[Internal task completion event]\nChild result: subagent finished processing data.";
+    const oldSummary =
+      "Previous turn context.\n" +
+      "[Internal task completion event]\n" +
+      "Child result: subagent finished processing data.\n" +
+      "End of previous context.";
+    await summaryStore.insertSummary({
+      summaryId: "sum_old_with_event_text",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: oldSummary,
+      tokenCount: estimateTokens(oldSummary),
+    });
+    await summaryStore.appendContextSummary(conversation.conversationId, "sum_old_with_event_text");
+
+    // A new volatile live input with identical content must NOT be consumed
+    // by the old summary — it's a separate event that the model needs to see.
+    const volatileEvent =
+      "[Inter-session message] sourceSession=agent:main:subagent:summary-consume sourceTool=subagent_announce\n" +
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+      repeatedEventContent + "\n" +
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [{ role: "user", content: volatileEvent }] as AgentMessage[],
+      tokenBudget: 10_000,
+    });
+    const rendered = result.messages.map((message) =>
+      typeof message.content === "string" ? message.content : JSON.stringify(message.content)
+    );
+    // The volatile input must appear explicitly as its own message, not be consumed by the summary.
+    // It may also appear inside the summary content (historical reference), so we
+    // check that it exists as a dedicated volatile-appended entry by verifying
+    // the full OPENCLAW_INTERNAL_CONTEXT wrapper is present.
+    expect(
+      rendered.filter((content) => content.includes("<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>") && content.includes(repeatedEventContent))
+    ).toHaveLength(1);
+    // The old summary should also be present (it's the only assembled context).
+    expect(rendered.some((content) => content.includes("Previous turn context"))).toBe(true);
+  });
+
+  it("matches tool results without tool names against assembled unknown-name results", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const sessionId = "session-tool-name-unknown-coverage";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {});
+    const summaryStore = engine.getSummaryStore();
+
+    const oldSummary = "old evictable summary before nameless tool result";
+    await summaryStore.insertSummary({
+      summaryId: "sum_old_before_nameless_tool",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: oldSummary,
+      tokenCount: estimateTokens(oldSummary),
+    });
+    await summaryStore.appendContextSummary(conversation.conversationId, "sum_old_before_nameless_tool");
+
+    // Ingest a tool result that will be stored with toolName="unknown"
+    // by the assembler (assembler fills missing tool names with "unknown").
+    const toolCallId = "call_nameless_tool";
+    const toolOutput = "tool output without a real tool name must anchor correctly";
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: toolCallId, name: "unknown", input: {} }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName: "unknown",
+        content: [{ type: "text", text: toolOutput }],
+      } as AgentMessage,
+    });
+
+    // Live volatile input before the tool result, where the live version
+    // has no toolName at all (not even "unknown").
+    const volatileEvent =
+      "[Inter-session message] sourceSession=agent:main:subagent:nameless-tool sourceTool=subagent_announce\n" +
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n" +
+      "[Internal task completion event]\n" +
+      "Child result: volatile input must anchor before nameless tool result.\n" +
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [
+        { role: "user", content: volatileEvent },
+        // Live tool result without toolName — should match assembled "unknown"
+        {
+          role: "toolResult",
+          toolCallId,
+          // No toolName — the assembler would fill "unknown" but live has none
+          content: [{ type: "text", text: toolOutput }],
+        } as AgentMessage,
+      ],
+      tokenBudget: 10_000,
+    });
+    const renderedText = result.messages
+      .map((message) => (typeof message.content === "string" ? message.content : JSON.stringify(message.content)))
+      .join("\n");
+    // The volatile input must appear BEFORE the tool result in the output.
+    const volatileIndex = renderedText.indexOf("volatile input must anchor before nameless tool result");
+    const toolIndex = renderedText.indexOf("tool output without a real tool name");
+    expect(volatileIndex).toBeGreaterThanOrEqual(0);
+    expect(toolIndex).toBeGreaterThanOrEqual(0);
+    expect(volatileIndex).toBeLessThan(toolIndex);
+  });
+
 });


### PR DESCRIPTION
## Problem

When `contextEngine.assemble()` rebuilds context from the DB `context_items` table, messages that were never persisted to DB are absent from the assembled output. This includes:

- **Inter-session subagent announcements** (`suppressPromptPersistence=true` for `inputProvenance.kind === "inter_session"`)
- **Retry/overflow retry prompts** (`suppressPromptPersistenceOnRetry`)
- **Other internal runtime events** that bypass DB persistence

The DB frontier lags behind `params.messages`, so the model never sees the current turn's volatile event — e.g., a subagent completion announcement that should trigger a response.

## Root Cause

LCM's assembler rebuilds from DB only. OpenClaw's `shouldSuppressAgentPromptPersistence()` marks certain messages as non-persistable, so they never enter `context_items`. The assembled output has no way to include them.

## Fix

After DB assembly, detect volatile live input in `params.messages` that is not represented in the assembled output and append it within the token budget.

### Key design choices

1. **Volatile inputs are never covered by summary substring matches.** A summary containing similar text captures a *past* turn; the current volatile event is a distinct occurrence the model must see explicitly. Only exact assembled-message matches count as coverage for volatile inputs.

2. **Occurrence-level bipartite maximum matching** (DFS augmenting-path) for deduplication. Two-layer slot allocation: exact-match slots first, then normalized-overlap generic slots.

3. **Live input takes priority.** If appending volatile input exceeds the token budget, evict from the front of assembled DB context. Protected fresh-tail messages and exact live anchors are never evicted.

4. **Tool-result/tool-call pair integrity.** `expandProtectedToolPairIndexes()` ensures protected toolResults and their paired assistant tool-call messages are both preserved during budget trimming.

5. **Tool name normalization.** `normalizeToolNameForCoverage()` treats `null`/`undefined`/`""`/`"unknown"` as equivalent in coverage signatures, fixing anchor mismatches when the assembler fills missing tool names with `"unknown"`.

6. **System volatile normalization.** System-role volatile messages are projected to `user` representation before coverage/anchor/append logic.

7. **Fresh-tail hash protection.** Assembler provides per-message hashes for fresh-tail messages; engine protects these alongside exact live anchors during volatile trimming.

## Files Changed

- `src/engine.ts` — core reconciliation logic (`appendUncoveredVolatileLiveInputsWithinBudget`, coverage matching, budget eviction)
- `src/assembler.ts` — fresh-tail message hash export for protection
- `test/engine.test.ts` — 931 tests (278 engine-specific), including regression tests for volatile coverage, budget eviction, tool-pair integrity, and tool-name normalization
- `.changeset/assemble-live-tail.md` — patch bump
- `.gitignore` — added `node_modules`

## Related

- openclaw/openclaw#80760 (Codex projection 24K cap)
- openclaw/openclaw#81164 (interceptCompaction proposal)
- openclaw/openclaw#81176 (relative budget shares)
- This is Track 1 (止血PR) from the three-track fix plan; Track 2 (OpenClaw RFC for `assemble()` contract) and Track 3 (upstream PR for live-input fields) are separate.
