### PR TITLE
fix: use current runtime config snapshot

### DIFF
--- a/.changeset/runtime-config-current.md
+++ b/.changeset/runtime-config-current.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use OpenClaw's current runtime config snapshot API to avoid the deprecated plugin `config.loadConfig()` warning on newer hosts.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -79,6 +79,26 @@ type RuntimeAgentSessionApi = {
 };
 type RuntimeAgentSessionApiCandidate = Partial<RuntimeAgentSessionApi>;
 
+type RuntimeConfigSnapshotApi = {
+  current?: () => unknown;
+  loadConfig?: () => unknown;
+};
+
+/** Read the host runtime config snapshot without using deprecated APIs on newer hosts. */
+function readRuntimeConfigSnapshot(api: OpenClawPluginApi): unknown {
+  const configApi = (api.runtime as unknown as { config?: RuntimeConfigSnapshotApi }).config;
+  if (!configApi) {
+    return undefined;
+  }
+  if (typeof configApi.current === "function") {
+    return configApi.current();
+  }
+  if (typeof configApi.loadConfig === "function") {
+    return configApi.loadConfig();
+  }
+  return undefined;
+}
+
 /** Return the runtime session registry API when the host exposes it. */
 function getRuntimeAgentSessionApi(api: OpenClawPluginApi): RuntimeAgentSessionApi | undefined {
   const runtime = api.runtime as unknown as {
@@ -450,7 +470,7 @@ function readDefaultModelFromConfig(config: unknown): string {
 /** Load the best available validated OpenClaw config during plugin registration. */
 function loadEffectiveOpenClawConfig(api: OpenClawPluginApi): unknown {
   try {
-    const runtimeConfig = api.runtime.config.loadConfig();
+    const runtimeConfig = readRuntimeConfigSnapshot(api);
     if (runtimeConfig !== undefined) {
       if (isRecord(runtimeConfig) && Object.keys(runtimeConfig).length > 0) {
         return runtimeConfig;
@@ -460,7 +480,7 @@ function loadEffectiveOpenClawConfig(api: OpenClawPluginApi): unknown {
       }
     }
   } catch {
-    // Older runtimes or early startup can leave loadConfig unavailable.
+    // Older runtimes or early startup can leave runtime config unavailable.
   }
   return api.config;
 }
@@ -1190,10 +1210,11 @@ function createLcmDependencies(
         if (!sessionApi) {
           return undefined;
         }
-        const cfg = api.runtime.config.loadConfig();
+        const cfg = readRuntimeConfigSnapshot(api);
+        const sessionConfig = isRecord(cfg) && isRecord(cfg.session) ? cfg.session : undefined;
         const parsed = parseAgentSessionKey(key);
         const agentId = normalizeAgentId(parsed?.agentId);
-        const storePath = sessionApi.resolveStorePath(cfg.session?.store, {
+        const storePath = sessionApi.resolveStorePath(getStringField(sessionConfig, "store"), {
           agentId,
         });
         const store = sessionApi.loadSessionStore(storePath) as Record<
@@ -1217,11 +1238,12 @@ function createLcmDependencies(
         if (!sessionApi) {
           return undefined;
         }
-        const cfg = api.runtime.config.loadConfig();
+        const cfg = readRuntimeConfigSnapshot(api);
+        const sessionConfig = isRecord(cfg) && isRecord(cfg.session) ? cfg.session : undefined;
         const normalizedSessionKey = sessionKey?.trim();
         const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
         const agentId = normalizeAgentId(parsed?.agentId);
-        const storePath = sessionApi.resolveStorePath(cfg.session?.store, {
+        const storePath = sessionApi.resolveStorePath(getStringField(sessionConfig, "store"), {
           agentId,
         });
         const store = sessionApi.loadSessionStore(storePath) as Record<
@@ -1252,7 +1274,10 @@ function createLcmDependencies(
 
       let cfg: unknown = registrationConfig.openClawConfig;
       try {
-        cfg = api.runtime.config.loadConfig();
+        const liveConfig = readRuntimeConfigSnapshot(api);
+        if (liveConfig !== undefined) {
+          cfg = liveConfig;
+        }
       } catch {
         // Fall back to the registration config snapshot when live config is unavailable.
       }
@@ -1451,7 +1476,10 @@ const lcmPlugin = {
 
       let cfg: unknown = registrationConfig.openClawConfig;
       try {
-        cfg = api.runtime.config.loadConfig();
+        const liveConfig = readRuntimeConfigSnapshot(api);
+        if (liveConfig !== undefined) {
+          cfg = liveConfig;
+        }
       } catch {
         // Fall back to the registration config snapshot when live config is unavailable.
       }

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -679,6 +679,102 @@ describe("lcm plugin registration", () => {
     );
   });
 
+  it("prefers runtime config current() over deprecated loadConfig()", () => {
+    const { api, infoLog } = buildApi({});
+    const current = vi.fn(() => ({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai-codex/gpt-5.5",
+            },
+          },
+        },
+      },
+    }));
+    const loadConfig = vi.fn(() => {
+      throw new Error("deprecated loadConfig should not be called");
+    });
+    (api.runtime as unknown as {
+      config: {
+        current: typeof current;
+        loadConfig: typeof loadConfig;
+      };
+    }).config = { current, loadConfig };
+    api.config = {} as OpenClawPluginApi["config"];
+
+    lcmPlugin.register(api);
+
+    expect(current).toHaveBeenCalled();
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(infoLog).toHaveBeenCalledWith(
+      "[lcm] Compaction summarization model: openai-codex/gpt-5.5 (override)",
+    );
+  });
+
+  it("preserves registration config fallback when live runtime config is unavailable for startup scans", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const sessionStorePath = join(
+      tmpdir(),
+      `lossless-claw-session-store-${Date.now()}-${Math.random().toString(16)}.json`,
+    );
+    const sessionId = `alpha-session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sessionKey = `agent:alpha:chat:${Math.random().toString(16).slice(2)}`;
+    const sessionFile = join(tmpdir(), `${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionStorePath,
+      `${JSON.stringify({
+        [sessionKey]: {
+          sessionId,
+          sessionFile,
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+    api.config = {
+      session: {
+        store: sessionStorePath,
+      },
+      agents: {
+        list: [{ id: "alpha", enabled: true }],
+      },
+    } as OpenClawPluginApi["config"];
+    attachSessionStoreApi(api, sessionStorePath);
+    delete (api.runtime as unknown as { config?: unknown }).config;
+
+    lcmPlugin.register(api);
+
+    const factory = getFactory();
+    expect(factory).toBeTypeOf("function");
+    const engine = factory!() as {
+      deps?: {
+        listStartupSessionFileCandidates: () => Promise<Array<{
+          sessionId: string;
+          sessionKey: string;
+          sessionFile: string;
+          agentId: string;
+          storePath: string;
+        }>>;
+      };
+    };
+
+    await expect(engine.deps?.listStartupSessionFileCandidates()).resolves.toEqual([
+      {
+        sessionId,
+        sessionKey,
+        sessionFile,
+        agentId: "alpha",
+        storePath: sessionStorePath,
+      },
+    ]);
+    rmSync(sessionStorePath, { force: true });
+  });
+
   it("uses runtime OpenClaw defaults when api.pluginConfig is ready before api.config", () => {
     const { api, getFactory, infoLog } = buildApi(
       {


### PR DESCRIPTION
## Summary
- Prefer OpenClaw runtime `config.current()` over deprecated `config.loadConfig()` when reading the host config snapshot.
- Keep the registration-time config fallback when live runtime config is unavailable during startup scans.
- Add regression coverage and a patch changeset.

## Tests
- `npm run build`
- `npm test`
- `codex review --uncommitted`

Fixes #618
Fixes #673