### PR TITLE
feat: expose context projection epochs

### DIFF
--- a/.changeset/context-engine-projection-epoch.md
+++ b/.changeset/context-engine-projection-epoch.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Advertise context-engine thread bootstrap projection epochs from DB-backed assembly so hosts can avoid reinjecting Lossless context every turn.

--- a/.changeset/full-sweep-leaf-exhaustion.md
+++ b/.changeset/full-sweep-leaf-exhaustion.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Run threshold full-sweep leaf compaction until eligible raw history is exhausted, and only trigger condensation from summarized-prefix pressure.

--- a/.changeset/runtime-overhead-threshold.md
+++ b/.changeset/runtime-overhead-threshold.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Account for runtime prompt overhead when threshold compaction is triggered from an observed token count. Lossless now compares Codex's live prompt count against its persisted context count and compacts far enough to cover the observed gap instead of clearing threshold debt while the live prompt may still be over target.

--- a/.changeset/structured-message-part-compaction.md
+++ b/.changeset/structured-message-part-compaction.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix leaf compaction, TUI previews, and TUI rewrite sources for structured message-part rows whose stored message content is empty.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,8 +92,8 @@ The **condensed pass** merges summaries at the same depth into a higher-level su
 
 **Full sweep (threshold, manual `/compact`, or overflow):**
 - Phase 1: Repeatedly runs leaf passes until no more eligible chunks
-- Phase 2: Repeatedly runs condensation passes starting from the shallowest eligible depth, respecting the preferred `sweepMaxDepth` (`0` for leaf-only, `-1` for unlimited)
-- Pressure phase: If the context is still over threshold or the summarized prefix is above `summaryPrefixTargetTokens`, condensation may go beyond `sweepMaxDepth` using the hard fanout floor
+- Phase 2: If the summarized prefix is above `summaryPrefixTargetTokens`, repeatedly runs condensation passes starting from the shallowest eligible depth, respecting the preferred `sweepMaxDepth` (`0` for leaf-only, `-1` for unlimited)
+- Pressure phase: If summarized-prefix pressure remains, condensation may go beyond `sweepMaxDepth` using the hard fanout floor
 - Each pass checks for progress; stops if no tokens were saved
 
 **Budget-targeted (`compactUntilUnder`):**

--- a/docs/compaction-redesign-map.md
+++ b/docs/compaction-redesign-map.md
@@ -102,9 +102,9 @@ Relevant code:
 The sweep has two phases:
 
 1. Leaf phase: repeatedly summarize the oldest raw chunks outside the fresh tail.
-2. Condensed phase: repeatedly summarize same-depth summary chunks, shallowest first.
+2. Condensed phase: if summarized-prefix tokens exceed `summaryPrefixTargetTokens`, repeatedly summarize same-depth summary chunks, shallowest first.
 
-Routine threshold sweeps stop once they get under the computed threshold and summarized-prefix target. Forced sweeps still stop when no eligible chunk remains or when a pass stops making token progress.
+Routine threshold sweeps use `contextThreshold` to decide when to start compaction. Once started, the leaf phase runs until no eligible raw-message chunk remains outside the fresh tail. Condensation is controlled by `summaryPrefixTargetTokens`, not by total context pressure. Forced sweeps still stop when no eligible chunk remains or when a pass stops making token progress.
 
 `sweepMaxDepth` is the preferred source-depth cap for routine full-sweep condensation:
 
@@ -113,7 +113,7 @@ Routine threshold sweeps stop once they get under the computed threshold and sum
 - `2`: depth 0 -> 1 and depth 1 -> 2 are allowed
 - `-1`: unlimited
 
-The cap is intentionally aspirational. If a sweep that obeys `sweepMaxDepth` still leaves the conversation over `contextThreshold`, or if summary tokens outside the fresh tail exceed `summaryPrefixTargetTokens`, Lossless runs a pressure condensation phase that may go deeper using `condensedMinFanoutHard`.
+The cap is intentionally aspirational. If summary tokens outside the fresh tail exceed `summaryPrefixTargetTokens` after routine condensation, Lossless runs a pressure condensation phase that may go deeper using `condensedMinFanoutHard`.
 
 Relevant code:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,7 @@ Automatic compaction is threshold-only:
 
 Lossless still records prompt-cache telemetry for status and diagnostics, but cache hotness no longer delays threshold debt. Legacy `cacheAwareCompaction.*` and `dynamicLeafChunkTokens.*` settings remain accepted so existing OpenClaw config continues to load, but they do not change automatic compaction behavior.
 
-Full sweeps treat `sweepMaxDepth` as the normal depth target, not an absolute safety ceiling. The routine condensation phase obeys `sweepMaxDepth`; if the context is still over threshold or the summarized prefix remains above `summaryPrefixTargetTokens`, a pressure phase may use `condensedMinFanoutHard` and condense deeper. This keeps ordinary sweeps shallow while still giving Lossless a way out when too many same-depth summaries would otherwise leave the prompt near full.
+Full sweeps first run leaf passes until there are no more eligible raw-message chunks outside the fresh tail. Condensation is then driven by summarized-prefix pressure: the routine condensation phase obeys `sweepMaxDepth`, and if the summarized prefix still exceeds `summaryPrefixTargetTokens`, a pressure phase may use `condensedMinFanoutHard` and condense deeper. Total context pressure starts the sweep, but does not by itself force deeper condensation once the raw prefix has been summarized.
 
 ### Prompt-aware eviction
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -49,7 +49,7 @@ Lists all agents discovered under `~/.openclaw/agents/`. Select an agent to see 
 
 ### Screen 2: Session List
 
-Shows JSONL session files for the selected agent, sorted by last modified time. Each entry shows the filename, last update time, message count, conversation ID (if LCM-tracked), summary count, and large file count.
+Shows JSONL session files for the selected agent, sorted by last modified time. Each entry shows the filename, last update time, message count, conversation ID (if LCM-tracked), summary count, and large file count. If an OpenClaw session has a Codex app-server binding, the row also shows a `codex:` marker with the local backend rollout row count when available.
 
 Sessions load in batches of 50. Scrolling near the bottom automatically loads more.
 
@@ -57,6 +57,8 @@ Sessions load in batches of 50. Scrolling near the bottom automatically loads mo
 |-----|--------|
 | `↑`/`↓` or `k`/`j` | Move cursor |
 | `Enter` | Open conversation |
+| `x` | Open bound Codex backend rollout transcript, when available |
+| `v` | Compare bound Codex backend rollout against the LCM active context |
 | `b`/`Backspace` | Back to agents |
 | `r` | Reload sessions |
 | `q` | Quit |
@@ -85,9 +87,14 @@ For sessions with an LCM `conv_id`, the conversation view uses keyset-paged wind
 | `l` | Open **Summary DAG** view |
 | `c` | Open **Context** view |
 | `f` | Open **Large Files** view |
+| `v` | Open **Codex ↔ LCM** comparison view |
 | `b`/`Backspace` | Back to sessions |
 | `r` | Reload messages |
 | `q` | Quit |
+
+### Codex ↔ LCM Comparison
+
+For Codex app-server bound sessions, the comparison view renders native Codex backend rollout rows beside the Lossless-managed active context items for the same OpenClaw session. The panes are index-aligned for inspection rather than treated as a causal one-to-one mapping: Codex rows show what the backend session recorded, while LCM rows show summaries and fresh-tail messages that Lossless would assemble.
 
 ## Summary DAG View
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -161,7 +161,7 @@ Why it matters:
 
 - Gives Lossless an escape hatch when too many summaries at the preferred depth still leave the prompt near full.
 - When unset, Lossless derives a target from `contextThreshold`, the active token budget, and `leafChunkTokens`.
-- Sweeps first honor `sweepMaxDepth`; pressure condensation can go deeper only when threshold or summary-prefix pressure remains.
+- Sweeps first exhaust eligible raw-message leaf chunks, then honor `sweepMaxDepth`; pressure condensation can go deeper only when summary-prefix pressure remains.
 
 ### `incrementalMaxDepth`
 

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import type { ConversationStore, CreateMessagePartInput } from "./store/conversation-store.js";
+import { contentFromParts } from "./assembler.js";
+import type {
+  ConversationStore,
+  CreateMessagePartInput,
+  MessagePartRecord,
+  MessageRecord,
+  MessageRole,
+} from "./store/conversation-store.js";
 import type { SummaryStore, SummaryRecord, ContextItemRecord } from "./store/summary-store.js";
 import { estimateTokens, truncateTextToEstimatedTokens } from "./estimate-tokens.js";
 import { extractFileIdsFromContent } from "./large-files.js";
@@ -198,7 +205,21 @@ const MEDIA_ATTACHMENT_PART_TYPES = new Set(["file", "snapshot"]);
 const MEDIA_ATTACHMENT_RAW_TYPES = new Set(["file", "image", "snapshot"]);
 const PROVIDER_REASONING_RAW_TYPES = new Set(["reasoning", "thinking"]);
 const STRUCTURED_MEDIA_TEXT_KEYS = ["text", "caption", "alt", "title", "summary"] as const;
-const STRUCTURED_MEDIA_NESTED_KEYS = ["content", "parts", "items", "message", "messages"] as const;
+const STRUCTURED_MEDIA_NESTED_KEYS = [
+  "content",
+  "parts",
+  "items",
+  "message",
+  "messages",
+  "input",
+  "arguments",
+  "output",
+  "result",
+  "results",
+  "data",
+  "query",
+  "command",
+] as const;
 
 const CONDENSED_MIN_INPUT_RATIO = 0.1;
 
@@ -336,6 +357,74 @@ function extractMeaningfulMessageText(content: string): string {
     }
   }
   return stripEmbeddedMediaPayloads(content);
+}
+
+/** Map stored message roles back to runtime roles for structured reconstruction. */
+function runtimeRoleForSummary(role: MessageRole): "user" | "assistant" | "toolResult" {
+  if (role === "tool") {
+    return "toolResult";
+  }
+  if (role === "user" || role === "system") {
+    return "user";
+  }
+  return "assistant";
+}
+
+/** Parse JSON-ish message-part values while preserving plain text values. */
+function parseStoredPartValue(value: string | null | undefined): unknown {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return trimmed;
+  }
+}
+
+/** Extract summarizable text from a structured runtime content value. */
+function extractMeaningfulStructuredText(value: unknown): string {
+  if (typeof value === "string") {
+    return extractMeaningfulMessageText(value);
+  }
+  const extracted = extractSanitizedStructuredText(value)
+    .map((fragment) => fragment.trim())
+    .filter(Boolean);
+  if (extracted.length > 0) {
+    return extracted.join("\n").trim();
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? extractMeaningfulMessageText(serialized) : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Extract a readable fallback from one structured message part. */
+function extractMessagePartSummaryText(part: MessagePartRecord): string {
+  const sections: string[] = [];
+  const text = extractMeaningfulStructuredText(part.textContent);
+  if (text) {
+    sections.push(text);
+  }
+
+  const toolName = part.toolName?.trim();
+  const toolLabel = toolName ? ` (${toolName})` : "";
+  const input = extractMeaningfulStructuredText(parseStoredPartValue(part.toolInput));
+  if (input) {
+    sections.push(`Tool input${toolLabel}:\n${input}`);
+  }
+  const output = extractMeaningfulStructuredText(parseStoredPartValue(part.toolOutput));
+  if (output) {
+    sections.push(`Tool output${toolLabel}:\n${output}`);
+  }
+
+  return sections.join("\n\n").trim();
 }
 
 /** Identify whether a stored message part represents a media attachment. */
@@ -716,10 +805,6 @@ export class CompactionEngine {
       previousSummaryContent = leafResult.content;
       runningTokens = passTokensAfter;
 
-      if (!force && passTokensAfter <= threshold) {
-        previousTokens = passTokensAfter;
-        break;
-      }
       if (passTokensAfter >= passTokensBefore || passTokensAfter >= previousTokens) {
         break;
       }
@@ -786,7 +871,7 @@ export class CompactionEngine {
       return "progress";
     };
 
-    while (force || previousTokens > threshold || await hasSummaryPrefixPressure()) {
+    while (await hasSummaryPrefixPressure()) {
       const status = await runCondensationPass({
         enforcePreferredDepth: true,
         useHardFanout: hardTrigger === true,
@@ -802,7 +887,7 @@ export class CompactionEngine {
     while (
       !hadAuthFailure &&
       !stoppedForNoProgress &&
-      (previousTokens > threshold || await hasSummaryPrefixPressure())
+      await hasSummaryPrefixPressure()
     ) {
       const status = await runCondensationPass({
         enforcePreferredDepth: false,
@@ -1535,8 +1620,9 @@ export class CompactionEngine {
   private async annotateMediaContent(
     messageId: number,
     content: string,
+    preloadedParts?: MessagePartRecord[],
   ): Promise<string> {
-    const parts = await this.conversationStore.getMessageParts(messageId);
+    const parts = preloadedParts ?? (await this.conversationStore.getMessageParts(messageId));
     const hasMediaParts = parts.some((part) => isMediaAttachmentPart(part));
     if (!hasMediaParts) {
       return content;
@@ -1562,6 +1648,48 @@ export class CompactionEngine {
     return `${meaningfulText} [with media attachment]`;
   }
 
+  /**
+   * Reconstruct the text used by leaf summaries from stored message data.
+   *
+   * Plain `messages.content` is preferred when present, but structured tool
+   * calls/results often store their actual payload in `message_parts` while the
+   * fallback content column is empty. Rehydrating through the assembler helper
+   * keeps compaction aligned with the prompt assembly path.
+   */
+  private async resolveLeafSummaryMessageContent(msg: MessageRecord): Promise<string> {
+    const parts = await this.conversationStore.getMessageParts(msg.messageId);
+    const annotatedContent = await this.annotateMediaContent(
+      msg.messageId,
+      msg.content,
+      parts,
+    );
+    const storedText = extractMeaningfulMessageText(annotatedContent);
+    if (storedText) {
+      return storedText;
+    }
+
+    if (parts.length === 0) {
+      return "";
+    }
+
+    const rehydrated = contentFromParts(
+      parts.map((part) => ({ ...part })),
+      runtimeRoleForSummary(msg.role),
+      msg.content,
+    );
+    const rehydratedText = extractMeaningfulStructuredText(rehydrated);
+    if (rehydratedText) {
+      return rehydratedText;
+    }
+
+    return parts
+      .map(extractMessagePartSummaryText)
+      .map((text) => text.trim())
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+  }
+
   // ── Private: Leaf Pass ───────────────────────────────────────────────────
 
   /**
@@ -1583,13 +1711,9 @@ export class CompactionEngine {
       }
       const msg = await this.conversationStore.getMessageById(item.messageId);
       if (msg) {
-        const annotatedContent = await this.annotateMediaContent(
-          msg.messageId,
-          msg.content,
-        );
         messageContents.push({
           messageId: msg.messageId,
-          content: annotatedContent,
+          content: await this.resolveLeafSummaryMessageContent(msg),
           createdAt: msg.createdAt,
           tokenCount: this.resolveMessageTokenCount(msg),
         });

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -11,6 +11,10 @@ import { LcmProviderAuthError } from "./summarize.js";
 export interface CompactionDecision {
   shouldCompact: boolean;
   reason: "threshold" | "manual" | "none";
+  /** Persisted Lossless context tokens before runtime prompt overhead. */
+  storedTokens: number;
+  /** Runtime-observed prompt tokens, when supplied by the host. */
+  observedTokens?: number;
   currentTokens: number;
   threshold: number;
 }
@@ -428,6 +432,8 @@ export class CompactionEngine {
       return {
         shouldCompact: true,
         reason: "threshold",
+        storedTokens,
+        ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
         currentTokens,
         threshold,
       };
@@ -436,6 +442,8 @@ export class CompactionEngine {
     return {
       shouldCompact: false,
       reason: "none",
+      storedTokens,
+      ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
       currentTokens,
       threshold,
     };

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -569,6 +569,8 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn;
     force?: boolean;
     hardTrigger?: boolean;
+    /** Optional persisted-context target used when host runtime overhead is known. */
+    stopAtTokens?: number;
     summaryModel?: string;
   }): Promise<CompactionResult> {
     return this.withContextCache(() => this.compactFullSweep(input));
@@ -732,14 +734,26 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn;
     force?: boolean;
     hardTrigger?: boolean;
+    /** Optional persisted-context target used when host runtime overhead is known. */
+    stopAtTokens?: number;
     summaryModel?: string;
   }): Promise<CompactionResult> {
     const { conversationId, tokenBudget, summarize, force, hardTrigger } = input;
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    const stopAtTokens =
+      typeof input.stopAtTokens === "number" &&
+      Number.isFinite(input.stopAtTokens) &&
+      input.stopAtTokens > 0
+        ? Math.floor(input.stopAtTokens)
+        : undefined;
 
-    if (!force && tokensBefore <= threshold) {
+    if (
+      !force &&
+      tokensBefore <= threshold &&
+      (stopAtTokens === undefined || tokensBefore <= stopAtTokens)
+    ) {
       return {
         actionTaken: false,
         tokensBefore,
@@ -816,6 +830,10 @@ export class CompactionEngine {
     const summaryPrefixTargetTokens = this.resolveSummaryPrefixTargetTokens(tokenBudget);
     const hasSummaryPrefixPressure = async (): Promise<boolean> =>
       (await this.countSummaryTokensOutsideFreshTail(conversationId)) > summaryPrefixTargetTokens;
+    const hasStopTargetPressure = (): boolean =>
+      stopAtTokens !== undefined && runningTokens > stopAtTokens;
+    const hasCondensationPressure = async (): Promise<boolean> =>
+      hasStopTargetPressure() || await hasSummaryPrefixPressure();
 
     const runCondensationPass = async (params: {
       enforcePreferredDepth: boolean;
@@ -860,6 +878,10 @@ export class CompactionEngine {
       level = condenseResult.level;
       runningTokens = passTokensAfter;
 
+      if (stopAtTokens !== undefined && passTokensAfter <= stopAtTokens) {
+        previousTokens = passTokensAfter;
+        return "progress";
+      }
       if (!force && passTokensAfter <= threshold) {
         previousTokens = passTokensAfter;
         return "progress";
@@ -871,7 +893,7 @@ export class CompactionEngine {
       return "progress";
     };
 
-    while (await hasSummaryPrefixPressure()) {
+    while (await hasCondensationPressure()) {
       const status = await runCondensationPass({
         enforcePreferredDepth: true,
         useHardFanout: hardTrigger === true,
@@ -887,7 +909,7 @@ export class CompactionEngine {
     while (
       !hadAuthFailure &&
       !stoppedForNoProgress &&
-      await hasSummaryPrefixPressure()
+      await hasCondensationPressure()
     ) {
       const status = await runCondensationPass({
         enforcePreferredDepth: false,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2652,6 +2652,24 @@ export class LcmContextEngine implements ContextEngine {
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
     const liveContextStillExceedsTarget =
       observedTokens !== undefined && observedTokens >= targetTokens;
+    // Codex can report a live prompt count that includes runtime framing,
+    // tool schemas, and other overhead not present in Lossless's stored count.
+    // If that live count crosses the threshold, compact stored context far
+    // enough that stored tokens plus the observed overhead should fit.
+    const decisionStoredTokens =
+      typeof decision.storedTokens === "number"
+      && Number.isFinite(decision.storedTokens)
+      && decision.storedTokens >= 0
+        ? Math.floor(decision.storedTokens)
+        : decision.currentTokens;
+    const observedRuntimeOverhead =
+      params.compactionTarget === "threshold" && observedTokens !== undefined
+        ? Math.max(0, observedTokens - decisionStoredTokens)
+        : 0;
+    const runtimeAdjustedSweepTargetTokens =
+      observedRuntimeOverhead > 0 && observedTokens !== undefined && observedTokens > targetTokens
+        ? Math.max(1, targetTokens - observedRuntimeOverhead)
+        : undefined;
 
     if (!forceCompaction && !decision.shouldCompact) {
       return {
@@ -2672,9 +2690,12 @@ export class LcmContextEngine implements ContextEngine {
         conversationId,
         tokenBudget,
         summarize,
-        force: forceCompaction,
+        force: forceCompaction || runtimeAdjustedSweepTargetTokens !== undefined,
         hardTrigger: false,
         summaryModel,
+        ...(runtimeAdjustedSweepTargetTokens !== undefined
+          ? { stopAtTokens: runtimeAdjustedSweepTargetTokens }
+          : {}),
       });
 
       if (sweepResult.authFailure && breakerKey) {
@@ -2689,10 +2710,14 @@ export class LcmContextEngine implements ContextEngine {
         typeof sweepResult.tokensAfter === "number" && Number.isFinite(sweepResult.tokensAfter)
           ? sweepResult.tokensAfter
           : undefined;
+      const projectedTokensAfterSweep =
+        sweepTokensAfter !== undefined && runtimeAdjustedSweepTargetTokens !== undefined
+          ? sweepTokensAfter + observedRuntimeOverhead
+          : sweepTokensAfter;
       const isThresholdSweep = params.compactionTarget === "threshold";
       const isUnderTargetAfterSweep =
-        sweepTokensAfter !== undefined
-          ? sweepTokensAfter <= targetTokens
+        projectedTokensAfterSweep !== undefined
+          ? projectedTokensAfterSweep <= targetTokens
           : isThresholdSweep
             ? false
             : !liveContextStillExceedsTarget;
@@ -2723,7 +2748,13 @@ export class LcmContextEngine implements ContextEngine {
           tokensAfter: sweepResult.tokensAfter,
           details: {
             rounds: sweepResult.actionTaken ? 1 : 0,
-            targetTokens,
+            targetTokens: runtimeAdjustedSweepTargetTokens ?? targetTokens,
+            ...(runtimeAdjustedSweepTargetTokens !== undefined
+              ? {
+                  observedOverheadTokens: observedRuntimeOverhead,
+                  projectedTokensAfter: projectedTokensAfterSweep,
+                }
+              : {}),
           },
         },
       };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -65,7 +65,7 @@ import {
   type MessagePartRecord,
   type MessagePartType,
 } from "./store/conversation-store.js";
-import { SummaryStore } from "./store/summary-store.js";
+import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "./summarize.js";
 import type { LcmDependencies, StartupSessionFileCandidate } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
@@ -89,6 +89,7 @@ type BootstrapImportObservation = {
 };
 
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
+const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 type CircuitBreakerState = {
   failures: number;
   openSince: number | null;
@@ -157,6 +158,35 @@ type DeferredCompactionDebtDrainParams = {
   currentTokenCount?: number;
   reason: string;
 };
+
+function buildContextEngineProjectionEpoch(
+  conversationId: number,
+  contextItems: ContextItemRecord[],
+): string {
+  const hash = createHash("sha256");
+  hash.update(CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION);
+  hash.update("\0");
+  hash.update(String(conversationId));
+
+  // Only summaries are part of the projection epoch. Raw tail growth is already
+  // visible to a live Codex backend thread, while summary changes represent a
+  // new compacted semantic prefix that must be bootstrapped into a fresh thread.
+  for (const item of contextItems) {
+    if (item.itemType !== "summary" || !item.summaryId) {
+      continue;
+    }
+    hash.update("\0");
+    hash.update(String(item.ordinal));
+    hash.update(":");
+    hash.update(item.summaryId);
+  }
+
+  return [
+    CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION,
+    conversationId,
+    hash.digest("hex").slice(0, 32),
+  ].join(":");
+}
 
 function checkpointIsPastTranscriptEof(
   checkpoint: BootstrapCheckpointFileState | null | undefined,
@@ -2593,6 +2623,11 @@ export class LcmContextEngine implements ContextEngine {
 
   /** Run the actual compaction body without taking the per-session queue. */
   private async executeCompactionCore(params: CompactionExecutionParams): Promise<CompactResult> {
+    const startedAt = Date.now();
+    const sessionLabel = [
+      `session=${params.sessionId}`,
+      ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+    ].join(" ");
     const { force = false } = params;
     const legacyParams = asRecord(params.runtimeContext) ?? params.legacyParams;
     const lp = legacyParams ?? {};
@@ -2671,7 +2706,14 @@ export class LcmContextEngine implements ContextEngine {
         ? Math.max(1, targetTokens - observedRuntimeOverhead)
         : undefined;
 
+    this.deps.log.info(
+      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
+    );
+
     if (!forceCompaction && !decision.shouldCompact) {
+      this.deps.log.info(
+        `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=true compacted=false reason=below_threshold tokensBefore=${decision.currentTokens} duration=${formatDurationMs(Date.now() - startedAt)}`,
+      );
       return {
         ok: true,
         compacted: false,
@@ -2726,23 +2768,27 @@ export class LcmContextEngine implements ContextEngine {
       const sweepOk =
         !sweepResult.authFailure &&
         (isUnderTargetAfterSweep || (sweepResult.actionTaken && !isThresholdSweep));
+      const sweepReason = sweepResult.authFailure
+        ? (sweepResult.actionTaken
+            ? "provider auth failure after partial compaction"
+            : "provider auth failure")
+        : thresholdSweepStillOverTarget
+          ? "compacted but still over target"
+        : sweepResult.actionTaken
+          ? "compacted"
+          : isUnderTargetAfterSweep
+            ? "already under target"
+            : manualCompactionRequested
+              ? "nothing to compact"
+              : "live context still exceeds target";
+      this.deps.log.info(
+        `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${sweepOk} compacted=${sweepResult.actionTaken} reason=${sweepReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${sweepResult.tokensAfter} createdSummaryId=${sweepResult.createdSummaryId ?? "none"} duration=${formatDurationMs(Date.now() - startedAt)}`,
+      );
 
       return {
         ok: sweepOk,
         compacted: sweepResult.actionTaken,
-        reason: sweepResult.authFailure
-          ? (sweepResult.actionTaken
-              ? "provider auth failure after partial compaction"
-              : "provider auth failure")
-          : thresholdSweepStillOverTarget
-            ? "compacted but still over target"
-          : sweepResult.actionTaken
-            ? "compacted"
-            : isUnderTargetAfterSweep
-              ? "already under target"
-              : manualCompactionRequested
-                ? "nothing to compact"
-                : "live context still exceeds target",
+        reason: sweepReason,
         result: {
           tokensBefore: decision.currentTokens,
           tokensAfter: sweepResult.tokensAfter,
@@ -2797,18 +2843,23 @@ export class LcmContextEngine implements ContextEngine {
       await this.markLeafCompactionTelemetrySuccess({ conversationId });
     }
 
+    const compactUntilReason = compactResult.authFailure
+      ? (didCompact
+          ? "provider auth failure after partial compaction"
+          : "provider auth failure")
+      : compactResult.success
+        ? didCompact
+          ? "compacted"
+          : "already under target"
+        : "could not reach target";
+    this.deps.log.info(
+      `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${compactResult.success} compacted=${didCompact} reason=${compactUntilReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${compactResult.finalTokens} rounds=${compactResult.rounds} duration=${formatDurationMs(Date.now() - startedAt)}`,
+    );
+
     return {
       ok: compactResult.success,
       compacted: didCompact,
-      reason: compactResult.authFailure
-        ? (didCompact
-            ? "provider auth failure after partial compaction"
-            : "provider auth failure")
-        : compactResult.success
-          ? didCompact
-            ? "compacted"
-            : "already under target"
-          : "could not reach target",
+      reason: compactUntilReason,
       result: {
         tokensBefore: decision.currentTokens,
         tokensAfter: compactResult.finalTokens,
@@ -6041,8 +6092,13 @@ export class LcmContextEngine implements ContextEngine {
       const stubStatsLog = assembled.debug?.stubStats
         ? ` stubbed=${assembled.debug.stubStats.stubbedCount} tokensSaved=${assembled.debug.stubStats.tokensSaved}`
         : "";
+      const contextProjectionEpoch = buildContextEngineProjectionEpoch(
+        conversation.conversationId,
+        contextItems,
+      );
+      const summaryContextItems = contextItems.filter((item) => item.itemType === "summary").length;
       this.deps.log.info(
-        `[lcm] assemble: done conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} hasSummaryItems=${hasSummaryItems} inputMessages=${params.messages.length} outputMessages=${assembled.messages.length} tokenBudget=${tokenBudget} estimatedTokens=${assembled.estimatedTokens}${stubStatsLog} duration=${formatDurationMs(Date.now() - startedAt)}`,
+        `[lcm] assemble: done conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} summaryContextItems=${summaryContextItems} hasSummaryItems=${hasSummaryItems} inputMessages=${params.messages.length} outputMessages=${assembled.messages.length} tokenBudget=${tokenBudget} estimatedTokens=${assembled.estimatedTokens} contextProjectionMode=thread_bootstrap contextProjectionEpoch=${contextProjectionEpoch}${stubStatsLog} duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
       const prefixChange = describeAssembledPrefixChange(
         this.getPreviousAssembledSnapshot(conversation.conversationId),
@@ -6077,6 +6133,10 @@ export class LcmContextEngine implements ContextEngine {
       const result: AssembleResult = {
         messages: assembled.messages,
         estimatedTokens: assembled.estimatedTokens,
+        contextProjection: {
+          mode: "thread_bootstrap",
+          epoch: contextProjectionEpoch,
+        },
       };
       return result;
     } catch (err) {
@@ -6130,6 +6190,9 @@ export class LcmContextEngine implements ContextEngine {
     force?: boolean;
   }): Promise<CompactResult> {
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      this.deps.log.info(
+        `[lcm] compact: skipped session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded`,
+      );
       return {
         ok: true,
         compacted: false,
@@ -6137,6 +6200,9 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
     if (this.isStatelessSession(params.sessionKey)) {
+      this.deps.log.info(
+        `[lcm] compact: skipped session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=stateless_session`,
+      );
       return {
         ok: true,
         compacted: false,
@@ -6152,6 +6218,9 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
         });
         if (!conversation) {
+          this.deps.log.info(
+            `[lcm] compact: skipped session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=no_conversation_found`,
+          );
           return {
             ok: true,
             compacted: false,

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -1,26 +1,146 @@
+export type {
+  AnyAgentTool,
+} from "openclaw/plugin-sdk";
+
 /**
  * Compatibility bridge for plugin-sdk context-engine symbols.
  *
- * This module intentionally exports only stable plugin-sdk surface area.
+ * This module intentionally keeps the context-engine contract local because
+ * older OpenClaw SDK packages do not publish these newer type symbols yet.
  */
 
-export type {
-  AnyAgentTool,
-  ContextEngine,
-  ContextEngineInfo,
-  AssembleResult,
-  CompactResult,
-  IngestResult,
-  IngestBatchResult,
-  BootstrapResult,
-  OpenClawPluginApi,
-  OpenClawPluginCommandDefinition,
-  PluginCommandContext,
-  SubagentSpawnPreparation,
-  SubagentEndReason,
-} from "openclaw/plugin-sdk";
+export type ContextEngineProjection = {
+  mode: "per_turn" | "thread_bootstrap";
+  epoch?: string;
+  fingerprint?: string;
+};
 
-export {
-  registerContextEngine,
-  type ContextEngineFactory,
-} from "openclaw/plugin-sdk";
+export type AssembleResult = {
+  messages: AgentMessage[];
+  estimatedTokens: number;
+  systemPromptAddition?: string;
+  contextProjection?: ContextEngineProjection;
+};
+
+export type BootstrapResult = {
+  bootstrapped: boolean;
+  importedMessages: number;
+  reason?: string;
+};
+
+export type CompactResult = {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+  summaryId?: string;
+  error?: string;
+  result?: unknown;
+};
+
+export type IngestResult = {
+  ingested: boolean;
+};
+
+export type IngestBatchResult = {
+  ingestedCount: number;
+};
+
+export type SubagentSpawnPreparation = {
+  systemPromptAddition?: string;
+  rollback?: () => void;
+};
+
+export type SubagentEndReason = string;
+
+export type ContextEngineInfo = {
+  id: string;
+  name: string;
+  version: string;
+  ownsCompaction?: boolean;
+  turnMaintenanceMode?: "background" | "inline" | string;
+};
+
+export type PluginCommandContext = {
+  [key: string]: any;
+};
+
+export type OpenClawPluginCommandDefinition = {
+  name?: string;
+  description?: string;
+  handler?: (ctx: PluginCommandContext) => unknown | Promise<unknown>;
+  [key: string]: any;
+};
+
+export type ContextEngineFactory = () => ContextEngine | Promise<ContextEngine>;
+
+export type OpenClawPluginApi = {
+  config?: any;
+  runtime?: any;
+  logger?: any;
+  log?: any;
+  registerCommand: (definition: OpenClawPluginCommandDefinition) => void;
+  registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
+  [key: string]: any;
+};
+
+export type AgentMessage = {
+  role: string;
+  content?: any;
+  timestamp?: number;
+  toolCallId?: string;
+  toolUseId?: string;
+  toolName?: string;
+  details?: any;
+  isError?: boolean;
+};
+
+export type ContextEngine = {
+  info: ContextEngineInfo;
+  bootstrap(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile?: string;
+    messages?: AgentMessage[];
+  }): Promise<BootstrapResult>;
+  ingest(params: {
+    sessionId: string;
+    sessionKey?: string;
+    message: AgentMessage;
+  }): Promise<IngestResult>;
+  ingestBatch?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+    isHeartbeat?: boolean;
+  }): Promise<IngestBatchResult>;
+  assemble(params: {
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+    prompt?: string;
+  }): Promise<AssembleResult>;
+  compact(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile?: string;
+    tokenBudget?: number;
+    currentTokenCount?: number;
+    compactionTarget?: "budget" | "threshold";
+    customInstructions?: string;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
+    force?: boolean;
+  }): Promise<CompactResult>;
+  prepareSubagentSpawn?(params: {
+    parentSessionId?: string;
+    parentSessionKey?: string;
+    childSessionId?: string;
+    childSessionKey: string;
+  }): Promise<SubagentSpawnPreparation | undefined>;
+  onSubagentEnded?(params: {
+    childSessionId?: string;
+    childSessionKey: string;
+    reason?: SubagentEndReason;
+  }): Promise<void>;
+};

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9010,8 +9010,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect.objectContaining({
         conversationId: conversation.conversationId,
         tokenBudget: 4_096,
-        force: false,
+        force: true,
         hardTrigger: false,
+        stopAtTokens: 1,
       }),
     );
     expect(maintenance?.pending).toBe(true);
@@ -10481,6 +10482,126 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         summarize: expect.any(Function),
         force: false,
         hardTrigger: false,
+      }),
+    );
+  });
+
+  it("forces threshold sweeps to account for runtime prompt overhead", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 7_000,
+      observedTokens: 12_000,
+      currentTokens: 12_000,
+      threshold: 8_200,
+    });
+    const compactFullSweepSpy = vi
+      .spyOn(privateEngine.compaction, "compactFullSweep")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 7_000,
+        tokensAfter: 3_200,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "threshold-runtime-overhead-session",
+      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-runtime-overhead-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(compactFullSweepSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 10_000,
+        summarize: expect.any(Function),
+        force: true,
+        hardTrigger: false,
+        stopAtTokens: 3_200,
+      }),
+    );
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 3_200,
+        observedOverheadTokens: 5_000,
+        projectedTokensAfter: 8_200,
+      }),
+    );
+  });
+
+  it("does not clear threshold pressure when persisted tokens are under target but runtime tokens remain over", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 7_000,
+      observedTokens: 12_000,
+      currentTokens: 12_000,
+      threshold: 8_200,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 7_000,
+      tokensAfter: 7_000,
+      condensed: false,
+    });
+
+    await engine.ingest({
+      sessionId: "threshold-runtime-still-over-session",
+      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-runtime-still-over-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("live context still exceeds target");
+    expect(result.result?.tokensBefore).toBe(12_000);
+    expect(result.result?.tokensAfter).toBe(7_000);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 3_200,
+        observedOverheadTokens: 5_000,
+        projectedTokensAfter: 12_000,
       }),
     );
   });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5434,6 +5434,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
     expect(result.estimatedTokens).toBe(0);
+    expect(result.contextProjection).toBeUndefined();
   });
 
   it("falls back when DB context clearly trails live context", async () => {
@@ -5459,6 +5460,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
     expect(result.estimatedTokens).toBe(0);
+    expect(result.contextProjection).toBeUndefined();
   });
 
   it("assembles context from DB when coverage exists", async () => {
@@ -5487,6 +5489,90 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages[0].content).toBe("persisted message one");
     expect(result.messages[1].role).toBe("assistant");
     expect(result.estimatedTokens).toBeGreaterThan(0);
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
+    });
+  });
+
+  it("logs the emitted context projection epoch", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: infoLog,
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "session-projection-log";
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "persisted message one" } as AgentMessage,
+    });
+    const result = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+
+    const assembleDoneLog = infoLog.mock.calls
+      .map((call: unknown[]) => call[0])
+      .find((entry: unknown) => typeof entry === "string" && entry.includes("[lcm] assemble: done"));
+    expect(assembleDoneLog).toEqual(expect.any(String));
+    expect(assembleDoneLog).toContain("contextProjectionMode=thread_bootstrap");
+    expect(assembleDoneLog).toContain(`contextProjectionEpoch=${result.contextProjection?.epoch}`);
+    expect(assembleDoneLog).toContain("summaryContextItems=0");
+  });
+
+  it("keeps projection epochs stable across raw tail growth and changes them for summaries", async () => {
+    const engine = createEngine();
+    const sessionId = "session-projection-epoch";
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "persisted message one" } as AgentMessage,
+    });
+    const first = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+    expect(first.contextProjection?.mode).toBe("thread_bootstrap");
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "assistant", content: "persisted message two" } as AgentMessage,
+    });
+    const afterRawTail = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+    expect(afterRawTail.contextProjection?.epoch).toBe(first.contextProjection?.epoch);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_projection_epoch",
+      conversationId: conversation!.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "Summary projection content",
+      tokenCount: 8,
+      descendantCount: 0,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(conversation!.conversationId, "sum_projection_epoch");
+
+    const afterSummary = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+    expect(afterSummary.contextProjection?.epoch).not.toBe(first.contextProjection?.epoch);
   });
 
   it("respects token budget in assembled output", async () => {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1426,6 +1426,85 @@ describe("LCM integration: compaction", () => {
     expect(capturedSourceText).toContain("A plain user message.");
   });
 
+  it("leaf compaction summarizes structured message parts when stored content is empty", async () => {
+    const structuredPartEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafChunkTokens: 1_000,
+    });
+    await convStore.createConversation({ sessionId: "structured-parts-session" });
+
+    const assistant = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 1,
+      role: "assistant",
+      content: "",
+      tokenCount: 120,
+    });
+    await convStore.createMessageParts(assistant.messageId, [
+      {
+        sessionId: "structured-parts-session",
+        partType: "tool",
+        ordinal: 0,
+        toolName: "supabase.execute_sql",
+        toolInput: JSON.stringify({
+          query: "select name from companies where status = 'active'",
+        }),
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          rawType: "function_call",
+        }),
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, assistant.messageId);
+
+    const toolResult = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 2,
+      role: "tool",
+      content: "",
+      tokenCount: 400,
+    });
+    await convStore.createMessageParts(toolResult.messageId, [
+      {
+        sessionId: "structured-parts-session",
+        partType: "tool",
+        ordinal: 0,
+        textContent: JSON.stringify({
+          content: [{ type: "text", text: "Active company: Acme Robotics" }],
+        }),
+        metadata: JSON.stringify({
+          originalRole: "toolResult",
+          rawType: "function_call_output",
+        }),
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, toolResult.messageId);
+
+    let capturedSourceText = "";
+    const summarize = vi.fn(async (text: string) => {
+      capturedSourceText = text;
+      return "Structured parts summary.";
+    });
+
+    const result = await structuredPartEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 10_000,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(capturedSourceText).toContain("select name from companies");
+    expect(capturedSourceText).toContain("Active company: Acme Robotics");
+
+    const leafSummary = sumStore._summaries.find((summary) => summary.kind === "leaf");
+    expect(leafSummary?.content).toBe("Structured parts summary.");
+    expect(leafSummary?.content).not.toContain("[Truncated from 0 tokens]");
+    expect(leafSummary?.sourceMessageTokenCount).toBe(520);
+  });
+
   it("leaf-trigger accounting respects fresh tail token caps", async () => {
     const tokenAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
@@ -1889,6 +1968,7 @@ describe("LCM integration: compaction", () => {
       leafChunkTokens: 200,
       condensedTargetTokens: 10,
       sweepMaxDepth: 1,
+      summaryPrefixTargetTokens: 100,
     });
     await seedLeafSummaries(sumStore, "sum_sweep_depth_one");
 
@@ -1918,6 +1998,41 @@ describe("LCM integration: compaction", () => {
     expect(
       sumStore._summaries.some((summary) => summary.kind === "condensed" && summary.depth === 1),
     ).toBe(true);
+  });
+
+  it("compactFullSweep runs leaf phase until no eligible raw chunks remain", async () => {
+    const sweepEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      contextThreshold: 0.75,
+      freshTailCount: 2,
+      leafChunkTokens: 400,
+      leafTargetTokens: 20,
+      condensedMinFanout: 2,
+      condensedMinFanoutHard: 2,
+      sweepMaxDepth: 1,
+      summaryPrefixTargetTokens: 10_000,
+    });
+
+    await ingestMessages(convStore, sumStore, 10, {
+      contentFn: (i) => `Message ${i} with enough text to summarize.`,
+      tokenCountFn: () => 200,
+    });
+
+    let leafIndex = 0;
+    const summarize = vi.fn(async () => `Leaf summary ${++leafIndex}`);
+    const result = await sweepEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 2_500,
+      summarize,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(summarize).toHaveBeenCalledTimes(4);
+    expect(sumStore._summaries.filter((summary) => summary.kind === "leaf")).toHaveLength(4);
+
+    const contextItems = await sumStore.getContextItems(CONV_ID);
+    expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(2);
+    expect(contextItems.filter((item) => item.itemType === "summary")).toHaveLength(4);
   });
 
   it("compactFullSweep pressure-condenses beyond sweepMaxDepth when summary prefix exceeds target", async () => {
@@ -1974,10 +2089,10 @@ describe("LCM integration: compaction", () => {
     ).toBe(true);
   });
 
-  it("compactFullSweep pressure-condenses beyond sweepMaxDepth when still over threshold", async () => {
+  it("compactFullSweep does not pressure-condense for total-threshold pressure alone", async () => {
     const pressureEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
-      freshTailCount: 0,
+      freshTailCount: 2,
       condensedMinFanout: 4,
       condensedMinFanoutHard: 2,
       leafChunkTokens: 500,
@@ -1999,6 +2114,10 @@ describe("LCM integration: compaction", () => {
       });
       await sumStore.appendContextSummary(CONV_ID, summaryId);
     }
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Fresh tail message ${i}`,
+      tokenCountFn: () => 1_000,
+    });
 
     const summarize = vi.fn(async () => "Depth two threshold pressure summary");
     const result = await pressureEngine.compactFullSweep({
@@ -2007,11 +2126,12 @@ describe("LCM integration: compaction", () => {
       summarize,
     });
 
-    expect(result.actionTaken).toBe(true);
-    expect(result.condensed).toBe(true);
+    expect(result.actionTaken).toBe(false);
+    expect(result.condensed).toBe(false);
+    expect(summarize).not.toHaveBeenCalled();
     expect(
       sumStore._summaries.some((summary) => summary.kind === "condensed" && summary.depth === 2),
-    ).toBe(true);
+    ).toBe(false);
   });
 
 
@@ -2093,6 +2213,7 @@ describe("LCM integration: compaction", () => {
       leafChunkTokens: 100,
       condensedTargetTokens: 10,
       incrementalMaxDepth: 1,
+      summaryPrefixTargetTokens: 1,
     });
 
     await convStore.createConversation({ sessionId: "leaf-condensed-session" });
@@ -2191,7 +2312,7 @@ describe("LCM integration: compaction", () => {
       leafChunkTokens: 200,
       condensedTargetTokens: 10,
       incrementalMaxDepth: 1,
-      summaryPrefixTargetTokens: 1_000,
+      summaryPrefixTargetTokens: 150,
     });
 
     await convStore.createConversation({ sessionId: "depth-break-session" });
@@ -2454,7 +2575,7 @@ describe("LCM integration: compaction", () => {
     expect(depthZeroCall?.options?.previousSummary).toContain("Depth zero prior context");
   });
 
-  it("enforces fanout thresholds and only relaxes them in hard-trigger mode", async () => {
+  it("relaxes fanout thresholds only under summarized-prefix pressure", async () => {
     const depthAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
       leafMinFanout: 3,
@@ -2495,14 +2616,23 @@ describe("LCM integration: compaction", () => {
     });
     expect(normalResult.actionTaken).toBe(false);
 
-    const hardResult = await depthAwareEngine.compactFullSweep({
+    const pressureEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      leafMinFanout: 3,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      leafChunkTokens: 200,
+      condensedTargetTokens: 10,
+      incrementalMaxDepth: 1,
+      summaryPrefixTargetTokens: 100,
+    });
+    const pressureResult = await pressureEngine.compactFullSweep({
       conversationId: CONV_ID,
       tokenBudget: 500,
       summarize,
       force: true,
-      hardTrigger: true,
     });
-    expect(hardResult.actionTaken).toBe(true);
+    expect(pressureResult.actionTaken).toBe(true);
   });
 
   it("keeps condensed parents at uniform depth across interleaved sweeps", async () => {
@@ -3429,11 +3559,11 @@ describe("LCM integration: full round-trip", () => {
       leafChunkTokens: 100,
       condensedTargetTokens: 10,
       incrementalMaxDepth: 1,
+      summaryPrefixTargetTokens: 1,
     });
 
-    // Ingest 12 messages with substantial content so that after the leaf pass,
-    // the remaining context (1 small summary + 4 fresh messages) still exceeds
-    // the threshold, forcing the condensed pass to run on the second round.
+    // Ingest 12 messages with substantial content so that leaf exhaustion
+    // creates enough summary-prefix pressure to force a condensed pass.
     await ingestMessages(convStore, sumStore, 12, {
       contentFn: (i) => `Turn ${i}: ${"z".repeat(200)}`,
       tokenCountFn: (_i, content) => estimateTokens(content),
@@ -3446,12 +3576,9 @@ describe("LCM integration: full round-trip", () => {
     });
 
     // First compaction with a tight budget.
-    // 12 messages at ~52 tokens each = ~624 total tokens.
-    // With budget=200, threshold=150. The leaf pass compacts the 8 oldest
-    // messages into a ~5-token summary. After leaf pass:
-    //   context = 1 summary (~5 tok) + 4 fresh messages (~208 tok) = ~213 tok
-    // 213 > 150 (threshold), so the condensed pass also runs, creating
-    // a condensed summary from the leaf. Result: 2 summaries in the store.
+    // 12 messages at ~52 tokens each = ~624 total tokens. The leaf phase
+    // compacts all 8 messages outside the fresh tail, and the low
+    // summaryPrefixTargetTokens setting makes phase 2 condense those leaves.
     const round1 = await condensedFriendlyEngine.compact({
       conversationId: CONV_ID,
       tokenBudget: 200,

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -2134,6 +2134,64 @@ describe("LCM integration: compaction", () => {
     ).toBe(false);
   });
 
+  it("compactFullSweep uses stopAtTokens to pressure-condense live-runtime overages", async () => {
+    const pressureEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 2,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      leafChunkTokens: 500,
+      condensedTargetTokens: 10,
+      sweepMaxDepth: 1,
+      summaryPrefixTargetTokens: 10_000,
+    });
+
+    await convStore.createConversation({ sessionId: "stop-target-pressure-depth" });
+    for (const suffix of ["a", "b"]) {
+      const summaryId = `sum_stop_target_depth_one_${suffix}`;
+      await sumStore.insertSummary({
+        summaryId,
+        conversationId: CONV_ID,
+        kind: "condensed",
+        depth: 1,
+        content: `Depth one stop target summary ${suffix}`,
+        tokenCount: 80,
+      });
+      await sumStore.appendContextSummary(CONV_ID, summaryId);
+    }
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Fresh tail message ${i}`,
+      tokenCountFn: () => 1_000,
+    });
+
+    const summarize = vi.fn(
+      async (
+        _text: string,
+        _aggressive?: boolean,
+        options?: { isCondensed?: boolean; depth?: number },
+      ) => {
+        return options?.isCondensed ? "Depth two stop target summary" : "Leaf summary";
+      },
+    );
+    const result = await pressureEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 100,
+      summarize,
+      stopAtTokens: 1_000,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(result.condensed).toBe(true);
+    expect(summarize).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Boolean),
+      expect.objectContaining({ isCondensed: true, depth: 2 }),
+    );
+    expect(
+      sumStore._summaries.some((summary) => summary.kind === "condensed" && summary.depth === 2),
+    ).toBe(true);
+  });
+
 
   it("compaction propagates referenced file ids into summary metadata", async () => {
     const productionTailEngine = new CompactionEngine(convStore as any, sumStore as any, {

--- a/tui/README.md
+++ b/tui/README.md
@@ -28,6 +28,8 @@ lcm-tui --db /path/to/lcm.db    # custom database path
 
 **Browse & Inspect**
 - **Agent/session browser** — drill down from agents → sessions → conversations
+- **Codex backend inspection** — open native Codex app-server rollout JSONL from a bound OpenClaw session
+- **Codex ↔ LCM comparison** — render Codex backend rows beside the Lossless-managed context window
 - **Windowed conversation paging** — keyset pagination by `message_id` for large LCM conversations
 - **Summary DAG** — expandable tree of the full summary hierarchy with depth, kind, token counts, and source messages
 - **Context view** — see the exact ordered list of summaries + messages the model receives each turn

--- a/tui/codex_backend.go
+++ b/tui/codex_backend.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type codexBackendMetadata struct {
+	threadID        string
+	path            string
+	messageCount    int
+	estimatedTokens int
+}
+
+type codexBindingFile struct {
+	ThreadID  string `json:"threadId"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	Model     string `json:"model"`
+	CWD       string `json:"cwd"`
+}
+
+type codexSessionLine struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexPayload struct {
+	Type       string          `json:"type"`
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	Message    string          `json:"message"`
+	Text       string          `json:"text"`
+	Name       string          `json:"name"`
+	CallID     string          `json:"call_id"`
+	Input      json.RawMessage `json:"input"`
+	Output     json.RawMessage `json:"output"`
+	Result     json.RawMessage `json:"result"`
+	Info       json.RawMessage `json:"info"`
+	RateLimits json.RawMessage `json:"rate_limits"`
+}
+
+func loadCodexBackendMetadata(sessionPath string) codexBackendMetadata {
+	binding, err := readCodexBinding(sessionPath + ".codex-app-server.json")
+	if err != nil || strings.TrimSpace(binding.ThreadID) == "" {
+		return codexBackendMetadata{}
+	}
+	backendPath := findCodexBackendSessionPath(sessionPath, binding.ThreadID)
+	metadata := codexBackendMetadata{threadID: binding.ThreadID, path: backendPath}
+	if backendPath == "" {
+		return metadata
+	}
+	if info, err := os.Stat(backendPath); err == nil {
+		metadata.estimatedTokens = estimateTokenCountFromBytes(info.Size())
+	}
+	if count, err := countCodexBackendRows(backendPath); err == nil {
+		metadata.messageCount = count
+	}
+	return metadata
+}
+
+func readCodexBinding(path string) (codexBindingFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return codexBindingFile{}, err
+	}
+	var binding codexBindingFile
+	if err := json.Unmarshal(data, &binding); err != nil {
+		return codexBindingFile{}, err
+	}
+	return binding, nil
+}
+
+func findCodexBackendSessionPath(sessionPath, threadID string) string {
+	if strings.TrimSpace(threadID) == "" {
+		return ""
+	}
+	sessionsDir := filepath.Dir(sessionPath)
+	agentDir := filepath.Dir(sessionsDir)
+	codexSessionsDir := filepath.Join(agentDir, "agent", "codex-home", "sessions")
+	pattern := filepath.Join(codexSessionsDir, "*", "*", "*", "*"+threadID+"*.jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+func countCodexBackendRows(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open codex backend session %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 64*1024)
+	scanner.Buffer(buf, 16*1024*1024)
+	count := 0
+	for scanner.Scan() {
+		if len(bytes.TrimSpace(scanner.Bytes())) > 0 {
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan codex backend session %q: %w", path, err)
+	}
+	return count, nil
+}
+
+func parseCodexBackendMessages(path string) ([]sessionMessage, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open codex backend session %q: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 64*1024)
+	scanner.Buffer(buf, 16*1024*1024)
+
+	messages := make([]sessionMessage, 0, 256)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var item codexSessionLine
+		if err := json.Unmarshal(line, &item); err != nil {
+			continue
+		}
+		msg, ok := normalizeCodexSessionLine(item, lineNumber)
+		if ok {
+			messages = append(messages, msg)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan codex backend session %q: %w", path, err)
+	}
+	return messages, nil
+}
+
+func normalizeCodexSessionLine(item codexSessionLine, lineNumber int) (sessionMessage, bool) {
+	role := "system"
+	text := ""
+	switch item.Type {
+	case "session_meta":
+		text = summarizeCodexSessionMeta(item.Payload)
+	case "turn_context":
+		text = "[turn_context]\n" + compactJSON(item.Payload)
+	case "compacted":
+		text = "[compacted]\n" + compactJSON(item.Payload)
+	case "response_item":
+		var payload codexPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			return sessionMessage{}, false
+		}
+		role, text = normalizeCodexResponseItem(payload)
+	case "event_msg":
+		var payload codexPayload
+		if err := json.Unmarshal(item.Payload, &payload); err != nil {
+			return sessionMessage{}, false
+		}
+		role, text = normalizeCodexEvent(payload)
+	default:
+		text = fmt.Sprintf("[%s]\n%s", item.Type, compactJSON(item.Payload))
+	}
+	if strings.TrimSpace(text) == "" {
+		return sessionMessage{}, false
+	}
+	return sessionMessage{
+		id:        fmt.Sprintf("codex:%d", lineNumber),
+		timestamp: item.Timestamp,
+		role:      role,
+		text:      sanitizeForTerminal(text),
+	}, true
+}
+
+func normalizeCodexResponseItem(payload codexPayload) (string, string) {
+	switch payload.Type {
+	case "message":
+		role := strings.TrimSpace(payload.Role)
+		if role == "" {
+			role = "unknown"
+		}
+		return role, normalizeCodexContent(payload.Content)
+	case "reasoning":
+		return "reasoning", "[reasoning]\n" + compactJSON(payload.Content)
+	case "custom_tool_call":
+		name := firstNonEmpty(payload.Name, "unknown")
+		return "tool", fmt.Sprintf("[toolCall] %s call_id=%s\n%s", name, payload.CallID, compactJSON(payload.Input))
+	case "custom_tool_call_output":
+		return "tool", fmt.Sprintf("[toolResult] call_id=%s\n%s", payload.CallID, firstNonEmpty(rawJSONText(payload.Output), rawJSONText(payload.Result), payload.Text))
+	default:
+		return "system", fmt.Sprintf("[response_item:%s]\n%s", payload.Type, compactJSONFromAny(payload))
+	}
+}
+
+func normalizeCodexEvent(payload codexPayload) (string, string) {
+	switch payload.Type {
+	case "user_message":
+		return "user", payload.Message
+	case "agent_message":
+		return "assistant", payload.Message
+	case "token_count":
+		return "system", "[token_count]\n" + firstNonEmpty(rawJSONText(payload.Info), compactJSONFromAny(payload))
+	case "task_started", "task_complete", "turn_aborted", "context_compacted":
+		return "system", fmt.Sprintf("[%s]\n%s", payload.Type, compactJSONFromAny(payload))
+	case "error":
+		return "system", "[error]\n" + compactJSONFromAny(payload)
+	default:
+		return "system", fmt.Sprintf("[event:%s]\n%s", payload.Type, compactJSONFromAny(payload))
+	}
+}
+
+func summarizeCodexSessionMeta(raw json.RawMessage) string {
+	var meta struct {
+		ID            string `json:"id"`
+		Timestamp     string `json:"timestamp"`
+		CWD           string `json:"cwd"`
+		Originator    string `json:"originator"`
+		CLIVersion    string `json:"cli_version"`
+		Source        string `json:"source"`
+		ModelProvider string `json:"model_provider"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return "[session_meta]\n" + compactJSON(raw)
+	}
+	return fmt.Sprintf("[session_meta]\nid=%s\ntimestamp=%s\ncwd=%s\noriginator=%s\ncli_version=%s\nsource=%s\nmodel_provider=%s",
+		meta.ID, meta.Timestamp, meta.CWD, meta.Originator, meta.CLIVersion, meta.Source, meta.ModelProvider)
+}
+
+func normalizeCodexContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return strings.TrimSpace(asString)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if strings.TrimSpace(block.Text) != "" {
+				parts = append(parts, strings.TrimSpace(block.Text))
+			} else if block.Type != "" {
+				parts = append(parts, "["+block.Type+"]")
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return compactJSON(raw)
+}
+
+func compactJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	return compactJSONFromAny(value)
+}
+
+func compactJSONFromAny(value any) string {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(data)
+}
+
+func rawJSONText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+	return compactJSON(raw)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/tui/codex_context_compare.go
+++ b/tui/codex_context_compare.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const compareDisplayMaxChars = 4_000
+
+func renderCodexContextComparison(codexMessages []sessionMessage, contextItems []contextItemEntry, width int) string {
+	if width <= 0 {
+		width = 120
+	}
+	leftWidth := max(32, (width-5)/2)
+	rightWidth := max(32, width-leftWidth-5)
+
+	leftTitle := truncateString("CODEX BACKEND THREAD", leftWidth)
+	rightTitle := truncateString("LOSSLESS-MANAGED CONTEXT", rightWidth)
+	lines := []string{
+		padRight(leftTitle, leftWidth) + "  │  " + padRight(rightTitle, rightWidth),
+		strings.Repeat("─", leftWidth) + "──┼──" + strings.Repeat("─", rightWidth),
+	}
+
+	maxRows := max(len(codexMessages), len(contextItems))
+	for idx := 0; idx < maxRows; idx++ {
+		var leftBlock []string
+		if idx < len(codexMessages) {
+			leftBlock = renderCompareCodexBlock(idx, codexMessages[idx], leftWidth)
+		}
+		var rightBlock []string
+		if idx < len(contextItems) {
+			rightBlock = renderCompareContextBlock(idx, contextItems[idx], rightWidth)
+		}
+		lines = append(lines, zipCompareBlocks(leftBlock, rightBlock, leftWidth, rightWidth)...)
+		if idx < maxRows-1 {
+			lines = append(lines, strings.Repeat(" ", leftWidth)+"  │  "+strings.Repeat(" ", rightWidth))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderCompareCodexBlock(idx int, msg sessionMessage, width int) []string {
+	header := fmt.Sprintf("#%d %s %s", idx+1, formatTimestamp(msg.timestamp), strings.ToUpper(msg.role))
+	body := conversationMessageDisplayText(sessionMessage{
+		role: msg.role,
+		text: truncateDisplayText(msg.text, compareDisplayMaxChars),
+	})
+	return renderCompareBlock(header, body, width)
+}
+
+func renderCompareContextBlock(idx int, item contextItemEntry, width int) []string {
+	label := item.kind
+	if item.itemType == "summary" {
+		if item.depth > 0 {
+			label = fmt.Sprintf("d%d", item.depth)
+		}
+		if item.summaryID != "" {
+			label += " " + item.summaryID
+		}
+	} else if item.messageID > 0 {
+		label += fmt.Sprintf(" #%d", item.messageID)
+	}
+	header := fmt.Sprintf("#%d ordinal:%d %s %dt", idx+1, item.ordinal, label, item.tokenCount)
+	body := truncateDisplayText(item.content, compareDisplayMaxChars)
+	return renderCompareBlock(header, body, width)
+}
+
+func renderCompareBlock(header, body string, width int) []string {
+	lines := []string{truncateString(header, width)}
+	if strings.TrimSpace(body) == "" {
+		body = "(no text content)"
+	}
+	wrapped := wrapText(body, max(20, width))
+	for _, line := range strings.Split(wrapped, "\n") {
+		lines = append(lines, truncateString(line, width))
+	}
+	return lines
+}
+
+func zipCompareBlocks(left, right []string, leftWidth, rightWidth int) []string {
+	count := max(len(left), len(right))
+	lines := make([]string, 0, count)
+	for idx := 0; idx < count; idx++ {
+		leftText := ""
+		if idx < len(left) {
+			leftText = left[idx]
+		}
+		rightText := ""
+		if idx < len(right) {
+			rightText = right[idx]
+		}
+		lines = append(lines, padRight(leftText, leftWidth)+"  │  "+padRight(rightText, rightWidth))
+	}
+	return lines
+}
+
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return truncateString(s, width)
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/tui/codex_context_compare_test.go
+++ b/tui/codex_context_compare_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderCodexContextComparisonShowsBothSides(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderCodexContextComparison(
+		[]sessionMessage{
+			{
+				timestamp: "2026-05-12T14:52:29Z",
+				role:      "assistant",
+				text:      "codex backend answer",
+			},
+		},
+		[]contextItemEntry{
+			{
+				ordinal:    7,
+				itemType:   "summary",
+				summaryID:  "sum_abc",
+				kind:       "condensed",
+				depth:      2,
+				tokenCount: 123,
+				content:    "lossless managed summary",
+			},
+		},
+		100,
+	)
+
+	for _, want := range []string{
+		"CODEX BACKEND THREAD",
+		"LOSSLESS-MANAGED CONTEXT",
+		"codex backend answer",
+		"ordinal:7 d2 sum_abc 123t",
+		"lossless managed summary",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected comparison to contain %q, got:\n%s", want, rendered)
+		}
+	}
+}

--- a/tui/context_items_test.go
+++ b/tui/context_items_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadContextItemsUsesMessagePartsForEmptyMessageContent(t *testing.T) {
+	t.Parallel()
+
+	dbPath := setupContextItemsTestDB(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		INSERT INTO conversations (conversation_id, session_id, session_key)
+		VALUES (7, 'session-context', NULL);
+
+		INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at)
+		VALUES (101, 7, 1, 'assistant', '', 120, '2026-05-14 22:00:00');
+
+		INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, tool_name, tool_input)
+		VALUES ('part-101', 101, 'session-context', 'tool', 0, 'supabase.execute_sql',
+			'{"query":"select name from companies where status = ''active''"}');
+
+		INSERT INTO context_items (conversation_id, ordinal, item_type, message_id, summary_id, created_at)
+		VALUES (7, 0, 'message', 101, NULL, '2026-05-14 22:00:00');
+	`); err != nil {
+		t.Fatalf("seed context item: %v", err)
+	}
+
+	items, err := loadContextItems(dbPath, "session-context")
+	if err != nil {
+		t.Fatalf("load context items: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("item count = %d, want 1", len(items))
+	}
+
+	got := items[0]
+	if got.preview == "" {
+		t.Fatalf("expected non-empty preview for structured message part")
+	}
+	if !strings.Contains(got.content, "select name from companies") {
+		t.Fatalf("expected rehydrated tool input in content, got %q", got.content)
+	}
+	if !strings.Contains(got.preview, "Tool input") {
+		t.Fatalf("expected labeled tool input in preview, got %q", got.preview)
+	}
+}
+
+func setupContextItemsTestDB(t *testing.T) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "lcm.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE conversations (
+			conversation_id INTEGER PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			session_key TEXT
+		);
+		CREATE TABLE messages (
+			message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+			conversation_id INTEGER NOT NULL,
+			seq INTEGER,
+			role TEXT,
+			content TEXT,
+			token_count INTEGER,
+			created_at TEXT
+		);
+		CREATE TABLE summaries (
+			summary_id TEXT PRIMARY KEY,
+			conversation_id INTEGER NOT NULL,
+			kind TEXT,
+			depth INTEGER,
+			content TEXT,
+			token_count INTEGER,
+			created_at TEXT
+		);
+		CREATE TABLE context_items (
+			conversation_id INTEGER NOT NULL,
+			ordinal INTEGER NOT NULL,
+			item_type TEXT NOT NULL,
+			message_id INTEGER,
+			summary_id TEXT,
+			created_at TEXT
+		);
+		CREATE TABLE message_parts (
+			part_id TEXT PRIMARY KEY,
+			message_id INTEGER NOT NULL,
+			session_id TEXT NOT NULL,
+			part_type TEXT NOT NULL,
+			ordinal INTEGER NOT NULL,
+			text_content TEXT,
+			tool_name TEXT,
+			tool_input TEXT,
+			tool_output TEXT,
+			metadata TEXT
+		);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return dbPath
+}

--- a/tui/conversation_window_test.go
+++ b/tui/conversation_window_test.go
@@ -85,7 +85,17 @@ func setupConversationWindowTestDB(t *testing.T) string {
 			role TEXT,
 			content TEXT,
 			created_at TEXT
-		)
+		);
+		CREATE TABLE message_parts (
+			part_id TEXT PRIMARY KEY,
+			message_id INTEGER NOT NULL,
+			session_id TEXT NOT NULL,
+			part_type TEXT NOT NULL,
+			ordinal INTEGER NOT NULL,
+			text_content TEXT,
+			tool_input TEXT,
+			tool_output TEXT
+		);
 	`); err != nil {
 		t.Fatalf("create messages table: %v", err)
 	}

--- a/tui/data.go
+++ b/tui/data.go
@@ -34,16 +34,20 @@ type agentEntry struct {
 
 // sessionEntry describes one JSONL session file.
 type sessionEntry struct {
-	id              string
-	sessionKey      string
-	filename        string
-	path            string
-	updatedAt       time.Time
-	conversationID  int64
-	messageCount    int
-	estimatedTokens int
-	summaryCount    int
-	fileCount       int
+	id                   string
+	sessionKey           string
+	filename             string
+	path                 string
+	updatedAt            time.Time
+	conversationID       int64
+	messageCount         int
+	estimatedTokens      int
+	codexThreadID        string
+	codexBackendPath     string
+	codexMessageCount    int
+	codexEstimatedTokens int
+	summaryCount         int
+	fileCount            int
 }
 
 // sessionFileEntry stores lightweight metadata used for incremental loading.
@@ -318,14 +322,19 @@ func loadSessionBatch(files []sessionFileEntry, offset, limit int, lcmDBPath str
 			messageCount = -1
 		}
 		id := strings.TrimSuffix(file.filename, filepath.Ext(file.filename))
+		codexBackend := loadCodexBackendMetadata(file.path)
 		sessionIDs = append(sessionIDs, id)
 		sessions = append(sessions, sessionEntry{
-			id:              id,
-			filename:        file.filename,
-			path:            file.path,
-			updatedAt:       file.updatedAt,
-			messageCount:    messageCount,
-			estimatedTokens: estimateTokenCountFromBytes(file.byteSize),
+			id:                   id,
+			filename:             file.filename,
+			path:                 file.path,
+			updatedAt:            file.updatedAt,
+			messageCount:         messageCount,
+			estimatedTokens:      estimateTokenCountFromBytes(file.byteSize),
+			codexThreadID:        codexBackend.threadID,
+			codexBackendPath:     codexBackend.path,
+			codexMessageCount:    codexBackend.messageCount,
+			codexEstimatedTokens: codexBackend.estimatedTokens,
 		})
 	}
 

--- a/tui/data.go
+++ b/tui/data.go
@@ -476,6 +476,37 @@ func loadConversationWindowAfter(dbPath string, conversationID, afterMessageID i
 	return loadConversationWindow(dbPath, conversationID, limit, "after", afterMessageID)
 }
 
+// messageDisplayContentSQL returns SQL that shows message_parts content when
+// the canonical messages.content preview is empty.
+func messageDisplayContentSQL(messageAlias string) string {
+	return fmt.Sprintf(`
+		CASE
+			WHEN TRIM(COALESCE(%[1]s.content, '')) != '' THEN COALESCE(%[1]s.content, '')
+			ELSE COALESCE((
+				SELECT group_concat(part_text, char(10) || char(10))
+				FROM (
+					SELECT TRIM(
+						COALESCE(mp.text_content, '') ||
+						CASE
+							WHEN TRIM(COALESCE(mp.tool_input, '')) != ''
+								THEN char(10) || 'Tool input: ' || mp.tool_input
+							ELSE ''
+						END ||
+						CASE
+							WHEN TRIM(COALESCE(mp.tool_output, '')) != ''
+								THEN char(10) || 'Tool output: ' || mp.tool_output
+							ELSE ''
+						END
+					) AS part_text
+					FROM message_parts mp
+					WHERE mp.message_id = %[1]s.message_id
+					ORDER BY mp.ordinal
+				)
+				WHERE TRIM(part_text) != ''
+			), '')
+		END`, messageAlias)
+}
+
 // loadConversationWindow executes one keyset-paged message query and computes paging boundaries.
 func loadConversationWindow(dbPath string, conversationID int64, limit int, mode string, cursorMessageID int64) (conversationWindowPage, error) {
 	if conversationID <= 0 {
@@ -491,26 +522,26 @@ func loadConversationWindow(dbPath string, conversationID int64, limit int, mode
 	}
 	defer db.Close()
 
-	baseQuery := `
-		SELECT message_id, role, content, created_at
-		FROM messages
-		WHERE conversation_id = ?
-	`
+	baseQuery := fmt.Sprintf(`
+		SELECT m.message_id, m.role, %s AS content, m.created_at
+		FROM messages m
+		WHERE m.conversation_id = ?
+	`, messageDisplayContentSQL("m"))
 	args := []any{conversationID}
-	orderClause := "ORDER BY message_id ASC"
+	orderClause := "ORDER BY m.message_id ASC"
 	reverse := false
 
 	switch mode {
 	case "latest":
-		orderClause = "ORDER BY message_id DESC"
+		orderClause = "ORDER BY m.message_id DESC"
 		reverse = true
 	case "before":
-		baseQuery += " AND message_id < ?"
+		baseQuery += " AND m.message_id < ?"
 		args = append(args, cursorMessageID)
-		orderClause = "ORDER BY message_id DESC"
+		orderClause = "ORDER BY m.message_id DESC"
 		reverse = true
 	case "after":
-		baseQuery += " AND message_id > ?"
+		baseQuery += " AND m.message_id > ?"
 		args = append(args, cursorMessageID)
 	case "":
 		return conversationWindowPage{}, fmt.Errorf("missing conversation window mode")
@@ -1282,7 +1313,7 @@ func loadContextItems(dbPath, sessionID string) ([]contextItemEntry, error) {
 		return nil, err
 	}
 
-	rows, err := db.Query(`
+	rows, err := db.Query(fmt.Sprintf(`
 		SELECT
 			ci.ordinal,
 			ci.item_type,
@@ -1302,7 +1333,7 @@ func loadContextItems(dbPath, sessionID string) ([]contextItemEntry, error) {
 			END AS token_count,
 			CASE
 				WHEN ci.item_type = 'summary' THEN COALESCE(s.content, '')
-				ELSE COALESCE(m.content, '')
+				ELSE %s
 			END AS content,
 			CASE
 				WHEN ci.item_type = 'summary' THEN COALESCE(s.created_at, '')
@@ -1313,7 +1344,7 @@ func loadContextItems(dbPath, sessionID string) ([]contextItemEntry, error) {
 		LEFT JOIN messages m ON ci.message_id = m.message_id
 		WHERE ci.conversation_id = ?
 		ORDER BY ci.ordinal
-	`, conversationID)
+	`, messageDisplayContentSQL("m")), conversationID)
 	if err != nil {
 		return nil, fmt.Errorf("query context items for conversation %d: %w", conversationID, err)
 	}

--- a/tui/main.go
+++ b/tui/main.go
@@ -25,6 +25,7 @@ const (
 	screenSummaries
 	screenFiles
 	screenContext
+	screenCodexContextCompare
 )
 
 const (
@@ -253,7 +254,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resizeViewport()
-		m.refreshConversationViewport()
+		if m.screen == screenCodexContextCompare {
+			if session, ok := m.currentSession(); ok {
+				if err := m.openCodexContextCompareForSession(session); err != nil {
+					m.status = "Error: " + err.Error()
+				}
+			}
+		} else {
+			m.refreshConversationViewport()
+		}
 		return m, nil
 	case rewriteResultMsg:
 		if m.pendingRewrite == nil || m.pendingRewrite.summaryID != msg.summaryID || m.pendingRewrite.phase != rewriteInflight {
@@ -330,6 +339,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleFilesKey(msg)
 	case screenContext:
 		return m.handleContextKey(msg)
+	case screenCodexContextCompare:
+		return m.handleCodexContextCompareKey(msg)
 	default:
 		return m, nil
 	}
@@ -392,6 +403,28 @@ func (m model) handleSessionsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.screen = screenConversation
+	case "x":
+		session, ok := m.currentSession()
+		if !ok {
+			m.status = "No session selected"
+			return m, nil
+		}
+		if err := m.openCodexBackendForSession(session); err != nil {
+			m.status = "Error: " + err.Error()
+			return m, nil
+		}
+		m.screen = screenConversation
+	case "v":
+		session, ok := m.currentSession()
+		if !ok {
+			m.status = "No session selected"
+			return m, nil
+		}
+		if err := m.openCodexContextCompareForSession(session); err != nil {
+			m.status = "Error: " + err.Error()
+			return m, nil
+		}
+		m.screen = screenCodexContextCompare
 	case "b", "backspace":
 		m.screen = screenAgents
 		m.sessionFiles = nil
@@ -513,6 +546,17 @@ func (m model) handleConversationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = fmt.Sprintf("Context: %d summaries + %d messages = %d items, %dk tokens",
 				summaryCount, messageCount, len(items), totalTokens/1000)
 		}
+	case "v":
+		session, ok := m.currentSession()
+		if !ok {
+			m.status = "No session selected"
+			return m, nil
+		}
+		if err := m.openCodexContextCompareForSession(session); err != nil {
+			m.status = "Error: " + err.Error()
+			return m, nil
+		}
+		m.screen = screenCodexContextCompare
 	}
 	return m, nil
 }
@@ -793,6 +837,36 @@ func (m model) handleContextKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) handleCodexContextCompareKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		m.convViewport.LineUp(1)
+	case "down", "j":
+		m.convViewport.LineDown(1)
+	case "pgup":
+		m.convViewport.HalfViewUp()
+	case "pgdown":
+		m.convViewport.HalfViewDown()
+	case "g":
+		m.convViewport.GotoTop()
+	case "G":
+		m.convViewport.GotoBottom()
+	case "r":
+		session, ok := m.currentSession()
+		if !ok {
+			m.status = "No session selected"
+			return m, nil
+		}
+		if err := m.openCodexContextCompareForSession(session); err != nil {
+			m.status = "Error: " + err.Error()
+		}
+	case "b", "backspace":
+		m.screen = screenSessions
+		m.status = "Back to sessions"
+	}
+	return m, nil
+}
+
 // openConversationForSession loads messages for the selected session into the conversation view.
 func (m *model) openConversationForSession(session sessionEntry) error {
 	m.conversationWindow.enabled = false
@@ -806,6 +880,83 @@ func (m *model) openConversationForSession(session sessionEntry) error {
 		return m.loadLatestConversationWindowForSession(session, "Loaded")
 	}
 	return m.loadConversationFromSessionFile(session, "Loaded")
+}
+
+// openCodexBackendForSession loads the native Codex backend rollout bound to a session.
+func (m *model) openCodexBackendForSession(session sessionEntry) error {
+	if session.codexThreadID == "" {
+		return fmt.Errorf("session has no Codex app-server binding")
+	}
+	if session.codexBackendPath == "" {
+		return fmt.Errorf("Codex binding %s has no local backend transcript", session.codexThreadID)
+	}
+	m.conversationWindow.enabled = false
+	m.conversationWindow.conversationID = 0
+	m.conversationWindow.oldestMessageID = 0
+	m.conversationWindow.newestMessageID = 0
+	m.conversationWindow.hasOlder = false
+	m.conversationWindow.hasNewer = false
+
+	parseStart := time.Now()
+	messages, err := parseCodexBackendMessages(session.codexBackendPath)
+	parseDuration := time.Since(parseStart)
+	if err != nil {
+		return err
+	}
+	m.messages = messages
+	renderDuration := m.refreshConversationViewportWithMode(conversationViewportBottom)
+	m.status = fmt.Sprintf(
+		"Loaded %d Codex backend rows thread:%s (file parse:%s render:%s)",
+		len(messages),
+		session.codexThreadID,
+		formatDuration(parseDuration),
+		formatDuration(renderDuration),
+	)
+	log.Printf(
+		"[lcm-tui] codex backend-load session=%s thread=%s messages=%d parse=%s render=%s path=%s",
+		session.id,
+		session.codexThreadID,
+		len(messages),
+		formatDuration(parseDuration),
+		formatDuration(renderDuration),
+		session.codexBackendPath,
+	)
+	return nil
+}
+
+// openCodexContextCompareForSession renders native Codex backend state beside LCM's managed context.
+func (m *model) openCodexContextCompareForSession(session sessionEntry) error {
+	if session.codexThreadID == "" {
+		return fmt.Errorf("session has no Codex app-server binding")
+	}
+	if session.codexBackendPath == "" {
+		return fmt.Errorf("Codex binding %s has no local backend transcript", session.codexThreadID)
+	}
+
+	parseStart := time.Now()
+	codexMessages, err := parseCodexBackendMessages(session.codexBackendPath)
+	parseDuration := time.Since(parseStart)
+	if err != nil {
+		return err
+	}
+	contextItems, err := loadContextItems(m.paths.lcmDBPath, session.id)
+	if err != nil {
+		return err
+	}
+	renderStart := time.Now()
+	content := renderCodexContextComparison(codexMessages, contextItems, m.convViewport.Width)
+	m.convViewport.SetContent(content)
+	m.convViewport.GotoBottom()
+	renderDuration := time.Since(renderStart)
+	m.status = fmt.Sprintf(
+		"Compare Codex %d rows ↔ LCM %d items thread:%s (parse:%s render:%s)",
+		len(codexMessages),
+		len(contextItems),
+		session.codexThreadID,
+		formatDuration(parseDuration),
+		formatDuration(renderDuration),
+	)
+	return nil
 }
 
 // reloadConversationWindow refreshes the conversation using the same loading mode as open.
@@ -1515,6 +1666,14 @@ func (m model) renderHeader() string {
 		if conversationID, ok := m.currentConversationID(); ok {
 			title += fmt.Sprintf(" | conv_id:%d", conversationID)
 		}
+	case screenCodexContextCompare:
+		title += " | Codex ↔ LCM Context"
+		if session, ok := m.currentSession(); ok {
+			title += fmt.Sprintf(" | session:%s", session.id)
+			if session.codexThreadID != "" {
+				title += fmt.Sprintf(" | codex:%s", session.codexThreadID)
+			}
+		}
 	}
 
 	help := m.renderHelp()
@@ -1526,9 +1685,9 @@ func (m model) renderHelp() string {
 	case screenAgents:
 		return "up/down: move | enter: open agent sessions | r: reload | q: quit"
 	case screenSessions:
-		return "up/down: move | enter: open conversation | b: back | r: reload | q: quit"
+		return "up/down: move | enter: open conversation | x: Codex backend | v: Codex↔LCM compare | b: back | r: reload | q: quit"
 	case screenConversation:
-		return "j/k/up/down: scroll | pgup/pgdown | g/G: top/bottom | [ / ]: older/newer window | r: reload | l: LCM summaries | c: context | f: LCM files | b: back | q: quit"
+		return "j/k/up/down: scroll | pgup/pgdown | g/G: top/bottom | [ / ]: older/newer window | r: reload | l: LCM summaries | c: context | f: LCM files | v: compare | b: back | q: quit"
 	case screenSummaries:
 		if m.pendingRewrite != nil {
 			switch m.pendingRewrite.phase {
@@ -1556,6 +1715,8 @@ func (m model) renderHelp() string {
 		return "up/down: move | g/G: top/bottom | r: reload | b: back | q: quit"
 	case screenContext:
 		return "up/down: move | g/G: top/bottom | r: reload | b: back | q: quit"
+	case screenCodexContextCompare:
+		return "j/k/up/down: scroll | pgup/pgdown | g/G: top/bottom | r: reload | b: back | q: quit"
 	default:
 		return "q: quit"
 	}
@@ -1575,6 +1736,8 @@ func (m model) renderBody() string {
 		return m.renderFiles()
 	case screenContext:
 		return m.renderContext()
+	case screenCodexContextCompare:
+		return m.renderCodexContextCompare()
 	default:
 		return "Unknown screen"
 	}
@@ -1627,12 +1790,13 @@ func (m model) renderSessions() string {
 			label += fmt.Sprintf("  key:%s", session.sessionKey)
 		}
 		line := fmt.Sprintf(
-			"  %-*s  %-19s  %-9s  %-12s  %-14s  %-8s  %-9s",
+			"  %-*s  %-19s  %-9s  %-12s  %-12s  %-14s  %-8s  %-9s",
 			labelWidth,
 			truncateString(label, labelWidth),
 			formatTimeForList(session.updatedAt),
 			fmt.Sprintf("msgs:%s", formatMessageCount(session.messageCount)),
 			fmt.Sprintf("est:%dt", session.estimatedTokens),
+			formatCodexSessionMetric(session),
 			formatOptionalSessionMetric("conv_id", session.conversationID > 0, session.conversationID),
 			formatOptionalSessionMetric("sums", session.summaryCount > 0, session.summaryCount),
 			formatOptionalSessionMetric("files", session.fileCount > 0, session.fileCount),
@@ -1649,7 +1813,7 @@ func (m model) sessionListLabelWidth(offset, end int) int {
 	const (
 		minLabelWidth = 24
 		maxLabelWidth = 72
-		fixedColumns  = 2 + 19 + 2 + 9 + 2 + 12 + 2 + 14 + 2 + 8 + 2 + 9
+		fixedColumns  = 2 + 19 + 2 + 9 + 2 + 12 + 2 + 12 + 2 + 14 + 2 + 8 + 2 + 9
 		rowPrefix     = 2
 	)
 
@@ -1674,12 +1838,32 @@ func formatOptionalSessionMetric(label string, present bool, value any) string {
 	return fmt.Sprintf("%s:%v", label, value)
 }
 
+func formatCodexSessionMetric(session sessionEntry) string {
+	if session.codexThreadID == "" {
+		return ""
+	}
+	if session.codexBackendPath == "" {
+		return "codex:meta"
+	}
+	if session.codexMessageCount > 0 {
+		return fmt.Sprintf("codex:%d", session.codexMessageCount)
+	}
+	return "codex:yes"
+}
+
 func (m model) renderConversation() string {
 	if len(m.messages) == 0 {
 		return "No messages found in this session"
 	}
 	if m.convViewport.Width <= 0 || m.convViewport.Height <= 0 {
 		return "Resizing conversation viewport..."
+	}
+	return m.convViewport.View()
+}
+
+func (m model) renderCodexContextCompare() string {
+	if m.convViewport.Width <= 0 || m.convViewport.Height <= 0 {
+		return "Resizing comparison viewport..."
 	}
 	return m.convViewport.View()
 }

--- a/tui/rewrite.go
+++ b/tui/rewrite.go
@@ -427,13 +427,13 @@ func buildSummaryRewriteSource(ctx context.Context, q sqlQueryer, item rewriteSu
 }
 
 func buildLeafRewriteSource(ctx context.Context, q sqlQueryer, summaryID string, includeTimestamps bool, loc *time.Location) (rewriteSource, error) {
-	rows, err := q.QueryContext(ctx, `
-		SELECT m.role, COALESCE(m.content, ''), COALESCE(m.created_at, '')
+	rows, err := q.QueryContext(ctx, fmt.Sprintf(`
+		SELECT m.role, %s AS content, COALESCE(m.created_at, '')
 		FROM summary_messages sm
 		JOIN messages m ON m.message_id = sm.message_id
 		WHERE sm.summary_id = ?
 		ORDER BY sm.ordinal ASC
-	`, summaryID)
+	`, messageDisplayContentSQL("m")), summaryID)
 	if err != nil {
 		return rewriteSource{}, fmt.Errorf("query leaf source for %s: %w", summaryID, err)
 	}

--- a/tui/rewrite_test.go
+++ b/tui/rewrite_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildLeafRewriteSourceUsesMessagePartsForEmptyMessageContent(t *testing.T) {
+	t.Parallel()
+
+	dbPath := setupRewriteSourceTestDB(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		INSERT INTO messages (message_id, role, content, created_at)
+		VALUES
+			(101, 'assistant', '', '2026-05-14 22:00:00'),
+			(102, 'tool', '', '2026-05-14 22:00:01');
+
+		INSERT INTO summary_messages (summary_id, message_id, ordinal)
+		VALUES
+			('sum_broken', 101, 0),
+			('sum_broken', 102, 1);
+	`); err != nil {
+		t.Fatalf("seed messages: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, tool_name, tool_input)
+		VALUES ('part-101', 101, 'session-rewrite', 'tool', 0, 'supabase.execute_sql', ?)
+	`, `{"query":"select name from companies where status = 'active'"}`); err != nil {
+		t.Fatalf("seed assistant part: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, tool_output)
+		VALUES ('part-102', 102, 'session-rewrite', 'tool_result', 0, ?)
+	`, `{"content":[{"type":"text","text":"Active company: Acme Robotics"}]}`); err != nil {
+		t.Fatalf("seed tool part: %v", err)
+	}
+
+	source, err := buildLeafRewriteSource(context.Background(), db, "sum_broken", false, time.UTC)
+	if err != nil {
+		t.Fatalf("build leaf rewrite source: %v", err)
+	}
+
+	if source.itemCount != 2 {
+		t.Fatalf("source item count = %d, want 2", source.itemCount)
+	}
+	if source.label != "messages" {
+		t.Fatalf("source label = %q, want messages", source.label)
+	}
+	if !strings.Contains(source.text, "Tool input") {
+		t.Fatalf("expected tool input label in rewrite source, got %q", source.text)
+	}
+	if !strings.Contains(source.text, "select name from companies") {
+		t.Fatalf("expected tool input content in rewrite source, got %q", source.text)
+	}
+	if !strings.Contains(source.text, "Active company: Acme Robotics") {
+		t.Fatalf("expected tool output content in rewrite source, got %q", source.text)
+	}
+	if strings.Contains(source.text, "(empty)") {
+		t.Fatalf("rewrite source should not fall back to empty marker, got %q", source.text)
+	}
+}
+
+func setupRewriteSourceTestDB(t *testing.T) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "lcm.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE messages (
+			message_id INTEGER PRIMARY KEY,
+			role TEXT,
+			content TEXT,
+			created_at TEXT
+		);
+		CREATE TABLE summary_messages (
+			summary_id TEXT NOT NULL,
+			message_id INTEGER NOT NULL,
+			ordinal INTEGER NOT NULL
+		);
+		CREATE TABLE message_parts (
+			part_id TEXT PRIMARY KEY,
+			message_id INTEGER NOT NULL,
+			session_id TEXT NOT NULL,
+			part_type TEXT NOT NULL,
+			ordinal INTEGER NOT NULL,
+			text_content TEXT,
+			tool_name TEXT,
+			tool_input TEXT,
+			tool_output TEXT
+		);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	return dbPath
+}

--- a/tui/sessions_test.go
+++ b/tui/sessions_test.go
@@ -41,6 +41,103 @@ func TestLoadSessionBatchIncludesEstimatedTokens(t *testing.T) {
 	}
 }
 
+func TestLoadSessionBatchIncludesCodexBackendMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "main")
+	sessionsDir := filepath.Join(agentDir, "sessions")
+	backendDir := filepath.Join(agentDir, "agent", "codex-home", "sessions", "2026", "05", "12")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+	if err := os.MkdirAll(backendDir, 0o755); err != nil {
+		t.Fatalf("create codex sessions dir: %v", err)
+	}
+
+	const threadID = "019e1cac-cdb8-7801-acf8-efc11c77d024"
+	path := filepath.Join(sessionsDir, "session-1.jsonl")
+	content := `{"type":"message","id":"1","message":{"role":"user","content":"hello"}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	binding := `{"threadId":"` + threadID + `","model":"gpt-5.5"}`
+	if err := os.WriteFile(path+".codex-app-server.json", []byte(binding), 0o644); err != nil {
+		t.Fatalf("write codex binding: %v", err)
+	}
+	backendContent := `{"timestamp":"2026-05-12T14:52:29Z","type":"event_msg","payload":{"type":"agent_message","message":"hello from codex"}}` + "\n" +
+		`{"timestamp":"2026-05-12T14:52:30Z","type":"event_msg","payload":{"type":"task_complete"}}` + "\n"
+	backendPath := filepath.Join(backendDir, "rollout-2026-05-12T07-52-27-"+threadID+".jsonl")
+	if err := os.WriteFile(backendPath, []byte(backendContent), 0o644); err != nil {
+		t.Fatalf("write codex backend session: %v", err)
+	}
+
+	files := []sessionFileEntry{
+		{
+			filename:  "session-1.jsonl",
+			path:      path,
+			updatedAt: time.Unix(1700000000, 0),
+			byteSize:  int64(len(content)),
+		},
+	}
+
+	sessions, _, err := loadSessionBatch(files, 0, 1, filepath.Join(dir, "missing.db"))
+	if err != nil {
+		t.Fatalf("load session batch: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].codexThreadID != threadID {
+		t.Fatalf("expected codex thread id %q, got %q", threadID, sessions[0].codexThreadID)
+	}
+	if sessions[0].codexBackendPath != backendPath {
+		t.Fatalf("expected backend path %q, got %q", backendPath, sessions[0].codexBackendPath)
+	}
+	if sessions[0].codexMessageCount != 2 {
+		t.Fatalf("expected codex row count 2, got %d", sessions[0].codexMessageCount)
+	}
+	if sessions[0].codexEstimatedTokens != len(backendContent)/4 {
+		t.Fatalf("expected codex estimated tokens %d, got %d", len(backendContent)/4, sessions[0].codexEstimatedTokens)
+	}
+	if !strings.Contains(formatCodexSessionMetric(sessions[0]), "codex:2") {
+		t.Fatalf("expected codex session metric, got %q", formatCodexSessionMetric(sessions[0]))
+	}
+}
+
+func TestParseCodexBackendMessagesNormalizesEvents(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := `{"timestamp":"2026-05-12T14:52:29Z","type":"session_meta","payload":{"id":"thread-1","cwd":"/tmp","originator":"openclaw","cli_version":"0.130.0","source":"vscode","model_provider":"openai"}}` + "\n" +
+		`{"timestamp":"2026-05-12T14:52:30Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}` + "\n" +
+		`{"timestamp":"2026-05-12T14:52:31Z","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"call-1","input":{"cmd":"true"}}}` + "\n" +
+		`{"timestamp":"2026-05-12T14:52:32Z","type":"event_msg","payload":{"type":"agent_message","message":"visible update"}}` + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write codex backend session: %v", err)
+	}
+
+	messages, err := parseCodexBackendMessages(path)
+	if err != nil {
+		t.Fatalf("parse codex backend messages: %v", err)
+	}
+	if len(messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(messages))
+	}
+	if messages[0].role != "system" || !strings.Contains(messages[0].text, "thread-1") {
+		t.Fatalf("expected session meta system row, got %#v", messages[0])
+	}
+	if messages[1].role != "assistant" || messages[1].text != "done" {
+		t.Fatalf("expected assistant message, got %#v", messages[1])
+	}
+	if messages[2].role != "tool" || !strings.Contains(messages[2].text, "[toolCall] exec") {
+		t.Fatalf("expected tool call row, got %#v", messages[2])
+	}
+	if messages[3].role != "assistant" || messages[3].text != "visible update" {
+		t.Fatalf("expected agent message event, got %#v", messages[3])
+	}
+}
+
 func TestLoadSessionBatchIncludesConversationMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds context-engine projection epoch support for Lossless Claw and updates compaction behavior for Codex thread-bootstrap operation. Lossless now exposes epoch metadata for assembled context, supports full-sweep threshold compaction, accounts for runtime prompt overhead with `stopAtTokens`, and includes TUI helpers for inspecting Codex backend session contents.

## Why

OpenClaw's Codex harness needs a context-engine-agnostic way to know when a context engine has compacted and must bootstrap a fresh backend thread. Lossless owns the compacted context, so it needs to provide stable projection epochs and compact aggressively enough to keep the projected context viable under host runtime overhead.

## Changes

- Expose projection epochs
- Honor `stopAtTokens`
- Add threshold full sweeps
- Preserve runtime-overhead pressure
- Add Codex TUI inspection
- Expand compaction tests
- Update config/docs/changesets

## Testing

- `pnpm vitest run test/lcm-integration.test.ts --testNamePattern "stopAtTokens|live-runtime overages"`
- `pnpm vitest run test/lcm-integration.test.ts`
- `pnpm run build`
- `pnpm test`
- Live-tested with OpenClaw Codex harness using reduced and restored context windows
