### PR TITLE
fix: make openclaw an optional peer

### DIFF
--- a/.changeset/optional-openclaw-peer.md
+++ b/.changeset/optional-openclaw-peer.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Mark OpenClaw as an optional peer dependency so standalone plugin installs do not pull a second OpenClaw runtime tree.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,12 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.2.17 <2026.6.0"
+    "openclaw": ">=2026.2.17"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Mark openclaw as an optional peer dependency with only the minimum supported lower bound.
- Leave package-lock.json unchanged because npm ci passes without it and the lockfile is not part of published install behavior.
- Add a patch changeset for the install/audit behavior.

## Verification
- npm run build
- npm test (871 tests)
- npm exec -- changeset status
- npm pack --dry-run --json
- npm ci --ignore-scripts with package-lock.json restored to origin/main
- local tarball install/audit repro: hasOpenClaw false, 0 vulnerabilities

Fixes #694
