### PR TITLE
fix: normalize provider-prefixed runtime llm model refs

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -727,6 +727,12 @@ function buildRuntimeModelRef(provider: string | undefined, model: string): stri
   if (!modelId) {
     return undefined;
   }
+  const slash = modelId.indexOf("/");
+  if (slash > 0 && slash < modelId.length - 1) {
+    const directProvider = modelId.slice(0, slash).trim();
+    const directModel = modelId.slice(slash + 1).trim();
+    return directProvider && directModel ? `${directProvider}/${directModel}` : undefined;
+  }
   const providerId = provider?.trim();
   return providerId ? `${providerId}/${modelId}` : modelId;
 }

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -652,6 +652,39 @@ describe("lcm plugin registration", () => {
     );
   });
 
+  it("does not combine summaryProvider with a provider-prefixed summaryModel for runtime LLM policy", () => {
+    const { api, warnLog } = buildApi({
+      enabled: true,
+      summaryProvider: "openai",
+      summaryModel: "openai/gpt-5.5",
+    });
+    api.config = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              summaryProvider: "openai",
+              summaryModel: "openai/gpt-5.5",
+            },
+            llm: {
+              allowModelOverride: true,
+              allowedModels: ["openai/gpt-5.5"],
+            },
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"];
+
+    lcmPlugin.register(api);
+
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("openai/openai/gpt-5.5"),
+    );
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("Runtime LLM model override policy"),
+    );
+  });
+
   it("falls back to runtime plugin config for the startup banner when register runs before api.pluginConfig is populated", () => {
     const { api, infoLog } = buildApi(
       {},


### PR DESCRIPTION
## Summary
- Treat provider-prefixed Lossless runtime LLM model refs as canonical before applying a separate provider hint.
- Prevent configs like summaryProvider=openai plus summaryModel=openai/gpt-5.5 from being checked as openai/openai/gpt-5.5.
- Add regression coverage for the startup policy warning path.

## Tests
- npm run build
- npm test -- doctor-contract-api.test.ts plugin-config-registration.test.ts index-runtime-llm-complete.test.ts