### PR TITLE
fix: repair expansionModel doctor compatibility and delegated fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Add a `subagent` policy under `plugins.entries.lossless-claw` and allowlist the 
 - `subagent.allowedModels` is optional but recommended. Use `"*"` only if you intentionally want to trust any target model.
 - The chosen expansion target must also be available in OpenClaw's normal model catalog. If it is not already configured elsewhere, add it under the top-level `models` map as shown above.
 - If you prefer splitting provider and model, set `config.expansionProvider` and use a bare `config.expansionModel`.
+- `openclaw doctor --fix` can add the required `subagent` policy for a configured `expansionModel`. If a host still rejects a stale or unavailable override, `lcm_expand_query` retries once without the override so recall does not fail hard.
 
 Plugin config equivalents:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rot
 | `summaryTimeoutMs` | `integer` | `60000` | `LCM_SUMMARY_TIMEOUT_MS` | Maximum time to wait for one model-backed summarizer call. |
 | `customInstructions` | `string` | `""` | `LCM_CUSTOM_INSTRUCTIONS` | Extra natural-language instructions injected into every summarization prompt. |
 
-Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capability. If you configure an explicit Lossless summary model (`summaryModel`, `largeFileSummaryModel`, or `fallbackProviders`), OpenClaw must allow that runtime LLM override under `plugins.entries.lossless-claw.llm.allowModelOverride` and `plugins.entries.lossless-claw.llm.allowedModels`. `openclaw doctor --fix` can add the minimal policy entries for configured Lossless summary models.
+Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capability. If you configure an explicit Lossless summary model (`summaryModel`, `largeFileSummaryModel`, or `fallbackProviders`), OpenClaw must allow that runtime LLM override under `plugins.entries.lossless-claw.llm.allowModelOverride` and `plugins.entries.lossless-claw.llm.allowedModels`. `openclaw doctor --fix` can add the minimal policy entries for configured Lossless summary models. Delegated expansion calls use OpenClaw's runtime sub-agent layer; explicit `expansionModel` values require `plugins.entries.lossless-claw.subagent.allowModelOverride` and a matching `subagent.allowedModels` entry, or `"*"` if you intentionally trust any expansion target. `openclaw doctor --fix` can add the minimal subagent policy, and `lcm_expand_query` retries once without the override if the host rejects it.
 
 ### Fallbacks, circuit breaking, and safety rails
 

--- a/doctor-contract-api.d.ts
+++ b/doctor-contract-api.d.ts
@@ -27,3 +27,8 @@ export function collectLosslessRuntimeLlmModelRefs(cfg: unknown): {
   modelRefs: LosslessRuntimeLlmModelRef[];
   skipped: LosslessRuntimeLlmSkippedModelRef[];
 };
+
+export function collectLosslessSubagentModelRefs(cfg: unknown): {
+  modelRefs: LosslessRuntimeLlmModelRef[];
+  skipped: LosslessRuntimeLlmSkippedModelRef[];
+};

--- a/doctor-contract-api.js
+++ b/doctor-contract-api.js
@@ -22,18 +22,26 @@ function readConfig(cfg) {
   return isRecord(config) ? config : undefined;
 }
 
-function readLlmPolicy(cfg) {
-  const llm = readEntry(cfg)?.llm;
-  if (!isRecord(llm)) {
+function readModelOverridePolicy(cfg, policyKey) {
+  const policy = readEntry(cfg)?.[policyKey];
+  if (!isRecord(policy)) {
     return {
       allowModelOverride: false,
       allowedModels: [],
     };
   }
   return {
-    allowModelOverride: llm.allowModelOverride === true,
-    allowedModels: Array.isArray(llm.allowedModels) ? llm.allowedModels : [],
+    allowModelOverride: policy.allowModelOverride === true,
+    allowedModels: Array.isArray(policy.allowedModels) ? policy.allowedModels : [],
   };
+}
+
+function readLlmPolicy(cfg) {
+  return readModelOverridePolicy(cfg, "llm");
+}
+
+function readSubagentPolicy(cfg) {
+  return readModelOverridePolicy(cfg, "subagent");
 }
 
 function toModelRef(provider, model) {
@@ -49,6 +57,18 @@ function toModelRef(provider, model) {
   }
   const providerId = readString(provider);
   return providerId ? `${providerId}/${modelId}` : undefined;
+}
+
+function uniqueModelRefs(modelRefs) {
+  const seen = new Set();
+  return modelRefs.filter((entry) => {
+    const key = `${entry.field}:${entry.modelRef}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 /** Collect configured Lossless summary model refs that doctor can safely allowlist. */
@@ -119,16 +139,42 @@ function collectLosslessRuntimeLlmModelRefs(cfg) {
     }
   }
 
-  const seen = new Set();
   return {
-    modelRefs: modelRefs.filter((entry) => {
-      const key = `${entry.field}:${entry.modelRef}`;
-      if (seen.has(key)) {
-        return false;
-      }
-      seen.add(key);
-      return true;
-    }),
+    modelRefs: uniqueModelRefs(modelRefs),
+    skipped,
+  };
+}
+
+/** Collect configured Lossless expansion model refs that doctor can safely allowlist. */
+function collectLosslessSubagentModelRefs(cfg) {
+  const config = readConfig(cfg);
+  if (!config) {
+    return { modelRefs: [], skipped: [] };
+  }
+
+  const modelRefs = [];
+  const skipped = [];
+  const modelId = readString(config.expansionModel);
+  if (modelId) {
+    const modelRef = toModelRef(config.expansionProvider, modelId);
+    if (modelRef) {
+      modelRefs.push({
+        field: "expansionModel",
+        modelRef,
+        configPath: [...CONFIG_PATH, "expansionModel"].join("."),
+      });
+    } else {
+      skipped.push({
+        field: "expansionModel",
+        configPath: [...CONFIG_PATH, "expansionModel"].join("."),
+        reason:
+          `expansionModel is a bare model without a provider; use provider/model or set plugins.entries.${PLUGIN_ID}.config.expansionProvider so doctor can update plugins.entries.${PLUGIN_ID}.subagent.allowedModels.`,
+      });
+    }
+  }
+
+  return {
+    modelRefs: uniqueModelRefs(modelRefs),
     skipped,
   };
 }
@@ -136,6 +182,19 @@ function collectLosslessRuntimeLlmModelRefs(cfg) {
 function collectMissingPolicyEntries(cfg) {
   const { modelRefs, skipped } = collectLosslessRuntimeLlmModelRefs(cfg);
   const policy = readLlmPolicy(cfg);
+  const allowedStrings = new Set(policy.allowedModels.filter((entry) => typeof entry === "string"));
+  const missingRefs = modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
+  return {
+    modelRefs,
+    skipped,
+    missingRefs,
+    missingAllowModelOverride: modelRefs.length > 0 && policy.allowModelOverride !== true,
+  };
+}
+
+function collectMissingSubagentPolicyEntries(cfg) {
+  const { modelRefs, skipped } = collectLosslessSubagentModelRefs(cfg);
+  const policy = readSubagentPolicy(cfg);
   const allowedStrings = new Set(policy.allowedModels.filter((entry) => typeof entry === "string"));
   const missingRefs = modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
   return {
@@ -155,7 +214,16 @@ function hasIssueForField(cfg, field) {
   );
 }
 
-/** Doctor warning rules for Lossless runtime LLM model override policy. */
+function hasSubagentIssueForField(cfg, field) {
+  const issues = collectMissingSubagentPolicyEntries(cfg);
+  return (
+    issues.missingAllowModelOverride ||
+    issues.missingRefs.some((entry) => entry.field === field) ||
+    issues.skipped.some((entry) => entry.field === field)
+  );
+}
+
+/** Doctor warning rules for Lossless runtime LLM and subagent model override policy. */
 export const legacyConfigRules = [
   {
     path: [...CONFIG_PATH, "summaryModel"],
@@ -175,39 +243,46 @@ export const legacyConfigRules = [
       'Lossless fallbackProviders use api.runtime.llm.complete model overrides. Configure plugins.entries.lossless-claw.llm.allowModelOverride and allowedModels, or run "openclaw doctor --fix".',
     match: (_value, root) => hasIssueForField(root, "fallbackProviders"),
   },
+  {
+    path: [...CONFIG_PATH, "expansionModel"],
+    message:
+      'Lossless expansionModel uses delegated sub-agent model overrides. Configure plugins.entries.lossless-claw.subagent.allowModelOverride and allowedModels, or run "openclaw doctor --fix".',
+    match: (_value, root) => hasSubagentIssueForField(root, "expansionModel"),
+  },
 ];
 
-function cloneRootWithLosslessLlm(cfg) {
+function cloneRootWithLosslessEntry(cfg) {
   const root = isRecord(cfg) ? { ...cfg } : {};
   const plugins = isRecord(root.plugins) ? { ...root.plugins } : {};
   const entries = isRecord(plugins.entries) ? { ...plugins.entries } : {};
   const entry = isRecord(entries[PLUGIN_ID]) ? { ...entries[PLUGIN_ID] } : {};
-  const llm = isRecord(entry.llm) ? { ...entry.llm } : {};
 
   root.plugins = plugins;
   plugins.entries = entries;
   entries[PLUGIN_ID] = entry;
-  entry.llm = llm;
 
-  return { root, llm };
+  return { root, entry };
 }
 
-/** Add the minimal plugin runtime LLM policy needed for configured Lossless summary models. */
-export function normalizeCompatibilityConfig({ cfg }) {
-  const issues = collectMissingPolicyEntries(cfg);
+function ensurePolicy(entry, policyKey) {
+  const policy = isRecord(entry[policyKey]) ? { ...entry[policyKey] } : {};
+  entry[policyKey] = policy;
+  return policy;
+}
+
+function applyModelOverridePolicyRepair({ policy, issues, changes, policyPath, subject }) {
   if (issues.modelRefs.length === 0) {
-    return { config: cfg, changes: [] };
+    return;
   }
 
-  const { root, llm } = cloneRootWithLosslessLlm(cfg);
-  const changes = [];
-
-  if (llm.allowModelOverride !== true) {
-    llm.allowModelOverride = true;
-    changes.push("Set plugins.entries.lossless-claw.llm.allowModelOverride = true for configured Lossless summary model overrides.");
+  if (policy.allowModelOverride !== true) {
+    policy.allowModelOverride = true;
+    changes.push(
+      `Set plugins.entries.lossless-claw.${policyPath}.allowModelOverride = true for configured Lossless ${subject} model overrides.`,
+    );
   }
 
-  const currentAllowed = Array.isArray(llm.allowedModels) ? [...llm.allowedModels] : [];
+  const currentAllowed = Array.isArray(policy.allowedModels) ? [...policy.allowedModels] : [];
   const allowedStrings = new Set(currentAllowed.filter((entry) => typeof entry === "string"));
   const added = [];
   for (const { modelRef } of issues.modelRefs) {
@@ -218,14 +293,45 @@ export function normalizeCompatibilityConfig({ cfg }) {
     }
   }
 
-  if (added.length > 0 || !Array.isArray(llm.allowedModels)) {
-    llm.allowedModels = currentAllowed;
+  if (added.length > 0 || !Array.isArray(policy.allowedModels)) {
+    policy.allowedModels = currentAllowed;
     changes.push(
-      `Added plugins.entries.lossless-claw.llm.allowedModels entries for configured Lossless summary models: ${added.join(", ")}`,
+      `Added plugins.entries.lossless-claw.${policyPath}.allowedModels entries for configured Lossless ${subject} models: ${added.join(", ")}`,
     );
+  }
+}
+
+/** Add the minimal plugin policies needed for configured Lossless model overrides. */
+export function normalizeCompatibilityConfig({ cfg }) {
+  const issues = collectMissingPolicyEntries(cfg);
+  const subagentIssues = collectMissingSubagentPolicyEntries(cfg);
+  if (issues.modelRefs.length === 0 && subagentIssues.modelRefs.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const { root, entry } = cloneRootWithLosslessEntry(cfg);
+  const changes = [];
+
+  if (issues.modelRefs.length > 0) {
+    applyModelOverridePolicyRepair({
+      policy: ensurePolicy(entry, "llm"),
+      issues,
+      changes,
+      policyPath: "llm",
+      subject: "summary",
+    });
+  }
+  if (subagentIssues.modelRefs.length > 0) {
+    applyModelOverridePolicyRepair({
+      policy: ensurePolicy(entry, "subagent"),
+      issues: subagentIssues,
+      changes,
+      policyPath: "subagent",
+      subject: "expansion",
+    });
   }
 
   return { config: root, changes };
 }
 
-export { collectLosslessRuntimeLlmModelRefs };
+export { collectLosslessRuntimeLlmModelRefs, collectLosslessSubagentModelRefs };

--- a/doctor-contract-api.js
+++ b/doctor-contract-api.js
@@ -183,7 +183,9 @@ function collectMissingPolicyEntries(cfg) {
   const { modelRefs, skipped } = collectLosslessRuntimeLlmModelRefs(cfg);
   const policy = readLlmPolicy(cfg);
   const allowedStrings = new Set(policy.allowedModels.filter((entry) => typeof entry === "string"));
-  const missingRefs = modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
+  const missingRefs = allowedStrings.has("*")
+    ? []
+    : modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
   return {
     modelRefs,
     skipped,
@@ -196,7 +198,9 @@ function collectMissingSubagentPolicyEntries(cfg) {
   const { modelRefs, skipped } = collectLosslessSubagentModelRefs(cfg);
   const policy = readSubagentPolicy(cfg);
   const allowedStrings = new Set(policy.allowedModels.filter((entry) => typeof entry === "string"));
-  const missingRefs = modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
+  const missingRefs = allowedStrings.has("*")
+    ? []
+    : modelRefs.filter((entry) => !allowedStrings.has(entry.modelRef));
   return {
     modelRefs,
     skipped,
@@ -221,6 +225,10 @@ function hasSubagentIssueForField(cfg, field) {
     issues.missingRefs.some((entry) => entry.field === field) ||
     issues.skipped.some((entry) => entry.field === field)
   );
+}
+
+function needsPolicyRepair(issues) {
+  return issues.missingAllowModelOverride || issues.missingRefs.length > 0;
 }
 
 /** Doctor warning rules for Lossless runtime LLM and subagent model override policy. */
@@ -285,11 +293,13 @@ function applyModelOverridePolicyRepair({ policy, issues, changes, policyPath, s
   const currentAllowed = Array.isArray(policy.allowedModels) ? [...policy.allowedModels] : [];
   const allowedStrings = new Set(currentAllowed.filter((entry) => typeof entry === "string"));
   const added = [];
-  for (const { modelRef } of issues.modelRefs) {
-    if (!allowedStrings.has(modelRef)) {
-      currentAllowed.push(modelRef);
-      allowedStrings.add(modelRef);
-      added.push(modelRef);
+  if (!allowedStrings.has("*")) {
+    for (const { modelRef } of issues.modelRefs) {
+      if (!allowedStrings.has(modelRef)) {
+        currentAllowed.push(modelRef);
+        allowedStrings.add(modelRef);
+        added.push(modelRef);
+      }
     }
   }
 
@@ -305,14 +315,16 @@ function applyModelOverridePolicyRepair({ policy, issues, changes, policyPath, s
 export function normalizeCompatibilityConfig({ cfg }) {
   const issues = collectMissingPolicyEntries(cfg);
   const subagentIssues = collectMissingSubagentPolicyEntries(cfg);
-  if (issues.modelRefs.length === 0 && subagentIssues.modelRefs.length === 0) {
+  const repairRuntimeLlmPolicy = needsPolicyRepair(issues);
+  const repairSubagentPolicy = needsPolicyRepair(subagentIssues);
+  if (!repairRuntimeLlmPolicy && !repairSubagentPolicy) {
     return { config: cfg, changes: [] };
   }
 
   const { root, entry } = cloneRootWithLosslessEntry(cfg);
   const changes = [];
 
-  if (issues.modelRefs.length > 0) {
+  if (repairRuntimeLlmPolicy) {
     applyModelOverridePolicyRepair({
       policy: ensurePolicy(entry, "llm"),
       issues,
@@ -321,7 +333,7 @@ export function normalizeCompatibilityConfig({ cfg }) {
       subject: "summary",
     });
   }
-  if (subagentIssues.modelRefs.length > 0) {
+  if (repairSubagentPolicy) {
     applyModelOverridePolicyRepair({
       policy: ensurePolicy(entry, "subagent"),
       issues: subagentIssues,

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -218,6 +218,8 @@ function shouldRetryWithoutOverride(message: string): boolean {
     "forbidden",
     "provider/model overrides are not authorized",
     "model override is not authorized",
+    "not allowed for agent",
+    "not allowlisted for plugin",
     "unknown model",
     "model not found",
     "invalid model",

--- a/test/doctor-contract-api.test.ts
+++ b/test/doctor-contract-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   collectLosslessRuntimeLlmModelRefs,
+  collectLosslessSubagentModelRefs,
   legacyConfigRules,
   normalizeCompatibilityConfig,
 } from "../doctor-contract-api.js";
@@ -92,6 +93,57 @@ describe("doctor contract runtime LLM compatibility", () => {
     expect(summaryRule?.match?.("openai-codex/gpt-5.5", cfg)).toBe(true);
   });
 
+  it("repairs expansionModel subagent policy while preserving Lossless config", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              enabled: true,
+              expansionModel: "openai/gpt-5.4-mini",
+              delegationTimeoutMs: 300000,
+            },
+          },
+        },
+      },
+    };
+
+    const mutation = normalizeCompatibilityConfig({ cfg });
+
+    expect(mutation.config.plugins.entries["lossless-claw"].config).toEqual({
+      enabled: true,
+      expansionModel: "openai/gpt-5.4-mini",
+      delegationTimeoutMs: 300000,
+    });
+    expect(mutation.config.plugins.entries["lossless-claw"].subagent).toEqual({
+      allowModelOverride: true,
+      allowedModels: ["openai/gpt-5.4-mini"],
+    });
+    expect(mutation.config.plugins.entries["lossless-claw"]).not.toHaveProperty("llm");
+    expect(mutation.changes.join("\n")).toContain(
+      "Added plugins.entries.lossless-claw.subagent.allowedModels entries",
+    );
+  });
+
+  it("warns when configured expansion models are not covered by subagent policy", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              expansionModel: "openai/gpt-5.4-mini",
+            },
+          },
+        },
+      },
+    };
+
+    const expansionRule = legacyConfigRules.find((rule) => rule.path.at(-1) === "expansionModel");
+
+    expect(expansionRule?.match?.("openai/gpt-5.4-mini", cfg)).toBe(true);
+  });
+
   it("reports bare fallback models as skipped instead of inventing refs", () => {
     const result = collectLosslessRuntimeLlmModelRefs({
       plugins: {
@@ -107,5 +159,22 @@ describe("doctor contract runtime LLM compatibility", () => {
 
     expect(result.modelRefs).toEqual([]);
     expect(result.skipped[0]?.reason).toContain("provider and model");
+  });
+
+  it("reports bare expansion models as skipped instead of inventing refs", () => {
+    const result = collectLosslessSubagentModelRefs({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              expansionModel: "gpt-5.4-mini",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.modelRefs).toEqual([]);
+    expect(result.skipped[0]?.reason).toContain("bare model without a provider");
   });
 });

--- a/test/doctor-contract-api.test.ts
+++ b/test/doctor-contract-api.test.ts
@@ -144,6 +144,39 @@ describe("doctor contract runtime LLM compatibility", () => {
     expect(expansionRule?.match?.("openai/gpt-5.4-mini", cfg)).toBe(true);
   });
 
+  it("treats wildcard allowedModels as covering configured summary and expansion models", () => {
+    const cfg = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              summaryModel: "openai-codex/gpt-5.5",
+              expansionModel: "openai/gpt-5.4-mini",
+            },
+            llm: {
+              allowModelOverride: true,
+              allowedModels: ["*"],
+            },
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["*"],
+            },
+          },
+        },
+      },
+    };
+
+    const summaryRule = legacyConfigRules.find((rule) => rule.path.at(-1) === "summaryModel");
+    const expansionRule = legacyConfigRules.find((rule) => rule.path.at(-1) === "expansionModel");
+    const mutation = normalizeCompatibilityConfig({ cfg });
+
+    expect(summaryRule?.match?.("openai-codex/gpt-5.5", cfg)).toBe(false);
+    expect(expansionRule?.match?.("openai/gpt-5.4-mini", cfg)).toBe(false);
+    expect(mutation.changes).toEqual([]);
+    expect(mutation.config.plugins.entries["lossless-claw"].llm.allowedModels).toEqual(["*"]);
+    expect(mutation.config.plugins.entries["lossless-claw"].subagent.allowedModels).toEqual(["*"]);
+  });
+
   it("reports bare fallback models as skipped instead of inventing refs", () => {
     const result = collectLosslessRuntimeLlmModelRefs({
       plugins: {

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -893,6 +893,99 @@ describe("createLcmExpandQueryTool", () => {
     );
   });
 
+  it("retries without override when delegated spawn rejects an agent model allowlist", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    let agentCalls = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCalls += 1;
+        if (agentCalls === 1) {
+          throw new Error(
+            'Model override "openai-codex/gpt-5.4-mini" is not allowed for agent "main".',
+          );
+        }
+        return { runId: "run-default-model" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    answer: "Recovered after agent allowlist fallback.",
+                    citedIds: ["sum_a"],
+                    expandedSummaryCount: 1,
+                    totalSourceTokens: 987,
+                    truncated: false,
+                  }),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const deps = makeDeps();
+    const tool = createLcmExpandQueryTool({
+      deps: {
+        ...deps,
+        config: {
+          ...deps.config,
+          expansionProvider: "openai-codex",
+          expansionModel: "gpt-5.4-mini",
+        },
+      },
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("call-agent-allowlist-fallback", {
+      summaryIds: ["sum_a"],
+      prompt: "Answer this",
+      conversationId: 42,
+    });
+
+    expect(result.details).toMatchObject({
+      answer: "Recovered after agent allowlist fallback.",
+      citedIds: ["sum_a"],
+      expandedSummaryCount: 1,
+    });
+
+    const agentCallsWithParams = callGatewayMock.mock.calls
+      .map(([opts]) => opts as { method?: string; params?: Record<string, unknown> })
+      .filter((entry) => entry.method === "agent");
+    expect(agentCallsWithParams).toHaveLength(2);
+    expect(agentCallsWithParams[0]?.params).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.4-mini",
+    });
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("provider");
+    expect(agentCallsWithParams[1]?.params).not.toHaveProperty("model");
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("not allowed for agent"),
+    );
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("retrying delegated expansion without provider/model override"),
+    );
+  });
+
   it("returns timeout when delegated run exceeds 120 seconds", async () => {
     const retrieval = makeRetrieval();
     retrieval.describe.mockResolvedValue({


### PR DESCRIPTION
## Summary

- repair `openclaw doctor --fix` compatibility handling for `config.expansionModel` by teaching the doctor contract to patch `plugins.entries.lossless-claw.subagent.*`, not just the `llm` policy used by summary overrides
- broaden `lcm_expand_query`'s retry-without-override matcher so host denials like `not allowed for agent` and `not allowlisted for plugin` degrade cleanly instead of hard-failing recall
- document the behavior so the recommended `gpt-5.4-mini` expansion path is resilient on hosts with stale or stricter override policy

## Why

A common cost-sensitive setup is:

- summary path on the host default or a small summary model
- delegated `lcm_expand_query` on `openai/gpt-5.4-mini`

Today that path is still brittle in two ways:

1. `openclaw doctor --fix` only repairs `plugins.entries.lossless-claw.llm.*` for summary overrides, so users can think the config is repaired while the required `plugins.entries.lossless-claw.subagent.*` allowlist for `expansionModel` is still missing.
2. When the host rejects the delegated override with real-world messages like:
   - `Model 'openai/gpt-5.4-mini' is not allowed for agent 'main'.`
   - `model override "openai/gpt-5.4-mini" is not allowlisted for plugin "lossless-claw"`
   `lcm_expand_query` can still bubble the failure out instead of retrying without the override.

The result is that the recommended mini-model expansion path can fail even though Lossless should be able to fall back to the host default model and keep recall working.

Closes #701.

## Changes

- add `collectLosslessSubagentModelRefs(...)` to the doctor contract API
- add an `expansionModel` doctor compatibility rule alongside the existing summary-model rule
- extend compatibility repair so `normalizeCompatibilityConfig(...)` patches both:
  - `plugins.entries.lossless-claw.llm.*` for summary overrides
  - `plugins.entries.lossless-claw.subagent.*` for delegated expansion overrides
- extend `shouldRetryWithoutOverride(...)` in `lcm_expand_query` to catch the actual host denial strings above
- document that `doctor --fix` now covers the required subagent policy and that delegated expansion will retry without the override when the host rejects it

## Testing

- `pnpm exec vitest run test/doctor-contract-api.test.ts test/lcm-expand-query-tool.test.ts`

Expected / observed:
- 2 test files passed
- 36 tests passed
