### PR TITLE
fix: block cross-conversation shrink replays

### DIFF
--- a/.changeset/same-path-shrink-raw-id-guard.md
+++ b/.changeset/same-path-shrink-raw-id-guard.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Block same-path-shrink no-anchor bootstrap imports when candidate raw event IDs already belong to another active conversation.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -387,6 +387,33 @@ function safeString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function extractRawIdsFromPartMetadata(metadata: string | null | undefined): string[] {
+  if (!metadata) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata);
+  } catch {
+    return [];
+  }
+
+  const raw = asRecord(asRecord(parsed)?.raw);
+  if (!raw) {
+    return [];
+  }
+
+  return [
+    safeString(raw.id),
+    safeString(raw.call_id),
+    safeString(raw.toolCallId),
+    safeString(raw.tool_call_id),
+    safeString(raw.toolUseId),
+    safeString(raw.tool_use_id),
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
 function formatDurationMs(durationMs: number): string {
   return `${durationMs}ms`;
 }
@@ -2717,6 +2744,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
 
 type TranscriptReconcileResult = {
   blockedByImportCap: boolean;
+  blockedReason?: "import-cap" | "cross-conversation-raw-id";
   importedMessages: number;
   hasOverlap: boolean;
 };
@@ -5085,7 +5113,34 @@ export class LcmContextEngine implements ContextEngine {
             this.deps.log.debug(
               `[lcm] reconcileSessionTail: blocked no-anchor import for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} existingDbCount=${existingDbCount} cap=${importCap} overlap=false`,
             );
-            return { blockedByImportCap: true, importedMessages: 0, hasOverlap: false };
+            return {
+              blockedByImportCap: true,
+              blockedReason: "import-cap",
+              importedMessages: 0,
+              hasOverlap: false,
+            };
+          }
+
+          if (params.noAnchorImportReason === "same-path-shrink") {
+            const rawIdMatches = this.countActiveCrossConversationRawIdMatches({
+              conversationId,
+              sessionId,
+              messages: historicalMessages,
+            });
+            if (rawIdMatches.matchedRawIds > 0) {
+              this.deps.log.warn(
+                `[lcm] reconcileSessionTail: blocked same-path-shrink no-anchor import for ${sessionContext} because ${rawIdMatches.matchedRawIds}/${rawIdMatches.candidateRawIds} candidate raw ids already exist in other active conversations`,
+              );
+              this.deps.log.debug(
+                `[lcm] reconcileSessionTail: blocked cross-conversation raw-id duplicate for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateRawIds=${rawIdMatches.candidateRawIds} matchedRawIds=${rawIdMatches.matchedRawIds} overlap=false`,
+              );
+              return {
+                blockedByImportCap: true,
+                blockedReason: "cross-conversation-raw-id",
+                importedMessages: 0,
+                hasOverlap: false,
+              };
+            }
           }
 
           let importedMessages = 0;
@@ -5132,7 +5187,12 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.debug(
         `[lcm] reconcileSessionTail: blocked for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} missingTail=${missingTail.length} existingDbCount=${existingDbCount}`,
       );
-      return { blockedByImportCap: true, importedMessages: 0, hasOverlap: true };
+      return {
+        blockedByImportCap: true,
+        blockedReason: "import-cap",
+        importedMessages: 0,
+        hasOverlap: true,
+      };
     }
 
     let importedMessages = 0;
@@ -5147,6 +5207,70 @@ export class LcmContextEngine implements ContextEngine {
       `[lcm] reconcileSessionTail: slow path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages}`,
     );
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+  }
+
+  /** Count candidate raw event IDs that already belong to another active conversation. */
+  private countActiveCrossConversationRawIdMatches(params: {
+    conversationId: number;
+    sessionId: string;
+    messages: AgentMessage[];
+  }): { candidateRawIds: number; matchedRawIds: number } {
+    const candidateRawIds = new Set<string>();
+    for (const message of params.messages) {
+      const stored = toStoredMessage(message);
+      const parts = buildMessageParts({
+        sessionId: params.sessionId,
+        message,
+        fallbackContent: stored.content,
+      });
+      for (const part of parts) {
+        for (const rawId of extractRawIdsFromPartMetadata(part.metadata)) {
+          candidateRawIds.add(rawId);
+        }
+      }
+    }
+
+    if (candidateRawIds.size === 0) {
+      return { candidateRawIds: 0, matchedRawIds: 0 };
+    }
+
+    const matchStmt = this.db.prepare(
+      `SELECT 1 AS found
+       FROM message_parts mp
+       JOIN messages m ON m.message_id = mp.message_id
+       JOIN conversations c ON c.conversation_id = m.conversation_id
+       WHERE c.active = 1
+         AND m.conversation_id <> ?
+         AND mp.metadata IS NOT NULL
+         AND json_valid(mp.metadata)
+         AND (
+           json_extract(mp.metadata, '$.raw.id') = ?
+           OR json_extract(mp.metadata, '$.raw.call_id') = ?
+           OR json_extract(mp.metadata, '$.raw.toolCallId') = ?
+           OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
+           OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
+           OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
+         )
+       LIMIT 1`,
+    );
+
+    let matchedRawIds = 0;
+    for (const rawId of candidateRawIds) {
+      const row = matchStmt.get(
+        params.conversationId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+      ) as { found: number } | undefined;
+      if (row?.found === 1) {
+        matchedRawIds += 1;
+      }
+    }
+
+    return { candidateRawIds: candidateRawIds.size, matchedRawIds };
   }
 
   /**
@@ -5926,7 +6050,10 @@ export class LcmContextEngine implements ContextEngine {
             return {
               bootstrapped: false,
               importedMessages: 0,
-              reason: "reconcile import capped",
+              reason:
+                reconcile.blockedReason === "cross-conversation-raw-id"
+                  ? "reconcile duplicate raw ids"
+                  : "reconcile import capped",
             };
           }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -192,6 +192,14 @@ function writeLeafTranscript(
   );
 }
 
+function writeLeafTranscriptMessages(sessionFile: string, messages: AgentMessage[]): void {
+  writeFileSync(
+    sessionFile,
+    messages.map((message) => JSON.stringify({ message })).join("\n") + "\n",
+    "utf8",
+  );
+}
+
 function createEngineWithConfig(overrides: Partial<LcmConfig>): LcmContextEngine {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
   tempDirs.push(tempDir);
@@ -4962,6 +4970,95 @@ describe("LcmContextEngine.bootstrap", () => {
       .getConversationBootstrapState(conversation!.conversationId);
     expect(newCheckpoint?.sessionFilePath).toBe(sessionFile);
     expect(newCheckpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("blocks same-path shrink import when raw ids belong to another active conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+
+    const mainSessionId = "bootstrap-same-path-shrink-cross-main";
+    const mainSessionKey = "agent:main:main";
+    const mainSessionFile = createSessionFilePath("bootstrap-same-path-shrink-cross-main");
+    writeLeafTranscript(mainSessionFile, [
+      { role: "user", content: "main old user" },
+      { role: "assistant", content: "main old assistant" },
+    ]);
+    appendFileSync(
+      mainSessionFile,
+      `${JSON.stringify({ type: "custom", payload: "x".repeat(20_000) })}\n`,
+      "utf8",
+    );
+
+    const first = await engine.bootstrap({
+      sessionId: mainSessionId,
+      sessionKey: mainSessionKey,
+      sessionFile: mainSessionFile,
+    });
+    expect(first.bootstrapped).toBe(true);
+    expect(first.importedMessages).toBe(2);
+
+    const mainConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: mainSessionId,
+      sessionKey: mainSessionKey,
+    });
+    expect(mainConversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(mainConversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(mainSessionFile);
+
+    const duplicateMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "raw-cross-user", text: "telegram duplicate user" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "raw-cross-assistant", text: "telegram duplicate assistant" }],
+      }),
+    ];
+    const directSessionFile = createSessionFilePath("bootstrap-same-path-shrink-cross-direct");
+    writeLeafTranscriptMessages(directSessionFile, duplicateMessages);
+    await engine.bootstrap({
+      sessionId: "bootstrap-same-path-shrink-cross-direct",
+      sessionKey: "agent:main:telegram:default:direct:8455538490",
+      sessionFile: directSessionFile,
+    });
+
+    writeLeafTranscriptMessages(mainSessionFile, duplicateMessages);
+    expect(oldCheckpoint!.lastProcessedOffset).toBeGreaterThan(statSync(mainSessionFile).size);
+
+    const second = await engine.bootstrap({
+      sessionId: mainSessionId,
+      sessionKey: mainSessionKey,
+      sessionFile: mainSessionFile,
+    });
+    expect(second).toEqual({
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: "reconcile duplicate raw ids",
+    });
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked same-path-shrink no-anchor import")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(mainConversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "main old user",
+      "main old assistant",
+    ]);
+
+    const checkpointAfterBlock = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(mainConversation!.conversationId);
+    expect(checkpointAfterBlock?.lastProcessedOffset).toBe(oldCheckpoint?.lastProcessedOffset);
   });
 
   it("imports the full bounded same-path shrink epoch instead of trusting a stale externalized frontier", async () => {


### PR DESCRIPTION
## What
Blocks same-path-shrink no-anchor bootstrap imports when candidate raw event IDs already exist in another active conversation.

## Why
A rewritten transcript can be misassociated with the main session during restart. Without a cross-conversation raw-id guard, LCM can import another session's transcript as fresh unsuppressed rows. Fixes #705.

## Changes
- Guard same-path-shrink no-anchor imports
- Detect active cross-conversation raw IDs
- Preserve stale checkpoint on block
- Add regression coverage
- Add patch changeset

## Testing
- `npm test -- --run test/engine.test.ts -t "same-path shrink"`
- `npm run build`
- `npm test`
- `git diff --check`