### PR TITLE
fix: keep short focus briefs usable

### DIFF
--- a/src/focus-briefs.ts
+++ b/src/focus-briefs.ts
@@ -43,6 +43,7 @@ export type FocusBriefGeneration = {
   truncated: boolean;
   rawReply?: string;
   rawResultJson?: string;
+  warning?: string;
   error?: string;
 };
 
@@ -271,13 +272,19 @@ function parseFocusEvidenceReply(rawReply: string | undefined): ParsedFocusEvide
 function buildPersistedFocusResultJson(
   parsed: ParsedFocusBriefReply,
   truncated: boolean,
+  warning?: string,
 ): string | undefined {
-  if (!parsed.rawResultJson || !truncated) {
+  if (!parsed.rawResultJson || (!truncated && !warning)) {
     return parsed.rawResultJson;
   }
   try {
     const raw = JSON.parse(parsed.rawResultJson) as Record<string, unknown>;
-    raw.truncated = true;
+    if (truncated) {
+      raw.truncated = true;
+    }
+    if (warning) {
+      raw.warning = warning;
+    }
     return JSON.stringify(raw);
   } catch {
     return parsed.rawResultJson;
@@ -830,10 +837,13 @@ async function runDelegatedFocusWorkflow(params: {
 
     const parsed = attempt.parsed;
     const stillShort = attempt.tokenCount < minimumTokens;
+    const warning = stillShort
+      ? `Focus brief is shorter than the requested ${minimumTokens}-token minimum.`
+      : undefined;
     const evidence = evidenceAttempt.parsed;
     const truncated = evidence.truncated || parsed.truncated;
     return {
-      status: stillShort ? "error" : "ok",
+      status: "ok",
       runId: attempt.runId,
       childSessionKey,
       briefMarkdown: parsed.briefMarkdown,
@@ -849,8 +859,8 @@ async function runDelegatedFocusWorkflow(params: {
       targetTokens,
       truncated,
       rawReply: attempt.rawReply,
-      rawResultJson: buildPersistedFocusResultJson(parsed, truncated),
-      error: stillShort ? `Focus brief remained below the ${minimumTokens}-token minimum.` : undefined,
+      rawResultJson: buildPersistedFocusResultJson(parsed, truncated, warning),
+      warning,
     };
   } catch (err) {
     return {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1628,6 +1628,9 @@ async function buildFocusGenerateText(params: {
       buildStatLine("truncated", formatBoolean(generation.truncated)),
     ]),
   );
+  if (generation.warning) {
+    lines.push("", buildSection("⚠️ Generation warning", [generation.warning]));
+  }
   if (!ok) {
     lines.push(
       "",
@@ -1877,6 +1880,9 @@ async function buildRefocusText(params: {
       buildStatLine("truncated", formatBoolean(generation.truncated)),
     ]),
   );
+  if (generation.warning) {
+    lines.push("", buildSection("⚠️ Generation warning", [generation.warning]));
+  }
   if (!ok) {
     lines.push(
       "",

--- a/test/focus-briefs.test.ts
+++ b/test/focus-briefs.test.ts
@@ -370,7 +370,7 @@ describe("focus brief generation", () => {
     });
   });
 
-  it("does not retry synthesis when the first brief is too short", async () => {
+  it("keeps a generated focus brief usable when the first brief is too short", async () => {
     let agentRuns = 0;
     let sessionReads = 0;
     const callGateway = vi.fn(async (request: { method: string; params?: Record<string, unknown> }) => {
@@ -426,12 +426,15 @@ describe("focus brief generation", () => {
       summaries: activeSummaries,
     });
 
-    expect(result.status).toBe("error");
+    expect(result.status).toBe("ok");
     expect(result.runId).toBe("focus-run-2");
     expect(result.briefMarkdown).toContain("Too short.");
     expect(result.expandedSummaryIds).toEqual(["summary_focus_a"]);
     expect(result.tokenCount).toBeLessThan(7200);
-    expect(result.error).toBe("Focus brief remained below the 7200-token minimum.");
+    expect(result.warning).toBe("Focus brief is shorter than the requested 7200-token minimum.");
+    expect(JSON.parse(result.rawResultJson ?? "{}")).toMatchObject({
+      warning: "Focus brief is shorter than the requested 7200-token minimum.",
+    });
     expect(callGateway.mock.calls.map((call) => call[0].method)).toEqual([
       "agent",
       "agent.wait",


### PR DESCRIPTION
## What
Keep generated focus briefs usable even when they come back shorter than the requested target window.

## Why
The previous hard minimum turned an eight-minute focus generation into a failed command with no active brief, even though the model returned usable content.

## Changes
- Treat short synthesis as successful
- Persist short-brief warnings
- Show warning in command output
- Update regression coverage

## Testing
- pnpm test test/focus-briefs.test.ts -- --runInBand
- pnpm test test/lcm-command.test.ts -- --runInBand
- npm run build