### PR TITLE
fix: add changeset for short focus briefs

### DIFF
--- a/.changeset/focus-brief-short-warning.md
+++ b/.changeset/focus-brief-short-warning.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep generated focus briefs usable when they are shorter than the target length, surfacing a warning instead of failing the command after generation.


### PR DESCRIPTION
## What
Adds the missing Changesets entry for PR #707.

## Why
PR #707 changed user-facing focus brief behavior after generation but merged without a changeset, so the next package release would otherwise omit it from release notes.

## Changes
- Add patch changeset

## Testing
- Not run; changeset-only PR