### PR TITLE
fix: remove stale afterTurn reconcile invalidation

### DIFF
--- a/.changeset/afterturn-placeholder-reconcile.md
+++ b/.changeset/afterturn-placeholder-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove a stale stable-orphan invalidation call from afterTurn placeholder-checkpoint recovery. Stable orphan stripping was removed with the cache-state-dependent assembly path, but the placeholder recovery branch still referenced the deleted method and could throw `clearStableOrphanStrippingOrdinal is not a function` during transcript reconcile.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5446,7 +5446,6 @@ export class LcmContextEngine implements ContextEngine {
                 noAnchorImportReason: "placeholder-checkpoint-recovery",
               });
               if (reconcile.importedMessages > 0) {
-                this.clearStableOrphanStrippingOrdinal(conversation.conversationId);
                 this.recordRecentBootstrapImport(
                   conversation.conversationId,
                   reconcile.importedMessages,


### PR DESCRIPTION
## Summary

- remove the stale `clearStableOrphanStrippingOrdinal` call from afterTurn placeholder-checkpoint recovery
- keep the existing placeholder recovery behavior intact now that stable orphan stripping has been removed
- add a patch changeset for the release notes

Fixes #713

## Verification

- `npm run build`
- `npm test -- test/engine.test.ts -t "seeds placeholder bootstrap_state"`
- `env -u OPENCLAW_STATE_DIR npm test`
