### PR TITLE
fix: keep deferred compaction off normal assemble path

### DIFF
--- a/.changeset/defer-assemble-compaction.md
+++ b/.changeset/defer-assemble-compaction.md
@@ -6,6 +6,6 @@ Keep deferred threshold compaction off the normal next-turn assemble path.
 
 Pending deferred compaction debt is now left for the after-turn background drain
 or host-approved maintenance while the live prompt is still within the active
-token budget. `assemble()` only drains pending debt synchronously when the live
-prompt estimate is already over budget, preserving the emergency safety path
+token budget. `assemble()` only drains pending debt synchronously as an
+emergency safeguard when the live prompt estimate is already over budget,
 without turning ordinary threshold debt into foreground latency.

--- a/.changeset/defer-assemble-compaction.md
+++ b/.changeset/defer-assemble-compaction.md
@@ -1,0 +1,11 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep deferred threshold compaction off the normal next-turn assemble path.
+
+Pending deferred compaction debt is now left for the after-turn background drain
+or host-approved maintenance while the live prompt is still within the active
+token budget. `assemble()` only drains pending debt synchronously when the live
+prompt estimate is already over budget, preserving the emergency safety path
+without turning ordinary threshold debt into foreground latency.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,7 +299,8 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 - deferred mode records a single coalesced maintenance debt row per conversation
 - new deferred compaction debt is only created for `contextThreshold` pressure and uses reason `"threshold"`
 - `maintain()` consumes threshold debt when the host explicitly opts in to deferred execution
-- `assemble()` consumes pending threshold debt before building the next prompt
+- `assemble()` leaves pending threshold debt for after-turn background drain or host-approved `maintain()` while the live prompt is still within budget
+- `assemble()` only consumes pending threshold debt synchronously when the live prompt estimate is already over the active token budget
 - old non-threshold debt from earlier builds is revalidated; if the conversation is no longer over threshold, it is cleared as a no-op
 - `/lcm status` / `/lossless status` shows the current maintenance state, including pending/running/last-failure details
 - status output also surfaces the latest API/cache telemetry as diagnostics, not as a deferral gate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,8 @@ Automatic compaction is threshold-only:
 - `afterTurn()` evaluates `contextThreshold` against the active token budget
 - below threshold, no automatic compaction runs and no leaf debt is recorded
 - at or above threshold, inline mode runs a threshold full sweep immediately
-- deferred mode records one coalesced `"threshold"` maintenance row and drains it in the background, `maintain()`, or pre-assembly
+- deferred mode records one coalesced `"threshold"` maintenance row and normally drains it in the background or host-approved `maintain()`
+- pre-assembly drain is reserved as an emergency safeguard when the live prompt is already over the active token budget
 
 Lossless still records prompt-cache telemetry for status and diagnostics, but cache hotness no longer delays threshold debt. Legacy `cacheAwareCompaction.*` and `dynamicLeafChunkTokens.*` settings remain accepted so existing OpenClaw config continues to load, but they do not change automatic compaction behavior.
 
@@ -300,7 +301,7 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 - new deferred compaction debt is only created for `contextThreshold` pressure and uses reason `"threshold"`
 - `maintain()` consumes threshold debt when the host explicitly opts in to deferred execution
 - `assemble()` leaves pending threshold debt for after-turn background drain or host-approved `maintain()` while the live prompt is still within budget
-- `assemble()` only consumes pending threshold debt synchronously when the live prompt estimate is already over the active token budget
+- `assemble()` only consumes pending threshold debt synchronously as an emergency safeguard when the live prompt estimate is already over the active token budget
 - old non-threshold debt from earlier builds is revalidated; if the conversation is no longer over threshold, it is cleared as a no-op
 - `/lcm status` / `/lossless status` shows the current maintenance state, including pending/running/last-failure details
 - status output also surfaces the latest API/cache telemetry as diagnostics, not as a deferral gate

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -266,7 +266,7 @@ Why it matters:
 - `deferred` also stores provider/model/cache telemetry so Anthropic-family sessions can avoid rewriting a still-hot prompt cache
 - `inline` preserves the legacy foreground compaction path for hosts that do not yet support deferred execution
 - `/lossless status` and `/lcm status` surface pending/running/last-failure maintenance state so operators can see when compaction is queued
-- background `maintain()` can still do non-prompt-mutating work, but prompt-mutating debt is consumed pre-assembly once cache is cold or the next turn is already approaching overflow
+- after-turn background drain and host-approved `maintain()` consume routine threshold debt; `assemble()` only drains pending threshold debt synchronously when the live prompt estimate is already over budget
 
 ### `autoRotateSessionFiles`
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -266,7 +266,7 @@ Why it matters:
 - `deferred` also stores provider/model/cache telemetry so Anthropic-family sessions can avoid rewriting a still-hot prompt cache
 - `inline` preserves the legacy foreground compaction path for hosts that do not yet support deferred execution
 - `/lossless status` and `/lcm status` surface pending/running/last-failure maintenance state so operators can see when compaction is queued
-- after-turn background drain and host-approved `maintain()` consume routine threshold debt; `assemble()` only drains pending threshold debt synchronously when the live prompt estimate is already over budget
+- after-turn background drain and host-approved `maintain()` consume routine threshold debt; `assemble()` only drains pending threshold debt synchronously as an emergency safeguard when the live prompt estimate is already over budget
 
 ### `autoRotateSessionFiles`
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3373,8 +3373,9 @@ export class LcmContextEngine implements ContextEngine {
   /**
    * Consume durable threshold debt only when the session queue is idle.
    *
-   * Any skipped busy-queue attempt leaves the maintenance row pending for
-   * assemble() or a later host-approved maintain() pass.
+   * Any skipped busy-queue attempt leaves the maintenance row pending for a
+   * later idle drain, host-approved maintain() pass, or emergency assemble()
+   * fallback if the live prompt is already over budget.
    */
   private async drainDeferredCompactionDebtIfIdle(
     params: DeferredCompactionDebtDrainParams & { queueKey: string },
@@ -3560,7 +3561,9 @@ export class LcmContextEngine implements ContextEngine {
    * Consume deferred debt for assemble() only after the caller has established
    * that the live prompt is already over budget. Routine threshold debt is
    * drained after turns or by host-approved maintain() calls so the next user
-   * turn is not held hostage by proactive compaction work.
+   * turn is not held hostage by proactive compaction work. Hitting this path
+   * means idle/background maintenance did not catch up before the prompt became
+   * unusable, so callers should treat it as an emergency safeguard.
    */
   private async maybeConsumeDeferredCompactionDebtForAssemble(params: {
     conversationId: number;
@@ -7252,8 +7255,8 @@ export class LcmContextEngine implements ContextEngine {
       );
       if (maintenance?.pending || maintenance?.running) {
         if (liveContextTokens > tokenBudget) {
-          this.deps.log.debug(
-            `[lcm] assemble: deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
+          this.deps.log.warn(
+            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
           );
           try {
             await this.maybeConsumeDeferredCompactionDebtForAssemble({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3557,8 +3557,10 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /**
-   * Re-check and consume deferred debt for assemble() while holding the
-   * session queue so pre-assembly writes cannot race queued maintenance.
+   * Consume deferred debt for assemble() only after the caller has established
+   * that the live prompt is already over budget. Routine threshold debt is
+   * drained after turns or by host-approved maintain() calls so the next user
+   * turn is not held hostage by proactive compaction work.
    */
   private async maybeConsumeDeferredCompactionDebtForAssemble(params: {
     conversationId: number;
@@ -7249,17 +7251,26 @@ export class LcmContextEngine implements ContextEngine {
         conversation.conversationId,
       );
       if (maintenance?.pending || maintenance?.running) {
-        try {
-          await this.maybeConsumeDeferredCompactionDebtForAssemble({
-            conversationId: conversation.conversationId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            tokenBudget,
-            currentTokenCount: liveContextTokens,
-          });
-        } catch (error) {
-          this.deps.log.warn(
-            `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
+        if (liveContextTokens > tokenBudget) {
+          this.deps.log.debug(
+            `[lcm] assemble: deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
+          );
+          try {
+            await this.maybeConsumeDeferredCompactionDebtForAssemble({
+              conversationId: conversation.conversationId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              tokenBudget,
+              currentTokenCount: liveContextTokens,
+            });
+          } catch (error) {
+            this.deps.log.warn(
+              `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
+            );
+          }
+        } else {
+          this.deps.log.debug(
+            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=not-over-budget`,
           );
         }
       }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7254,9 +7254,16 @@ export class LcmContextEngine implements ContextEngine {
         conversation.conversationId,
       );
       if (maintenance?.pending || maintenance?.running) {
-        if (liveContextTokens > tokenBudget) {
+        const recordedContextTokens = this.normalizeObservedTokenCount(
+          maintenance.currentTokenCount ?? undefined,
+        );
+        const emergencyContextTokens = Math.max(
+          liveContextTokens,
+          recordedContextTokens ?? 0,
+        );
+        if (emergencyContextTokens > tokenBudget) {
           this.deps.log.warn(
-            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
+            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${emergencyContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
           );
           try {
             await this.maybeConsumeDeferredCompactionDebtForAssemble({
@@ -7264,7 +7271,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               tokenBudget,
-              currentTokenCount: liveContextTokens,
+              currentTokenCount: emergencyContextTokens,
             });
           } catch (error) {
             this.deps.log.warn(
@@ -7273,7 +7280,7 @@ export class LcmContextEngine implements ContextEngine {
           }
         } else {
           this.deps.log.debug(
-            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${liveContextTokens} tokenBudget=${tokenBudget} reason=not-over-budget`,
+            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${emergencyContextTokens} tokenBudget=${tokenBudget} reason=not-over-budget`,
           );
         }
       }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9735,8 +9735,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
-  it("assemble() consumes pending threshold debt before returning context when already over budget", async () => {
-    const engine = createEngine();
+  it("assemble() drains pending threshold debt as an emergency when already over budget", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
     };
@@ -9779,6 +9785,12 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.pending).toBe(false);
     expect(maintenance?.running).toBe(false);
     expect(assembleResult.messages).toHaveLength(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lcm] assemble: emergency deferred compaction debt draining pre-assembly",
+      ),
+    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=over-budget"));
   });
 
   it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9696,12 +9696,12 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(result.reason).toBe("compacted but still over target");
   });
 
-  it("assemble() consumes pending threshold debt before returning context", async () => {
+  it("assemble() leaves pending threshold debt for post-turn maintenance while under budget", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
     };
-    const sessionId = "assemble-threshold-debt-drains";
+    const sessionId = "assemble-threshold-debt-left-pending";
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
@@ -9729,11 +9729,50 @@ describe("LcmContextEngine fidelity and token budget", () => {
     const maintenance = await engine
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() consumes pending threshold debt before returning context when already over budget", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-threshold-debt-over-budget-drains";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 3_500,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello ".repeat(200) })],
+      tokenBudget: 10,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
     expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: conversation.conversationId,
         sessionId,
-        tokenBudget: 4_096,
+        tokenBudget: 10,
         compactionTarget: "threshold",
       }),
     );
@@ -9742,7 +9781,55 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
-  it("assemble() waits for the session queue before consuming deferred threshold debt", async () => {
+  it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      withSessionQueue<T>(queueKey: string, operation: () => Promise<T>): Promise<T>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-not-urgent";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 42,
+    });
+    const consumeSpy = vi.spyOn(privateEngine, "consumeDeferredCompactionDebt");
+
+    let releaseQueue!: () => void;
+    const heldQueue = privateEngine.withSessionQueue(sessionId, async () => {
+      await new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+    });
+
+    let assembleSettled = false;
+    const assemblePromise = engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    }).then((result) => {
+      assembleSettled = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consumeSpy).not.toHaveBeenCalled();
+    expect(assembleSettled).toBe(true);
+
+    releaseQueue();
+    await heldQueue;
+    const assembleResult = await assemblePromise;
+
+    expect(consumeSpy).not.toHaveBeenCalled();
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() waits for the session queue before emergency deferred threshold compaction", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
       withSessionQueue<T>(queueKey: string, operation: () => Promise<T>): Promise<T>;
@@ -9770,8 +9857,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
     let assembleSettled = false;
     const assemblePromise = engine.assemble({
       sessionId,
-      messages: [makeMessage({ role: "user", content: "hello" })],
-      tokenBudget: 4_096,
+      messages: [makeMessage({ role: "user", content: "hello ".repeat(200) })],
+      tokenBudget: 10,
     }).then((result) => {
       assembleSettled = true;
       return result;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9793,6 +9793,53 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=over-budget"));
   });
 
+  it("assemble() drains pending threshold debt when recorded runtime tokens are over budget", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-threshold-debt-runtime-over-budget-drains";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: conversation.conversationId,
+        sessionId,
+        tokenBudget: 4_096,
+        currentTokenCount: 5_000,
+        compactionTarget: "threshold",
+      }),
+    );
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
   it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {


### PR DESCRIPTION
## Summary

- keep pending deferred threshold compaction out of the normal `assemble()` path while the live prompt is still within budget
- preserve the emergency pre-assembly drain when the live prompt estimate is already over the active token budget
- add paired debug logs for `reason=not-over-budget` vs `reason=over-budget`
- update regression coverage for under-budget skip, over-budget emergency drain, and session-queue behavior

## Why

Deferred threshold compaction currently records debt after a turn, but if that debt is still pending when the next user turn starts, `assemble()` drains it synchronously before returning context. That turns ordinary threshold debt into next-turn foreground latency.

This PR keeps the desired after-turn/background maintenance model for routine threshold debt. `assemble()` only blocks for deferred compaction when the prompt is already over budget, where compaction is needed as a correctness/safety fallback.

## Observability

The new assemble decision logs are:

- `[lcm] assemble: deferred compaction debt left pending ... reason=not-over-budget`
- `[lcm] assemble: deferred compaction debt draining pre-assembly ... reason=over-budget`

Existing background and maintain logs still report whether deferred compaction was skipped, completed, or failed.

## Tests

- `npx vitest run test/engine.test.ts --maxWorkers=1`
- `npm run build`
