### PR TITLE
Add independent Lossless log file

### DIFF
--- a/.changeset/independent-log-file.md
+++ b/.changeset/independent-log-file.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Write lossless-claw operational logs to an independent daily JSONL log file beside OpenClaw's logs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,11 @@ Most installations only need to override a handful of keys. If you want a comple
     "startup": "rotate",
     "runtime": "rotate"
   },
+  "independentLogFile": {
+    "enabled": true,
+    "file": "/tmp/openclaw/lossless-claw-2026-05-19.log",
+    "maxFileBytes": 104857600
+  },
   "cacheAwareCompaction": {
     "enabled": true,
     "cacheTTLSeconds": 300,
@@ -133,8 +138,13 @@ openclaw plugins install --link /path/to/lossless-claw
 | `autoRotateSessionFiles.sizeBytes` | `integer` | `2097152` | `LCM_AUTO_ROTATE_SESSION_FILES_SIZE_BYTES` | Byte threshold that triggers automatic session-file rotation. |
 | `autoRotateSessionFiles.startup` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_STARTUP` | Startup behavior for oversized indexed OpenClaw session transcripts that also have active LCM bootstrap state. |
 | `autoRotateSessionFiles.runtime` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME` | Runtime behavior after `afterTurn()` and `maintain()` check the current transcript size. |
+| `independentLogFile.enabled` | `boolean` | `true` | `LCM_LOG_FILE_ENABLED` | Writes lossless-claw JSONL logs to an independent plugin-owned file in addition to OpenClaw's runtime logger. |
+| `independentLogFile.file` | `string` | `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log` | `LCM_LOG_FILE` | Optional log path. A dated `lossless-claw-YYYY-MM-DD.log` path rolls over daily. |
+| `independentLogFile.maxFileBytes` | `integer` | `104857600` | `LCM_LOG_MAX_FILE_BYTES` | Size threshold for rotating the active lossless-claw log file to `.1.log` through `.5.log`. |
 
 > **Multi-profile note:** `OPENCLAW_STATE_DIR` (set by the host OpenClaw gateway) controls where state is stored. When two gateways run on the same host (e.g. separate bot personas), each gateway sets its own `OPENCLAW_STATE_DIR` and lossless-claw automatically uses that directory for the database, large-file payloads, auth-profile lookups, and legacy secrets — no per-profile plugin config is needed.
+
+Lossless-claw also writes its own operational JSONL log by default at `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log`, beside OpenClaw's `/tmp/openclaw/openclaw-YYYY-MM-DD.log`. The plugin still forwards every line to OpenClaw's runtime logger, so existing gateway logs and diagnostics continue to work. The independent file follows the same practical rotation model as OpenClaw: a dated filename rolls over when the local date changes, stale dated files are pruned after 24 hours, and an oversized active file is rotated through `.1.log` to `.5.log`.
 
 Automatic session-file rotation rewrites only the live session transcript, keeps the active LCM conversation and durable history intact, and refreshes the bootstrap checkpoint. Startup rotation first scans OpenClaw's current indexed session stores for configured agents, then intersects those candidates with active LCM conversations and matching bootstrap file mappings. Automatic rotation does not create a SQLite backup by default; set `autoRotateSessionFiles.createBackups` to `true` to make runtime rotation replace the rolling `rotate-latest` backup and to make startup rotation create one pre-rotation LCM database backup for the batch before any transcript is rewritten. Manual `/lcm rotate` always keeps its backup-backed behavior regardless of this flag. Rotation never runs for ignored sessions, stateless sessions, or sessions without active LCM state. The preserved JSONL tail follows the existing rotate behavior, which is controlled by `freshTailCount`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,11 @@ Most installations only need to override a handful of keys. If you want a comple
     "startup": "rotate",
     "runtime": "rotate"
   },
+  "independentLogFile": {
+    "enabled": true,
+    "file": "/tmp/openclaw/lossless-claw-2026-05-19.log",
+    "maxFileBytes": 104857600
+  },
   "cacheAwareCompaction": {
     "enabled": true,
     "cacheTTLSeconds": 300,
@@ -158,10 +163,15 @@ openclaw plugins install --link /path/to/lossless-claw
 | `autoRotateSessionFiles.sizeBytes` | `integer` | `2097152` | `LCM_AUTO_ROTATE_SESSION_FILES_SIZE_BYTES` | Byte threshold that triggers automatic session-file rotation. |
 | `autoRotateSessionFiles.startup` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_STARTUP` | Startup behavior for oversized indexed OpenClaw session transcripts that also have active LCM bootstrap state. |
 | `autoRotateSessionFiles.runtime` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME` | Runtime behavior after post-turn checks. Runtime `rotate` logs deferral for active session JSONL rewrites and leaves direct rotation to startup or manual `/lcm rotate`. |
+| `independentLogFile.enabled` | `boolean` | `true` | `LCM_LOG_FILE_ENABLED` | Writes lossless-claw JSONL logs to an independent plugin-owned file in addition to OpenClaw's runtime logger. |
+| `independentLogFile.file` | `string` | `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log` | `LCM_LOG_FILE` | Optional log path. A dated `lossless-claw-YYYY-MM-DD.log` path rolls over daily. |
+| `independentLogFile.maxFileBytes` | `integer` | `104857600` | `LCM_LOG_MAX_FILE_BYTES` | Size threshold for rotating the active lossless-claw log file to `.1.log` through `.5.log`. |
 
 > **Multi-profile note:** `OPENCLAW_STATE_DIR` (set by the host OpenClaw gateway) controls where state is stored. When two gateways run on the same host (e.g. separate bot personas), each gateway sets its own `OPENCLAW_STATE_DIR` and lossless-claw automatically uses that directory for the database, large-file payloads, auth-profile lookups, and legacy secrets — no per-profile plugin config is needed.
 
 Automatic session-file rotation rewrites only the live session transcript, keeps the active LCM conversation and durable history intact, and refreshes the bootstrap checkpoint. Before manual or startup rewrites, rotation forces leaf-only compaction for raw context outside the preserved tail so trimmed transcript messages are covered by LCM summaries without running unrelated summary-condensation passes. Startup rotation first scans OpenClaw's current indexed session stores for configured agents, then intersects those candidates with active LCM conversations and matching bootstrap file mappings. Runtime rotation checks from `afterTurn()` and `maintain()` intentionally do not directly rewrite active session JSONL because embedded prompt-lock fences can still be open while tool-call loops and host background maintenance overlap; runtime `rotate` logs a deferral until startup, manual `/lcm rotate`, or a future host-owned full-transcript rewrite primitive is available. Automatic rotation does not create a SQLite backup by default; set `autoRotateSessionFiles.createBackups` to `true` to make startup rotation create one pre-rotation LCM database backup for the batch before any transcript is rewritten. Manual `/lcm rotate` always keeps its backup-backed behavior regardless of this flag. Rotation never runs for ignored sessions, stateless sessions, or sessions without active LCM state. The preserved JSONL tail follows the existing rotate behavior, which is controlled by `freshTailCount`. Transcript GC uses the host-provided `rewriteTranscriptEntries` primitive and defers until host-approved background maintenance when `transcriptGcEnabled` is enabled.
+
+Lossless-claw writes routine operational JSONL logs by default at `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log`, beside OpenClaw's `/tmp/openclaw/openclaw-YYYY-MM-DD.log`. Routine info and debug lines go to the independent file instead of the shared OpenClaw log. Startup banners and warning/error lines still go through OpenClaw's runtime logger so gateway-level startup and failure diagnostics remain visible. The independent file follows the same practical rotation model as OpenClaw: a dated filename rolls over when the local date changes, stale dated files are pruned after 3 days, and an oversized active file is rotated through `.1.log` to `.5.log`.
 
 Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rotate:`. Startup emits one compact summary line with `phase=startup`, `action=summary`, `scanned`, `eligible`, `rotated`, `warned`, `skipped`, `durationMs`, `bytesRemoved`, and backup fields when a batch backup was created; quiet skips such as missing files, missing bootstrap mappings, and below-threshold files are counted there instead of producing one line per candidate. Rotation detail lines include `phase`, `action`, `sessionId`, `sessionKey`, `sessionFile`, `sizeBytes`, `thresholdBytes`, `durationMs`, `backupPath`, `bytesRemoved`, `preservedTailMessageCount`, and `checkpointSize`; real warning lines include the same available context plus `reason` or `error`.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -248,6 +248,18 @@
       "label": "Runtime Auto-Rotate",
       "help": "Runtime behavior for oversized current LCM session files: rotate, warn, or off"
     },
+    "independentLogFile.enabled": {
+      "label": "Independent Log File",
+      "help": "Write lossless-claw JSONL logs to a plugin-owned file in addition to OpenClaw's runtime logger"
+    },
+    "independentLogFile.file": {
+      "label": "Independent Log Path",
+      "help": "Optional lossless-claw log path; defaults to /tmp/openclaw/lossless-claw-YYYY-MM-DD.log with daily rollover"
+    },
+    "independentLogFile.maxFileBytes": {
+      "label": "Independent Log Max Bytes",
+      "help": "Byte threshold for size rotation of the current lossless-claw log file (default: 104857600)"
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit runtime LLM fallback provider/model pairs for compaction summarization; entries require plugins.entries.lossless-claw.llm policy"
@@ -494,6 +506,22 @@
               "warn",
               "off"
             ]
+          }
+        }
+      },
+      "independentLogFile": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "file": {
+            "type": "string"
+          },
+          "maxFileBytes": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -285,6 +285,18 @@
       "label": "Runtime Auto-Rotate",
       "help": "Runtime behavior for oversized current LCM session files: rotate, warn, or off"
     },
+    "independentLogFile.enabled": {
+      "label": "Independent Log File",
+      "help": "Write lossless-claw JSONL logs to a plugin-owned file in addition to OpenClaw's runtime logger"
+    },
+    "independentLogFile.file": {
+      "label": "Independent Log Path",
+      "help": "Optional lossless-claw log path; defaults to /tmp/openclaw/lossless-claw-YYYY-MM-DD.log with daily rollover"
+    },
+    "independentLogFile.maxFileBytes": {
+      "label": "Independent Log Max Bytes",
+      "help": "Byte threshold for size rotation of the current lossless-claw log file (default: 104857600)"
+    },
     "fallbackProviders": {
       "label": "Fallback Providers",
       "help": "Explicit runtime LLM fallback provider/model pairs for compaction summarization; entries require plugins.entries.lossless-claw.llm policy"
@@ -570,6 +582,22 @@
               "warn",
               "off"
             ]
+          }
+        }
+      },
+      "independentLogFile": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "file": {
+            "type": "string"
+          },
+          "maxFileBytes": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -295,6 +295,28 @@ Operational logging:
 - rotate logs include `phase`, `action`, `sessionId`, `sessionKey`, `sessionFile`, `sizeBytes`, `thresholdBytes`, `durationMs`, `backupPath`, `bytesRemoved`, `preservedTailMessageCount`, and `checkpointSize`
 - real warning logs include the same available context plus `reason` or `error`; quiet startup skips such as missing files, missing bootstrap mappings, and below-threshold files are counted in the summary instead of logged per candidate
 
+### `independentLogFile`
+
+Writes lossless-claw JSONL logs to an independent plugin-owned file in addition to OpenClaw's runtime logger.
+
+Defaults:
+
+- `enabled: true`
+- `file: /tmp/openclaw/lossless-claw-YYYY-MM-DD.log`
+- `maxFileBytes: 104857600`
+
+Why it matters:
+
+- keeps high-volume `[lcm]` operational traces separate from the shared OpenClaw gateway log
+- still mirrors the same log lines through OpenClaw's runtime logger, so existing diagnostics and `logs.tail` behavior do not regress
+- a dated `lossless-claw-YYYY-MM-DD.log` path rolls over daily, stale dated files are pruned after 24 hours, and oversized files rotate through `.1.log` to `.5.log`
+
+Env overrides:
+
+- `LCM_LOG_FILE_ENABLED`
+- `LCM_LOG_FILE`
+- `LCM_LOG_MAX_FILE_BYTES`
+
 ## Compaction timing and shape
 
 ### `contextThreshold`

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -340,6 +340,28 @@ Operational logging:
 - rotate logs include `phase`, `action`, `sessionId`, `sessionKey`, `sessionFile`, `sizeBytes`, `thresholdBytes`, `durationMs`, `backupPath`, `bytesRemoved`, `preservedTailMessageCount`, and `checkpointSize`
 - real warning logs include the same available context plus `reason` or `error`; quiet startup skips such as missing files, missing bootstrap mappings, and below-threshold files are counted in the summary instead of logged per candidate
 
+### `independentLogFile`
+
+Writes lossless-claw JSONL logs to an independent plugin-owned file in addition to OpenClaw's runtime logger.
+
+Defaults:
+
+- `enabled: true`
+- `file: /tmp/openclaw/lossless-claw-YYYY-MM-DD.log`
+- `maxFileBytes: 104857600`
+
+Why it matters:
+
+- keeps high-volume `[lcm]` operational traces separate from the shared OpenClaw gateway log
+- still sends startup banners and warning/error lines through OpenClaw's runtime logger, so gateway-level startup and failure diagnostics remain visible
+- a dated `lossless-claw-YYYY-MM-DD.log` path rolls over daily, stale dated files are pruned after 3 days, and oversized files rotate through `.1.log` to `.5.log`
+
+Env overrides:
+
+- `LCM_LOG_FILE_ENABLED`
+- `LCM_LOG_FILE`
+- `LCM_LOG_MAX_FILE_BYTES`
+
 ## Compaction timing and shape
 
 ### `contextThreshold`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -52,6 +52,12 @@ export type AutoRotateSessionFilesConfig = {
   runtime: AutoRotateSessionFileMode;
 };
 
+export type IndependentLogFileConfig = {
+  enabled: boolean;
+  file?: string;
+  maxFileBytes: number;
+};
+
 export type LcmConfigSource = "env" | "plugin-config" | "default";
 
 export type LcmConfigDiagnostics = {
@@ -130,6 +136,8 @@ export type LcmConfig = {
   proactiveThresholdCompactionMode: ProactiveThresholdCompactionMode;
   /** Automatically rotate LCM-managed session JSONL files that exceed a size ceiling. */
   autoRotateSessionFiles: AutoRotateSessionFilesConfig;
+  /** Lossless-owned JSONL log file, written in addition to the OpenClaw runtime logger. */
+  independentLogFile: IndependentLogFileConfig;
   /** Hard ceiling for assembly token budget — caps runtime-provided and fallback budgets. */
   maxAssemblyTokenBudget?: number;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
@@ -335,6 +343,7 @@ export function resolveLcmConfigWithDiagnostics(
   const cacheAwareCompaction = toRecord(pc.cacheAwareCompaction);
   const dynamicLeafChunkTokens = toRecord(pc.dynamicLeafChunkTokens);
   const autoRotateSessionFiles = toRecord(pc.autoRotateSessionFiles);
+  const independentLogFile = toRecord(pc.independentLogFile);
   const proactiveThresholdCompactionMode = toProactiveThresholdCompactionMode(
     env.LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE,
   ) ?? toProactiveThresholdCompactionMode(pc.proactiveThresholdCompactionMode) ?? "deferred";
@@ -530,6 +539,17 @@ export function resolveLcmConfigWithDiagnostics(
           toAutoRotateSessionFileMode(env.LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME)
             ?? toAutoRotateSessionFileMode(autoRotateSessionFiles?.runtime)
             ?? "rotate",
+      },
+      independentLogFile: {
+        enabled:
+          env.LCM_LOG_FILE_ENABLED !== undefined
+            ? env.LCM_LOG_FILE_ENABLED !== "false"
+            : toBool(independentLogFile?.enabled) ?? true,
+        file: env.LCM_LOG_FILE?.trim() ?? toStr(independentLogFile?.file),
+        maxFileBytes:
+          toPositiveInteger(parseFiniteInt(env.LCM_LOG_MAX_FILE_BYTES))
+            ?? toPositiveInteger(toNumber(independentLogFile?.maxFileBytes))
+            ?? 100 * 1024 * 1024,
       },
       maxAssemblyTokenBudget:
         parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -55,6 +55,12 @@ export type AutoRotateSessionFilesConfig = {
   runtime: AutoRotateSessionFileMode;
 };
 
+export type IndependentLogFileConfig = {
+  enabled: boolean;
+  file?: string;
+  maxFileBytes: number;
+};
+
 export type LcmConfigSource = "env" | "plugin-config" | "default";
 
 export type LcmConfigDiagnostics = {
@@ -147,6 +153,8 @@ export type LcmConfig = {
   proactiveThresholdCompactionMode: ProactiveThresholdCompactionMode;
   /** Automatically rotate LCM-managed session JSONL files that exceed a size ceiling. */
   autoRotateSessionFiles: AutoRotateSessionFilesConfig;
+  /** Lossless-owned JSONL log file, written in addition to the OpenClaw runtime logger. */
+  independentLogFile: IndependentLogFileConfig;
   /** Hard ceiling for assembly token budget — caps runtime-provided and fallback budgets. */
   maxAssemblyTokenBudget?: number;
   /** Maximum allowed overage factor for summaries relative to target tokens (default 3). */
@@ -414,6 +422,7 @@ export function resolveLcmConfigWithDiagnostics(
   const cacheAwareCompaction = toRecord(pc.cacheAwareCompaction);
   const dynamicLeafChunkTokens = toRecord(pc.dynamicLeafChunkTokens);
   const autoRotateSessionFiles = toRecord(pc.autoRotateSessionFiles);
+  const independentLogFile = toRecord(pc.independentLogFile);
   const proactiveThresholdCompactionMode = toProactiveThresholdCompactionMode(
     env.LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE,
   ) ?? toProactiveThresholdCompactionMode(pc.proactiveThresholdCompactionMode) ?? "deferred";
@@ -649,6 +658,17 @@ export function resolveLcmConfigWithDiagnostics(
           toAutoRotateSessionFileMode(env.LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME)
             ?? toAutoRotateSessionFileMode(autoRotateSessionFiles?.runtime)
             ?? "rotate",
+      },
+      independentLogFile: {
+        enabled:
+          env.LCM_LOG_FILE_ENABLED !== undefined
+            ? env.LCM_LOG_FILE_ENABLED !== "false"
+            : toBool(independentLogFile?.enabled) ?? true,
+        file: env.LCM_LOG_FILE?.trim() ?? toStr(independentLogFile?.file),
+        maxFileBytes:
+          toPositiveInteger(parseFiniteInt(env.LCM_LOG_MAX_FILE_BYTES))
+            ?? toPositiveInteger(toNumber(independentLogFile?.maxFileBytes))
+            ?? 100 * 1024 * 1024,
       },
       maxAssemblyTokenBudget:
         parseFiniteInt(env.LCM_MAX_ASSEMBLY_TOKEN_BUDGET)

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3720,7 +3720,7 @@ export class LcmContextEngine implements ContextEngine {
       );
       logStartupBannerOnce({
         key: "ignore-session-patterns",
-        log: (message) => this.deps.log.info(message),
+        log: (message) => (this.deps.log.hostInfo ?? this.deps.log.info)(message),
         message: `[lcm] Ignoring sessions matching ${this.config.ignoreSessionPatterns.length} pattern(s) from ${source}: ${this.config.ignoreSessionPatterns.join(", ")}`,
       });
     }
@@ -3731,7 +3731,7 @@ export class LcmContextEngine implements ContextEngine {
       const enforcement = this.config.skipStatelessSessions ? "" : " (skipStatelessSessions=false)";
       logStartupBannerOnce({
         key: "stateless-session-patterns",
-        log: (message) => this.deps.log.info(message),
+        log: (message) => (this.deps.log.hostInfo ?? this.deps.log.info)(message),
         message: `[lcm] Stateless session patterns${enforcement} from ${source}: ${this.config.statelessSessionPatterns.length} pattern(s): ${this.config.statelessSessionPatterns.join(", ")}`,
       });
     }

--- a/src/lcm-file-log.ts
+++ b/src/lcm-file-log.ts
@@ -1,0 +1,239 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IndependentLogFileConfig } from "./db/config.js";
+
+const LOG_PREFIX = "lossless-claw";
+const LOG_SUFFIX = ".log";
+const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
+const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000;
+const MAX_ROTATED_LOG_FILES = 5;
+
+export type LcmFileLogLevel = "info" | "warn" | "error" | "debug";
+
+type LcmFileLogger = {
+  write: (level: LcmFileLogLevel, message: string) => void;
+};
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function rollingPathForDate(dir: string, date: Date): string {
+  return path.join(dir, `${LOG_PREFIX}-${formatLocalDate(date)}${LOG_SUFFIX}`);
+}
+
+function defaultRollingPath(date = new Date()): string {
+  return rollingPathForDate(resolvePreferredOpenClawTmpDir(), date);
+}
+
+function isRollingPath(file: string): boolean {
+  const base = path.basename(file);
+  return (
+    base.startsWith(`${LOG_PREFIX}-`) &&
+    base.endsWith(LOG_SUFFIX) &&
+    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
+  );
+}
+
+function resolveActiveLogFile(file: string): string {
+  const expandedFile = expandHomePrefix(file);
+  if (!isRollingPath(expandedFile)) {
+    return expandedFile;
+  }
+  return rollingPathForDate(path.dirname(expandedFile), new Date());
+}
+
+function expandHomePrefix(file: string): string {
+  if (file === "~") {
+    return os.homedir();
+  }
+  if (file.startsWith("~/")) {
+    return path.join(os.homedir(), file.slice(2));
+  }
+  return file;
+}
+
+function resolvePreferredOpenClawTmpDir(): string {
+  if (process.platform === "win32") {
+    return path.join(os.tmpdir(), "openclaw");
+  }
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : "user";
+  const fallbackDir = path.join(os.tmpdir(), `openclaw-${uid}`);
+  const ensureTrustedFallbackDir = (): string => {
+    fs.mkdirSync(fallbackDir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(fallbackDir, 0o700);
+    const stat = fs.lstatSync(fallbackDir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackDir}`);
+    }
+    return fallbackDir;
+  };
+
+  try {
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.lstatSync(POSIX_OPENCLAW_TMP_DIR);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      fs.mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
+      stat = fs.lstatSync(POSIX_OPENCLAW_TMP_DIR);
+    }
+    if (stat.isDirectory() && !stat.isSymbolicLink()) {
+      fs.chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);
+      return POSIX_OPENCLAW_TMP_DIR;
+    }
+  } catch {
+    // Fall back below.
+  }
+
+  return ensureTrustedFallbackDir();
+}
+
+function pruneOldRollingLogs(dir: string): void {
+  try {
+    const cutoff = Date.now() - MAX_LOG_AGE_MS;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!entry.name.startsWith(`${LOG_PREFIX}-`) || !entry.name.endsWith(LOG_SUFFIX)) {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      try {
+        if (fs.statSync(fullPath).mtimeMs < cutoff) {
+          fs.rmSync(fullPath, { force: true });
+        }
+      } catch {
+        // Ignore pruning failures.
+      }
+    }
+  } catch {
+    // Ignore missing dir or read errors.
+  }
+}
+
+function getCurrentLogFileBytes(file: string): number {
+  try {
+    return fs.statSync(file).size;
+  } catch {
+    return 0;
+  }
+}
+
+function rotatedLogPath(file: string, index: number): string {
+  const ext = path.extname(file);
+  const base = file.slice(0, file.length - ext.length);
+  return `${base}.${index}${ext}`;
+}
+
+function rotateLogFile(file: string): boolean {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.rmSync(rotatedLogPath(file, MAX_ROTATED_LOG_FILES), { force: true });
+    for (let index = MAX_ROTATED_LOG_FILES - 1; index >= 1; index -= 1) {
+      const from = rotatedLogPath(file, index);
+      if (fs.existsSync(from)) {
+        fs.renameSync(from, rotatedLogPath(file, index + 1));
+      }
+    }
+    if (fs.existsSync(file)) {
+      fs.renameSync(file, rotatedLogPath(file, 1));
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, "[REDACTED]")
+    .replace(/\b(Bearer)\s+[A-Za-z0-9._~+/=-]{12,}\b/gi, "$1 [REDACTED]")
+    .replace(/\b(api[_-]?key|token|password|secret)=\S+/gi, "$1=[REDACTED]");
+}
+
+function appendRegularFileSync(file: string, content: string): boolean {
+  try {
+    const stat = fs.existsSync(file) ? fs.lstatSync(file) : undefined;
+    if (stat?.isSymbolicLink() || stat?.isDirectory()) {
+      return false;
+    }
+    fs.appendFileSync(file, content, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createIndependentLcmFileLogger(
+  config: IndependentLogFileConfig,
+): LcmFileLogger | undefined {
+  if (!config.enabled) {
+    return undefined;
+  }
+
+  let configuredFile: string;
+  let rollingFile: boolean;
+  let activeFile: string;
+  let currentFileBytes: number;
+  try {
+    configuredFile = config.file?.trim() || defaultRollingPath();
+    rollingFile = isRollingPath(expandHomePrefix(configuredFile));
+    activeFile = resolveActiveLogFile(configuredFile);
+    fs.mkdirSync(path.dirname(activeFile), { recursive: true, mode: 0o700 });
+    if (rollingFile) {
+      pruneOldRollingLogs(path.dirname(activeFile));
+    }
+    currentFileBytes = getCurrentLogFileBytes(activeFile);
+  } catch {
+    return undefined;
+  }
+
+  return {
+    write(level, message) {
+      try {
+        const nextActiveFile = resolveActiveLogFile(configuredFile);
+        if (nextActiveFile !== activeFile) {
+          activeFile = nextActiveFile;
+          fs.mkdirSync(path.dirname(activeFile), { recursive: true, mode: 0o700 });
+          if (rollingFile) {
+            pruneOldRollingLogs(path.dirname(activeFile));
+          }
+          currentFileBytes = getCurrentLogFileBytes(activeFile);
+        }
+
+        const record = {
+          time: new Date().toISOString(),
+          level,
+          plugin: "lossless-claw",
+          message,
+        };
+        const payload = `${redactSensitiveText(JSON.stringify(record))}\n`;
+        const payloadBytes = Buffer.byteLength(payload, "utf8");
+        if (currentFileBytes > 0 && currentFileBytes + payloadBytes > config.maxFileBytes) {
+          if (rotateLogFile(activeFile)) {
+            currentFileBytes = getCurrentLogFileBytes(activeFile);
+          }
+        }
+        if (appendRegularFileSync(activeFile, payload)) {
+          currentFileBytes += payloadBytes;
+        }
+      } catch {
+        // Logging must never affect Lossless runtime behavior.
+      }
+    },
+  };
+}
+
+export const __testing = {
+  defaultRollingPath,
+  resolveActiveLogFile,
+};

--- a/src/lcm-file-log.ts
+++ b/src/lcm-file-log.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { redactSensitiveText as redactOpenClawSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import type { IndependentLogFileConfig } from "./db/config.js";
 
 const LOG_PREFIX = "lossless-claw";
@@ -20,6 +20,10 @@ export type IndependentLogRedactionConfig = {
   mode?: "off" | "tools";
   patterns?: string[];
 };
+
+type OpenClawRedactor = (value: string, redaction?: IndependentLogRedactionConfig) => string;
+
+let openClawRedactor: OpenClawRedactor | undefined = loadOpenClawRedactor();
 
 function formatLocalDate(date: Date): string {
   const year = date.getFullYear();
@@ -169,8 +173,61 @@ function rotateLogFile(file: string): boolean {
   }
 }
 
+function loadOpenClawRedactor(): OpenClawRedactor | undefined {
+  try {
+    const require = createRequire(import.meta.url);
+    const loggingCore = require("openclaw/plugin-sdk/logging-core") as {
+      redactSensitiveText?: unknown;
+    };
+    if (typeof loggingCore.redactSensitiveText === "function") {
+      return loggingCore.redactSensitiveText as OpenClawRedactor;
+    }
+  } catch {
+    // OpenClaw is an optional peer; package tests and tooling run without it.
+  }
+  return undefined;
+}
+
+function redactionPattern(rawPattern: string): RegExp | undefined {
+  try {
+    const match = rawPattern.match(/^\/(.+)\/([dgimsuvy]*)$/);
+    if (match) {
+      const flags = match[2].includes("g") ? match[2] : `${match[2]}g`;
+      return new RegExp(match[1], flags);
+    }
+    return new RegExp(rawPattern, "gi");
+  } catch {
+    return undefined;
+  }
+}
+
+function fallbackRedactSensitiveText(
+  value: string,
+  redaction?: IndependentLogRedactionConfig,
+): string {
+  if (redaction?.mode === "off") {
+    return value;
+  }
+
+  let next = value
+    .replace(/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{10,}\b/g, "[REDACTED]")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[REDACTED]")
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED]")
+    .replace(/\b(?:sk|rk|pk)[-_][A-Za-z0-9_-]{10,}\b/g, "[REDACTED]")
+    .replace(/\btoken=([^\s]+)/gi, "token=[REDACTED]")
+    .replace(/"token"\s*:\s*"[^"]+"/gi, '"token":"[REDACTED]"');
+
+  for (const rawPattern of redaction?.patterns ?? []) {
+    const pattern = redactionPattern(rawPattern);
+    if (pattern) {
+      next = next.replace(pattern, "[REDACTED]");
+    }
+  }
+  return next;
+}
+
 function redactSensitiveText(value: string, redaction?: IndependentLogRedactionConfig): string {
-  return redactOpenClawSensitiveText(value, redaction);
+  return (openClawRedactor ?? fallbackRedactSensitiveText)(value, redaction);
 }
 
 function appendRegularFileSync(file: string, content: string): boolean {
@@ -272,5 +329,11 @@ export function createIndependentLcmFileLogger(
 export const __testing = {
   defaultRollingPath,
   isTrustedExistingOpenClawTmpDir,
+  resetOpenClawRedactor: () => {
+    openClawRedactor = loadOpenClawRedactor();
+  },
   resolveActiveLogFile,
+  setOpenClawRedactor: (redactor: OpenClawRedactor | undefined) => {
+    openClawRedactor = redactor;
+  },
 };

--- a/src/lcm-file-log.ts
+++ b/src/lcm-file-log.ts
@@ -1,0 +1,276 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { redactSensitiveText as redactOpenClawSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import type { IndependentLogFileConfig } from "./db/config.js";
+
+const LOG_PREFIX = "lossless-claw";
+const LOG_SUFFIX = ".log";
+const POSIX_OPENCLAW_TMP_DIR = "/tmp/openclaw";
+const MAX_LOG_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+const MAX_ROTATED_LOG_FILES = 5;
+
+export type LcmFileLogLevel = "info" | "warn" | "error" | "debug";
+
+type LcmFileLogger = {
+  write: (level: LcmFileLogLevel, message: string) => boolean;
+};
+
+export type IndependentLogRedactionConfig = {
+  mode?: "off" | "tools";
+  patterns?: string[];
+};
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function rollingPathForDate(dir: string, date: Date): string {
+  return path.join(dir, `${LOG_PREFIX}-${formatLocalDate(date)}${LOG_SUFFIX}`);
+}
+
+function defaultRollingPath(date = new Date()): string {
+  return rollingPathForDate(resolvePreferredOpenClawTmpDir(), date);
+}
+
+function isRollingPath(file: string): boolean {
+  const base = path.basename(file);
+  return /^lossless-claw-\d{4}-\d{2}-\d{2}\.log$/.test(base);
+}
+
+function isRollingLogSegmentPath(file: string): boolean {
+  const base = path.basename(file);
+  return /^lossless-claw-\d{4}-\d{2}-\d{2}(?:\.[1-5])?\.log$/.test(base);
+}
+
+function resolveActiveLogFile(file: string): string {
+  const expandedFile = expandHomePrefix(file);
+  if (!isRollingPath(expandedFile)) {
+    return expandedFile;
+  }
+  return rollingPathForDate(path.dirname(expandedFile), new Date());
+}
+
+function expandHomePrefix(file: string): string {
+  if (file === "~") {
+    return os.homedir();
+  }
+  if (file.startsWith("~/")) {
+    return path.join(os.homedir(), file.slice(2));
+  }
+  return file;
+}
+
+function resolvePreferredOpenClawTmpDir(): string {
+  if (process.platform === "win32") {
+    return path.join(os.tmpdir(), "openclaw");
+  }
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : "user";
+  const fallbackDir = path.join(os.tmpdir(), `openclaw-${uid}`);
+  const ensureTrustedFallbackDir = (): string => {
+    fs.mkdirSync(fallbackDir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(fallbackDir, 0o700);
+    const stat = fs.lstatSync(fallbackDir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackDir}`);
+    }
+    return fallbackDir;
+  };
+
+  try {
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.lstatSync(POSIX_OPENCLAW_TMP_DIR);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      fs.mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
+      stat = fs.lstatSync(POSIX_OPENCLAW_TMP_DIR);
+    }
+    if (isTrustedExistingOpenClawTmpDir(stat, uid)) {
+      return POSIX_OPENCLAW_TMP_DIR;
+    }
+  } catch {
+    // Fall back below.
+  }
+
+  return ensureTrustedFallbackDir();
+}
+
+function isTrustedExistingOpenClawTmpDir(stat: fs.Stats, uid: number | "user"): boolean {
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    return false;
+  }
+  if (typeof uid === "number" && stat.uid !== uid) {
+    return false;
+  }
+  return (stat.mode & 0o077) === 0;
+}
+
+function pruneOldRollingLogs(dir: string): void {
+  try {
+    const cutoff = Date.now() - MAX_LOG_AGE_MS;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!isRollingLogSegmentPath(entry.name)) {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      try {
+        if (fs.statSync(fullPath).mtimeMs < cutoff) {
+          fs.rmSync(fullPath, { force: true });
+        }
+      } catch {
+        // Ignore pruning failures.
+      }
+    }
+  } catch {
+    // Ignore missing dir or read errors.
+  }
+}
+
+function getCurrentLogFileBytes(file: string): number {
+  try {
+    return fs.statSync(file).size;
+  } catch {
+    return 0;
+  }
+}
+
+function rotatedLogPath(file: string, index: number): string {
+  const ext = path.extname(file);
+  const base = file.slice(0, file.length - ext.length);
+  return `${base}.${index}${ext}`;
+}
+
+function rotateLogFile(file: string): boolean {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.rmSync(rotatedLogPath(file, MAX_ROTATED_LOG_FILES), { force: true });
+    for (let index = MAX_ROTATED_LOG_FILES - 1; index >= 1; index -= 1) {
+      const from = rotatedLogPath(file, index);
+      if (fs.existsSync(from)) {
+        fs.renameSync(from, rotatedLogPath(file, index + 1));
+      }
+    }
+    if (fs.existsSync(file)) {
+      fs.renameSync(file, rotatedLogPath(file, 1));
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function redactSensitiveText(value: string, redaction?: IndependentLogRedactionConfig): string {
+  return redactOpenClawSensitiveText(value, redaction);
+}
+
+function appendRegularFileSync(file: string, content: string): boolean {
+  let fd: number | undefined;
+  try {
+    const stat = fs.existsSync(file) ? fs.lstatSync(file) : undefined;
+    if (stat?.isSymbolicLink() || stat?.isDirectory()) {
+      return false;
+    }
+    const flags =
+      fs.constants.O_WRONLY |
+      fs.constants.O_CREAT |
+      fs.constants.O_APPEND |
+      (fs.constants.O_NOFOLLOW ?? 0);
+    fd = fs.openSync(file, flags, 0o600);
+    if (!fs.fstatSync(fd).isFile()) {
+      return false;
+    }
+    fs.writeSync(fd, content, undefined, "utf8");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore close failures for the best-effort log sink.
+      }
+    }
+  }
+}
+
+export function createIndependentLcmFileLogger(
+  config: IndependentLogFileConfig,
+  redaction?: IndependentLogRedactionConfig,
+): LcmFileLogger | undefined {
+  if (!config.enabled) {
+    return undefined;
+  }
+
+  let configuredFile: string;
+  let rollingFile: boolean;
+  let activeFile: string;
+  let currentFileBytes: number;
+  try {
+    configuredFile = config.file?.trim() || defaultRollingPath();
+    rollingFile = isRollingPath(expandHomePrefix(configuredFile));
+    activeFile = resolveActiveLogFile(configuredFile);
+    fs.mkdirSync(path.dirname(activeFile), { recursive: true, mode: 0o700 });
+    if (rollingFile) {
+      pruneOldRollingLogs(path.dirname(activeFile));
+    }
+    currentFileBytes = getCurrentLogFileBytes(activeFile);
+  } catch {
+    return undefined;
+  }
+
+  return {
+    write(level, message) {
+      try {
+        const nextActiveFile = resolveActiveLogFile(configuredFile);
+        if (nextActiveFile !== activeFile) {
+          activeFile = nextActiveFile;
+          fs.mkdirSync(path.dirname(activeFile), { recursive: true, mode: 0o700 });
+          if (rollingFile) {
+            pruneOldRollingLogs(path.dirname(activeFile));
+          }
+          currentFileBytes = getCurrentLogFileBytes(activeFile);
+        }
+
+        const record = {
+          time: new Date().toISOString(),
+          level,
+          plugin: "lossless-claw",
+          message: redactSensitiveText(message, redaction),
+        };
+        const payload = `${JSON.stringify(record)}\n`;
+        const payloadBytes = Buffer.byteLength(payload, "utf8");
+        if (currentFileBytes > 0 && currentFileBytes + payloadBytes > config.maxFileBytes) {
+          if (rotateLogFile(activeFile)) {
+            currentFileBytes = getCurrentLogFileBytes(activeFile);
+          }
+        }
+        const appended = appendRegularFileSync(activeFile, payload);
+        if (!appended) {
+          return false;
+        }
+        currentFileBytes += payloadBytes;
+        return true;
+      } catch {
+        // Logging must never affect Lossless runtime behavior.
+        return false;
+      }
+    },
+  };
+}
+
+export const __testing = {
+  defaultRollingPath,
+  isTrustedExistingOpenClawTmpDir,
+  resolveActiveLogFile,
+};

--- a/src/lcm-file-log.ts
+++ b/src/lcm-file-log.ts
@@ -140,11 +140,27 @@ function pruneOldRollingLogs(dir: string): void {
   }
 }
 
-function getCurrentLogFileBytes(file: string): number {
+function getCurrentRegularLogFileBytes(file: string): number | undefined {
   try {
-    return fs.statSync(file).size;
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      return undefined;
+    }
+    return stat.size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+    return undefined;
+  }
+}
+
+function isExistingRegularFile(file: string): boolean {
+  try {
+    const stat = fs.lstatSync(file);
+    return stat.isFile() && !stat.isSymbolicLink();
   } catch {
-    return 0;
+    return false;
   }
 }
 
@@ -157,6 +173,9 @@ function rotatedLogPath(file: string, index: number): string {
 function rotateLogFile(file: string): boolean {
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
+    if (!isExistingRegularFile(file)) {
+      return false;
+    }
     fs.rmSync(rotatedLogPath(file, MAX_ROTATED_LOG_FILES), { force: true });
     for (let index = MAX_ROTATED_LOG_FILES - 1; index >= 1; index -= 1) {
       const from = rotatedLogPath(file, index);
@@ -246,6 +265,9 @@ function appendRegularFileSync(file: string, content: string): boolean {
     if (!fs.fstatSync(fd).isFile()) {
       return false;
     }
+    if (process.platform !== "win32") {
+      fs.fchmodSync(fd, 0o600);
+    }
     fs.writeSync(fd, content, undefined, "utf8");
     return true;
   } catch {
@@ -281,7 +303,11 @@ export function createIndependentLcmFileLogger(
     if (rollingFile) {
       pruneOldRollingLogs(path.dirname(activeFile));
     }
-    currentFileBytes = getCurrentLogFileBytes(activeFile);
+    const bytes = getCurrentRegularLogFileBytes(activeFile);
+    if (bytes === undefined) {
+      return undefined;
+    }
+    currentFileBytes = bytes;
   } catch {
     return undefined;
   }
@@ -296,7 +322,11 @@ export function createIndependentLcmFileLogger(
           if (rollingFile) {
             pruneOldRollingLogs(path.dirname(activeFile));
           }
-          currentFileBytes = getCurrentLogFileBytes(activeFile);
+          const bytes = getCurrentRegularLogFileBytes(activeFile);
+          if (bytes === undefined) {
+            return false;
+          }
+          currentFileBytes = bytes;
         }
 
         const record = {
@@ -307,9 +337,18 @@ export function createIndependentLcmFileLogger(
         };
         const payload = `${JSON.stringify(record)}\n`;
         const payloadBytes = Buffer.byteLength(payload, "utf8");
+        const bytes = getCurrentRegularLogFileBytes(activeFile);
+        if (bytes === undefined) {
+          return false;
+        }
+        currentFileBytes = bytes;
         if (currentFileBytes > 0 && currentFileBytes + payloadBytes > config.maxFileBytes) {
           if (rotateLogFile(activeFile)) {
-            currentFileBytes = getCurrentLogFileBytes(activeFile);
+            const rotatedBytes = getCurrentRegularLogFileBytes(activeFile);
+            if (rotatedBytes === undefined) {
+              return false;
+            }
+            currentFileBytes = rotatedBytes;
           }
         }
         const appended = appendRegularFileSync(activeFile, payload);

--- a/src/lcm-log.ts
+++ b/src/lcm-log.ts
@@ -1,5 +1,7 @@
 import type { OpenClawPluginApi } from "./openclaw-bridge.js";
 import type { LcmDependencies } from "./types.js";
+import type { LcmConfig } from "./db/config.js";
+import { createIndependentLcmFileLogger, type LcmFileLogLevel } from "./lcm-file-log.js";
 
 export type LcmLogger = LcmDependencies["log"];
 
@@ -16,22 +18,45 @@ export function describeLogError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function teeLogger(
+  base: LcmLogger,
+  fileLogger: ReturnType<typeof createIndependentLcmFileLogger>,
+): LcmLogger {
+  const write = (level: LcmFileLogLevel, message: string, emit: (message: string) => void) => {
+    emit(message);
+    fileLogger?.write(level, message);
+  };
+  return {
+    info: (message) => write("info", message, base.info),
+    warn: (message) => write("warn", message, base.warn),
+    error: (message) => write("error", message, base.error),
+    debug: (message) => write("debug", message, base.debug),
+  };
+}
+
 /** Create the LCM logger, preferring OpenClaw's file-backed runtime logger. */
-export function createLcmLogger(api: OpenClawPluginApi): LcmLogger {
-  const runtimeLogger = api.runtime.logging?.getChildLogger?.({ plugin: "lossless-claw" });
+export function createLcmLogger(api: OpenClawPluginApi, config: LcmConfig): LcmLogger {
+  const fileLogger = createIndependentLcmFileLogger(config.independentLogFile);
+  const runtimeLogger = api.runtime?.logging?.getChildLogger?.({ plugin: "lossless-claw" });
   if (runtimeLogger) {
-    return {
-      info: (message) => runtimeLogger.info(message),
-      warn: (message) => runtimeLogger.warn(message),
-      error: (message) => runtimeLogger.error(message),
-      debug: (message) => runtimeLogger.debug?.(message),
-    };
+    return teeLogger(
+      {
+        info: (message) => runtimeLogger.info(message),
+        warn: (message) => runtimeLogger.warn(message),
+        error: (message) => runtimeLogger.error(message),
+        debug: (message) => runtimeLogger.debug?.(message),
+      },
+      fileLogger,
+    );
   }
 
-  return {
-    info: (message) => api.logger.info(message),
-    warn: (message) => api.logger.warn(message),
-    error: (message) => api.logger.error(message),
-    debug: (message) => api.logger.debug?.(message),
-  };
+  return teeLogger(
+    {
+      info: (message) => api.logger.info(message),
+      warn: (message) => api.logger.warn(message),
+      error: (message) => api.logger.error(message),
+      debug: (message) => api.logger.debug?.(message),
+    },
+    fileLogger,
+  );
 }

--- a/src/lcm-log.ts
+++ b/src/lcm-log.ts
@@ -1,5 +1,11 @@
 import type { OpenClawPluginApi } from "./openclaw-bridge.js";
 import type { LcmDependencies } from "./types.js";
+import type { LcmConfig } from "./db/config.js";
+import {
+  createIndependentLcmFileLogger,
+  type IndependentLogRedactionConfig,
+  type LcmFileLogLevel,
+} from "./lcm-file-log.js";
 
 export type LcmLogger = LcmDependencies["log"];
 
@@ -9,6 +15,8 @@ export const NOOP_LCM_LOGGER: LcmLogger = {
   warn: () => {},
   error: () => {},
   debug: () => {},
+  hostInfo: () => {},
+  hostWarn: () => {},
 };
 
 /** Format unknown failures into stable one-line log text. */
@@ -16,22 +24,115 @@ export function describeLogError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** Create the LCM logger, preferring OpenClaw's file-backed runtime logger. */
-export function createLcmLogger(api: OpenClawPluginApi): LcmLogger {
-  const runtimeLogger = api.runtime.logging?.getChildLogger?.({ plugin: "lossless-claw" });
+function teeLogger(
+  base: LcmLogger,
+  fileLogger: ReturnType<typeof createIndependentLcmFileLogger>,
+  options: { writeDebugToFile: boolean },
+): LcmLogger {
+  const fileOnly = (level: LcmFileLogLevel, message: string, emit: (message: string) => void) => {
+    if (!fileLogger) {
+      emit(message);
+      return;
+    }
+    if (!fileLogger.write(level, message)) {
+      emit(message);
+    }
+  };
+  const hostAndFile = (
+    level: LcmFileLogLevel,
+    message: string,
+    emit: (message: string) => void,
+  ) => {
+    emit(message);
+    fileLogger?.write(level, message);
+  };
+  return {
+    info: (message) => fileOnly("info", message, base.info),
+    warn: (message) => hostAndFile("warn", message, base.warn),
+    error: (message) => hostAndFile("error", message, base.error),
+    debug: (message) => {
+      if (!fileLogger) {
+        base.debug(message);
+        return;
+      }
+      if (options.writeDebugToFile) {
+        if (!fileLogger.write("debug", message)) {
+          base.debug(message);
+        }
+      }
+    },
+    hostInfo: (message) => hostAndFile("info", message, base.info),
+    hostWarn: (message) => hostAndFile("warn", message, base.warn),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readRuntimeConfigCandidates(api: OpenClawPluginApi): Record<string, unknown>[] {
+  const candidates: Record<string, unknown>[] = [];
+  if (isRecord(api.config)) {
+    candidates.push(api.config);
+  }
+  const runtimeConfig = api.runtime?.config;
+  if (typeof runtimeConfig?.current === "function") {
+    const current = runtimeConfig.current();
+    if (isRecord(current)) {
+      candidates.push(current);
+    }
+  }
+  return candidates;
+}
+
+function readOpenClawRedactionConfig(api: OpenClawPluginApi): IndependentLogRedactionConfig {
+  const loggingConfig = readRuntimeConfigCandidates(api)
+    .map((candidate) => candidate.logging)
+    .find(isRecord);
+  const redactSensitive = loggingConfig?.redactSensitive;
+  const patterns = Array.isArray(loggingConfig?.redactPatterns)
+    ? loggingConfig.redactPatterns.filter((pattern): pattern is string => typeof pattern === "string")
+    : undefined;
+  return {
+    mode: redactSensitive === "off" || redactSensitive === "tools" ? redactSensitive : undefined,
+    patterns,
+  };
+}
+
+function shouldWriteIndependentDebug(api: OpenClawPluginApi): boolean {
+  const shouldLogVerbose = api.runtime?.logging?.shouldLogVerbose;
+  return typeof shouldLogVerbose === "function" ? shouldLogVerbose() === true : false;
+}
+
+/** Create the LCM logger, preferring OpenClaw's runtime child logger. */
+export function createLcmLogger(api: OpenClawPluginApi, config: LcmConfig): LcmLogger {
+  const fileLogger = createIndependentLcmFileLogger(
+    config.independentLogFile,
+    readOpenClawRedactionConfig(api),
+  );
+  const writeDebugToFile = shouldWriteIndependentDebug(api);
+  const runtimeLogger = api.runtime?.logging?.getChildLogger?.({ plugin: "lossless-claw" });
   if (runtimeLogger) {
-    return {
-      info: (message) => runtimeLogger.info(message),
-      warn: (message) => runtimeLogger.warn(message),
-      error: (message) => runtimeLogger.error(message),
-      debug: (message) => runtimeLogger.debug?.(message),
-    };
+    return teeLogger(
+      {
+        info: (message) => runtimeLogger.info(message),
+        warn: (message) => runtimeLogger.warn(message),
+        error: (message) => runtimeLogger.error(message),
+        debug: (message) => runtimeLogger.debug?.(message),
+      },
+      fileLogger,
+      { writeDebugToFile },
+    );
   }
 
-  return {
-    info: (message) => api.logger.info(message),
-    warn: (message) => api.logger.warn(message),
-    error: (message) => api.logger.error(message),
-    debug: (message) => api.logger.debug?.(message),
-  };
+  return teeLogger(
+    {
+      info: (message) => api.logger.info(message),
+      warn: (message) => api.logger.warn(message),
+      error: (message) => api.logger.error(message),
+      debug: (message) => api.logger.debug?.(message),
+    },
+    fileLogger,
+    { writeDebugToFile },
+  );
 }

--- a/src/openclaw-plugin-sdk-logging-core.d.ts
+++ b/src/openclaw-plugin-sdk-logging-core.d.ts
@@ -1,0 +1,12 @@
+declare module "openclaw/plugin-sdk/logging-core" {
+  export type RedactSensitiveMode = "off" | "tools";
+  export type RedactPattern = string | RegExp;
+
+  export function redactSensitiveText(
+    text: string,
+    options?: {
+      mode?: RedactSensitiveMode;
+      patterns?: RedactPattern[];
+    },
+  ): string;
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -985,8 +985,8 @@ function createLcmDependencies(
   const envSnapshot = snapshotPluginEnv();
   envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(registrationConfig.openClawConfig);
   const pluginConfig = registrationConfig.pluginConfig;
-  const log = createLcmLogger(api);
   const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
+  const log = createLcmLogger(api, config);
 
   if (diagnostics.ignoreSessionPatternsEnvOverridesPluginConfig) {
     logStartupBannerOnce({

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1181,8 +1181,8 @@ function createLcmDependencies(
   const envSnapshot = snapshotPluginEnv();
   envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(registrationConfig.openClawConfig);
   const pluginConfig = registrationConfig.pluginConfig;
-  const log = createLcmLogger(api);
   const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
+  const log = createLcmLogger(api, config);
 
   if (diagnostics.ignoreSessionPatternsEnvOverridesPluginConfig) {
     logStartupBannerOnce({
@@ -1215,12 +1215,12 @@ function createLcmDependencies(
 
   logStartupBannerOnce({
     key: "transcript-gc-enabled",
-    log: (message) => log.info(message),
+    log: (message) => (log.hostInfo ?? log.info)(message),
     message: `[lcm] Transcript GC ${config.transcriptGcEnabled ? "enabled" : "disabled"} (default false)`,
   });
   logStartupBannerOnce({
     key: "proactive-threshold-compaction-mode",
-    log: (message) => log.info(message),
+    log: (message) => (log.hostInfo ?? log.info)(message),
     message: `[lcm] Proactive threshold compaction mode: ${config.proactiveThresholdCompactionMode} (default deferred)`,
   });
 
@@ -1808,7 +1808,7 @@ const lcmPlugin = {
       }
 
       if (recovered > 0) {
-        deps.log.info(
+        (deps.log.hostInfo ?? deps.log.info)(
           `[lcm] startup totalTokens recovery updated ${recovered} session ${recovered === 1 ? "entry" : "entries"}`,
         );
       }
@@ -1832,7 +1832,7 @@ const lcmPlugin = {
         database = nextDatabase;
         lcm = nextEngine;
         initError = null;
-        deps.log.info(
+        (deps.log.hostInfo ?? deps.log.info)(
           `[lcm] Engine initialized for db=${normalizedDbPath} duration=${Date.now() - startedAt}ms`,
         );
         scheduleStartupAutoRotate(nextEngine);
@@ -1840,7 +1840,7 @@ const lcmPlugin = {
         return nextEngine;
       } catch (error) {
         closeLcmConnection(nextDatabase);
-        deps.log.info(
+        (deps.log.hostWarn ?? deps.log.warn)(
           `[lcm] Engine init failed for db=${normalizedDbPath} duration=${Date.now() - startedAt}ms error=${toInitError(error).message}`,
         );
         throw error;
@@ -1972,17 +1972,17 @@ const lcmPlugin = {
 
     logStartupBannerOnce({
       key: "plugin-loaded",
-      log: (message) => deps.log.info(message),
+      log: (message) => (deps.log.hostInfo ?? deps.log.info)(message),
       message: `[lcm] Plugin loaded (enabled=${deps.config.enabled}, db=${deps.config.databasePath}, threshold=${deps.config.contextThreshold}, proactiveThresholdCompactionMode=${deps.config.proactiveThresholdCompactionMode})`,
     });
     logStartupBannerOnce({
       key: "state-dir",
-      log: (message) => deps.log.info(message),
+      log: (message) => (deps.log.hostInfo ?? deps.log.info)(message),
       message: `[lcm] State dir: ${resolveOpenclawStateDir(process.env)}`,
     });
     logStartupBannerOnce({
       key: "compaction-model",
-      log: (message) => deps.log.info(message),
+      log: (message) => (deps.log.hostInfo ?? deps.log.info)(message),
       message: buildCompactionModelLog({
         config: deps.config,
         openClawConfig: registrationConfig.openClawConfig,
@@ -1992,7 +1992,7 @@ const lcmPlugin = {
     if (deps.config.fallbackProviders.length > 0) {
       logStartupBannerOnce({
         key: "fallback-providers",
-        log: (message) => deps.log.info(message),
+        log: (message) => (deps.log.hostInfo ?? deps.log.info)(message),
         message: `[lcm] Fallback providers: ${deps.config.fallbackProviders.map((fp) => `${fp.provider}/${fp.model}`).join(", ")}`,
       });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,5 +177,7 @@ export interface LcmDependencies {
     warn: (msg: string) => void;
     error: (msg: string) => void;
     debug: (msg: string) => void;
+    hostInfo?: (msg: string) => void;
+    hostWarn?: (msg: string) => void;
   };
 }

--- a/test/anti-replay-burst-regression.test.ts
+++ b/test/anti-replay-burst-regression.test.ts
@@ -97,6 +97,10 @@ function createTestConfig(databasePath: string): LcmConfig {
       startup: "rotate",
       runtime: "rotate",
     },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     expansionProvider: "",

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -62,6 +62,10 @@ function createTestConfig(databasePath: string): LcmConfig {
       startup: "rotate",
       runtime: "rotate",
     },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     expansionProvider: "",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -712,6 +712,18 @@ describe("resolveLcmConfig", () => {
     });
   });
 
+  it("ships a manifest with independentLogFile in schema", () => {
+    expect(manifest.configSchema.properties.independentLogFile).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        file: { type: "string" },
+        maxFileBytes: { type: "integer", minimum: 1 },
+      },
+    });
+  });
+
   it("ships a manifest with cacheAwareCompaction in schema", () => {
     expect(manifest.configSchema.properties.cacheAwareCompaction).toEqual({
       type: "object",
@@ -784,6 +796,41 @@ describe("resolveLcmConfig", () => {
     expect(config.delegationTimeoutMs).toBe(120000);
     expect(config.summaryMaxOverageFactor).toBe(3);
     expect(config.maxAssemblyTokenBudget).toBeUndefined();
+    expect(config.independentLogFile).toEqual({
+      enabled: true,
+      file: undefined,
+      maxFileBytes: 100 * 1024 * 1024,
+    });
+  });
+
+  it("resolves independent log file config from plugin config and env overrides", () => {
+    expect(resolveLcmConfig({}, {
+      independentLogFile: {
+        enabled: false,
+        file: "/tmp/custom-lcm.log",
+        maxFileBytes: 1234,
+      },
+    }).independentLogFile).toEqual({
+      enabled: false,
+      file: "/tmp/custom-lcm.log",
+      maxFileBytes: 1234,
+    });
+
+    expect(resolveLcmConfig({
+      LCM_LOG_FILE_ENABLED: "true",
+      LCM_LOG_FILE: "/tmp/env-lcm.log",
+      LCM_LOG_MAX_FILE_BYTES: "5678",
+    } as NodeJS.ProcessEnv, {
+      independentLogFile: {
+        enabled: false,
+        file: "/tmp/plugin-lcm.log",
+        maxFileBytes: 1234,
+      },
+    }).independentLogFile).toEqual({
+      enabled: true,
+      file: "/tmp/env-lcm.log",
+      maxFileBytes: 5678,
+    });
   });
 
   it("derives bootstrapMaxTokens from leafChunkTokens and allows override", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -751,6 +751,18 @@ describe("resolveLcmConfig", () => {
     });
   });
 
+  it("ships a manifest with independentLogFile in schema", () => {
+    expect(manifest.configSchema.properties.independentLogFile).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        file: { type: "string" },
+        maxFileBytes: { type: "integer", minimum: 1 },
+      },
+    });
+  });
+
   it("ships a manifest with cacheAwareCompaction in schema", () => {
     expect(manifest.configSchema.properties.cacheAwareCompaction).toEqual({
       type: "object",
@@ -835,6 +847,41 @@ describe("resolveLcmConfig", () => {
     expect(config.delegationTimeoutMs).toBe(120000);
     expect(config.summaryMaxOverageFactor).toBe(3);
     expect(config.maxAssemblyTokenBudget).toBeUndefined();
+    expect(config.independentLogFile).toEqual({
+      enabled: true,
+      file: undefined,
+      maxFileBytes: 100 * 1024 * 1024,
+    });
+  });
+
+  it("resolves independent log file config from plugin config and env overrides", () => {
+    expect(resolveLcmConfig({}, {
+      independentLogFile: {
+        enabled: false,
+        file: "/tmp/custom-lcm.log",
+        maxFileBytes: 1234,
+      },
+    }).independentLogFile).toEqual({
+      enabled: false,
+      file: "/tmp/custom-lcm.log",
+      maxFileBytes: 1234,
+    });
+
+    expect(resolveLcmConfig({
+      LCM_LOG_FILE_ENABLED: "true",
+      LCM_LOG_FILE: "/tmp/env-lcm.log",
+      LCM_LOG_MAX_FILE_BYTES: "5678",
+    } as NodeJS.ProcessEnv, {
+      independentLogFile: {
+        enabled: false,
+        file: "/tmp/plugin-lcm.log",
+        maxFileBytes: 1234,
+      },
+    }).independentLogFile).toEqual({
+      enabled: true,
+      file: "/tmp/env-lcm.log",
+      maxFileBytes: 5678,
+    });
   });
 
   it("ignores non-positive replay flood thresholds from env and plugin config", () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -92,6 +92,10 @@ function createTestConfig(databasePath: string): LcmConfig {
       startup: "rotate",
       runtime: "rotate",
     },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
     summaryMaxOverageFactor: 3,
     customInstructions: "",
     circuitBreakerThreshold: 5,

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -46,6 +46,10 @@ const BASE_CONFIG: LcmConfig = {
     startup: "rotate",
     runtime: "rotate",
   },
+  independentLogFile: {
+    enabled: false,
+    maxFileBytes: 100 * 1024 * 1024,
+  },
   summaryMaxOverageFactor: 3,
   expansionProvider: "",
   expansionModel: "",

--- a/test/lcm-file-log.test.ts
+++ b/test/lcm-file-log.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createIndependentLcmFileLogger } from "../src/lcm-file-log.js";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lcm-file-log-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("createIndependentLcmFileLogger", () => {
+  it("writes JSONL records to the configured lossless-owned file", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] Plugin loaded");
+
+    const line = fs.readFileSync(file, "utf8").trim();
+    const record = JSON.parse(line) as Record<string, unknown>;
+    expect(record.level).toBe("info");
+    expect(record.plugin).toBe("lossless-claw");
+    expect(record.message).toBe("[lcm] Plugin loaded");
+    expect(typeof record.time).toBe("string");
+  });
+
+  it("rotates oversized active files through numbered suffixes", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 80,
+    });
+
+    logger?.write("info", "[lcm] first message with enough bytes to rotate next");
+    logger?.write("warn", "[lcm] second message rotates the first file");
+
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "lossless-claw-test.1.log"))).toBe(true);
+  });
+
+  it("redacts obvious secret-shaped text before writing", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("error", "[lcm] failed token=super-secret-token-value");
+
+    expect(fs.readFileSync(file, "utf8")).toContain("token=[REDACTED]");
+  });
+
+  it("does not write when disabled", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: false,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] ignored");
+
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("disables independent file logging when setup cannot create the log directory", () => {
+    const parentAsFile = path.join(tempDir, "not-a-directory");
+    fs.writeFileSync(parentAsFile, "occupied");
+
+    expect(
+      createIndependentLcmFileLogger({
+        enabled: true,
+        file: path.join(parentAsFile, "lossless-claw-test.log"),
+        maxFileBytes: 1024 * 1024,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/lcm-file-log.test.ts
+++ b/test/lcm-file-log.test.ts
@@ -4,16 +4,6 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing, createIndependentLcmFileLogger } from "../src/lcm-file-log.js";
 
-vi.mock("openclaw/plugin-sdk/logging-core", () => ({
-  redactSensitiveText: (text: string) =>
-    text
-      .replace(/token=[^\s]+/g, "token=[REDACTED]")
-      .replace(/ghp_[A-Za-z0-9]+/g, "[REDACTED]")
-      .replace(/github_pat_[A-Za-z0-9_]+/g, "[REDACTED]")
-      .replace(/AKIA[A-Z0-9]+/g, "[REDACTED]")
-      .replace(/"token":"[^"]+"/g, '"token":"[REDACTED]"'),
-}));
-
 let tempDir: string;
 
 beforeEach(() => {
@@ -22,6 +12,7 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
+  __testing.resetOpenClawRedactor();
 });
 
 describe("createIndependentLcmFileLogger", () => {
@@ -181,6 +172,26 @@ describe("createIndependentLcmFileLogger", () => {
     expect(record.message).not.toContain(githubPat);
     expect(record.message).not.toContain(awsKey);
     expect(record.message).not.toContain(jsonToken);
+  });
+
+  it("uses the OpenClaw redactor when the optional host dependency is available", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const redactSensitiveText = vi.fn(() => "[lcm] host redacted");
+    __testing.setOpenClawRedactor(redactSensitiveText);
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("error", "[lcm] failed token=super-secret-token-value");
+
+    const record = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(redactSensitiveText).toHaveBeenCalledWith(
+      "[lcm] failed token=super-secret-token-value",
+      undefined,
+    );
+    expect(record.message).toBe("[lcm] host redacted");
   });
 
   it("creates configured log files with owner-only permissions", () => {

--- a/test/lcm-file-log.test.ts
+++ b/test/lcm-file-log.test.ts
@@ -1,0 +1,226 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing, createIndependentLcmFileLogger } from "../src/lcm-file-log.js";
+
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  redactSensitiveText: (text: string) =>
+    text
+      .replace(/token=[^\s]+/g, "token=[REDACTED]")
+      .replace(/ghp_[A-Za-z0-9]+/g, "[REDACTED]")
+      .replace(/github_pat_[A-Za-z0-9_]+/g, "[REDACTED]")
+      .replace(/AKIA[A-Z0-9]+/g, "[REDACTED]")
+      .replace(/"token":"[^"]+"/g, '"token":"[REDACTED]"'),
+}));
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lcm-file-log-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("createIndependentLcmFileLogger", () => {
+  it("trusts only private same-owner existing OpenClaw temp dirs", () => {
+    const stat = (mode: number, uid = 501, directory = true, symlink = false) =>
+      ({
+        mode,
+        uid,
+        isDirectory: () => directory,
+        isSymbolicLink: () => symlink,
+      }) as fs.Stats;
+
+    expect(__testing.isTrustedExistingOpenClawTmpDir(stat(0o700), 501)).toBe(true);
+    expect(__testing.isTrustedExistingOpenClawTmpDir(stat(0o755), 501)).toBe(false);
+    expect(__testing.isTrustedExistingOpenClawTmpDir(stat(0o700, 502), 501)).toBe(false);
+    expect(__testing.isTrustedExistingOpenClawTmpDir(stat(0o700, 501, true, true), 501)).toBe(false);
+  });
+
+  it("writes JSONL records to the configured lossless-owned file", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] Plugin loaded");
+
+    const line = fs.readFileSync(file, "utf8").trim();
+    const record = JSON.parse(line) as Record<string, unknown>;
+    expect(record.level).toBe("info");
+    expect(record.plugin).toBe("lossless-claw");
+    expect(record.message).toBe("[lcm] Plugin loaded");
+    expect(typeof record.time).toBe("string");
+  });
+
+  it("rotates oversized active files through numbered suffixes", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 80,
+    });
+
+    logger?.write("info", "[lcm] first message with enough bytes to rotate next");
+    logger?.write("warn", "[lcm] second message rotates the first file");
+
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "lossless-claw-test.1.log"))).toBe(true);
+  });
+
+  it("does not treat fixed filenames as dated rolling paths", () => {
+    const file = path.join(tempDir, "lossless-claw-production.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] fixed path");
+
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "lossless-claw-2026-06-07.log"))).toBe(false);
+  });
+
+  it("keeps rolling log files for at least 3 days", () => {
+    const oldFile = path.join(tempDir, "lossless-claw-2026-06-01.log");
+    const recentFile = path.join(tempDir, "lossless-claw-2026-06-02.log");
+    fs.writeFileSync(oldFile, "old\n");
+    fs.writeFileSync(recentFile, "recent\n");
+    const now = Date.now();
+    const fourDaysAgo = new Date(now - 4 * 24 * 60 * 60 * 1000);
+    const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(oldFile, fourDaysAgo, fourDaysAgo);
+    fs.utimesSync(recentFile, twoDaysAgo, twoDaysAgo);
+
+    createIndependentLcmFileLogger({
+      enabled: true,
+      file: path.join(tempDir, "lossless-claw-2026-06-07.log"),
+      maxFileBytes: 1024 * 1024,
+    });
+
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(recentFile)).toBe(true);
+  });
+
+  it("does not prune fixed lossless-claw log filenames", () => {
+    const fixedFile = path.join(tempDir, "lossless-claw-incident.log");
+    fs.writeFileSync(fixedFile, "incident\n");
+    const fourDaysAgo = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(fixedFile, fourDaysAgo, fourDaysAgo);
+
+    createIndependentLcmFileLogger({
+      enabled: true,
+      file: path.join(tempDir, "lossless-claw-2026-06-07.log"),
+      maxFileBytes: 1024 * 1024,
+    });
+
+    expect(fs.existsSync(fixedFile)).toBe(true);
+  });
+
+  it("prunes stale rotated segments for dated rolling logs", () => {
+    const oldSegment = path.join(tempDir, "lossless-claw-2026-06-01.1.log");
+    const recentSegment = path.join(tempDir, "lossless-claw-2026-06-02.1.log");
+    fs.writeFileSync(oldSegment, "old segment\n");
+    fs.writeFileSync(recentSegment, "recent segment\n");
+    const now = Date.now();
+    const fourDaysAgo = new Date(now - 4 * 24 * 60 * 60 * 1000);
+    const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(oldSegment, fourDaysAgo, fourDaysAgo);
+    fs.utimesSync(recentSegment, twoDaysAgo, twoDaysAgo);
+
+    createIndependentLcmFileLogger({
+      enabled: true,
+      file: path.join(tempDir, "lossless-claw-2026-06-07.log"),
+      maxFileBytes: 1024 * 1024,
+    });
+
+    expect(fs.existsSync(oldSegment)).toBe(false);
+    expect(fs.existsSync(recentSegment)).toBe(true);
+  });
+
+  it("redacts obvious secret-shaped text before writing", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("error", "[lcm] failed token=super-secret-token-value");
+
+    const record = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(record.message).toBe("[lcm] failed token=[REDACTED]");
+  });
+
+  it("redacts common host logger secret shapes before writing", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const githubToken = "ghp_12345678901234567890";
+    const githubPat = "github_pat_12345678901234567890";
+    const awsKey = "AKIA1234567890ABCDEF";
+    const jsonToken = "json-secret-token-value";
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write(
+      "error",
+      `[lcm] failed github=${githubToken} pat=${githubPat} aws=${awsKey} body={"token":"${jsonToken}"}`,
+    );
+
+    const record = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>;
+    expect(record.message).toContain("[REDACTED]");
+    expect(record.message).not.toContain(githubToken);
+    expect(record.message).not.toContain(githubPat);
+    expect(record.message).not.toContain(awsKey);
+    expect(record.message).not.toContain(jsonToken);
+  });
+
+  it("creates configured log files with owner-only permissions", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] private file mode");
+
+    if (process.platform !== "win32") {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("does not write when disabled", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const logger = createIndependentLcmFileLogger({
+      enabled: false,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] ignored");
+
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("disables independent file logging when setup cannot create the log directory", () => {
+    const parentAsFile = path.join(tempDir, "not-a-directory");
+    fs.writeFileSync(parentAsFile, "occupied");
+
+    expect(
+      createIndependentLcmFileLogger({
+        enabled: true,
+        file: path.join(parentAsFile, "lossless-claw-test.log"),
+        maxFileBytes: 1024 * 1024,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/lcm-file-log.test.ts
+++ b/test/lcm-file-log.test.ts
@@ -64,6 +64,21 @@ describe("createIndependentLcmFileLogger", () => {
     expect(fs.existsSync(path.join(tempDir, "lossless-claw-test.1.log"))).toBe(true);
   });
 
+  it("does not rotate non-regular configured log targets", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    fs.mkdirSync(file);
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1,
+    });
+
+    logger?.write("warn", "[lcm] should not move directory");
+
+    expect(fs.lstatSync(file).isDirectory()).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "lossless-claw-test.1.log"))).toBe(false);
+  });
+
   it("does not treat fixed filenames as dated rolling paths", () => {
     const file = path.join(tempDir, "lossless-claw-production.log");
     const logger = createIndependentLcmFileLogger({
@@ -207,6 +222,23 @@ describe("createIndependentLcmFileLogger", () => {
     if (process.platform !== "win32") {
       expect(fs.statSync(file).mode & 0o777).toBe(0o600);
     }
+  });
+
+  it("makes existing configured log files owner-only before appending", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    fs.writeFileSync(file, "existing\n", { mode: 0o644 });
+    const logger = createIndependentLcmFileLogger({
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    });
+
+    logger?.write("info", "[lcm] private append");
+
+    if (process.platform !== "win32") {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+    expect(fs.readFileSync(file, "utf8")).toContain("[lcm] private append");
   });
 
   it("does not write when disabled", () => {

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLcmLogger } from "../src/lcm-log.js";
+import type { LcmConfig } from "../src/db/config.js";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lcm-log-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function baseConfig(file: string): LcmConfig {
+  return {
+    enabled: true,
+    databasePath: path.join(tempDir, "lcm.db"),
+    largeFilesDir: path.join(tempDir, "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 64,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 1,
+    leafChunkTokens: 20000,
+    leafTargetTokens: 2400,
+    condensedTargetTokens: 2000,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120000,
+    summaryTimeoutMs: 60000,
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2097152,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: true,
+      file,
+      maxFileBytes: 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1800000,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.9,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40000,
+    },
+  };
+}
+
+describe("createLcmLogger", () => {
+  it("tees runtime logger lines to the independent log file", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const info = vi.fn();
+    const logger = createLcmLogger({
+      runtime: {
+        logging: {
+          getChildLogger: vi.fn(() => ({
+            info,
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+          })),
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as never, baseConfig(file));
+
+    logger.info("[lcm] tee me");
+
+    expect(info).toHaveBeenCalledWith("[lcm] tee me");
+    expect(fs.readFileSync(file, "utf8")).toContain("[lcm] tee me");
+  });
+});

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLcmLogger } from "../src/lcm-log.js";
+import type { LcmConfig } from "../src/db/config.js";
+
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  redactSensitiveText: (text: string, options?: { patterns?: string[] }) => {
+    let next = text;
+    for (const rawPattern of options?.patterns ?? []) {
+      const match = rawPattern.match(/^\/(.+)\/([gimsuy]*)$/);
+      const pattern = match
+        ? new RegExp(match[1], match[2].includes("g") ? match[2] : `${match[2]}g`)
+        : new RegExp(rawPattern, "gi");
+      next = next.replace(pattern, "[REDACTED]");
+    }
+    return next;
+  },
+}));
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lcm-log-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
+  return {
+    enabled: true,
+    databasePath: path.join(tempDir, "lcm.db"),
+    largeFilesDir: path.join(tempDir, "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 64,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 1,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120000,
+    compactUntilUnderDeadlineMs: 300000,
+    leafChunkTokens: 20000,
+    leafTargetTokens: 2400,
+    condensedTargetTokens: 2000,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120000,
+    summaryTimeoutMs: 60000,
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    enableSummaryThinking: true,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2097152,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: independentLogFileEnabled,
+      file,
+      maxFileBytes: 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1800000,
+    replayFloodThresholdExternal: 3,
+    replayFloodThresholdInternal: 32,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.9,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40000,
+    },
+    stripInjectedContextTags: [],
+  };
+}
+
+describe("createLcmLogger", () => {
+  function createRuntimeLogger(
+    file: string,
+    options: { shouldLogVerbose?: boolean; runtimeConfig?: Record<string, unknown> } = {},
+  ) {
+    const runtimeLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const logger = createLcmLogger({
+      runtime: {
+        config: {
+          current: vi.fn(() => options.runtimeConfig ?? {}),
+        },
+        logging: {
+          shouldLogVerbose: vi.fn(() => options.shouldLogVerbose ?? false),
+          getChildLogger: vi.fn(() => runtimeLogger),
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as never, baseConfig(file));
+
+    return { logger, runtimeLogger };
+  }
+
+  it("routes routine info lines to the independent log file only", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const { logger, runtimeLogger } = createRuntimeLogger(file);
+
+    logger.info("[lcm] routine detail");
+
+    expect(runtimeLogger.info).not.toHaveBeenCalled();
+    expect(fs.readFileSync(file, "utf8")).toContain("[lcm] routine detail");
+  });
+
+  it("keeps warning and error lines visible in OpenClaw logs", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const { logger, runtimeLogger } = createRuntimeLogger(file);
+
+    logger.warn("[lcm] warning");
+    logger.error("[lcm] failure");
+
+    expect(runtimeLogger.warn).toHaveBeenCalledWith("[lcm] warning");
+    expect(runtimeLogger.error).toHaveBeenCalledWith("[lcm] failure");
+    const logText = fs.readFileSync(file, "utf8");
+    expect(logText).toContain("[lcm] warning");
+    expect(logText).toContain("[lcm] failure");
+  });
+
+  it("allows startup info lines to remain visible in OpenClaw logs", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const { logger, runtimeLogger } = createRuntimeLogger(file);
+
+    logger.hostInfo?.("[lcm] Plugin loaded");
+
+    expect(runtimeLogger.info).toHaveBeenCalledWith("[lcm] Plugin loaded");
+    expect(fs.readFileSync(file, "utf8")).toContain("[lcm] Plugin loaded");
+  });
+
+  it("does not persist debug lines when OpenClaw verbose logging is disabled", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const { logger, runtimeLogger } = createRuntimeLogger(file, { shouldLogVerbose: false });
+
+    logger.debug("[lcm] hidden debug detail");
+
+    expect(runtimeLogger.debug).not.toHaveBeenCalled();
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("persists debug lines when OpenClaw verbose logging is enabled", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const { logger, runtimeLogger } = createRuntimeLogger(file, { shouldLogVerbose: true });
+
+    logger.debug("[lcm] visible debug detail");
+
+    expect(runtimeLogger.debug).not.toHaveBeenCalled();
+    expect(fs.readFileSync(file, "utf8")).toContain("[lcm] visible debug detail");
+  });
+
+  it("applies OpenClaw custom redaction patterns to independent logs", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const customSecret = "tenant-secret-12345";
+    const { logger } = createRuntimeLogger(file, {
+      runtimeConfig: {
+        logging: {
+          redactPatterns: ["/tenant-secret-[0-9]+/g"],
+        },
+      },
+    });
+
+    logger.info(`[lcm] saw ${customSecret}`);
+
+    const logText = fs.readFileSync(file, "utf8");
+    expect(logText).toContain("[REDACTED]");
+    expect(logText).not.toContain(customSecret);
+  });
+
+  it("falls back to OpenClaw logging when the independent file target is invalid", () => {
+    const directoryTarget = path.join(tempDir, "not-a-file");
+    fs.mkdirSync(directoryTarget);
+    const { logger, runtimeLogger } = createRuntimeLogger(directoryTarget);
+
+    logger.info("[lcm] routine fallback for invalid file target");
+
+    expect(runtimeLogger.info).toHaveBeenCalledWith("[lcm] routine fallback for invalid file target");
+  });
+
+  it("falls back to OpenClaw logging when independent logging is disabled", () => {
+    const file = path.join(tempDir, "lossless-claw-test.log");
+    const runtimeLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const logger = createLcmLogger({
+      runtime: {
+        logging: {
+          getChildLogger: vi.fn(() => runtimeLogger),
+        },
+      },
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    } as never, baseConfig(file, false));
+
+    logger.info("[lcm] routine fallback");
+
+    expect(runtimeLogger.info).toHaveBeenCalledWith("[lcm] routine fallback");
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +15,10 @@ vi.mock("openclaw/plugin-sdk/core", () => ({
   buildMemorySystemPromptAddition: buildMemorySystemPromptAdditionMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  redactSensitiveText: (text: string) => text,
+}));
+
 type RegisteredEngineFactory = (() => unknown) | undefined;
 type HookHandler = (event: unknown, context: unknown) => unknown;
 type RegisteredContextEngine = { id: string; factory: () => unknown };
@@ -28,10 +32,11 @@ function buildApi(
   options?: {
     includeModelAuth?: boolean;
     includeRuntimeLlm?: boolean;
-    agentDir?: string;
-    runtimeConfig?: Record<string, unknown>;
-    registrationMode?: string;
-  },
+	    agentDir?: string;
+	    runtimeConfig?: Record<string, unknown>;
+	    registrationMode?: string;
+	    shouldLogVerbose?: boolean;
+	  },
 ): {
   api: OpenClawPluginApi;
   getFactory: () => RegisteredEngineFactory;
@@ -91,12 +96,14 @@ function buildApi(
               resolveApiKeyForProvider: vi.fn(async () => undefined),
             },
           }),
-      config: {
-        loadConfig: vi.fn(() => options?.runtimeConfig ?? {}),
-      },
-      logging: {
-        getChildLogger: vi.fn(() => ({
-          info: infoLog,
+	      config: {
+	        current: vi.fn(() => options?.runtimeConfig ?? {}),
+	        loadConfig: vi.fn(() => options?.runtimeConfig ?? {}),
+	      },
+	      logging: {
+	        shouldLogVerbose: vi.fn(() => options?.shouldLogVerbose ?? false),
+	        getChildLogger: vi.fn(() => ({
+	          info: infoLog,
           warn: warnLog,
           error: errorLog,
           debug: debugLog,
@@ -337,23 +344,32 @@ describe("lcm plugin registration", () => {
   it("uses api.pluginConfig values during register", { timeout: 20000 }, () => {
     const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
     dbPaths.add(dbPath);
+    const logDir = mkdtempSync(join(tmpdir(), "lossless-claw-plugin-log-"));
+    tempDirs.add(logDir);
+    const logFile = join(logDir, "lcm.log");
 
-    const { api, getFactory, debugLog, infoLog, sessionInfoLog } = buildApi({
-      enabled: true,
-      contextThreshold: 0.33,
-      incrementalMaxDepth: -1,
-      freshTailCount: 7,
-      promptAwareEviction: false,
-      leafChunkTokens: 80000,
-      newSessionRetainDepth: 4,
-      dbPath,
-      ignoreSessionPatterns: ["agent:*:cron:**", "agent:main:subagent:**"],
-      statelessSessionPatterns: ["agent:*:subagent:**"],
-      skipStatelessSessions: true,
-      transcriptGcEnabled: true,
-      proactiveThresholdCompactionMode: "inline",
-      largeFileThresholdTokens: 12345,
-    });
+    const { api, getFactory, debugLog, infoLog, sessionInfoLog } = buildApi(
+      {
+        enabled: true,
+        contextThreshold: 0.33,
+        incrementalMaxDepth: -1,
+        freshTailCount: 7,
+        promptAwareEviction: false,
+        leafChunkTokens: 80000,
+        newSessionRetainDepth: 4,
+        dbPath,
+        ignoreSessionPatterns: ["agent:*:cron:**", "agent:main:subagent:**"],
+        statelessSessionPatterns: ["agent:*:subagent:**"],
+        skipStatelessSessions: true,
+        transcriptGcEnabled: true,
+        proactiveThresholdCompactionMode: "inline",
+        largeFileThresholdTokens: 12345,
+        independentLogFile: {
+          file: logFile,
+        },
+      },
+      { shouldLogVerbose: true },
+    );
     lcmPlugin.register(api);
     expect(api.registerCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -411,7 +427,8 @@ describe("lcm plugin registration", () => {
       "[lcm] Compaction summarization model: (unconfigured)",
     );
     expect(sessionInfoLog).not.toHaveBeenCalled();
-    expect(debugLog).toHaveBeenCalledWith(expect.stringContaining("[lcm] Migration successful"));
+    expect(debugLog).not.toHaveBeenCalledWith(expect.stringContaining("[lcm] Migration successful"));
+    expect(readFileSync(logFile, "utf8")).toContain("[lcm] Migration successful");
     expect(api.on).toHaveBeenCalledWith("before_reset", expect.any(Function));
     expect(api.on).toHaveBeenCalledWith("session_end", expect.any(Function));
   });
@@ -966,6 +983,9 @@ describe("lcm plugin registration", () => {
   it("dedupes startup banner logs across repeated registration and engine construction", () => {
     const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
     dbPaths.add(dbPath);
+    const logDir = mkdtempSync(join(tmpdir(), "lossless-claw-plugin-log-"));
+    tempDirs.add(logDir);
+    const logFile = join(logDir, "lcm.log");
 
     const pluginConfig = {
       enabled: true,
@@ -975,9 +995,12 @@ describe("lcm plugin registration", () => {
       statelessSessionPatterns: ["agent:*:subagent:**"],
       skipStatelessSessions: true,
       proactiveThresholdCompactionMode: "deferred",
+      independentLogFile: {
+        file: logFile,
+      },
     };
-    const first = buildApi(pluginConfig);
-    const second = buildApi(pluginConfig);
+    const first = buildApi(pluginConfig, { shouldLogVerbose: true });
+    const second = buildApi(pluginConfig, { shouldLogVerbose: true });
     lcmPlugin.register(first.api);
     lcmPlugin.register(second.api);
 
@@ -1017,8 +1040,9 @@ describe("lcm plugin registration", () => {
     expect(firstSessionMessages).toEqual([]);
     expect(secondSessionMessages).toEqual([]);
     expect(debugMessages).toEqual(
-      expect.arrayContaining([expect.stringContaining("[lcm] Migration successful")]),
+      expect.not.arrayContaining([expect.stringContaining("[lcm] Migration successful")]),
     );
+    expect(readFileSync(logFile, "utf8")).toContain("[lcm] Migration successful");
     expect(firstMessages).toEqual(
       expect.not.arrayContaining([expect.stringContaining("[lcm] Migration successful")]),
     );

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -66,6 +66,10 @@ function createTestConfig(databasePath: string): LcmConfig {
       startup: "rotate",
       runtime: "rotate",
     },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
     summaryMaxOverageFactor: 3,
     expansionProvider: "",
     expansionModel: "",


### PR DESCRIPTION
## Summary
- add a plugin-owned Lossless JSONL log file alongside OpenClaw logs
- support daily dated rollover, stale dated-log pruning, and size rotation
- document and expose independentLogFile config plus env overrides

## Verification
- npm run build
- env -u OPENCLAW_STATE_DIR npm test