### PR TITLE
feat: v4.1 foundation — schema + concurrency primitives

### DIFF
--- a/src/concurrency/model.ts
+++ b/src/concurrency/model.ts
@@ -1,0 +1,147 @@
+/**
+ * §0 Concurrency Model — LCM v4.1.1
+ *
+ * The load-bearing invariants for cross-process safety between gateway and worker.
+ * This module is the single source of truth for §0 of architecture-v4.1.md +
+ * v4.1.1 A6/A9 amendments. Code that violates these invariants must fail
+ * loudly (assertion / throw) — never silently degrade.
+ *
+ * Invariants (architecture-v4.1.md §0.1, plus v4.1.1 A6 + A9):
+ *
+ *   1. NO LLM/network call inside any SQLite write transaction.
+ *      Leaf-write commits in T1; embed/extract queue async to worker T2.
+ *      Synthesis call happens OUTSIDE cache-write transaction (insert
+ *      `status='building'` row in T1, run LLM, then update to `status='ready'`
+ *      in T2 per v3.1 A8).
+ *
+ *   2. Gateway owns the hot path. Per-turn assemble + leaf write + agent
+ *      tool calls. Latency budget: assemble <100ms; leaf write <50ms.
+ *
+ *   3. Worker owns cold rewrites. Condensation, extraction, embedding
+ *      backfill, theme consolidation, synthesis profile rebuilds. May take
+ *      seconds-to-minutes per job; gateway never waits on it.
+ *
+ *   4. Both processes use the same SQLite DB; no IPC beyond DB rows.
+ *
+ *   5. Worker uses SHORTER `busy_timeout` than gateway so gateway always
+ *      wins on contention. See {@link GATEWAY_BUSY_TIMEOUT_MS} and
+ *      {@link WORKER_BUSY_TIMEOUT_MS}.
+ *
+ *   6. Migration ratchet owned by gateway only. Worker startup checks
+ *      `lcm_migration_state` for required v4.1 step; refuses to start if
+ *      not present. Worker NEVER calls `runLcmMigrations`.
+ *
+ *   7. PRAGMA foreign_keys = ON on every connection (gateway and worker).
+ *      Already set by `src/db/connection.ts:configureConnection()`. v4.1.1
+ *      A6 amendment: any new connection path must run through that helper
+ *      OR explicitly set the PRAGMA. Verified via {@link assertForeignKeysEnabled}.
+ *
+ *   8. Worker heartbeat must run on Node `worker_threads` Worker with its
+ *      OWN DatabaseSync connection (v4.1.1 A9). Otherwise event-loop
+ *      blocking by job code (long LLM call, ml-hclust pass) starves the
+ *      heartbeat → fallback gateway steals an active worker's lock.
+ *      (Worker_threads scaffolding lands in Group A.NN; this constant
+ *      anchors the contract.)
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+
+/**
+ * Gateway SQLite busy_timeout (ms). Already set by
+ * `src/db/connection.ts:configureConnection()` to this value. Long timeout
+ * accommodates worker-process write transactions during condensation /
+ * extraction passes.
+ */
+export const GATEWAY_BUSY_TIMEOUT_MS = 30_000;
+
+/**
+ * Worker SQLite busy_timeout (ms). MUST be shorter than
+ * {@link GATEWAY_BUSY_TIMEOUT_MS} so gateway always wins on contention.
+ * Worker that hits SQLITE_BUSY backs off and retries; gateway hot path
+ * does not stall waiting for worker writes.
+ */
+export const WORKER_BUSY_TIMEOUT_MS = 5_000;
+
+/**
+ * Worker heartbeat cadence (ms). Worker writes
+ * `last_heartbeat_at = now, expires_at = now + WORKER_LOCK_TTL_MS` on its
+ * held locks at this interval. See `lcm_worker_lock` table.
+ */
+export const WORKER_HEARTBEAT_MS = 30_000;
+
+/**
+ * Worker lock TTL (ms). If a worker dies without releasing its lock,
+ * other workers / fallback gateway can GC the lock once `expires_at < now`.
+ * 90s = 3× heartbeat cadence (allows one missed heartbeat without stealing).
+ */
+export const WORKER_LOCK_TTL_MS = 90_000;
+
+/**
+ * Gateway-fallback soak window (ms). Gateway can take over a worker job
+ * only when BOTH:
+ *   - lock is GC'd (per WORKER_LOCK_TTL_MS expiry), AND
+ *   - last_heartbeat_at < now - GATEWAY_FALLBACK_SOAK_MS
+ * Two conditions prevent gateway from racing a slow-LLM-but-alive worker
+ * (v4.1.1 A9 amendment).
+ */
+export const GATEWAY_FALLBACK_SOAK_MS = 300_000;
+
+/**
+ * Job kinds tracked by the cross-process lock table. Adding a new kind
+ * requires updating both this list AND the `lcm_worker_lock.job_kind`
+ * CHECK constraint (when added; current schema is freeform TEXT for
+ * forward-compat).
+ */
+export const WORKER_JOB_KINDS = [
+  "condensation",
+  "extraction",
+  "embedding-backfill",
+  "profile-rebuild",
+  "theme-consolidation",
+  "eval", // §11 ensemble judge runs (v4.1.1 §C MED item)
+] as const;
+
+export type WorkerJobKind = (typeof WORKER_JOB_KINDS)[number];
+
+/**
+ * Asserts `PRAGMA foreign_keys = ON` for the given connection. Throws if
+ * disabled. Per v4.1.1 A6 invariant: every code path that opens a
+ * SQLite connection MUST end up with FKs enabled, otherwise every
+ * `ON DELETE CASCADE` clause in the schema becomes documentation-only.
+ *
+ * `src/db/connection.ts:configureConnection()` already does this for the
+ * standard connection path — call this assertion in tests / hot paths
+ * to defend against future paths that bypass `configureConnection`.
+ */
+export function assertForeignKeysEnabled(db: DatabaseSync): void {
+  const row = db.prepare("PRAGMA foreign_keys").get() as { foreign_keys?: number } | undefined;
+  if (!row || row.foreign_keys !== 1) {
+    throw new Error(
+      "[concurrency.model] foreign_keys is not ON for this connection — " +
+        "every ON DELETE CASCADE in the schema would silently no-op. " +
+        "Ensure the connection passes through configureConnection() in " +
+        "src/db/connection.ts, or set PRAGMA foreign_keys = ON explicitly.",
+    );
+  }
+}
+
+/**
+ * Asserts the connection is set up such that `BEGIN EXCLUSIVE` migration
+ * + worker writes won't deadlock under contention. Specifically: busy_timeout
+ * must be ≥ {@link WORKER_BUSY_TIMEOUT_MS} (worker) or
+ * {@link GATEWAY_BUSY_TIMEOUT_MS} (gateway). Caller specifies which role.
+ */
+export function assertBusyTimeoutForRole(
+  db: DatabaseSync,
+  role: "gateway" | "worker",
+): void {
+  const expected = role === "gateway" ? GATEWAY_BUSY_TIMEOUT_MS : WORKER_BUSY_TIMEOUT_MS;
+  const row = db.prepare("PRAGMA busy_timeout").get() as { timeout?: number } | undefined;
+  const actual = row?.timeout ?? 0;
+  if (actual < expected) {
+    throw new Error(
+      `[concurrency.model] busy_timeout for ${role} is ${actual}ms, ` +
+        `expected at least ${expected}ms. Set via PRAGMA busy_timeout = ${expected}.`,
+    );
+  }
+}

--- a/src/concurrency/worker-lock.ts
+++ b/src/concurrency/worker-lock.ts
@@ -1,0 +1,215 @@
+/**
+ * Cross-process worker job lock — LCM v4.1 §0.
+ *
+ * Backed by `lcm_worker_lock` table (one row per job_kind). All worker
+ * jobs (condensation, extraction, embedding-backfill, profile-rebuild,
+ * theme-consolidation, eval) coordinate via this table so only one
+ * process at a time runs each kind.
+ *
+ * Acquisition is atomic via PRIMARY KEY uniqueness on (job_kind):
+ * INSERT OR IGNORE returns 1 row affected if we got the lock, 0 if
+ * someone else already holds it. No advisory lock dance, no application
+ * semaphore — SQLite's row-uniqueness IS the lock.
+ *
+ * TTL + heartbeat (v4.1.1 A9):
+ *   - WORKER_LOCK_TTL_MS = 90s default
+ *   - Worker calls heartbeatLock() every WORKER_HEARTBEAT_MS = 30s while running
+ *   - If a worker dies without releasing, its lock auto-expires after 90s
+ *   - acquireLock() GC's stale (expired) locks BEFORE attempting INSERT
+ *
+ * Why TTL is short and heartbeat is shorter: gateway-fallback soak window
+ * (GATEWAY_FALLBACK_SOAK_MS = 5min) prevents a slow-LLM-but-alive worker
+ * from being preempted. The fast TTL only matters when the worker is
+ * actually dead.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { WORKER_LOCK_TTL_MS, type WorkerJobKind } from "./model.js";
+
+export interface AcquireLockOptions {
+  /** Unique worker identifier (e.g. process.pid + start time + nonce). */
+  workerId: string;
+  /** Lock expiration in ms from now. Defaults to WORKER_LOCK_TTL_MS. */
+  ttlMs?: number;
+  /**
+   * Optional scope — if set, the lock is logically scoped to this
+   * session_key. Other code paths can read this column to make
+   * "same kind but different session" decisions (e.g. condensation
+   * runs simultaneously on different sessions but only one per session).
+   * NOTE: the lock itself is still per-job_kind (table PK). This column
+   * is informational only.
+   */
+  jobSessionKey?: string;
+  /** Arbitrary worker-set tag for diagnostics (e.g. "backfill: model=voyage4large"). */
+  jobMetadata?: string;
+}
+
+export interface LockInfo {
+  jobKind: string;
+  workerId: string;
+  acquiredAt: string;
+  expiresAt: string;
+  lastHeartbeatAt: string;
+  jobSessionKey: string | null;
+  jobMetadata: string | null;
+}
+
+/**
+ * Try to acquire a job lock. Returns true if acquired (caller now owns
+ * the lock; must call {@link releaseLock} or let it expire). Returns
+ * false if another worker holds it and the lock has not yet expired.
+ *
+ * Side effect: GC's any expired lock for this job_kind before attempting
+ * acquisition (so a stale dead-worker lock doesn't permanently block).
+ *
+ * Best practice: caller should wrap acquire + work + release in
+ * try/finally and emit telemetry on contention (acquire returning false
+ * frequently means the work isn't fitting into the lock window).
+ */
+export function acquireLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  opts: AcquireLockOptions,
+): boolean {
+  if (!opts.workerId || opts.workerId.trim().length === 0) {
+    throw new Error("[worker-lock] workerId is required");
+  }
+  // GC stale lock (if any). datetime('now') comparison; SQLite TEXT
+  // comparison works lexicographically on ISO-8601 strings.
+  // Note: `<=` not `<` so a lock with ttl=0 is immediately reclaimable.
+  // The race "another process acquires in the gap between DELETE and
+  // INSERT" is handled by the INSERT OR IGNORE on PK uniqueness — the
+  // second writer's INSERT just no-ops. Worst case: caller is told false
+  // when they could have had the lock; never silently double-acquires.
+  db.prepare(
+    `DELETE FROM lcm_worker_lock
+       WHERE job_kind = ? AND expires_at <= datetime('now')`,
+  ).run(jobKind);
+
+  const ttlSeconds = Math.round((opts.ttlMs ?? WORKER_LOCK_TTL_MS) / 1000);
+  // INSERT OR IGNORE: succeeds (changes=1) if no row holds the PK; no-ops
+  // (changes=0) if someone else is already there.
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO lcm_worker_lock
+         (job_kind, worker_id, acquired_at, expires_at, last_heartbeat_at,
+          job_session_key, job_metadata)
+       VALUES (?, ?, datetime('now'),
+               datetime('now', '+' || ? || ' seconds'),
+               datetime('now'), ?, ?)`,
+    )
+    .run(
+      jobKind,
+      opts.workerId,
+      ttlSeconds,
+      opts.jobSessionKey ?? null,
+      opts.jobMetadata ?? null,
+    );
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Release a held lock. Returns true if the row existed and matched the
+ * worker_id (so we deleted it). Returns false if the lock was already
+ * gone (e.g. expired + GC'd, or never acquired by this worker).
+ *
+ * NOTE: a stale-but-not-yet-GC'd lock CAN be deleted here if you pass
+ * the worker_id that originally acquired it. This is intentional —
+ * worker that just woke from sleep should be able to release its old
+ * lock if it remembers having it.
+ */
+export function releaseLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  workerId: string,
+): boolean {
+  const result = db
+    .prepare(`DELETE FROM lcm_worker_lock WHERE job_kind = ? AND worker_id = ?`)
+    .run(jobKind, workerId);
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Extend the expiration on a lock the worker still holds. Idempotent.
+ * Returns true if the worker still owns the lock (so the heartbeat
+ * succeeded). Returns false if the lock was lost (e.g. preempted by
+ * fallback gateway, or a different worker now owns it) — caller MUST
+ * abort its work in that case to avoid double-processing.
+ */
+export function heartbeatLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  workerId: string,
+  ttlMs?: number,
+): boolean {
+  const ttlSeconds = Math.round((ttlMs ?? WORKER_LOCK_TTL_MS) / 1000);
+  // Wave-1 Auditor #2 finding #2: previous version had no `expires_at`
+  // predicate. If our 90s lock had already expired (worker was blocked
+  // in a long Voyage call), but no other worker had yet stolen it via
+  // acquireLock's lazy-DELETE, this UPDATE would silently re-extend an
+  // EXPIRED lock — making it look alive again. A concurrent autostart
+  // tick that started just before our heartbeat could then GC + acquire
+  // in between, both holding "the" lock simultaneously.
+  //
+  // Fix: require `expires_at > now` AND `worker_id = ?`. If our lock has
+  // expired we report `false` (caller MUST abort) and DO NOT extend it —
+  // the lazy-GC in acquireLock will then clean up.
+  const result = db
+    .prepare(
+      `UPDATE lcm_worker_lock
+         SET last_heartbeat_at = datetime('now'),
+             expires_at = datetime('now', '+' || ? || ' seconds')
+         WHERE job_kind = ?
+           AND worker_id = ?
+           AND expires_at > datetime('now')`,
+    )
+    .run(ttlSeconds, jobKind, workerId);
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Inspect the current lock holder (or null if no one holds the lock).
+ * Used by `/lcm health` to report worker state.
+ */
+export function lockInfo(db: DatabaseSync, jobKind: WorkerJobKind): LockInfo | null {
+  const row = db
+    .prepare(
+      `SELECT job_kind, worker_id, acquired_at, expires_at, last_heartbeat_at,
+              job_session_key, job_metadata
+         FROM lcm_worker_lock WHERE job_kind = ?`,
+    )
+    .get(jobKind) as
+    | {
+        job_kind: string;
+        worker_id: string;
+        acquired_at: string;
+        expires_at: string;
+        last_heartbeat_at: string;
+        job_session_key: string | null;
+        job_metadata: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    jobKind: row.job_kind,
+    workerId: row.worker_id,
+    acquiredAt: row.acquired_at,
+    expiresAt: row.expires_at,
+    lastHeartbeatAt: row.last_heartbeat_at,
+    jobSessionKey: row.job_session_key,
+    jobMetadata: row.job_metadata,
+  };
+}
+
+/**
+ * Generate a worker_id suitable for {@link acquireLock}. Format:
+ * `<role>-<pid>-<startMs>-<nonce>` where nonce is a 6-char hex string.
+ * Uniqueness is across-time + across-process; collisions are
+ * astronomically unlikely.
+ */
+export function generateWorkerId(role: string): string {
+  const nonce = Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, "0");
+  return `${role}-${process.pid}-${Date.now()}-${nonce}`;
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { assertForeignKeysEnabled } from "../concurrency/model.js";
 
 type ConnectionKey = string;
 /**
@@ -51,6 +52,11 @@ function configureConnection(db: DatabaseSync): DatabaseSync {
   db.exec("PRAGMA journal_mode = WAL");
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
   db.exec("PRAGMA foreign_keys = ON");
+  // v4.1 B.fix — Gap 7: verify the PRAGMA actually took effect. Catches
+  // future regressions where a code path opens a connection that bypasses
+  // configureConnection and leaves FK enforcement off — making every
+  // ON DELETE CASCADE in the schema a silent no-op.
+  assertForeignKeysEnabled(db);
   // 64MB page cache (default 2MB is severely undersized for multi-GB databases
   // with concurrent agents). Memory is demand-allocated, released on close.
   db.exec("PRAGMA cache_size = -65536");
@@ -112,7 +118,11 @@ function closeDatabase(db: DatabaseSync | undefined): void {
  */
 export function createLcmDatabaseConnection(dbPath: string): DatabaseSync {
   ensureDbDirectory(dbPath);
-  const db = new DatabaseSync(dbPath);
+  // v4.1 Final.review P1 #1 fix: open with allowExtension=true so
+  // sqlite-vec can be loaded. Without this, db.loadExtension() throws
+  // and the entire v4.1 semantic feature is silently inert in
+  // production (autostart pre-flight returns NO_OP).
+  const db = new DatabaseSync(dbPath, { allowExtension: true });
   try {
     configureConnection(db);
   } catch (err) {

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -109,6 +109,91 @@ function ensureSummaryModelColumn(db: DatabaseSync): void {
   }
 }
 
+/**
+ * v4.1 schema additions to `summaries`:
+ *   - session_key                  (v3.1 A1: cross-conv identity for assemble + retrieval)
+ *   - suppressed_at                (v3.1 A3: lossless-forget flag; cascade triggers)
+ *   - entity_index                 (v3.1: JSON sidecar populated by §7.2 entity coreference)
+ *   - contains_suppressed_leaves   (v3.1 A3: marks condensed needing idle rebuild)
+ *   - suppress_reason              (v4.1.1 A2: read by lcm_describe; written by lcm_suppress)
+ *   - superseded_by                (v4.1.1 A2: forwarder pattern; idle rebuild keeps old row immutable
+ *                                   and points to new row via this FK)
+ *   - leaf_summarizer_cap_was      (v4.1: forensic marker for the 2,415-token cap fix; NULL =
+ *                                   leaf was never capped or has been regenerated)
+ *
+ * SQLite ADD COLUMN constraints satisfied:
+ *   - No PRIMARY KEY / UNIQUE in any new column.
+ *   - No CURRENT_TIMESTAMP defaults.
+ *   - NOT NULL columns have non-NULL defaults.
+ *   - REFERENCES columns have NULL default (per SQLite ADD COLUMN with FK rule).
+ */
+function ensureSummaryV41Columns(db: DatabaseSync): void {
+  const cols = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
+  const has = (name: string): boolean => cols.some((c) => c.name === name);
+
+  if (!has("session_key")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN session_key TEXT NOT NULL DEFAULT ''`);
+  }
+  if (!has("suppressed_at")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN suppressed_at TEXT`);
+  }
+  if (!has("entity_index")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN entity_index TEXT`);
+  }
+  if (!has("contains_suppressed_leaves")) {
+    db.exec(
+      `ALTER TABLE summaries ADD COLUMN contains_suppressed_leaves INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+  if (!has("suppress_reason")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN suppress_reason TEXT`);
+  }
+  if (!has("superseded_by")) {
+    // FK with SET NULL on parent delete. SQLite ADD COLUMN with REFERENCES requires NULL default.
+    db.exec(
+      `ALTER TABLE summaries ADD COLUMN superseded_by TEXT REFERENCES summaries(summary_id) ON DELETE SET NULL`,
+    );
+  }
+  if (!has("leaf_summarizer_cap_was")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN leaf_summarizer_cap_was INTEGER`);
+  }
+}
+
+/**
+ * v3.1 A3 (extended in v4.1.1 A3): suppression cascade reaches raw messages
+ * via `messages.suppressed_at`. All message-search read paths
+ * (conversation-store FTS / LIKE / regex + grep mode='verbatim') filter on this.
+ */
+function ensureMessageSuppressedAtColumn(db: DatabaseSync): void {
+  const cols = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
+  const hasSuppressedAt = cols.some((c) => c.name === "suppressed_at");
+  if (!hasSuppressedAt) {
+    db.exec(`ALTER TABLE messages ADD COLUMN suppressed_at TEXT`);
+  }
+}
+
+/**
+ * v4.1.1 A8 — feature-flag storage for v4.1 sections (e.g. semantic
+ * retrieval can be disabled if vec0 extension fails to load).
+ *
+ * Code-as-ground-truth note: v4.1.1 A8 originally proposed extending
+ * `lcm_migration_flags` with a `value` column. That table doesn't exist
+ * in the upstream source — it's a fork-side legacy table that only
+ * exists on Eva's live DB. This implementation creates a clean new
+ * `lcm_feature_flags` table that doesn't conflict with the legacy table.
+ */
+function ensureLcmFeatureFlagsTable(db: DatabaseSync): void {
+  // Note: explicit NOT NULL on the TEXT PRIMARY KEY column — SQLite's
+  // legacy behavior allows NULL in TEXT PK columns without it.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS lcm_feature_flags (
+      flag TEXT NOT NULL PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+}
+
 function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const telemetryColumns = db.prepare(`PRAGMA table_info(conversation_compaction_telemetry)`).all() as SummaryColumnInfo[];
   const hasConsecutiveColdObservations = telemetryColumns.some(
@@ -867,7 +952,17 @@ function ensureStandaloneFtsTable(db: DatabaseSync, spec: FtsTableSpec): void {
 
 export function runLcmMigrations(
   db: DatabaseSync,
-  options?: { fts5Available?: boolean; log?: MigrationLogger },
+  options?: {
+    fts5Available?: boolean;
+    log?: MigrationLogger;
+    /**
+     * Accepted for forward-compatibility. This migration creates the
+     * lcm_prompt_registry table; seeding it with default prompts is
+     * performed by the synthesis layer in a later PR. Until then this
+     * option is a no-op (schema/concurrency tests pass `false`).
+     */
+    seedDefaultPrompts?: boolean;
+  },
 ): void {
   const log = options?.log;
   let transactionActive = false;
@@ -1265,6 +1360,751 @@ export function runLcmMigrations(
         }
       });
     }
+
+    // ── v4.1 schema additions ────────────────────────────────────────────────
+    // Each block resolves a specific amendment from architecture-v4.1.1.md.
+    // Tables are created idempotently so the migration is safe to re-run.
+    //
+    // v4.1.1 A9 — `lcm_worker_lock`: cross-process job lock for the worker
+    // sidecar (condensation, extraction, embedding backfill, theme
+    // consolidation, eval, profile rebuild). `last_heartbeat_at` is
+    // required by §0.5 fallback rule (gateway can take over only when
+    // BOTH `expires_at < now` AND `last_heartbeat_at < now - 300s`).
+    // See `src/concurrency/model.ts` for the invariants and constants.
+    runMigrationStep("ensureLcmWorkerLockTable", log, () => {
+      // Note: explicit NOT NULL on the TEXT PRIMARY KEY column — SQLite's
+      // legacy behavior allows NULL in TEXT PK columns without it.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_worker_lock (
+          job_kind TEXT NOT NULL PRIMARY KEY,
+          worker_id TEXT NOT NULL,
+          acquired_at TEXT NOT NULL DEFAULT (datetime('now')),
+          expires_at TEXT NOT NULL,
+          last_heartbeat_at TEXT NOT NULL DEFAULT (datetime('now')),
+          job_session_key TEXT,
+          job_metadata TEXT
+        )
+      `);
+    });
+
+    // v3.1 A1/A3 + v4.1.1 A2 — additive columns on summaries (session_key,
+    // suppressed_at, entity_index, contains_suppressed_leaves, suppress_reason,
+    // superseded_by, leaf_summarizer_cap_was). Idempotent via PRAGMA check.
+    runMigrationStep("ensureSummaryV41Columns", log, () => ensureSummaryV41Columns(db));
+
+    // v3.1 A3 — messages.suppressed_at for raw-message suppression cascade.
+    runMigrationStep("ensureMessageSuppressedAtColumn", log, () =>
+      ensureMessageSuppressedAtColumn(db),
+    );
+
+    // v4.1.1 A8 — feature flags for v4.1 sections (e.g. v4_section_1_enabled
+    // when vec0 extension is available). Creates clean new table; does NOT
+    // touch Eva's legacy lcm_migration_flags table.
+    runMigrationStep("ensureLcmFeatureFlagsTable", log, () =>
+      ensureLcmFeatureFlagsTable(db),
+    );
+
+    // v4.1.1 A3 — lcm_extraction_queue: gateway atomically inserts a row
+    // alongside every leaf write; worker picks up the queue to run entity
+    // coreference (and procedure-recheck on demand). Per v4.1.1 A3 + B18
+    // atomicity rule: leaf-write transaction MUST insert the queue row in
+    // the same transaction as the leaf insert (Group B leaf-write code).
+    runMigrationStep("ensureLcmExtractionQueueTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_extraction_queue (
+          queue_id TEXT NOT NULL PRIMARY KEY,
+          leaf_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          kind TEXT NOT NULL CHECK (kind IN ('entity', 'procedure-recheck')),
+          queued_at TEXT NOT NULL DEFAULT (datetime('now')),
+          picked_at TEXT,
+          worker_id TEXT,
+          completed_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_extraction_queue_pending_idx
+          ON lcm_extraction_queue (queued_at)
+          WHERE picked_at IS NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_extraction_queue_dead_letter_idx
+          ON lcm_extraction_queue (attempts)
+          WHERE attempts >= 5
+      `);
+    });
+
+    // v4.1.1 B2 — lcm_purge_rebuild_queue REMOVED in first-principles pass
+    // (2026-05-06). The hard-delete drainer worker (`runPurge --immediate`)
+    // was never built (~20-40h work, HIGH risk to assemble-pyramid
+    // invariants). Schema + producer code preserved in deferred-features
+    // draft PR (#616). Without the queue table, runPurge always operates
+    // in soft mode (which is what it actually does today anyway).
+
+    // v4.1.1 B3 — lcm_voyage_rate_state REMOVED in first-principles pass
+    // (2026-05-06). Table-only feature, ZERO production readers/writers.
+    // Per-process throttle in voyage/client.ts covers single-gateway use.
+    // Schema + tests preserved in deferred-features draft PR (#616). When
+    // multi-gateway scenario emerges, re-add with the cross-process
+    // coordination pattern documented at the original site.
+
+    // v4.1.1 §C item — lcm_session_key_audit: reversibility log for the
+    // §2.1 step 1 re-key of 5 legacy convs to agent:main:main. Eva can
+    // run /lcm undo-session-key-rekey <conversation_id> if the spike's
+    // identification turns out to be wrong for any of those convs.
+    runMigrationStep("ensureLcmSessionKeyAuditTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_session_key_audit (
+          audit_id TEXT NOT NULL PRIMARY KEY,
+          conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+          original_session_key TEXT,
+          new_session_key TEXT NOT NULL,
+          reason TEXT NOT NULL,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+          applied_by TEXT NOT NULL DEFAULT 'migration'
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_session_key_audit_conv_idx
+          ON lcm_session_key_audit (conversation_id, applied_at DESC)
+      `);
+    });
+
+    // ── v4.1 synthesis layer (A.04) ─────────────────────────────────────────
+    // Prompt registry → synthesis cache (FK on prompt_id) → audit trail (FK
+    // on both summary_id and cache_id, CHECK that at least one is set).
+    // Tables created in dependency order so FKs work on first run.
+    //
+    // v4.1 §3 + v4.1.1 D items — lcm_prompt_registry: versioned prompts per
+    // memory_type × tier × pass_kind. Append-only (old versions deactivated,
+    // never deleted). bundle_version groups synchronized prompt sets so
+    // voice-consistency rebuild fires on bundle delta.
+    runMigrationStep("ensureLcmPromptRegistryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_prompt_registry (
+          prompt_id TEXT NOT NULL PRIMARY KEY,
+          memory_type TEXT NOT NULL CHECK (memory_type IN (
+            'episodic-leaf',
+            'episodic-condensed',
+            'episodic-yearly',
+            'procedural-extract',
+            'entity-extract',
+            'theme-consolidation'
+          )),
+          tier_label TEXT,
+          pass_kind TEXT NOT NULL CHECK (pass_kind IN ('single', 'verify_fidelity', 'best_of_n_judge')),
+          version INTEGER NOT NULL,
+          template TEXT NOT NULL,
+          model_recommendation TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          active INTEGER NOT NULL DEFAULT 1,
+          bundle_version INTEGER NOT NULL DEFAULT 1,
+          notes TEXT,
+          UNIQUE(memory_type, tier_label, pass_kind, version)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_prompt_registry_active_idx
+          ON lcm_prompt_registry (memory_type, tier_label, pass_kind)
+          WHERE active = 1
+      `);
+    });
+
+    // v4.1 B.fix — Gap 2: catch NULL tier_label collisions that the
+    // table's UNIQUE constraint admits (SQLite treats multiple NULLs
+    // as distinct in UNIQUE). COALESCE-based index follows the same
+    // pattern used for lcm_synthesis_cache_lookup_uniq.
+    runMigrationStep("ensureLcmPromptRegistryNullSafeUniqueIdx", log, () => {
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_prompt_registry_uniq_lookup
+          ON lcm_prompt_registry (
+            memory_type, COALESCE(tier_label, ''), pass_kind, version
+          )
+      `);
+    });
+
+    // v4.1 Final.review.3 (Loop 4 Bug 4.4) — widen lcm_synthesis_cache.tier_label
+    // CHECK to include all tier values dispatch may produce. Original CHECK
+    // only allowed ('year', 'custom', 'filtered'); dispatch tier vocabulary
+    // is ('daily', 'weekly', 'monthly', 'yearly', 'custom', 'filtered').
+    // Latent BLOCKER: yearly synthesis would crash on cache write because
+    // `tier_label='yearly'` was rejected by the old CHECK.
+    //
+    // SQLite can't ALTER a CHECK constraint, so we DROP+recreate. SAFE because
+    // lcm_synthesis_cache is REBUILDABLE by design (it's a cache, not bedrock).
+    // Idempotent: only fires if existing CHECK is the old narrow form.
+    runMigrationStep("widenLcmSynthesisCacheTierCheck_v413", log, () => {
+      const existing = db
+        .prepare(
+          `SELECT sql FROM sqlite_master
+             WHERE type='table' AND name='lcm_synthesis_cache'`,
+        )
+        .get() as { sql: string } | undefined;
+      if (!existing) return; // table doesn't exist yet; the next step creates it with new CHECK
+      // Detect the OLD CHECK signature. The new CHECK contains 'monthly'
+      // (one of the new values); old does not. Skip-if-already-widened.
+      if (existing.sql.includes("'monthly'") || existing.sql.includes('"monthly"')) {
+        return;
+      }
+      // Old CHECK detected → rebuildable, just DROP. Cache rows are derivable
+      // from primary sources (raw leaves + prompts).
+      //
+      // Wave-1 Auditor #1 finding #3 (HIGH): if `foreign_keys = OFF` during
+      // migration (the common pattern for ratchet steps), `lcm_synthesis_audit`
+      // rows referencing the dropped cache_ids become DANGLING — they survive
+      // the DROP but their target_cache_id no longer exists. Clean them up
+      // BEFORE the DROP so we never leave orphans pointing to recreated
+      // cache_ids that might be re-used. Audit rows are themselves
+      // rebuildable (re-run the synthesis pass and the new audits land).
+      // Wave-2 Auditor #8 fix F2: narrow the catch to expected error
+      // ("no such table"). Previously the bare catch swallowed any error
+      // (corrupted DB, schema mismatch, etc.) — too broad.
+      try {
+        db.exec(
+          `DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`,
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!/no such table.*lcm_synthesis_audit/i.test(msg)) {
+          throw e;
+        }
+        // Audit table doesn't exist yet (first migration of an old DB);
+        // nothing to clean. Continue.
+      }
+      db.exec(`DROP TABLE IF EXISTS lcm_synthesis_cache`);
+      log?.info?.(
+        "[migration] dropped lcm_synthesis_cache (old narrow CHECK; rebuildable; recreated next step with widened CHECK; orphaned audit rows pruned)",
+      );
+    });
+
+    // v3.1 A8 + v4.1.1 B4 — lcm_synthesis_cache: rebuildable derived layer
+    // for ad-hoc synthesize() output (custom ranges + filtered grep + yearly
+    // tier per A2). Has `status='building'` single-flight (v3.1 A8) and
+    // prompt_id FK (v4.1.1 B2 fix — cache invalidation can be prompt-selective).
+    // UNIQUE lookup index (v4.1.1 B4) enables `INSERT OR IGNORE` cross-process
+    // single-flight pattern (loser of race reads back the in-flight row).
+    runMigrationStep("ensureLcmSynthesisCacheTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_synthesis_cache (
+          cache_id TEXT NOT NULL PRIMARY KEY,
+          session_key TEXT NOT NULL,
+          range_start TEXT NOT NULL,
+          range_end TEXT NOT NULL,
+          grep_filter TEXT,
+          leaf_fingerprint TEXT NOT NULL,
+          content TEXT,
+          entity_index TEXT NOT NULL DEFAULT '{}',
+          model_used TEXT NOT NULL,
+          prompt_id TEXT NOT NULL REFERENCES lcm_prompt_registry(prompt_id) ON DELETE RESTRICT,
+          tier_label TEXT NOT NULL CHECK (tier_label IN ('year', 'yearly', 'monthly', 'weekly', 'daily', 'custom', 'filtered')),
+          source_leaf_ids TEXT NOT NULL,
+          source_condensed_ids TEXT,
+          built_at TEXT NOT NULL DEFAULT (datetime('now')),
+          source_token_count INTEGER NOT NULL,
+          output_token_count INTEGER NOT NULL,
+          actual_range_covered TEXT NOT NULL,
+          leaf_count_synthesized INTEGER NOT NULL,
+          status TEXT NOT NULL DEFAULT 'ready'
+            CHECK (status IN ('building', 'ready', 'failed')),
+          building_started_at TEXT,
+          failure_reason TEXT
+        )
+      `);
+      // UNIQUE lookup index (v4.1.1 B4): enables INSERT OR IGNORE for
+      // cross-process single-flight. Both gateway + worker can attempt to
+      // create the same cache row; exactly one wins.
+      //
+      // Wave-10 reviewer P1 fix: previously the UNIQUE index keyed on
+      // (session_key, range_start, range_end, leaf_fingerprint, grep_filter)
+      // — NO `prompt_id` and NO `tier_label`. Two correctness bugs:
+      //   1. Same range/leaves with `tier='custom'` then `tier='filtered'`
+      //      collided on the UNIQUE index — INSERT OR IGNORE silently
+      //      returned the wrong-tier cached text.
+      //   2. When the active prompt changed via registerPrompt(), the
+      //      cache continued to serve text generated by the OLD prompt
+      //      because the lookup ignored prompt_id.
+      // Fix: include `tier_label` and `prompt_id` in the UNIQUE index so
+      // distinct (tier, prompt) combinations get distinct cache rows.
+      // Drop+recreate the index — cache is fully rebuildable so wiping
+      // existing rows on the new key is safe (callers re-synthesize).
+      db.exec(`DROP INDEX IF EXISTS lcm_synthesis_cache_lookup_uniq`);
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_synthesis_cache_lookup_uniq
+          ON lcm_synthesis_cache (session_key, range_start, range_end,
+                                  leaf_fingerprint,
+                                  COALESCE(grep_filter, ''),
+                                  tier_label,
+                                  prompt_id)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_cache_built_idx
+          ON lcm_synthesis_cache (session_key, built_at DESC)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_cache_status_building_idx
+          ON lcm_synthesis_cache (building_started_at)
+          WHERE status = 'building'
+      `);
+    });
+
+    // v3.1 A3 (extension) — lcm_cache_leaf_refs: inverse index for the
+    // proactive purge path. When a leaf is suppressed, query this table
+    // to find every cache_id that referenced it; delete those rows so
+    // stale content doesn't get served. CASCADE both directions so the
+    // refs go when either parent (cache_id or leaf_summary_id) is deleted.
+    runMigrationStep("ensureLcmCacheLeafRefsTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_cache_leaf_refs (
+          cache_id TEXT NOT NULL REFERENCES lcm_synthesis_cache(cache_id) ON DELETE CASCADE,
+          leaf_summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          PRIMARY KEY (cache_id, leaf_summary_id)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_cache_leaf_refs_by_leaf_idx
+          ON lcm_cache_leaf_refs (leaf_summary_id)
+      `);
+    });
+
+    // v4.1.1 B1 — lcm_synthesis_audit: per-pass log for synthesis (draft,
+    // verify_fidelity, best-of-N drafts, judge). pass_output is NULLable
+    // so it can be inserted BEFORE the LLM call returns (status='started');
+    // post-LLM UPDATE sets pass_output + status='completed'/'failed'.
+    // pass_session_id groups all passes of one logical synthesis attempt
+    // (helps debug best-of-N runs + GC orphaned partial sessions).
+    runMigrationStep("ensureLcmSynthesisAuditTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_synthesis_audit (
+          audit_id TEXT NOT NULL PRIMARY KEY,
+          pass_session_id TEXT NOT NULL,
+          target_summary_id TEXT REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          target_cache_id TEXT REFERENCES lcm_synthesis_cache(cache_id) ON DELETE CASCADE,
+          prompt_id TEXT NOT NULL REFERENCES lcm_prompt_registry(prompt_id) ON DELETE RESTRICT,
+          pass_kind TEXT NOT NULL,
+          pass_input_truncated TEXT NOT NULL,
+          pass_output TEXT,
+          status TEXT NOT NULL DEFAULT 'started'
+            CHECK (status IN ('started', 'completed', 'failed')),
+          model_used TEXT NOT NULL,
+          latency_ms INTEGER,
+          cost_usd_cents INTEGER,
+          last_error TEXT,
+          ran_at TEXT NOT NULL DEFAULT (datetime('now')),
+          CHECK (target_summary_id IS NOT NULL OR target_cache_id IS NOT NULL)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_target_summary_idx
+          ON lcm_synthesis_audit (target_summary_id, ran_at DESC)
+          WHERE target_summary_id IS NOT NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_target_cache_idx
+          ON lcm_synthesis_audit (target_cache_id, ran_at DESC)
+          WHERE target_cache_id IS NOT NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_session_idx
+          ON lcm_synthesis_audit (pass_session_id)
+      `);
+      // GC index: orphaned 'started' rows stuck >1h (v4.1.1 B1 GC pattern)
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_started_gc_idx
+          ON lcm_synthesis_audit (ran_at)
+          WHERE status = 'started'
+      `);
+      // Wave-3 Auditor #1 fix M1: add a parallel index for the 30-day GC
+      // sweep on `completed`/`failed` rows. Without this, the GC runs a
+      // full table scan on every `lcm_synthesize_around` call (the GC is
+      // inline per-call by design). With this partial index, the sweep
+      // is O(log n) on a hot DB.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_completed_gc_idx
+          ON lcm_synthesis_audit (ran_at)
+          WHERE status IN ('completed', 'failed')
+      `);
+    });
+
+    // ── v4.1 eval harness tables (A.05) ─────────────────────────────────────
+    // Per v4.1 §11 + v4.1.1 (revising the v4 design): N≥100 stratified
+    // queries, 2× empirical SD threshold (calibrate by 5x repeated runs),
+    // ensemble judge, mixed absolute+pairwise per dimension, drift index
+    // for cumulative regression. Measures BOTH retrieval recall AND
+    // synthesis quality (separate metrics, not collapsed).
+    runMigrationStep("ensureLcmEvalQuerySetTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_query_set (
+          query_set_id TEXT NOT NULL PRIMARY KEY,
+          version INTEGER NOT NULL,
+          description TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalQueryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_query (
+          query_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          query_text TEXT NOT NULL,
+          stratum TEXT NOT NULL CHECK (stratum IN ('fts-easy', 'fts-medium', 'paraphrastic')),
+          expected_topics TEXT NOT NULL,
+          expected_sources TEXT,
+          reference_summary TEXT,
+          must_not_regress INTEGER NOT NULL DEFAULT 0,
+          rubric TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_query_set_stratum_idx
+          ON lcm_eval_query (query_set_id, stratum)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_query_must_not_regress_idx
+          ON lcm_eval_query (query_set_id)
+          WHERE must_not_regress = 1
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalRunTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_run (
+          run_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          prompt_bundle_version INTEGER NOT NULL,
+          ran_at TEXT NOT NULL DEFAULT (datetime('now')),
+          retrieval_recall_score REAL NOT NULL,
+          synthesis_quality_score REAL NOT NULL,
+          per_query_scores TEXT NOT NULL,
+          judge_models TEXT NOT NULL,
+          noise_floor_sd REAL,
+          trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'prompt-update', 'model-update', 'ci', 'nightly'))
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_run_recent_idx
+          ON lcm_eval_run (query_set_id, ran_at DESC)
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalDriftTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_drift (
+          drift_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          cumulative_delta REAL NOT NULL,
+          window_runs INTEGER NOT NULL,
+          computed_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_drift_recent_idx
+          ON lcm_eval_drift (query_set_id, computed_at DESC)
+      `);
+    });
+
+    // ── v4.1 entity layer (A.06) ────────────────────────────────────────────
+    // Per v4.1 §7 + v4.1.1 B5/B6 — simplified entity schema (no separate
+    // lcm_aliases table; alternate surface forms denormalized into
+    // lcm_entities.alternate_surfaces JSON; entity embeddings live in
+    // vec0 with embedded_kind='entity'). Coreference uses entity-table
+    // lookup (B6), not the v4 ±N leaf positional window.
+    //
+    // entity_type is freeform TEXT (no CHECK constraint per v4.1.1
+    // §C — Eva's domain has session_keys, config_flags, error_codes,
+    // R-XXX agent IDs, etc. that don't fit a closed enum). The
+    // type_registry table tracks first-seen + occurrence count per type
+    // so the operator can review/normalize types post-hoc.
+    runMigrationStep("ensureLcmEntityTypeRegistryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entity_type_registry (
+          type_name TEXT NOT NULL PRIMARY KEY,
+          first_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+          occurrence_count INTEGER NOT NULL DEFAULT 1
+        )
+      `);
+    });
+
+    // v4.1.1 B4 — UNIQUE index on (session_key, canonical_text COLLATE NOCASE)
+    // enables INSERT OR IGNORE for cross-process entity coref single-flight.
+    runMigrationStep("ensureLcmEntitiesTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entities (
+          entity_id TEXT NOT NULL PRIMARY KEY,
+          session_key TEXT NOT NULL,
+          canonical_text TEXT NOT NULL,
+          entity_type TEXT NOT NULL,
+          first_seen_at TEXT NOT NULL,
+          last_seen_at TEXT NOT NULL,
+          first_seen_in_summary_id TEXT REFERENCES summaries(summary_id) ON DELETE SET NULL,
+          occurrence_count INTEGER NOT NULL DEFAULT 1,
+          alternate_surfaces TEXT,
+          metadata TEXT
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entities_lookup_idx
+          ON lcm_entities (session_key, entity_type, last_seen_at DESC)
+      `);
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_entities_canonical_uniq
+          ON lcm_entities (session_key, canonical_text COLLATE NOCASE)
+      `);
+    });
+
+    runMigrationStep("ensureLcmEntityMentionsTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entity_mentions (
+          mention_id TEXT NOT NULL PRIMARY KEY,
+          entity_id TEXT NOT NULL REFERENCES lcm_entities(entity_id) ON DELETE CASCADE,
+          summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          surface_form TEXT NOT NULL,
+          span_start INTEGER,
+          span_end INTEGER,
+          mentioned_at TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entity_mentions_by_entity_idx
+          ON lcm_entity_mentions (entity_id, mentioned_at DESC)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entity_mentions_by_summary_idx
+          ON lcm_entity_mentions (summary_id)
+      `);
+    });
+
+    // v4.1 §7.1 — procedures feature was REMOVED in first-principles pass
+    // (2026-05-06). Schema (lcm_procedures) + worker (mineProceduresPass) +
+    // prefilter all preserved in deferred-features draft PR (#616). Cut
+    // reason: 0% shipped (no agent tool, no LLM injection, no auto-tick)
+    // per challenger agent C5. Will ship as focused PR with worker +
+    // lcm_get_procedure / lcm_search_procedures agent tools together.
+
+    // v3 + v4.1 §7.3 — intentions feature was REMOVED in first-principles
+    // pass (2026-05-06). Schema (lcm_intentions) + prospective-extract
+    // prompt template all preserved in deferred-features draft PR (#616).
+    // Cut reason: ZERO producer, ZERO consumer, ZERO agent tools, served
+    // ZERO of the 25 test cases. Per challenger agent C3 at 99% confidence.
+
+    // ── v4.1 embedding registry tables (A.07) ───────────────────────────────
+    // Per v4.1 §1 + v4.1.1 A5/A7 — these are the MANAGED tables (regular
+    // SQLite tables, not vec0 virtual). The vec0 table itself
+    // (`lcm_embeddings_<model_slug>` virtual table) defers to Group B
+    // because creating a vec0 table requires the sqlite-vec extension to
+    // be loaded — which is best-effort (graceful degrade per v4.1.1 A7
+    // splits the migration into Transaction 1 = required schema (this
+    // file) + Transaction 2 = vec0 + triggers (loaded at runtime in
+    // src/embeddings/store.ts during Group B)).
+    //
+    // lcm_embedding_profile: registry of embedding models (active/archive).
+    // Used by Group B's profile-versioning logic. seed row added during
+    // Group B startup when sqlite-vec successfully loads.
+    runMigrationStep("ensureLcmEmbeddingProfileTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_embedding_profile (
+          model_name TEXT NOT NULL PRIMARY KEY,
+          dim INTEGER NOT NULL,
+          registered_at TEXT NOT NULL DEFAULT (datetime('now')),
+          active INTEGER NOT NULL DEFAULT 1,
+          archive_after TEXT
+        )
+      `);
+    });
+
+    // lcm_embedding_meta: sidecar for non-vector queries (model attribution,
+    // backfill progress, archival state). Composite PK supports parallel
+    // rows during model-bump cutover (one summary embedded under both
+    // old + new model). NOTE: no FK to summaries (polymorphic — embedded_id
+    // can also reference lcm_entities.entity_id or lcm_themes.theme_id).
+    // Polymorphic-orphan cleanup deferred to Group B's idle pass.
+    runMigrationStep("ensureLcmEmbeddingMetaTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_embedding_meta (
+          embedded_id TEXT NOT NULL,
+          embedded_kind TEXT NOT NULL CHECK (embedded_kind IN ('summary', 'entity', 'theme')),
+          embedding_model TEXT NOT NULL REFERENCES lcm_embedding_profile(model_name) ON DELETE RESTRICT,
+          embedded_at TEXT NOT NULL DEFAULT (datetime('now')),
+          source_token_count INTEGER NOT NULL,
+          archived INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (embedded_id, embedded_kind, embedding_model)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_embedding_meta_active_idx
+          ON lcm_embedding_meta (embedding_model, embedded_at DESC)
+          WHERE archived = 0
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_embedding_meta_by_kind_idx
+          ON lcm_embedding_meta (embedded_kind, embedded_id)
+      `);
+    });
+
+    // v4.1 B.03 — meta-table cleanup trigger on summaries hard-delete.
+    //
+    // lcm_embedding_meta has no FK to summaries (polymorphic embedded_id —
+    // can also reference lcm_entities or lcm_themes). So FK CASCADE can't
+    // do this cleanup. Trigger fires on summaries DELETE and removes only
+    // the rows for the corresponding summary (kind='summary' filter so we
+    // never accidentally delete entity/theme meta).
+    //
+    // Note: this trigger is INDEPENDENT of the per-model triggers in
+    // src/embeddings/store.ts. Those handle vec0 cleanup (one per
+    // active embedding model). This trigger handles the SHARED meta
+    // sidecar that exists once regardless of how many models are active.
+    runMigrationStep("ensureLcmEmbeddingMetaCleanupTrigger", log, () => {
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS lcm_embedding_meta_cleanup_summary
+          AFTER DELETE ON summaries
+          BEGIN
+            DELETE FROM lcm_embedding_meta
+              WHERE embedded_id = OLD.summary_id
+                AND embedded_kind = 'summary';
+          END
+      `);
+    });
+
+    // v4.1 §6.3 / Group G — themes feature was REMOVED in first-principles
+    // pass (2026-05-06). Schema (lcm_themes, lcm_theme_sources) + worker
+    // (consolidateThemesPass) + 3 agent tools all preserved in draft PR
+    // feat/lcm-v4.1-deferred-features (PR #616). They'll come back as a
+    // focused PR with worker auto-tick + LLM injection wired together.
+    // Cut reason: half-shipped UX (tools shipped but worker had no auto-tick;
+    // operators couldn't manually trigger via /lcm worker tick) per C3+C5.
+
+    // ── v4.1 indexes on summaries (A.08) ────────────────────────────────────
+    // These are CONDITIONAL on the v4.1 columns existing (added by A.02
+    // ensureSummaryV41Columns above), so we run them after that step.
+    // CREATE INDEX IF NOT EXISTS is idempotent.
+    //
+    // ── v4.1 data cleanup migration (A.09) ─────────────────────────────────
+    // General cleanup that runs on any DB. Specifically per-user re-keying
+    // (e.g. Eva's 5 legacy convs → agent:main:main) is OPERATOR-DRIVEN via
+    // Group F's `/lcm reconcile-session-keys` — NOT hardcoded into upstream
+    // migration code.
+    //
+    // Steps (each idempotent + audited):
+    //   1. Backfill conversations.session_key NULL → 'legacy:conv_<id>'
+    //      Records each re-key in lcm_session_key_audit.
+    //   2. Backfill summaries.session_key='' → conversations.session_key
+    //      (JOIN). This targets the rows that A.02 added with the default
+    //      empty-string value.
+    runMigrationStep("backfillConversationSessionKeys", log, () => {
+      // Audit each re-key BEFORE applying it (so the audit row exists even
+      // if the UPDATE fails for any row). Uses ULID-shape audit_id derived
+      // from conversation_id for idempotency (re-running won't duplicate
+      // audit rows for already-keyed convs).
+      db.exec(`
+        INSERT OR IGNORE INTO lcm_session_key_audit
+          (audit_id, conversation_id, original_session_key, new_session_key, reason, applied_by)
+        SELECT
+          'audit-backfill-conv-' || conversation_id,
+          conversation_id,
+          NULL,
+          'legacy:conv_' || conversation_id,
+          'v4.1 A.09: NULL session_key backfilled with legacy: prefix to enable cross-conv lookups',
+          'migration'
+        FROM conversations
+        WHERE session_key IS NULL
+      `);
+      db.exec(`
+        UPDATE conversations
+        SET session_key = 'legacy:conv_' || conversation_id
+        WHERE session_key IS NULL
+      `);
+    });
+
+    runMigrationStep("backfillSummarySessionKeys", log, () => {
+      // For every summary whose session_key is still '' (the A.02 default),
+      // populate it from the parent conversation. After step 1 above ran,
+      // conversations.session_key is non-NULL for every conv, so this
+      // covers all summaries.
+      db.exec(`
+        UPDATE summaries
+        SET session_key = (
+          SELECT c.session_key FROM conversations c
+          WHERE c.conversation_id = summaries.conversation_id
+        )
+        WHERE session_key = ''
+      `);
+    });
+
+    // Forward-compat: if Eva's fork-side lcm_rollups table exists on this DB
+    // (not in upstream src/), backfill its session_key column similarly
+    // (the table is otherwise out-of-scope for v4.1 — synthesis_cache replaces it).
+    // We only touch it if it exists AND has the session_key column. No-op
+    // on a fresh upstream install.
+    runMigrationStep("backfillForkRollupsSessionKeys", log, () => {
+      const hasRollupsTable = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name = 'lcm_rollups'`,
+        )
+        .get() as { name?: string } | undefined;
+      if (!hasRollupsTable) return;
+
+      const rollupCols = db
+        .prepare(`PRAGMA table_info(lcm_rollups)`)
+        .all() as Array<{ name: string }>;
+      const hasSessionKeyCol = rollupCols.some((c) => c.name === "session_key");
+      if (!hasSessionKeyCol) return;
+
+      // Backfill: rollups with empty session_key get it from their parent conv.
+      db.exec(`
+        UPDATE lcm_rollups
+        SET session_key = COALESCE(
+          (SELECT c.session_key FROM conversations c
+           WHERE c.conversation_id = lcm_rollups.conversation_id),
+          ''
+        )
+        WHERE session_key = '' OR session_key IS NULL
+      `);
+    });
+
+    // session_key index supports cross-conv assemble (PR #338 session-family
+    // scope) + every retrieval surface that filters by scope.
+    runMigrationStep("ensureSummariesV41Indexes", log, () => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_session_key_kind_latest_idx
+          ON summaries (session_key, kind, latest_at DESC)
+          WHERE session_key != ''
+      `);
+      // suppressed_at filter index — every retrieval surface filters
+      // WHERE suppressed_at IS NULL per v3.1 A3 invariant. Partial index
+      // is small (only suppressed rows; NULL-row count grows with corpus
+      // but suppressed-row count stays small).
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_suppressed_idx
+          ON summaries (suppressed_at)
+          WHERE suppressed_at IS NOT NULL
+      `);
+      // Idle-rebuild candidate scan: §8.1 finds condensed rows whose
+      // descendants got suppressed but haven't been rebuilt yet.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_contains_suppressed_idx
+          ON summaries (contains_suppressed_leaves)
+          WHERE contains_suppressed_leaves = 1 AND superseded_by IS NULL
+      `);
+      // messages.suppressed_at filter (for lcm_grep mode='verbatim' + conversation-store search paths)
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS messages_suppressed_idx
+          ON messages (suppressed_at)
+          WHERE suppressed_at IS NOT NULL
+      `);
+      // session_key index on conversations (boosts the cross-conv JOIN
+      // path used by retrieval surfaces). Already indexed by existing
+      // conversations_session_key_active_created_idx but the v4.1 read
+      // pattern often filters by session_key WITHOUT the active flag
+      // (e.g. legacy:conv_<id> session_keys are on archived conversations).
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS conversations_session_key_v41_idx
+          ON conversations (session_key)
+          WHERE session_key IS NOT NULL
+      `);
+    });
+
     db.exec(`COMMIT`);
     transactionActive = false;
   } catch (error) {

--- a/test/concurrency-model.test.ts
+++ b/test/concurrency-model.test.ts
@@ -1,0 +1,81 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_BUSY_TIMEOUT_MS,
+  GATEWAY_FALLBACK_SOAK_MS,
+  WORKER_BUSY_TIMEOUT_MS,
+  WORKER_HEARTBEAT_MS,
+  WORKER_JOB_KINDS,
+  WORKER_LOCK_TTL_MS,
+  assertBusyTimeoutForRole,
+  assertForeignKeysEnabled,
+} from "../src/concurrency/model.js";
+
+describe("concurrency model invariants (v4.1.1 §0)", () => {
+  it("worker busy_timeout is shorter than gateway so gateway always wins on contention", () => {
+    expect(WORKER_BUSY_TIMEOUT_MS).toBeLessThan(GATEWAY_BUSY_TIMEOUT_MS);
+  });
+
+  it("worker lock TTL is at least 3× the heartbeat cadence (allows one missed heartbeat)", () => {
+    expect(WORKER_LOCK_TTL_MS).toBeGreaterThanOrEqual(3 * WORKER_HEARTBEAT_MS);
+  });
+
+  it("gateway fallback soak window is longer than worker lock TTL (prevents racing slow-LLM workers)", () => {
+    expect(GATEWAY_FALLBACK_SOAK_MS).toBeGreaterThan(WORKER_LOCK_TTL_MS);
+  });
+
+  it("declares the expected v4.1 worker job kinds (must match docs + future lcm_worker_lock CHECK)", () => {
+    expect(WORKER_JOB_KINDS).toContain("condensation");
+    expect(WORKER_JOB_KINDS).toContain("extraction");
+    expect(WORKER_JOB_KINDS).toContain("embedding-backfill");
+    expect(WORKER_JOB_KINDS).toContain("profile-rebuild");
+    expect(WORKER_JOB_KINDS).toContain("theme-consolidation");
+    expect(WORKER_JOB_KINDS).toContain("eval");
+  });
+});
+
+describe("assertForeignKeysEnabled (v4.1.1 A6)", () => {
+  it("throws when PRAGMA foreign_keys is OFF", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = OFF");
+    expect(() => assertForeignKeysEnabled(db)).toThrow(/foreign_keys is not ON/);
+    db.close();
+  });
+
+  it("passes when PRAGMA foreign_keys is ON", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    expect(() => assertForeignKeysEnabled(db)).not.toThrow();
+    db.close();
+  });
+});
+
+describe("assertBusyTimeoutForRole (v4.1.1 §0)", () => {
+  it("throws for gateway role when busy_timeout < gateway threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${GATEWAY_BUSY_TIMEOUT_MS - 1}`);
+    expect(() => assertBusyTimeoutForRole(db, "gateway")).toThrow(/busy_timeout for gateway/);
+    db.close();
+  });
+
+  it("passes for gateway role when busy_timeout = gateway threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${GATEWAY_BUSY_TIMEOUT_MS}`);
+    expect(() => assertBusyTimeoutForRole(db, "gateway")).not.toThrow();
+    db.close();
+  });
+
+  it("throws for worker role when busy_timeout < worker threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${WORKER_BUSY_TIMEOUT_MS - 1}`);
+    expect(() => assertBusyTimeoutForRole(db, "worker")).toThrow(/busy_timeout for worker/);
+    db.close();
+  });
+
+  it("passes for worker role when busy_timeout = worker threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${WORKER_BUSY_TIMEOUT_MS}`);
+    expect(() => assertBusyTimeoutForRole(db, "worker")).not.toThrow();
+    db.close();
+  });
+});

--- a/test/lcm-worker-lock.test.ts
+++ b/test/lcm-worker-lock.test.ts
@@ -1,0 +1,120 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+describe("lcm_worker_lock table (v4.1.1 A9)", () => {
+  it("is created by runLcmMigrations with the expected schema", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    const columns = db.prepare("PRAGMA table_info(lcm_worker_lock)").all() as ColumnInfo[];
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.has("job_kind")).toBe(true);
+    expect(byName.get("job_kind")?.pk).toBe(1);
+    expect(byName.get("job_kind")?.type.toUpperCase()).toBe("TEXT");
+
+    expect(byName.has("worker_id")).toBe(true);
+    expect(byName.get("worker_id")?.notnull).toBe(1);
+
+    expect(byName.has("acquired_at")).toBe(true);
+    expect(byName.get("acquired_at")?.notnull).toBe(1);
+
+    expect(byName.has("expires_at")).toBe(true);
+    expect(byName.get("expires_at")?.notnull).toBe(1);
+
+    // v4.1.1 A9 specifically: last_heartbeat_at column must exist for the
+    // §0.5 gateway-fallback rule to work (BOTH expires_at < now AND
+    // last_heartbeat_at < now - 300s).
+    expect(byName.has("last_heartbeat_at")).toBe(true);
+    expect(byName.get("last_heartbeat_at")?.notnull).toBe(1);
+
+    expect(byName.has("job_session_key")).toBe(true);
+    expect(byName.get("job_session_key")?.notnull).toBe(0); // nullable
+
+    expect(byName.has("job_metadata")).toBe(true);
+    expect(byName.get("job_metadata")?.notnull).toBe(0); // nullable for JSON sidecar
+
+    db.close();
+  });
+
+  it("is idempotent (running migrations twice does not fail)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+
+  it("supports basic acquire pattern (INSERT new lock + UPDATE heartbeat)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Acquire the condensation lock for worker-A with 90s TTL
+    db.prepare(
+      `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at)
+       VALUES (?, ?, datetime('now', '+90 seconds'))`,
+    ).run("condensation", "worker-A");
+
+    const acquired = db
+      .prepare("SELECT * FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("condensation") as { worker_id: string } | undefined;
+    expect(acquired?.worker_id).toBe("worker-A");
+
+    // Second worker attempting same kind hits PK conflict (one lock per kind)
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at)
+           VALUES (?, ?, datetime('now', '+90 seconds'))`,
+        )
+        .run("condensation", "worker-B"),
+    ).toThrow();
+
+    // Heartbeat refreshes both expires_at and last_heartbeat_at
+    db.prepare(
+      `UPDATE lcm_worker_lock
+       SET expires_at = datetime('now', '+90 seconds'),
+           last_heartbeat_at = datetime('now')
+       WHERE job_kind = ? AND worker_id = ?`,
+    ).run("condensation", "worker-A");
+
+    db.close();
+  });
+
+  it("supports stale-lock GC (expires_at < now → row can be deleted)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Insert an expired lock (expires_at in the past)
+    db.prepare(
+      `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at, last_heartbeat_at)
+       VALUES (?, ?, datetime('now', '-10 seconds'), datetime('now', '-400 seconds'))`,
+    ).run("extraction", "worker-stale");
+
+    const beforeGc = db
+      .prepare("SELECT COUNT(*) AS n FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("extraction") as { n: number };
+    expect(beforeGc.n).toBe(1);
+
+    // GC pattern: delete locks whose expires_at has passed
+    const result = db
+      .prepare(`DELETE FROM lcm_worker_lock WHERE expires_at < datetime('now')`)
+      .run();
+    expect(result.changes).toBeGreaterThanOrEqual(1);
+
+    const afterGc = db
+      .prepare("SELECT COUNT(*) AS n FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("extraction") as { n: number };
+    expect(afterGc.n).toBe(0);
+
+    db.close();
+  });
+});

--- a/test/v41-data-cleanup.test.ts
+++ b/test/v41-data-cleanup.test.ts
@@ -1,0 +1,197 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+describe("v4.1 conversation session_key backfill (A.09)", () => {
+  it("backfills NULL session_keys to 'legacy:conv_<id>' AND writes audit rows", () => {
+    const db = new DatabaseSync(":memory:");
+    // Pre-populate conversations BEFORE running migrations (simulating
+    // existing DB with legacy NULL session_keys)
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', NULL)`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s2', NULL)`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s3', 'agent:main:main')`).run();
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const rows = db
+      .prepare(`SELECT conversation_id, session_key FROM conversations ORDER BY conversation_id`)
+      .all() as Array<{ conversation_id: number; session_key: string }>;
+    expect(rows[0]).toEqual({ conversation_id: 1, session_key: "legacy:conv_1" });
+    expect(rows[1]).toEqual({ conversation_id: 2, session_key: "legacy:conv_2" });
+    expect(rows[2]).toEqual({ conversation_id: 3, session_key: "agent:main:main" }); // unchanged
+
+    // Audit rows recorded for the 2 backfilled
+    const audits = db
+      .prepare(`SELECT conversation_id, original_session_key, new_session_key FROM lcm_session_key_audit ORDER BY conversation_id`)
+      .all() as Array<{ conversation_id: number; original_session_key: string | null; new_session_key: string }>;
+    expect(audits).toEqual([
+      { conversation_id: 1, original_session_key: null, new_session_key: "legacy:conv_1" },
+      { conversation_id: 2, original_session_key: null, new_session_key: "legacy:conv_2" },
+    ]);
+    db.close();
+  });
+
+  it("is idempotent — re-running migration does not duplicate audit rows or re-key existing", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', NULL)`).run();
+    runLcmMigrations(db, { fts5Available: false });
+
+    const auditCountAfterFirstRun = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_session_key_audit`).get() as { n: number }
+    ).n;
+
+    // Re-run
+    runLcmMigrations(db, { fts5Available: false });
+    const auditCountAfterSecondRun = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_session_key_audit`).get() as { n: number }
+    ).n;
+    expect(auditCountAfterSecondRun).toBe(auditCountAfterFirstRun);
+    db.close();
+  });
+});
+
+describe("v4.1 summaries session_key backfill (A.09)", () => {
+  it("populates summaries.session_key from conversations.session_key via JOIN", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'agent:main:main')`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s2', NULL)`).run(); // → legacy:conv_2
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Now insert some summaries (they'll get session_key='' default from A.02)
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 1)`,
+    ).run("sum_a", 1, "x");
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 1)`,
+    ).run("sum_b", 2, "y");
+
+    // Verify they have session_key='' before re-running migration
+    const before = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    expect(before[0].session_key).toBe(""); // A.02 default
+    expect(before[1].session_key).toBe("");
+
+    // Run migration again — should backfill summaries.session_key from conv
+    runLcmMigrations(db, { fts5Available: false });
+
+    const after = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    expect(after[0].session_key).toBe("agent:main:main");
+    expect(after[1].session_key).toBe("legacy:conv_2");
+    db.close();
+  });
+
+  it("does NOT overwrite already-set summaries.session_key", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s', 'conv-key-A')`).run();
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key) VALUES (?, ?, 'leaf', ?, 1, ?)`,
+    ).run("sum_explicit", 1, "x", "summary-key-A-different-from-conv");
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const row = db
+      .prepare(`SELECT session_key FROM summaries WHERE summary_id = ?`)
+      .get("sum_explicit") as { session_key: string };
+    // Backfill condition is `WHERE session_key = ''` — the explicit value
+    // 'summary-key-A-different-from-conv' is preserved.
+    expect(row.session_key).toBe("summary-key-A-different-from-conv");
+    db.close();
+  });
+});
+
+describe("v4.1 lcm_rollups forward-compat (A.09)", () => {
+  it("no-op on a fresh upstream install (lcm_rollups table doesn't exist)", () => {
+    const db = new DatabaseSync(":memory:");
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    const tables = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name = 'lcm_rollups'`)
+      .all();
+    expect(tables.length).toBe(0); // table never created
+    db.close();
+  });
+
+  it("backfills lcm_rollups.session_key when the fork-side table exists with the column", () => {
+    const db = new DatabaseSync(":memory:");
+    // Simulate Eva's DB having lcm_rollups (from PR #516 work that's
+    // not in upstream src but is on her live DB)
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.exec(`
+      CREATE TABLE lcm_rollups (
+        rollup_id TEXT PRIMARY KEY,
+        conversation_id INTEGER NOT NULL,
+        session_key TEXT NOT NULL DEFAULT '',
+        period_kind TEXT NOT NULL,
+        period_key TEXT NOT NULL
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s', 'conv-key-A')`).run();
+    db.prepare(
+      `INSERT INTO lcm_rollups (rollup_id, conversation_id, period_kind, period_key) VALUES (?, ?, ?, ?)`,
+    ).run("r1", 1, "day", "2026-04-01");
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const row = db
+      .prepare(`SELECT session_key FROM lcm_rollups WHERE rollup_id = ?`)
+      .get("r1") as { session_key: string };
+    expect(row.session_key).toBe("conv-key-A");
+    db.close();
+  });
+});

--- a/test/v41-embedding-meta-tables.test.ts
+++ b/test/v41-embedding-meta-tables.test.ts
@@ -1,0 +1,118 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = { name: string; notnull: number; pk: number; dflt_value: string | null };
+type FkInfo = { from: string; table: string; on_delete: string };
+
+describe("lcm_embedding_profile (v4.1 §1)", () => {
+  it("creates table with model_name PK + active default 1", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_embedding_profile)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("model_name")?.pk).toBe(1);
+    expect(byName.get("dim")?.notnull).toBe(1);
+    expect(byName.get("active")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("supports registering voyage-4-large + future model in parallel for cutover", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const ins = db.prepare(
+      `INSERT INTO lcm_embedding_profile (model_name, dim, active) VALUES (?, ?, ?)`,
+    );
+    ins.run("voyage-4-large", 1024, 1);
+    ins.run("voyage-5-large", 1536, 0); // not yet active
+    const rows = db
+      .prepare(`SELECT model_name, dim, active FROM lcm_embedding_profile ORDER BY model_name`)
+      .all() as Array<{ model_name: string; dim: number; active: number }>;
+    expect(rows).toEqual([
+      { model_name: "voyage-4-large", dim: 1024, active: 1 },
+      { model_name: "voyage-5-large", dim: 1536, active: 0 },
+    ]);
+    db.close();
+  });
+});
+
+describe("lcm_embedding_meta (v4.1 §1)", () => {
+  it("creates table with composite PK enabling parallel-rows during cutover", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_embedding_meta)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    // PK is composite (embedded_id, embedded_kind, embedding_model)
+    expect(byName.get("embedded_id")?.pk).toBe(1);
+    expect(byName.get("embedded_kind")?.pk).toBe(2);
+    expect(byName.get("embedding_model")?.pk).toBe(3);
+    db.close();
+  });
+
+  it("FK to lcm_embedding_profile prevents orphan model references", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+        )
+        .run("e1", "summary", "voyage-99-bogus", 100),
+    ).toThrow();
+
+    db.prepare(`INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`).run(
+      "voyage-4-large",
+      1024,
+    );
+    db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+    ).run("e1", "summary", "voyage-4-large", 100);
+    db.close();
+  });
+
+  it("CHECK constraint enforces embedded_kind enum", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    db.prepare(`INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`).run(
+      "voyage-4-large",
+      1024,
+    );
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+        )
+        .run("x", "bogus-kind", "voyage-4-large", 100),
+    ).toThrow();
+
+    // Valid kinds
+    for (const kind of ["summary", "entity", "theme"]) {
+      db.prepare(
+        `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+      ).run(`x_${kind}`, kind, "voyage-4-large", 100);
+    }
+    db.close();
+  });
+
+  it("composite PK allows same summary embedded under multiple models (cutover scenario)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const insProfile = db.prepare(
+      `INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`,
+    );
+    insProfile.run("voyage-4-large", 1024);
+    insProfile.run("voyage-5-large", 1536);
+
+    const insMeta = db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+    );
+    insMeta.run("sum_a", "summary", "voyage-4-large", 100);
+    insMeta.run("sum_a", "summary", "voyage-5-large", 100); // same id, different model — allowed
+
+    const rows = db
+      .prepare(`SELECT embedding_model FROM lcm_embedding_meta WHERE embedded_id = ?`)
+      .all("sum_a") as Array<{ embedding_model: string }>;
+    expect(rows.length).toBe(2);
+    db.close();
+  });
+});

--- a/test/v41-entity-layer-tables.test.ts
+++ b/test/v41-entity-layer-tables.test.ts
@@ -1,0 +1,130 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = { name: string; notnull: number; pk: number; dflt_value: string | null };
+type FkInfo = { from: string; table: string; on_delete: string };
+type IndexInfo = { name: string };
+
+function setupDb(): { db: DatabaseSync; sumA: string; sumB: string } {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  db.prepare(`INSERT INTO conversations (session_id) VALUES ('s')`).run();
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+  ).run("sum_a");
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'y', 1)`,
+  ).run("sum_b");
+  return { db, sumA: "sum_a", sumB: "sum_b" };
+}
+
+describe("lcm_entity_type_registry (v4.1 §7.2 + v4.1.1 §C)", () => {
+  it("creates table with type_name PK + occurrence_count default 1", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_entity_type_registry)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("type_name")?.pk).toBe(1);
+    expect(byName.get("occurrence_count")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("supports freeform Eva-domain types (no CHECK constraint)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const insert = db.prepare(`INSERT INTO lcm_entity_type_registry (type_name) VALUES (?)`);
+    insert.run("session_key");
+    insert.run("config_flag");
+    insert.run("R-agent-id");
+    insert.run("error_code");
+    insert.run("pr");
+    const types = db
+      .prepare(`SELECT type_name FROM lcm_entity_type_registry ORDER BY type_name`)
+      .all() as Array<{ type_name: string }>;
+    expect(types.length).toBe(5);
+    db.close();
+  });
+});
+
+describe("lcm_entities (v4.1 §7.2 + v4.1.1 B4/B5/B6)", () => {
+  it("creates table with simplified schema (alternate_surfaces JSON, no separate aliases table)", () => {
+    const { db } = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_entities)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("entity_id")?.pk).toBe(1);
+    expect(byName.get("canonical_text")?.notnull).toBe(1);
+    expect(byName.get("entity_type")?.notnull).toBe(1);
+    expect(byName.get("alternate_surfaces")).toBeDefined();
+    db.close();
+  });
+
+  it("UNIQUE index on (session_key, canonical_text COLLATE NOCASE) enables case-insensitive single-flight (v4.1.1 B4)", () => {
+    const { db } = setupDb();
+    const insert = db.prepare(
+      `INSERT OR IGNORE INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    );
+    expect(insert.run("e1", "agent:main:main", "openclaw-gateway", "tool").changes).toBe(1);
+    // Same canonical text different case → CONFLICT (NOCASE collation)
+    expect(insert.run("e2", "agent:main:main", "OpenClaw-Gateway", "tool").changes).toBe(0);
+    // Same canonical text different session → no conflict (different session_key)
+    expect(insert.run("e3", "agent:other", "openclaw-gateway", "tool").changes).toBe(1);
+    db.close();
+  });
+
+  it("supports ON DELETE SET NULL on first_seen_in_summary_id when source leaf deleted", () => {
+    const { db, sumA } = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at, first_seen_in_summary_id) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
+    ).run("e1", "s", "x", "concept", sumA);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run(sumA);
+    const row = db
+      .prepare(`SELECT first_seen_in_summary_id FROM lcm_entities WHERE entity_id = ?`)
+      .get("e1") as { first_seen_in_summary_id: string | null };
+    expect(row.first_seen_in_summary_id).toBeNull(); // SET NULL fired
+    db.close();
+  });
+});
+
+describe("lcm_entity_mentions (v4.1 §7.2)", () => {
+  it("creates table with cascade-delete on both entity_id and summary_id", () => {
+    const { db } = setupDb();
+    const fks = db
+      .prepare(`PRAGMA foreign_key_list(lcm_entity_mentions)`)
+      .all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "entity_id")?.on_delete).toBe("CASCADE");
+    expect(fks.find((fk) => fk.from === "summary_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+
+  it("deletes mentions when leaf is deleted (cascade — basis for v4.1.1 §C suppression cascade)", () => {
+    const { db, sumA } = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    ).run("e1", "s", "gateway", "tool");
+    db.prepare(
+      `INSERT INTO lcm_entity_mentions (mention_id, entity_id, summary_id, surface_form, mentioned_at) VALUES (?, ?, ?, ?, datetime('now'))`,
+    ).run("m1", "e1", sumA, "the gateway");
+
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM lcm_entity_mentions WHERE entity_id = ?`).get("e1") as {
+        n: number;
+      }).n,
+    ).toBe(1);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run(sumA);
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM lcm_entity_mentions WHERE entity_id = ?`).get("e1") as {
+        n: number;
+      }).n,
+    ).toBe(0);
+    db.close();
+  });
+});
+
+// lcm_procedures tests REMOVED in first-principles pass (2026-05-06).
+// Schema + tests preserved in deferred-features draft PR (#616).
+
+// lcm_intentions tests REMOVED in first-principles pass (2026-05-06).
+// Schema + tests preserved in deferred-features draft PR (#616).

--- a/test/v41-eval-tables.test.ts
+++ b/test/v41-eval-tables.test.ts
@@ -1,0 +1,159 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  notnull: number;
+  pk: number;
+  dflt_value: string | null;
+};
+type FkInfo = { from: string; table: string; on_delete: string };
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  return db;
+}
+
+describe("lcm_eval_query_set (v4.1 §11)", () => {
+  it("creates table with PK and required columns", () => {
+    const db = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_eval_query_set)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("query_set_id")?.pk).toBe(1);
+    expect(byName.get("version")?.notnull).toBe(1);
+    db.close();
+  });
+
+  it("supports inserting a baseline query set ('eva-baseline-v2')", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version, description) VALUES (?, ?, ?)`,
+    ).run("eva-baseline-v2", 1, "100-query stratified eval set");
+    const row = db
+      .prepare("SELECT * FROM lcm_eval_query_set WHERE query_set_id = ?")
+      .get("eva-baseline-v2") as { description: string };
+    expect(row.description).toContain("stratified");
+    db.close();
+  });
+});
+
+describe("lcm_eval_query (v4.1 §11)", () => {
+  it("rejects invalid stratum values via CHECK", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`,
+    ).run("test", 1);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, rubric) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("q1", "test", "what?", "bogus-stratum", "[]", "{}"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("supports the 3 valid strata + must_not_regress flag", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`,
+    ).run("eva-baseline-v2", 1);
+
+    const insert = db.prepare(
+      `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, must_not_regress, rubric) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run("q1", "eva-baseline-v2", "What did we decide about gbrain bridge?", "fts-easy", "[]", 1, "{}");
+    insert.run("q2", "eva-baseline-v2", "Tell me about context collapsing", "paraphrastic", "[]", 0, "{}");
+    insert.run("q3", "eva-baseline-v2", "What were April blockers?", "fts-medium", "[]", 0, "{}");
+
+    const counts = db
+      .prepare(`SELECT stratum, COUNT(*) AS n FROM lcm_eval_query GROUP BY stratum ORDER BY stratum`)
+      .all() as Array<{ stratum: string; n: number }>;
+    expect(counts).toEqual([
+      { stratum: "fts-easy", n: 1 },
+      { stratum: "fts-medium", n: 1 },
+      { stratum: "paraphrastic", n: 1 },
+    ]);
+
+    const must = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_eval_query WHERE must_not_regress = 1`)
+      .get() as { n: number };
+    expect(must.n).toBe(1);
+    db.close();
+  });
+
+  it("CASCADE on query_set delete removes queries", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("x", 1);
+    db.prepare(
+      `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, rubric) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("q1", "x", "?", "fts-easy", "[]", "{}");
+    db.prepare(`DELETE FROM lcm_eval_query_set WHERE query_set_id = 'x'`).run();
+    const remaining = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_eval_query WHERE query_set_id = 'x'`)
+      .get() as { n: number };
+    expect(remaining.n).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_eval_run (v4.1 §11)", () => {
+  it("rejects invalid trigger values", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("s", 1);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_eval_run (run_id, query_set_id, prompt_bundle_version, retrieval_recall_score, synthesis_quality_score, per_query_scores, judge_models, trigger) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("r1", "s", 1, 0.8, 8.5, "[]", "[]", "bogus-trigger"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("supports recording a run with both recall + quality metrics (separate per v4.1.1)", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("s", 1);
+    db.prepare(
+      `INSERT INTO lcm_eval_run (run_id, query_set_id, prompt_bundle_version, retrieval_recall_score, synthesis_quality_score, per_query_scores, judge_models, noise_floor_sd, trigger) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "r1",
+      "s",
+      1,
+      0.78,
+      8.4,
+      JSON.stringify({ q1: 9, q2: 8, q3: 7 }),
+      JSON.stringify(["gpt-5.5", "claude-sonnet-X", "voyage-judge"]),
+      0.5,
+      "ci",
+    );
+    const row = db
+      .prepare(`SELECT retrieval_recall_score, synthesis_quality_score, noise_floor_sd FROM lcm_eval_run WHERE run_id = ?`)
+      .get("r1") as {
+      retrieval_recall_score: number;
+      synthesis_quality_score: number;
+      noise_floor_sd: number;
+    };
+    expect(row.retrieval_recall_score).toBeCloseTo(0.78);
+    expect(row.synthesis_quality_score).toBeCloseTo(8.4);
+    expect(row.noise_floor_sd).toBeCloseTo(0.5);
+    db.close();
+  });
+});
+
+describe("lcm_eval_drift (v4.1 §11.5)", () => {
+  it("creates table for cumulative-regression drift index", () => {
+    const db = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_eval_drift)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("drift_id")?.pk).toBe(1);
+    expect(byName.get("cumulative_delta")?.notnull).toBe(1);
+    expect(byName.get("window_runs")?.notnull).toBe(1);
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_eval_drift)").all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "query_set_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+});

--- a/test/v41-indexes.test.ts
+++ b/test/v41-indexes.test.ts
@@ -1,0 +1,73 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type IndexInfo = { name: string; tbl_name: string; sql: string };
+
+function getIndexNames(db: DatabaseSync, tableName: string): string[] {
+  const rows = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name = ?`)
+    .all(tableName) as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+describe("v4.1 summaries indexes (A.08)", () => {
+  it("creates session_key + kind + latest_at index for retrieval", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "summaries")).toContain("summaries_session_key_kind_latest_idx");
+    db.close();
+  });
+
+  it("creates partial suppressed_at index (small footprint, fast filter)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const sql = db
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type='index' AND name = 'summaries_suppressed_idx'`,
+      )
+      .get() as { sql: string };
+    expect(sql.sql).toContain("WHERE suppressed_at IS NOT NULL");
+    db.close();
+  });
+
+  it("creates partial contains_suppressed_leaves index for idle-rebuild candidate scan", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const sql = db
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type='index' AND name = 'summaries_contains_suppressed_idx'`,
+      )
+      .get() as { sql: string };
+    expect(sql.sql).toContain("contains_suppressed_leaves = 1");
+    expect(sql.sql).toContain("superseded_by IS NULL");
+    db.close();
+  });
+
+  it("creates messages.suppressed_at partial index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "messages")).toContain("messages_suppressed_idx");
+    db.close();
+  });
+
+  it("creates conversations.session_key index for v4.1 read patterns", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "conversations")).toContain("conversations_session_key_v41_idx");
+    db.close();
+  });
+
+  // Note: EXPLAIN QUERY PLAN testing was attempted here but removed — SQLite's
+  // optimizer correctly picks full-table scan over index for tiny test
+  // datasets (3 rows). Verifying actual index USE requires production-scale
+  // data; verifying index PRESENCE is what these unit tests cover. End-to-end
+  // verification on Eva's live DB copy in A.09's run-script handles the rest.
+
+  it("is idempotent — re-running migration does not fail on existing indexes", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+});

--- a/test/v41-pre-existing-schema-migration.test.ts
+++ b/test/v41-pre-existing-schema-migration.test.ts
@@ -1,0 +1,233 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+/**
+ * v4.1 B.fix — Gap 9: live-DB-shape regression test.
+ *
+ * All other v41-*.test.ts files start from a fresh `:memory:` and run the
+ * full migration on an empty DB. This test instead seeds the upstream
+ * pre-v4.1 schema by hand (conversations + summaries + messages with rows
+ * but NO lcm_* tables yet) and runs the v4.1 migration against it. This
+ * is the shape Eva's live DB had at the start of the v4.1 rollout.
+ *
+ * If this test ever fails, that's a SIGNAL — investigate before "fixing"
+ * the test. The migration IS being live-DB-verified after each commit;
+ * if a fresh-:memory:-with-pre-existing-data run breaks, something is
+ * wrong with assumptions baked into the migration steps.
+ */
+
+/** v4.1 tables that the migration is expected to create. */
+const EXPECTED_V41_TABLES = [
+  "lcm_worker_lock",
+  "lcm_extraction_queue",
+  "lcm_session_key_audit",
+  "lcm_prompt_registry",
+  "lcm_synthesis_cache",
+  "lcm_cache_leaf_refs",
+  "lcm_synthesis_audit",
+  "lcm_eval_query_set",
+  "lcm_eval_query",
+  "lcm_eval_run",
+  "lcm_eval_drift",
+  "lcm_entity_type_registry",
+  "lcm_entities",
+  "lcm_entity_mentions",
+  "lcm_embedding_profile",
+  "lcm_embedding_meta",
+  "lcm_feature_flags",
+] as const;
+
+function seedUpstreamPreV41Schema(db: DatabaseSync): void {
+  // Upstream pre-v4.1 baseline shape (the schema Eva's live DB had right
+  // before v4.1 column additions). This must match the CREATE TABLE
+  // statements at the top of runLcmMigrations — those are themselves
+  // CREATE TABLE IF NOT EXISTS, so the migration accepts any DB whose
+  // baseline matches this shape and proceeds to layer v4.1 changes onto it.
+  db.exec(`
+    CREATE TABLE conversations (
+      conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      active INTEGER NOT NULL DEFAULT 1,
+      archived_at TEXT,
+      title TEXT,
+      bootstrapped_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  db.exec(`
+    CREATE TABLE messages (
+      message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      identity_hash TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (conversation_id, seq)
+    )
+  `);
+  db.exec(`
+    CREATE TABLE summaries (
+      summary_id TEXT PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      kind TEXT NOT NULL CHECK (kind IN ('leaf', 'condensed')),
+      depth INTEGER NOT NULL DEFAULT 0,
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      earliest_at TEXT,
+      latest_at TEXT,
+      descendant_count INTEGER NOT NULL DEFAULT 0,
+      descendant_token_count INTEGER NOT NULL DEFAULT 0,
+      source_message_token_count INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      file_ids TEXT NOT NULL DEFAULT '[]'
+    )
+  `);
+}
+
+function listTableNames(db: DatabaseSync): Set<string> {
+  const rows = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table'`)
+    .all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+describe("v4.1 migration against a partially pre-existing schema (B.fix Gap 9)", () => {
+  it("runs end-to-end without throwing and produces the expected DB shape", () => {
+    const db = new DatabaseSync(":memory:");
+    seedUpstreamPreV41Schema(db);
+
+    // 3 conversations: 2 with NULL session_key (should be backfilled), 1 set.
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_a");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_b");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, ?)`,
+    ).run("s_set", "agent:main:main");
+
+    // Summaries pointing into the conversations.
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_a", 1, "leaf", "x", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_b", 2, "leaf", "y", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_c", 3, "leaf", "z", 1);
+
+    // Run the v4.1 migration — must not throw.
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+
+    // ── Conversations: NULL session_keys were backfilled to legacy:conv_<id>
+    const convs = db
+      .prepare(
+        `SELECT conversation_id, session_key FROM conversations ORDER BY conversation_id`,
+      )
+      .all() as Array<{ conversation_id: number; session_key: string }>;
+    for (const c of convs) {
+      expect(c.session_key).not.toBeNull();
+      expect(typeof c.session_key).toBe("string");
+      expect(c.session_key.length).toBeGreaterThan(0);
+    }
+    expect(convs[0].session_key).toBe("legacy:conv_1");
+    expect(convs[1].session_key).toBe("legacy:conv_2");
+    expect(convs[2].session_key).toBe("agent:main:main");
+
+    // ── Audit rows for the NULL-backfilled conversations
+    const audits = db
+      .prepare(
+        `SELECT conversation_id, original_session_key, new_session_key
+         FROM lcm_session_key_audit ORDER BY conversation_id`,
+      )
+      .all() as Array<{
+      conversation_id: number;
+      original_session_key: string | null;
+      new_session_key: string;
+    }>;
+    expect(audits).toEqual([
+      { conversation_id: 1, original_session_key: null, new_session_key: "legacy:conv_1" },
+      { conversation_id: 2, original_session_key: null, new_session_key: "legacy:conv_2" },
+    ]);
+
+    // ── Summaries.session_key populated via the JOIN backfill
+    const sums = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    for (const s of sums) {
+      expect(typeof s.session_key).toBe("string");
+      expect(s.session_key.length).toBeGreaterThan(0);
+    }
+    expect(sums.find((s) => s.summary_id === "sum_a")?.session_key).toBe("legacy:conv_1");
+    expect(sums.find((s) => s.summary_id === "sum_b")?.session_key).toBe("legacy:conv_2");
+    expect(sums.find((s) => s.summary_id === "sum_c")?.session_key).toBe("agent:main:main");
+
+    // ── All v4.1 tables present in sqlite_master
+    const tables = listTableNames(db);
+    for (const expected of EXPECTED_V41_TABLES) {
+      expect(tables.has(expected), `table ${expected} should exist after migration`).toBe(true);
+    }
+
+    // ── Gap 2 fix is in place: lcm_prompt_registry_uniq_lookup index exists
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type='index' AND tbl_name='lcm_prompt_registry'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("lcm_prompt_registry_uniq_lookup");
+
+    db.close();
+  });
+
+  it("re-running migration is idempotent (no row count changes, no errors)", () => {
+    const db = new DatabaseSync(":memory:");
+    seedUpstreamPreV41Schema(db);
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_a");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, ?)`,
+    ).run("s_set", "agent:main:main");
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_a", 1, "leaf", "x", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_b", 2, "leaf", "y", 1);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Snapshot the row counts of every user-visible table after first run
+    const tableNames = [...listTableNames(db)].filter((n) => !n.startsWith("sqlite_"));
+    const countsAfterFirst = new Map<string, number>();
+    for (const t of tableNames) {
+      const n = (
+        db.prepare(`SELECT COUNT(*) AS n FROM ${t}`).get() as { n: number }
+      ).n;
+      countsAfterFirst.set(t, n);
+    }
+
+    // Re-run migration — must not throw and must not change row counts
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+
+    for (const t of tableNames) {
+      const n = (
+        db.prepare(`SELECT COUNT(*) AS n FROM ${t}`).get() as { n: number }
+      ).n;
+      expect(n, `table ${t} row count should be stable across re-runs`).toBe(
+        countsAfterFirst.get(t),
+      );
+    }
+
+    db.close();
+  });
+});

--- a/test/v41-prompt-registry-null-uniq.test.ts
+++ b/test/v41-prompt-registry-null-uniq.test.ts
@@ -1,0 +1,159 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+/**
+ * v4.1 B.fix — Gap 2: lcm_prompt_registry NULL tier_label deduplication.
+ *
+ * The original UNIQUE(memory_type, tier_label, pass_kind, version) constraint
+ * admits multiple rows where tier_label IS NULL because SQLite treats NULLs
+ * as distinct in UNIQUE. The synthesis spec wants singletons-per-version, so
+ * a follow-up migration step adds a COALESCE-based UNIQUE INDEX that catches
+ * NULL collisions. Same pattern is used for lcm_synthesis_cache_lookup_uniq.
+ */
+describe("lcm_prompt_registry NULL-safe UNIQUE index (v4.1 B.fix Gap 2)", () => {
+  const insertRegistryRow = (
+    db: DatabaseSync,
+    args: {
+      prompt_id: string;
+      memory_type: string;
+      tier_label: string | null;
+      pass_kind: string;
+      version: number;
+    },
+  ): void => {
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry
+         (prompt_id, memory_type, tier_label, pass_kind, version, template)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      args.prompt_id,
+      args.memory_type,
+      args.tier_label,
+      args.pass_kind,
+      args.version,
+      "tmpl-body",
+    );
+  };
+
+  it("creates the lcm_prompt_registry_uniq_lookup index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type='index' AND tbl_name='lcm_prompt_registry'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("lcm_prompt_registry_uniq_lookup");
+    db.close();
+  });
+
+  it("rejects a second row with the same memory_type + NULL tier_label + pass_kind + version", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+
+    expect(() =>
+      insertRegistryRow(db, {
+        prompt_id: "p_2",
+        memory_type: "episodic-leaf",
+        tier_label: null,
+        pass_kind: "single",
+        version: 1,
+      }),
+    ).toThrow(/UNIQUE/i);
+    db.close();
+  });
+
+  it("allows two NULL-tier_label rows that differ only in version", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+    insertRegistryRow(db, {
+      prompt_id: "p_2",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 2,
+    });
+
+    const count = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_prompt_registry`).get() as { n: number }
+    ).n;
+    expect(count).toBe(2);
+    db.close();
+  });
+
+  it("treats NULL and 'monthly' as distinct (different tier_label values)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_null",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+    insertRegistryRow(db, {
+      prompt_id: "p_monthly",
+      memory_type: "episodic-leaf",
+      tier_label: "monthly",
+      pass_kind: "single",
+      version: 1,
+    });
+
+    const count = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_prompt_registry`).get() as { n: number }
+    ).n;
+    expect(count).toBe(2);
+    db.close();
+  });
+
+  it("the original UNIQUE constraint still catches non-NULL collisions", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: "monthly",
+      pass_kind: "single",
+      version: 1,
+    });
+
+    expect(() =>
+      insertRegistryRow(db, {
+        prompt_id: "p_2",
+        memory_type: "episodic-leaf",
+        tier_label: "monthly",
+        pass_kind: "single",
+        version: 1,
+      }),
+    ).toThrow(/UNIQUE/i);
+    db.close();
+  });
+
+  it("is idempotent — running migrations twice does not fail", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false })).not.toThrow();
+    db.close();
+  });
+});

--- a/test/v41-summaries-columns.test.ts
+++ b/test/v41-summaries-columns.test.ts
@@ -1,0 +1,196 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+describe("v4.1 summaries column additions (v3.1 A1/A3 + v4.1.1 A2)", () => {
+  it("adds session_key with NOT NULL DEFAULT '' (v3.1 A1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sk = cols.find((c) => c.name === "session_key");
+    expect(sk).toBeDefined();
+    expect(sk?.notnull).toBe(1);
+    expect(sk?.dflt_value).toBe("''");
+    db.close();
+  });
+
+  it("adds suppressed_at as nullable TEXT (v3.1 A3)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sa = cols.find((c) => c.name === "suppressed_at");
+    expect(sa).toBeDefined();
+    expect(sa?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds entity_index as nullable TEXT (v3.1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const ei = cols.find((c) => c.name === "entity_index");
+    expect(ei).toBeDefined();
+    expect(ei?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds contains_suppressed_leaves with NOT NULL DEFAULT 0 (v3.1 A3)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const csl = cols.find((c) => c.name === "contains_suppressed_leaves");
+    expect(csl).toBeDefined();
+    expect(csl?.notnull).toBe(1);
+    expect(csl?.dflt_value).toBe("0");
+    db.close();
+  });
+
+  it("adds suppress_reason as nullable TEXT (v4.1.1 A2)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sr = cols.find((c) => c.name === "suppress_reason");
+    expect(sr).toBeDefined();
+    expect(sr?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds superseded_by as FK to summaries(summary_id) ON DELETE SET NULL (v4.1.1 A2/A4)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sb = cols.find((c) => c.name === "superseded_by");
+    expect(sb).toBeDefined();
+    expect(sb?.notnull).toBe(0); // nullable per SQLite ADD COLUMN+FK rule
+
+    // Verify the FK is actually declared
+    const fks = db.prepare("PRAGMA foreign_key_list(summaries)").all() as Array<{
+      from: string;
+      to: string;
+      table: string;
+      on_delete: string;
+    }>;
+    const sbFk = fks.find((fk) => fk.from === "superseded_by");
+    expect(sbFk).toBeDefined();
+    expect(sbFk?.table).toBe("summaries");
+    expect(sbFk?.to).toBe("summary_id");
+    expect(sbFk?.on_delete).toBe("SET NULL");
+    db.close();
+  });
+
+  it("adds leaf_summarizer_cap_was as nullable INTEGER (v4.1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const lcw = cols.find((c) => c.name === "leaf_summarizer_cap_was");
+    expect(lcw).toBeDefined();
+    expect(lcw?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("is idempotent — running migrations twice does not fail", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+
+  // Forward-compat upgrade test (against a partial pre-existing schema) is
+  // deferred to Group A.10 — that step covers the full live-DB-shaped
+  // verification including all v3-era tables and indexes that the migration
+  // assumes are present.
+});
+
+describe("messages.suppressed_at column (v3.1 A3 extension)", () => {
+  it("adds suppressed_at to messages table", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(messages)").all() as ColumnInfo[];
+    const sa = cols.find((c) => c.name === "suppressed_at");
+    expect(sa).toBeDefined();
+    expect(sa?.notnull).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_feature_flags table (v4.1.1 A8 — clean new table)", () => {
+  it("creates lcm_feature_flags with (flag PK, value NOT NULL, updated_at NOT NULL)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_feature_flags)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+
+    expect(byName.get("flag")?.pk).toBe(1);
+    expect(byName.get("flag")?.notnull).toBe(1); // PRIMARY KEY → NOT NULL
+    expect(byName.get("value")?.notnull).toBe(1);
+    expect(byName.get("updated_at")?.notnull).toBe(1);
+    db.close();
+  });
+
+  it("supports basic feature-flag pattern (set + read)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(
+      `INSERT INTO lcm_feature_flags (flag, value) VALUES (?, ?)`,
+    ).run("v4_section_1_enabled", "true");
+
+    const row = db
+      .prepare(`SELECT value FROM lcm_feature_flags WHERE flag = ?`)
+      .get("v4_section_1_enabled") as { value: string } | undefined;
+    expect(row?.value).toBe("true");
+
+    // Update flips value
+    db.prepare(
+      `UPDATE lcm_feature_flags SET value = ?, updated_at = datetime('now') WHERE flag = ?`,
+    ).run("false", "v4_section_1_enabled");
+    const row2 = db
+      .prepare(`SELECT value FROM lcm_feature_flags WHERE flag = ?`)
+      .get("v4_section_1_enabled") as { value: string } | undefined;
+    expect(row2?.value).toBe("false");
+
+    db.close();
+  });
+
+  it("does NOT collide with Eva's legacy lcm_migration_flags table (separate concern)", () => {
+    const db = new DatabaseSync(":memory:");
+    // Pre-create the legacy table (simulating Eva's live DB shape)
+    db.exec(`
+      CREATE TABLE lcm_migration_flags (
+        flag TEXT PRIMARY KEY,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO lcm_migration_flags (flag) VALUES (?)`).run(
+      "tool-call-columns-backfilled-v1",
+    );
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Both tables should coexist
+    const tables = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('lcm_migration_flags', 'lcm_feature_flags')`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name).sort()).toEqual([
+      "lcm_feature_flags",
+      "lcm_migration_flags",
+    ]);
+
+    // Legacy table content untouched
+    const legacy = db
+      .prepare(`SELECT flag FROM lcm_migration_flags`)
+      .all() as Array<{ flag: string }>;
+    expect(legacy.map((r) => r.flag)).toContain("tool-call-columns-backfilled-v1");
+    db.close();
+  });
+});

--- a/test/v41-support-tables.test.ts
+++ b/test/v41-support-tables.test.ts
@@ -1,0 +1,142 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+type IndexInfo = { name: string };
+
+describe("lcm_extraction_queue (v4.1.1 A3)", () => {
+  it("creates the table with expected schema + indexes", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    const cols = db.prepare("PRAGMA table_info(lcm_extraction_queue)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("queue_id")?.pk).toBe(1);
+    expect(byName.get("queue_id")?.notnull).toBe(1);
+    expect(byName.get("leaf_id")?.notnull).toBe(1);
+    expect(byName.get("kind")?.notnull).toBe(1);
+    expect(byName.get("attempts")?.notnull).toBe(1);
+    expect(byName.get("attempts")?.dflt_value).toBe("0");
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_extraction_queue)").all() as Array<{
+      from: string;
+      table: string;
+      on_delete: string;
+    }>;
+    const leafFk = fks.find((fk) => fk.from === "leaf_id");
+    expect(leafFk?.table).toBe("summaries");
+    expect(leafFk?.on_delete).toBe("CASCADE");
+
+    const indexes = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_extraction_queue'`)
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_extraction_queue_pending_idx");
+    expect(indexes.map((i) => i.name)).toContain("lcm_extraction_queue_dead_letter_idx");
+    db.close();
+  });
+
+  it("rejects unknown kinds via CHECK constraint", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    // Need a real summary to satisfy FK
+    db.prepare(`INSERT INTO conversations (session_id) VALUES ('s1')`).run();
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+    ).run("sum_1");
+
+    expect(() =>
+      db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+        "q1",
+        "sum_1",
+        "bogus-kind",
+      ),
+    ).toThrow();
+
+    // Real kinds work
+    db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+      "q2",
+      "sum_1",
+      "entity",
+    );
+    db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+      "q3",
+      "sum_1",
+      "procedure-recheck",
+    );
+
+    db.close();
+  });
+});
+
+// lcm_purge_rebuild_queue + lcm_voyage_rate_state tests REMOVED in
+// first-principles pass (2026-05-06). Schema + tests preserved in
+// deferred-features draft PR (#616).
+
+describe("lcm_session_key_audit (v4.1.1 §C reversibility log)", () => {
+  it("creates the audit table with FK + index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_session_key_audit)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+
+    expect(byName.get("audit_id")?.pk).toBe(1);
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("new_session_key")?.notnull).toBe(1);
+    expect(byName.get("reason")?.notnull).toBe(1);
+    expect(byName.get("applied_at")?.notnull).toBe(1);
+    expect(byName.get("applied_by")?.notnull).toBe(1);
+    expect(byName.get("original_session_key")?.notnull).toBe(0); // nullable; legacy convs had NULL
+
+    const fks = db
+      .prepare("PRAGMA foreign_key_list(lcm_session_key_audit)")
+      .all() as Array<{ from: string; table: string; on_delete: string }>;
+    expect(fks.find((fk) => fk.from === "conversation_id")?.on_delete).toBe("CASCADE");
+
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_session_key_audit'`,
+      )
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_session_key_audit_conv_idx");
+    db.close();
+  });
+
+  it("supports recording a re-key with NULL original_session_key (legacy conv case)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(`INSERT INTO conversations (session_id) VALUES ('s1')`).run();
+
+    db.prepare(
+      `INSERT INTO lcm_session_key_audit (audit_id, conversation_id, original_session_key, new_session_key, reason)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      "audit_1",
+      1,
+      null, // legacy conv had NULL session_key
+      "agent:main:main",
+      "v4.1 cleanup: legacy leaf-bearing conv re-keyed to true main thread",
+    );
+
+    const row = db
+      .prepare("SELECT * FROM lcm_session_key_audit WHERE audit_id = ?")
+      .get("audit_1") as {
+      original_session_key: string | null;
+      new_session_key: string;
+      reason: string;
+    };
+    expect(row.original_session_key).toBeNull();
+    expect(row.new_session_key).toBe("agent:main:main");
+    expect(row.reason).toContain("legacy leaf-bearing");
+
+    db.close();
+  });
+});

--- a/test/v41-synthesis-tables.test.ts
+++ b/test/v41-synthesis-tables.test.ts
@@ -1,0 +1,440 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+type IndexInfo = { name: string };
+type FkInfo = {
+  from: string;
+  to: string;
+  table: string;
+  on_delete: string;
+};
+
+function setupDbWithRequiredFixtures(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+  // Seed a conversation + summary so FK references work
+  db.prepare(`INSERT INTO conversations (session_id) VALUES ('test-session')`).run();
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+  ).run("sum_a");
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'y', 1)`,
+  ).run("sum_b");
+
+  // Seed a prompt registry row so cache + audit FKs work
+  db.prepare(
+    `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run("prompt_v1", "episodic-condensed", "single", 1, "Summarize: {input}");
+
+  return db;
+}
+
+describe("lcm_prompt_registry (v4.1 §3)", () => {
+  it("creates table with memory_type + pass_kind CHECK constraints", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_prompt_registry)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("prompt_id")?.pk).toBe(1);
+    expect(byName.get("memory_type")?.notnull).toBe(1);
+    expect(byName.get("pass_kind")?.notnull).toBe(1);
+    expect(byName.get("template")?.notnull).toBe(1);
+    expect(byName.get("active")?.dflt_value).toBe("1");
+    expect(byName.get("bundle_version")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("rejects invalid memory_type values", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("p1", "bogus-type", "single", 1, "x"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("rejects invalid pass_kind values", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("p2", "episodic-leaf", "critique-revise", 1, "x"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("UNIQUE constraint prevents duplicate (memory_type, tier_label, pass_kind, version)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("pa", "episodic-condensed", "monthly", "single", 1, "v1");
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("pb", "episodic-condensed", "monthly", "single", 1, "v1-dup"),
+    ).toThrow();
+    // Different version is fine
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("pc", "episodic-condensed", "monthly", "single", 2, "v2");
+    db.close();
+  });
+});
+
+describe("lcm_synthesis_cache (v3.1 A8 + v4.1.1 B4)", () => {
+  it("creates table with status CHECK + tier_label CHECK + prompt_id FK", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_synthesis_cache)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("cache_id")?.pk).toBe(1);
+    expect(byName.get("status")?.dflt_value).toBe("'ready'");
+    expect(byName.get("content")?.notnull).toBe(0); // NULL while building
+    expect(byName.get("entity_index")?.dflt_value).toBe("'{}'");
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_synthesis_cache)").all() as FkInfo[];
+    const promptFk = fks.find((fk) => fk.from === "prompt_id");
+    expect(promptFk?.table).toBe("lcm_prompt_registry");
+
+    db.close();
+  });
+
+  it("UNIQUE lookup index enables INSERT OR IGNORE single-flight (v4.1.1 B4)", () => {
+    const db = setupDbWithRequiredFixtures();
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO lcm_synthesis_cache (
+        cache_id, session_key, range_start, range_end, leaf_fingerprint,
+        model_used, prompt_id, tier_label, source_leaf_ids,
+        source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized,
+        status, building_started_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'building', datetime('now'))
+    `);
+
+    // First INSERT wins
+    const r1 = insert.run(
+      "cache_A",
+      "agent:main:main",
+      "2026-04-01T00:00:00Z",
+      "2026-04-30T23:59:59Z",
+      "fp_xyz",
+      "voyage-4-large",
+      "prompt_v1",
+      "custom",
+      "[]",
+      0,
+      0,
+      "2026-04-01T00:00:00Z..2026-04-30T23:59:59Z",
+      0,
+    );
+    expect(r1.changes).toBe(1);
+
+    // Second INSERT with same lookup key conflicts → DO NOTHING
+    const r2 = insert.run(
+      "cache_B", // different cache_id, but same lookup composite
+      "agent:main:main",
+      "2026-04-01T00:00:00Z",
+      "2026-04-30T23:59:59Z",
+      "fp_xyz",
+      "voyage-4-large",
+      "prompt_v1",
+      "custom",
+      "[]",
+      0,
+      0,
+      "2026-04-01T00:00:00Z..2026-04-30T23:59:59Z",
+      0,
+    );
+    expect(r2.changes).toBe(0); // ON CONFLICT DO NOTHING fired
+
+    // Verify the winner is cache_A
+    const winner = db
+      .prepare(
+        `SELECT cache_id FROM lcm_synthesis_cache
+         WHERE session_key = ? AND range_start = ? AND range_end = ?
+           AND leaf_fingerprint = ? AND COALESCE(grep_filter, '') = ''`,
+      )
+      .get(
+        "agent:main:main",
+        "2026-04-01T00:00:00Z",
+        "2026-04-30T23:59:59Z",
+        "fp_xyz",
+      ) as { cache_id: string };
+    expect(winner.cache_id).toBe("cache_A");
+    db.close();
+  });
+
+  it("rejects invalid status / tier_label values", () => {
+    const db = setupDbWithRequiredFixtures();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c1", "sk", "s", "e", "fp", "m", "prompt_v1", "year", "[]", 0, 0, "x", 0, "bogus-status"),
+    ).toThrow();
+
+    // Final.review.3 fix (Loop 4 Bug 4.4): the cache CHECK constraint was
+    // widened to include all dispatch tiers ('daily', 'weekly', 'monthly',
+    // 'yearly', 'year', 'custom', 'filtered'). 'monthly' is now ACCEPTED.
+    // Verify with 'bogus-tier' instead, which is still rejected.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c2", "sk", "s", "e", "fp", "m", "prompt_v1", "bogus-tier", "[]", 0, 0, "x", 0),
+    ).toThrow();
+
+    // 'monthly' should now succeed (post-widen fix); verify it was a real change.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c3", "sk", "s2", "e2", "fp2", "m", "prompt_v1", "monthly", "[]", 0, 0, "x", 0),
+    ).not.toThrow();
+
+    db.close();
+  });
+});
+
+describe("lcm_cache_leaf_refs (v3.1 A3 inverse index)", () => {
+  it("creates table with composite PK + cascade both directions", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_cache_leaf_refs)").all() as ColumnInfo[];
+    expect(cols.find((c) => c.name === "cache_id")?.pk).toBe(1);
+    expect(cols.find((c) => c.name === "leaf_summary_id")?.pk).toBe(2);
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_cache_leaf_refs)").all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "cache_id")?.on_delete).toBe("CASCADE");
+    expect(fks.find((fk) => fk.from === "leaf_summary_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+
+  it("CASCADE on leaf delete removes refs (cleans up after leaf is purged)", () => {
+    const db = setupDbWithRequiredFixtures();
+    // Build a cache row + ref
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("c1", "sk", "s", "e", "fp", "m", "prompt_v1", "custom", "[]", 0, 0, "x", 0);
+    db.prepare(`INSERT INTO lcm_cache_leaf_refs (cache_id, leaf_summary_id) VALUES (?, ?)`).run(
+      "c1",
+      "sum_a",
+    );
+
+    // Delete the leaf — ref should cascade
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run("sum_a");
+    const refs = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_cache_leaf_refs WHERE cache_id = 'c1'`)
+      .get() as { n: number };
+    expect(refs.n).toBe(0);
+    db.close();
+  });
+
+  it("CASCADE on cache delete removes refs", () => {
+    const db = setupDbWithRequiredFixtures();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("c2", "sk", "s", "e", "fp2", "m", "prompt_v1", "custom", "[]", 0, 0, "x", 0);
+    db.prepare(`INSERT INTO lcm_cache_leaf_refs (cache_id, leaf_summary_id) VALUES (?, ?)`).run(
+      "c2",
+      "sum_b",
+    );
+
+    db.prepare(`DELETE FROM lcm_synthesis_cache WHERE cache_id = ?`).run("c2");
+    const refs = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_cache_leaf_refs WHERE leaf_summary_id = 'sum_b'`)
+      .get() as { n: number };
+    expect(refs.n).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_synthesis_audit (v4.1.1 B1)", () => {
+  it("pass_output is NULLable so audit row can be inserted before LLM call returns", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_synthesis_audit)").all() as ColumnInfo[];
+    const passOutput = cols.find((c) => c.name === "pass_output");
+    expect(passOutput?.notnull).toBe(0);
+
+    const status = cols.find((c) => c.name === "status");
+    expect(status?.notnull).toBe(1);
+    expect(status?.dflt_value).toBe("'started'");
+    db.close();
+  });
+
+  it("CHECK constraint requires either target_summary_id OR target_cache_id", () => {
+    const db = setupDbWithRequiredFixtures();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("a1", "sess1", "prompt_v1", "single", "input", "voyage-4-large"),
+    ).toThrow(); // both target columns NULL
+
+    // With target_summary_id: works
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("a2", "sess1", "sum_a", "prompt_v1", "single", "input", "voyage-4-large");
+
+    db.close();
+  });
+
+  it("supports the started → completed pattern (insert with NULL pass_output, update on LLM return)", () => {
+    const db = setupDbWithRequiredFixtures();
+
+    // Step 1: insert audit row with status='started', pass_output NULL
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("a3", "sess2", "sum_a", "prompt_v1", "single", "input", "voyage-4-large");
+
+    // Step 2: LLM call happens OUTSIDE transaction (per §0 invariant 1)
+    // Step 3: UPDATE on success
+    db.prepare(
+      `UPDATE lcm_synthesis_audit SET pass_output = ?, status = 'completed', latency_ms = ? WHERE audit_id = ?`,
+    ).run("the resulting summary text", 1234, "a3");
+
+    const row = db
+      .prepare(`SELECT status, pass_output, latency_ms FROM lcm_synthesis_audit WHERE audit_id = ?`)
+      .get("a3") as { status: string; pass_output: string; latency_ms: number };
+    expect(row.status).toBe("completed");
+    expect(row.pass_output).toBe("the resulting summary text");
+    expect(row.latency_ms).toBe(1234);
+    db.close();
+  });
+
+  it("started-GC index supports the v4.1.1 B1 1-hour orphan cleanup query", () => {
+    const db = setupDbWithRequiredFixtures();
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_synthesis_audit'`,
+      )
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_synthesis_audit_started_gc_idx");
+    db.close();
+  });
+});
+
+// Wave-2 Auditor #8 fix F1: regression test for the migration's
+// DELETE-before-DROP cleanup of orphan audit rows. The Wave-1 commit
+// added the cleanup; this test pins the behavior so a future refactor
+// doesn't silently regress it.
+//
+// Strategy: run runLcmMigrations once (gets fully-migrated schema with
+// new wide CHECK), seed audit rows referencing real cache_ids, then
+// directly invoke the same DELETE that the migration runs and verify
+// it cleans the right rows. This is a unit test of the cleanup SQL,
+// not a full migration upgrade simulation (the upgrade path is
+// covered by v41-pre-existing-schema-migration.test.ts).
+describe("v4.1.3 widenLcmSynthesisCacheTierCheck — orphan-cleanup SQL", () => {
+  it("DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL prunes only orphan-pointing rows", () => {
+    const db = setupDbWithRequiredFixtures();
+    // Pre-condition: count audit rows with target_cache_id set vs NULL
+    // (the fixture seeds none; we'll seed both kinds).
+
+    // Need a real cache_id to FK against
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache
+         (cache_id, session_key, range_start, range_end, leaf_fingerprint,
+          content, model_used, prompt_id, tier_label, source_leaf_ids,
+          source_token_count, output_token_count, actual_range_covered,
+          leaf_count_synthesized)
+       VALUES ('cache_for_orphan_test', 'agent:main:main', '2026-01-01', '2026-01-31',
+         'fp1', null, 'm1', 'prompt_v1', 'year', '["sum_a"]', 100, 50, '...', 1)`,
+    ).run();
+
+    // Seed: 2 audit rows pointing at the cache (will be the "orphans"
+    // after the eventual DROP), 1 row pointing at a summary instead
+    // (must be PRESERVED).
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_cache_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_cache_1', 'pass_1', 'cache_for_orphan_test', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_cache_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_cache_2', 'pass_2', 'cache_for_orphan_test', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_summary', 'pass_3', 'sum_a', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+
+    const beforeCacheTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`)
+      .get() as { n: number };
+    const beforeSummaryTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_summary_id IS NOT NULL`)
+      .get() as { n: number };
+    expect(beforeCacheTargeted.n).toBe(2);
+    expect(beforeSummaryTargeted.n).toBeGreaterThanOrEqual(1);
+
+    // Apply the same DELETE the migration runs.
+    db.exec(`DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`);
+
+    const afterCacheTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`)
+      .get() as { n: number };
+    const afterSummaryTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_summary_id IS NOT NULL`)
+      .get() as { n: number };
+    expect(afterCacheTargeted.n).toBe(0);
+    expect(afterSummaryTargeted.n).toBe(beforeSummaryTargeted.n);
+
+    db.close();
+  });
+
+  it("re-running runLcmMigrations on already-widened DB is a no-op (idempotent)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const before = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const after = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    expect(after.sql).toBe(before.sql);
+    db.close();
+  });
+
+  it("schema includes the wide CHECK including 'monthly' on first migration", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const sql = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    expect(sql.sql).toMatch(/'monthly'|"monthly"/);
+    expect(sql.sql).toMatch(/'weekly'|"weekly"/);
+    expect(sql.sql).toMatch(/'daily'|"daily"/);
+    db.close();
+  });
+});

--- a/test/worker-lock.test.ts
+++ b/test/worker-lock.test.ts
@@ -1,0 +1,150 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  acquireLock,
+  generateWorkerId,
+  heartbeatLock,
+  lockInfo,
+  releaseLock,
+} from "../src/concurrency/worker-lock.js";
+
+function newDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  return db;
+}
+
+describe("worker-lock — acquire / release single-process", () => {
+  it("first acquire succeeds; second from different worker blocks", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w1" })).toBe(true);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+
+    // Both expect to be told the truth — w1 holds, w2 doesn't
+    const info = lockInfo(db, "embedding-backfill");
+    expect(info?.workerId).toBe("w1");
+    db.close();
+  });
+
+  it("release frees the lock for next acquirer", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(releaseLock(db, "embedding-backfill", "w1")).toBe(true);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(true);
+    db.close();
+  });
+
+  it("release with wrong workerId does not free the lock", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(releaseLock(db, "embedding-backfill", "wrong")).toBe(false);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+    db.close();
+  });
+
+  it("acquireLock requires non-empty workerId", () => {
+    const db = newDb();
+    expect(() => acquireLock(db, "embedding-backfill", { workerId: "" })).toThrow(/workerId is required/);
+    expect(() => acquireLock(db, "embedding-backfill", { workerId: "  " })).toThrow(/workerId is required/);
+    db.close();
+  });
+});
+
+describe("worker-lock — TTL + GC", () => {
+  it("acquireLock with ttlMs=0 immediately stale, gets GC'd on next acquire", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "dead", ttlMs: 0 })).toBe(true);
+    // Immediately stale — the next worker should be able to acquire
+    expect(acquireLock(db, "embedding-backfill", { workerId: "alive" })).toBe(true);
+    expect(lockInfo(db, "embedding-backfill")?.workerId).toBe("alive");
+    db.close();
+  });
+
+  it("non-expired lock blocks new acquirer (TTL not reached yet)", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1", ttlMs: 60_000 });
+    // w2 cannot acquire — TTL not reached
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+    db.close();
+  });
+});
+
+describe("worker-lock — heartbeat", () => {
+  it("heartbeat from current holder extends expires_at", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1", ttlMs: 1_000 });
+    const initial = lockInfo(db, "embedding-backfill");
+    // Wait briefly so timestamps differ
+    const t1 = initial!.expiresAt;
+    expect(heartbeatLock(db, "embedding-backfill", "w1", 60_000)).toBe(true);
+    const after = lockInfo(db, "embedding-backfill");
+    // expires_at should have moved forward (later time)
+    expect(after!.expiresAt >= t1).toBe(true);
+    db.close();
+  });
+
+  it("heartbeat from non-holder fails (lock owned by other worker)", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(heartbeatLock(db, "embedding-backfill", "w2")).toBe(false);
+    db.close();
+  });
+
+  it("heartbeat after stale lock GC + reacquire by different worker fails for old worker", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "old", ttlMs: 0 });
+    // Stale; new worker grabs it
+    expect(acquireLock(db, "embedding-backfill", { workerId: "new" })).toBe(true);
+    // Old worker tries to heartbeat — sees the lock is now owned by 'new', returns false
+    expect(heartbeatLock(db, "embedding-backfill", "old")).toBe(false);
+    db.close();
+  });
+});
+
+describe("worker-lock — metadata + scope", () => {
+  it("jobSessionKey and jobMetadata are stored and retrievable via lockInfo", () => {
+    const db = newDb();
+    acquireLock(db, "condensation", {
+      workerId: "w1",
+      jobSessionKey: "agent:main:main",
+      jobMetadata: "weekly:2026-W18",
+    });
+    const info = lockInfo(db, "condensation");
+    expect(info?.jobSessionKey).toBe("agent:main:main");
+    expect(info?.jobMetadata).toBe("weekly:2026-W18");
+    db.close();
+  });
+
+  it("lockInfo returns null when no lock held", () => {
+    const db = newDb();
+    expect(lockInfo(db, "extraction")).toBeNull();
+    db.close();
+  });
+});
+
+describe("worker-lock — generateWorkerId", () => {
+  it("generates IDs with the role prefix and pid + nonce uniqueness", () => {
+    const id1 = generateWorkerId("backfill");
+    const id2 = generateWorkerId("backfill");
+    expect(id1.startsWith("backfill-")).toBe(true);
+    expect(id2.startsWith("backfill-")).toBe(true);
+    expect(id1).not.toBe(id2); // different nonces
+    // Format: backfill-<pid>-<ms>-<6char hex>
+    expect(id1).toMatch(/^backfill-\d+-\d+-[0-9a-f]{6}$/);
+  });
+});
+
+describe("worker-lock — multiple job kinds independent", () => {
+  it("locks for different job_kinds don't conflict", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w1" })).toBe(true);
+    expect(acquireLock(db, "extraction", { workerId: "w2" })).toBe(true);
+    expect(acquireLock(db, "condensation", { workerId: "w3" })).toBe(true);
+    // All three held simultaneously
+    expect(lockInfo(db, "embedding-backfill")?.workerId).toBe("w1");
+    expect(lockInfo(db, "extraction")?.workerId).toBe("w2");
+    expect(lockInfo(db, "condensation")?.workerId).toBe("w3");
+    db.close();
+  });
+});


### PR DESCRIPTION
## TL;DR

**First PR of the LCM v4.1 stacked series** — the bones the next 12 PRs build on. Adds the v4.1 database schema (16 tables) + worker concurrency primitives. All-additive: new files plus append-only, idempotent migration steps. **No existing code path changes; no user-visible behavior change yet.** This PR ships the skeleton; the next 12 ship the muscles.

## The v4.1 story in one paragraph

v4.1 rebuilds LCM the way a person actually remembers: **keep the raw conversation forever, embed it for similarity search, synthesize fresh views on demand.** The v3 `lcm_recent` tool produced summaries-of-summaries-of-summaries that got worse the further back you looked; v4.1 stops building rollups and adds an agent surface mapped to the five question types a person actually asks:

> "What did we work on yesterday?" · "Have we ever discussed X?" · "What did X *exactly* say?" · "Tell me about person/project Y" · "Where did this claim come from?"

This first PR is the SQL schema + worker coordination primitives that make the rest possible.

## Before / after — what this enables

```mermaid
flowchart LR
  subgraph Before["Before — v3 rollup era"]
    M1[messages] --> L1[leaf summaries]
    L1 --> D[day rollup]
    D --> W[week rollup]
    W --> Mo[month rollup<br/>summary OF summary<br/>OF summary]
    style Mo fill:#f99
  end
  subgraph After["After — this stack lands"]
    M2[messages<br/>+ suppressed_at] --> L2[leaf summaries<br/>+ suppressed_at]
    L2 -.->|sidecar| V[vec0 embeddings<br/>this PR creates table]
    L2 -.->|sidecar| E[lcm_entities<br/>this PR creates table]
    L2 -->|on demand only| S[synthesis_cache<br/>this PR creates table]
    style V fill:#9f9
    style E fill:#9f9
    style S fill:#9f9
  end
```

The green tables are what this PR creates; the next 12 PRs light them up.

## What this PR adds

### Schema (`src/db/migration.ts`)
Append-only `runMigrationStep(...)` blocks creating the v4.1 surface:

| Cluster | Tables |
|---|---|
| Embeddings substrate | `lcm_embedding_profile`, `lcm_embedding_meta`, `lcm_embedding_meta_cleanup_summary` (suppression-cascade trigger) |
| Entity catalog | `lcm_entities`, `lcm_entity_mentions`, `lcm_entity_type_registry`, `lcm_extraction_queue` |
| Synthesis | `lcm_prompt_registry`, `lcm_synthesis_cache`, `lcm_synthesis_audit` |
| Eval | `lcm_eval_run`, `lcm_eval_query_result` |
| Operator + workers | `lcm_worker_lock`, `lcm_feature_flags` |
| Pre-existing extensions | `summaries.suppressed_at`, `messages.suppressed_at` columns |

`CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ADD COLUMN` only — no existing step modified, no column drops, no type changes. **Zero collisions with upstream's focus-mode** (focus uses `focus_*`; this uses `lcm_*` / extends `summaries`).

### Concurrency primitives (`src/concurrency/`)

- **`model.ts`** — worker job kinds (`embedding-backfill`, `entity-coreference`, …) + `WORKER_LOCK_TTL_MS` / `WORKER_HEARTBEAT_MS`. Single source of truth that workers and locks agree on.
- **`worker-lock.ts`** — advisory single-flight lock over `lcm_worker_lock`. Used by every background worker the next 11 PRs add.

```mermaid
flowchart LR
  W1[Backfill autostart<br/>5min cadence] -->|INSERT OR IGNORE| L[lcm_worker_lock<br/>job-kind PK<br/>expires_at TTL]
  W2[Entity coref autostart<br/>60s cadence] -->|INSERT OR IGNORE| L
  L -->|heartbeat 30s<br/>UPDATE WHERE expires_at > now| L
  L -.->|crash → expires_at < now| Stolen[next acquirer takes lock]
```

Verified against parallel writers via `worker_threads` in `test/v41-concurrency-invariants.test.ts` (full suite ships in pr12; the lock itself is tested here in `test/worker-lock.test.ts`).

### `src/db/connection.ts` (small additive)

- `assertForeignKeysEnabled()` — verifies `PRAGMA foreign_keys = ON` actually took effect (silent-degrade-to-off was a real Wave-2 trap).
- `new DatabaseSync(dbPath, { allowExtension: true })` — enables `sqlite-vec` loading in pr02. **Behavior-preserving when no extension loads** — the flag is a capability, not an activation.

### 13 tests
Each table cluster has a schema-shape test; concurrency-model has 3; migration idempotence has 2. **The schema is verified before any consumer code lights it up.**

## Deferred on purpose

The prompt-registry **default-prompt seeding** step is intentionally deferred to the Synthesis PR (#726). This PR creates `lcm_prompt_registry` but does not populate it — the `seedDefaultPrompts` migration option is accepted (so schema tests can pass `false`) but is a no-op until #726 wires in the `synthesis/seed-default-prompts.ts` seeder. Keeps the foundation PR free of any synthesis-layer code dependency.

## The science: why schema-first?

Two ways to ship 16 cross-feature tables: (a) per-feature schema in each feature PR, or (b) one foundation PR.

(a) means each feature PR re-audits its migration in isolation, but v4.1's migrations are tightly entwined — the shared `lcm_embedding_meta_cleanup_summary` trigger references both `lcm_embedding_meta` AND `summaries`; the extraction queue references `lcm_entity_mentions`. Slicing those across PRs creates cross-PR ordering risk and re-reviews the same migration safety multiple times.

(b) concentrates the riskiest schema operation in one carefully-audited PR; downstream PRs become "what does this code do with tables that already exist" rather than "is this migration safe." Migrations are simple by design (`CREATE TABLE IF NOT EXISTS`); the complexity is in the consumer code, which gets one PR per feature.

Picked (b). The migrations are verifiable in isolation; the features that consume them are reviewable in isolation.

## Stack position

```
#719 pr01 foundation  ← this PR
 └ #720 pr01b leaf-cap default 2400 → 4000
   └ #721 pr02 Voyage + embeddings store + sqlite-vec dep
     └ #722 pr03 embedding backfill + worker loop
       └ #723 pr04 semantic + hybrid retrieval services
         └ #724 pr05 lcm_grep hybrid/semantic/verbatim modes
           └ #725 pr05b lcm_describe expand-flags + retrieval changes
             └ #726 pr06 synthesis layer (prompt registry, dispatch, seeder)
               └ #727 pr07 eval harness + /lcm eval
                 └ #728 pr08 entity coreference + entity tools
                   └ #729 pr09 operator core + soft-suppression + fallback-marker
                     └ #730 pr10 autostart wiring
                       └ #731 pr11 lcm_synthesize_around tool
                         └ #732 pr12 agent compaction (last)
```

Replaces the unreviewable omnibus (#613).

## Test plan

- [x] `npm run build` — esbuild bundle clean
- [x] `npx tsc --noEmit` — zero new type errors vs `main`
- [x] CI green — `npm test` (13 schema/concurrency suites + full existing suite) + smoke-import
- [x] Migration idempotence verified (`v41-pre-existing-schema-migration.test.ts`)

## For deep context

The full v4.1 architecture brief — including the mermaid diagrams for the synthesis dispatch, the suppression cascade across 10+ read paths, the cost discipline tables, the 10-wave audit history (~140 bugs closed), and the live-DB verification numbers — is checked in at `docs/v4.1/PR_DESCRIPTION.md` (lands with #732, the final PR).
