### PR TITLE
feat: v4.1 — lcm_describe expand-flags + retrieval changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": ">=0.74 <1",
@@ -20,6 +20,9 @@
         "esbuild": "^0.28.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "sqlite-vec": "^0.1.7-alpha.2"
       },
       "peerDependencies": {
         "openclaw": ">=2026.5.12"
@@ -3116,7 +3119,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3687,7 +3690,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -3961,7 +3964,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4153,7 +4156,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -4373,7 +4376,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -4389,7 +4392,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -4427,7 +4430,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4459,7 +4462,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4950,14 +4953,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5050,6 +5053,85 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optional": true,
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -5317,7 +5399,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-algebra": {
@@ -6035,14 +6117,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "@earendil-works/pi-coding-agent": ">=0.74 <1",
     "@sinclair/typebox": "0.34.48"
   },
+  "optionalDependencies": {
+    "sqlite-vec": "^0.1.7-alpha.2"
+  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",

--- a/src/concurrency/model.ts
+++ b/src/concurrency/model.ts
@@ -1,0 +1,147 @@
+/**
+ * §0 Concurrency Model — LCM v4.1.1
+ *
+ * The load-bearing invariants for cross-process safety between gateway and worker.
+ * This module is the single source of truth for §0 of architecture-v4.1.md +
+ * v4.1.1 A6/A9 amendments. Code that violates these invariants must fail
+ * loudly (assertion / throw) — never silently degrade.
+ *
+ * Invariants (architecture-v4.1.md §0.1, plus v4.1.1 A6 + A9):
+ *
+ *   1. NO LLM/network call inside any SQLite write transaction.
+ *      Leaf-write commits in T1; embed/extract queue async to worker T2.
+ *      Synthesis call happens OUTSIDE cache-write transaction (insert
+ *      `status='building'` row in T1, run LLM, then update to `status='ready'`
+ *      in T2 per v3.1 A8).
+ *
+ *   2. Gateway owns the hot path. Per-turn assemble + leaf write + agent
+ *      tool calls. Latency budget: assemble <100ms; leaf write <50ms.
+ *
+ *   3. Worker owns cold rewrites. Condensation, extraction, embedding
+ *      backfill, theme consolidation, synthesis profile rebuilds. May take
+ *      seconds-to-minutes per job; gateway never waits on it.
+ *
+ *   4. Both processes use the same SQLite DB; no IPC beyond DB rows.
+ *
+ *   5. Worker uses SHORTER `busy_timeout` than gateway so gateway always
+ *      wins on contention. See {@link GATEWAY_BUSY_TIMEOUT_MS} and
+ *      {@link WORKER_BUSY_TIMEOUT_MS}.
+ *
+ *   6. Migration ratchet owned by gateway only. Worker startup checks
+ *      `lcm_migration_state` for required v4.1 step; refuses to start if
+ *      not present. Worker NEVER calls `runLcmMigrations`.
+ *
+ *   7. PRAGMA foreign_keys = ON on every connection (gateway and worker).
+ *      Already set by `src/db/connection.ts:configureConnection()`. v4.1.1
+ *      A6 amendment: any new connection path must run through that helper
+ *      OR explicitly set the PRAGMA. Verified via {@link assertForeignKeysEnabled}.
+ *
+ *   8. Worker heartbeat must run on Node `worker_threads` Worker with its
+ *      OWN DatabaseSync connection (v4.1.1 A9). Otherwise event-loop
+ *      blocking by job code (long LLM call, ml-hclust pass) starves the
+ *      heartbeat → fallback gateway steals an active worker's lock.
+ *      (Worker_threads scaffolding lands in Group A.NN; this constant
+ *      anchors the contract.)
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+
+/**
+ * Gateway SQLite busy_timeout (ms). Already set by
+ * `src/db/connection.ts:configureConnection()` to this value. Long timeout
+ * accommodates worker-process write transactions during condensation /
+ * extraction passes.
+ */
+export const GATEWAY_BUSY_TIMEOUT_MS = 30_000;
+
+/**
+ * Worker SQLite busy_timeout (ms). MUST be shorter than
+ * {@link GATEWAY_BUSY_TIMEOUT_MS} so gateway always wins on contention.
+ * Worker that hits SQLITE_BUSY backs off and retries; gateway hot path
+ * does not stall waiting for worker writes.
+ */
+export const WORKER_BUSY_TIMEOUT_MS = 5_000;
+
+/**
+ * Worker heartbeat cadence (ms). Worker writes
+ * `last_heartbeat_at = now, expires_at = now + WORKER_LOCK_TTL_MS` on its
+ * held locks at this interval. See `lcm_worker_lock` table.
+ */
+export const WORKER_HEARTBEAT_MS = 30_000;
+
+/**
+ * Worker lock TTL (ms). If a worker dies without releasing its lock,
+ * other workers / fallback gateway can GC the lock once `expires_at < now`.
+ * 90s = 3× heartbeat cadence (allows one missed heartbeat without stealing).
+ */
+export const WORKER_LOCK_TTL_MS = 90_000;
+
+/**
+ * Gateway-fallback soak window (ms). Gateway can take over a worker job
+ * only when BOTH:
+ *   - lock is GC'd (per WORKER_LOCK_TTL_MS expiry), AND
+ *   - last_heartbeat_at < now - GATEWAY_FALLBACK_SOAK_MS
+ * Two conditions prevent gateway from racing a slow-LLM-but-alive worker
+ * (v4.1.1 A9 amendment).
+ */
+export const GATEWAY_FALLBACK_SOAK_MS = 300_000;
+
+/**
+ * Job kinds tracked by the cross-process lock table. Adding a new kind
+ * requires updating both this list AND the `lcm_worker_lock.job_kind`
+ * CHECK constraint (when added; current schema is freeform TEXT for
+ * forward-compat).
+ */
+export const WORKER_JOB_KINDS = [
+  "condensation",
+  "extraction",
+  "embedding-backfill",
+  "profile-rebuild",
+  "theme-consolidation",
+  "eval", // §11 ensemble judge runs (v4.1.1 §C MED item)
+] as const;
+
+export type WorkerJobKind = (typeof WORKER_JOB_KINDS)[number];
+
+/**
+ * Asserts `PRAGMA foreign_keys = ON` for the given connection. Throws if
+ * disabled. Per v4.1.1 A6 invariant: every code path that opens a
+ * SQLite connection MUST end up with FKs enabled, otherwise every
+ * `ON DELETE CASCADE` clause in the schema becomes documentation-only.
+ *
+ * `src/db/connection.ts:configureConnection()` already does this for the
+ * standard connection path — call this assertion in tests / hot paths
+ * to defend against future paths that bypass `configureConnection`.
+ */
+export function assertForeignKeysEnabled(db: DatabaseSync): void {
+  const row = db.prepare("PRAGMA foreign_keys").get() as { foreign_keys?: number } | undefined;
+  if (!row || row.foreign_keys !== 1) {
+    throw new Error(
+      "[concurrency.model] foreign_keys is not ON for this connection — " +
+        "every ON DELETE CASCADE in the schema would silently no-op. " +
+        "Ensure the connection passes through configureConnection() in " +
+        "src/db/connection.ts, or set PRAGMA foreign_keys = ON explicitly.",
+    );
+  }
+}
+
+/**
+ * Asserts the connection is set up such that `BEGIN EXCLUSIVE` migration
+ * + worker writes won't deadlock under contention. Specifically: busy_timeout
+ * must be ≥ {@link WORKER_BUSY_TIMEOUT_MS} (worker) or
+ * {@link GATEWAY_BUSY_TIMEOUT_MS} (gateway). Caller specifies which role.
+ */
+export function assertBusyTimeoutForRole(
+  db: DatabaseSync,
+  role: "gateway" | "worker",
+): void {
+  const expected = role === "gateway" ? GATEWAY_BUSY_TIMEOUT_MS : WORKER_BUSY_TIMEOUT_MS;
+  const row = db.prepare("PRAGMA busy_timeout").get() as { timeout?: number } | undefined;
+  const actual = row?.timeout ?? 0;
+  if (actual < expected) {
+    throw new Error(
+      `[concurrency.model] busy_timeout for ${role} is ${actual}ms, ` +
+        `expected at least ${expected}ms. Set via PRAGMA busy_timeout = ${expected}.`,
+    );
+  }
+}

--- a/src/concurrency/worker-lock.ts
+++ b/src/concurrency/worker-lock.ts
@@ -1,0 +1,215 @@
+/**
+ * Cross-process worker job lock — LCM v4.1 §0.
+ *
+ * Backed by `lcm_worker_lock` table (one row per job_kind). All worker
+ * jobs (condensation, extraction, embedding-backfill, profile-rebuild,
+ * theme-consolidation, eval) coordinate via this table so only one
+ * process at a time runs each kind.
+ *
+ * Acquisition is atomic via PRIMARY KEY uniqueness on (job_kind):
+ * INSERT OR IGNORE returns 1 row affected if we got the lock, 0 if
+ * someone else already holds it. No advisory lock dance, no application
+ * semaphore — SQLite's row-uniqueness IS the lock.
+ *
+ * TTL + heartbeat (v4.1.1 A9):
+ *   - WORKER_LOCK_TTL_MS = 90s default
+ *   - Worker calls heartbeatLock() every WORKER_HEARTBEAT_MS = 30s while running
+ *   - If a worker dies without releasing, its lock auto-expires after 90s
+ *   - acquireLock() GC's stale (expired) locks BEFORE attempting INSERT
+ *
+ * Why TTL is short and heartbeat is shorter: gateway-fallback soak window
+ * (GATEWAY_FALLBACK_SOAK_MS = 5min) prevents a slow-LLM-but-alive worker
+ * from being preempted. The fast TTL only matters when the worker is
+ * actually dead.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { WORKER_LOCK_TTL_MS, type WorkerJobKind } from "./model.js";
+
+export interface AcquireLockOptions {
+  /** Unique worker identifier (e.g. process.pid + start time + nonce). */
+  workerId: string;
+  /** Lock expiration in ms from now. Defaults to WORKER_LOCK_TTL_MS. */
+  ttlMs?: number;
+  /**
+   * Optional scope — if set, the lock is logically scoped to this
+   * session_key. Other code paths can read this column to make
+   * "same kind but different session" decisions (e.g. condensation
+   * runs simultaneously on different sessions but only one per session).
+   * NOTE: the lock itself is still per-job_kind (table PK). This column
+   * is informational only.
+   */
+  jobSessionKey?: string;
+  /** Arbitrary worker-set tag for diagnostics (e.g. "backfill: model=voyage4large"). */
+  jobMetadata?: string;
+}
+
+export interface LockInfo {
+  jobKind: string;
+  workerId: string;
+  acquiredAt: string;
+  expiresAt: string;
+  lastHeartbeatAt: string;
+  jobSessionKey: string | null;
+  jobMetadata: string | null;
+}
+
+/**
+ * Try to acquire a job lock. Returns true if acquired (caller now owns
+ * the lock; must call {@link releaseLock} or let it expire). Returns
+ * false if another worker holds it and the lock has not yet expired.
+ *
+ * Side effect: GC's any expired lock for this job_kind before attempting
+ * acquisition (so a stale dead-worker lock doesn't permanently block).
+ *
+ * Best practice: caller should wrap acquire + work + release in
+ * try/finally and emit telemetry on contention (acquire returning false
+ * frequently means the work isn't fitting into the lock window).
+ */
+export function acquireLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  opts: AcquireLockOptions,
+): boolean {
+  if (!opts.workerId || opts.workerId.trim().length === 0) {
+    throw new Error("[worker-lock] workerId is required");
+  }
+  // GC stale lock (if any). datetime('now') comparison; SQLite TEXT
+  // comparison works lexicographically on ISO-8601 strings.
+  // Note: `<=` not `<` so a lock with ttl=0 is immediately reclaimable.
+  // The race "another process acquires in the gap between DELETE and
+  // INSERT" is handled by the INSERT OR IGNORE on PK uniqueness — the
+  // second writer's INSERT just no-ops. Worst case: caller is told false
+  // when they could have had the lock; never silently double-acquires.
+  db.prepare(
+    `DELETE FROM lcm_worker_lock
+       WHERE job_kind = ? AND expires_at <= datetime('now')`,
+  ).run(jobKind);
+
+  const ttlSeconds = Math.round((opts.ttlMs ?? WORKER_LOCK_TTL_MS) / 1000);
+  // INSERT OR IGNORE: succeeds (changes=1) if no row holds the PK; no-ops
+  // (changes=0) if someone else is already there.
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO lcm_worker_lock
+         (job_kind, worker_id, acquired_at, expires_at, last_heartbeat_at,
+          job_session_key, job_metadata)
+       VALUES (?, ?, datetime('now'),
+               datetime('now', '+' || ? || ' seconds'),
+               datetime('now'), ?, ?)`,
+    )
+    .run(
+      jobKind,
+      opts.workerId,
+      ttlSeconds,
+      opts.jobSessionKey ?? null,
+      opts.jobMetadata ?? null,
+    );
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Release a held lock. Returns true if the row existed and matched the
+ * worker_id (so we deleted it). Returns false if the lock was already
+ * gone (e.g. expired + GC'd, or never acquired by this worker).
+ *
+ * NOTE: a stale-but-not-yet-GC'd lock CAN be deleted here if you pass
+ * the worker_id that originally acquired it. This is intentional —
+ * worker that just woke from sleep should be able to release its old
+ * lock if it remembers having it.
+ */
+export function releaseLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  workerId: string,
+): boolean {
+  const result = db
+    .prepare(`DELETE FROM lcm_worker_lock WHERE job_kind = ? AND worker_id = ?`)
+    .run(jobKind, workerId);
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Extend the expiration on a lock the worker still holds. Idempotent.
+ * Returns true if the worker still owns the lock (so the heartbeat
+ * succeeded). Returns false if the lock was lost (e.g. preempted by
+ * fallback gateway, or a different worker now owns it) — caller MUST
+ * abort its work in that case to avoid double-processing.
+ */
+export function heartbeatLock(
+  db: DatabaseSync,
+  jobKind: WorkerJobKind,
+  workerId: string,
+  ttlMs?: number,
+): boolean {
+  const ttlSeconds = Math.round((ttlMs ?? WORKER_LOCK_TTL_MS) / 1000);
+  // Wave-1 Auditor #2 finding #2: previous version had no `expires_at`
+  // predicate. If our 90s lock had already expired (worker was blocked
+  // in a long Voyage call), but no other worker had yet stolen it via
+  // acquireLock's lazy-DELETE, this UPDATE would silently re-extend an
+  // EXPIRED lock — making it look alive again. A concurrent autostart
+  // tick that started just before our heartbeat could then GC + acquire
+  // in between, both holding "the" lock simultaneously.
+  //
+  // Fix: require `expires_at > now` AND `worker_id = ?`. If our lock has
+  // expired we report `false` (caller MUST abort) and DO NOT extend it —
+  // the lazy-GC in acquireLock will then clean up.
+  const result = db
+    .prepare(
+      `UPDATE lcm_worker_lock
+         SET last_heartbeat_at = datetime('now'),
+             expires_at = datetime('now', '+' || ? || ' seconds')
+         WHERE job_kind = ?
+           AND worker_id = ?
+           AND expires_at > datetime('now')`,
+    )
+    .run(ttlSeconds, jobKind, workerId);
+  return Number(result.changes) > 0;
+}
+
+/**
+ * Inspect the current lock holder (or null if no one holds the lock).
+ * Used by `/lcm health` to report worker state.
+ */
+export function lockInfo(db: DatabaseSync, jobKind: WorkerJobKind): LockInfo | null {
+  const row = db
+    .prepare(
+      `SELECT job_kind, worker_id, acquired_at, expires_at, last_heartbeat_at,
+              job_session_key, job_metadata
+         FROM lcm_worker_lock WHERE job_kind = ?`,
+    )
+    .get(jobKind) as
+    | {
+        job_kind: string;
+        worker_id: string;
+        acquired_at: string;
+        expires_at: string;
+        last_heartbeat_at: string;
+        job_session_key: string | null;
+        job_metadata: string | null;
+      }
+    | undefined;
+  if (!row) return null;
+  return {
+    jobKind: row.job_kind,
+    workerId: row.worker_id,
+    acquiredAt: row.acquired_at,
+    expiresAt: row.expires_at,
+    lastHeartbeatAt: row.last_heartbeat_at,
+    jobSessionKey: row.job_session_key,
+    jobMetadata: row.job_metadata,
+  };
+}
+
+/**
+ * Generate a worker_id suitable for {@link acquireLock}. Format:
+ * `<role>-<pid>-<startMs>-<nonce>` where nonce is a 6-char hex string.
+ * Uniqueness is across-time + across-process; collisions are
+ * astronomically unlikely.
+ */
+export function generateWorkerId(role: string): string {
+  const nonce = Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, "0");
+  return `${role}-${process.pid}-${Date.now()}-${nonce}`;
+}

--- a/src/concurrency/worker-loop.ts
+++ b/src/concurrency/worker-loop.ts
@@ -1,0 +1,238 @@
+/**
+ * Generic single-process worker loop — LCM v4.1 §0.
+ *
+ * One Node process running multiple background jobs cooperatively. Each
+ * job has its own cadence (intervalMs) and runs in turn, single-threaded,
+ * with the cross-process worker_lock providing single-flight across
+ * processes.
+ *
+ * This is intentionally minimal — no thread pool, no cron expressions,
+ * no priority queue. The plugin's worker scheduling needs are simple:
+ *
+ *   - Run backfill every ~10s (when there are pending docs)
+ *   - Run extraction-queue every ~5s (when there are queued items)
+ *   - Run condensation periodically
+ *   - Run theme consolidation when idle
+ *
+ * Each job's run() function returns telemetry; the loop logs nothing on
+ * its own (callers wire telemetry / logs).
+ *
+ * Lifecycle:
+ *
+ *   const loop = new WorkerLoop(db, {
+ *     jobs: [
+ *       { kind: "embedding-backfill", intervalMs: 10_000, run: async (db) => runBackfillTick(db, opts) },
+ *       { kind: "extraction", intervalMs: 5_000, run: async (db) => runExtractionTick(db) },
+ *       ...
+ *     ],
+ *   });
+ *   loop.start();
+ *   // ... process runs ...
+ *   await loop.stop({ gracefulTimeoutMs: 30_000 });
+ *
+ * Single-process model: everything runs in this Node process. We do NOT
+ * spawn worker_threads (per v4.1.1 A9, the worker_threads scaffolding
+ * for true heartbeat-isolation is a future enhancement). For now, the
+ * loop's setInterval-driven dispatch is good enough at these cadences.
+ *
+ * Cross-process safety: the per-job `run()` MUST acquire its own
+ * lcm_worker_lock for its job_kind. Multiple processes may run the
+ * same WorkerLoop concurrently (e.g. dev box + CI on the same DB),
+ * and the lock prevents double-work.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import type { WorkerJobKind } from "./model.js";
+
+export interface WorkerJob {
+  /** Job kind matching {@link WorkerJobKind} (used for telemetry + lock). */
+  kind: WorkerJobKind;
+  /**
+   * How often to invoke `run()`. The loop schedules with setInterval so
+   * the actual cadence is approximate — drift accumulates if `run()`
+   * exceeds intervalMs.
+   */
+  intervalMs: number;
+  /**
+   * Job entrypoint. Should:
+   *   - Acquire lcm_worker_lock for `kind` (single-flight across processes)
+   *   - Do its work
+   *   - Release the lock
+   *   - Return any telemetry; loop only uses it for `onJobComplete` hook
+   *
+   * If the function throws, the loop logs to telemetry and continues —
+   * a single bad tick doesn't crash the loop. (Re-throws are NOT
+   * propagated; if the job needs to fatally abort, it should call
+   * loop.stop() explicitly first.)
+   */
+  run: (db: DatabaseSync) => Promise<unknown>;
+}
+
+export interface WorkerLoopOptions {
+  jobs: WorkerJob[];
+  /**
+   * Hook called after each job tick (success or thrown). Used for
+   * telemetry / logging. Loop never blocks on this.
+   */
+  onJobComplete?: (info: {
+    kind: WorkerJobKind;
+    durationMs: number;
+    result?: unknown;
+    error?: unknown;
+  }) => void;
+}
+
+export class WorkerLoop {
+  private readonly db: DatabaseSync;
+  private readonly jobs: WorkerJob[];
+  private readonly onJobComplete?: WorkerLoopOptions["onJobComplete"];
+  private timers: NodeJS.Timeout[] = [];
+  private running = false;
+  // Ticks currently in-flight per kind. Used by stop() to wait for
+  // graceful shutdown.
+  private inFlight: Map<WorkerJobKind, Promise<void>> = new Map();
+  // Set during start() to a unique token, checked at scheduled-tick time
+  // so stop()-then-start() doesn't run leftover ticks from the old loop.
+  private generationId = 0;
+
+  constructor(db: DatabaseSync, opts: WorkerLoopOptions) {
+    this.db = db;
+    this.jobs = opts.jobs;
+    this.onJobComplete = opts.onJobComplete;
+    this.validateJobs();
+  }
+
+  private validateJobs(): void {
+    const seen = new Set<string>();
+    for (const job of this.jobs) {
+      if (seen.has(job.kind)) {
+        throw new Error(`[worker-loop] duplicate job kind: ${job.kind}`);
+      }
+      seen.add(job.kind);
+      if (!Number.isFinite(job.intervalMs) || job.intervalMs <= 0) {
+        throw new Error(`[worker-loop] job ${job.kind} has invalid intervalMs ${job.intervalMs}`);
+      }
+    }
+  }
+
+  /**
+   * Start scheduling. Idempotent — calling on an already-running loop
+   * is a no-op (returns false; doesn't throw).
+   */
+  start(): boolean {
+    if (this.running) return false;
+    this.running = true;
+    this.generationId++;
+    const myGeneration = this.generationId;
+    for (const job of this.jobs) {
+      const timer = setInterval(() => {
+        if (!this.running || this.generationId !== myGeneration) return;
+        // Only dispatch if no in-flight tick for this kind. Skip
+        // overlapping ticks — the next interval will pick up.
+        if (this.inFlight.has(job.kind)) return;
+        const startedAt = Date.now();
+        const promise = (async () => {
+          try {
+            const result = await job.run(this.db);
+            this.onJobComplete?.({
+              kind: job.kind,
+              durationMs: Date.now() - startedAt,
+              result,
+            });
+          } catch (error: unknown) {
+            this.onJobComplete?.({
+              kind: job.kind,
+              durationMs: Date.now() - startedAt,
+              error,
+            });
+          }
+        })();
+        this.inFlight.set(job.kind, promise);
+        promise.finally(() => {
+          this.inFlight.delete(job.kind);
+        });
+      }, job.intervalMs);
+      this.timers.push(timer);
+    }
+    return true;
+  }
+
+  /**
+   * Stop scheduling. Optionally waits for in-flight ticks up to
+   * `gracefulTimeoutMs` (default 30s). Returns true if all in-flight
+   * ticks finished cleanly; false if any timed out.
+   */
+  async stop(opts: { gracefulTimeoutMs?: number } = {}): Promise<boolean> {
+    if (!this.running) return true;
+    this.running = false;
+    for (const timer of this.timers) clearInterval(timer);
+    this.timers = [];
+
+    if (this.inFlight.size === 0) return true;
+
+    const timeout = opts.gracefulTimeoutMs ?? 30_000;
+    const inFlightPromises = Array.from(this.inFlight.values());
+    const allDone = Promise.all(inFlightPromises);
+    const timer: { handle: NodeJS.Timeout | null } = { handle: null };
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timer.handle = setTimeout(() => resolve("timeout"), timeout);
+    });
+    const result = await Promise.race([
+      allDone.then(() => "done" as const),
+      timeoutPromise,
+    ]);
+    if (timer.handle) clearTimeout(timer.handle);
+    return result === "done";
+  }
+
+  /** Is the loop currently running (i.e., scheduling new ticks)? */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /** How many job kinds have a tick currently in flight? */
+  inFlightCount(): number {
+    return this.inFlight.size;
+  }
+
+  /**
+   * Run a specific job kind once, immediately, outside the regular
+   * schedule. Returns whatever the job's run() returned. Throws if
+   * the job is in flight already (use isJobRunning to check).
+   *
+   * Useful for: leaf-write hooks that want to nudge backfill, manual
+   * /lcm worker tick CLI, tests.
+   */
+  async runOnce(kind: WorkerJobKind): Promise<unknown> {
+    const job = this.jobs.find((j) => j.kind === kind);
+    if (!job) throw new Error(`[worker-loop] no job kind: ${kind}`);
+    if (this.inFlight.has(kind)) {
+      throw new Error(`[worker-loop] job ${kind} is already in flight`);
+    }
+    const startedAt = Date.now();
+    const promise = (async () => {
+      try {
+        const result = await job.run(this.db);
+        this.onJobComplete?.({
+          kind,
+          durationMs: Date.now() - startedAt,
+          result,
+        });
+        return result;
+      } catch (error: unknown) {
+        this.onJobComplete?.({
+          kind,
+          durationMs: Date.now() - startedAt,
+          error,
+        });
+        throw error;
+      }
+    })();
+    this.inFlight.set(kind, promise.then(() => undefined).catch(() => undefined));
+    try {
+      return await promise;
+    } finally {
+      this.inFlight.delete(kind);
+    }
+  }
+}

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -474,7 +474,9 @@ export function resolveLcmConfigWithDiagnostics(
       bootstrapMaxTokens: resolvedBootstrapMaxTokens,
       leafTargetTokens:
         parseFiniteInt(env.LCM_LEAF_TARGET_TOKENS)
-          ?? toNumber(pc.leafTargetTokens) ?? 2400,
+          // v4.1 (A.10): default raised from 2400 → 4000 to stop LLM-truncating
+          // dense leaves at the cap. See src/summarize.ts comment.
+          ?? toNumber(pc.leafTargetTokens) ?? 4000,
       condensedTargetTokens:
         parseFiniteInt(env.LCM_CONDENSED_TARGET_TOKENS)
           ?? toNumber(pc.condensedTargetTokens) ?? 2000,

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { assertForeignKeysEnabled } from "../concurrency/model.js";
 
 type ConnectionKey = string;
 /**
@@ -51,6 +52,11 @@ function configureConnection(db: DatabaseSync): DatabaseSync {
   db.exec("PRAGMA journal_mode = WAL");
   db.exec(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
   db.exec("PRAGMA foreign_keys = ON");
+  // v4.1 B.fix — Gap 7: verify the PRAGMA actually took effect. Catches
+  // future regressions where a code path opens a connection that bypasses
+  // configureConnection and leaves FK enforcement off — making every
+  // ON DELETE CASCADE in the schema a silent no-op.
+  assertForeignKeysEnabled(db);
   // 64MB page cache (default 2MB is severely undersized for multi-GB databases
   // with concurrent agents). Memory is demand-allocated, released on close.
   db.exec("PRAGMA cache_size = -65536");
@@ -112,7 +118,11 @@ function closeDatabase(db: DatabaseSync | undefined): void {
  */
 export function createLcmDatabaseConnection(dbPath: string): DatabaseSync {
   ensureDbDirectory(dbPath);
-  const db = new DatabaseSync(dbPath);
+  // v4.1 Final.review P1 #1 fix: open with allowExtension=true so
+  // sqlite-vec can be loaded. Without this, db.loadExtension() throws
+  // and the entire v4.1 semantic feature is silently inert in
+  // production (autostart pre-flight returns NO_OP).
+  const db = new DatabaseSync(dbPath, { allowExtension: true });
   try {
     configureConnection(db);
   } catch (err) {

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -109,6 +109,91 @@ function ensureSummaryModelColumn(db: DatabaseSync): void {
   }
 }
 
+/**
+ * v4.1 schema additions to `summaries`:
+ *   - session_key                  (v3.1 A1: cross-conv identity for assemble + retrieval)
+ *   - suppressed_at                (v3.1 A3: lossless-forget flag; cascade triggers)
+ *   - entity_index                 (v3.1: JSON sidecar populated by §7.2 entity coreference)
+ *   - contains_suppressed_leaves   (v3.1 A3: marks condensed needing idle rebuild)
+ *   - suppress_reason              (v4.1.1 A2: read by lcm_describe; written by lcm_suppress)
+ *   - superseded_by                (v4.1.1 A2: forwarder pattern; idle rebuild keeps old row immutable
+ *                                   and points to new row via this FK)
+ *   - leaf_summarizer_cap_was      (v4.1: forensic marker for the 2,415-token cap fix; NULL =
+ *                                   leaf was never capped or has been regenerated)
+ *
+ * SQLite ADD COLUMN constraints satisfied:
+ *   - No PRIMARY KEY / UNIQUE in any new column.
+ *   - No CURRENT_TIMESTAMP defaults.
+ *   - NOT NULL columns have non-NULL defaults.
+ *   - REFERENCES columns have NULL default (per SQLite ADD COLUMN with FK rule).
+ */
+function ensureSummaryV41Columns(db: DatabaseSync): void {
+  const cols = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
+  const has = (name: string): boolean => cols.some((c) => c.name === name);
+
+  if (!has("session_key")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN session_key TEXT NOT NULL DEFAULT ''`);
+  }
+  if (!has("suppressed_at")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN suppressed_at TEXT`);
+  }
+  if (!has("entity_index")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN entity_index TEXT`);
+  }
+  if (!has("contains_suppressed_leaves")) {
+    db.exec(
+      `ALTER TABLE summaries ADD COLUMN contains_suppressed_leaves INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+  if (!has("suppress_reason")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN suppress_reason TEXT`);
+  }
+  if (!has("superseded_by")) {
+    // FK with SET NULL on parent delete. SQLite ADD COLUMN with REFERENCES requires NULL default.
+    db.exec(
+      `ALTER TABLE summaries ADD COLUMN superseded_by TEXT REFERENCES summaries(summary_id) ON DELETE SET NULL`,
+    );
+  }
+  if (!has("leaf_summarizer_cap_was")) {
+    db.exec(`ALTER TABLE summaries ADD COLUMN leaf_summarizer_cap_was INTEGER`);
+  }
+}
+
+/**
+ * v3.1 A3 (extended in v4.1.1 A3): suppression cascade reaches raw messages
+ * via `messages.suppressed_at`. All message-search read paths
+ * (conversation-store FTS / LIKE / regex + grep mode='verbatim') filter on this.
+ */
+function ensureMessageSuppressedAtColumn(db: DatabaseSync): void {
+  const cols = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
+  const hasSuppressedAt = cols.some((c) => c.name === "suppressed_at");
+  if (!hasSuppressedAt) {
+    db.exec(`ALTER TABLE messages ADD COLUMN suppressed_at TEXT`);
+  }
+}
+
+/**
+ * v4.1.1 A8 — feature-flag storage for v4.1 sections (e.g. semantic
+ * retrieval can be disabled if vec0 extension fails to load).
+ *
+ * Code-as-ground-truth note: v4.1.1 A8 originally proposed extending
+ * `lcm_migration_flags` with a `value` column. That table doesn't exist
+ * in the upstream source — it's a fork-side legacy table that only
+ * exists on Eva's live DB. This implementation creates a clean new
+ * `lcm_feature_flags` table that doesn't conflict with the legacy table.
+ */
+function ensureLcmFeatureFlagsTable(db: DatabaseSync): void {
+  // Note: explicit NOT NULL on the TEXT PRIMARY KEY column — SQLite's
+  // legacy behavior allows NULL in TEXT PK columns without it.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS lcm_feature_flags (
+      flag TEXT NOT NULL PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+}
+
 function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   const telemetryColumns = db.prepare(`PRAGMA table_info(conversation_compaction_telemetry)`).all() as SummaryColumnInfo[];
   const hasConsecutiveColdObservations = telemetryColumns.some(
@@ -867,7 +952,17 @@ function ensureStandaloneFtsTable(db: DatabaseSync, spec: FtsTableSpec): void {
 
 export function runLcmMigrations(
   db: DatabaseSync,
-  options?: { fts5Available?: boolean; log?: MigrationLogger },
+  options?: {
+    fts5Available?: boolean;
+    log?: MigrationLogger;
+    /**
+     * Accepted for forward-compatibility. This migration creates the
+     * lcm_prompt_registry table; seeding it with default prompts is
+     * performed by the synthesis layer in a later PR. Until then this
+     * option is a no-op (schema/concurrency tests pass `false`).
+     */
+    seedDefaultPrompts?: boolean;
+  },
 ): void {
   const log = options?.log;
   let transactionActive = false;
@@ -1265,6 +1360,751 @@ export function runLcmMigrations(
         }
       });
     }
+
+    // ── v4.1 schema additions ────────────────────────────────────────────────
+    // Each block resolves a specific amendment from architecture-v4.1.1.md.
+    // Tables are created idempotently so the migration is safe to re-run.
+    //
+    // v4.1.1 A9 — `lcm_worker_lock`: cross-process job lock for the worker
+    // sidecar (condensation, extraction, embedding backfill, theme
+    // consolidation, eval, profile rebuild). `last_heartbeat_at` is
+    // required by §0.5 fallback rule (gateway can take over only when
+    // BOTH `expires_at < now` AND `last_heartbeat_at < now - 300s`).
+    // See `src/concurrency/model.ts` for the invariants and constants.
+    runMigrationStep("ensureLcmWorkerLockTable", log, () => {
+      // Note: explicit NOT NULL on the TEXT PRIMARY KEY column — SQLite's
+      // legacy behavior allows NULL in TEXT PK columns without it.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_worker_lock (
+          job_kind TEXT NOT NULL PRIMARY KEY,
+          worker_id TEXT NOT NULL,
+          acquired_at TEXT NOT NULL DEFAULT (datetime('now')),
+          expires_at TEXT NOT NULL,
+          last_heartbeat_at TEXT NOT NULL DEFAULT (datetime('now')),
+          job_session_key TEXT,
+          job_metadata TEXT
+        )
+      `);
+    });
+
+    // v3.1 A1/A3 + v4.1.1 A2 — additive columns on summaries (session_key,
+    // suppressed_at, entity_index, contains_suppressed_leaves, suppress_reason,
+    // superseded_by, leaf_summarizer_cap_was). Idempotent via PRAGMA check.
+    runMigrationStep("ensureSummaryV41Columns", log, () => ensureSummaryV41Columns(db));
+
+    // v3.1 A3 — messages.suppressed_at for raw-message suppression cascade.
+    runMigrationStep("ensureMessageSuppressedAtColumn", log, () =>
+      ensureMessageSuppressedAtColumn(db),
+    );
+
+    // v4.1.1 A8 — feature flags for v4.1 sections (e.g. v4_section_1_enabled
+    // when vec0 extension is available). Creates clean new table; does NOT
+    // touch Eva's legacy lcm_migration_flags table.
+    runMigrationStep("ensureLcmFeatureFlagsTable", log, () =>
+      ensureLcmFeatureFlagsTable(db),
+    );
+
+    // v4.1.1 A3 — lcm_extraction_queue: gateway atomically inserts a row
+    // alongside every leaf write; worker picks up the queue to run entity
+    // coreference (and procedure-recheck on demand). Per v4.1.1 A3 + B18
+    // atomicity rule: leaf-write transaction MUST insert the queue row in
+    // the same transaction as the leaf insert (Group B leaf-write code).
+    runMigrationStep("ensureLcmExtractionQueueTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_extraction_queue (
+          queue_id TEXT NOT NULL PRIMARY KEY,
+          leaf_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          kind TEXT NOT NULL CHECK (kind IN ('entity', 'procedure-recheck')),
+          queued_at TEXT NOT NULL DEFAULT (datetime('now')),
+          picked_at TEXT,
+          worker_id TEXT,
+          completed_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_extraction_queue_pending_idx
+          ON lcm_extraction_queue (queued_at)
+          WHERE picked_at IS NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_extraction_queue_dead_letter_idx
+          ON lcm_extraction_queue (attempts)
+          WHERE attempts >= 5
+      `);
+    });
+
+    // v4.1.1 B2 — lcm_purge_rebuild_queue REMOVED in first-principles pass
+    // (2026-05-06). The hard-delete drainer worker (`runPurge --immediate`)
+    // was never built (~20-40h work, HIGH risk to assemble-pyramid
+    // invariants). Schema + producer code preserved in deferred-features
+    // draft PR (#616). Without the queue table, runPurge always operates
+    // in soft mode (which is what it actually does today anyway).
+
+    // v4.1.1 B3 — lcm_voyage_rate_state REMOVED in first-principles pass
+    // (2026-05-06). Table-only feature, ZERO production readers/writers.
+    // Per-process throttle in voyage/client.ts covers single-gateway use.
+    // Schema + tests preserved in deferred-features draft PR (#616). When
+    // multi-gateway scenario emerges, re-add with the cross-process
+    // coordination pattern documented at the original site.
+
+    // v4.1.1 §C item — lcm_session_key_audit: reversibility log for the
+    // §2.1 step 1 re-key of 5 legacy convs to agent:main:main. Eva can
+    // run /lcm undo-session-key-rekey <conversation_id> if the spike's
+    // identification turns out to be wrong for any of those convs.
+    runMigrationStep("ensureLcmSessionKeyAuditTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_session_key_audit (
+          audit_id TEXT NOT NULL PRIMARY KEY,
+          conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+          original_session_key TEXT,
+          new_session_key TEXT NOT NULL,
+          reason TEXT NOT NULL,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+          applied_by TEXT NOT NULL DEFAULT 'migration'
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_session_key_audit_conv_idx
+          ON lcm_session_key_audit (conversation_id, applied_at DESC)
+      `);
+    });
+
+    // ── v4.1 synthesis layer (A.04) ─────────────────────────────────────────
+    // Prompt registry → synthesis cache (FK on prompt_id) → audit trail (FK
+    // on both summary_id and cache_id, CHECK that at least one is set).
+    // Tables created in dependency order so FKs work on first run.
+    //
+    // v4.1 §3 + v4.1.1 D items — lcm_prompt_registry: versioned prompts per
+    // memory_type × tier × pass_kind. Append-only (old versions deactivated,
+    // never deleted). bundle_version groups synchronized prompt sets so
+    // voice-consistency rebuild fires on bundle delta.
+    runMigrationStep("ensureLcmPromptRegistryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_prompt_registry (
+          prompt_id TEXT NOT NULL PRIMARY KEY,
+          memory_type TEXT NOT NULL CHECK (memory_type IN (
+            'episodic-leaf',
+            'episodic-condensed',
+            'episodic-yearly',
+            'procedural-extract',
+            'entity-extract',
+            'theme-consolidation'
+          )),
+          tier_label TEXT,
+          pass_kind TEXT NOT NULL CHECK (pass_kind IN ('single', 'verify_fidelity', 'best_of_n_judge')),
+          version INTEGER NOT NULL,
+          template TEXT NOT NULL,
+          model_recommendation TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          active INTEGER NOT NULL DEFAULT 1,
+          bundle_version INTEGER NOT NULL DEFAULT 1,
+          notes TEXT,
+          UNIQUE(memory_type, tier_label, pass_kind, version)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_prompt_registry_active_idx
+          ON lcm_prompt_registry (memory_type, tier_label, pass_kind)
+          WHERE active = 1
+      `);
+    });
+
+    // v4.1 B.fix — Gap 2: catch NULL tier_label collisions that the
+    // table's UNIQUE constraint admits (SQLite treats multiple NULLs
+    // as distinct in UNIQUE). COALESCE-based index follows the same
+    // pattern used for lcm_synthesis_cache_lookup_uniq.
+    runMigrationStep("ensureLcmPromptRegistryNullSafeUniqueIdx", log, () => {
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_prompt_registry_uniq_lookup
+          ON lcm_prompt_registry (
+            memory_type, COALESCE(tier_label, ''), pass_kind, version
+          )
+      `);
+    });
+
+    // v4.1 Final.review.3 (Loop 4 Bug 4.4) — widen lcm_synthesis_cache.tier_label
+    // CHECK to include all tier values dispatch may produce. Original CHECK
+    // only allowed ('year', 'custom', 'filtered'); dispatch tier vocabulary
+    // is ('daily', 'weekly', 'monthly', 'yearly', 'custom', 'filtered').
+    // Latent BLOCKER: yearly synthesis would crash on cache write because
+    // `tier_label='yearly'` was rejected by the old CHECK.
+    //
+    // SQLite can't ALTER a CHECK constraint, so we DROP+recreate. SAFE because
+    // lcm_synthesis_cache is REBUILDABLE by design (it's a cache, not bedrock).
+    // Idempotent: only fires if existing CHECK is the old narrow form.
+    runMigrationStep("widenLcmSynthesisCacheTierCheck_v413", log, () => {
+      const existing = db
+        .prepare(
+          `SELECT sql FROM sqlite_master
+             WHERE type='table' AND name='lcm_synthesis_cache'`,
+        )
+        .get() as { sql: string } | undefined;
+      if (!existing) return; // table doesn't exist yet; the next step creates it with new CHECK
+      // Detect the OLD CHECK signature. The new CHECK contains 'monthly'
+      // (one of the new values); old does not. Skip-if-already-widened.
+      if (existing.sql.includes("'monthly'") || existing.sql.includes('"monthly"')) {
+        return;
+      }
+      // Old CHECK detected → rebuildable, just DROP. Cache rows are derivable
+      // from primary sources (raw leaves + prompts).
+      //
+      // Wave-1 Auditor #1 finding #3 (HIGH): if `foreign_keys = OFF` during
+      // migration (the common pattern for ratchet steps), `lcm_synthesis_audit`
+      // rows referencing the dropped cache_ids become DANGLING — they survive
+      // the DROP but their target_cache_id no longer exists. Clean them up
+      // BEFORE the DROP so we never leave orphans pointing to recreated
+      // cache_ids that might be re-used. Audit rows are themselves
+      // rebuildable (re-run the synthesis pass and the new audits land).
+      // Wave-2 Auditor #8 fix F2: narrow the catch to expected error
+      // ("no such table"). Previously the bare catch swallowed any error
+      // (corrupted DB, schema mismatch, etc.) — too broad.
+      try {
+        db.exec(
+          `DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`,
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!/no such table.*lcm_synthesis_audit/i.test(msg)) {
+          throw e;
+        }
+        // Audit table doesn't exist yet (first migration of an old DB);
+        // nothing to clean. Continue.
+      }
+      db.exec(`DROP TABLE IF EXISTS lcm_synthesis_cache`);
+      log?.info?.(
+        "[migration] dropped lcm_synthesis_cache (old narrow CHECK; rebuildable; recreated next step with widened CHECK; orphaned audit rows pruned)",
+      );
+    });
+
+    // v3.1 A8 + v4.1.1 B4 — lcm_synthesis_cache: rebuildable derived layer
+    // for ad-hoc synthesize() output (custom ranges + filtered grep + yearly
+    // tier per A2). Has `status='building'` single-flight (v3.1 A8) and
+    // prompt_id FK (v4.1.1 B2 fix — cache invalidation can be prompt-selective).
+    // UNIQUE lookup index (v4.1.1 B4) enables `INSERT OR IGNORE` cross-process
+    // single-flight pattern (loser of race reads back the in-flight row).
+    runMigrationStep("ensureLcmSynthesisCacheTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_synthesis_cache (
+          cache_id TEXT NOT NULL PRIMARY KEY,
+          session_key TEXT NOT NULL,
+          range_start TEXT NOT NULL,
+          range_end TEXT NOT NULL,
+          grep_filter TEXT,
+          leaf_fingerprint TEXT NOT NULL,
+          content TEXT,
+          entity_index TEXT NOT NULL DEFAULT '{}',
+          model_used TEXT NOT NULL,
+          prompt_id TEXT NOT NULL REFERENCES lcm_prompt_registry(prompt_id) ON DELETE RESTRICT,
+          tier_label TEXT NOT NULL CHECK (tier_label IN ('year', 'yearly', 'monthly', 'weekly', 'daily', 'custom', 'filtered')),
+          source_leaf_ids TEXT NOT NULL,
+          source_condensed_ids TEXT,
+          built_at TEXT NOT NULL DEFAULT (datetime('now')),
+          source_token_count INTEGER NOT NULL,
+          output_token_count INTEGER NOT NULL,
+          actual_range_covered TEXT NOT NULL,
+          leaf_count_synthesized INTEGER NOT NULL,
+          status TEXT NOT NULL DEFAULT 'ready'
+            CHECK (status IN ('building', 'ready', 'failed')),
+          building_started_at TEXT,
+          failure_reason TEXT
+        )
+      `);
+      // UNIQUE lookup index (v4.1.1 B4): enables INSERT OR IGNORE for
+      // cross-process single-flight. Both gateway + worker can attempt to
+      // create the same cache row; exactly one wins.
+      //
+      // Wave-10 reviewer P1 fix: previously the UNIQUE index keyed on
+      // (session_key, range_start, range_end, leaf_fingerprint, grep_filter)
+      // — NO `prompt_id` and NO `tier_label`. Two correctness bugs:
+      //   1. Same range/leaves with `tier='custom'` then `tier='filtered'`
+      //      collided on the UNIQUE index — INSERT OR IGNORE silently
+      //      returned the wrong-tier cached text.
+      //   2. When the active prompt changed via registerPrompt(), the
+      //      cache continued to serve text generated by the OLD prompt
+      //      because the lookup ignored prompt_id.
+      // Fix: include `tier_label` and `prompt_id` in the UNIQUE index so
+      // distinct (tier, prompt) combinations get distinct cache rows.
+      // Drop+recreate the index — cache is fully rebuildable so wiping
+      // existing rows on the new key is safe (callers re-synthesize).
+      db.exec(`DROP INDEX IF EXISTS lcm_synthesis_cache_lookup_uniq`);
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_synthesis_cache_lookup_uniq
+          ON lcm_synthesis_cache (session_key, range_start, range_end,
+                                  leaf_fingerprint,
+                                  COALESCE(grep_filter, ''),
+                                  tier_label,
+                                  prompt_id)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_cache_built_idx
+          ON lcm_synthesis_cache (session_key, built_at DESC)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_cache_status_building_idx
+          ON lcm_synthesis_cache (building_started_at)
+          WHERE status = 'building'
+      `);
+    });
+
+    // v3.1 A3 (extension) — lcm_cache_leaf_refs: inverse index for the
+    // proactive purge path. When a leaf is suppressed, query this table
+    // to find every cache_id that referenced it; delete those rows so
+    // stale content doesn't get served. CASCADE both directions so the
+    // refs go when either parent (cache_id or leaf_summary_id) is deleted.
+    runMigrationStep("ensureLcmCacheLeafRefsTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_cache_leaf_refs (
+          cache_id TEXT NOT NULL REFERENCES lcm_synthesis_cache(cache_id) ON DELETE CASCADE,
+          leaf_summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          PRIMARY KEY (cache_id, leaf_summary_id)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_cache_leaf_refs_by_leaf_idx
+          ON lcm_cache_leaf_refs (leaf_summary_id)
+      `);
+    });
+
+    // v4.1.1 B1 — lcm_synthesis_audit: per-pass log for synthesis (draft,
+    // verify_fidelity, best-of-N drafts, judge). pass_output is NULLable
+    // so it can be inserted BEFORE the LLM call returns (status='started');
+    // post-LLM UPDATE sets pass_output + status='completed'/'failed'.
+    // pass_session_id groups all passes of one logical synthesis attempt
+    // (helps debug best-of-N runs + GC orphaned partial sessions).
+    runMigrationStep("ensureLcmSynthesisAuditTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_synthesis_audit (
+          audit_id TEXT NOT NULL PRIMARY KEY,
+          pass_session_id TEXT NOT NULL,
+          target_summary_id TEXT REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          target_cache_id TEXT REFERENCES lcm_synthesis_cache(cache_id) ON DELETE CASCADE,
+          prompt_id TEXT NOT NULL REFERENCES lcm_prompt_registry(prompt_id) ON DELETE RESTRICT,
+          pass_kind TEXT NOT NULL,
+          pass_input_truncated TEXT NOT NULL,
+          pass_output TEXT,
+          status TEXT NOT NULL DEFAULT 'started'
+            CHECK (status IN ('started', 'completed', 'failed')),
+          model_used TEXT NOT NULL,
+          latency_ms INTEGER,
+          cost_usd_cents INTEGER,
+          last_error TEXT,
+          ran_at TEXT NOT NULL DEFAULT (datetime('now')),
+          CHECK (target_summary_id IS NOT NULL OR target_cache_id IS NOT NULL)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_target_summary_idx
+          ON lcm_synthesis_audit (target_summary_id, ran_at DESC)
+          WHERE target_summary_id IS NOT NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_target_cache_idx
+          ON lcm_synthesis_audit (target_cache_id, ran_at DESC)
+          WHERE target_cache_id IS NOT NULL
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_session_idx
+          ON lcm_synthesis_audit (pass_session_id)
+      `);
+      // GC index: orphaned 'started' rows stuck >1h (v4.1.1 B1 GC pattern)
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_started_gc_idx
+          ON lcm_synthesis_audit (ran_at)
+          WHERE status = 'started'
+      `);
+      // Wave-3 Auditor #1 fix M1: add a parallel index for the 30-day GC
+      // sweep on `completed`/`failed` rows. Without this, the GC runs a
+      // full table scan on every `lcm_synthesize_around` call (the GC is
+      // inline per-call by design). With this partial index, the sweep
+      // is O(log n) on a hot DB.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_synthesis_audit_completed_gc_idx
+          ON lcm_synthesis_audit (ran_at)
+          WHERE status IN ('completed', 'failed')
+      `);
+    });
+
+    // ── v4.1 eval harness tables (A.05) ─────────────────────────────────────
+    // Per v4.1 §11 + v4.1.1 (revising the v4 design): N≥100 stratified
+    // queries, 2× empirical SD threshold (calibrate by 5x repeated runs),
+    // ensemble judge, mixed absolute+pairwise per dimension, drift index
+    // for cumulative regression. Measures BOTH retrieval recall AND
+    // synthesis quality (separate metrics, not collapsed).
+    runMigrationStep("ensureLcmEvalQuerySetTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_query_set (
+          query_set_id TEXT NOT NULL PRIMARY KEY,
+          version INTEGER NOT NULL,
+          description TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalQueryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_query (
+          query_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          query_text TEXT NOT NULL,
+          stratum TEXT NOT NULL CHECK (stratum IN ('fts-easy', 'fts-medium', 'paraphrastic')),
+          expected_topics TEXT NOT NULL,
+          expected_sources TEXT,
+          reference_summary TEXT,
+          must_not_regress INTEGER NOT NULL DEFAULT 0,
+          rubric TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_query_set_stratum_idx
+          ON lcm_eval_query (query_set_id, stratum)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_query_must_not_regress_idx
+          ON lcm_eval_query (query_set_id)
+          WHERE must_not_regress = 1
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalRunTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_run (
+          run_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          prompt_bundle_version INTEGER NOT NULL,
+          ran_at TEXT NOT NULL DEFAULT (datetime('now')),
+          retrieval_recall_score REAL NOT NULL,
+          synthesis_quality_score REAL NOT NULL,
+          per_query_scores TEXT NOT NULL,
+          judge_models TEXT NOT NULL,
+          noise_floor_sd REAL,
+          trigger TEXT NOT NULL CHECK (trigger IN ('manual', 'prompt-update', 'model-update', 'ci', 'nightly'))
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_run_recent_idx
+          ON lcm_eval_run (query_set_id, ran_at DESC)
+      `);
+    });
+
+    runMigrationStep("ensureLcmEvalDriftTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_eval_drift (
+          drift_id TEXT NOT NULL PRIMARY KEY,
+          query_set_id TEXT NOT NULL REFERENCES lcm_eval_query_set(query_set_id) ON DELETE CASCADE,
+          cumulative_delta REAL NOT NULL,
+          window_runs INTEGER NOT NULL,
+          computed_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_eval_drift_recent_idx
+          ON lcm_eval_drift (query_set_id, computed_at DESC)
+      `);
+    });
+
+    // ── v4.1 entity layer (A.06) ────────────────────────────────────────────
+    // Per v4.1 §7 + v4.1.1 B5/B6 — simplified entity schema (no separate
+    // lcm_aliases table; alternate surface forms denormalized into
+    // lcm_entities.alternate_surfaces JSON; entity embeddings live in
+    // vec0 with embedded_kind='entity'). Coreference uses entity-table
+    // lookup (B6), not the v4 ±N leaf positional window.
+    //
+    // entity_type is freeform TEXT (no CHECK constraint per v4.1.1
+    // §C — Eva's domain has session_keys, config_flags, error_codes,
+    // R-XXX agent IDs, etc. that don't fit a closed enum). The
+    // type_registry table tracks first-seen + occurrence count per type
+    // so the operator can review/normalize types post-hoc.
+    runMigrationStep("ensureLcmEntityTypeRegistryTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entity_type_registry (
+          type_name TEXT NOT NULL PRIMARY KEY,
+          first_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+          occurrence_count INTEGER NOT NULL DEFAULT 1
+        )
+      `);
+    });
+
+    // v4.1.1 B4 — UNIQUE index on (session_key, canonical_text COLLATE NOCASE)
+    // enables INSERT OR IGNORE for cross-process entity coref single-flight.
+    runMigrationStep("ensureLcmEntitiesTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entities (
+          entity_id TEXT NOT NULL PRIMARY KEY,
+          session_key TEXT NOT NULL,
+          canonical_text TEXT NOT NULL,
+          entity_type TEXT NOT NULL,
+          first_seen_at TEXT NOT NULL,
+          last_seen_at TEXT NOT NULL,
+          first_seen_in_summary_id TEXT REFERENCES summaries(summary_id) ON DELETE SET NULL,
+          occurrence_count INTEGER NOT NULL DEFAULT 1,
+          alternate_surfaces TEXT,
+          metadata TEXT
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entities_lookup_idx
+          ON lcm_entities (session_key, entity_type, last_seen_at DESC)
+      `);
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS lcm_entities_canonical_uniq
+          ON lcm_entities (session_key, canonical_text COLLATE NOCASE)
+      `);
+    });
+
+    runMigrationStep("ensureLcmEntityMentionsTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_entity_mentions (
+          mention_id TEXT NOT NULL PRIMARY KEY,
+          entity_id TEXT NOT NULL REFERENCES lcm_entities(entity_id) ON DELETE CASCADE,
+          summary_id TEXT NOT NULL REFERENCES summaries(summary_id) ON DELETE CASCADE,
+          surface_form TEXT NOT NULL,
+          span_start INTEGER,
+          span_end INTEGER,
+          mentioned_at TEXT NOT NULL
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entity_mentions_by_entity_idx
+          ON lcm_entity_mentions (entity_id, mentioned_at DESC)
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_entity_mentions_by_summary_idx
+          ON lcm_entity_mentions (summary_id)
+      `);
+    });
+
+    // v4.1 §7.1 — procedures feature was REMOVED in first-principles pass
+    // (2026-05-06). Schema (lcm_procedures) + worker (mineProceduresPass) +
+    // prefilter all preserved in deferred-features draft PR (#616). Cut
+    // reason: 0% shipped (no agent tool, no LLM injection, no auto-tick)
+    // per challenger agent C5. Will ship as focused PR with worker +
+    // lcm_get_procedure / lcm_search_procedures agent tools together.
+
+    // v3 + v4.1 §7.3 — intentions feature was REMOVED in first-principles
+    // pass (2026-05-06). Schema (lcm_intentions) + prospective-extract
+    // prompt template all preserved in deferred-features draft PR (#616).
+    // Cut reason: ZERO producer, ZERO consumer, ZERO agent tools, served
+    // ZERO of the 25 test cases. Per challenger agent C3 at 99% confidence.
+
+    // ── v4.1 embedding registry tables (A.07) ───────────────────────────────
+    // Per v4.1 §1 + v4.1.1 A5/A7 — these are the MANAGED tables (regular
+    // SQLite tables, not vec0 virtual). The vec0 table itself
+    // (`lcm_embeddings_<model_slug>` virtual table) defers to Group B
+    // because creating a vec0 table requires the sqlite-vec extension to
+    // be loaded — which is best-effort (graceful degrade per v4.1.1 A7
+    // splits the migration into Transaction 1 = required schema (this
+    // file) + Transaction 2 = vec0 + triggers (loaded at runtime in
+    // src/embeddings/store.ts during Group B)).
+    //
+    // lcm_embedding_profile: registry of embedding models (active/archive).
+    // Used by Group B's profile-versioning logic. seed row added during
+    // Group B startup when sqlite-vec successfully loads.
+    runMigrationStep("ensureLcmEmbeddingProfileTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_embedding_profile (
+          model_name TEXT NOT NULL PRIMARY KEY,
+          dim INTEGER NOT NULL,
+          registered_at TEXT NOT NULL DEFAULT (datetime('now')),
+          active INTEGER NOT NULL DEFAULT 1,
+          archive_after TEXT
+        )
+      `);
+    });
+
+    // lcm_embedding_meta: sidecar for non-vector queries (model attribution,
+    // backfill progress, archival state). Composite PK supports parallel
+    // rows during model-bump cutover (one summary embedded under both
+    // old + new model). NOTE: no FK to summaries (polymorphic — embedded_id
+    // can also reference lcm_entities.entity_id or lcm_themes.theme_id).
+    // Polymorphic-orphan cleanup deferred to Group B's idle pass.
+    runMigrationStep("ensureLcmEmbeddingMetaTable", log, () => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS lcm_embedding_meta (
+          embedded_id TEXT NOT NULL,
+          embedded_kind TEXT NOT NULL CHECK (embedded_kind IN ('summary', 'entity', 'theme')),
+          embedding_model TEXT NOT NULL REFERENCES lcm_embedding_profile(model_name) ON DELETE RESTRICT,
+          embedded_at TEXT NOT NULL DEFAULT (datetime('now')),
+          source_token_count INTEGER NOT NULL,
+          archived INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (embedded_id, embedded_kind, embedding_model)
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_embedding_meta_active_idx
+          ON lcm_embedding_meta (embedding_model, embedded_at DESC)
+          WHERE archived = 0
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS lcm_embedding_meta_by_kind_idx
+          ON lcm_embedding_meta (embedded_kind, embedded_id)
+      `);
+    });
+
+    // v4.1 B.03 — meta-table cleanup trigger on summaries hard-delete.
+    //
+    // lcm_embedding_meta has no FK to summaries (polymorphic embedded_id —
+    // can also reference lcm_entities or lcm_themes). So FK CASCADE can't
+    // do this cleanup. Trigger fires on summaries DELETE and removes only
+    // the rows for the corresponding summary (kind='summary' filter so we
+    // never accidentally delete entity/theme meta).
+    //
+    // Note: this trigger is INDEPENDENT of the per-model triggers in
+    // src/embeddings/store.ts. Those handle vec0 cleanup (one per
+    // active embedding model). This trigger handles the SHARED meta
+    // sidecar that exists once regardless of how many models are active.
+    runMigrationStep("ensureLcmEmbeddingMetaCleanupTrigger", log, () => {
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS lcm_embedding_meta_cleanup_summary
+          AFTER DELETE ON summaries
+          BEGIN
+            DELETE FROM lcm_embedding_meta
+              WHERE embedded_id = OLD.summary_id
+                AND embedded_kind = 'summary';
+          END
+      `);
+    });
+
+    // v4.1 §6.3 / Group G — themes feature was REMOVED in first-principles
+    // pass (2026-05-06). Schema (lcm_themes, lcm_theme_sources) + worker
+    // (consolidateThemesPass) + 3 agent tools all preserved in draft PR
+    // feat/lcm-v4.1-deferred-features (PR #616). They'll come back as a
+    // focused PR with worker auto-tick + LLM injection wired together.
+    // Cut reason: half-shipped UX (tools shipped but worker had no auto-tick;
+    // operators couldn't manually trigger via /lcm worker tick) per C3+C5.
+
+    // ── v4.1 indexes on summaries (A.08) ────────────────────────────────────
+    // These are CONDITIONAL on the v4.1 columns existing (added by A.02
+    // ensureSummaryV41Columns above), so we run them after that step.
+    // CREATE INDEX IF NOT EXISTS is idempotent.
+    //
+    // ── v4.1 data cleanup migration (A.09) ─────────────────────────────────
+    // General cleanup that runs on any DB. Specifically per-user re-keying
+    // (e.g. Eva's 5 legacy convs → agent:main:main) is OPERATOR-DRIVEN via
+    // Group F's `/lcm reconcile-session-keys` — NOT hardcoded into upstream
+    // migration code.
+    //
+    // Steps (each idempotent + audited):
+    //   1. Backfill conversations.session_key NULL → 'legacy:conv_<id>'
+    //      Records each re-key in lcm_session_key_audit.
+    //   2. Backfill summaries.session_key='' → conversations.session_key
+    //      (JOIN). This targets the rows that A.02 added with the default
+    //      empty-string value.
+    runMigrationStep("backfillConversationSessionKeys", log, () => {
+      // Audit each re-key BEFORE applying it (so the audit row exists even
+      // if the UPDATE fails for any row). Uses ULID-shape audit_id derived
+      // from conversation_id for idempotency (re-running won't duplicate
+      // audit rows for already-keyed convs).
+      db.exec(`
+        INSERT OR IGNORE INTO lcm_session_key_audit
+          (audit_id, conversation_id, original_session_key, new_session_key, reason, applied_by)
+        SELECT
+          'audit-backfill-conv-' || conversation_id,
+          conversation_id,
+          NULL,
+          'legacy:conv_' || conversation_id,
+          'v4.1 A.09: NULL session_key backfilled with legacy: prefix to enable cross-conv lookups',
+          'migration'
+        FROM conversations
+        WHERE session_key IS NULL
+      `);
+      db.exec(`
+        UPDATE conversations
+        SET session_key = 'legacy:conv_' || conversation_id
+        WHERE session_key IS NULL
+      `);
+    });
+
+    runMigrationStep("backfillSummarySessionKeys", log, () => {
+      // For every summary whose session_key is still '' (the A.02 default),
+      // populate it from the parent conversation. After step 1 above ran,
+      // conversations.session_key is non-NULL for every conv, so this
+      // covers all summaries.
+      db.exec(`
+        UPDATE summaries
+        SET session_key = (
+          SELECT c.session_key FROM conversations c
+          WHERE c.conversation_id = summaries.conversation_id
+        )
+        WHERE session_key = ''
+      `);
+    });
+
+    // Forward-compat: if Eva's fork-side lcm_rollups table exists on this DB
+    // (not in upstream src/), backfill its session_key column similarly
+    // (the table is otherwise out-of-scope for v4.1 — synthesis_cache replaces it).
+    // We only touch it if it exists AND has the session_key column. No-op
+    // on a fresh upstream install.
+    runMigrationStep("backfillForkRollupsSessionKeys", log, () => {
+      const hasRollupsTable = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name = 'lcm_rollups'`,
+        )
+        .get() as { name?: string } | undefined;
+      if (!hasRollupsTable) return;
+
+      const rollupCols = db
+        .prepare(`PRAGMA table_info(lcm_rollups)`)
+        .all() as Array<{ name: string }>;
+      const hasSessionKeyCol = rollupCols.some((c) => c.name === "session_key");
+      if (!hasSessionKeyCol) return;
+
+      // Backfill: rollups with empty session_key get it from their parent conv.
+      db.exec(`
+        UPDATE lcm_rollups
+        SET session_key = COALESCE(
+          (SELECT c.session_key FROM conversations c
+           WHERE c.conversation_id = lcm_rollups.conversation_id),
+          ''
+        )
+        WHERE session_key = '' OR session_key IS NULL
+      `);
+    });
+
+    // session_key index supports cross-conv assemble (PR #338 session-family
+    // scope) + every retrieval surface that filters by scope.
+    runMigrationStep("ensureSummariesV41Indexes", log, () => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_session_key_kind_latest_idx
+          ON summaries (session_key, kind, latest_at DESC)
+          WHERE session_key != ''
+      `);
+      // suppressed_at filter index — every retrieval surface filters
+      // WHERE suppressed_at IS NULL per v3.1 A3 invariant. Partial index
+      // is small (only suppressed rows; NULL-row count grows with corpus
+      // but suppressed-row count stays small).
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_suppressed_idx
+          ON summaries (suppressed_at)
+          WHERE suppressed_at IS NOT NULL
+      `);
+      // Idle-rebuild candidate scan: §8.1 finds condensed rows whose
+      // descendants got suppressed but haven't been rebuilt yet.
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS summaries_contains_suppressed_idx
+          ON summaries (contains_suppressed_leaves)
+          WHERE contains_suppressed_leaves = 1 AND superseded_by IS NULL
+      `);
+      // messages.suppressed_at filter (for lcm_grep mode='verbatim' + conversation-store search paths)
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS messages_suppressed_idx
+          ON messages (suppressed_at)
+          WHERE suppressed_at IS NOT NULL
+      `);
+      // session_key index on conversations (boosts the cross-conv JOIN
+      // path used by retrieval surfaces). Already indexed by existing
+      // conversations_session_key_active_created_idx but the v4.1 read
+      // pattern often filters by session_key WITHOUT the active flag
+      // (e.g. legacy:conv_<id> session_keys are on archived conversations).
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS conversations_session_key_v41_idx
+          ON conversations (session_key)
+          WHERE session_key IS NOT NULL
+      `);
+    });
+
     db.exec(`COMMIT`);
     transactionActive = false;
   } catch (error) {

--- a/src/embeddings/backfill.ts
+++ b/src/embeddings/backfill.ts
@@ -1,0 +1,637 @@
+/**
+ * Embedding backfill cron — LCM v4.1 §13 Group B.04.
+ *
+ * Walks unembedded `summaries` rows, batches them by token budget,
+ * sends to Voyage, writes vec0 + meta. Designed to run as a worker
+ * job (lock-protected, resumable, rate-limited). Single-tick API:
+ * caller (worker scheduler) invokes once per tick; the function
+ * acquires the worker lock, processes up to `perTickLimit` documents,
+ * releases the lock, returns a summary.
+ *
+ * Key invariants (v4.1 §13 + §0):
+ *
+ *   1. NO LLM/network call inside any SQLite write transaction. Each
+ *      Voyage HTTP call happens OUTSIDE the per-batch DB transaction:
+ *      we (a) prepare the batch (read-only SELECT), (b) call Voyage,
+ *      (c) write results (transaction). Rate-state UPDATE happens
+ *      BEFORE the HTTP call as a brief BEGIN IMMEDIATE that COMMITs
+ *      immediately — never holding a DB write lock through HTTP latency.
+ *
+ *   2. Single-flight via lcm_worker_lock. Only one process runs
+ *      embedding-backfill at a time; otherwise we'd burn quota and
+ *      potentially write duplicate vec0 rows.
+ *
+ *   3. Rate limit is per-process: simple per-call sleep
+ *      (1/maxRequestsPerSecond). The worker_lock already guarantees
+ *      single-flight, so RPM/TPM throttling is a single-process concern.
+ *      Cross-process Voyage budget coordination via lcm_voyage_rate_state
+ *      table was preserved in deferred-features draft PR (#616) for when
+ *      multi-gateway scenario emerges.
+ *
+ *   4. Resumable. Each batch's writes commit independently, so a
+ *      mid-tick crash loses at most one in-flight batch worth of
+ *      Voyage spend. Next tick picks up the still-unembedded rows.
+ *
+ *   5. Idempotent on per-row basis. Caller's pre-filter "rows where
+ *      no `lcm_embedding_meta` row exists for (model, kind, id)"
+ *      means re-running the cron never re-embeds an already-embedded
+ *      row. UPSERT semantics on the meta table also guard against
+ *      double-write.
+ *
+ *   6. Suppression-aware. Rows where `summaries.suppressed_at IS NOT NULL`
+ *      are skipped (we don't pay for embedding text the operator has
+ *      asked us to forget).
+ *
+ *   7. Over-cap guard. Rows where `summaries.token_count > MAX_TOKENS_PER_EMBED_DOC`
+ *      are skipped + reported in `BackfillResult.skippedOverCap`. v4.1
+ *      operator tooling (Group F) should investigate these (likely a
+ *      summary that didn't get re-summarized after the A.10 cap bump).
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { WORKER_HEARTBEAT_MS } from "../concurrency/model.js";
+import {
+  acquireLock,
+  generateWorkerId,
+  heartbeatLock,
+  releaseLock,
+} from "../concurrency/worker-lock.js";
+import {
+  embeddingsTableExists,
+  isEmbedded,
+  recordEmbedding,
+  vec0Version,
+  type EmbeddedKind,
+} from "./store.js";
+import {
+  embedTexts,
+  MAX_TOKENS_PER_EMBED_BATCH,
+  MAX_TOKENS_PER_EMBED_DOC,
+  VoyageError,
+  type VoyageEmbeddingModel,
+  type VoyageInputType,
+} from "../voyage/client.js";
+
+export interface BackfillOptions {
+  /**
+   * Profile model name (must match a row in lcm_embedding_profile).
+   * E.g. "voyage-4-large".
+   */
+  modelName: string;
+  /**
+   * Voyage API model id (the actual model passed to Voyage). Usually
+   * == modelName but kept separate so we can switch profile names
+   * (e.g. "voyage-4-large-v2" → still uses "voyage-4-large" upstream).
+   */
+  voyageModel: VoyageEmbeddingModel;
+  /**
+   * Voyage `input_type`. For backfilling stored documents this MUST be
+   * 'document' — using 'query' here would degrade retrieval quality
+   * because Voyage's asymmetric embedding optimizes queries for
+   * matching documents, not the reverse.
+   */
+  inputType: VoyageInputType;
+  /** Override VOYAGE_API_KEY env. */
+  voyageApiKey?: string;
+  /** Inject mock fetch for tests. */
+  voyageFetch?: typeof fetch;
+  /**
+   * Override Voyage client retry count. Default 1 (so backfill caps at
+   * 2 total attempts per batch). The Voyage client's own default (3
+   * retries) means worst-case wall-time per batch can be ~4 minutes
+   * (4 attempts × 60s timeoutMs). With WORKER_LOCK_TTL_MS = 90s, that
+   * means a slow batch can let another worker GC the lock and
+   * double-process. Capping at 1 retry + reduced timeoutMs (below)
+   * keeps worst-case per-batch under 90s. (Group B adversarial Gap 1.)
+   * Tests can opt to 0 (surface 5xx immediately, no backoff).
+   */
+  voyageMaxRetries?: number;
+  /**
+   * Wave-11 reviewer P1 fix: target output dimension. If the registered
+   * profile is 256/512/2048 dim (non-default), this MUST be passed so
+   * Voyage returns the right-shape vectors. Default: omit (Voyage uses
+   * 1024). Resolved from `lcm_embedding_profile.dim` by callers.
+   */
+  voyageOutputDimension?: number;
+  /**
+   * Override Voyage per-attempt timeout. Default 30_000 ms (30s) here
+   * (vs Voyage client's 60s default). Combined with default
+   * voyageMaxRetries=1 → worst case per batch ≈ 2×30 + 0.5s backoff
+   * ≈ 60.5s, comfortably under WORKER_LOCK_TTL_MS=90s. (Group B Gap 1.)
+   */
+  voyageTimeoutMs?: number;
+  /**
+   * Max requests per second to Voyage. Default 0.5 (one request every
+   * 2 seconds) — generous safety margin under Voyage tier-1 limits
+   * (300 RPM = 5 RPS). Worker lock-holder is the only RPS source so
+   * this rate IS what hits the API.
+   */
+  maxRequestsPerSecond?: number;
+  /** Max total Voyage tokens per single request batch. */
+  maxBatchTokens?: number;
+  /** What kind to embed. Default 'summary'. */
+  embeddedKind?: EmbeddedKind;
+  /**
+   * Limit how many DOCUMENTS to embed in one cron tick. After this many,
+   * release the lock and return so the next worker tick can re-acquire.
+   * Default 200 — at 80K tokens/batch and 2s/batch (0.5 RPS), this is
+   * roughly 7-15 minutes per tick depending on doc length. Tune up
+   * for first-run backfill (no contention); down for steady state
+   * (where the cron should yield to other work).
+   */
+  perTickLimit?: number;
+  /** Min token count for a leaf to be considered. Skips empty stubs. Default 1. */
+  minTokenCount?: number;
+  /**
+   * Max token count per single doc. Voyage rejects > 32K for voyage-4-large.
+   * Default = MAX_TOKENS_PER_EMBED_DOC = 30K.
+   */
+  maxTokenCount?: number;
+  /**
+   * Worker ID for the lock. Default: generated. Caller can override
+   * (e.g. tests, or worker-process scheduling that needs a stable ID
+   * across cron ticks).
+   */
+  workerId?: string;
+  /**
+   * Hook for tests / observability. Called for each batch with the
+   * count of docs in the batch (whether successful or failed).
+   */
+  onBatchComplete?: (info: {
+    batchSize: number;
+    succeeded: number;
+    failed: number;
+    voyageTokens: number;
+  }) => void;
+  /**
+   * Skip the worker-lock acquisition. Tests/operators sometimes want
+   * to run a single backfill pass without coordinating with other
+   * workers. Default false.
+   */
+  skipLock?: boolean;
+}
+
+export interface BackfillSkippedDoc {
+  summaryId: string;
+  reason: "over_cap" | "voyage_400" | "voyage_other" | "lock_stolen_mid_embed";
+  detail?: string;
+}
+
+export interface BackfillResult {
+  /** Number of rows successfully embedded (vec0 + meta inserts succeeded). */
+  embeddedCount: number;
+  /** Rows skipped without spending quota (over-cap, suppressed). */
+  skippedOverCap: number;
+  /** Rows that were attempted but failed (voyage error per row). */
+  skipped: BackfillSkippedDoc[];
+  /** Did we hit perTickLimit? (Caller schedules next tick if so.) */
+  perTickLimitReached: boolean;
+  /** Did we fail to acquire the lock? (Caller skips this tick.) */
+  lockNotAcquired: boolean;
+  /** Total tokens consumed on Voyage (from API response usage.total_tokens). */
+  voyageTokensConsumed: number;
+  /** Walltime in ms. */
+  durationMs: number;
+}
+
+interface PendingDoc {
+  summaryId: string;
+  content: string;
+  tokenCount: number;
+}
+
+const DEFAULT_MAX_RPS = 0.5;
+const DEFAULT_PER_TICK_LIMIT = 200;
+const DEFAULT_MIN_TOKEN_COUNT = 1;
+
+/**
+ * Run one backfill tick. Acquires the worker lock, processes pending
+ * documents, returns. See {@link BackfillOptions} + {@link BackfillResult}.
+ *
+ * Caller is responsible for re-scheduling the next tick if
+ * `perTickLimitReached === true` or if more rows are still pending
+ * (cheap `SELECT COUNT(*)` to check).
+ *
+ * Throws only on PROGRAMMER errors (bad opts, unloadable vec0, missing
+ * profile, missing embeddings table). Voyage errors are caught per-batch
+ * and surfaced in the result; the cron continues with the next batch.
+ */
+export async function runBackfillTick(
+  db: DatabaseSync,
+  opts: BackfillOptions,
+): Promise<BackfillResult> {
+  const startedAt = Date.now();
+
+  // Validate vec0 environment up-front.
+  if (vec0Version(db) === null) {
+    throw new Error("[backfill] sqlite-vec is not loaded — call tryLoadSqliteVec() first");
+  }
+  if (!embeddingsTableExists(db, opts.modelName)) {
+    throw new Error(
+      `[backfill] embeddings table for ${opts.modelName} doesn't exist — ` +
+        `call ensureEmbeddingsTable() first`,
+    );
+  }
+
+  const workerId = opts.workerId ?? generateWorkerId("embed-backfill");
+  const embeddedKind: EmbeddedKind = opts.embeddedKind ?? "summary";
+  const maxBatchTokens = opts.maxBatchTokens ?? MAX_TOKENS_PER_EMBED_BATCH;
+  const maxTokenCount = opts.maxTokenCount ?? MAX_TOKENS_PER_EMBED_DOC;
+  const minTokenCount = opts.minTokenCount ?? DEFAULT_MIN_TOKEN_COUNT;
+  const perTickLimit = opts.perTickLimit ?? DEFAULT_PER_TICK_LIMIT;
+  const maxRps = opts.maxRequestsPerSecond ?? DEFAULT_MAX_RPS;
+  const minBatchInterval = maxRps > 0 ? 1000 / maxRps : 0;
+
+  const empty: BackfillResult = {
+    embeddedCount: 0,
+    skippedOverCap: 0,
+    skipped: [],
+    perTickLimitReached: false,
+    lockNotAcquired: false,
+    voyageTokensConsumed: 0,
+    durationMs: 0,
+  };
+
+  // Acquire worker lock (unless explicitly skipping).
+  if (!opts.skipLock) {
+    const got = acquireLock(db, "embedding-backfill", {
+      workerId,
+      jobMetadata: `model=${opts.modelName} kind=${embeddedKind}`,
+    });
+    if (!got) {
+      return { ...empty, lockNotAcquired: true, durationMs: Date.now() - startedAt };
+    }
+  }
+
+  let result = empty;
+  let lastBatchAt = 0;
+  // Per-tick blocklist: docs that already failed Voyage this tick. Each
+  // is excluded from subsequent SELECTs so we don't retry within the
+  // same tick (next tick will re-attempt — Voyage may have recovered).
+  const failedThisTick = new Set<string>();
+  try {
+    let processed = 0;
+
+    while (processed < perTickLimit) {
+      // 1. SELECT next batch — only documents NOT in lcm_embedding_meta
+      //    for this (model, kind), within token bounds, not suppressed.
+      const remaining = perTickLimit - processed;
+      const batchSize = Math.min(remaining, 64); // cap per SELECT
+      const candidates = selectPendingDocs(db, {
+        modelName: opts.modelName,
+        embeddedKind,
+        minTokenCount,
+        maxTokenCount,
+        limit: batchSize,
+        excludeIds: failedThisTick,
+      });
+      if (candidates.length === 0) {
+        // No more pending — done.
+        break;
+      }
+
+      // 2. Identify over-cap (shouldn't happen due to SELECT filter, but
+      //    defensive). And separate the over-cap from the queryable.
+      const queryable: PendingDoc[] = [];
+      for (const doc of candidates) {
+        if (doc.tokenCount > maxTokenCount) {
+          result = withSkippedOverCap(result, doc.summaryId);
+        } else {
+          queryable.push(doc);
+        }
+      }
+      if (queryable.length === 0) {
+        processed += candidates.length;
+        continue;
+      }
+
+      // 3. Group queryable into batches that fit maxBatchTokens.
+      const batches = packBatches(queryable, maxBatchTokens);
+
+      for (const batch of batches) {
+        // Rate-limit pacing: wait at least minBatchInterval since last call.
+        if (lastBatchAt > 0 && minBatchInterval > 0) {
+          const elapsed = Date.now() - lastBatchAt;
+          if (elapsed < minBatchInterval) {
+            await sleep(minBatchInterval - elapsed);
+          }
+        }
+        // Heartbeat the lock so we don't get preempted mid-tick.
+        if (!opts.skipLock) {
+          const stillOurs = heartbeatLock(db, "embedding-backfill", workerId);
+          if (!stillOurs) {
+            // Another worker stole the lock — abort cleanly.
+            return {
+              ...result,
+              durationMs: Date.now() - startedAt,
+              lockNotAcquired: true,
+            };
+          }
+        }
+
+        lastBatchAt = Date.now();
+        let resp;
+        try {
+          resp = await embedTexts({
+            model: opts.voyageModel,
+            texts: batch.map((d) => d.content),
+            inputType: opts.inputType,
+            apiKey: opts.voyageApiKey,
+            fetch: opts.voyageFetch,
+            // Group B Gap 1 fix: cap per-batch wall-time below
+            // WORKER_LOCK_TTL_MS=90s. See voyageMaxRetries / voyageTimeoutMs
+            // option docs for rationale. Use ?? not || so an explicit 0
+            // (test scenarios) is honored.
+            maxRetries: opts.voyageMaxRetries ?? 1,
+            timeoutMs: opts.voyageTimeoutMs ?? 30_000,
+            // Wave-11 reviewer P1: forward output dimension so 256/512/
+            // 2048-dim profiles get the right-shape vectors back.
+            outputDimension: opts.voyageOutputDimension,
+          });
+        } catch (e: unknown) {
+          // Voyage error — record in skipped list, continue with next
+          // batch. We DO NOT retry per-doc; that would amplify cost.
+          // The next tick will re-attempt the same docs (they still
+          // have no meta row).
+          if (e instanceof VoyageError && e.kind === "auth") {
+            // Auth error is fatal — every subsequent batch will fail too.
+            // Re-throw so caller (worker scheduler) surfaces to operator.
+            throw e;
+          }
+          for (const doc of batch) {
+            failedThisTick.add(doc.summaryId);
+            result = withSkippedDoc(result, {
+              summaryId: doc.summaryId,
+              reason: e instanceof VoyageError && e.kind === "bad_request" ? "voyage_400" : "voyage_other",
+              detail: e instanceof Error ? e.message : String(e),
+            });
+          }
+          opts.onBatchComplete?.({
+            batchSize: batch.length,
+            succeeded: 0,
+            failed: batch.length,
+            voyageTokens: 0,
+          });
+          processed += batch.length;
+          continue;
+        }
+
+        // 4. Wave-12 reviewer P2 fix (defense in depth): Voyage 429 with
+        //    Retry-After up to 60s + 30s timeout = 90s wall-time worst
+        //    case, which equals WORKER_LOCK_TTL_MS. If we crossed the TTL
+        //    during embedTexts, another worker may have GC'd the lock and
+        //    started processing the SAME docs. Re-check ownership before
+        //    writing to vec0 — a second writer would corrupt the vec0
+        //    table or duplicate-write meta rows.
+        if (!opts.skipLock) {
+          const stillOursAfterEmbed = heartbeatLock(db, "embedding-backfill", workerId);
+          if (!stillOursAfterEmbed) {
+            // Lock stolen mid-call. Skip writes for this batch; the next
+            // tick (this worker, after re-acquiring) or the other worker
+            // (which now owns the lock) will reprocess.
+            for (const doc of batch) {
+              failedThisTick.add(doc.summaryId);
+              result = withSkippedDoc(result, {
+                summaryId: doc.summaryId,
+                reason: "lock_stolen_mid_embed",
+                detail: "Worker lock expired during Voyage call (likely Retry-After exceeded TTL); writes aborted.",
+              });
+            }
+            return {
+              ...result,
+              durationMs: Date.now() - startedAt,
+              lockNotAcquired: true,
+            };
+          }
+        }
+        // 5. Write results (vec0 + meta). One implicit transaction per
+        //    batch via writeBatch's internal BEGIN/COMMIT.
+        const writeReport = writeBatch(db, opts.modelName, embeddedKind, batch, resp.vectors);
+        result = {
+          ...result,
+          embeddedCount: result.embeddedCount + writeReport.succeeded,
+          voyageTokensConsumed: result.voyageTokensConsumed + resp.totalTokens,
+          skipped: [...result.skipped, ...writeReport.errors],
+        };
+        opts.onBatchComplete?.({
+          batchSize: batch.length,
+          succeeded: writeReport.succeeded,
+          failed: writeReport.errors.length,
+          voyageTokens: resp.totalTokens,
+        });
+        processed += batch.length;
+      }
+    }
+
+    if (processed >= perTickLimit) {
+      result = { ...result, perTickLimitReached: true };
+    }
+  } finally {
+    if (!opts.skipLock) {
+      releaseLock(db, "embedding-backfill", workerId);
+    }
+  }
+
+  return { ...result, durationMs: Date.now() - startedAt };
+}
+
+/** How many documents are pending embedding for this (model, kind)? */
+export function countPendingDocs(
+  db: DatabaseSync,
+  args: {
+    modelName: string;
+    embeddedKind?: EmbeddedKind;
+    minTokenCount?: number;
+    maxTokenCount?: number;
+  },
+): number {
+  const kind = args.embeddedKind ?? "summary";
+  const minTC = args.minTokenCount ?? DEFAULT_MIN_TOKEN_COUNT;
+  const maxTC = args.maxTokenCount ?? MAX_TOKENS_PER_EMBED_DOC;
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n
+         FROM summaries s
+         WHERE s.suppressed_at IS NULL
+           AND s.token_count BETWEEN ? AND ?
+           AND s.kind = 'leaf'
+           AND NOT EXISTS (
+             SELECT 1 FROM lcm_embedding_meta m
+               WHERE m.embedded_id = s.summary_id
+                 AND m.embedded_kind = ?
+                 AND m.embedding_model = ?
+                 AND m.archived = 0
+           )`,
+    )
+    .get(minTC, maxTC, kind, args.modelName) as { n: number };
+  return row.n;
+}
+
+// ---------- internals ----------
+
+function selectPendingDocs(
+  db: DatabaseSync,
+  args: {
+    modelName: string;
+    embeddedKind: EmbeddedKind;
+    minTokenCount: number;
+    maxTokenCount: number;
+    limit: number;
+    /** IDs to exclude (e.g. failed-this-tick blocklist). */
+    excludeIds?: Set<string>;
+  },
+): PendingDoc[] {
+  // ORDER BY summary_id DESC: prioritize newer leaves so freshest content
+  // gets queryable fastest. Deterministic ordering also helps us debug
+  // (next tick pulls the same set if conditions don't change).
+  const exclude = args.excludeIds && args.excludeIds.size > 0 ? Array.from(args.excludeIds) : [];
+  // Build IN-list dynamically; exclude can be empty (no IN clause needed).
+  const excludeClause = exclude.length > 0
+    ? `AND s.summary_id NOT IN (${exclude.map(() => "?").join(",")})`
+    : "";
+  const sql = `SELECT s.summary_id, s.content, s.token_count
+       FROM summaries s
+       WHERE s.suppressed_at IS NULL
+         AND s.token_count BETWEEN ? AND ?
+         AND s.kind = 'leaf'
+         ${excludeClause}
+         AND NOT EXISTS (
+           SELECT 1 FROM lcm_embedding_meta m
+             WHERE m.embedded_id = s.summary_id
+               AND m.embedded_kind = ?
+               AND m.embedding_model = ?
+               AND m.archived = 0
+         )
+       ORDER BY s.summary_id DESC
+       LIMIT ?`;
+  const rows = db
+    .prepare(sql)
+    .all(
+      args.minTokenCount,
+      args.maxTokenCount,
+      ...exclude,
+      args.embeddedKind,
+      args.modelName,
+      args.limit,
+    ) as Array<{ summary_id: string; content: string; token_count: number }>;
+  return rows.map((r) => ({
+    summaryId: r.summary_id,
+    content: r.content,
+    tokenCount: r.token_count,
+  }));
+}
+
+/**
+ * Pack docs into batches that fit `maxBatchTokens`. Greedy-bin-pack —
+ * docs are already in SELECT order; we don't re-sort. Each batch
+ * respects: sum(token_count) <= maxBatchTokens AND batch.length >= 1.
+ * If a single doc exceeds maxBatchTokens, it goes in a batch of 1
+ * (Voyage rejects with 400; caller records as skipped voyage_400 and moves on).
+ */
+function packBatches(docs: PendingDoc[], maxBatchTokens: number): PendingDoc[][] {
+  const batches: PendingDoc[][] = [];
+  let current: PendingDoc[] = [];
+  let currentTokens = 0;
+  for (const doc of docs) {
+    if (current.length > 0 && currentTokens + doc.tokenCount > maxBatchTokens) {
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(doc);
+    currentTokens += doc.tokenCount;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+function writeBatch(
+  db: DatabaseSync,
+  modelName: string,
+  embeddedKind: EmbeddedKind,
+  batch: PendingDoc[],
+  vectors: Float32Array[],
+): { succeeded: number; errors: BackfillSkippedDoc[] } {
+  const errors: BackfillSkippedDoc[] = [];
+  let succeeded = 0;
+  // Wave-1 Auditor #2 finding #4: per-row write failure inside the batch
+  // tx left a phantom vec0 row (no corresponding meta) when recordEmbedding
+  // partially succeeded — the meta-side INSERT failed but the vec0-side
+  // had already gone through. On the next tick, NOT EXISTS in meta would
+  // re-pick the doc, INSERT a SECOND vec0 row, and now we have duplicate
+  // KNN entries.
+  //
+  // Each row gets its own SAVEPOINT so we can roll back JUST that row's
+  // partial writes (vec0 + meta together) on per-row failure, without
+  // killing the whole batch.
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    for (let i = 0; i < batch.length; i++) {
+      const doc = batch[i];
+      const vec = vectors[i];
+      const sp = `bf_${i}`;
+      db.exec(`SAVEPOINT ${sp}`);
+      try {
+        recordEmbedding(db, {
+          modelName,
+          embeddedId: doc.summaryId,
+          embeddedKind,
+          vector: vec,
+          sourceTokenCount: doc.tokenCount,
+        });
+        db.exec(`RELEASE ${sp}`);
+        succeeded++;
+      } catch (e: unknown) {
+        // Per-row write failure (rare — dim mismatch, e.g.). Roll back to
+        // SAVEPOINT — that erases any vec0 partial write, leaving the row
+        // entirely unsynced. Caller will re-pick on next tick (clean slate).
+        try {
+          db.exec(`ROLLBACK TO ${sp}`);
+          db.exec(`RELEASE ${sp}`);
+        } catch {
+          // best-effort; if savepoint rollback fails the outer
+          // try/catch will catch and ROLLBACK the whole tx.
+        }
+        errors.push({
+          summaryId: doc.summaryId,
+          reason: "voyage_other",
+          detail: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    db.exec("COMMIT");
+  } catch (e) {
+    // Transaction-level error (constraint failure, lock loss). Roll
+    // back; caller will see no progress on these docs and re-attempt.
+    db.exec("ROLLBACK");
+    for (const doc of batch) {
+      errors.push({
+        summaryId: doc.summaryId,
+        reason: "voyage_other",
+        detail: `tx-rollback: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    }
+    succeeded = 0;
+  }
+  return { succeeded, errors };
+}
+
+function withSkippedOverCap(prev: BackfillResult, summaryId: string): BackfillResult {
+  return {
+    ...prev,
+    skippedOverCap: prev.skippedOverCap + 1,
+    skipped: [...prev.skipped, { summaryId, reason: "over_cap" }],
+  };
+}
+
+function withSkippedDoc(prev: BackfillResult, doc: BackfillSkippedDoc): BackfillResult {
+  return { ...prev, skipped: [...prev.skipped, doc] };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Re-export for backfill internals so the caller doesn't have to know about
+// the heartbeat cadence externally.
+export { WORKER_HEARTBEAT_MS, isEmbedded };

--- a/src/embeddings/hybrid-search.ts
+++ b/src/embeddings/hybrid-search.ts
@@ -1,0 +1,437 @@
+/**
+ * Hybrid retrieval — LCM v4.1 §13 / Group C.02.
+ *
+ * Combines FTS (BM25-style relevance over `summaries_fts`) with semantic
+ * search (vec0 KNN over the active embedding model), then optionally
+ * reranks the union via Voyage rerank-2.5 to produce a final ranked
+ * list. Empirically (Phase A spike: voyage-spike-results.md) lifts
+ * paraphrastic queries by +52.5pp over FTS-only on Eva's 31-query eval.
+ *
+ * Why this lives outside the lcm_grep tool: the same pipeline is needed
+ * by lcm_synthesize_around (window_kind='semantic') and any future tool
+ * that needs ranked-by-relevance content windows. Centralizing here so
+ * suppression filters, dedup logic, and the rerank cache stay coherent
+ * across all callers.
+ *
+ * Pipeline:
+ *
+ *   1. Run FTS + semantic in parallel (Promise.all). Both restricted to
+ *      summaries (semantic doesn't cover raw messages — we don't embed
+ *      messages directly).
+ *   2. Build deduplicated candidate union (by summary_id). Each side
+ *      contributes up to `kFts` / `kSemantic` candidates.
+ *   3. If `rerank: true`: send the union to Voyage rerank-2.5; take
+ *      top-N from rerank score.
+ *      If `rerank: false`: merge by reciprocal-rank-fusion (RRF) across
+ *      the FTS rank and semantic rank. Cheap fallback for when the
+ *      Voyage rerank quota is exhausted or the operator opts out.
+ *   4. Return final hits with `score` (rerank score OR RRF score) +
+ *      provenance flags (`fromFts`, `fromSemantic`).
+ *
+ * Suppression: both arms exclude suppressed by default; the rerank input
+ * is the post-suppression union, so no post-rerank filter needed.
+ *
+ * Graceful degrade: if semantic search throws SemanticSearchUnavailableError
+ * (vec0 not loaded, no model registered), we fall back to FTS-only and
+ * set `degradedToFtsOnly: true` in the result so the caller can warn.
+ * Voyage rerank failures (auth/network) similarly fall back to RRF
+ * fusion with `degradedSkippedRerank: true`.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import {
+  MAX_TOKENS_PER_RERANK_CALL,
+  rerankCandidates,
+  VoyageError,
+  type VoyageRerankerModel,
+} from "../voyage/client.js";
+import {
+  runSemanticSearch,
+  SemanticSearchUnavailableError,
+  type SemanticHit,
+  type SemanticSearchOptions,
+} from "./semantic-search.js";
+
+export interface HybridSearchOptions {
+  query: string;
+
+  /**
+   * FTS-side candidate count. Default 50.
+   */
+  kFts?: number;
+  /** Semantic-side candidate count. Default 50. */
+  kSemantic?: number;
+  /** How many final hits to return after rerank/RRF. Default 20. */
+  topN?: number;
+
+  // Filters — passed through to both arms
+  sessionKeys?: string[];
+  conversationIds?: number[];
+  since?: Date;
+  before?: Date;
+  excludeSuppressed?: boolean;
+  summaryKinds?: Array<"leaf" | "condensed">;
+
+  /**
+   * If true (default), call Voyage rerank-2.5 over the candidate union.
+   * If false, fuse FTS + semantic via reciprocal-rank-fusion (much
+   * cheaper, slightly less accurate).
+   */
+  rerank?: boolean;
+  /** Voyage reranker model. Default 'rerank-2.5'. */
+  rerankerModel?: VoyageRerankerModel;
+
+  // Voyage HTTP wiring
+  voyageApiKey?: string;
+  voyageFetch?: typeof fetch;
+  voyageMaxRetries?: number;
+  /**
+   * Voyage per-attempt timeout in ms. Agent-tool callers should cap
+   * this (e.g. 15s) to avoid blocking the agent's turn.
+   */
+  voyageTimeoutMs?: number;
+
+  // Semantic-side overrides (rarely used; passed through to semantic-search)
+  semantic?: Pick<
+    SemanticSearchOptions,
+    "voyageModel" | "inputType" | "queryVector"
+  >;
+
+  /**
+   * FTS provider — caller injects a function that runs FTS over
+   * summaries given the same filters and returns ranked hits. We don't
+   * own the FTS query here because the existing summary-store/retrieval
+   * code is already wired with FTS5 sanitization, hybrid-recency
+   * sorting, etc. Caller wraps `summaryStore.searchSummaries` and
+   * normalizes to the FtsHit shape.
+   *
+   * Returning [] is fine (treated as "no FTS results").
+   */
+  ftsSearch: (args: {
+    query: string;
+    sessionKeys?: string[];
+    conversationIds?: number[];
+    since?: Date;
+    before?: Date;
+    summaryKinds?: Array<"leaf" | "condensed">;
+    excludeSuppressed?: boolean;
+    limit: number;
+  }) => Promise<FtsHit[]>;
+}
+
+export interface FtsHit {
+  summaryId: string;
+  conversationId: number;
+  sessionKey: string;
+  kind: "leaf" | "condensed";
+  content: string;
+  tokenCount: number;
+  createdAt: string;
+  /** FTS rank (0-indexed; 0 = best match). Used for RRF when rerank
+   *  is off. */
+  rank: number;
+}
+
+export interface HybridHit {
+  summaryId: string;
+  conversationId: number;
+  sessionKey: string;
+  kind: "leaf" | "condensed";
+  content: string;
+  tokenCount: number;
+  createdAt: string;
+  /** Final score: rerank relevance (range ~[0, 1]) OR RRF score. */
+  score: number;
+  fromFts: boolean;
+  fromSemantic: boolean;
+  /** Cosine distance from semantic hit (when applicable; null otherwise). */
+  semanticDistance: number | null;
+  /** FTS rank (0-indexed; null if not in FTS results). */
+  ftsRank: number | null;
+}
+
+export interface HybridSearchResult {
+  hits: HybridHit[];
+  /** Candidate union size before rerank/cut. */
+  candidateCount: number;
+  /** Voyage tokens consumed across embed (semantic) + rerank calls. */
+  voyageTokensConsumed: number;
+  /** True if vec0 unavailable; we ran FTS-only. */
+  degradedToFtsOnly: boolean;
+  /** True if rerank failed; we used RRF instead. */
+  degradedSkippedRerank: boolean;
+  /**
+   * Wave-10 reviewer P1: true if the rerank input was packed to fit the
+   * 600K-token cap. Lower-rank candidates were dropped from rerank
+   * consideration (still available in `candidateCount` for backstop).
+   */
+  rerankPackTruncated?: boolean;
+  /** Wave-10: number of candidates that survived packing into rerank. */
+  rerankPackedCount?: number;
+  /** Hint for caller logs / `/lcm health`. */
+  modelName: string | null;
+}
+
+const DEFAULT_K_FTS = 50;
+const DEFAULT_K_SEMANTIC = 50;
+const DEFAULT_TOP_N = 20;
+
+/**
+ * Run a hybrid retrieval. See module docs for pipeline detail.
+ *
+ * Caller is responsible for passing a working `ftsSearch` that respects
+ * the existing FTS5 sanitization rules. We don't rebuild FTS here — we
+ * delegate to it.
+ */
+export async function runHybridSearch(
+  db: DatabaseSync,
+  opts: HybridSearchOptions,
+): Promise<HybridSearchResult> {
+  const query = opts.query?.trim() ?? "";
+  if (query.length === 0) {
+    throw new Error("[hybrid-search] query is required");
+  }
+  const kFts = opts.kFts ?? DEFAULT_K_FTS;
+  const kSemantic = opts.kSemantic ?? DEFAULT_K_SEMANTIC;
+  const topN = opts.topN ?? DEFAULT_TOP_N;
+
+  // 1. Run both arms in parallel. Catch SemanticSearchUnavailableError
+  //    and downgrade to FTS-only.
+  const ftsPromise = opts.ftsSearch({
+    query,
+    sessionKeys: opts.sessionKeys,
+    conversationIds: opts.conversationIds,
+    since: opts.since,
+    before: opts.before,
+    summaryKinds: opts.summaryKinds,
+    excludeSuppressed: opts.excludeSuppressed,
+    limit: kFts,
+  });
+  const semanticPromise = (async () => {
+    try {
+      const sem = await runSemanticSearch(db, {
+        query,
+        sessionKeys: opts.sessionKeys,
+        conversationIds: opts.conversationIds,
+        since: opts.since,
+        before: opts.before,
+        summaryKinds: opts.summaryKinds,
+        excludeSuppressed: opts.excludeSuppressed,
+        k: kSemantic,
+        voyageModel: opts.semantic?.voyageModel,
+        voyageApiKey: opts.voyageApiKey,
+        voyageFetch: opts.voyageFetch,
+        voyageMaxRetries: opts.voyageMaxRetries,
+        voyageTimeoutMs: opts.voyageTimeoutMs,
+        inputType: opts.semantic?.inputType,
+        queryVector: opts.semantic?.queryVector,
+        embeddedKinds: ["summary"],
+      });
+      return { hits: sem.hits, tokens: sem.voyageTokensConsumed, modelName: sem.modelName };
+    } catch (e: unknown) {
+      if (e instanceof SemanticSearchUnavailableError) {
+        return { hits: [] as SemanticHit[], tokens: 0, modelName: null, degraded: true };
+      }
+      // v4.1 Final.review.3 fix (Slice 1 Gap A / Loop 8 B-1 HIGH):
+      // Mirror the rerank arm's behavior — auth errors propagate out (so the
+      // tool surface returns a useful "set VOYAGE_API_KEY" message), but
+      // transient VoyageError kinds (server_error, rate_limit, network,
+      // unexpected, bad_request) degrade to FTS-only. Without this, a single
+      // Voyage 5xx hiccup kills the whole hybrid query when FTS could have
+      // returned useful results. Matches the contract documented in PR
+      // description: "If VOYAGE_API_KEY is missing... falls back to FTS-only".
+      // (Auth still throws so the operator gets a clear setup-action error,
+      // not silent degradation that hides a misconfigured deploy.)
+      if (e instanceof VoyageError && e.kind !== "auth") {
+        return { hits: [] as SemanticHit[], tokens: 0, modelName: null, degraded: true };
+      }
+      throw e;
+    }
+  })();
+
+  const [ftsHits, semResult] = await Promise.all([ftsPromise, semanticPromise]);
+  const degradedToFtsOnly = "degraded" in semResult ? Boolean(semResult.degraded) : false;
+  let voyageTokensConsumed = "tokens" in semResult ? semResult.tokens : 0;
+  const modelName = "modelName" in semResult ? semResult.modelName : null;
+
+  // 2. Build deduplicated union. Use summaryId as key. Each side gets
+  //    its rank recorded.
+  const merged = new Map<string, HybridHit>();
+  for (let i = 0; i < ftsHits.length; i++) {
+    const f = ftsHits[i];
+    merged.set(f.summaryId, {
+      summaryId: f.summaryId,
+      conversationId: f.conversationId,
+      sessionKey: f.sessionKey,
+      kind: f.kind,
+      content: f.content,
+      tokenCount: f.tokenCount,
+      createdAt: f.createdAt,
+      score: 0, // computed below
+      fromFts: true,
+      fromSemantic: false,
+      semanticDistance: null,
+      ftsRank: i,
+    });
+  }
+  for (const s of semResult.hits) {
+    const existing = merged.get(s.summaryId);
+    if (existing) {
+      existing.fromSemantic = true;
+      existing.semanticDistance = s.distance;
+    } else {
+      merged.set(s.summaryId, {
+        summaryId: s.summaryId,
+        conversationId: s.conversationId,
+        sessionKey: s.sessionKey,
+        kind: s.kind,
+        content: s.content,
+        tokenCount: s.tokenCount,
+        createdAt: s.createdAt,
+        score: 0,
+        fromFts: false,
+        fromSemantic: true,
+        semanticDistance: s.distance,
+        ftsRank: null,
+      });
+    }
+  }
+
+  const candidates = Array.from(merged.values());
+  const candidateCount = candidates.length;
+  if (candidateCount === 0) {
+    return {
+      hits: [],
+      candidateCount: 0,
+      voyageTokensConsumed,
+      degradedToFtsOnly,
+      degradedSkippedRerank: false,
+      modelName,
+    };
+  }
+
+  // 3. Rerank or RRF.
+  const rerankRequested = opts.rerank !== false;
+  let degradedSkippedRerank = false;
+  // Wave-10 reviewer P1 fix: previously sent ALL candidates' full content
+  // to rerank without enforcing the ~600K token cap, so a query with many
+  // large condensed summaries either: (a) hit Voyage's 400 bad_request
+  // and silently degraded to RRF (losing the +52.5pp paraphrastic lift),
+  // or (b) consumed the entire month's quota in one call. Pack candidates
+  // until cumulative token count would exceed the cap, with a small
+  // safety margin. Drop tail candidates (highest-rank survives by virtue
+  // of FTS/semantic ordering before this point — by the time we get to
+  // tail they're lower-confidence anyway). If no candidates would fit
+  // even individually (a single 600K-token summary), fall through to RRF.
+  let rerankPacked = candidates;
+  let rerankPackTruncated = false;
+  let rerankPackSkippedOversized = 0;
+  if (rerankRequested) {
+    const RERANK_BUDGET = Math.floor(MAX_TOKENS_PER_RERANK_CALL * 0.85);
+    const queryTokenEstimate = Math.ceil(query.length / 4);
+    let cumulative = queryTokenEstimate;
+    const packed: typeof candidates = [];
+    // Wave-11 reviewer P1 fix: previously broke out of the loop when
+    // the first candidate was oversized, disabling rerank for the
+    // entire result set even though smaller later candidates would fit.
+    // Now SKIP individual oversized candidates and continue packing —
+    // a single huge FTS hit no longer takes down the whole rerank.
+    for (const c of candidates) {
+      const candTokens = c.tokenCount ?? Math.ceil((c.content?.length ?? 0) / 4);
+      // Skip individually oversized candidates (rare but possible —
+      // a 700K-token condensed summary that exceeds the 510K rerank
+      // budget by itself). They still appear in `candidates` for the
+      // RRF backstop scoring.
+      if (candTokens > RERANK_BUDGET) {
+        rerankPackSkippedOversized++;
+        rerankPackTruncated = true;
+        continue;
+      }
+      if (cumulative + candTokens > RERANK_BUDGET) {
+        // Cumulative budget exceeded — stop packing. Rerank still runs
+        // on what we have so far.
+        rerankPackTruncated = true;
+        break;
+      }
+      packed.push(c);
+      cumulative += candTokens;
+    }
+    rerankPacked = packed;
+  }
+  if (rerankRequested && rerankPacked.length > 0) {
+    try {
+      const rerankResp = await rerankCandidates({
+        model: opts.rerankerModel ?? "rerank-2.5",
+        query,
+        candidates: rerankPacked.map((c) => ({ id: c.summaryId, text: c.content })),
+        topK: Math.min(topN, rerankPacked.length),
+        apiKey: opts.voyageApiKey,
+        fetch: opts.voyageFetch,
+        maxRetries: opts.voyageMaxRetries,
+        timeoutMs: opts.voyageTimeoutMs,
+      });
+      voyageTokensConsumed += rerankResp.totalTokens;
+      // Apply rerank scores; return only items that survived rerank.
+      // Note: only the packed subset went through rerank, so unpacked
+      // candidates (the dropped tail) won't have rerank scores. They
+      // remain available via `candidates` for callers that want a
+      // backstop, but the primary `hits` list is rerank-sorted within
+      // the packed subset.
+      const byId = new Map(rerankPacked.map((c) => [c.summaryId, c] as const));
+      const finalHits: HybridHit[] = rerankResp.results
+        .map((r) => {
+          const c = byId.get(r.id);
+          if (!c) return null;
+          return { ...c, score: r.score };
+        })
+        .filter((h): h is HybridHit => h !== null);
+      return {
+        hits: finalHits,
+        candidateCount,
+        voyageTokensConsumed,
+        degradedToFtsOnly,
+        degradedSkippedRerank: false,
+        // Wave-10 reviewer P1 fix: surface when rerank input was packed
+        // to fit the 600K-token cap; callers can warn the operator that
+        // the lower-rank candidates were dropped from rerank consideration.
+        rerankPackTruncated,
+        rerankPackedCount: rerankPacked.length,
+        modelName,
+      };
+    } catch (e: unknown) {
+      if (e instanceof VoyageError && e.kind === "auth") {
+        // Auth errors are fatal — re-throw so operator surfaces.
+        throw e;
+      }
+      // Otherwise, fall back to RRF.
+      degradedSkippedRerank = true;
+    }
+  } else if (rerankRequested && rerankPacked.length === 0) {
+    // Wave-10: single candidate exceeded 600K-token budget. Skip rerank
+    // entirely; RRF fallback below will handle ranking.
+    degradedSkippedRerank = true;
+  }
+
+  // RRF fallback (also when rerank=false explicitly)
+  const RRF_K = 60; // standard reciprocal-rank-fusion constant
+  for (const c of candidates) {
+    let score = 0;
+    if (c.ftsRank !== null) score += 1 / (RRF_K + c.ftsRank);
+    if (c.fromSemantic && c.semanticDistance !== null) {
+      // Semantic rank — recover from semantic-arm position. We need to
+      // know the rank. Search semResult.hits for the summaryId.
+      const semIdx = semResult.hits.findIndex((h) => h.summaryId === c.summaryId);
+      if (semIdx >= 0) score += 1 / (RRF_K + semIdx);
+    }
+    c.score = score;
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return {
+    hits: candidates.slice(0, topN),
+    candidateCount,
+    voyageTokensConsumed,
+    degradedToFtsOnly,
+    degradedSkippedRerank,
+    modelName,
+  };
+}

--- a/src/embeddings/semantic-search.ts
+++ b/src/embeddings/semantic-search.ts
@@ -1,0 +1,419 @@
+/**
+ * Semantic search service — LCM v4.1 §13 / Group C.
+ *
+ * Wraps the embed-query → KNN → join-back-to-summary flow used by
+ * the `semantic` and `hybrid` modes of `lcm_grep`.
+ *
+ * Caller passes a free-text query + optional filters. We embed it via
+ * Voyage (with `inputType='query'` for asymmetric retrieval), run KNN
+ * against the active model's vec0 table, JOIN back to `summaries` for
+ * content + metadata, and return ranked hits.
+ *
+ * Invariants:
+ *   - Suppression is filtered at TWO layers: vec0 metadata col
+ *     (`suppressed=0` pre-filter inside MATCH) AND a final JOIN to
+ *     summaries WHERE `suppressed_at IS NULL` (defense in depth — a
+ *     race between trigger fire and KNN call could leak a stale row
+ *     through the metadata layer; the JOIN catches it).
+ *   - Session-family scoping uses `summaries.session_key` (populated
+ *     atomically at write time per Gap 8 fix).
+ *   - Time filters via `summaries.created_at` (when present in input).
+ *   - NEVER fall back to FTS silently if vec0 isn't loaded — caller
+ *     gets `vec0_unavailable` error and decides whether to degrade.
+ *
+ * NOT in this module: rerank. Rerank lives in the hybrid path in
+ * lcm_grep (Group C.02), where it can score across BOTH semantic and
+ * FTS hits.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import {
+  embeddingsTableExists,
+  embeddingsTableName,
+  searchSimilar,
+  vec0Version,
+  type EmbeddedKind,
+} from "./store.js";
+import {
+  embedTexts,
+  type VoyageEmbeddingModel,
+  type VoyageInputType,
+} from "../voyage/client.js";
+
+export interface SemanticSearchOptions {
+  /** Free-text query. */
+  query: string;
+  /**
+   * How many candidates to retrieve from vec0 BEFORE optional rerank.
+   * Default 50. Rerank caller (Group C.02) typically asks for 100.
+   */
+  k?: number;
+  /**
+   * Filter to specific session_keys. If provided, results restricted
+   * to summaries.session_key IN (sessionKeys).
+   */
+  sessionKeys?: string[];
+  /**
+   * Filter to specific conversation_ids. Honored if provided; sessionKeys
+   * takes precedence if both are passed (unusual).
+   */
+  conversationIds?: number[];
+  /** ISO timestamp. Result restricted to summaries created at or after. */
+  since?: Date;
+  /** ISO timestamp. Result restricted to summaries created before. */
+  before?: Date;
+  /**
+   * Restrict by summary kind: 'leaf' / 'condensed'. Default both.
+   */
+  summaryKinds?: Array<"leaf" | "condensed">;
+  /**
+   * Restrict by embedded kind. Default ['summary']. Operator/admin tools
+   * may pass ['summary', 'entity'] etc.
+   */
+  embeddedKinds?: EmbeddedKind[];
+  /**
+   * If false, INCLUDES suppressed rows. Default true (excludes).
+   * v4.1 §10 invariant: every retrieval surface defaults to suppressed-
+   * filter ON. Operator tools opt-in to false.
+   */
+  excludeSuppressed?: boolean;
+
+  // Voyage call wiring — passed through to embedTexts.
+  voyageModel?: VoyageEmbeddingModel;
+  voyageApiKey?: string;
+  voyageFetch?: typeof fetch;
+  voyageMaxRetries?: number;
+  /**
+   * Voyage per-attempt timeout in ms. Default = Voyage client default
+   * (60s). Agent-tool callers should cap this (e.g. 15s) to avoid
+   * blocking the agent's turn on a slow Voyage response.
+   */
+  voyageTimeoutMs?: number;
+  /** Override `inputType` (default 'query' — asymmetric retrieval). */
+  inputType?: VoyageInputType;
+
+  /**
+   * Inject a precomputed query vector instead of calling Voyage. Useful
+   * for tests AND for the hybrid path that may want to embed once and
+   * call both semantic + rerank with the same vector.
+   *
+   * If provided: voyageModel/voyageApiKey are ignored; queryVector
+   * length must match the active model's dim.
+   */
+  queryVector?: Float32Array | number[];
+}
+
+export interface SemanticHit {
+  summaryId: string;
+  embeddedKind: EmbeddedKind;
+  /**
+   * vec0's reported L2 (Euclidean) distance from the query vector.
+   * Voyage embeddings are unit-normalized (norm=1.0); on unit vectors,
+   * L2² = 2·(1 - cosine_similarity). Range:
+   *   - 0.0 = identical
+   *   - ~0.45 (cos ≈ 0.9) = strongly related
+   *   - ~1.00 (cos ≈ 0.5) = weakly related
+   *   - ~1.41 (cos ≈ 0.0) = orthogonal / unrelated
+   *   - ~2.00 (cos ≈ -1.0) = opposite (rare with text embeddings)
+   * Use {@link cosineSimilarity} for the [-1, 1] cosine score.
+   */
+  distance: number;
+  /**
+   * Convenience: cosine similarity in [-1, 1] derived from `distance`
+   * (assumes unit-normalized vectors, which Voyage guarantees).
+   * Higher = more similar. The agent-facing tool maps this into bands:
+   *   ≥0.65 high / ≥0.5 medium / ≥0.35 low / <0.35 noise.
+   * (Calibrated against Eva's live DB on 2026-05-06; see
+   *  `lcm-grep-tool.ts` semantic mode for the band logic.)
+   */
+  cosineSimilarity: number;
+  /** From summaries: content + metadata (after suppression-filter join). */
+  conversationId: number;
+  sessionKey: string;
+  kind: "leaf" | "condensed";
+  content: string;
+  tokenCount: number;
+  createdAt: string;
+  earliestAt: string | null;
+  latestAt: string | null;
+  /** True if the row passed the metadata-only check but failed the JOIN
+   *  (i.e. summary exists but is suppressed). Should always be false in
+   *  practice; surfaced for diagnostic / metric. */
+  filteredAfterJoin?: boolean;
+}
+
+export interface SemanticSearchResult {
+  hits: SemanticHit[];
+  /** Total candidates returned by vec0 KNN (before suppression-JOIN filter). */
+  candidateCount: number;
+  /** Voyage tokens consumed by the embed call (0 if queryVector provided). */
+  voyageTokensConsumed: number;
+  /** Active embedding model used. */
+  modelName: string;
+}
+
+export class SemanticSearchUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SemanticSearchUnavailableError";
+  }
+}
+
+/**
+ * Look up the currently-active embedding model from `lcm_embedding_profile`.
+ * Returns the row with `active=1` AND highest registered_at (most recent
+ * activation wins on ties). Returns null if no active row exists.
+ */
+export function getActiveEmbeddingModel(
+  db: DatabaseSync,
+): { modelName: string; dim: number } | null {
+  const row = db
+    .prepare(
+      `SELECT model_name, dim FROM lcm_embedding_profile
+         WHERE active = 1 AND archive_after IS NULL
+         ORDER BY registered_at DESC LIMIT 1`,
+    )
+    .get() as { model_name?: string; dim?: number } | undefined;
+  if (!row?.model_name || !row.dim) return null;
+  return { modelName: row.model_name, dim: row.dim };
+}
+
+/**
+ * Run a semantic search. Returns ranked hits sorted by distance ascending.
+ *
+ * Throws {@link SemanticSearchUnavailableError} if vec0 isn't loaded or
+ * no active embedding model is registered. Caller (e.g. lcm_grep with
+ * mode='hybrid') should catch this and gracefully degrade to FTS-only.
+ */
+export async function runSemanticSearch(
+  db: DatabaseSync,
+  opts: SemanticSearchOptions,
+): Promise<SemanticSearchResult> {
+  // 1. Validate vec0 + active model
+  if (vec0Version(db) === null) {
+    throw new SemanticSearchUnavailableError(
+      "[semantic-search] sqlite-vec is not loaded — semantic retrieval unavailable",
+    );
+  }
+  const active = getActiveEmbeddingModel(db);
+  if (!active) {
+    throw new SemanticSearchUnavailableError(
+      "[semantic-search] no active embedding model registered in lcm_embedding_profile",
+    );
+  }
+  if (!embeddingsTableExists(db, active.modelName)) {
+    throw new SemanticSearchUnavailableError(
+      `[semantic-search] vec0 table for ${active.modelName} doesn't exist — call ensureEmbeddingsTable() during setup`,
+    );
+  }
+
+  // 2. Embed query (or use injected vector)
+  let queryVector: Float32Array | number[];
+  let voyageTokensConsumed = 0;
+  if (opts.queryVector) {
+    if (opts.queryVector.length !== active.dim) {
+      throw new Error(
+        `[semantic-search] queryVector dim ${opts.queryVector.length} != active model dim ${active.dim}`,
+      );
+    }
+    queryVector = opts.queryVector;
+  } else {
+    const query = opts.query?.trim() ?? "";
+    if (query.length === 0) {
+      throw new Error("[semantic-search] query is required (or pass queryVector)");
+    }
+    const voyageModel = (opts.voyageModel ?? active.modelName) as VoyageEmbeddingModel;
+    const embed = await embedTexts({
+      model: voyageModel,
+      texts: [query],
+      inputType: opts.inputType ?? "query",
+      apiKey: opts.voyageApiKey,
+      fetch: opts.voyageFetch,
+      maxRetries: opts.voyageMaxRetries,
+      timeoutMs: opts.voyageTimeoutMs,
+      // Wave-11 reviewer P1 fix: query embedding must request the
+      // same dim as the indexed corpus. Pulled from the active
+      // profile so query vectors match vec0's column shape.
+      outputDimension: active.dim,
+    });
+    if (embed.vectors.length !== 1) {
+      throw new Error(
+        `[semantic-search] Voyage returned ${embed.vectors.length} vectors (expected 1)`,
+      );
+    }
+    queryVector = embed.vectors[0];
+    voyageTokensConsumed = embed.totalTokens;
+  }
+
+  // 3. KNN search (with vec0-side suppression + kind filter)
+  //
+  // P1 FIX (2026-05-06 harness finding): when any filter (time / conversation
+  // / sessionKey / kind) is present, vec0's nearest-K does not know about it.
+  // Top-K globally may all live OUTSIDE the filter window, leading to
+  // 0 hits even though hundreds of matching docs exist. Counter by
+  // OVER-FETCHING from vec0 (10× the user's k, capped at 500) when filters
+  // are active, then trimming after the JOIN. Without filters, request just
+  // k — no waste.
+  const userK = opts.k ?? 50;
+  const hasFilter = Boolean(
+    opts.since ||
+      opts.before ||
+      (opts.conversationIds && opts.conversationIds.length > 0) ||
+      (opts.sessionKeys && opts.sessionKeys.length > 0) ||
+      (opts.summaryKinds && opts.summaryKinds.length > 0),
+  );
+  const VEC0_OVERFETCH_MULT = 10;
+  const VEC0_OVERFETCH_MAX = 500;
+  const k = hasFilter
+    ? Math.min(VEC0_OVERFETCH_MAX, Math.max(userK, userK * VEC0_OVERFETCH_MULT))
+    : userK;
+  const candidates = searchSimilar(db, {
+    modelName: active.modelName,
+    queryVector,
+    k,
+    embeddedKinds: opts.embeddedKinds ?? ["summary"],
+    excludeSuppressed: opts.excludeSuppressed !== false,
+  });
+
+  if (candidates.length === 0) {
+    return { hits: [], candidateCount: 0, voyageTokensConsumed, modelName: active.modelName };
+  }
+
+  // 4. JOIN back to summaries with all the filter clauses applied at the
+  //    SQL layer. Defense-in-depth suppression: filter vec0-metadata AND
+  //    summaries.suppressed_at to handle a race between trigger + KNN.
+  const summaryHits = candidates.filter((c) => c.embeddedKind === "summary");
+  const summaryIds = summaryHits.map((c) => c.embeddedId);
+  if (summaryIds.length === 0) {
+    // All candidates were entity/theme — return them with no JOIN. Caller
+    // tools (lcm_grep semantic mode) may or may not handle these.
+    // Audit 1 finding #1 (HIGH): cosineSimilarity is a required field —
+    // omitting it crashes downstream `.toFixed(3)` calls. Compute it here.
+    return {
+      hits: candidates.map((c) => ({
+        summaryId: c.embeddedId,
+        embeddedKind: c.embeddedKind,
+        distance: c.distance,
+        cosineSimilarity: Math.max(-1, Math.min(1, 1 - (c.distance * c.distance) / 2)),
+        conversationId: -1, // unknown — not a summary
+        sessionKey: "",
+        kind: "leaf",
+        content: "",
+        tokenCount: 0,
+        createdAt: "",
+        earliestAt: null,
+        latestAt: null,
+        // Wave-8 Auditor #2-5 B-P1 fix: `filteredAfterJoin: true` was
+        // being set on EVERY entity/theme hit despite no JOIN being
+        // attempted. The field's documented semantic is "row passed
+        // metadata-only check but failed JOIN" — meaningless for the
+        // entity branch where no JOIN exists. Now `false` (these rows
+        // didn't fail any JOIN; there was no JOIN to fail).
+        filteredAfterJoin: false,
+      })),
+      candidateCount: candidates.length,
+      voyageTokensConsumed,
+      modelName: active.modelName,
+    };
+  }
+
+  // Build dynamic WHERE clauses + bind params
+  const placeholders = summaryIds.map(() => "?").join(",");
+  const filters: string[] = [];
+  // Wave-9 TS-tightening: typed for DatabaseSync.all(...args) which
+  // requires SQLInputValue. summaryIds are strings; appended values
+  // are ISO timestamps (since/before) and summaryKinds (strings).
+  const binds: (string | number)[] = [...summaryIds];
+
+  if (opts.excludeSuppressed !== false) {
+    filters.push("s.suppressed_at IS NULL");
+  }
+  if (opts.sessionKeys && opts.sessionKeys.length > 0) {
+    filters.push(`s.session_key IN (${opts.sessionKeys.map(() => "?").join(",")})`);
+    binds.push(...opts.sessionKeys);
+  }
+  if (opts.conversationIds && opts.conversationIds.length > 0) {
+    filters.push(`s.conversation_id IN (${opts.conversationIds.map(() => "?").join(",")})`);
+    binds.push(...opts.conversationIds);
+  }
+  // Wave-1 Auditor #4 finding #3: semantic and FTS arms had divergent
+  // time-filter semantics — semantic used `s.created_at` (row-write
+  // time), FTS used `COALESCE(s.latest_at, s.created_at)` (the content's
+  // covered-time bracket). On condensed summaries written long after the
+  // content they cover, the two arms returned different sets for the
+  // same since/before window. Use COALESCE here to match FTS.
+  if (opts.since) {
+    filters.push(
+      `julianday(COALESCE(s.latest_at, s.created_at)) >= julianday(?)`,
+    );
+    binds.push(opts.since.toISOString());
+  }
+  if (opts.before) {
+    filters.push(
+      `julianday(COALESCE(s.latest_at, s.created_at)) < julianday(?)`,
+    );
+    binds.push(opts.before.toISOString());
+  }
+  if (opts.summaryKinds && opts.summaryKinds.length > 0) {
+    filters.push(`s.kind IN (${opts.summaryKinds.map(() => "?").join(",")})`);
+    binds.push(...opts.summaryKinds);
+  }
+  const whereExtra = filters.length > 0 ? " AND " + filters.join(" AND ") : "";
+
+  const rows = db
+    .prepare(
+      `SELECT s.summary_id, s.conversation_id, s.session_key, s.kind, s.content,
+              s.token_count, s.created_at, s.earliest_at, s.latest_at
+         FROM summaries s
+         WHERE s.summary_id IN (${placeholders})${whereExtra}`,
+    )
+    .all(...binds) as Array<{
+    summary_id: string;
+    conversation_id: number;
+    session_key: string;
+    kind: "leaf" | "condensed";
+    content: string;
+    token_count: number;
+    created_at: string;
+    earliest_at: string | null;
+    latest_at: string | null;
+  }>;
+
+  const rowsById = new Map(rows.map((r) => [r.summary_id, r] as const));
+
+  // 5. Build hits in candidate (distance) order, dropping any that didn't
+  //    survive the filter JOIN. Mark filtered-out for diagnostics.
+  //    P1 FIX: trim to user-requested k after filtering — the over-fetch
+  //    above was just to give the post-filter step survivors to choose from.
+  const hits: SemanticHit[] = [];
+  for (const cand of summaryHits) {
+    const row = rowsById.get(cand.embeddedId);
+    if (!row) continue;
+    // Cosine similarity from L2 distance on unit vectors:
+    //   cos = 1 - L²/2
+    // Clamp to [-1, 1] to absorb floating-point error.
+    const cosSim = Math.max(-1, Math.min(1, 1 - (cand.distance * cand.distance) / 2));
+    hits.push({
+      summaryId: cand.embeddedId,
+      embeddedKind: cand.embeddedKind,
+      distance: cand.distance,
+      cosineSimilarity: cosSim,
+      conversationId: row.conversation_id,
+      sessionKey: row.session_key,
+      kind: row.kind,
+      content: row.content,
+      tokenCount: row.token_count,
+      createdAt: row.created_at,
+      earliestAt: row.earliest_at,
+      latestAt: row.latest_at,
+    });
+    if (hits.length >= userK) break;
+  }
+
+  return {
+    hits,
+    candidateCount: candidates.length,
+    voyageTokensConsumed,
+    modelName: active.modelName,
+  };
+}

--- a/src/embeddings/store.ts
+++ b/src/embeddings/store.ts
@@ -1,0 +1,609 @@
+/**
+ * Embeddings store — LCM v4.1 §13
+ *
+ * Per-model `lcm_embeddings_<slug>` vec0 virtual tables. All vec0
+ * interaction goes through this module — callers never touch vec0 SQL
+ * directly. Reasons:
+ *
+ *   1. sqlite-vec is best-effort. The extension may not be loadable in
+ *      every environment (CI without it, dev box without npm install,
+ *      forked installations). v4.1.1 A7 amendment: graceful degrade — if
+ *      vec0 is missing, the rest of LCM still works (FTS-only retrieval,
+ *      no semantic recall, lower retrieval quality but no crash). All
+ *      embedding writes become no-ops.
+ *
+ *   2. vec0 schema discipline. vec0 partition keys, metadata columns,
+ *      and auxiliary columns each have different syntax + UPDATE
+ *      semantics. v4.1.1 noted that "UPDATE on PARTITION KEY corrupts
+ *      vec0" — we use METADATA columns for `suppressed` (UPDATE works)
+ *      and AUXILIARY columns for `embedded_id` / `embedded_kind` (UPDATE
+ *      not needed; these are insert-once). Centralizing the SQL here
+ *      prevents callers from accidentally choosing the wrong column
+ *      class.
+ *
+ *   3. INTEGER metadata cols in vec0 require BigInt at the binding
+ *      site under Node's `node:sqlite`. JS `0` literal binds as FLOAT
+ *      and vec0 rejects it ("Expected integer for INTEGER metadata
+ *      column"). Centralizing BigInt conversion here prevents callers
+ *      from learning this the hard way.
+ *
+ *   4. Mapping (embedded_id TEXT, embedded_kind TEXT) ↔ vec0 internal
+ *      rowid. We store both as auxiliary columns so KNN queries return
+ *      them directly — no separate join to a mapping table needed.
+ *      `lcm_embedding_meta` is a parallel sidecar for non-vector queries
+ *      (was-this-id-embedded-yet?) but is not required to resolve KNN
+ *      results back to source documents.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { existsSync } from "node:fs";
+import { homedir, platform, arch } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Allowed model-name shape for use in `lcm_embeddings_<slug>` table names.
+ * SQL identifiers don't accept arbitrary strings; we sanitize aggressively
+ * and reject anything outside `[a-z0-9_]` after sluggification. This
+ * doubles as defense-in-depth against table-name injection.
+ */
+const MODEL_NAME_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+
+/**
+ * Convert a Voyage model name (e.g. `voyage-4-large`) into a SQL-safe
+ * table-name suffix (e.g. `voyage4large`). Lowercase, alphanumeric only.
+ *
+ * Throws if `modelName` is empty or contains characters outside the
+ * accepted set — caller bug.
+ */
+export function embeddingsTableName(modelName: string): string {
+  if (!MODEL_NAME_PATTERN.test(modelName)) {
+    throw new Error(
+      `[embeddings.store] invalid model name: ${JSON.stringify(modelName)} ` +
+        `(must match ${MODEL_NAME_PATTERN}; got len=${modelName.length})`,
+    );
+  }
+  const slug = modelName.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (slug.length === 0) {
+    throw new Error(
+      `[embeddings.store] model name "${modelName}" sluggifies to empty — pick a different model name`,
+    );
+  }
+  return `lcm_embeddings_${slug}`;
+}
+
+/**
+ * Where this module looks for `vec0.dylib` / `vec0.so` / `vec0.dll`. In
+ * order:
+ *
+ *   1. Explicit path passed via `opts.path`.
+ *   2. Env var `LCM_SQLITE_VEC_PATH`.
+ *   3. Plugin's `node_modules/sqlite-vec-<platform>-<arch>/vec0.<ext>`.
+ *   4. OpenClaw extensions dir's `node_modules/sqlite-vec-<platform>-<arch>/vec0.<ext>`.
+ */
+export function candidateVec0Paths(): string[] {
+  const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+  const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+  const candidates: string[] = [];
+
+  const envPath = process.env.LCM_SQLITE_VEC_PATH?.trim();
+  if (envPath) candidates.push(envPath);
+
+  // Plugin-local install (when this module is bundled with the plugin)
+  candidates.push(resolve(process.cwd(), "node_modules", platformPkg, `vec0.${ext}`));
+
+  // OpenClaw extensions dir (typical local-dev install)
+  candidates.push(
+    join(homedir(), ".openclaw", "extensions", "node_modules", platformPkg, `vec0.${ext}`),
+  );
+
+  return candidates;
+}
+
+export interface LoadVec0Options {
+  /** Override candidate-search with explicit path. */
+  path?: string;
+  /** Suppress console.warn on failure. Default false. */
+  silent?: boolean;
+}
+
+/**
+ * Best-effort load of the sqlite-vec extension. Returns true on success.
+ * Returns false (and optionally logs a warning) if the extension is
+ * unavailable — the rest of LCM continues to work without semantic search.
+ *
+ * After this returns true, vec0 SQL is available on the connection. The
+ * connection's `allowExtension` option must have been set when the
+ * connection was opened (default false in `node:sqlite`).
+ *
+ * Idempotent: safe to call multiple times on the same connection;
+ * sqlite-vec only registers vec0 once per process (subsequent
+ * `loadExtension` calls are essentially no-ops).
+ */
+export function tryLoadSqliteVec(db: DatabaseSync, opts: LoadVec0Options = {}): boolean {
+  const candidates = opts.path ? [opts.path] : candidateVec0Paths();
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    try {
+      // Node 22+ DatabaseSync exposes loadExtension; throws if the
+      // connection wasn't opened with `allowExtension: true`. We surface
+      // that as a controlled failure rather than a crash.
+      (db as unknown as { loadExtension(filename: string): void }).loadExtension(candidate);
+      return true;
+    } catch (e: unknown) {
+      if (!opts.silent) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[embeddings.store] failed to load sqlite-vec at ${candidate}: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+      // Continue to next candidate — maybe a different one works
+    }
+  }
+  return false;
+}
+
+/**
+ * Cheap probe: did sqlite-vec successfully register? Tries to call
+ * `vec_version()`. Returns `null` if not loaded.
+ */
+export function vec0Version(db: DatabaseSync): string | null {
+  try {
+    const row = db.prepare("SELECT vec_version() AS v").get() as { v?: string } | undefined;
+    return row?.v ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create the `lcm_embeddings_<slug>` vec0 virtual table for a given model
+ * if it doesn't exist. Throws if sqlite-vec is not loaded (caller should
+ * gate with {@link vec0Version}).
+ *
+ * Schema:
+ *   - `embedding float[<dim>]` — the actual vector
+ *   - `+embedded_id text` — AUXILIARY; stores `summaries.summary_id` /
+ *     `lcm_entities.entity_id` / `lcm_themes.theme_id` (polymorphic).
+ *     Auxiliary because we never WHERE-filter on it — KNN returns at most
+ *     k rows and the application joins/displays from there.
+ *   - `embedded_kind text` — METADATA; one of 'summary'/'entity'/'theme'.
+ *     Metadata (not auxiliary) because retrieval surfaces filter by kind
+ *     during the KNN traversal (`WHERE embedded_kind IN ('summary')`),
+ *     and vec0 only allows WHERE on metadata cols inside MATCH queries —
+ *     auxiliary cols throw "illegal WHERE constraint" if filtered.
+ *   - `suppressed integer` — METADATA; 0/1 for fast WHERE-pre-filter on
+ *     KNN queries (so suppressed rows never appear in retrieval results
+ *     without a separate JOIN to summaries).
+ *
+ * Idempotent via `IF NOT EXISTS`.
+ *
+ * Also creates per-model triggers on `summaries` (B.03):
+ *
+ *   - `lcm_embed_suppress_<slug>` — AFTER UPDATE OF suppressed_at on
+ *     summaries, mirrors NULL-vs-not-NULL into vec0.suppressed metadata
+ *     col. Why we use a trigger: the suppression cascade has to fire
+ *     every time the operator marks a leaf suppressed (could be from
+ *     any path — `lcm_purge`, agent tool, manual SQL); a trigger is
+ *     guaranteed-by-DB rather than guaranteed-by-convention.
+ *
+ *   - `lcm_embed_delete_<slug>` — AFTER DELETE on summaries, removes
+ *     vec0 row. Why a trigger and not FK CASCADE: vec0 corrupts under
+ *     FK constraints (v4.1.1 finding). Trigger is the only safe path.
+ *
+ * Both triggers are per-model (one set per `lcm_embeddings_<slug>` table)
+ * because vec0 SQL doesn't support dynamic table-name resolution inside
+ * triggers — each trigger references its specific vec0 table by name.
+ *
+ * v4.1.1 NOTE on entities/themes: parallel triggers should be created
+ * for `lcm_entities` and `lcm_themes` when those embeddings are added
+ * (Group E entity coreference, Group G themes). For now the embedding
+ * store only knows about summary embeddings; entity/theme triggers will
+ * extend this helper or land their own when Groups E/G ship.
+ */
+export function ensureEmbeddingsTable(
+  db: DatabaseSync,
+  modelName: string,
+  dim: number,
+): void {
+  if (!Number.isInteger(dim) || dim <= 0 || dim > 4096) {
+    throw new Error(`[embeddings.store] invalid dim ${dim} (must be 1-4096)`);
+  }
+  const tableName = embeddingsTableName(modelName);
+  // No bind params allowed in CREATE VIRTUAL TABLE / CREATE TRIGGER;
+  // tableName has been validated via embeddingsTableName regex (alphanum+underscore).
+  db.exec(
+    `CREATE VIRTUAL TABLE IF NOT EXISTS ${tableName} USING vec0(
+       embedding float[${dim}],
+       +embedded_id text,
+       embedded_kind text,
+       suppressed integer
+     )`,
+  );
+
+  // Per-model suppression cascade trigger. Fires only when the
+  // suppressed_at column actually transitioned NULL ↔ not-NULL — avoids
+  // unnecessary work when other columns of summaries are updated. We use
+  // BigInt literal-style 0/1 in CASE because vec0 INTEGER metadata cols
+  // require integer-typed values (JS-floats rejected).
+  db.exec(
+    `CREATE TRIGGER IF NOT EXISTS lcm_embed_suppress_${tableName.replace(/^lcm_embeddings_/, "")}
+       AFTER UPDATE OF suppressed_at ON summaries
+       WHEN (NEW.suppressed_at IS NULL) != (OLD.suppressed_at IS NULL)
+       BEGIN
+         UPDATE ${tableName}
+           SET suppressed = CASE WHEN NEW.suppressed_at IS NULL THEN 0 ELSE 1 END
+           WHERE embedded_id = NEW.summary_id AND embedded_kind = 'summary';
+       END`,
+  );
+
+  // Per-model deletion cascade trigger. Fires on hard-delete of a summary
+  // (only path: lcm_purge with --immediate, or migration cleanup). Removes
+  // the vec0 row so KNN doesn't return a dangling pointer.
+  db.exec(
+    `CREATE TRIGGER IF NOT EXISTS lcm_embed_delete_${tableName.replace(/^lcm_embeddings_/, "")}
+       AFTER DELETE ON summaries
+       BEGIN
+         DELETE FROM ${tableName}
+           WHERE embedded_id = OLD.summary_id AND embedded_kind = 'summary';
+       END`,
+  );
+}
+
+/**
+ * Drop the per-model triggers (and optionally the vec0 table) for a
+ * given model. Used during model archival / cutover.
+ *
+ * If `dropTable` is true, also drops the vec0 virtual table itself —
+ * unrecoverable. Default false (keeps the table for forensic queries
+ * even after archival; only the active flag flips in `lcm_embedding_profile`).
+ */
+export function dropEmbeddingsTriggers(
+  db: DatabaseSync,
+  modelName: string,
+  opts: { dropTable?: boolean } = {},
+): void {
+  const tableName = embeddingsTableName(modelName);
+  const slug = tableName.replace(/^lcm_embeddings_/, "");
+  db.exec(`DROP TRIGGER IF EXISTS lcm_embed_suppress_${slug}`);
+  db.exec(`DROP TRIGGER IF EXISTS lcm_embed_delete_${slug}`);
+  if (opts.dropTable) {
+    db.exec(`DROP TABLE IF EXISTS ${tableName}`);
+  }
+}
+
+/**
+ * INSERT OR IGNORE into lcm_embedding_profile. Idempotent. Caller passes
+ * the dim we'll use for the vec0 table — this couples profile registration
+ * to actual table creation so the two can't drift.
+ *
+ * v4.1 §13 / Group B Gap 2 fix: also enforces SLUG uniqueness across
+ * profiles. Two model names that sluggify to the same vec0 table name
+ * (e.g. "voyage-4-large" and "voyage_4_large" both → "voyage4large")
+ * would silently corrupt KNN by routing inserts to the same table —
+ * the second registration here throws to prevent that.
+ *
+ * Throws if:
+ *   - modelName fails MODEL_NAME_PATTERN regex
+ *   - dim is not a positive integer or > 4096 (Gap 8: align with ensureEmbeddingsTable)
+ *   - existing profile with same name has different dim
+ *   - existing profile has same SLUG but different name
+ */
+export function registerEmbeddingProfile(
+  db: DatabaseSync,
+  modelName: string,
+  dim: number,
+): void {
+  if (!MODEL_NAME_PATTERN.test(modelName)) {
+    throw new Error(`[embeddings.store] invalid model name: ${JSON.stringify(modelName)}`);
+  }
+  if (!Number.isInteger(dim) || dim <= 0) {
+    throw new Error(`[embeddings.store] invalid dim ${dim}`);
+  }
+  // Group B Gap 8 fix: align dim upper bound between
+  // registerEmbeddingProfile and ensureEmbeddingsTable.
+  if (dim > 4096) {
+    throw new Error(`[embeddings.store] invalid dim ${dim} (max 4096)`);
+  }
+
+  // Group B Gap 2 fix: check slug uniqueness BEFORE inserting. Compute
+  // slug, scan existing profiles, throw if a different model_name already
+  // has the same slug (would cause vec0 table-name collision).
+  const ourSlug = modelName.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const existingSlugCollision = db
+    .prepare(`SELECT model_name FROM lcm_embedding_profile WHERE model_name != ?`)
+    .all(modelName) as Array<{ model_name: string }>;
+  for (const other of existingSlugCollision) {
+    const otherSlug = other.model_name.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (otherSlug === ourSlug) {
+      throw new Error(
+        `[embeddings.store] slug collision: model_name "${modelName}" sluggifies to ` +
+          `"${ourSlug}" which is already used by registered model "${other.model_name}". ` +
+          `Two profiles cannot share a vec0 table name. Pick a model_name that sluggifies differently.`,
+      );
+    }
+  }
+
+  // INSERT OR IGNORE: if a row exists with the same model_name, leave it
+  // alone (whether the dim matches or not is checked next).
+  db.prepare(
+    `INSERT OR IGNORE INTO lcm_embedding_profile (model_name, dim, active)
+     VALUES (?, ?, 1)`,
+  ).run(modelName, dim);
+
+  // Defensive: if a profile exists with a DIFFERENT dim, that's a bug —
+  // dim is locked at first registration. Silently accepting a mismatched
+  // dim would corrupt the vec0 table.
+  const row = db
+    .prepare(`SELECT dim FROM lcm_embedding_profile WHERE model_name = ?`)
+    .get(modelName) as { dim?: number } | undefined;
+  if (!row) {
+    throw new Error(`[embeddings.store] failed to register profile ${modelName}`);
+  }
+  if (row.dim !== dim) {
+    throw new Error(
+      `[embeddings.store] dim mismatch for ${modelName}: existing profile has dim=${row.dim}, ` +
+        `caller passed dim=${dim}. Profiles are immutable; bump model_name (e.g. add suffix) instead.`,
+    );
+  }
+}
+
+export type EmbeddedKind = "summary" | "entity" | "theme";
+
+/**
+ * Insert (or replace) an embedding for a (id, kind) pair under the given
+ * model. Updates BOTH the vec0 table AND `lcm_embedding_meta` in the
+ * caller's transaction (caller wraps both calls together for atomicity).
+ *
+ * Throws if the dim of `vector` doesn't match the registered profile dim.
+ *
+ * Note: we DO NOT wrap in a transaction here — the caller does, because
+ * the leaf-write path embeds inside its existing T1, and the backfill
+ * cron groups multiple inserts into a single transaction for throughput.
+ */
+export function recordEmbedding(
+  db: DatabaseSync,
+  args: {
+    modelName: string;
+    embeddedId: string;
+    embeddedKind: EmbeddedKind;
+    vector: Float32Array | number[];
+    suppressed?: boolean;
+    sourceTokenCount: number;
+  },
+): void {
+  const { modelName, embeddedId, embeddedKind, vector, suppressed, sourceTokenCount } = args;
+  const profile = db
+    .prepare(`SELECT dim FROM lcm_embedding_profile WHERE model_name = ?`)
+    .get(modelName) as { dim?: number } | undefined;
+  if (!profile) {
+    throw new Error(
+      `[embeddings.store] no profile registered for ${modelName} — call registerEmbeddingProfile first`,
+    );
+  }
+  if (vector.length !== profile.dim) {
+    throw new Error(
+      `[embeddings.store] dim mismatch: vector.length=${vector.length}, profile.dim=${profile.dim}`,
+    );
+  }
+  const tableName = embeddingsTableName(modelName);
+
+  // vec0 stores vectors as JSON arrays; binding a Float32Array directly
+  // does NOT serialize correctly under node:sqlite (it becomes a BLOB
+  // that vec0 doesn't know how to parse into a vector). Stringify.
+  const vecJson = JSON.stringify(Array.from(vector));
+  // INTEGER metadata cols require BigInt under node:sqlite, see
+  // module-level docs (vec0 sees JS number 0 as FLOAT and rejects).
+  const suppressedBig = suppressed ? 1n : 0n;
+
+  // Wave-4 Auditor #3 P0 fix: vec0 auxiliary cols aren't UNIQUE-indexed,
+  // so back-to-back recordEmbedding(...) calls on the same
+  // (embedded_id, embedded_kind) created DUPLICATE vec0 rows. The meta
+  // sidecar is INSERT OR REPLACE so it self-heals to one row, but vec0
+  // accumulates duplicates that surface as duplicate KNN hits at search
+  // time (semantic_recall returns the same summary multiple times).
+  // Defense-in-depth: DELETE any prior matching row before INSERT,
+  // wrapped with the meta INSERT in a SAVEPOINT so the pair is atomic
+  // (compounds with Wave-1's writeBatch SAVEPOINT-per-row in
+  // backfill.ts — that protects bulk paths; this protects all callers).
+  //
+  // Wave-5 P1 fix: SAVEPOINT name uses crypto.randomUUID-derived hex
+  // (was Math.random 24-bit, ~1/4096 collision risk under concurrent
+  // outer-tx callers). 12 hex chars = 48 bits, collision-free for any
+  // realistic concurrency.
+  const cryptoSuffix =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID().replace(/-/g, "").slice(0, 12)
+      : `${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0")}${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0")}`;
+  const sp = `re_${cryptoSuffix}`;
+  db.exec(`SAVEPOINT ${sp}`);
+  try {
+    db.prepare(
+      `DELETE FROM ${tableName} WHERE embedded_id = ? AND embedded_kind = ?`,
+    ).run(embeddedId, embeddedKind);
+    db.prepare(
+      `INSERT INTO ${tableName} (embedding, embedded_id, embedded_kind, suppressed)
+       VALUES (?, ?, ?, ?)`,
+    ).run(vecJson, embeddedId, embeddedKind, suppressedBig);
+
+    // Mirror in lcm_embedding_meta — sidecar for "is this thing embedded?"
+    // queries that don't need to load the vector.
+    db.prepare(
+      `INSERT OR REPLACE INTO lcm_embedding_meta
+         (embedded_id, embedded_kind, embedding_model, embedded_at, source_token_count, archived)
+       VALUES (?, ?, ?, datetime('now'), ?, 0)`,
+    ).run(embeddedId, embeddedKind, modelName, sourceTokenCount);
+    db.exec(`RELEASE ${sp}`);
+  } catch (e) {
+    try { db.exec(`ROLLBACK TO ${sp}`); db.exec(`RELEASE ${sp}`); } catch {}
+    throw e;
+  }
+}
+
+/**
+ * Replace an existing embedding for a (id, kind, model) tuple. Deletes
+ * any prior vec0 rows then inserts. Use when the source content was
+ * regenerated (e.g., leaf re-summarized at higher cap per A.10).
+ */
+export function replaceEmbedding(
+  db: DatabaseSync,
+  args: Parameters<typeof recordEmbedding>[1],
+): void {
+  const tableName = embeddingsTableName(args.modelName);
+  db.prepare(
+    `DELETE FROM ${tableName} WHERE embedded_id = ? AND embedded_kind = ?`,
+  ).run(args.embeddedId, args.embeddedKind);
+  recordEmbedding(db, args);
+}
+
+/**
+ * Delete an embedding (e.g., when source row is hard-deleted by purge).
+ * Removes from both vec0 and lcm_embedding_meta.
+ */
+export function deleteEmbedding(
+  db: DatabaseSync,
+  args: { modelName: string; embeddedId: string; embeddedKind: EmbeddedKind },
+): void {
+  const tableName = embeddingsTableName(args.modelName);
+  db.prepare(
+    `DELETE FROM ${tableName} WHERE embedded_id = ? AND embedded_kind = ?`,
+  ).run(args.embeddedId, args.embeddedKind);
+  db.prepare(
+    `DELETE FROM lcm_embedding_meta
+       WHERE embedded_id = ? AND embedded_kind = ? AND embedding_model = ?`,
+  ).run(args.embeddedId, args.embeddedKind, args.modelName);
+}
+
+/**
+ * Mark / unmark an embedding as suppressed. Updates the metadata column
+ * inside vec0 so subsequent KNN queries can pre-filter via
+ * `WHERE suppressed = 0` (much cheaper than a JOIN to summaries).
+ *
+ * Note: vec0 supports UPDATE on metadata columns. (UPDATE on PARTITION
+ * KEY columns is documented as broken; we don't use partition keys.)
+ */
+export function markEmbeddingSuppressed(
+  db: DatabaseSync,
+  args: {
+    modelName: string;
+    embeddedId: string;
+    embeddedKind: EmbeddedKind;
+    suppressed: boolean;
+  },
+): void {
+  const tableName = embeddingsTableName(args.modelName);
+  db.prepare(
+    `UPDATE ${tableName} SET suppressed = ?
+       WHERE embedded_id = ? AND embedded_kind = ?`,
+  ).run(args.suppressed ? 1n : 0n, args.embeddedId, args.embeddedKind);
+}
+
+export interface SearchSimilarOptions {
+  modelName: string;
+  queryVector: Float32Array | number[];
+  k?: number;
+  /** Filter to specific embedded_kind values. Default = ['summary']. */
+  embeddedKinds?: EmbeddedKind[];
+  /**
+   * If true (default), excludes rows with suppressed=1 via vec0 metadata
+   * pre-filter. v4.1 §10 invariant: every retrieval surface MUST suppress
+   * by default; opt-in to false only for operator/admin tools.
+   */
+  excludeSuppressed?: boolean;
+}
+
+export interface SearchHit {
+  embeddedId: string;
+  embeddedKind: EmbeddedKind;
+  distance: number;
+}
+
+/**
+ * KNN search against the per-model vec0 table. Returns nearest-K rows
+ * by L2 (Euclidean) distance ascending (smallest = most similar).
+ *
+ * Distance metric note: vec0's `CREATE VIRTUAL TABLE ... USING vec0(embedding float[N])`
+ * uses L2 by default — there is NO cosine column-modifier in this declaration.
+ * We rely on Voyage embeddings being unit-normalized (norm ≈ 1.0), which
+ * makes L2 monotone with cosine: L² = 2·(1 - cosine_similarity). For unit
+ * vectors, distances cluster as:
+ *   - ~0.45 (cos ≈ 0.9) = strongly related
+ *   - ~1.00 (cos ≈ 0.5) = weakly related
+ *   - ~1.41 (cos ≈ 0.0) = orthogonal / unrelated
+ * Callers that need cosine for thresholding should derive it from `distance`
+ * (see runSemanticSearch which exposes `cosineSimilarity` on each hit).
+ *
+ * Throws if the embeddings table for this model doesn't exist. Caller
+ * should `vec0Version(db) !== null && embeddingsTableExists(db, modelName)`
+ * gate.
+ */
+export function searchSimilar(
+  db: DatabaseSync,
+  opts: SearchSimilarOptions,
+): SearchHit[] {
+  const k = opts.k ?? 50;
+  if (!Number.isInteger(k) || k <= 0 || k > 1000) {
+    throw new Error(`[embeddings.store] invalid k=${k} (must be 1-1000)`);
+  }
+  const excludeSuppressed = opts.excludeSuppressed !== false;
+  const kinds = opts.embeddedKinds ?? ["summary"];
+  if (kinds.length === 0) return [];
+
+  const tableName = embeddingsTableName(opts.modelName);
+  const vecJson = JSON.stringify(Array.from(opts.queryVector));
+
+  // Build kinds filter — placeholder list, parameterized
+  const kindPlaceholders = kinds.map(() => "?").join(",");
+  const suppressedFilter = excludeSuppressed ? "AND suppressed = 0" : "";
+
+  const sql = `
+    SELECT embedded_id, embedded_kind, distance
+    FROM ${tableName}
+    WHERE embedding MATCH ?
+      AND k = ?
+      ${suppressedFilter}
+      AND embedded_kind IN (${kindPlaceholders})
+    ORDER BY distance
+  `;
+  const rows = db.prepare(sql).all(vecJson, k, ...kinds) as Array<{
+    embedded_id: string;
+    embedded_kind: EmbeddedKind;
+    distance: number;
+  }>;
+  return rows.map((r) => ({
+    embeddedId: r.embedded_id,
+    embeddedKind: r.embedded_kind,
+    distance: r.distance,
+  }));
+}
+
+/**
+ * Does the vec0 virtual table for this model exist? Cheap sqlite_master
+ * check; safe to call when vec0 isn't loaded (returns false).
+ */
+export function embeddingsTableExists(db: DatabaseSync, modelName: string): boolean {
+  const tableName = embeddingsTableName(modelName);
+  const row = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?`)
+    .get(tableName) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+/**
+ * Has this (id, kind, model) tuple been embedded? Cheap meta lookup; no
+ * vec0 access. Used by backfill cron to skip already-embedded rows.
+ */
+export function isEmbedded(
+  db: DatabaseSync,
+  args: { embeddedId: string; embeddedKind: EmbeddedKind; modelName: string },
+): boolean {
+  const row = db
+    .prepare(
+      `SELECT 1 AS x FROM lcm_embedding_meta
+         WHERE embedded_id = ? AND embedded_kind = ? AND embedding_model = ? AND archived = 0`,
+    )
+    .get(args.embeddedId, args.embeddedKind, args.modelName) as { x?: number } | undefined;
+  return Boolean(row?.x);
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8852,6 +8852,17 @@ export class LcmContextEngine implements ContextEngine {
     return this.retrieval;
   }
 
+  /**
+   * Expose the active SQLite connection for v4.1 retrieval surfaces
+   * (lcm_grep semantic and hybrid modes) that need to call
+   * `runSemanticSearch` / `runHybridSearch` directly. Tools should treat
+   * the returned handle as read-mostly; long-running writes should still
+   * route through the appropriate store helper.
+   */
+  getDb(): DatabaseSync {
+    return this.db;
+  }
+
   getConversationStore(): ConversationStore {
     return this.conversationStore;
   }

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -29,6 +29,14 @@ export interface DescribeResult {
   /** Summary-specific fields */
   summary?: {
     conversationId: number;
+    /**
+     * v4.1 §13 / Group C.05: session_key sourced from the parent
+     * conversations row. summaries.session_key is atomically populated
+     * at write time per Gap 8 (B.05); we pull through the conversation
+     * record so callers don't need a separate lookup. Empty string when
+     * the parent conversation has no session_key set.
+     */
+    sessionKey: string;
     kind: "leaf" | "condensed";
     content: string;
     depth: number;
@@ -42,6 +50,17 @@ export interface DescribeResult {
     messageIds: number[];
     earliestAt: Date | null;
     latestAt: Date | null;
+    /**
+     * v4.1 §13 / Group C.05: normalized time bracket — earliest covered
+     * content, latest covered content, and the row's own creation time.
+     * Mirrors earliestAt/latestAt/createdAt above for callers (esp.
+     * agents) that prefer a single struct.
+     */
+    timeRange: {
+      earliestAt: Date | null;
+      latestAt: Date | null;
+      createdAt: Date;
+    };
     subtree: Array<{
       summaryId: string;
       parentSummaryId: string | null;
@@ -171,19 +190,27 @@ export class RetrievalEngine {
       return null;
     }
 
-    // Fetch lineage in parallel
-    const [parents, children, messageIds, subtree] = await Promise.all([
+    // Fetch lineage + parent conversation (for session_key) in parallel.
+    // session_key is atomically populated on summaries (Gap 8 / B.05) but
+    // SummaryRecord doesn't carry it through the public store API; pull
+    // from the parent conversation, which holds the same value by
+    // invariant.
+    const [parents, children, messageIds, subtree, conversation] = await Promise.all([
       this.summaryStore.getSummaryParents(id),
       this.summaryStore.getSummaryChildren(id),
       this.summaryStore.getSummaryMessages(id),
       this.summaryStore.getSummarySubtree(id),
+      this.conversationStore.getConversation(summary.conversationId),
     ]);
+
+    const sessionKey = conversation?.sessionKey ?? "";
 
     return {
       id,
       type: "summary",
       summary: {
         conversationId: summary.conversationId,
+        sessionKey,
         kind: summary.kind,
         content: summary.content,
         depth: summary.depth,
@@ -197,6 +224,11 @@ export class RetrievalEngine {
         messageIds,
         earliestAt: summary.earliestAt,
         latestAt: summary.latestAt,
+        timeRange: {
+          earliestAt: summary.earliestAt,
+          latestAt: summary.latestAt,
+          createdAt: summary.createdAt,
+        },
         subtree: subtree.map((node) => ({
           summaryId: node.summaryId,
           parentSummaryId: node.parentSummaryId,
@@ -378,7 +410,17 @@ export class RetrievalEngine {
       truncated: false,
     };
 
-    await this.expandRecursive(input.summaryId, depth, includeMessages, tokenCap, result);
+    // Wave-4 Auditor #7 P1 fix + Wave-5 P1 fix: cycle-guard. The DAG is
+    // acyclic by invariant, but if a doctor bug or migration produces a
+    // cycle, the recursion would loop forever (default tokenCap is
+    // Infinity in some call paths). Track ACTIVE call-stack ancestors
+    // (in-flight DFS path) — NOT all-time visits. This prevents cycles
+    // without breaking legitimate cross-path re-entry: if A→B and C→B
+    // (B reachable from two distinct ancestors), B's subtree is
+    // explored under each ancestor as before. We `add` on entry, `delete`
+    // on return, so the set always reflects the current call stack only.
+    const stackAncestors = new Set<string>();
+    await this.expandRecursive(input.summaryId, depth, includeMessages, tokenCap, result, stackAncestors);
 
     return result;
   }
@@ -389,6 +431,7 @@ export class RetrievalEngine {
     includeMessages: boolean,
     tokenCap: number,
     result: ExpandResult,
+    stackAncestors: Set<string>,
   ): Promise<void> {
     if (depth <= 0) {
       return;
@@ -396,7 +439,27 @@ export class RetrievalEngine {
     if (result.truncated) {
       return;
     }
+    // Cycle guard: if this id is an ancestor on the current call stack,
+    // we've hit a cycle — return without exploring (would loop forever).
+    if (stackAncestors.has(summaryId)) {
+      return;
+    }
+    stackAncestors.add(summaryId);
+    try {
+      await this.expandRecursiveInner(summaryId, depth, includeMessages, tokenCap, result, stackAncestors);
+    } finally {
+      stackAncestors.delete(summaryId);
+    }
+  }
 
+  private async expandRecursiveInner(
+    summaryId: string,
+    depth: number,
+    includeMessages: boolean,
+    tokenCap: number,
+    result: ExpandResult,
+    stackAncestors: Set<string>,
+  ): Promise<void> {
     const summary = await this.summaryStore.getSummary(summaryId);
     if (!summary) {
       return;
@@ -430,7 +493,7 @@ export class RetrievalEngine {
 
         // Recurse into children if depth allows
         if (depth > 1) {
-          await this.expandRecursive(child.summaryId, depth - 1, includeMessages, tokenCap, result);
+          await this.expandRecursive(child.summaryId, depth - 1, includeMessages, tokenCap, result, stackAncestors);
         }
       }
     } else if (summary.kind === "leaf" && includeMessages) {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -75,7 +75,14 @@ function buildSummarizerBreakerKey(candidate: ResolvedSummaryCandidate): string 
 
 type SummaryMode = "normal" | "aggressive";
 
-const DEFAULT_LEAF_TARGET_TOKENS = 2400;
+// v4.1 (A.10): raised from 2400 → 4000. The empirical-spike-agent found
+// 543 leaves on Eva's live DB pegged at exactly 2,415 tokens — the LLM
+// was hitting the old 2400 default and producing artificially-truncated
+// summaries. Voyage embedding (Group B) supports 32K input context, so
+// 4000-token leaves are well within budget. Average leaf on Eva's corpus
+// is 1,167 tokens (most leaves don't approach the cap); the change only
+// affects leaves where the source content is dense enough to need it.
+const DEFAULT_LEAF_TARGET_TOKENS = 4000;
 const DEFAULT_CONDENSED_TARGET_TOKENS = 2000;
 const LCM_SUMMARIZER_SYSTEM_PROMPT =
   "You are a context-compaction summarization engine. Follow user instructions exactly and return plain text summary content only.";

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -10,6 +10,42 @@ import { jsonResult } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import { formatTimestamp } from "../compaction.js";
 
+const MAX_RESULT_CHARS = 40_000;
+
+/**
+ * Wave-12 audit (W1A8 #3): describe was previously unbounded — a single
+ * `describe(condensed_id, expandChildren=true)` against a wide condensed
+ * could emit ~210K tokens (10K base + 20×10K children). The estimator's
+ * needsCompact gate caught the worst cases via projection, but a tool
+ * that genuinely needed to emit large amounts under the gate's threshold
+ * still had no per-tool char cap. Mirror lcm_grep's truncation policy:
+ * cap the joined output at MAX_RESULT_CHARS and append a clear notice
+ * when we trim. Sub-agent grant ledger (consumeTokenBudget below) is a
+ * separate enforcement layer for delegated sessions; this is the main-
+ * agent equivalent.
+ */
+function truncateLinesToCap(
+  lines: string[],
+  reasonHint: string,
+): { text: string; truncated: boolean } {
+  let total = 0;
+  const out: string[] = [];
+  for (const line of lines) {
+    // +1 for the newline that join("\n") will insert between lines.
+    const next = total + line.length + (out.length > 0 ? 1 : 0);
+    if (next > MAX_RESULT_CHARS) {
+      out.push("");
+      out.push(
+        `*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — ${reasonHint}; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`,
+      );
+      return { text: out.join("\n"), truncated: true };
+    }
+    out.push(line);
+    total = next;
+  }
+  return { text: out.join("\n"), truncated: false };
+}
+
 function formatDisplayTime(
   value: Date | string | number | null | undefined,
   timezone: string,
@@ -65,6 +101,39 @@ const LcmDescribeSchema = Type.Object({
       maximum: 512_000,
     }),
   ),
+  expandChildren: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true (and target is a sum_xxx), include the first-hop child summaries' full content inline (capped at expandChildrenLimit, default 5). For deeper / wider expansion use the sub-agent lcm_expand_query path. Ignored for file_xxx targets.",
+    }),
+  ),
+  expandChildrenLimit: Type.Optional(
+    Type.Number({
+      description: "Max child summaries to inline when expandChildren=true (default 20, max 50).",
+      minimum: 1,
+      maximum: 50,
+    }),
+  ),
+  expandMessages: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true (and target is a sum_xxx leaf), include the first-hop source messages' full verbatim content inline (capped at expandMessagesLimit, default 20). Ignored for condensed summaries (no direct messages) and file_xxx targets. Suppressed messages are filtered out.",
+    }),
+  ),
+  expandMessagesLimit: Type.Optional(
+    Type.Number({
+      description: "Max source messages to inline when expandMessages=true (default 20, max 50).",
+      minimum: 1,
+      maximum: 50,
+    }),
+  ),
+  expandMessagesOffset: Type.Optional(
+    Type.Number({
+      description:
+        "Skip the first N messages before returning expandMessagesLimit. Use to paginate through long leaves (e.g. 216-message leaves where the default 20 only covers ~10% of source). Default 0.",
+      minimum: 0,
+    }),
+  ),
 });
 
 function normalizeRequestedTokenCap(value: unknown): number | undefined {
@@ -111,15 +180,18 @@ export function createLcmDescribeTool(input: {
     name: "lcm_describe",
     label: "LCM Describe",
     description:
-      "Look up metadata and content for an LCM item by ID. " +
-      "Use this to inspect summaries (sum_xxx) or stored files (file_xxx) " +
-      "from compacted conversation history. Returns summary content, lineage, " +
-      "token counts, and file exploration results. " +
+      "Look up an LCM item by ID, with optional one-hop drilldown. " +
+      "PRIMARY tool for Type E queries (drilldown / source-tracing): " +
+      "'where did this synthesized claim come from?', 'show me the source leaves " +
+      "for this summary'. Set expandChildren=true to inline child summaries " +
+      "(capped 20, max 50) and/or expandMessages=true to inline raw source " +
+      "messages. Inspects summaries (sum_xxx) or stored files (file_xxx). " +
       "ALSO USE THIS when you see a `[LCM Tool Output: file_xxx | tool=… | N bytes]` " +
-      "reference in the conversation — that means an older tool result was elided " +
-      "for context efficiency. Call lcm_describe(id=file_xxx, expandFile=true) to " +
-      "fetch the original output content before answering questions that depend on " +
-      "its specifics.",
+      "reference — an older tool result was elided; call " +
+      "lcm_describe(id=file_xxx, expandFile=true) to fetch the original output. " +
+      "For multi-hop drilldown beyond one level, use lcm_expand_query " +
+      "(delegated sub-agent expansion). Returns summary content, lineage, " +
+      "token counts, file exploration, and (with expand flags) one-hop detail.",
     parameters: LcmDescribeSchema,
     async execute(_toolCallId, params) {
       const lcm = input.lcm ?? (await input.getLcm?.());
@@ -237,11 +309,20 @@ export function createLcmDescribeTool(input: {
         const lines: string[] = [];
         lines.push(`LCM_SUMMARY ${id}`);
         lines.push(
-          `meta conv=${s.conversationId} kind=${s.kind} depth=${s.depth} tok=${s.tokenCount} ` +
+          `meta conv=${s.conversationId} sessionKey=${s.sessionKey || "-"} kind=${s.kind} depth=${s.depth} tok=${s.tokenCount} ` +
             `descTok=${s.descendantTokenCount} srcTok=${s.sourceMessageTokenCount} ` +
             `desc=${s.descendantCount} range=${formatDisplayTime(s.earliestAt, timezone)}..${formatDisplayTime(s.latestAt, timezone)} ` +
+            `created=${formatDisplayTime(s.createdAt, timezone)} ` +
             `budgetCap=${resolvedTokenCap}`,
         );
+        // Wave-1 Auditor #5 finding #3: when delegated grant is exhausted
+        // resolvedTokenCap=0 and every node shows budget=over with no
+        // explanation. Surface the exhaustion explicitly.
+        if (resolvedTokenCap === 0 && typeof delegatedRemainingBudget === "number") {
+          lines.push(
+            "budget exhausted: delegated grant has 0 tokens remaining; expansion is blocked. Re-issue the grant via lcm_expand_query with a higher remainingTokens before drilling further.",
+          );
+        }
         if (s.parentIds.length > 0) {
           lines.push(`parents ${s.parentIds.join(" ")}`);
         }
@@ -260,13 +341,405 @@ export function createLcmDescribeTool(input: {
               `m=${node.budgetFit.withMessages ? "in" : "over"}]`,
           );
         }
-        lines.push("content");
-        lines.push(s.content);
+        // P4 harness fix: emit a HEADER signal line BEFORE content (which
+        // can be very long for condensed summaries). The detailed expansion
+        // sections still go below content, but the early header guarantees
+        // an agent sees the empty-vs-found signal even when content gets
+        // truncated by an outer wrapper.
+        // Audit 2 finding #5: the early signal must NOT promise candidates
+        // when all of them might be suppressed; phrase it as "raw count
+        // before suppression filter — see details for survivors".
+        const expandChildren = p.expandChildren === true;
+        const expandMessages = p.expandMessages === true;
+        if (expandChildren) {
+          // Wave-7 Auditor #9 P0 fix: `s.childIds` is ALREADY suppression-
+          // filtered upstream by `getSummaryChildren()` (defaults to
+          // includeSuppressed=false). The previous header labeled this as
+          // "raw count BEFORE suppression filter" — a lie. Re-query the
+          // raw count separately so the header is honest. Cheap COUNT.
+          let rawChildCountForHeader = s.childIds.length;
+          try {
+            const dbForRawCount = lcm.getDb();
+            const cr = dbForRawCount
+              .prepare(
+                `SELECT COUNT(*) AS n FROM summary_parents WHERE parent_summary_id = ?`,
+              )
+              .get(id) as { n?: number } | undefined;
+            rawChildCountForHeader = cr?.n ?? s.childIds.length;
+          } catch {
+            // Fall back to filtered count if the COUNT query fails
+          }
+          if (rawChildCountForHeader === 0) {
+            lines.push("expansion (children): 0 — terminal node, nothing to drill into");
+          } else if (s.childIds.length === 0 && rawChildCountForHeader > 0) {
+            lines.push(
+              `expansion (children): 0 of ${rawChildCountForHeader} raw — ALL children suppressed; details below`,
+            );
+          } else {
+            const suppressedCount = rawChildCountForHeader - s.childIds.length;
+            const suppNote = suppressedCount > 0 ? ` (${suppressedCount} suppressed and filtered)` : "";
+            lines.push(
+              `expansion (children): ${s.childIds.length} of ${rawChildCountForHeader} raw${suppNote}; details below`,
+            );
+          }
+        }
+        if (expandMessages) {
+          if (s.kind !== "leaf") {
+            lines.push("expansion (messages): n/a — target is not a leaf");
+          }
+        }
+        // Wave-11 reviewer P1 fix: previously emitted `s.content` then
+        // charged the grant AFTER. For sub-agents at zero remaining budget,
+        // that meant the content was already disclosed before accounting
+        // could prevent it. Now: if this is a delegated session AND the
+        // base summary's tokens exceed the remaining grant budget, redact
+        // the content and surface a budget-exhausted error EARLY (before
+        // emit). Charge the budget after a successful emit, as before, so
+        // the grant accounting still reflects what the agent actually saw.
+        const baseSummaryTokens = s.tokenCount ?? 0;
+        const isDelegatedAndOverBudget =
+          delegatedGrantId !== "" &&
+          typeof delegatedRemainingBudget === "number" &&
+          delegatedRemainingBudget < baseSummaryTokens;
+        if (isDelegatedAndOverBudget) {
+          lines.push("content");
+          lines.push(
+            `[REDACTED — base summary content is ${baseSummaryTokens} tokens but the delegated grant has only ${delegatedRemainingBudget} tokens remaining. Re-issue the grant with a larger remainingTokens via lcm_expand_query, or call from a non-delegated session.]`,
+          );
+        } else {
+          lines.push("content");
+          lines.push(s.content);
+        }
 
+        // Phase 2.9 — one-hop expansion flags. Lets main agents see source
+        // children + messages WITHOUT delegating through lcm_expand_query
+        // (which paraphrases via sub-agent LLM call). The lcm_expand sub-
+        // agent gate stays intact for deeper traversal; this is the
+        // "describe is safe" mental model extension Agent 2 recommended.
+        // Hard-capped (default 20, max 50) to prevent runaway context loads.
+        const expandedChildren: Array<{
+          summaryId: string;
+          kind: string;
+          tokenCount: number;
+          createdAt: string;
+          content: string;
+        }> = [];
+        const expandedMessages: Array<{
+          messageId: number;
+          role: string;
+          tokenCount: number;
+          createdAt: string;
+          content: string;
+        }> = [];
+
+        // P4 FIX (2026-05-06 harness): always emit a status line when
+        // expandChildren is requested — silent empty was indistinguishable
+        // from "tool ignored my flag" / "node terminal" / "all suppressed".
+        let expandChildrenStatus:
+          | "no-children"
+          | "all-suppressed"
+          | "ok"
+          | "capped"
+          | "skipped-non-summary"
+          | "budget-exhausted" // Wave-8 P1 fix: distinct from "skipped-non-summary"
+          | undefined;
+        // Wave-4 Auditor #9 P1 fix: when delegated-grant budget is
+        // exhausted (resolvedTokenCap === 0), refuse to expand AT ALL
+        // instead of just printing a warning. Previous behavior emitted
+        // "expansion is blocked" then silently expanded anyway —
+        // misleading, and can cost the grant beyond its budget.
+        const budgetExhausted =
+          resolvedTokenCap === 0 && typeof delegatedRemainingBudget === "number";
+
+        if (expandChildren && budgetExhausted) {
+          // Wave-8 P1 fix: distinct status string (was reusing
+          // "skipped-non-summary"). Agents programmatically branching
+          // on details.expansion.childrenStatus can now distinguish
+          // file-target skips from budget-exhausted skips.
+          expandChildrenStatus = "budget-exhausted";
+          lines.push("");
+          lines.push(
+            `expanded children: SKIPPED — delegated grant has 0 tokens remaining; expansion blocked. Re-issue the grant via lcm_expand_query with a higher remainingTokens to unblock.`,
+          );
+        } else if (expandChildren) {
+          // Wave-4 Auditor #9 P1 fix: `s.childIds` is already
+          // suppression-filtered upstream (getSummaryChildren defaults
+          // to includeSuppressed=false). When all children are
+          // suppressed, childIds.length === 0 — but that's
+          // indistinguishable from "no children at all". Re-query the
+          // RAW count via SQL to detect the all-suppressed case
+          // accurately. Cheap (single COUNT query).
+          let rawChildCount: number;
+          try {
+            const dbForCount = lcm.getDb();
+            const countRow = dbForCount
+              .prepare(
+                `SELECT COUNT(*) AS n FROM summary_parents
+                   WHERE parent_summary_id = ?`,
+              )
+              .get(id) as { n?: number } | undefined;
+            rawChildCount = countRow?.n ?? 0;
+          } catch {
+            rawChildCount = s.childIds.length;
+          }
+          if (s.childIds.length === 0 && rawChildCount === 0) {
+            expandChildrenStatus = "no-children";
+            lines.push("");
+            lines.push(
+              `expanded children: 0 (this node has no children — it is a terminal in the DAG; nothing to drill into)`,
+            );
+          } else if (s.childIds.length === 0 && rawChildCount > 0) {
+            // All children suppressed
+            expandChildrenStatus = "all-suppressed";
+            lines.push("");
+            lines.push(
+              `expanded children: 0/${rawChildCount} (this node has ${rawChildCount} children but ALL are suppressed — they exist in the DAG but have been removed from the agent surface)`,
+            );
+          } else {
+            const requestedLimit =
+              typeof p.expandChildrenLimit === "number" && Number.isFinite(p.expandChildrenLimit)
+                ? Math.max(1, Math.min(50, Math.trunc(p.expandChildrenLimit)))
+                : 20;
+            const ids = s.childIds.slice(0, requestedLimit);
+            const placeholders = ids.map(() => "?").join(",");
+            const db = lcm.getDb();
+            const rows = db
+              .prepare(
+                `SELECT summary_id, kind, content, token_count, created_at
+                   FROM summaries
+                   WHERE summary_id IN (${placeholders})
+                     AND suppressed_at IS NULL
+                   ORDER BY created_at ASC`,
+              )
+              .all(...ids) as Array<{
+              summary_id: string;
+              kind: string;
+              content: string;
+              token_count: number;
+              created_at: string;
+            }>;
+            for (const r of rows) {
+              expandedChildren.push({
+                summaryId: r.summary_id,
+                kind: r.kind,
+                tokenCount: r.token_count,
+                createdAt: r.created_at,
+                content: r.content,
+              });
+            }
+            const requestedCount = ids.length;
+            const survived = expandedChildren.length;
+            const totalChildren = s.childIds.length;
+            const wasCapped = totalChildren > requestedLimit;
+            if (survived === 0) {
+              expandChildrenStatus = "all-suppressed";
+              lines.push("");
+              lines.push(
+                `expanded children: 0/${totalChildren} (all children are suppressed — none returned; the node has children but they have been removed from the agent surface)`,
+              );
+            } else {
+              expandChildrenStatus = wasCapped ? "capped" : "ok";
+              lines.push("");
+              const suffix =
+                survived < requestedCount
+                  ? ` (${requestedCount - survived} children suppressed and filtered out)`
+                  : "";
+              lines.push(
+                `expanded children: ${survived}/${totalChildren}${
+                  wasCapped ? ` (capped at limit=${requestedLimit}; raise expandChildrenLimit up to 50 for more)` : ""
+                }${suffix}`,
+              );
+              for (const child of expandedChildren) {
+                lines.push("");
+                lines.push(
+                  `### child ${child.summaryId} (${child.kind}, ${child.tokenCount} tokens, ${formatDisplayTime(child.createdAt, timezone)})`,
+                );
+                lines.push("");
+                lines.push(child.content);
+              }
+            }
+          }
+        }
+
+        // P4+P5 FIX: always emit status line; default cap raised 5→20 with
+        // optional `expandMessagesOffset` for pagination on long leaves.
+        let expandMessagesStatus:
+          | "not-leaf"
+          | "no-messages"
+          | "all-suppressed"
+          | "ok"
+          | "capped"
+          | "offset-past-end"
+          | "budget-exhausted" // Wave-8 P1 fix
+          | undefined;
+        if (expandMessages && budgetExhausted) {
+          // Wave-7 Auditor #9 P0 fix + Wave-8 P1 distinct-status:
+          // distinguish budget-exhausted from "not-leaf" so programmatic
+          // consumers can branch correctly.
+          expandMessagesStatus = "budget-exhausted";
+          lines.push("");
+          lines.push(
+            `expanded source messages: SKIPPED — delegated grant has 0 tokens remaining; expansion blocked. Re-issue the grant via lcm_expand_query with a higher remainingTokens to unblock.`,
+          );
+        } else if (expandMessages) {
+          if (s.kind !== "leaf") {
+            expandMessagesStatus = "not-leaf";
+            lines.push("");
+            lines.push(
+              `expanded source messages: 0 (target is a ${s.kind} summary, not a leaf — condensed summaries don't have direct messages; expand its children first to find leaves)`,
+            );
+          } else {
+            const requestedLimit =
+              typeof p.expandMessagesLimit === "number" && Number.isFinite(p.expandMessagesLimit)
+                ? Math.max(1, Math.min(50, Math.trunc(p.expandMessagesLimit)))
+                : 20;
+            // Audit 2 finding #4: clamp offset upper-bound so an adversarial
+            // / runaway agent can't trigger LIMIT/OFFSET full-table scans.
+            // 100k messages is well past any realistic leaf size (max
+            // observed: 216) and stops a runaway loop from costing seconds-
+            // per-call.
+            const OFFSET_HARD_CAP = 100_000;
+            const requestedOffset =
+              typeof p.expandMessagesOffset === "number" && Number.isFinite(p.expandMessagesOffset)
+                ? Math.max(0, Math.min(OFFSET_HARD_CAP, Math.trunc(p.expandMessagesOffset)))
+                : 0;
+            const db = lcm.getDb();
+            // Total source-message count (before offset/limit) to drive the
+            // capped-vs-ok status + pagination hint.
+            const totalRow = db
+              .prepare(
+                `SELECT COUNT(*) AS n
+                   FROM summary_messages sm
+                   JOIN messages m ON m.message_id = sm.message_id
+                   WHERE sm.summary_id = ?
+                     AND m.suppressed_at IS NULL`,
+              )
+              .get(id) as { n: number };
+            const totalMessages = totalRow?.n ?? 0;
+
+            const rows = db
+              .prepare(
+                `SELECT m.message_id, m.role, m.content, m.token_count, m.created_at
+                   FROM summary_messages sm
+                   JOIN messages m ON m.message_id = sm.message_id
+                   WHERE sm.summary_id = ?
+                     AND m.suppressed_at IS NULL
+                   ORDER BY m.created_at ASC
+                   LIMIT ? OFFSET ?`,
+              )
+              .all(id, requestedLimit, requestedOffset) as Array<{
+              message_id: number;
+              role: string;
+              content: string;
+              token_count: number;
+              created_at: string;
+            }>;
+            for (const r of rows) {
+              expandedMessages.push({
+                messageId: r.message_id,
+                role: r.role,
+                tokenCount: r.token_count,
+                createdAt: r.created_at,
+                content: r.content,
+              });
+            }
+            if (totalMessages === 0) {
+              expandMessagesStatus = "no-messages";
+              lines.push("");
+              lines.push(
+                `expanded source messages: 0 (this leaf has no associated messages — likely a synthetic / migrated leaf without source-message lineage)`,
+              );
+            } else if (expandedMessages.length === 0) {
+              // Either offset went past the end or all in-range messages
+              // were suppressed. Audit 2 finding #6 fix: distinct status
+              // for offset-past-end so callers don't read "ok" + 0 results
+              // and conclude the leaf is empty.
+              expandMessagesStatus =
+                requestedOffset >= totalMessages
+                  ? "offset-past-end"
+                  : "all-suppressed";
+              lines.push("");
+              if (requestedOffset >= totalMessages) {
+                lines.push(
+                  `expanded source messages: 0/${totalMessages} (offset=${requestedOffset} is past the end; reduce offset to see content)`,
+                );
+              } else {
+                lines.push(
+                  `expanded source messages: 0/${totalMessages} (all messages in this offset window were suppressed and filtered out)`,
+                );
+              }
+            } else {
+              const remaining =
+                totalMessages - (requestedOffset + expandedMessages.length);
+              expandMessagesStatus = remaining > 0 ? "capped" : "ok";
+              lines.push("");
+              const range = `[${requestedOffset + 1}..${requestedOffset + expandedMessages.length}]`;
+              const paginationHint =
+                remaining > 0
+                  ? ` — ${remaining} more after this window; paginate with expandMessagesOffset=${requestedOffset + expandedMessages.length}`
+                  : "";
+              lines.push(
+                `expanded source messages: ${expandedMessages.length}/${totalMessages} ${range}${paginationHint}`,
+              );
+              for (const msg of expandedMessages) {
+                lines.push("");
+                lines.push(
+                  `### msg#${msg.messageId} (${msg.role}, ${msg.tokenCount} tokens, ${formatDisplayTime(msg.createdAt, timezone)})`,
+                );
+                lines.push("");
+                lines.push(msg.content);
+              }
+            }
+          }
+        }
+
+        // Wave-9 Agent #5 P1 fix: lcm_describe expandChildren/expandMessages
+        // were a side channel that bypassed the grant token cap. The grant's
+        // delegatedRemainingBudget was CHECKED (budgetExhausted detection
+        // above) but never DECREMENTED — sub-agents could call
+        // lcm_describe ... expandChildren=true expandMessages=true
+        // expandChildrenLimit=50 expandMessagesLimit=50 back-to-back, each
+        // returning up to ~100K tokens, and the grant cap (default 4K)
+        // never decreased. This defeated the W4/W6 expansion-budget
+        // design — a runaway sub-agent could drain raw verbatim content
+        // without auth manager seeing it. Now we sum the token costs of
+        // any expanded payload and consume them from the grant.
+        if (delegatedGrantId !== "") {
+          // Wave-10 + Wave-11 reviewer P1 fix: charge consumed tokens
+          // against the grant. If the base summary was REDACTED (Wave-11
+          // early-gate above), don't charge for it — the agent didn't
+          // actually receive it. Otherwise charge base + expansions.
+          const baseTokens = isDelegatedAndOverBudget ? 0 : (s.tokenCount ?? 0);
+          const expandedChildrenTokens = expandedChildren.reduce(
+            (total, c) => total + (c.tokenCount ?? 0),
+            0,
+          );
+          const expandedMessagesTokens = expandedMessages.reduce(
+            (total, m) => total + (m.tokenCount ?? 0),
+            0,
+          );
+          const consumedTokens =
+            baseTokens + expandedChildrenTokens + expandedMessagesTokens;
+          if (consumedTokens > 0) {
+            getRuntimeExpansionAuthManager().consumeTokenBudget(
+              delegatedGrantId,
+              consumedTokens,
+            );
+          }
+        }
+
+        const trimmed = truncateLinesToCap(
+          lines,
+          "lower expandChildrenLimit / expandMessagesLimit, or request a narrower id",
+        );
         return {
-          content: [{ type: "text", text: lines.join("\n") }],
+          content: [{ type: "text", text: trimmed.text }],
           details: {
             ...compactDescribeDetails(result),
+            // Wave-12 retro review N2: top-level `truncated` is the
+            // canonical agent-facing contract field (mirrored across
+            // all content-emitting tools).
+            truncated: trimmed.truncated,
             manifest: {
               tokenCap: resolvedTokenCap,
               budgetSource:
@@ -276,6 +749,13 @@ export function createLcmDescribeTool(input: {
                     ? "delegated_grant_remaining"
                     : "config_default",
               nodes: manifestNodes,
+              truncated: trimmed.truncated,  // duplicate for back-compat with manifest readers
+            },
+            expansion: {
+              children: expandedChildren,
+              childrenStatus: expandChildrenStatus,
+              messages: expandedMessages,
+              messagesStatus: expandMessagesStatus,
             },
           },
         };
@@ -323,9 +803,13 @@ export function createLcmDescribeTool(input: {
           lines.push("*Content unavailable: file missing on disk or path failed validation.*");
         }
 
+        const trimmed = truncateLinesToCap(
+          lines,
+          "the file's exploration summary is large; trim externally if needed",
+        );
         return {
-          content: [{ type: "text", text: lines.join("\n") }],
-          details: compactDescribeDetails(result),
+          content: [{ type: "text", text: trimmed.text }],
+          details: { ...compactDescribeDetails(result), truncated: trimmed.truncated },
         };
       }
 

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -5,8 +5,21 @@ import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { parseIsoTimestampParam, resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import { formatTimestamp } from "../compaction.js";
+import {
+  runHybridSearch,
+  type FtsHit,
+  type HybridHit,
+} from "../embeddings/hybrid-search.js";
+import {
+  runSemanticSearch,
+  SemanticSearchUnavailableError,
+} from "../embeddings/semantic-search.js";
+import { VoyageError } from "../voyage/client.js";
+import { containsCjk } from "../store/full-text-fallback.js";
 
-const MAX_RESULT_CHARS = 40_000; // ~10k tokens
+// Tool-result hard cap — protects against back-to-back tool calls
+// blowing out the agent's context window (~10K tokens / 40K chars).
+const MAX_RESULT_CHARS = 40_000;
 
 function formatDisplayTime(
   value: Date | string | number | null | undefined,
@@ -30,8 +43,8 @@ const LcmGrepSchema = Type.Object({
   mode: Type.Optional(
     Type.String({
       description:
-        'Search mode: "regex" for regular expression matching, "full_text" for text search. Default: "regex".',
-      enum: ["regex", "full_text"],
+        'Search mode: "regex" for regular expression matching, "full_text" for text search, "hybrid" to blend FTS + semantic vector search via Voyage rerank, "semantic" for pure-vector recall (no FTS, no rerank — cheapest semantic mode), or "verbatim" to return FULL untruncated content of matched messages (for citation / quote-back use cases where the agent needs literal wording). "hybrid" and "semantic" return hits scoped to summaries only (semantic doesn\'t cover raw messages); "verbatim" returns full message rows and is hard-capped at 20 results. Default: "regex".',
+      enum: ["regex", "full_text", "hybrid", "semantic", "verbatim"],
     }),
   ),
   scope: Type.Optional(
@@ -76,6 +89,33 @@ const LcmGrepSchema = Type.Object({
         'Sort order: "recency" (newest first, default), "relevance" (best FTS5 match first, full_text mode only), or "hybrid" (full_text mode only; balances relevance with recency). Applied before limit is enforced.',
       enum: ["recency", "relevance", "hybrid"],
     }),
+  ),
+  // P6 fix (2026-05-06 harness): in verbatim mode, the 20-result cap was
+  // saturating with tool-role messages (code grep output, audit blobs) on
+  // common queries, crowding out the user/assistant turns the agent
+  // actually wants to quote. `role` filters at the SQL layer.
+  // Audit 2 finding #2 fix: include 'system' in the enum since system
+  // messages exist in the messages table (toDbRole writes them).
+  role: Type.Optional(
+    Type.String({
+      description:
+        'Restrict matches to messages of this role. Useful in verbatim mode where tool-role messages (code grep output, audit blobs) often crowd out user/assistant turns. Accepts "user", "assistant", "tool", "system", or "all" (default). Honored only by mode="verbatim" — other modes already match summaries that have no role.',
+      enum: ["user", "assistant", "tool", "system", "all"],
+    }),
+  ),
+  // Wave-12 consolidation SA: summaryKinds was previously a
+  // lcm_semantic_recall-only param. Folded into lcm_grep when
+  // semantic_recall consolidated into mode='semantic'. Honored only by
+  // mode='semantic' and 'hybrid' (modes that target summaries); ignored
+  // by regex/full_text/verbatim.
+  summaryKinds: Type.Optional(
+    Type.Array(
+      Type.String({ enum: ["leaf", "condensed"] }),
+      {
+        description:
+          "Filter by summary kind. Defaults to both 'leaf' and 'condensed'. Honored only by mode='semantic' and 'hybrid'. Useful when the agent wants to scope to high-level rollups (kind='condensed') or fresh leaves (kind='leaf') instead of both.",
+      },
+    ),
   ),
 });
 
@@ -146,6 +186,51 @@ function validateFullTextPattern(pattern: string): string | null {
   return `full_text mode does not support regex syntax (${syntax}). Use mode: "regex" for \`${pattern}\`, or rewrite the full_text query as 1-3 literal terms or one quoted phrase.`;
 }
 
+/**
+ * P7 fix (2026-05-06 harness): FTS5 MATCH chokes on bare non-tokenizer
+ * characters in user input (`v4.1`, `[brackets]`, hyphenated terms,
+ * leading/trailing operators). Users hit opaque "fts5: syntax error" with
+ * no recovery hint.
+ *
+ * Strategy: detect patterns that FTS5 would reject AS-IS, and auto-wrap
+ * them in double quotes (FTS5 phrase syntax — literal multi-token match).
+ * Leave already-quoted patterns alone (user explicitly opted-in to FTS5
+ * phrase semantics) AND leave patterns containing FTS5 boolean operators
+ * alone (`AND`, `OR`, `NEAR(...)`).
+ *
+ * For verbatim mode this is always-on because verbatim is by definition
+ * "I want literal text." For full_text mode this is opt-in via the existing
+ * convention: if your pattern looks like an FTS5 query (uppercase boolean
+ * operators, parens), we leave it; otherwise we sanitize.
+ *
+ * Returns the (possibly transformed) pattern.
+ */
+function sanitizeFts5Pattern(pattern: string): string {
+  const trimmed = pattern.trim();
+  if (trimmed.length === 0) return trimmed;
+  // Already double-quoted phrase — user knows what they're doing.
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed;
+  }
+  // Contains FTS5 boolean operators or grouping — assume user knows FTS5.
+  // Match \bAND\b / \bOR\b / \bNOT\b / \bNEAR\b / opening paren.
+  if (/\b(?:AND|OR|NOT|NEAR)\b/.test(trimmed) || /[()]/.test(trimmed)) {
+    return trimmed;
+  }
+  // Detect chars FTS5 default tokenizer treats as separators or operators
+  // when present BARE (not inside a phrase): `.` `[` `]` `-` (leading/trailing)
+  // `+` `*` `^` `:` `/` `\\`.
+  const HAS_PROBLEM_CHAR = /[.\[\]+*^:\/\\!~]/;
+  const STARTS_OR_ENDS_WITH_HYPHEN = /^-|-$/;
+  if (HAS_PROBLEM_CHAR.test(trimmed) || STARTS_OR_ENDS_WITH_HYPHEN.test(trimmed)) {
+    // Wrap as a phrase. Escape internal double quotes by doubling them
+    // (FTS5's escape convention).
+    const escaped = trimmed.replace(/"/g, '""');
+    return `"${escaped}"`;
+  }
+  return trimmed;
+}
+
 export function createLcmGrepTool(input: {
   deps: LcmDependencies;
   lcm?: LcmContextEngine;
@@ -157,11 +242,15 @@ export function createLcmGrepTool(input: {
     name: "lcm_grep",
     label: "LCM Grep",
     description:
-      "Search compacted conversation history using regex or full-text search. " +
-      "Searches across messages and/or summaries stored by LCM. " +
-      "Use this to find specific content that may have been compacted away from " +
-      "active context. In full_text mode, queries use FTS5 AND semantics by default, so keep them short and focused; quoted phrases stay intact and optional sort modes can prioritize relevance for older topics. Returns matching snippets with their summary/message IDs " +
-      "for follow-up with lcm_expand or lcm_describe.",
+      "Search compacted conversation history with FIVE modes (`mode` parameter): " +
+      "(1) `regex` — literal or regex pattern over summary content; " +
+      "(2) `full_text` — FTS5 keyword search; queries use FTS5 AND semantics by default, so keep them short and focused; quoted phrases stay intact and optional sort modes can prioritize relevance for older topics; " +
+      "(3) `hybrid` — FTS5 + Voyage semantic + rerank (PRIMARY for Type B topic-anchored queries: 'have we ever discussed X', 'what work has been done on Y' — handles paraphrases like 'merge mess' → 'rebase blew up'); " +
+      "(4) `semantic` — pure-vector KNN over summaries via Voyage embed (no rerank, cheaper than hybrid). Use for paraphrastic exploration where keyword precision doesn't matter; " +
+      "(5) `verbatim` — returns FULL untruncated source messages (PRIMARY for Type C verbatim/citation queries: 'what exactly did X say about Y', 'quote me the original wording'). " +
+      "Optional `summaryKinds` filter (mode='semantic' / 'hybrid' only) scopes hits to ['leaf'] or ['condensed'] — useful when you want fresh source leaves vs higher-level rollups. " +
+      "Returns matching snippets with summary/message IDs for follow-up with lcm_describe (one-hop) or lcm_expand_query (multi-hop drilldown). " +
+      "Tool result is hard-capped at LCM_TOOL_RESULT_TOKEN_BUDGET (default 10K tokens / 40K chars) — when context is near full, prefer narrower queries (smaller `limit`, more specific `pattern`) over big sweeps; chained calls accumulate context, and compaction only fires post-turn.",
     parameters: LcmGrepSchema,
     async execute(_toolCallId, params) {
       const lcm = input.lcm ?? (await input.getLcm?.());
@@ -173,10 +262,26 @@ export function createLcmGrepTool(input: {
 
       const p = params as Record<string, unknown>;
       const pattern = (p.pattern as string).trim();
-      const mode = (p.mode as "regex" | "full_text") ?? "regex";
+      // Wave-1 Auditor #9 + QA-runner adv-empty-pattern fix: empty
+      // pattern was reaching FTS5 sanitizer which returns `'""'`,
+      // causing FTS5 to match all rows. Reject explicitly.
+      if (pattern.length === 0) {
+        return jsonResult({
+          error: "`pattern` is required and must be a non-empty string.",
+        });
+      }
+      const mode =
+        (p.mode as "regex" | "full_text" | "hybrid" | "semantic" | "verbatim") ?? "regex";
       const scope = (p.scope as "messages" | "summaries" | "both") ?? "both";
-      const limit = typeof p.limit === "number" ? Math.trunc(p.limit) : 50;
+      // verbatim mode is hard-capped to 20 (full message rows can be large)
+      const VERBATIM_HARD_CAP = 20;
+      const requestedLimit = typeof p.limit === "number" ? Math.trunc(p.limit) : 50;
+      const limit =
+        mode === "verbatim" ? Math.min(requestedLimit, VERBATIM_HARD_CAP) : requestedLimit;
       const requestedSort = (p.sort as "recency" | "relevance" | "hybrid") ?? "recency";
+      // Wave-7 Auditor #8 P1 fix: silent sort override is misleading. If
+      // a caller explicitly passes sort=relevance with mode=regex, surface
+      // a `sortIgnored` field in details so they can see the override.
       const effectiveSort = mode === "full_text" ? requestedSort : "recency";
       if (mode === "full_text") {
         const fullTextPatternError = validateFullTextPattern(pattern);
@@ -184,6 +289,8 @@ export function createLcmGrepTool(input: {
           return jsonResult({ error: fullTextPatternError });
         }
       }
+      const sortIgnored =
+        p.sort != null && requestedSort !== "recency" && mode !== "full_text";
       let since: Date | undefined;
       let before: Date | undefined;
       try {
@@ -212,6 +319,65 @@ export function createLcmGrepTool(input: {
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
         });
       }
+
+      // Wave-12 audit (W1A5 P1): summaryKinds was previously plumbed only
+      // through `mode='semantic'` even though the schema description claims
+      // both 'semantic' AND 'hybrid' honor it. Now resolved once and passed
+      // to both helper functions.
+      const summaryKindsParam = Array.isArray(p.summaryKinds)
+        ? (p.summaryKinds as Array<"leaf" | "condensed">)
+        : undefined;
+
+      if (mode === "hybrid") {
+        return runHybridLcmGrep({
+          lcm,
+          pattern,
+          conversationScope,
+          since,
+          before,
+          limit,
+          timezone,
+          summaryKinds: summaryKindsParam,
+        });
+      }
+
+      if (mode === "semantic") {
+        return runSemanticLcmGrep({
+          lcm,
+          pattern,
+          conversationScope,
+          since,
+          before,
+          limit,
+          timezone,
+          summaryKinds: summaryKindsParam,
+        });
+      }
+
+      if (mode === "verbatim") {
+        const roleFilterRaw =
+          typeof p.role === "string" ? p.role.trim() : undefined;
+        const roleFilter =
+          roleFilterRaw && roleFilterRaw !== "all" ? roleFilterRaw : undefined;
+        return runVerbatimLcmGrep({
+          lcm,
+          pattern,
+          conversationScope,
+          since,
+          before,
+          limit,
+          timezone,
+          roleFilter,
+        });
+      }
+
+      // P7 fix (revisited per audit 2 finding #1): the full_text mode goes
+      // through retrieval.grep → conversation-store / summary-store, which
+      // already apply sanitizeFts5Query (src/store/fts5-sanitize.ts). That
+      // sanitizer correctly tokenizes-and-quotes problematic chars. Adding
+      // OUR sanitizer here was redundant and risked double-quoting.
+      // verbatim mode has its own SQL path that bypasses the store's
+      // sanitizer, so sanitize is applied there (in runVerbatimLcmGrep).
       const result = await retrieval.grep({
         query: pattern,
         mode,
@@ -249,6 +415,7 @@ export function createLcmGrepTool(input: {
       lines.push("");
 
       let currentChars = lines.join("\n").length;
+      let truncated = false;
 
       if (result.messages.length > 0) {
         lines.push("### Messages");
@@ -257,7 +424,8 @@ export function createLcmGrepTool(input: {
           const snippet = truncateSnippet(msg.snippet);
           const line = `- [msg#${msg.messageId}] (${msg.role}, ${formatDisplayTime(msg.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
-            lines.push("*(truncated — more results available)*");
+            lines.push(`*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — narrow query, lower limit, or wait for next-turn compaction; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`);
+            truncated = true;
             break;
           }
           lines.push(line);
@@ -266,14 +434,15 @@ export function createLcmGrepTool(input: {
         lines.push("");
       }
 
-      if (result.summaries.length > 0) {
+      if (result.summaries.length > 0 && !truncated) {
         lines.push("### Summaries");
         lines.push("");
         for (const sum of result.summaries) {
           const snippet = truncateSnippet(sum.snippet);
           const line = `- [${sum.summaryId}] (${sum.kind}, ${formatDisplayTime(sum.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
-            lines.push("*(truncated — more results available)*");
+            lines.push(`*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — narrow query, lower limit, or wait for next-turn compaction; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`);
+            truncated = true;
             break;
           }
           lines.push(line);
@@ -287,13 +456,762 @@ export function createLcmGrepTool(input: {
       }
 
       return {
-        content: [{ type: "text", text: lines.join("\n") }],
+        // Wave-9 TS-tightening: `as const` preserves the literal "text"
+        // type so this branch matches the AgentToolResult contract.
+        content: [{ type: "text" as const, text: lines.join("\n") }],
         details: {
           messageCount: result.messages.length,
           summaryCount: result.summaries.length,
           totalMatches: result.totalMatches,
+          // Wave-12 retro N2: top-level `truncated` is the canonical
+          // agent-facing contract field across all content-emitting
+          // tools. Mirrors lcm_describe + verbatim-mode parity.
+          truncated,
+          // Wave-7 Auditor #8 P1: surface sort override
+          ...(sortIgnored
+            ? { sortIgnored: true, requestedSort, effectiveSort }
+            : {}),
         },
       };
     },
   };
+}
+
+interface HybridGrepInput {
+  lcm: LcmContextEngine;
+  pattern: string;
+  conversationScope: {
+    conversationId?: number;
+    conversationIds?: number[];
+    allConversations: boolean;
+  };
+  since?: Date;
+  before?: Date;
+  limit: number;
+  timezone: string;
+  // P6 fix: optional role filter, honored only by verbatim mode (other
+  // paths run on summaries which have no role).
+  roleFilter?: string;
+  // Wave-12 consolidation SA: summaryKinds was lcm_semantic_recall-only
+  // pre-consolidation. Now plumbed through grep mode='semantic' so the
+  // capability survives the recall→grep merge. Honored only by semantic
+  // mode (other modes run against FTS or raw messages).
+  summaryKinds?: Array<"leaf" | "condensed">;
+}
+
+/**
+ * Hybrid lcm_grep path. Routes pattern → runHybridSearch (FTS arm calls
+ * summaryStore.searchSummaries, which we hydrate via the same db
+ * connection to get content + sessionKey + tokenCount + createdAt).
+ *
+ * Output format mirrors the regex/full_text branch but with hybrid-
+ * specific extras: per-hit provenance flags ([from FTS+semantic],
+ * [from FTS only], [from semantic only]), the rerank/RRF score, and
+ * degraded-mode warnings when vec0 or rerank is unavailable.
+ */
+async function runHybridLcmGrep(input: HybridGrepInput) {
+  const { lcm, pattern, conversationScope, since, before, limit, timezone, summaryKinds } = input;
+  const summaryStore = lcm.getSummaryStore();
+  const db = lcm.getDb();
+
+  const hydrateRowsById = (summaryIds: string[]) => {
+    if (summaryIds.length === 0) return new Map<string, {
+      sessionKey: string;
+      content: string;
+      tokenCount: number;
+      createdAt: string;
+      kind: "leaf" | "condensed";
+      conversationId: number;
+    }>();
+    const placeholders = summaryIds.map(() => "?").join(",");
+    const rows = db
+      .prepare(
+        // v4.1 §10 + Group C Finding #5 (defense in depth): hydrate
+        // step also filters suppressed_at IS NULL. Source FTS already
+        // filters this (C.03), but a row could be suppressed BETWEEN
+        // FTS query and hydrate. This guarantees the hybrid surface
+        // never returns content for a suppressed row even under that
+        // race.
+        `SELECT summary_id, conversation_id, session_key, kind, content, token_count, created_at
+           FROM summaries
+           WHERE summary_id IN (${placeholders})
+             AND suppressed_at IS NULL`,
+      )
+      .all(...summaryIds) as Array<{
+      summary_id: string;
+      conversation_id: number;
+      session_key: string;
+      kind: "leaf" | "condensed";
+      content: string;
+      token_count: number;
+      created_at: string;
+    }>;
+    return new Map(
+      rows.map(
+        (r) =>
+          [
+            r.summary_id,
+            {
+              sessionKey: r.session_key,
+              content: r.content,
+              tokenCount: r.token_count,
+              createdAt: r.created_at,
+              kind: r.kind,
+              conversationId: r.conversation_id,
+            },
+          ] as const,
+      ),
+    );
+  };
+
+  const ftsSearch = async (args: {
+    sessionKeys?: string[];
+    conversationIds?: number[];
+    since?: Date;
+    before?: Date;
+    summaryKinds?: Array<"leaf" | "condensed">;
+    excludeSuppressed?: boolean;
+    limit: number;
+  }): Promise<FtsHit[]> => {
+    // Wave-1 Auditor #4 finding #2: SummarySearchInput doesn't expose
+    // sessionKeys/summaryKinds. Caller-passed filters were SILENTLY
+    // DROPPED, leaking cross-session content into the FTS arm of hybrid
+    // search. Fix: over-fetch, then post-filter on what searchSummaries
+    // doesn't support.
+    const overFetchK = args.sessionKeys?.length || args.summaryKinds?.length
+      ? Math.max(args.limit, args.limit * 5, 100)
+      : args.limit;
+    const ftsResults = await summaryStore.searchSummaries({
+      query: pattern,
+      mode: "full_text",
+      conversationId: conversationScope.allConversations
+        ? undefined
+        : conversationScope.conversationId,
+      conversationIds: conversationScope.allConversations
+        ? undefined
+        : conversationScope.conversationIds,
+      since: args.since,
+      before: args.before,
+      limit: overFetchK,
+      sort: "relevance",
+    });
+    if (ftsResults.length === 0) return [];
+    const hydrated = hydrateRowsById(ftsResults.map((r) => r.summaryId));
+    const sessionKeysFilter =
+      args.sessionKeys && args.sessionKeys.length > 0
+        ? new Set(args.sessionKeys)
+        : null;
+    const summaryKindsFilter =
+      args.summaryKinds && args.summaryKinds.length > 0
+        ? new Set(args.summaryKinds)
+        : null;
+    const out: FtsHit[] = [];
+    for (let i = 0; i < ftsResults.length; i++) {
+      const r = ftsResults[i];
+      const row = hydrated.get(r.summaryId);
+      if (!row) continue; // suppressed/deleted between FTS and hydrate — drop
+      // Post-filter on sessionKeys (auditor #4 #2 fix) — required for
+      // session-family scoping invariant per v4.1 §10.
+      if (sessionKeysFilter && !sessionKeysFilter.has(row.sessionKey)) continue;
+      // Post-filter on summaryKinds (parity with semantic arm).
+      if (summaryKindsFilter && !summaryKindsFilter.has(row.kind)) continue;
+      out.push({
+        summaryId: r.summaryId,
+        conversationId: row.conversationId,
+        sessionKey: row.sessionKey,
+        kind: row.kind,
+        content: row.content,
+        tokenCount: row.tokenCount,
+        createdAt: row.createdAt,
+        rank: i,
+      });
+      if (out.length >= args.limit) break;
+    }
+    return out;
+  };
+
+  const conversationIds = conversationScope.allConversations
+    ? undefined
+    : conversationScope.conversationIds && conversationScope.conversationIds.length > 0
+      ? conversationScope.conversationIds
+      : conversationScope.conversationId != null
+        ? [conversationScope.conversationId]
+        : undefined;
+
+  let hybridResult;
+  try {
+    // Wave-7 Auditor #8 P1 fix: over-fetch ratio. Previously kFts/kSemantic
+    // = max(limit, 50) — at limit=200, this gave rerank zero headroom to
+    // reorder. Recall pipelines typically over-fetch 3-5×. Use 3× user
+    // limit floored at 50, capped at 500 (Voyage rerank budget).
+    hybridResult = await runHybridSearch(db, {
+      query: pattern,
+      kFts: Math.min(500, Math.max(50, limit * 3)),
+      kSemantic: Math.min(500, Math.max(50, limit * 3)),
+      topN: limit,
+      conversationIds,
+      since,
+      before,
+      // Wave-12 audit (W1A5 P1): summaryKinds was schema-documented for
+      // hybrid mode but never plumbed to runHybridSearch. Now passed
+      // through for parity with semantic mode.
+      ...(summaryKinds && summaryKinds.length > 0 ? { summaryKinds } : {}),
+      ftsSearch,
+      // Final review Finding #2: cap Voyage wall-time on agent hot path.
+      // Embed call + rerank call each capped at 15s × 1 retry ≈ 30s
+      // worst case per call. Default Voyage client (3×60s) would block
+      // agent turn for minutes if Voyage throttles.
+      voyageMaxRetries: 1,
+      voyageTimeoutMs: 15_000,
+    });
+  } catch (error) {
+    if (error instanceof VoyageError && error.kind === "auth") {
+      return jsonResult({
+        error:
+          "Voyage API key is missing or invalid (set VOYAGE_API_KEY) — hybrid mode requires it. Use mode='full_text' for keyword-only search.",
+        detail: error.message,
+      });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    if (/VOYAGE_API_KEY/i.test(message)) {
+      return jsonResult({
+        error:
+          "Voyage API key is missing (set VOYAGE_API_KEY) — hybrid mode requires it. Use mode='full_text' for keyword-only search.",
+        detail: message,
+      });
+    }
+    return jsonResult({
+      error: `Hybrid search failed: ${message}`,
+    });
+  }
+
+  const lines: string[] = [];
+  lines.push("## LCM Grep Results");
+  lines.push(`**Pattern:** \`${pattern}\``);
+  lines.push(`**Mode:** hybrid`);
+  if (conversationScope.allConversations) {
+    lines.push("**Conversation scope:** all conversations");
+  } else if (conversationScope.conversationId != null) {
+    const familyCount = conversationScope.conversationIds?.length ?? 0;
+    lines.push(
+      familyCount > 1
+        ? `**Conversation scope:** session family rooted at ${conversationScope.conversationId} (${familyCount} segments)`
+        : `**Conversation scope:** ${conversationScope.conversationId}`,
+    );
+  }
+  if (since || before) {
+    lines.push(
+      `**Time filter:** ${since ? `since ${formatDisplayTime(since, timezone)}` : "since -∞"} | ${
+        before ? `before ${formatDisplayTime(before, timezone)}` : "before +∞"
+      }`,
+    );
+  }
+  lines.push(`**Total matches:** ${hybridResult.hits.length}`);
+  if (hybridResult.degradedToFtsOnly) {
+    lines.push("*(semantic search unavailable; degraded to FTS-only)*");
+  }
+  if (hybridResult.degradedSkippedRerank) {
+    lines.push("*(rerank failed; using RRF fusion fallback)*");
+  }
+  lines.push("");
+
+  let currentChars = lines.join("\n").length;
+  let truncated = false;
+
+  if (hybridResult.hits.length > 0) {
+    lines.push("### Summaries");
+    lines.push("");
+    for (const hit of hybridResult.hits) {
+      const provenance = hitProvenanceTag(hit);
+      const snippet = truncateSnippet(hit.content);
+      const score = hit.score.toFixed(4);
+      const line = `- [${hit.summaryId}] ${provenance} (${hit.kind}, score=${score}, ${formatDisplayTime(hit.createdAt, timezone)}): ${snippet}`;
+      if (currentChars + line.length > MAX_RESULT_CHARS) {
+        lines.push(`*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — narrow query, lower limit, or wait for next-turn compaction; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`);
+        truncated = true;
+        break;
+      }
+      lines.push(line);
+      currentChars += line.length;
+    }
+    lines.push("");
+  } else {
+    lines.push("No matches found.");
+  }
+
+  return {
+    // Wave-9 TS-tightening: `as const` preserves the literal "text" type.
+    content: [{ type: "text" as const, text: lines.join("\n") }],
+    details: {
+      mode: "hybrid",
+      messageCount: 0,
+      summaryCount: hybridResult.hits.length,
+      totalMatches: hybridResult.hits.length,
+      // Wave-12 retro N2: top-level truncated for parity with other tools.
+      truncated,
+      candidateCount: hybridResult.candidateCount,
+      voyageTokensConsumed: hybridResult.voyageTokensConsumed,
+      degradedToFtsOnly: hybridResult.degradedToFtsOnly,
+      degradedSkippedRerank: hybridResult.degradedSkippedRerank,
+      modelName: hybridResult.modelName,
+      // Wave-4 Auditor #21 P1 fix + Wave-7 P1: emit confidenceBand for
+      // parity with semantic mode + lcm_semantic_recall. Hybrid's `score`
+      // is a rerank score (0..1 typically), NOT a cosine similarity —
+      // calibration thresholds are tuned for cosine. Wave-7 surfaces
+      // confidenceBandSource so callers can see whether the band came
+      // from cosine (calibrated) or rerank (heuristic).
+      ...(() => {
+        const top = hybridResult.hits[0];
+        if (!top) return { confidenceBand: "no-match" as const, confidenceBandSource: null };
+        if (typeof top.semanticDistance === "number") {
+          const cos = 1 - (top.semanticDistance * top.semanticDistance) / 2;
+          const band =
+            cos >= 0.65 ? "high" : cos >= 0.5 ? "medium" : cos >= 0.35 ? "low" : "noise";
+          return { confidenceBand: band, confidenceBandSource: "cosine" as const };
+        }
+        const s = top.score;
+        const band =
+          s >= 0.65 ? "high" : s >= 0.5 ? "medium" : s >= 0.35 ? "low" : "noise";
+        return { confidenceBand: band, confidenceBandSource: "rerank" as const };
+      })(),
+      hits: hybridResult.hits.map((h) => ({
+        summaryId: h.summaryId,
+        conversationId: h.conversationId,
+        sessionKey: h.sessionKey,
+        kind: h.kind,
+        // Wave-4 Auditor #21 P1: add cosineSimilarity (computed from
+        // semanticDistance when present) so hybrid hits have shape
+        // parity with semantic + recall hits. Fall back to null when
+        // the hit was FTS-only (no semantic distance).
+        cosineSimilarity:
+          typeof h.semanticDistance === "number"
+            ? 1 - (h.semanticDistance * h.semanticDistance) / 2
+            : null,
+        score: h.score,
+        fromFts: h.fromFts,
+        fromSemantic: h.fromSemantic,
+        semanticDistance: h.semanticDistance,
+        ftsRank: h.ftsRank,
+      })),
+    },
+  };
+}
+
+function hitProvenanceTag(hit: HybridHit): string {
+  if (hit.fromFts && hit.fromSemantic) return "[from FTS+semantic]";
+  if (hit.fromFts) return "[from FTS only]";
+  return "[from semantic only]";
+}
+
+/**
+ * Semantic-only lcm_grep path. Pure embedding KNN via runSemanticSearch
+ * (no rerank — that's the cost-profile distinction from mode='hybrid').
+ *
+ * Use case: "find me everything similar to X across all of time" without
+ * paying the rerank cost. Hits are summaries only (semantic doesn't cover
+ * raw messages — embeddedKinds defaults to ['summary']).
+ */
+async function runSemanticLcmGrep(input: HybridGrepInput) {
+  const { lcm, pattern, conversationScope, since, before, limit, timezone, summaryKinds } = input;
+  const db = lcm.getDb();
+
+  let semResult;
+  try {
+    const sessionKeys = conversationScope.allConversations
+      ? undefined
+      : conversationScope.conversationIds && conversationScope.conversationIds.length > 0
+        ? deriveSessionKeysFromConversationIds(db, conversationScope.conversationIds)
+        : conversationScope.conversationId != null
+          ? deriveSessionKeysFromConversationIds(db, [conversationScope.conversationId])
+          : undefined;
+    // Reviewer Wave-3 fix: cap Voyage wall-time on agent hot path. Parity
+    // with the hybrid mode at line 538-539. Without this cap, default
+    // Voyage client (3×60s) could block an agent turn for minutes if
+    // Voyage throttles. 15s × 1 retry ≈ 30s worst case.
+    semResult = await runSemanticSearch(db, {
+      query: pattern,
+      sessionKeys,
+      k: limit,
+      since,
+      before,
+      embeddedKinds: ["summary"],
+      // Wave-12 consolidation SA: summaryKinds came from lcm_semantic_recall.
+      // Pre-consolidation, runSemanticSearch's underlying SQL post-filters on
+      // summary kind via Set membership; pass it through when the agent supplies
+      // it. Defaults to undefined (no filter) for parity with the prior
+      // grep mode='semantic' behavior.
+      ...(summaryKinds && summaryKinds.length > 0 ? { summaryKinds } : {}),
+      excludeSuppressed: true,
+      voyageMaxRetries: 1,
+      voyageTimeoutMs: 15_000,
+    });
+  } catch (e: unknown) {
+    if (e instanceof SemanticSearchUnavailableError) {
+      return jsonResult({
+        error:
+          "Semantic search unavailable: vec0 extension not loaded or no embedding profile registered. Use mode='regex' or mode='full_text' instead.",
+      });
+    }
+    if (e instanceof VoyageError) {
+      // Wave-9 Agent #4 P1 fix: previously only `auth` was caught; the
+      // other transient kinds (`rate_limit`, `server_error`, `network`,
+      // `bad_request`, `unexpected`) propagated as raw exceptions. Sister
+      // tool `lcm_semantic_recall` correctly catches all VoyageError
+      // kinds. Mirror that catch shape so two surfaces routed the same
+      // way (Question B) have the same error contract.
+      if (e.kind === "auth") {
+        return jsonResult({
+          error:
+            "Voyage API key is missing or invalid (set VOYAGE_API_KEY) - semantic mode requires it. Use mode='regex' or mode='full_text' instead.",
+        });
+      }
+      return jsonResult({
+        error: `Voyage embed call failed (${e.kind}). Try mode='full_text' or wait and retry.`,
+        detail: e.message,
+      });
+    }
+    throw e;
+  }
+
+  const lines: string[] = [];
+  lines.push("## LCM Grep Results");
+  lines.push(`**Pattern:** \`${pattern}\``);
+  lines.push(`**Mode:** semantic | **Scope:** summaries (semantic doesn't index raw messages)`);
+  if (conversationScope.allConversations) {
+    lines.push("**Conversation scope:** all conversations");
+  } else if (conversationScope.conversationId != null) {
+    lines.push(`**Conversation scope:** ${conversationScope.conversationId}`);
+  }
+  if (since || before) {
+    lines.push(
+      `**Time filter:** ${since ? `since ${formatDisplayTime(since, timezone)}` : "since -∞"} | ${
+        before ? `before ${formatDisplayTime(before, timezone)}` : "before +∞"
+      }`,
+    );
+  }
+  lines.push(`**Total matches:** ${semResult.hits.length}`);
+  lines.push(`**Voyage tokens consumed:** ${semResult.voyageTokensConsumed}`);
+  lines.push(`**Model:** ${semResult.modelName ?? "unknown"}`);
+  lines.push("");
+
+  // Wave-3 Auditor #4 fix #5: parity with lcm_semantic_recall — emit
+  // confidenceBand based on top-hit cosineSimilarity. Same calibration
+  // (≥0.65 high / ≥0.5 medium / ≥0.35 low / <0.35 noise / no-match).
+  const topCos = semResult.hits[0]?.cosineSimilarity ?? -1;
+  const confidenceBand =
+    semResult.hits.length === 0
+      ? "no-match"
+      : topCos >= 0.65
+        ? "high"
+        : topCos >= 0.5
+          ? "medium"
+          : topCos >= 0.35
+            ? "low"
+            : "noise";
+  if (semResult.hits.length > 0) {
+    lines.push(`**Confidence (top hit):** ${confidenceBand} (cosine=${topCos.toFixed(3)})`);
+  }
+  lines.push("");
+
+  let truncatedSemantic = false;
+
+  if (semResult.hits.length === 0) {
+    lines.push(
+      "_No semantic matches. Try mode='hybrid' for rerank-boosted recall, or mode='regex'/'full_text' for keyword-only._",
+    );
+  } else {
+    if (confidenceBand === "low" || confidenceBand === "noise") {
+      lines.push(
+        `*Note: top-hit cosine ${topCos.toFixed(3)} is below the medium-confidence threshold (0.5). Treat results as candidates, not answers.*`,
+      );
+      lines.push("");
+    }
+    lines.push("### Hits (ranked by semantic distance — lower = more similar)");
+    lines.push("");
+    let currentChars = lines.join("\n").length;
+    for (const hit of semResult.hits) {
+      const snippet = truncateSnippet(hit.content);
+      const cosStr = hit.cosineSimilarity.toFixed(3);
+      const line = `- [${hit.summaryId}] (${hit.kind}, cosine=${cosStr}, ${formatDisplayTime(hit.createdAt, timezone)}): ${snippet}`;
+      if (currentChars + line.length > MAX_RESULT_CHARS) {
+        lines.push(`*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — narrow query, lower limit, or wait for next-turn compaction; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`);
+        truncatedSemantic = true;
+        break;
+      }
+      lines.push(line);
+      currentChars += line.length;
+    }
+  }
+
+  return {
+    content: [{ type: "text" as const, text: lines.join("\n") }],
+    details: {
+      mode: "semantic",
+      pattern,
+      totalMatches: semResult.hits.length,
+      // Wave-12 retro N2: top-level truncated for parity with other tools.
+      truncated: truncatedSemantic,
+      voyageTokensConsumed: semResult.voyageTokensConsumed,
+      modelName: semResult.modelName,
+      // Wave-3 Auditor #4 fix #5: confidenceBand mirrors lcm_semantic_recall
+      confidenceBand,
+      // Wave-3 Auditor #4 fix #3: include conversationId + tokenCount
+      // (was missing — broke parity with hybrid mode + semantic-recall).
+      // cosineSimilarity is the standard cross-tool field.
+      hits: semResult.hits.map((h) => ({
+        summaryId: h.summaryId,
+        conversationId: h.conversationId,
+        sessionKey: h.sessionKey,
+        kind: h.kind,
+        distance: h.distance,
+        cosineSimilarity: h.cosineSimilarity,
+        tokenCount: h.tokenCount,
+        createdAt: h.createdAt,
+      })),
+    },
+  };
+}
+
+/**
+ * Verbatim lcm_grep path. Returns FULL untruncated message content for
+ * matches — for citation, quote-back, and "show me what was actually said"
+ * use cases where the literal wording matters and snippets aren't enough.
+ *
+ * Implementation: FTS5 over messages + return full m.content (not snippet).
+ * Hard-capped at 20 results because full message rows can be large.
+ * Filters suppressed_at IS NULL (per §10 invariant). Scope is messages only
+ * (verbatim is a raw-message concept; summaries are by definition paraphrased).
+ */
+async function runVerbatimLcmGrep(input: HybridGrepInput) {
+  const { lcm, pattern, conversationScope, since, before, limit, timezone, roleFilter } =
+    input;
+  const db = lcm.getDb();
+
+  // Build the SQL query. Mirror conversation-store.searchFullText shape but
+  // return full m.content instead of snippet.
+  const filters: string[] = ["m.suppressed_at IS NULL"];
+  const binds: (string | number)[] = [];
+
+  // Wave-9 Agent #4 P1 fix: detect CJK queries and route directly through
+  // LIKE substring match. messages_fts is created with `tokenize='porter
+  // unicode61'` which can't segment CJK ideographs - `messages_fts MATCH
+  // '<chinese characters>'` returns 0 rows WITHOUT throwing, so the
+  // existing exception-driven LIKE fallback never triggers. There is no
+  // messages_fts_cjk trigram table for messages (only for summaries).
+  // For Chinese/Japanese/Korean conversations every Question-C verbatim
+  // query was returning "No verbatim matches" silently. By detecting CJK
+  // at the JS layer and skipping FTS entirely we get correct LIKE-based
+  // verbatim recall on CJK content.
+  const useLikeForCjk = containsCjk(pattern);
+
+  // FTS5 join: messages_fts virtual table indexed on content
+  // (we use FTS5 here since it's faster than LIKE for natural-language patterns)
+  // P7 fix: sanitize the pattern so dots/brackets/hyphens don't trigger
+  // "fts5: syntax error". Always-on for verbatim - by definition you want
+  // literal text.
+  // Wave-8 P1 fix: track ftsBindIndex AT THE PUSH SITE so future refactors
+  // that move the FTS bind don't break the LIKE-fallback substitution.
+  // Previously hard-coded to 0 with a comment that's brittle to refactor.
+  const ftsBindIndex = binds.length;
+  if (useLikeForCjk) {
+    filters.push("m.content LIKE ?");
+    binds.push(`%${pattern}%`);
+  } else {
+    filters.push("messages_fts MATCH ?");
+    binds.push(sanitizeFts5Pattern(pattern));
+  }
+
+  // P6 fix: role filter — at SQL layer so it composes with FTS5 and doesn't
+  // burn the 20-result cap on tool-message blobs when the agent wants user
+  // or assistant turns. Audit 2 finding #2: include 'system'.
+  const VALID_ROLES = new Set(["user", "assistant", "tool", "system"]);
+  if (roleFilter && VALID_ROLES.has(roleFilter)) {
+    filters.push("m.role = ?");
+    binds.push(roleFilter);
+  }
+
+  if (conversationScope.allConversations) {
+    // no conversation filter
+  } else if (
+    conversationScope.conversationIds &&
+    conversationScope.conversationIds.length > 0
+  ) {
+    const placeholders = conversationScope.conversationIds.map(() => "?").join(",");
+    filters.push(`m.conversation_id IN (${placeholders})`);
+    for (const id of conversationScope.conversationIds) binds.push(id);
+  } else if (conversationScope.conversationId != null) {
+    filters.push("m.conversation_id = ?");
+    binds.push(conversationScope.conversationId);
+  }
+
+  if (since) {
+    filters.push("julianday(m.created_at) >= julianday(?)");
+    binds.push(since.toISOString());
+  }
+  if (before) {
+    filters.push("julianday(m.created_at) < julianday(?)");
+    binds.push(before.toISOString());
+  }
+
+  // Best to detect FTS5 absence and fall back to LIKE
+  let rows: Array<{
+    message_id: number;
+    conversation_id: number;
+    role: string;
+    content: string;
+    token_count: number;
+    created_at: string;
+  }>;
+  try {
+    // Wave-9 Agent #4 P1 fix: when CJK detected at the JS layer above,
+    // skip the messages_fts JOIN entirely - the filter is already a
+    // direct `m.content LIKE ?` substring match.
+    const sql = useLikeForCjk
+      ? `SELECT m.message_id, m.conversation_id, m.role, m.content, m.token_count, m.created_at
+           FROM messages m
+           WHERE ${filters.join(" AND ")}
+           ORDER BY datetime(m.created_at) DESC
+           LIMIT ?`
+      : `SELECT m.message_id, m.conversation_id, m.role, m.content, m.token_count, m.created_at
+           FROM messages m
+           JOIN messages_fts ON messages_fts.rowid = m.rowid
+           WHERE ${filters.join(" AND ")}
+           ORDER BY datetime(m.created_at) DESC
+           LIMIT ?`;
+    rows = db
+      .prepare(sql)
+      .all(...binds, limit) as Array<{
+      message_id: number;
+      conversation_id: number;
+      role: string;
+      content: string;
+      token_count: number;
+      created_at: string;
+    }>;
+  } catch (e: unknown) {
+    // FTS5 not available — fall back to LIKE on m.content.
+    // Audit 3 finding #1 (HIGH): the `binds` array was poisoned by the
+    // sanitizeFts5Pattern wrapping above (e.g. `"v4.1"` instead of raw
+    // `v4.1`). The previous `findIndex(bb => bb === pattern)` returned -1,
+    // so no replacement happened and LIKE got the literal phrase-quoted
+    // form, matching nothing on old-SQLite (no-FTS5) installations.
+    // Fix: replace the FTS5 bind with the raw LIKE pattern. The bind
+    // index was tracked explicitly at the push site (ftsBindIndex) so
+    // this no longer assumes FTS is the first push.
+    const fallbackFilters = filters.map((f) =>
+      f === "messages_fts MATCH ?" ? "m.content LIKE ?" : f,
+    );
+    const fallbackBinds = binds.map((b, i) =>
+      i === ftsBindIndex ? `%${pattern}%` : b,
+    );
+    rows = db
+      .prepare(
+        `SELECT m.message_id, m.conversation_id, m.role, m.content, m.token_count, m.created_at
+           FROM messages m
+           WHERE ${fallbackFilters.join(" AND ")}
+           ORDER BY datetime(m.created_at) DESC
+           LIMIT ?`,
+      )
+      .all(...fallbackBinds, limit) as typeof rows;
+  }
+
+  const lines: string[] = [];
+  lines.push("## LCM Grep Results");
+  lines.push(`**Pattern:** \`${pattern}\``);
+  lines.push(
+    `**Mode:** verbatim | **Scope:** messages${
+      roleFilter ? ` (role=${roleFilter})` : ""
+    } | **Cap:** ${limit} (full message rows; hard limit 20)`,
+  );
+  if (conversationScope.allConversations) {
+    lines.push("**Conversation scope:** all conversations");
+  } else if (conversationScope.conversationId != null) {
+    lines.push(`**Conversation scope:** ${conversationScope.conversationId}`);
+  }
+  if (since || before) {
+    lines.push(
+      `**Time filter:** ${since ? `since ${formatDisplayTime(since, timezone)}` : "since -∞"} | ${
+        before ? `before ${formatDisplayTime(before, timezone)}` : "before +∞"
+      }`,
+    );
+  }
+  lines.push(`**Total matches:** ${rows.length}`);
+  lines.push("");
+
+  // Wave-12 reviewer F6 fix: track which rows were emitted into markdown
+  // and cap each hit's content at PER_HIT_CONTENT_CHAR_CAP. Pre-fix:
+  // `details.hits[].content` returned full untruncated body for every
+  // fetched row regardless of markdown truncation — empirical validation
+  // showed 200-385K chars/call leaking through details while markdown
+  // capped at 25-33K. Now: details.hits is sliced to renderedRowCount,
+  // each hit's content capped at 5K chars (~96th percentile of message
+  // lengths in observed corpus). Callers needing full body for a
+  // specific message follow up with lcm_describe(messageId,
+  // expandMessages=true).
+  const PER_HIT_CONTENT_CHAR_CAP = 5_000;
+  let renderedRowCount = 0;
+  let truncated = false;
+  if (rows.length === 0) {
+    lines.push("_No verbatim matches in raw messages. Try mode='regex' or mode='full_text' for broader search._");
+  } else {
+    let currentChars = lines.join("\n").length;
+    for (const row of rows) {
+      const header = `### [msg#${row.message_id}] ${row.role} — ${formatDisplayTime(row.created_at, timezone)} (${row.token_count} tokens)`;
+      const block = `${header}\n\n${row.content}\n`;
+      if (currentChars + block.length > MAX_RESULT_CHARS) {
+        lines.push(`*(truncated at ~${Math.round(MAX_RESULT_CHARS / 4)} tokens to protect agent context — narrow time range, lower limit, or wait for next-turn compaction; raise LCM_TOOL_RESULT_TOKEN_BUDGET env to increase the cap)*`);
+        truncated = true;
+        break;
+      }
+      lines.push(block);
+      currentChars += block.length;
+      renderedRowCount++;
+    }
+  }
+
+  return {
+    content: [{ type: "text" as const, text: lines.join("\n") }],
+    details: {
+      mode: "verbatim",
+      pattern,
+      totalMatches: rows.length,
+      truncated,
+      // Only include hits actually emitted into markdown. Each hit's
+      // content is per-hit-capped at 5K chars. Full body via lcm_describe.
+      hits: rows.slice(0, renderedRowCount).map((r) => {
+        const fullLen = r.content.length;
+        const capped = fullLen > PER_HIT_CONTENT_CHAR_CAP
+          ? r.content.slice(0, PER_HIT_CONTENT_CHAR_CAP) + "…[truncated; full body via lcm_describe]"
+          : r.content;
+        return {
+          messageId: r.message_id,
+          conversationId: r.conversation_id,
+          role: r.role,
+          content: capped,
+          contentTruncated: fullLen > PER_HIT_CONTENT_CHAR_CAP,
+          fullContentLength: fullLen,
+          tokenCount: r.token_count,
+          createdAt: r.created_at,
+        };
+      }),
+    },
+  };
+}
+
+/**
+ * Look up session_keys for a list of conversation_ids. Used by semantic
+ * mode to scope KNN to the agent's session family.
+ */
+function deriveSessionKeysFromConversationIds(
+  db: import("node:sqlite").DatabaseSync,
+  conversationIds: number[],
+): string[] {
+  if (conversationIds.length === 0) return [];
+  const placeholders = conversationIds.map(() => "?").join(",");
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT session_key FROM conversations WHERE conversation_id IN (${placeholders}) AND session_key IS NOT NULL`,
+    )
+    .all(...conversationIds) as Array<{ session_key: string }>;
+  return rows.map((r) => r.session_key);
 }

--- a/src/voyage/client.ts
+++ b/src/voyage/client.ts
@@ -1,0 +1,616 @@
+/**
+ * Voyage AI HTTP client — LCM v4.1 §13
+ *
+ * Raw `fetch` wrapper for Voyage embeddings + reranker. We do NOT use the
+ * `voyageai` npm SDK because v0.2.1 has an ESM resolution bug that breaks
+ * under Node 22's native ESM loader (verified during Phase A spike — see
+ * `docs/projects/lcm-rollup-overhaul/voyage-spike-results.md`).
+ *
+ * Design constraints baked in here:
+ *
+ *   1. Per-batch token budget cap. Voyage server-side limit is 120K tokens
+ *      per request; the Voyage tokenizer counts ~9.5% higher than our
+ *      stored `summaries.token_count` (also measured during the spike).
+ *      We batch at {@link MAX_TOKENS_PER_EMBED_BATCH} = 80K to leave
+ *      generous margin (≈22K tokens of headroom even at 9.5% inflation).
+ *
+ *   2. Rate-limit budget visible to caller. The 429 response carries
+ *      `Retry-After` (sometimes seconds, sometimes HTTP-date). The
+ *      response body has more detail. Caller (backfill cron) handles
+ *      backoff at per-process level — this client JUST surfaces the
+ *      retry hint and lets the caller decide the backoff strategy.
+ *      (The client's own retry is for transient 5xx / network blips,
+ *      not sustained 429s. Cross-process coordination via
+ *      lcm_voyage_rate_state preserved in deferred-features draft PR.)
+ *
+ *   3. Truncation policy explicit. We pass `truncation: false` so Voyage
+ *      will reject (HTTP 400) any input over its per-document cap, rather
+ *      than silently truncate and produce a vector that doesn't reflect
+ *      the full document. v4.1 §13 amendment: caller must catch 400 and
+ *      either (a) suppress + log the over-cap leaf or (b) split. We
+ *      chose `truncation: false` over `truncation: true` because lossless
+ *      is a hard requirement and a silently-truncated embedding is worse
+ *      than no embedding (you can't tell from the vector that the source
+ *      was clipped).
+ *
+ *   4. Mockable fetch. Production calls `globalThis.fetch`; tests inject a
+ *      stub via the `fetch` option. No global side effects, no module-level
+ *      singleton state.
+ *
+ *   5. NO retries on 4xx. 4xx means caller bug — bad input, bad auth,
+ *      over-cap document. Retrying just spends quota. We retry only on
+ *      network errors and 5xx.
+ *
+ *   6. Bounded retries. {@link DEFAULT_MAX_RETRIES} = 3 attempts (so 4
+ *      total tries: t0 + 3 retries). Exponential backoff base 500ms,
+ *      doubled each attempt, capped at 30s. Total worst-case wall time:
+ *      ≈37.5s before giving up. Caller (backfill cron) requeues for
+ *      next pass on failure.
+ *
+ *   7. No PII in error messages. Voyage echoes the input back in some
+ *      400 responses; we surface the response body verbatim only when
+ *      it doesn't contain `input` or `texts` keys, otherwise we
+ *      summarize ("voyage_400: <error_type> on input length=N").
+ */
+
+/**
+ * Per-request token budget. Voyage server cap is 120K; we use 80K because
+ * Voyage's tokenizer counts ~9.5% higher than our `summaries.token_count`
+ * (empirically measured Phase A). 80K * 1.10 = 88K << 120K — safe margin.
+ */
+export const MAX_TOKENS_PER_EMBED_BATCH = 80_000;
+
+/**
+ * Per-document token budget for {@link embedTexts}. Voyage embeddings cap
+ * is 32K tokens per document for `voyage-4-large`. Voyage's tokenizer
+ * counts ~9.5% higher than the DB-stored token_count (different tokenizer
+ * than ours). 30K stored × 1.095 = ~32.85K Voyage tokens — would 400 at
+ * the per-doc cap. Use 27K stored as the safety budget: 27K × 1.095 ≈
+ * 29.6K, comfortably under the 32K Voyage cap.
+ *
+ * Wave-1 Auditor #2 finding #3: previous 30K value was right at the edge
+ * and observed 400s in production on 28-30K stored-token leaves.
+ *
+ * Caller MUST pre-filter documents over this size — this client does not
+ * silently drop or truncate them, it sends them and lets Voyage 400.
+ */
+export const MAX_TOKENS_PER_EMBED_DOC = 27_000;
+
+/**
+ * Reranker per-call budget (Voyage `rerank-2.5`). 600K tokens total across
+ * (query + all candidate documents). Caller must enforce this.
+ */
+export const MAX_TOKENS_PER_RERANK_CALL = 600_000;
+
+const DEFAULT_MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 500;
+// Per-attempt backoff cap. Wave-1 Auditor #2 finding #1: previous value
+// (30s) plus 30s timeout × 2 attempts = 90s == WORKER_LOCK_TTL_MS. Drop
+// to 25s so worst-case retry path is 25s + 30s + 30s = 85s, leaving 5s
+// of margin under the 90s lock TTL.
+const BACKOFF_CAP_MS = 25_000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const VOYAGE_API_BASE = "https://api.voyageai.com/v1";
+
+export type VoyageEmbeddingModel =
+  | "voyage-4-large"
+  | "voyage-3"
+  | "voyage-3-large"
+  | "voyage-3-lite"
+  | "voyage-code-3";
+
+export type VoyageRerankerModel = "rerank-2" | "rerank-2.5" | "rerank-2-lite";
+
+export type VoyageInputType = "query" | "document" | null;
+
+export interface VoyageEmbedOptions {
+  /** Voyage model id, e.g. `voyage-4-large`. */
+  model: VoyageEmbeddingModel;
+  /**
+   * Texts to embed. Caller MUST batch such that
+   * `sum(estimateTokens(text)) <= MAX_TOKENS_PER_EMBED_BATCH`. Each text MUST
+   * be ≤ {@link MAX_TOKENS_PER_EMBED_DOC} (Voyage rejects over-cap with 400).
+   */
+  texts: string[];
+  /**
+   * `query` for retrieval queries, `document` for stored items, `null` for
+   * Voyage default. Per Voyage docs, asymmetric embedding (different prompts
+   * for queries vs documents) measurably improves retrieval quality.
+   */
+  inputType: VoyageInputType;
+  /** Override default base URL (for tests). */
+  baseUrl?: string;
+  /** Inject mock `fetch` (for tests). Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch;
+  /**
+   * Override `VOYAGE_API_KEY` env var (for tests). MUST be a valid Voyage key
+   * in production (loaded from `~/.openclaw/credentials/voyage-api-key`).
+   */
+  apiKey?: string;
+  /** Per-attempt timeout in ms. Default 60s. */
+  timeoutMs?: number;
+  /** Max retries on 5xx / network errors. Default 3 (4 attempts total). */
+  maxRetries?: number;
+  /**
+   * Wave-11 reviewer P1 fix: output dimension override. voyage-4-large
+   * supports 256/512/1024/2048 dimensions; the registered embedding
+   * profile (lcm_embedding_profile.dim) determines what the vec0 column
+   * expects. If callers register a non-default dim and don't pass this
+   * field, Voyage returns its default (1024) and vec0 INSERT fails with
+   * dim mismatch. Default 1024 (Voyage default).
+   */
+  outputDimension?: number;
+}
+
+export interface VoyageEmbedResult {
+  /** Embeddings in same order as `texts`. */
+  vectors: Float32Array[];
+  /** Voyage server-reported token count for this batch. */
+  totalTokens: number;
+  /** Voyage model id echoed back. */
+  model: string;
+}
+
+export interface VoyageRerankCandidate {
+  /** Caller-supplied opaque id; passed through in result for joining. */
+  id: string;
+  /** Document text to rerank. */
+  text: string;
+}
+
+export interface VoyageRerankOptions {
+  model: VoyageRerankerModel;
+  query: string;
+  candidates: VoyageRerankCandidate[];
+  /** How many top results to return. Default = candidates.length. */
+  topK?: number;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  apiKey?: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+export interface VoyageRerankItem {
+  /** Caller-supplied id, joined back from candidates. */
+  id: string;
+  /** Original index in `candidates` (Voyage returns this). */
+  index: number;
+  /** Relevance score, higher is better. */
+  score: number;
+}
+
+export interface VoyageRerankResult {
+  /** Sorted by `score` descending. */
+  results: VoyageRerankItem[];
+  totalTokens: number;
+  model: string;
+}
+
+/**
+ * Thrown for any Voyage HTTP error (4xx or exhausted retries on 5xx). The
+ * `kind` discriminates how the caller should react:
+ *
+ *  - `auth`: 401/403. Caller should stop, surface to operator. Don't retry.
+ *  - `bad_request`: 400. Likely caller bug (over-cap doc, malformed input).
+ *      Don't retry; caller may suppress the offending doc and continue.
+ *  - `rate_limit`: 429 after exhausted retries. Caller should park the
+ *      backfill cron until {@link retryAfterMs} elapses.
+ *  - `server_error`: 5xx after exhausted retries. Caller should requeue
+ *      and try again later.
+ *  - `network`: fetch threw (connection refused, DNS, timeout). Same
+ *      treatment as `server_error`.
+ *  - `unexpected`: malformed Voyage response (missing `data`, wrong shape).
+ *      Bug in Voyage or in this client; caller should surface to operator.
+ */
+export class VoyageError extends Error {
+  constructor(
+    public readonly kind:
+      | "auth"
+      | "bad_request"
+      | "rate_limit"
+      | "server_error"
+      | "network"
+      | "unexpected",
+    message: string,
+    public readonly status?: number,
+    public readonly retryAfterMs?: number,
+    public readonly responseBody?: string,
+  ) {
+    super(message);
+    this.name = "VoyageError";
+  }
+}
+
+/**
+ * Embed a batch of texts. Caller is responsible for token budget pre-checks.
+ * Throws {@link VoyageError} on failure (no silent fallback to empty vectors).
+ */
+export async function embedTexts(opts: VoyageEmbedOptions): Promise<VoyageEmbedResult> {
+  if (opts.texts.length === 0) {
+    return { vectors: [], totalTokens: 0, model: opts.model };
+  }
+
+  const apiKey = resolveApiKey(opts.apiKey);
+  const baseUrl = opts.baseUrl ?? VOYAGE_API_BASE;
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const url = `${baseUrl}/embeddings`;
+
+  const body: Record<string, unknown> = {
+    model: opts.model,
+    input: opts.texts,
+    truncation: false,
+  };
+  if (opts.inputType !== null) {
+    body.input_type = opts.inputType;
+  }
+  // Wave-11 reviewer P1 fix: forward output_dimension to Voyage so
+  // non-default-dim profiles (256/512/2048) actually get those dims
+  // back. Without this, Voyage returns its default (1024) and vec0
+  // INSERT fails with dim mismatch on the per-model table.
+  if (typeof opts.outputDimension === "number" && opts.outputDimension > 0) {
+    body.output_dimension = opts.outputDimension;
+  }
+
+  const response = await postWithRetry(
+    fetchImpl,
+    url,
+    apiKey,
+    body,
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    opts.maxRetries ?? DEFAULT_MAX_RETRIES,
+    opts.texts.length,
+  );
+
+  const json = (await response.json()) as VoyageEmbeddingsResponse;
+  if (!Array.isArray(json.data) || json.data.length !== opts.texts.length) {
+    throw new VoyageError(
+      "unexpected",
+      `voyage_unexpected: embeddings response shape — expected data[${opts.texts.length}], got ${
+        Array.isArray(json.data) ? `data[${json.data.length}]` : "no data array"
+      }`,
+      response.status,
+    );
+  }
+
+  const dims = json.data[0]?.embedding?.length ?? 0;
+  const vectors: Float32Array[] = new Array(opts.texts.length);
+  // Voyage may return data out of order in pathological cases; index by `index` field.
+  for (const item of json.data) {
+    if (!Array.isArray(item.embedding) || item.embedding.length !== dims) {
+      throw new VoyageError(
+        "unexpected",
+        `voyage_unexpected: dimension mismatch in batch (expected ${dims}, got ${
+          Array.isArray(item.embedding) ? item.embedding.length : "non-array"
+        })`,
+        response.status,
+      );
+    }
+    if (typeof item.index !== "number" || item.index < 0 || item.index >= opts.texts.length) {
+      throw new VoyageError(
+        "unexpected",
+        `voyage_unexpected: bad index ${String(item.index)} (batch size ${opts.texts.length})`,
+        response.status,
+      );
+    }
+    vectors[item.index] = Float32Array.from(item.embedding);
+  }
+  for (let i = 0; i < vectors.length; i++) {
+    if (!vectors[i]) {
+      throw new VoyageError(
+        "unexpected",
+        `voyage_unexpected: missing embedding for index ${i}`,
+        response.status,
+      );
+    }
+  }
+
+  return {
+    vectors,
+    totalTokens: typeof json.usage?.total_tokens === "number" ? json.usage.total_tokens : 0,
+    model: typeof json.model === "string" ? json.model : opts.model,
+  };
+}
+
+/**
+ * Rerank candidates by relevance to query. Returns top-K sorted by score.
+ */
+export async function rerankCandidates(
+  opts: VoyageRerankOptions,
+): Promise<VoyageRerankResult> {
+  if (opts.candidates.length === 0) {
+    return { results: [], totalTokens: 0, model: opts.model };
+  }
+
+  const apiKey = resolveApiKey(opts.apiKey);
+  const baseUrl = opts.baseUrl ?? VOYAGE_API_BASE;
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  const url = `${baseUrl}/rerank`;
+
+  const body: Record<string, unknown> = {
+    model: opts.model,
+    query: opts.query,
+    documents: opts.candidates.map((c) => c.text),
+    top_k: opts.topK ?? opts.candidates.length,
+    truncation: false,
+  };
+
+  const response = await postWithRetry(
+    fetchImpl,
+    url,
+    apiKey,
+    body,
+    opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    opts.maxRetries ?? DEFAULT_MAX_RETRIES,
+    opts.candidates.length,
+  );
+
+  const json = (await response.json()) as VoyageRerankResponse;
+  if (!Array.isArray(json.data)) {
+    throw new VoyageError(
+      "unexpected",
+      "voyage_unexpected: rerank response missing data array",
+      response.status,
+    );
+  }
+
+  const items: VoyageRerankItem[] = json.data.map((item) => {
+    if (
+      typeof item.index !== "number" ||
+      item.index < 0 ||
+      item.index >= opts.candidates.length ||
+      typeof item.relevance_score !== "number"
+    ) {
+      throw new VoyageError(
+        "unexpected",
+        `voyage_unexpected: bad rerank item (index=${String(item.index)}, score=${String(item.relevance_score)})`,
+        response.status,
+      );
+    }
+    return {
+      id: opts.candidates[item.index].id,
+      index: item.index,
+      score: item.relevance_score,
+    };
+  });
+  // Voyage docs say they return sorted descending; sort defensively.
+  items.sort((a, b) => b.score - a.score);
+
+  return {
+    results: items,
+    totalTokens: typeof json.usage?.total_tokens === "number" ? json.usage.total_tokens : 0,
+    model: typeof json.model === "string" ? json.model : opts.model,
+  };
+}
+
+// ---------- internals ----------
+
+interface VoyageEmbeddingItem {
+  embedding: number[];
+  index: number;
+  object?: string;
+}
+interface VoyageEmbeddingsResponse {
+  data?: VoyageEmbeddingItem[];
+  model?: string;
+  usage?: { total_tokens?: number };
+}
+interface VoyageRerankItemRaw {
+  index: number;
+  relevance_score: number;
+  document?: string;
+}
+interface VoyageRerankResponse {
+  data?: VoyageRerankItemRaw[];
+  model?: string;
+  usage?: { total_tokens?: number };
+}
+
+function resolveApiKey(explicit: string | undefined): string {
+  const key = (explicit ?? process.env.VOYAGE_API_KEY ?? "").trim();
+  if (!key) {
+    throw new VoyageError(
+      "auth",
+      "voyage_auth: VOYAGE_API_KEY is empty (set env or pass `apiKey` option)",
+    );
+  }
+  return key;
+}
+
+async function postWithRetry(
+  fetchImpl: typeof fetch,
+  url: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+  timeoutMs: number,
+  maxRetries: number,
+  inputCount: number,
+): Promise<Response> {
+  let lastErr: VoyageError | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (e: unknown) {
+      lastErr = new VoyageError(
+        "network",
+        `voyage_network: ${e instanceof Error ? e.message : String(e)} (attempt ${attempt + 1}/${maxRetries + 1})`,
+      );
+      if (attempt < maxRetries) {
+        await sleep(backoffMs(attempt));
+        continue;
+      }
+      throw lastErr;
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    if (response.ok) {
+      return response;
+    }
+
+    const status = response.status;
+    const bodyText = await safeReadBody(response);
+
+    if (status === 401 || status === 403) {
+      // Wave-7 Auditor #2 P1 fix: route responseBody through summarizeBody
+      // for parity with the 400 path. Voyage 401/403 bodies are unlikely
+      // to echo input but defense-in-depth — Sentry/log capture of the
+      // exception object should never see raw input text.
+      throw new VoyageError(
+        "auth",
+        `voyage_auth: ${status} (check VOYAGE_API_KEY)`,
+        status,
+        undefined,
+        summarizeBody(bodyText),
+      );
+    }
+    if (status === 400) {
+      // Wave-4 Auditor #2 P1 fix: previously the raw `bodyText` was
+      // attached to the VoyageError as `responseBody`, bypassing the
+      // `summarizeBody` privacy filter that suppressed input echoes in
+      // the error message. Upstream loggers / Sentry capture the full
+      // exception object — so passing raw bodyText leaked the input
+      // texts even when the message was suppressed. Defense-in-depth:
+      // pass the SAME suppressed body to both fields.
+      const suppressedBody = summarizeBody(bodyText);
+      throw new VoyageError(
+        "bad_request",
+        `voyage_400: bad request on ${inputCount} inputs (${suppressedBody})`,
+        status,
+        undefined,
+        suppressedBody,
+      );
+    }
+    if (status === 429) {
+      const retryAfterMs = parseRetryAfterMs(response.headers.get("Retry-After"));
+      // Wave-7 Auditor #2 P1 fix: summarize 429 body too (parity with 400)
+      lastErr = new VoyageError(
+        "rate_limit",
+        `voyage_429: rate limited (attempt ${attempt + 1}/${maxRetries + 1})`,
+        status,
+        retryAfterMs,
+        summarizeBody(bodyText),
+      );
+      // Wave-2 Auditor #2 fix F1: previously we silently clamped Retry-After
+      // against BACKOFF_CAP_MS (25s), so a server-supplied 60s wait became a
+      // 25s wait — still rate-limited on next attempt. Now we honor the
+      // server's value verbatim BUT throw immediately if it would push us
+      // past the worker-lock TTL budget. Caller (backfill) releases lock
+      // cleanly and the autostart's next interval picks up where we left
+      // off — much better than burning a lock + retry slot on a stale wait.
+      const LOCK_BUDGET_AWARE_RETRY_MS = 60_000; // ~2/3 of WORKER_LOCK_TTL_MS=90s
+      if (
+        attempt < maxRetries &&
+        (retryAfterMs ?? 0) <= LOCK_BUDGET_AWARE_RETRY_MS
+      ) {
+        // Honor server hint if present; else exponential backoff.
+        await sleep(retryAfterMs ?? backoffMs(attempt));
+        continue;
+      }
+      // Either: (a) we exhausted retries, OR (b) server told us to wait
+      // longer than our lock-aware budget. Throw so caller can release
+      // lock and the next tick will retry fresh.
+      throw lastErr;
+    }
+    if (status >= 500 && status < 600) {
+      // Wave-7 Auditor #2 P1 fix: summarize 5xx body too (parity with 400)
+      lastErr = new VoyageError(
+        "server_error",
+        `voyage_5xx: ${status} (attempt ${attempt + 1}/${maxRetries + 1})`,
+        status,
+        undefined,
+        summarizeBody(bodyText),
+      );
+      if (attempt < maxRetries) {
+        await sleep(backoffMs(attempt));
+        continue;
+      }
+      throw lastErr;
+    }
+    // Some other 4xx — treat as bad_request, no retry.
+    // Wave-7 Auditor #2 P1 fix: summarizeBody on responseBody too
+    throw new VoyageError(
+      "bad_request",
+      `voyage_4xx: ${status} ${summarizeBody(bodyText)}`,
+      status,
+      undefined,
+      summarizeBody(bodyText),
+    );
+  }
+
+  // Exhausted loop without throwing or returning — should be unreachable
+  // because every code path in the loop either returns or throws on the
+  // last attempt. Defensive throw.
+  throw lastErr ?? new VoyageError("unexpected", "voyage_unexpected: postWithRetry exited loop");
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.length > 800 ? text.slice(0, 800) + "…(truncated)" : text;
+  } catch {
+    return "";
+  }
+}
+
+function summarizeBody(body: string): string {
+  // Avoid echoing input back to logs / errors. Voyage 400 responses sometimes
+  // include the offending input in the error message.
+  if (body.includes('"input"') || body.includes('"texts"') || body.includes('"documents"')) {
+    return "input echoed in error body — suppressed for privacy";
+  }
+  return body.slice(0, 200);
+}
+
+/**
+ * Wave-2 Auditor #2 finding F1: previously clamped server-supplied
+ * Retry-After against BACKOFF_CAP_MS. If Voyage returns `Retry-After: 60`,
+ * we'd silently retry at 25s — still rate-limited, wasting a retry slot.
+ * Server contract requires honoring its retry-after value. Return the
+ * server's value verbatim; caller decides whether to honor or abandon.
+ *
+ * Retry-after returned in milliseconds. `undefined` means no header.
+ * A retry-after-from-server of >2 minutes signals server is heavily
+ * loaded — caller (backfill, semantic-search) must ABORT the in-flight
+ * call rather than wait, since waiting >90s would exceed lock TTL.
+ *
+ * Soft cap at 5 minutes (no realistic Voyage Retry-After exceeds this).
+ */
+const RETRY_AFTER_HARD_CAP_MS = 5 * 60 * 1000;
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined;
+  // Voyage may send seconds (numeric) or HTTP-date.
+  const asNum = Number.parseFloat(header);
+  if (Number.isFinite(asNum) && asNum >= 0) {
+    return Math.min(asNum * 1000, RETRY_AFTER_HARD_CAP_MS);
+  }
+  const asDate = Date.parse(header);
+  if (Number.isFinite(asDate)) {
+    const ms = asDate - Date.now();
+    return ms > 0 ? Math.min(ms, RETRY_AFTER_HARD_CAP_MS) : undefined;
+  }
+  return undefined;
+}
+
+function backoffMs(attempt: number): number {
+  // Exponential: 500, 1000, 2000, 4000, ... capped at 30s.
+  const ms = BACKOFF_BASE_MS * 2 ** attempt;
+  return Math.min(ms, BACKOFF_CAP_MS);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/concurrency-model.test.ts
+++ b/test/concurrency-model.test.ts
@@ -1,0 +1,81 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_BUSY_TIMEOUT_MS,
+  GATEWAY_FALLBACK_SOAK_MS,
+  WORKER_BUSY_TIMEOUT_MS,
+  WORKER_HEARTBEAT_MS,
+  WORKER_JOB_KINDS,
+  WORKER_LOCK_TTL_MS,
+  assertBusyTimeoutForRole,
+  assertForeignKeysEnabled,
+} from "../src/concurrency/model.js";
+
+describe("concurrency model invariants (v4.1.1 §0)", () => {
+  it("worker busy_timeout is shorter than gateway so gateway always wins on contention", () => {
+    expect(WORKER_BUSY_TIMEOUT_MS).toBeLessThan(GATEWAY_BUSY_TIMEOUT_MS);
+  });
+
+  it("worker lock TTL is at least 3× the heartbeat cadence (allows one missed heartbeat)", () => {
+    expect(WORKER_LOCK_TTL_MS).toBeGreaterThanOrEqual(3 * WORKER_HEARTBEAT_MS);
+  });
+
+  it("gateway fallback soak window is longer than worker lock TTL (prevents racing slow-LLM workers)", () => {
+    expect(GATEWAY_FALLBACK_SOAK_MS).toBeGreaterThan(WORKER_LOCK_TTL_MS);
+  });
+
+  it("declares the expected v4.1 worker job kinds (must match docs + future lcm_worker_lock CHECK)", () => {
+    expect(WORKER_JOB_KINDS).toContain("condensation");
+    expect(WORKER_JOB_KINDS).toContain("extraction");
+    expect(WORKER_JOB_KINDS).toContain("embedding-backfill");
+    expect(WORKER_JOB_KINDS).toContain("profile-rebuild");
+    expect(WORKER_JOB_KINDS).toContain("theme-consolidation");
+    expect(WORKER_JOB_KINDS).toContain("eval");
+  });
+});
+
+describe("assertForeignKeysEnabled (v4.1.1 A6)", () => {
+  it("throws when PRAGMA foreign_keys is OFF", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = OFF");
+    expect(() => assertForeignKeysEnabled(db)).toThrow(/foreign_keys is not ON/);
+    db.close();
+  });
+
+  it("passes when PRAGMA foreign_keys is ON", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    expect(() => assertForeignKeysEnabled(db)).not.toThrow();
+    db.close();
+  });
+});
+
+describe("assertBusyTimeoutForRole (v4.1.1 §0)", () => {
+  it("throws for gateway role when busy_timeout < gateway threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${GATEWAY_BUSY_TIMEOUT_MS - 1}`);
+    expect(() => assertBusyTimeoutForRole(db, "gateway")).toThrow(/busy_timeout for gateway/);
+    db.close();
+  });
+
+  it("passes for gateway role when busy_timeout = gateway threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${GATEWAY_BUSY_TIMEOUT_MS}`);
+    expect(() => assertBusyTimeoutForRole(db, "gateway")).not.toThrow();
+    db.close();
+  });
+
+  it("throws for worker role when busy_timeout < worker threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${WORKER_BUSY_TIMEOUT_MS - 1}`);
+    expect(() => assertBusyTimeoutForRole(db, "worker")).toThrow(/busy_timeout for worker/);
+    db.close();
+  });
+
+  it("passes for worker role when busy_timeout = worker threshold", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`PRAGMA busy_timeout = ${WORKER_BUSY_TIMEOUT_MS}`);
+    expect(() => assertBusyTimeoutForRole(db, "worker")).not.toThrow();
+    db.close();
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,7 +39,7 @@ describe("resolveLcmConfig", () => {
     expect(config.leafMinFanout).toBe(8);
     expect(config.condensedMinFanout).toBe(4);
     expect(config.condensedMinFanoutHard).toBe(2);
-    expect(config.leafTargetTokens).toBe(2400);
+    expect(config.leafTargetTokens).toBe(4000); // v4.1 (A.10): raised from 2400
     expect(config.summaryProvider).toBe("");
     expect(config.summaryModel).toBe("");
     expect(config.pruneHeartbeatOk).toBe(false);

--- a/test/embeddings-backfill.test.ts
+++ b/test/embeddings-backfill.test.ts
@@ -1,0 +1,474 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  countPendingDocs,
+  runBackfillTick,
+} from "../src/embeddings/backfill.js";
+import {
+  ensureEmbeddingsTable,
+  isEmbedded,
+  registerEmbeddingProfile,
+  tryLoadSqliteVec,
+} from "../src/embeddings/store.js";
+
+/**
+ * Backfill cron tests. Voyage HTTP is mocked end-to-end via the
+ * `voyageFetch` option (the embedTexts() inside the cron honors this).
+ * No live API calls.
+ *
+ * vec0-dependent — gated on LCM_TEST_VEC0_PATH (or default dev box path).
+ */
+
+const VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(VEC0_PATH);
+
+function mockResponse(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  const headers = new Headers({ "Content-Type": "application/json", ...(init.headers ?? {}) });
+  return new Response(JSON.stringify(body), { status: init.status ?? 200, headers });
+}
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:", { allowExtension: true });
+  tryLoadSqliteVec(db, { path: VEC0_PATH });
+  runLcmMigrations(db, { fts5Available: false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+  registerEmbeddingProfile(db, "voyage-4-large", 3);
+  ensureEmbeddingsTable(db, "voyage-4-large", 3);
+  return db;
+}
+
+function insertLeaf(db: DatabaseSync, summaryId: string, tokenCount: number, content = "x"): void {
+  // FYI signature: (id, count, content) — with content optional. Note
+  // the SQL column order: content before token_count.
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+     VALUES (?, 1, 'leaf', ?, ?, 'sk1')`,
+  ).run(summaryId, content, tokenCount);
+}
+
+describe.skipIf(!VEC0_AVAILABLE)("embeddings-backfill — basic tick (no lock contention)", () => {
+  it("embeds all pending leaves; result count matches; isEmbedded true after", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100, "alpha");
+    insertLeaf(db, "leaf_b", 200, "beta");
+    insertLeaf(db, "leaf_c", 300, "gamma");
+
+    const calls: number[] = [];
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      calls.push(body.input.length);
+      // One response per input, indexed in order
+      return mockResponse({
+        data: body.input.map((_, i) => ({
+          embedding: [0.1 * (i + 1), 0.2 * (i + 1), 0.3 * (i + 1)],
+          index: i,
+        })),
+        model: "voyage-4-large",
+        usage: { total_tokens: body.input.length * 50 },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "test",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000, // skip rate-limit pacing in test
+      perTickLimit: 10,
+    });
+
+    expect(result.embeddedCount).toBe(3);
+    expect(result.skippedOverCap).toBe(0);
+    expect(result.skipped).toEqual([]);
+    expect(result.lockNotAcquired).toBe(false);
+    expect(result.perTickLimitReached).toBe(false);
+
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_a", embeddedKind: "summary" })).toBe(true);
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_b", embeddedKind: "summary" })).toBe(true);
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_c", embeddedKind: "summary" })).toBe(true);
+    db.close();
+  });
+
+  it("skips suppressed leaves (suppressed_at IS NOT NULL) — no Voyage call for them", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+    insertLeaf(db, "leaf_suppressed", 100);
+    db.prepare(`UPDATE summaries SET suppressed_at = ? WHERE summary_id = ?`).run(
+      "2026-05-05",
+      "leaf_suppressed",
+    );
+
+    const inputs: string[] = [];
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      inputs.push(...body.input);
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 1 },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+    });
+
+    expect(result.embeddedCount).toBe(1); // only leaf_a
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_a", embeddedKind: "summary" })).toBe(true);
+    expect(
+      isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_suppressed", embeddedKind: "summary" }),
+    ).toBe(false);
+    db.close();
+  });
+
+  it("skips already-embedded leaves on subsequent ticks (idempotent)", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+    insertLeaf(db, "leaf_b", 100);
+
+    let callCount = 0;
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      callCount++;
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 1 },
+      });
+    }) as unknown as typeof fetch;
+
+    const r1 = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+    });
+    expect(r1.embeddedCount).toBe(2);
+
+    // Second tick — should embed nothing, no Voyage calls
+    const callsAfterFirst = callCount;
+    const r2 = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+    });
+    expect(r2.embeddedCount).toBe(0);
+    expect(callCount).toBe(callsAfterFirst); // no new calls
+    db.close();
+  });
+
+  it("over-cap leaves (token_count > maxTokenCount) skipped + reported", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_normal", 1000);
+    insertLeaf(db, "leaf_over", 50_000); // way over 30K cap
+
+    let callCount = 0;
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      callCount++;
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 100 },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+    });
+
+    // The over-cap doc was filtered at SELECT level (token_count BETWEEN min..max)
+    expect(result.embeddedCount).toBe(1);
+    // The over-cap doc isn't included in skippedOverCap — SELECT filtered it
+    // out before runBackfillTick saw it. countPendingDocs would still report
+    // 1 pending (the over-cap one). We expect the operator to track via
+    // `lcm_describe` / `/lcm health`.
+    const stillPending = countPendingDocs(db, {
+      modelName: "voyage-4-large",
+      maxTokenCount: 1_000_000, // bypass the limit to find the over-cap doc
+    });
+    expect(stillPending).toBe(1); // leaf_over still unembedded
+    db.close();
+  });
+
+  it("perTickLimit caps work, returns perTickLimitReached=true", async () => {
+    const db = setupDb();
+    for (let i = 0; i < 10; i++) {
+      insertLeaf(db, `leaf_${i}`, 100);
+    }
+
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 100 },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+      perTickLimit: 5,
+    });
+
+    expect(result.embeddedCount).toBe(5);
+    expect(result.perTickLimitReached).toBe(true);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("embeddings-backfill — error handling", () => {
+  it("Voyage 400 records skipped doc but does NOT abort the tick", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+
+    const fetchMock = (async () =>
+      mockResponse({ error: "bad input" }, { status: 400 })) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      voyageMaxRetries: 0,
+      maxRequestsPerSecond: 1000,
+    });
+
+    expect(result.embeddedCount).toBe(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("voyage_400");
+    expect(result.skipped[0].summaryId).toBe("leaf_a");
+    db.close();
+  });
+
+  it("Voyage 401 (auth error) is fatal and re-thrown to caller", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+
+    const fetchMock = (async () =>
+      mockResponse({ error: "bad key" }, { status: 401 })) as unknown as typeof fetch;
+
+    await expect(
+      runBackfillTick(db, {
+        modelName: "voyage-4-large",
+        voyageModel: "voyage-4-large",
+        inputType: "document",
+        voyageApiKey: "k",
+        voyageFetch: fetchMock,
+        maxRequestsPerSecond: 1000,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "auth" });
+    db.close();
+  });
+
+  it("Voyage 500 on first batch — marks skipped, continues with other batches", async () => {
+    const db = setupDb();
+    for (let i = 0; i < 6; i++) {
+      insertLeaf(db, `leaf_${i}`, 100, `distinct_${i}`);
+    }
+
+    // Track first batch's input set. Anything matching it 500's; everything
+    // else succeeds. voyageMaxRetries=0 keeps the test fast.
+    let firstKey: string | null = null;
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      const key = body.input.join("|");
+      if (firstKey === null) firstKey = key;
+      if (key === firstKey) {
+        return mockResponse({ error: "internal" }, { status: 500 });
+      }
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 1 },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      voyageMaxRetries: 0, // immediate surface, no backoff
+      maxRequestsPerSecond: 1000,
+      maxBatchTokens: 200,
+    });
+
+    // 6 leaves total, batches of 2 (200 tokens / 100 each). First batch
+    // fails → 2 skipped. Other 2 batches succeed → 4 embedded.
+    expect(result.embeddedCount).toBe(4);
+    expect(result.skipped).toHaveLength(2);
+    expect(result.skipped.every((s) => s.reason === "voyage_other")).toBe(true);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("embeddings-backfill — single-flight via worker lock", () => {
+  it("if another worker holds the lock, returns lockNotAcquired=true (no Voyage calls)", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+
+    // Simulate another worker holding the lock
+    db.prepare(
+      `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at)
+       VALUES ('embedding-backfill', 'other-worker', datetime('now', '+1 hour'))`,
+    ).run();
+
+    let calls = 0;
+    const fetchMock = (async () => {
+      calls++;
+      return mockResponse({ data: [], usage: { total_tokens: 0 } });
+    }) as unknown as typeof fetch;
+
+    const result = await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+    });
+
+    expect(result.lockNotAcquired).toBe(true);
+    expect(result.embeddedCount).toBe(0);
+    expect(calls).toBe(0); // no Voyage calls
+    db.close();
+  });
+
+  it("releases lock on success — next tick can re-acquire", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 1 },
+      });
+    }) as unknown as typeof fetch;
+
+    await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+    });
+
+    // Lock should be released
+    const lockHolder = db
+      .prepare(`SELECT worker_id FROM lcm_worker_lock WHERE job_kind = 'embedding-backfill'`)
+      .get();
+    expect(lockHolder).toBeUndefined();
+    db.close();
+  });
+
+  it("releases lock on Voyage auth error (re-throw) too — try/finally", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+
+    const fetchMock = (async () =>
+      mockResponse({ error: "bad key" }, { status: 401 })) as unknown as typeof fetch;
+
+    await expect(
+      runBackfillTick(db, {
+        modelName: "voyage-4-large",
+        voyageModel: "voyage-4-large",
+        inputType: "document",
+        voyageApiKey: "k",
+        voyageFetch: fetchMock,
+        maxRequestsPerSecond: 1000,
+      }),
+    ).rejects.toMatchObject({ kind: "auth" });
+
+    // Lock must still be released so the next tick can run after operator
+    // fixes the API key
+    const lockHolder = db
+      .prepare(`SELECT worker_id FROM lcm_worker_lock WHERE job_kind = 'embedding-backfill'`)
+      .get();
+    expect(lockHolder).toBeUndefined();
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("embeddings-backfill — batching (token budget)", () => {
+  it("packs batches that respect maxBatchTokens", async () => {
+    // Wave-1 Auditor #2 finding #3: MAX_TOKENS_PER_EMBED_DOC dropped 30K→27K
+    // to absorb Voyage's ~9.5% tokenizer inflation. Use 25K-token leaves
+    // here so the per-doc filter doesn't drop them before batching.
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 25_000);
+    insertLeaf(db, "leaf_b", 25_000);
+    insertLeaf(db, "leaf_c", 25_000);
+
+    const seenBatchSizes: number[] = [];
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[] };
+      seenBatchSizes.push(body.input.length);
+      return mockResponse({
+        data: body.input.map((_, i) => ({ embedding: [0.1, 0.2, 0.3], index: i })),
+        usage: { total_tokens: 25_000 * body.input.length },
+      });
+    }) as unknown as typeof fetch;
+
+    await runBackfillTick(db, {
+      modelName: "voyage-4-large",
+      voyageModel: "voyage-4-large",
+      inputType: "document",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      maxRequestsPerSecond: 1000,
+      maxBatchTokens: 60_000, // → batches of 2 + 1
+    });
+
+    // 75K total tokens, 60K limit per batch — must be at least 2 batches.
+    // Bin packing is greedy: 25+25=50≤60, then add 25 → 75>60, flush, new batch with 25.
+    // So 2 batches: [2 docs, 1 doc].
+    expect(seenBatchSizes).toEqual([2, 1]);
+    db.close();
+  });
+
+  it("countPendingDocs returns accurate count of unembedded documents", () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", 100);
+    insertLeaf(db, "leaf_b", 100);
+    insertLeaf(db, "leaf_c", 100);
+    expect(countPendingDocs(db, { modelName: "voyage-4-large" })).toBe(3);
+
+    // Simulate one being already embedded
+    db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count)
+       VALUES ('leaf_a', 'summary', 'voyage-4-large', 100)`,
+    ).run();
+    expect(countPendingDocs(db, { modelName: "voyage-4-large" })).toBe(2);
+    db.close();
+  });
+});

--- a/test/embeddings-store.test.ts
+++ b/test/embeddings-store.test.ts
@@ -1,0 +1,525 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  candidateVec0Paths,
+  deleteEmbedding,
+  embeddingsTableExists,
+  embeddingsTableName,
+  ensureEmbeddingsTable,
+  isEmbedded,
+  markEmbeddingSuppressed,
+  recordEmbedding,
+  registerEmbeddingProfile,
+  replaceEmbedding,
+  searchSimilar,
+  tryLoadSqliteVec,
+  vec0Version,
+} from "../src/embeddings/store.js";
+
+/**
+ * Tests for src/embeddings/store.ts.
+ *
+ * vec0-dependent tests are gated on the extension being loadable. The
+ * vitest config (vitest.config.ts) overrides $HOME to a temp dir, so
+ * `homedir()`-based path discovery WILL NOT find a dev-box-installed
+ * sqlite-vec — set `LCM_TEST_VEC0_PATH` env var to point to a
+ * `vec0.<dylib|so|dll>` to enable the vec0-dependent suite.
+ *
+ * On CI without sqlite-vec, the suite skips cleanly. On Eva's dev box,
+ * `LCM_TEST_VEC0_PATH=/Users/lume/.openclaw/extensions/node_modules/sqlite-vec-darwin-arm64/vec0.dylib`
+ * (or set in shell rc) enables the full suite.
+ */
+
+const DEV_VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  // Fallback default: most-common dev install location with REAL_HOME if set
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(DEV_VEC0_PATH);
+
+function newDbWithExtAllowed(): DatabaseSync {
+  return new DatabaseSync(":memory:", { allowExtension: true });
+}
+
+describe("embeddings store — embeddingsTableName", () => {
+  it("sluggifies voyage-4-large to voyage4large", () => {
+    expect(embeddingsTableName("voyage-4-large")).toBe("lcm_embeddings_voyage4large");
+  });
+  it("sluggifies voyage-3-lite to voyage3lite", () => {
+    expect(embeddingsTableName("voyage-3-lite")).toBe("lcm_embeddings_voyage3lite");
+  });
+  it("rejects empty model name", () => {
+    expect(() => embeddingsTableName("")).toThrow(/invalid model name/);
+  });
+  it("rejects model names with bad characters (defense vs SQL injection)", () => {
+    expect(() => embeddingsTableName("foo; DROP TABLE")).toThrow(/invalid model name/);
+    expect(() => embeddingsTableName("foo'bar")).toThrow(/invalid model name/);
+    expect(() => embeddingsTableName("foo\nbar")).toThrow(/invalid model name/);
+  });
+  it("rejects model names that sluggify to empty", () => {
+    expect(() => embeddingsTableName("___")).toThrow(/sluggifies to empty/);
+  });
+  it("accepts dot/underscore/dash characters", () => {
+    expect(embeddingsTableName("voyage.4_large-test")).toBe("lcm_embeddings_voyage4largetest");
+  });
+});
+
+describe("embeddings store — candidateVec0Paths", () => {
+  it("includes LCM_SQLITE_VEC_PATH when set", () => {
+    const original = process.env.LCM_SQLITE_VEC_PATH;
+    process.env.LCM_SQLITE_VEC_PATH = "/custom/path/vec0.dylib";
+    try {
+      const paths = candidateVec0Paths();
+      expect(paths[0]).toBe("/custom/path/vec0.dylib");
+    } finally {
+      if (original === undefined) delete process.env.LCM_SQLITE_VEC_PATH;
+      else process.env.LCM_SQLITE_VEC_PATH = original;
+    }
+  });
+  it("includes plugin-local node_modules path", () => {
+    const paths = candidateVec0Paths();
+    expect(paths.some((p) => p.includes("node_modules") && p.includes("sqlite-vec"))).toBe(true);
+  });
+  it("includes ~/.openclaw/extensions path", () => {
+    const paths = candidateVec0Paths();
+    expect(paths.some((p) => p.includes(".openclaw"))).toBe(true);
+  });
+});
+
+describe("embeddings store — tryLoadSqliteVec graceful degrade", () => {
+  it("returns false when no extension is found at any candidate path (silent)", () => {
+    // Override with non-existent path; suppress console.warn
+    const db = newDbWithExtAllowed();
+    const loaded = tryLoadSqliteVec(db, { path: "/nonexistent/path/vec0.dylib", silent: true });
+    expect(loaded).toBe(false);
+    db.close();
+  });
+  it("vec0Version returns null when not loaded", () => {
+    const db = newDbWithExtAllowed();
+    expect(vec0Version(db)).toBeNull();
+    db.close();
+  });
+});
+
+describe("embeddings store — registerEmbeddingProfile", () => {
+  it("inserts profile row, idempotent on second call with same dim", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    registerEmbeddingProfile(db, "voyage-4-large", 1024);
+    const row1 = db
+      .prepare(`SELECT model_name, dim, active FROM lcm_embedding_profile WHERE model_name = ?`)
+      .get("voyage-4-large") as { model_name: string; dim: number; active: number };
+    expect(row1).toEqual({ model_name: "voyage-4-large", dim: 1024, active: 1 });
+
+    registerEmbeddingProfile(db, "voyage-4-large", 1024); // again — no-op
+    const count = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_embedding_profile WHERE model_name = ?`)
+      .get("voyage-4-large") as { n: number };
+    expect(count.n).toBe(1);
+    db.close();
+  });
+
+  it("throws on dim mismatch (profiles are immutable; bump model_name to switch)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    registerEmbeddingProfile(db, "voyage-4-large", 1024);
+    expect(() => registerEmbeddingProfile(db, "voyage-4-large", 2048)).toThrow(/dim mismatch/);
+    db.close();
+  });
+
+  it("rejects bad model names", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => registerEmbeddingProfile(db, "foo;DROP", 1024)).toThrow(/invalid model name/);
+    db.close();
+  });
+
+  it("rejects bad dim", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => registerEmbeddingProfile(db, "x", 0)).toThrow(/invalid dim/);
+    expect(() => registerEmbeddingProfile(db, "x", -5)).toThrow(/invalid dim/);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)(
+  "embeddings store — vec0-dependent (requires sqlite-vec at ~/.openclaw/extensions/...)",
+  () => {
+    it("loads vec0 from the dev path; vec0Version returns a version string", () => {
+      const db = newDbWithExtAllowed();
+      const loaded = tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      expect(loaded).toBe(true);
+      const v = vec0Version(db);
+      expect(v).toMatch(/^v\d/); // e.g. "v0.1.9"
+      db.close();
+    });
+
+    it("ensureEmbeddingsTable creates lcm_embeddings_<slug> virtual table; idempotent", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 1024);
+
+      expect(embeddingsTableExists(db, "voyage-4-large")).toBe(false);
+      ensureEmbeddingsTable(db, "voyage-4-large", 1024);
+      expect(embeddingsTableExists(db, "voyage-4-large")).toBe(true);
+
+      // idempotent
+      ensureEmbeddingsTable(db, "voyage-4-large", 1024);
+      expect(embeddingsTableExists(db, "voyage-4-large")).toBe(true);
+      db.close();
+    });
+
+    it("recordEmbedding inserts vec0 row + meta row; isEmbedded reflects this", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 4);
+      ensureEmbeddingsTable(db, "voyage-4-large", 4);
+
+      expect(
+        isEmbedded(db, {
+          embeddedId: "leaf_a",
+          embeddedKind: "summary",
+          modelName: "voyage-4-large",
+        }),
+      ).toBe(false);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: new Float32Array([0.1, 0.2, 0.3, 0.4]),
+        sourceTokenCount: 100,
+      });
+
+      expect(
+        isEmbedded(db, {
+          embeddedId: "leaf_a",
+          embeddedKind: "summary",
+          modelName: "voyage-4-large",
+        }),
+      ).toBe(true);
+
+      const meta = db
+        .prepare(`SELECT source_token_count, archived FROM lcm_embedding_meta WHERE embedded_id = ?`)
+        .get("leaf_a") as { source_token_count: number; archived: number };
+      expect(meta).toEqual({ source_token_count: 100, archived: 0 });
+      db.close();
+    });
+
+    it("recordEmbedding rejects vector with wrong dimension", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 4);
+      ensureEmbeddingsTable(db, "voyage-4-large", 4);
+
+      expect(() =>
+        recordEmbedding(db, {
+          modelName: "voyage-4-large",
+          embeddedId: "leaf_a",
+          embeddedKind: "summary",
+          vector: new Float32Array([0.1, 0.2]), // dim 2, not 4
+          sourceTokenCount: 100,
+        }),
+      ).toThrow(/dim mismatch/);
+      db.close();
+    });
+
+    it("recordEmbedding throws when no profile registered for model", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      // Skip registerEmbeddingProfile — should fail
+      expect(() =>
+        recordEmbedding(db, {
+          modelName: "voyage-4-large",
+          embeddedId: "x",
+          embeddedKind: "summary",
+          vector: new Float32Array([0.1]),
+          sourceTokenCount: 1,
+        }),
+      ).toThrow(/no profile registered/);
+      db.close();
+    });
+
+    it("searchSimilar finds nearest vectors, excludes suppressed by default", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.1, 0.2, 0.3],
+        sourceTokenCount: 1,
+      });
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_b",
+        embeddedKind: "summary",
+        vector: [0.4, 0.5, 0.6],
+        sourceTokenCount: 1,
+      });
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_suppressed",
+        embeddedKind: "summary",
+        vector: [0.1, 0.2, 0.3], // identical to leaf_a, but suppressed
+        suppressed: true,
+        sourceTokenCount: 1,
+      });
+
+      const hits = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.2, 0.3],
+        k: 5,
+      });
+      // leaf_a should be top result (distance 0); leaf_suppressed excluded
+      expect(hits.length).toBe(2);
+      expect(hits[0].embeddedId).toBe("leaf_a");
+      expect(hits.map((h) => h.embeddedId)).not.toContain("leaf_suppressed");
+      db.close();
+    });
+
+    it("searchSimilar with excludeSuppressed=false returns suppressed rows too", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_visible",
+        embeddedKind: "summary",
+        vector: [0.1, 0.2, 0.3],
+        sourceTokenCount: 1,
+      });
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_hidden",
+        embeddedKind: "summary",
+        vector: [0.4, 0.5, 0.6],
+        suppressed: true,
+        sourceTokenCount: 1,
+      });
+
+      const hitsAll = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.2, 0.3],
+        k: 5,
+        excludeSuppressed: false,
+      });
+      expect(hitsAll.length).toBe(2);
+      expect(new Set(hitsAll.map((h) => h.embeddedId))).toEqual(
+        new Set(["leaf_visible", "leaf_hidden"]),
+      );
+      db.close();
+    });
+
+    it("searchSimilar filters by embeddedKind", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.1, 0.1, 0.1],
+        sourceTokenCount: 1,
+      });
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "ent_b",
+        embeddedKind: "entity",
+        vector: [0.1, 0.1, 0.1], // identical, so distance 0 for both
+        sourceTokenCount: 1,
+      });
+
+      const summariesOnly = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.1, 0.1],
+        k: 5,
+      });
+      expect(summariesOnly.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+
+      const entitiesOnly = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.1, 0.1],
+        k: 5,
+        embeddedKinds: ["entity"],
+      });
+      expect(entitiesOnly.map((h) => h.embeddedId)).toEqual(["ent_b"]);
+
+      const both = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.1, 0.1],
+        k: 5,
+        embeddedKinds: ["summary", "entity"],
+      });
+      expect(new Set(both.map((h) => h.embeddedId))).toEqual(new Set(["leaf_a", "ent_b"]));
+      db.close();
+    });
+
+    it("markEmbeddingSuppressed flips visibility on subsequent search", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.1, 0.2, 0.3],
+        sourceTokenCount: 1,
+      });
+      const before = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.2, 0.3],
+        k: 5,
+      });
+      expect(before.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+
+      markEmbeddingSuppressed(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        suppressed: true,
+      });
+      const after = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.2, 0.3],
+        k: 5,
+      });
+      expect(after).toEqual([]); // suppressed by metadata pre-filter
+
+      // Restoring works
+      markEmbeddingSuppressed(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        suppressed: false,
+      });
+      const restored = searchSimilar(db, {
+        modelName: "voyage-4-large",
+        queryVector: [0.1, 0.2, 0.3],
+        k: 5,
+      });
+      expect(restored.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+      db.close();
+    });
+
+    it("replaceEmbedding removes prior + inserts new in one logical op", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.1, 0.0, 0.0],
+        sourceTokenCount: 100,
+      });
+      replaceEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.0, 0.0, 1.0], // very different — query toward old vec should miss
+        sourceTokenCount: 200,
+      });
+
+      const tableName = embeddingsTableName("voyage-4-large");
+      const count = db
+        .prepare(`SELECT COUNT(*) AS n FROM ${tableName} WHERE embedded_id = ?`)
+        .get("leaf_a") as { n: number };
+      expect(count.n).toBe(1); // not 2 — old row removed
+
+      const meta = db
+        .prepare(`SELECT source_token_count FROM lcm_embedding_meta WHERE embedded_id = ?`)
+        .get("leaf_a") as { source_token_count: number };
+      expect(meta.source_token_count).toBe(200); // updated
+      db.close();
+    });
+
+    it("deleteEmbedding removes from both vec0 and meta", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 3);
+      ensureEmbeddingsTable(db, "voyage-4-large", 3);
+
+      recordEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+        vector: [0.1, 0.2, 0.3],
+        sourceTokenCount: 1,
+      });
+      deleteEmbedding(db, {
+        modelName: "voyage-4-large",
+        embeddedId: "leaf_a",
+        embeddedKind: "summary",
+      });
+
+      expect(
+        isEmbedded(db, {
+          modelName: "voyage-4-large",
+          embeddedId: "leaf_a",
+          embeddedKind: "summary",
+        }),
+      ).toBe(false);
+      const tableName = embeddingsTableName("voyage-4-large");
+      const count = db
+        .prepare(`SELECT COUNT(*) AS n FROM ${tableName} WHERE embedded_id = ?`)
+        .get("leaf_a") as { n: number };
+      expect(count.n).toBe(0);
+      db.close();
+    });
+
+    it("ensureEmbeddingsTable rejects bad dim", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      expect(() => ensureEmbeddingsTable(db, "voyage-4-large", 0)).toThrow(/invalid dim/);
+      expect(() => ensureEmbeddingsTable(db, "voyage-4-large", 99999)).toThrow(/invalid dim/);
+      db.close();
+    });
+
+    it("two different models get two independent vec0 tables", () => {
+      const db = newDbWithExtAllowed();
+      tryLoadSqliteVec(db, { path: DEV_VEC0_PATH });
+      runLcmMigrations(db, { fts5Available: false });
+      registerEmbeddingProfile(db, "voyage-4-large", 4);
+      registerEmbeddingProfile(db, "voyage-3-lite", 2);
+      ensureEmbeddingsTable(db, "voyage-4-large", 4);
+      ensureEmbeddingsTable(db, "voyage-3-lite", 2);
+
+      expect(embeddingsTableExists(db, "voyage-4-large")).toBe(true);
+      expect(embeddingsTableExists(db, "voyage-3-lite")).toBe(true);
+
+      // Names differ
+      expect(embeddingsTableName("voyage-4-large")).not.toBe(embeddingsTableName("voyage-3-lite"));
+      db.close();
+    });
+  },
+);

--- a/test/hybrid-search.test.ts
+++ b/test/hybrid-search.test.ts
@@ -1,0 +1,313 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  ensureEmbeddingsTable,
+  recordEmbedding,
+  registerEmbeddingProfile,
+  tryLoadSqliteVec,
+} from "../src/embeddings/store.js";
+import {
+  runHybridSearch,
+  type FtsHit,
+} from "../src/embeddings/hybrid-search.js";
+
+const VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(VEC0_PATH);
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:", { allowExtension: true });
+  tryLoadSqliteVec(db, { path: VEC0_PATH });
+  runLcmMigrations(db, { fts5Available: false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+  registerEmbeddingProfile(db, "voyage-4-large", 3);
+  ensureEmbeddingsTable(db, "voyage-4-large", 3);
+  return db;
+}
+
+function insertLeaf(
+  db: DatabaseSync,
+  summaryId: string,
+  vector: [number, number, number] | null,
+  content: string,
+  conversationId = 1,
+): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key, created_at)
+     VALUES (?, ?, 'leaf', ?, 1, (SELECT session_key FROM conversations WHERE conversation_id = ?), datetime('now'))`,
+  ).run(summaryId, conversationId, content, conversationId);
+  if (vector) {
+    recordEmbedding(db, {
+      modelName: "voyage-4-large",
+      embeddedId: summaryId,
+      embeddedKind: "summary",
+      vector,
+      sourceTokenCount: 1,
+    });
+  }
+}
+
+function makeFtsSearch(hits: Array<Pick<FtsHit, "summaryId" | "content">>) {
+  // Helper: convert id+content tuples into full FtsHit shape
+  return async (_args: unknown): Promise<FtsHit[]> =>
+    hits.map((h, i) => ({
+      summaryId: h.summaryId,
+      conversationId: 1,
+      sessionKey: "sk1",
+      kind: "leaf" as const,
+      content: h.content,
+      tokenCount: 1,
+      createdAt: "2026-05-05",
+      rank: i,
+    }));
+}
+
+function rerankFetch(scores: Record<string, number>): typeof fetch {
+  return (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as {
+      documents: string[];
+      top_k: number;
+    };
+    // Score each doc by content lookup; default 0.1 if missing
+    const data = body.documents.map((doc, idx) => ({
+      index: idx,
+      relevance_score: scores[doc] ?? 0.1,
+    }));
+    return new Response(
+      JSON.stringify({
+        data,
+        model: "rerank-2.5",
+        usage: { total_tokens: 100 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+describe.skipIf(!VEC0_AVAILABLE)("hybrid-search — happy path with rerank", () => {
+  it("merges FTS + semantic candidates, reranks, returns top-N", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", [0.1, 0.2, 0.3], "alpha doc"); // semantic match
+    insertLeaf(db, "leaf_b", [0.9, 0.9, 0.9], "beta doc");  // semantic far
+
+    const result = await runHybridSearch(db, {
+      query: "alpha",
+      ftsSearch: makeFtsSearch([
+        { summaryId: "leaf_a", content: "alpha doc" },
+        // FTS misses leaf_b; it shows up only via semantic
+      ]),
+      semantic: { queryVector: new Float32Array([0.1, 0.2, 0.3]) },
+      voyageApiKey: "k",
+      voyageFetch: rerankFetch({
+        "alpha doc": 0.95,
+        "beta doc": 0.30,
+      }),
+      voyageMaxRetries: 0,
+      topN: 5,
+    });
+
+    expect(result.hits).toHaveLength(2);
+    expect(result.hits[0].summaryId).toBe("leaf_a");
+    expect(result.hits[0].score).toBe(0.95);
+    expect(result.hits[0].fromFts).toBe(true);
+    expect(result.hits[0].fromSemantic).toBe(true);
+    expect(result.hits[0].semanticDistance).toBe(0); // identical vector
+    expect(result.hits[0].ftsRank).toBe(0);
+
+    expect(result.hits[1].summaryId).toBe("leaf_b");
+    expect(result.hits[1].fromFts).toBe(false);
+    expect(result.hits[1].fromSemantic).toBe(true);
+    expect(result.hits[1].ftsRank).toBeNull();
+
+    expect(result.candidateCount).toBe(2);
+    expect(result.degradedToFtsOnly).toBe(false);
+    expect(result.degradedSkippedRerank).toBe(false);
+  });
+
+  it("dedupes overlap (FTS + semantic both find same doc)", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_x", [0.1, 0.2, 0.3], "shared doc");
+
+    const result = await runHybridSearch(db, {
+      query: "shared",
+      ftsSearch: makeFtsSearch([{ summaryId: "leaf_x", content: "shared doc" }]),
+      semantic: { queryVector: new Float32Array([0.1, 0.2, 0.3]) },
+      voyageApiKey: "k",
+      voyageFetch: rerankFetch({ "shared doc": 0.99 }),
+      voyageMaxRetries: 0,
+    });
+
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0].fromFts).toBe(true);
+    expect(result.hits[0].fromSemantic).toBe(true);
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("hybrid-search — graceful degrade", () => {
+  it("vec0 not loaded → degradedToFtsOnly=true, FTS-only results", async () => {
+    // Use a fresh DB without loading vec0
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+
+    const result = await runHybridSearch(db, {
+      query: "hello",
+      ftsSearch: makeFtsSearch([{ summaryId: "leaf_a", content: "hello world" }]),
+      voyageApiKey: "k",
+      voyageFetch: rerankFetch({ "hello world": 0.8 }),
+      voyageMaxRetries: 0,
+    });
+
+    expect(result.degradedToFtsOnly).toBe(true);
+    expect(result.hits[0].summaryId).toBe("leaf_a");
+    expect(result.hits[0].fromFts).toBe(true);
+    expect(result.hits[0].fromSemantic).toBe(false);
+    db.close();
+  });
+
+  it("rerank Voyage 500 → falls back to RRF, sets degradedSkippedRerank=true", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", [0.1, 0.2, 0.3], "alpha");
+    insertLeaf(db, "leaf_b", [0.9, 0.9, 0.9], "beta");
+
+    let calls = 0;
+    const fetchMock = (async (url: string) => {
+      calls++;
+      if (url.endsWith("/rerank")) {
+        return new Response(JSON.stringify({ error: "internal" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // For /embeddings (semantic side), succeed
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+          usage: { total_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await runHybridSearch(db, {
+      query: "alpha",
+      ftsSearch: makeFtsSearch([
+        { summaryId: "leaf_a", content: "alpha" },
+        { summaryId: "leaf_b", content: "beta" },
+      ]),
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      voyageMaxRetries: 0,
+    });
+
+    expect(result.degradedSkippedRerank).toBe(true);
+    expect(result.hits.length).toBeGreaterThan(0);
+    // Both hits got an RRF-fused score
+    expect(result.hits[0].score).toBeGreaterThan(0);
+  });
+
+  it("rerank Voyage 401 (auth) → re-thrown, NOT degraded silently", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_a", [0.1, 0.2, 0.3], "alpha");
+
+    const fetchMock = (async (url: string) => {
+      if (url.endsWith("/rerank")) {
+        return new Response(JSON.stringify({ error: "bad key" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+          usage: { total_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      runHybridSearch(db, {
+        query: "alpha",
+        ftsSearch: makeFtsSearch([{ summaryId: "leaf_a", content: "alpha" }]),
+        voyageApiKey: "k",
+        voyageFetch: fetchMock,
+        voyageMaxRetries: 0,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "auth" });
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("hybrid-search — rerank=false → RRF mode", () => {
+  it("RRF fuses FTS+semantic ranks without calling Voyage rerank", async () => {
+    const db = setupDb();
+    insertLeaf(db, "leaf_top", [0.1, 0.2, 0.3], "top doc");
+    insertLeaf(db, "leaf_other", [0.5, 0.5, 0.5], "other");
+
+    let rerankCalls = 0;
+    const fetchMock = (async (url: string) => {
+      if (url.endsWith("/rerank")) rerankCalls++;
+      return new Response(JSON.stringify({ data: [], usage: { total_tokens: 0 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runHybridSearch(db, {
+      query: "top",
+      ftsSearch: makeFtsSearch([
+        { summaryId: "leaf_top", content: "top doc" }, // rank 0
+        { summaryId: "leaf_other", content: "other" }, // rank 1
+      ]),
+      semantic: { queryVector: new Float32Array([0.1, 0.2, 0.3]) },
+      rerank: false,
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      voyageMaxRetries: 0,
+    });
+
+    expect(rerankCalls).toBe(0); // no rerank
+    expect(result.hits[0].summaryId).toBe("leaf_top"); // best in both arms
+    expect(result.degradedSkippedRerank).toBe(false); // explicit choice, not failure
+    // RRF score ~ 1/(60+0) + 1/(60+0) for leaf_top (best in both)
+    expect(result.hits[0].score).toBeGreaterThan(0.03);
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("hybrid-search — input validation", () => {
+  it("rejects empty query", async () => {
+    const db = setupDb();
+    await expect(
+      runHybridSearch(db, {
+        query: "",
+        ftsSearch: makeFtsSearch([]),
+        voyageApiKey: "k",
+      }),
+    ).rejects.toThrow(/query is required/);
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("hybrid-search — no candidates", () => {
+  it("returns empty hits + 0 candidates when both arms return nothing", async () => {
+    const db = setupDb();
+    const result = await runHybridSearch(db, {
+      query: "nonexistent",
+      ftsSearch: makeFtsSearch([]),
+      semantic: { queryVector: new Float32Array([0.1, 0.2, 0.3]) },
+      voyageApiKey: "k",
+      voyageFetch: rerankFetch({}),
+      voyageMaxRetries: 0,
+    });
+    expect(result.hits).toEqual([]);
+    expect(result.candidateCount).toBe(0);
+  });
+});

--- a/test/lcm-describe-expand-flags.test.ts
+++ b/test/lcm-describe-expand-flags.test.ts
@@ -1,0 +1,415 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
+import type { LcmDependencies } from "../src/types.js";
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) return null;
+  const parts = trimmed.split(":");
+  if (parts.length < 3) return null;
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      ignoreSessionPatterns: [],
+      statelessSessionPatterns: [],
+      skipStatelessSessions: true,
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      newSessionRetainDepth: 2,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 4000,
+      largeFileTokenThreshold: 25_000,
+      summaryProvider: "",
+      summaryModel: "",
+      largeFileSummaryProvider: "",
+      largeFileSummaryModel: "",
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
+      autoRotateSessionFiles: {
+        enabled: true,
+        sizeBytes: 2 * 1024 * 1024,
+        startup: "rotate",
+        runtime: "rotate",
+      },
+      summaryMaxOverageFactor: 3,
+    },
+    complete: vi.fn(),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: () => ({ provider: "anthropic", model: "claude-opus-4-5" }),
+    getApiKey: async () => undefined,
+    requireApiKey: async () => "",
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    ...overrides,
+  } as LcmDependencies;
+}
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'agent:main:main')`).run();
+  return db;
+}
+
+function insertSummary(
+  db: DatabaseSync,
+  args: {
+    summaryId: string;
+    kind?: "leaf" | "condensed";
+    content: string;
+    tokenCount?: number;
+    suppressedAt?: string | null;
+    sessionKey?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key, suppressed_at)
+     VALUES (?, 1, ?, ?, ?, ?, ?)`,
+  ).run(
+    args.summaryId,
+    args.kind ?? "leaf",
+    args.content,
+    args.tokenCount ?? Math.ceil(args.content.length / 4),
+    args.sessionKey ?? "agent:main:main",
+    args.suppressedAt ?? null,
+  );
+}
+
+let _parentOrdinal = 0;
+function insertParent(
+  db: DatabaseSync,
+  parentSummaryId: string,
+  childSummaryId: string,
+): void {
+  db.prepare(
+    `INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal) VALUES (?, ?, ?)`,
+  ).run(childSummaryId, parentSummaryId, _parentOrdinal++);
+}
+
+function insertMessage(
+  db: DatabaseSync,
+  args: {
+    messageId: number;
+    content: string;
+    role?: string;
+    suppressedAt?: string | null;
+    createdAt?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at, suppressed_at, identity_hash)
+     VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    args.messageId,
+    args.messageId,
+    args.role ?? "user",
+    args.content,
+    Math.ceil(args.content.length / 4),
+    args.createdAt ?? new Date().toISOString(),
+    args.suppressedAt ?? null,
+    `hash_${args.messageId}`,
+  );
+}
+
+function linkSummaryMessage(
+  db: DatabaseSync,
+  summaryId: string,
+  messageId: number,
+  ordinal = 0,
+): void {
+  db.prepare(
+    `INSERT INTO summary_messages (summary_id, message_id, ordinal) VALUES (?, ?, ?)`,
+  ).run(summaryId, messageId, ordinal);
+}
+
+function buildLcmEngine(db: DatabaseSync, timezone = "UTC") {
+  return {
+    info: { id: "lcm", name: "LCM", version: "0.0.0" },
+    timezone,
+    getDb: () => db,
+    getRetrieval: () => ({
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: async (id: string) => {
+        // Minimal describe shim that returns enough to exercise the tool's
+        // expansion flag handling. Real RetrievalEngine.describe builds a
+        // full subtree manifest; we shortcut to just the immediate row.
+        const row = db
+          .prepare(
+            `SELECT summary_id, conversation_id, session_key, kind, depth, content, token_count, source_message_token_count, descendant_count, descendant_token_count, earliest_at, latest_at, created_at
+               FROM summaries WHERE summary_id = ? AND suppressed_at IS NULL`,
+          )
+          .get(id) as
+          | {
+              summary_id: string;
+              conversation_id: number;
+              session_key: string;
+              kind: string;
+              depth: number;
+              content: string;
+              token_count: number;
+              source_message_token_count: number;
+              descendant_count: number;
+              descendant_token_count: number;
+              earliest_at: string | null;
+              latest_at: string | null;
+              created_at: string;
+            }
+          | undefined;
+        if (!row) return null;
+        const childRows = db
+          .prepare(
+            `SELECT summary_id FROM summary_parents WHERE parent_summary_id = ?`,
+          )
+          .all(id) as Array<{ summary_id: string }>;
+        return {
+          type: "summary" as const,
+          summary: {
+            summaryId: row.summary_id,
+            conversationId: row.conversation_id,
+            sessionKey: row.session_key,
+            kind: row.kind as "leaf" | "condensed",
+            depth: row.depth,
+            content: row.content,
+            tokenCount: row.token_count,
+            sourceMessageTokenCount: row.source_message_token_count,
+            descendantCount: row.descendant_count,
+            descendantTokenCount: row.descendant_token_count,
+            earliestAt: row.earliest_at,
+            latestAt: row.latest_at,
+            createdAt: row.created_at,
+            parentIds: [],
+            childIds: childRows.map((r) => r.summary_id),
+            subtree: [],
+          },
+        };
+      },
+    }),
+    getConversationStore: () => ({
+      getConversationBySessionId: vi.fn(),
+      getConversationBySessionKey: vi.fn(),
+      getConversationFamilyIds: vi.fn(async () => [1]),
+    }),
+  };
+}
+
+describe("createLcmDescribeTool — expandChildren flag", () => {
+  it("returns first-hop child summaries inline when expandChildren=true", async () => {
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_parent", kind: "condensed", content: "parent summary content" });
+    insertSummary(db, { summaryId: "sum_child_a", content: "First child content with race-condition fix details" });
+    insertSummary(db, { summaryId: "sum_child_b", content: "Second child content with another concrete topic" });
+    insertParent(db, "sum_parent", "sum_child_a");
+    insertParent(db, "sum_parent", "sum_child_b");
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_parent",
+      conversationId: 1,
+      expandChildren: true,
+    });
+    const text = (r.content[0] as { text: string }).text;
+    // Format updated 2026-05-06: now uses colon prefix and explicit status
+    // (P4 harness fix — silent empty results were ambiguous).
+    expect(text).toContain("expanded children: 2/2");
+    expect(text).toContain("First child content with race-condition fix details");
+    expect(text).toContain("Second child content with another concrete topic");
+
+    const details = r.details as {
+      expansion: { children: Array<{ summaryId: string }>; childrenStatus?: string };
+    };
+    expect(details.expansion.children).toHaveLength(2);
+    expect(details.expansion.childrenStatus).toBe("ok");
+
+    db.close();
+  });
+
+  it("filters suppressed children", async () => {
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_parent", kind: "condensed", content: "parent" });
+    insertSummary(db, { summaryId: "sum_visible", content: "visible child content" });
+    insertSummary(db, {
+      summaryId: "sum_suppressed",
+      content: "suppressed child content",
+      suppressedAt: new Date().toISOString(),
+    });
+    insertParent(db, "sum_parent", "sum_visible");
+    insertParent(db, "sum_parent", "sum_suppressed");
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_parent",
+      conversationId: 1,
+      expandChildren: true,
+    });
+    const details = r.details as { expansion: { children: Array<{ summaryId: string }> } };
+    expect(details.expansion.children).toHaveLength(1);
+    expect(details.expansion.children[0]!.summaryId).toBe("sum_visible");
+
+    db.close();
+  });
+
+  it("respects expandChildrenLimit (capped at 50)", async () => {
+    // Cap raised 20 → 50 on 2026-05-06 (P5 harness fix). The 5-default
+    // was too low for typical 100-msg leaves; new defaults are
+    // expandChildrenLimit=20, max=50.
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_parent", kind: "condensed", content: "parent" });
+    for (let i = 1; i <= 60; i++) {
+      insertSummary(db, { summaryId: `sum_c${i}`, content: `child ${i}` });
+      insertParent(db, "sum_parent", `sum_c${i}`);
+    }
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_parent",
+      conversationId: 1,
+      expandChildren: true,
+      expandChildrenLimit: 100, // user asks for 100; tool caps at 50
+    });
+    const details = r.details as {
+      expansion: { children: unknown[]; childrenStatus?: string };
+    };
+    expect(details.expansion.children.length).toBeLessThanOrEqual(50);
+    expect(details.expansion.childrenStatus).toBe("capped");
+
+    db.close();
+  });
+
+  it("does NOT expand when expandChildren is omitted (default false)", async () => {
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_parent", kind: "condensed", content: "parent" });
+    insertSummary(db, { summaryId: "sum_child", content: "child content" });
+    insertParent(db, "sum_parent", "sum_child");
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", { id: "sum_parent", conversationId: 1 });
+    const details = r.details as { expansion?: { children: unknown[] } };
+    // expansion key should not exist or children should be empty
+    expect(details.expansion?.children ?? []).toHaveLength(0);
+    const text = (r.content[0] as { text: string }).text;
+    expect(text).not.toContain("expanded children");
+
+    db.close();
+  });
+});
+
+describe("createLcmDescribeTool — expandMessages flag", () => {
+  it("returns first-hop source messages inline for leaf summaries when expandMessages=true", async () => {
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_leaf", content: "leaf summary text" });
+    insertMessage(db, { messageId: 100, content: "First raw message verbatim", role: "user" });
+    insertMessage(db, { messageId: 101, content: "Second raw message verbatim", role: "assistant" });
+    linkSummaryMessage(db, "sum_leaf", 100, 0);
+    linkSummaryMessage(db, "sum_leaf", 101, 1);
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_leaf",
+      conversationId: 1,
+      expandMessages: true,
+    });
+    const text = (r.content[0] as { text: string }).text;
+    expect(text).toContain("expanded source messages");
+    expect(text).toContain("First raw message verbatim");
+    expect(text).toContain("Second raw message verbatim");
+
+    const details = r.details as { expansion: { messages: Array<{ messageId: number }> } };
+    expect(details.expansion.messages).toHaveLength(2);
+
+    db.close();
+  });
+
+  it("filters suppressed messages", async () => {
+    const db = setupDb();
+    insertSummary(db, { summaryId: "sum_leaf", content: "leaf" });
+    insertMessage(db, { messageId: 100, content: "visible message" });
+    insertMessage(db, {
+      messageId: 101,
+      content: "suppressed message",
+      suppressedAt: new Date().toISOString(),
+    });
+    linkSummaryMessage(db, "sum_leaf", 100, 0);
+    linkSummaryMessage(db, "sum_leaf", 101, 1);
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_leaf",
+      conversationId: 1,
+      expandMessages: true,
+    });
+    const details = r.details as { expansion: { messages: Array<{ messageId: number }> } };
+    expect(details.expansion.messages).toHaveLength(1);
+    expect(details.expansion.messages[0]!.messageId).toBe(100);
+
+    db.close();
+  });
+
+  it("does NOT expand messages for condensed summaries", async () => {
+    const db = setupDb();
+    insertSummary(db, {
+      summaryId: "sum_condensed",
+      kind: "condensed",
+      content: "condensed text",
+    });
+    insertMessage(db, { messageId: 100, content: "raw message" });
+    linkSummaryMessage(db, "sum_condensed", 100, 0);
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      id: "sum_condensed",
+      conversationId: 1,
+      expandMessages: true,
+    });
+    const details = r.details as { expansion: { messages: unknown[] } };
+    expect(details.expansion.messages).toHaveLength(0);
+
+    db.close();
+  });
+});

--- a/test/lcm-grep-tool-hybrid.test.ts
+++ b/test/lcm-grep-tool-hybrid.test.ts
@@ -1,0 +1,419 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  ensureEmbeddingsTable,
+  recordEmbedding,
+  registerEmbeddingProfile,
+  tryLoadSqliteVec,
+} from "../src/embeddings/store.js";
+import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(VEC0_PATH);
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) return null;
+  const parts = trimmed.split(":");
+  if (parts.length < 3) return null;
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      ignoreSessionPatterns: [],
+      statelessSessionPatterns: [],
+      skipStatelessSessions: true,
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      newSessionRetainDepth: 2,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 120,
+      largeFileTokenThreshold: 25_000,
+      summaryProvider: "",
+      summaryModel: "",
+      largeFileSummaryProvider: "",
+      largeFileSummaryModel: "",
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
+      autoRotateSessionFiles: {
+        enabled: true,
+        sizeBytes: 2 * 1024 * 1024,
+        startup: "rotate",
+        runtime: "rotate",
+      },
+      summaryMaxOverageFactor: 3,
+    },
+    complete: vi.fn(),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: () => ({ provider: "anthropic", model: "claude-opus-4-5" }),
+    getApiKey: async () => undefined,
+    requireApiKey: async () => "",
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => "/tmp/openclaw-agent",
+    resolveSessionIdFromSessionKey: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    ...overrides,
+  } as LcmDependencies;
+}
+
+function setupDb(opts: { vec0?: boolean; fts5?: boolean } = {}): DatabaseSync {
+  const allowVec0 = opts.vec0 !== false;
+  const db = new DatabaseSync(":memory:", { allowExtension: allowVec0 });
+  if (allowVec0) tryLoadSqliteVec(db, { path: VEC0_PATH });
+  runLcmMigrations(db, { fts5Available: opts.fts5 ?? false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+  if (allowVec0) {
+    registerEmbeddingProfile(db, "voyage-4-large", 3);
+    ensureEmbeddingsTable(db, "voyage-4-large", 3);
+  }
+  return db;
+}
+
+function insertLeafWithEmbedding(
+  db: DatabaseSync,
+  summaryId: string,
+  conversationId: number,
+  vector: [number, number, number],
+  content: string,
+): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+     VALUES (?, ?, 'leaf', ?, 1, (SELECT session_key FROM conversations WHERE conversation_id = ?))`,
+  ).run(summaryId, conversationId, content, conversationId);
+  recordEmbedding(db, {
+    modelName: "voyage-4-large",
+    embeddedId: summaryId,
+    embeddedKind: "summary",
+    vector,
+    sourceTokenCount: 1,
+  });
+}
+
+function insertLeafNoEmbedding(
+  db: DatabaseSync,
+  summaryId: string,
+  conversationId: number,
+  content: string,
+): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+     VALUES (?, ?, 'leaf', ?, 1, (SELECT session_key FROM conversations WHERE conversation_id = ?))`,
+  ).run(summaryId, conversationId, content, conversationId);
+}
+
+/**
+ * Build a minimal LCM engine stub backed by a real DB. Bypasses retrieval
+ * (hybrid mode runs against db + summaryStore directly).
+ */
+function buildEngine(params: {
+  db: DatabaseSync;
+  conversationId?: number;
+  conversationFamilyIds?: number[];
+  timezone?: string;
+}) {
+  const summaryStoreSearch = vi.fn(async (input: {
+    query: string;
+    mode: "regex" | "full_text";
+    conversationId?: number;
+    conversationIds?: number[];
+    since?: Date;
+    before?: Date;
+    limit: number;
+  }) => {
+    // Naive FTS over the in-memory db's summaries table. Matches when
+    // content includes any whitespace-delimited token from the query.
+    const q = input.query.toLowerCase().trim();
+    const rows = params.db
+      .prepare(`SELECT summary_id, conversation_id, kind, content, created_at FROM summaries`)
+      .all() as Array<{
+      summary_id: string;
+      conversation_id: number;
+      kind: "leaf" | "condensed";
+      content: string;
+      created_at: string;
+    }>;
+    const matches = rows
+      .filter((r) => r.content.toLowerCase().includes(q))
+      .filter((r) =>
+        input.conversationId == null ? true : r.conversation_id === input.conversationId,
+      )
+      .map((r, idx) => ({
+        summaryId: r.summary_id,
+        conversationId: r.conversation_id,
+        kind: r.kind,
+        snippet: r.content.slice(0, 80),
+        createdAt: new Date(r.created_at + "Z"),
+        rank: idx,
+      }));
+    return matches.slice(0, input.limit ?? 50);
+  });
+
+  return {
+    info: { id: "lcm", name: "LCM", version: "0.0.0" },
+    timezone: params.timezone ?? "UTC",
+    getDb: () => params.db,
+    getRetrieval: () => ({ grep: vi.fn(), expand: vi.fn(), describe: vi.fn() }),
+    getSummaryStore: () => ({ searchSummaries: summaryStoreSearch }),
+    getConversationStore: () => ({
+      getConversationBySessionId: vi.fn(async () =>
+        params.conversationId == null
+          ? null
+          : {
+              conversationId: params.conversationId,
+              sessionId: "session-1",
+              title: null,
+              bootstrappedAt: null,
+              createdAt: new Date("2026-01-01T00:00:00.000Z"),
+              updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+            },
+      ),
+      getConversationBySessionKey: vi.fn(async () => null),
+      getConversationFamilyIds: vi.fn(async () => {
+        if (params.conversationFamilyIds && params.conversationFamilyIds.length > 0) {
+          return params.conversationFamilyIds;
+        }
+        if (typeof params.conversationId === "number") return [params.conversationId];
+        return [];
+      }),
+    }),
+  };
+}
+
+describe("createLcmGrepTool — hybrid mode metadata", () => {
+  it("schema enum exposes hybrid alongside regex/full_text", () => {
+    const tool = createLcmGrepTool({ deps: makeDeps() });
+    const params = tool.parameters as {
+      properties: { mode?: { enum?: string[] } };
+    };
+    expect(params.properties.mode?.enum).toContain("hybrid");
+    expect(params.properties.mode?.enum).toContain("regex");
+    expect(params.properties.mode?.enum).toContain("full_text");
+  });
+
+  it("description mentions all 5 modes and the consolidated mode='semantic' path", () => {
+    // Wave-12 consolidation SA: lcm_semantic_recall removed; folded
+    // into `lcm_grep mode='semantic'`. Test now asserts the description
+    // reflects the new arrangement (all 5 modes documented, semantic
+    // surfaced as the pure-vector entry point).
+    const tool = createLcmGrepTool({ deps: makeDeps() });
+    const desc = tool.description.toLowerCase();
+    expect(desc).toContain("hybrid");
+    expect(desc).toContain("semantic");
+    expect(desc).toContain("verbatim");
+    expect(desc).toContain("regex");
+    expect(desc).toContain("full_text");
+    // No more cross-defer to a separate lcm_semantic_recall tool.
+    expect(tool.description).not.toContain("lcm_semantic_recall");
+  });
+});
+
+describe("createLcmGrepTool — hybrid mode degraded path", () => {
+  let envBackup: string | undefined;
+  let fetchBackup: typeof fetch | undefined;
+
+  beforeEach(() => {
+    envBackup = process.env.VOYAGE_API_KEY;
+    fetchBackup = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (envBackup === undefined) delete process.env.VOYAGE_API_KEY;
+    else process.env.VOYAGE_API_KEY = envBackup;
+    globalThis.fetch = fetchBackup as typeof fetch;
+  });
+
+  it("emits 'semantic search unavailable; degraded to FTS-only' warning when vec0 missing", async () => {
+    process.env.VOYAGE_API_KEY = "test-key";
+    const db = setupDb({ vec0: false });
+    insertLeafNoEmbedding(db, "leaf_a", 1, "alpha doc about embeddings");
+
+    // Rerank still gets called because FTS produced a candidate. Mock fetch
+    // so rerank returns a sane score; embed should never be hit because
+    // vec0 is missing and runSemanticSearch short-circuits.
+    let embedHit = false;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      if (typeof url === "string" && url.includes("/rerank")) {
+        const body = JSON.parse(init.body as string) as { documents: string[] };
+        return new Response(
+          JSON.stringify({
+            data: body.documents.map((_d, idx) => ({
+              index: idx,
+              relevance_score: 0.5,
+            })),
+            model: "rerank-2.5",
+            usage: { total_tokens: 5 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      embedHit = true;
+      return new Response("embed should not be called when vec0 missing", { status: 500 });
+    }) as typeof fetch;
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildEngine({ db, conversationId: 1 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-degraded", {
+      pattern: "alpha",
+      mode: "hybrid",
+    });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("**Mode:** hybrid");
+    expect(text).toContain("semantic search unavailable; degraded to FTS-only");
+    expect(text).toContain("[from FTS only]");
+    expect(embedHit).toBe(false);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("createLcmGrepTool — hybrid mode happy paths", () => {
+  let envBackup: string | undefined;
+  let fetchBackup: typeof fetch | undefined;
+
+  beforeEach(() => {
+    envBackup = process.env.VOYAGE_API_KEY;
+    fetchBackup = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (envBackup === undefined) delete process.env.VOYAGE_API_KEY;
+    else process.env.VOYAGE_API_KEY = envBackup;
+    globalThis.fetch = fetchBackup as typeof fetch;
+  });
+
+  it("returns hybrid-format result with provenance flags + Mode line", async () => {
+    process.env.VOYAGE_API_KEY = "test-key";
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3], "the alpha doc");
+    insertLeafWithEmbedding(db, "leaf_b", 1, [0.9, 0.9, 0.9], "the beta doc");
+
+    // Mock fetch: 1) Voyage embed for query → vec [0.1,0.2,0.3]
+    //            2) Voyage rerank → score by content lookup
+    const rerankScores: Record<string, number> = {
+      "the alpha doc": 0.95,
+      "the beta doc": 0.30,
+    };
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      if (typeof url === "string" && url.includes("/rerank")) {
+        const body = JSON.parse(init.body as string) as { documents: string[] };
+        return new Response(
+          JSON.stringify({
+            data: body.documents.map((doc, idx) => ({
+              index: idx,
+              relevance_score: rerankScores[doc] ?? 0.1,
+            })),
+            model: "rerank-2.5",
+            usage: { total_tokens: 30 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // embed
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+          usage: { total_tokens: 7 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildEngine({ db, conversationId: 1 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-hybrid-happy", {
+      pattern: "alpha",
+      mode: "hybrid",
+    });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("## LCM Grep Results");
+    expect(text).toContain("**Pattern:** `alpha`");
+    expect(text).toContain("**Mode:** hybrid");
+    expect(text).toContain("[leaf_a]");
+    // leaf_a appears via both FTS (content matches) and semantic
+    expect(text).toContain("[from FTS+semantic]");
+    // leaf_b appears only via semantic (FTS won't match "alpha" in beta doc)
+    expect(text).toContain("[from semantic only]");
+    expect(text).not.toContain("semantic search unavailable");
+    expect(text).not.toContain("rerank failed");
+
+    const details = result.details as {
+      mode: string;
+      degradedToFtsOnly: boolean;
+      degradedSkippedRerank: boolean;
+      hits: Array<{ summaryId: string; fromFts: boolean; fromSemantic: boolean }>;
+    };
+    expect(details.mode).toBe("hybrid");
+    expect(details.degradedToFtsOnly).toBe(false);
+    expect(details.degradedSkippedRerank).toBe(false);
+    expect(details.hits[0].summaryId).toBe("leaf_a");
+    db.close();
+  });
+
+  it("emits 'rerank failed; using RRF fusion fallback' when rerank network errors", async () => {
+    process.env.VOYAGE_API_KEY = "test-key";
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3], "the alpha doc");
+
+    let callIdx = 0;
+    globalThis.fetch = (async (url: string) => {
+      callIdx++;
+      if (typeof url === "string" && url.includes("/rerank")) {
+        return new Response("oops", { status: 500 });
+      }
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+          usage: { total_tokens: 7 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildEngine({ db, conversationId: 1 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-rrf", {
+      pattern: "alpha",
+      mode: "hybrid",
+    });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("rerank failed; using RRF fusion fallback");
+    expect(callIdx).toBeGreaterThan(0);
+    db.close();
+  });
+});

--- a/test/lcm-grep-verbatim-mode.test.ts
+++ b/test/lcm-grep-verbatim-mode.test.ts
@@ -1,0 +1,435 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
+import type { LcmDependencies } from "../src/types.js";
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) return null;
+  const parts = trimmed.split(":");
+  if (parts.length < 3) return null;
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      ignoreSessionPatterns: [],
+      statelessSessionPatterns: [],
+      skipStatelessSessions: true,
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      newSessionRetainDepth: 2,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 120,
+      largeFileTokenThreshold: 25_000,
+      summaryProvider: "",
+      summaryModel: "",
+      largeFileSummaryProvider: "",
+      largeFileSummaryModel: "",
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
+      autoRotateSessionFiles: {
+        enabled: true,
+        sizeBytes: 2 * 1024 * 1024,
+        startup: "rotate",
+        runtime: "rotate",
+      },
+      summaryMaxOverageFactor: 3,
+    },
+    complete: vi.fn(),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: () => ({ provider: "anthropic", model: "claude-opus-4-5" }),
+    getApiKey: async () => undefined,
+    requireApiKey: async () => "",
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    ...overrides,
+  } as LcmDependencies;
+}
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: true, seedDefaultPrompts: false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'agent:main:main')`).run();
+  return db;
+}
+
+function insertMessage(
+  db: DatabaseSync,
+  args: {
+    messageId: number;
+    conversationId?: number;
+    role?: string;
+    content: string;
+    suppressedAt?: string | null;
+    createdAt?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, created_at, suppressed_at, identity_hash)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    args.messageId,
+    args.conversationId ?? 1,
+    args.messageId,
+    args.role ?? "user",
+    args.content,
+    Math.ceil(args.content.length / 4),
+    args.createdAt ?? new Date().toISOString(),
+    args.suppressedAt ?? null,
+    `hash_${args.messageId}`,
+  );
+  // messages_fts is standalone (not contentless) and not auto-synced via
+  // triggers in this codebase — we mirror the schema's bulk-seed pattern
+  // for test inserts. Without this, FTS5 MATCH queries return 0 hits.
+  db.prepare(
+    `INSERT INTO messages_fts(rowid, content) VALUES (?, ?)`,
+  ).run(args.messageId, args.content);
+}
+
+function buildLcmEngine(db: DatabaseSync, timezone = "UTC") {
+  return {
+    info: { id: "lcm", name: "LCM", version: "0.0.0" },
+    timezone,
+    getDb: () => db,
+    getRetrieval: () => ({
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    }),
+    getConversationStore: () => ({
+      getConversationBySessionId: vi.fn(),
+      getConversationBySessionKey: vi.fn(),
+      getConversationFamilyIds: vi.fn(async () => [1]),
+    }),
+  };
+}
+
+describe("createLcmGrepTool — verbatim mode", () => {
+  it("returns FULL untruncated message content (not snippets)", async () => {
+    const db = setupDb();
+    const longContent =
+      "This is a very long message that exceeds the normal 200-character snippet limit. " +
+      "It contains specific phrasing about race conditions in the empty plan body fix that " +
+      "Eva would want to quote verbatim — the literal wording matters here for citation purposes, " +
+      "and snippet truncation would lose the specific terminology she used.";
+    insertMessage(db, { messageId: 1, content: longContent });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race condition",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as {
+      mode: string;
+      totalMatches: number;
+      hits: Array<{ messageId: number; content: string }>;
+    };
+    expect(details.mode).toBe("verbatim");
+    expect(details.totalMatches).toBe(1);
+    expect(details.hits[0]!.content).toBe(longContent); // FULL content, not snippet
+    expect(details.hits[0]!.content.length).toBeGreaterThan(200);
+
+    const text = (r.content[0] as { text: string }).text;
+    expect(text).toContain("**Mode:** verbatim");
+    expect(text).toContain(longContent); // verbatim text inlined in markdown output
+
+    db.close();
+  });
+
+  it("hard-caps at 20 results even if user requests more", async () => {
+    const db = setupDb();
+    for (let i = 1; i <= 30; i++) {
+      insertMessage(db, { messageId: i, content: `Race condition message ${i}` });
+    }
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race",
+      mode: "verbatim",
+      limit: 100, // user asks for 100 → still capped at 20
+      conversationId: 1,
+    });
+    const details = r.details as { hits: unknown[] };
+    expect(details.hits.length).toBeLessThanOrEqual(20);
+
+    db.close();
+  });
+
+  it("filters suppressed_at IS NOT NULL messages", async () => {
+    const db = setupDb();
+    insertMessage(db, { messageId: 1, content: "race condition visible message" });
+    insertMessage(db, {
+      messageId: 2,
+      content: "race condition suppressed message",
+      suppressedAt: new Date().toISOString(),
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race condition",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as { hits: Array<{ messageId: number }> };
+    expect(details.hits).toHaveLength(1);
+    expect(details.hits[0]!.messageId).toBe(1);
+
+    db.close();
+  });
+
+  it("returns empty result with helpful message when no matches", async () => {
+    const db = setupDb();
+    insertMessage(db, { messageId: 1, content: "irrelevant content" });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "nonexistent",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as { totalMatches: number };
+    expect(details.totalMatches).toBe(0);
+    const text = (r.content[0] as { text: string }).text;
+    expect(text).toContain("No verbatim matches");
+
+    db.close();
+  });
+
+  it("respects since/before time filters", async () => {
+    const db = setupDb();
+    insertMessage(db, {
+      messageId: 1,
+      content: "race condition old",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    insertMessage(db, {
+      messageId: 2,
+      content: "race condition new",
+      createdAt: "2026-05-01T00:00:00Z",
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race",
+      mode: "verbatim",
+      since: "2026-04-01T00:00:00Z",
+      conversationId: 1,
+    });
+    const details = r.details as { hits: Array<{ messageId: number }> };
+    expect(details.hits).toHaveLength(1);
+    expect(details.hits[0]!.messageId).toBe(2);
+
+    db.close();
+  });
+
+  // P6 harness fix (2026-05-06): the 20-result cap was saturating with
+  // tool-role messages on common queries, crowding out user/assistant turns.
+  // The new `role` param filters at the SQL layer.
+  it("role='user' filter restricts to user messages only", async () => {
+    const db = setupDb();
+    // Insert a mix of roles all matching the same pattern.
+    insertMessage(db, { messageId: 1, role: "tool", content: "race condition tool blob 1" });
+    insertMessage(db, { messageId: 2, role: "tool", content: "race condition tool blob 2" });
+    insertMessage(db, { messageId: 3, role: "user", content: "race condition user query" });
+    insertMessage(db, {
+      messageId: 4,
+      role: "assistant",
+      content: "race condition assistant turn",
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race",
+      mode: "verbatim",
+      role: "user",
+      conversationId: 1,
+    });
+    const details = r.details as { hits: Array<{ messageId: number; role: string }> };
+    expect(details.hits).toHaveLength(1);
+    expect(details.hits[0]!.role).toBe("user");
+    expect(details.hits[0]!.messageId).toBe(3);
+
+    db.close();
+  });
+
+  // P7 harness fix: FTS5 chokes on bare dots/brackets/leading-hyphens.
+  // The tool now auto-quotes problematic patterns so they don't crash.
+  it("auto-sanitizes patterns with dots so FTS5 doesn't crash (e.g. v4.1)", async () => {
+    const db = setupDb();
+    insertMessage(db, { messageId: 1, content: "v4.1 architecture decision" });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    // Pre-fix this would throw "fts5: syntax error"; post-fix it auto-quotes
+    // to "v4.1" and matches the inserted message.
+    const r = await tool.execute("c", {
+      pattern: "v4.1",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as { totalMatches: number; hits: Array<{ messageId: number }> };
+    expect(details.totalMatches).toBe(1);
+    expect(details.hits[0]!.messageId).toBe(1);
+
+    db.close();
+  });
+
+  // Wave-9 Agent #4 P1 regression: messages_fts is created with
+  // tokenize='porter unicode61' which can't segment CJK ideographs.
+  // FTS5 MATCH on CJK queries returns 0 rows WITHOUT throwing, so the
+  // exception-driven LIKE fallback never triggers. The fix detects CJK
+  // at the JS layer and routes directly to LIKE substring match.
+  it("Wave-9 P1: matches CJK queries via LIKE fallback (FTS5 unicode61 can't segment ideographs)", async () => {
+    const db = setupDb();
+    insertMessage(db, {
+      messageId: 1,
+      content: "Eva said about 机器学习 (machine learning) yesterday",
+    });
+    insertMessage(db, {
+      messageId: 2,
+      content: "Discussion of 机器学习 algorithms",
+    });
+    insertMessage(db, {
+      messageId: 3,
+      content: "Unrelated English-only message",
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "机器学习",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as {
+      totalMatches: number;
+      hits: Array<{ messageId: number; content: string }>;
+    };
+    expect(details.totalMatches).toBe(2);
+    const ids = details.hits.map((h) => h.messageId).sort();
+    expect(ids).toEqual([1, 2]);
+
+    db.close();
+  });
+
+  it("INVARIANT: per-hit content cap at 5K chars + truncation flags (Wave-12 reviewer F6)", async () => {
+    // Pre-fix: details.hits[].content carried full untruncated bodies
+    // (200-385K chars/call observed) even when markdown said "*(truncated)*".
+    // Post-fix: per-hit cap at 5K chars + contentTruncated + fullContentLength
+    // flags so callers know when full body is available via lcm_describe.
+    const db = setupDb();
+    const huge = "x".repeat(8_000); // 8K chars > 5K cap
+    insertMessage(db, { messageId: 1, content: `Race condition prefix ${huge}` });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race condition",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as {
+      hits: Array<{
+        content: string;
+        contentTruncated: boolean;
+        fullContentLength: number;
+      }>;
+    };
+    expect(details.hits).toHaveLength(1);
+    // Cap is 5000 chars; truncation suffix adds a few chars more.
+    expect(details.hits[0]!.content.length).toBeLessThan(5_100);
+    expect(details.hits[0]!.contentTruncated).toBe(true);
+    expect(details.hits[0]!.fullContentLength).toBeGreaterThan(8_000);
+    expect(details.hits[0]!.content).toMatch(/lcm_describe/);
+    db.close();
+  });
+
+  it("INVARIANT: details.hits sliced to renderedRowCount when markdown truncates (Wave-12 reviewer F6)", async () => {
+    // Pre-fix: details.hits returned ALL fetched rows even when the
+    // markdown loop broke after MAX_RESULT_CHARS. So an agent reading
+    // details bypassed the markdown truncation entirely.
+    // Now: hits is sliced to the count of rows actually rendered.
+    const db = setupDb();
+    // 20 rows × 8K chars = 160K chars total; default MAX_RESULT_CHARS
+    // is 40K, so markdown truncates partway → details.hits matches.
+    for (let i = 1; i <= 20; i++) {
+      insertMessage(db, {
+        messageId: i,
+        content: `Race condition row ${i} ${"y".repeat(8_000)}`,
+      });
+    }
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine(db) as never,
+      sessionKey: "agent:main:main",
+    });
+    const r = await tool.execute("c", {
+      pattern: "race condition",
+      mode: "verbatim",
+      conversationId: 1,
+    });
+    const details = r.details as {
+      totalMatches: number;
+      truncated: boolean;
+      hits: Array<{ messageId: number }>;
+    };
+    expect(details.totalMatches).toBe(20);
+    expect(details.truncated).toBe(true);
+    // 160K chars / 40K cap → markdown fits ~5-7 hits, so hits.length must
+    // be < 20 and reflect what's in the markdown.
+    expect(details.hits.length).toBeLessThan(20);
+    expect(details.hits.length).toBeGreaterThan(0);
+    db.close();
+  });
+});

--- a/test/lcm-worker-lock.test.ts
+++ b/test/lcm-worker-lock.test.ts
@@ -1,0 +1,120 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+describe("lcm_worker_lock table (v4.1.1 A9)", () => {
+  it("is created by runLcmMigrations with the expected schema", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    const columns = db.prepare("PRAGMA table_info(lcm_worker_lock)").all() as ColumnInfo[];
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.has("job_kind")).toBe(true);
+    expect(byName.get("job_kind")?.pk).toBe(1);
+    expect(byName.get("job_kind")?.type.toUpperCase()).toBe("TEXT");
+
+    expect(byName.has("worker_id")).toBe(true);
+    expect(byName.get("worker_id")?.notnull).toBe(1);
+
+    expect(byName.has("acquired_at")).toBe(true);
+    expect(byName.get("acquired_at")?.notnull).toBe(1);
+
+    expect(byName.has("expires_at")).toBe(true);
+    expect(byName.get("expires_at")?.notnull).toBe(1);
+
+    // v4.1.1 A9 specifically: last_heartbeat_at column must exist for the
+    // §0.5 gateway-fallback rule to work (BOTH expires_at < now AND
+    // last_heartbeat_at < now - 300s).
+    expect(byName.has("last_heartbeat_at")).toBe(true);
+    expect(byName.get("last_heartbeat_at")?.notnull).toBe(1);
+
+    expect(byName.has("job_session_key")).toBe(true);
+    expect(byName.get("job_session_key")?.notnull).toBe(0); // nullable
+
+    expect(byName.has("job_metadata")).toBe(true);
+    expect(byName.get("job_metadata")?.notnull).toBe(0); // nullable for JSON sidecar
+
+    db.close();
+  });
+
+  it("is idempotent (running migrations twice does not fail)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+
+  it("supports basic acquire pattern (INSERT new lock + UPDATE heartbeat)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Acquire the condensation lock for worker-A with 90s TTL
+    db.prepare(
+      `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at)
+       VALUES (?, ?, datetime('now', '+90 seconds'))`,
+    ).run("condensation", "worker-A");
+
+    const acquired = db
+      .prepare("SELECT * FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("condensation") as { worker_id: string } | undefined;
+    expect(acquired?.worker_id).toBe("worker-A");
+
+    // Second worker attempting same kind hits PK conflict (one lock per kind)
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at)
+           VALUES (?, ?, datetime('now', '+90 seconds'))`,
+        )
+        .run("condensation", "worker-B"),
+    ).toThrow();
+
+    // Heartbeat refreshes both expires_at and last_heartbeat_at
+    db.prepare(
+      `UPDATE lcm_worker_lock
+       SET expires_at = datetime('now', '+90 seconds'),
+           last_heartbeat_at = datetime('now')
+       WHERE job_kind = ? AND worker_id = ?`,
+    ).run("condensation", "worker-A");
+
+    db.close();
+  });
+
+  it("supports stale-lock GC (expires_at < now → row can be deleted)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Insert an expired lock (expires_at in the past)
+    db.prepare(
+      `INSERT INTO lcm_worker_lock (job_kind, worker_id, expires_at, last_heartbeat_at)
+       VALUES (?, ?, datetime('now', '-10 seconds'), datetime('now', '-400 seconds'))`,
+    ).run("extraction", "worker-stale");
+
+    const beforeGc = db
+      .prepare("SELECT COUNT(*) AS n FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("extraction") as { n: number };
+    expect(beforeGc.n).toBe(1);
+
+    // GC pattern: delete locks whose expires_at has passed
+    const result = db
+      .prepare(`DELETE FROM lcm_worker_lock WHERE expires_at < datetime('now')`)
+      .run();
+    expect(result.changes).toBeGreaterThanOrEqual(1);
+
+    const afterGc = db
+      .prepare("SELECT COUNT(*) AS n FROM lcm_worker_lock WHERE job_kind = ?")
+      .get("extraction") as { n: number };
+    expect(afterGc.n).toBe(0);
+
+    db.close();
+  });
+});

--- a/test/semantic-search.test.ts
+++ b/test/semantic-search.test.ts
@@ -1,0 +1,355 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  ensureEmbeddingsTable,
+  recordEmbedding,
+  registerEmbeddingProfile,
+  tryLoadSqliteVec,
+} from "../src/embeddings/store.js";
+import {
+  getActiveEmbeddingModel,
+  runSemanticSearch,
+  SemanticSearchUnavailableError,
+} from "../src/embeddings/semantic-search.js";
+
+const VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(VEC0_PATH);
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:", { allowExtension: true });
+  tryLoadSqliteVec(db, { path: VEC0_PATH });
+  runLcmMigrations(db, { fts5Available: false });
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s2', 'sk2')`).run();
+  registerEmbeddingProfile(db, "voyage-4-large", 3);
+  ensureEmbeddingsTable(db, "voyage-4-large", 3);
+  return db;
+}
+
+function insertLeafWithEmbedding(
+  db: DatabaseSync,
+  summaryId: string,
+  conversationId: number,
+  vector: [number, number, number],
+  content = "x",
+  suppressed = false,
+): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+     VALUES (?, ?, 'leaf', ?, 1, (SELECT session_key FROM conversations WHERE conversation_id = ?))`,
+  ).run(summaryId, conversationId, content, conversationId);
+  recordEmbedding(db, {
+    modelName: "voyage-4-large",
+    embeddedId: summaryId,
+    embeddedKind: "summary",
+    vector,
+    suppressed,
+    sourceTokenCount: 1,
+  });
+}
+
+describe("semantic-search — getActiveEmbeddingModel", () => {
+  it("returns null when no profile registered", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getActiveEmbeddingModel(db)).toBeNull();
+    db.close();
+  });
+
+  it("returns the active profile (active=1, archive_after IS NULL)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    registerEmbeddingProfile(db, "voyage-4-large", 1024);
+    expect(getActiveEmbeddingModel(db)).toEqual({ modelName: "voyage-4-large", dim: 1024 });
+    db.close();
+  });
+
+  it("returns the most-recent active when multiple are active (e.g. cutover in progress)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    registerEmbeddingProfile(db, "voyage-3-lite", 512);
+    // Sleep to ensure registered_at differs (sqlite datetime is second-grain)
+    db.prepare(`UPDATE lcm_embedding_profile SET registered_at = '2026-01-01 00:00:00' WHERE model_name = 'voyage-3-lite'`).run();
+    registerEmbeddingProfile(db, "voyage-4-large", 1024);
+    db.prepare(`UPDATE lcm_embedding_profile SET registered_at = '2026-05-05 00:00:00' WHERE model_name = 'voyage-4-large'`).run();
+
+    expect(getActiveEmbeddingModel(db)).toEqual({ modelName: "voyage-4-large", dim: 1024 });
+    db.close();
+  });
+
+  it("excludes archived profiles (archive_after IS NOT NULL)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    registerEmbeddingProfile(db, "voyage-3-lite", 512);
+    db.prepare(`UPDATE lcm_embedding_profile SET archive_after = '2026-01-01' WHERE model_name = 'voyage-3-lite'`).run();
+    registerEmbeddingProfile(db, "voyage-4-large", 1024);
+    expect(getActiveEmbeddingModel(db)?.modelName).toBe("voyage-4-large");
+    db.close();
+  });
+});
+
+describe("semantic-search — error paths", () => {
+  it("throws SemanticSearchUnavailableError when vec0 not loaded", async () => {
+    const db = new DatabaseSync(":memory:"); // no extension allow
+    runLcmMigrations(db, { fts5Available: false });
+    await expect(
+      runSemanticSearch(db, { query: "anything" }),
+    ).rejects.toBeInstanceOf(SemanticSearchUnavailableError);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("semantic-search — vec0-dependent paths", () => {
+  it("throws SemanticSearchUnavailableError when no active profile registered", async () => {
+    const db = new DatabaseSync(":memory:", { allowExtension: true });
+    tryLoadSqliteVec(db, { path: VEC0_PATH });
+    runLcmMigrations(db, { fts5Available: false });
+    await expect(
+      runSemanticSearch(db, { query: "anything" }),
+    ).rejects.toBeInstanceOf(SemanticSearchUnavailableError);
+    db.close();
+  });
+
+  it("requires either query or queryVector", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3]);
+    await expect(
+      runSemanticSearch(db, { query: "" }),
+    ).rejects.toThrow(/query is required/);
+    db.close();
+  });
+
+  it("queryVector dim mismatch is caught", async () => {
+    const db = setupDb();
+    await expect(
+      runSemanticSearch(db, { query: "x", queryVector: new Float32Array([0.1, 0.2]) }),
+    ).rejects.toThrow(/queryVector dim 2 != active model dim 3/);
+    db.close();
+  });
+
+  it("returns ranked hits joined with summary content (queryVector path)", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_close", 1, [0.1, 0.2, 0.3], "the alpha doc");
+    insertLeafWithEmbedding(db, "leaf_far", 1, [0.9, 0.9, 0.9], "the omega doc");
+
+    const result = await runSemanticSearch(db, {
+      query: "ignored when queryVector provided",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      k: 5,
+    });
+
+    expect(result.hits).toHaveLength(2);
+    expect(result.hits[0].summaryId).toBe("leaf_close");
+    expect(result.hits[0].content).toBe("the alpha doc");
+    expect(result.hits[0].sessionKey).toBe("sk1");
+    expect(result.hits[0].distance).toBe(0); // identical vector
+    expect(result.voyageTokensConsumed).toBe(0); // no Voyage call (queryVector path)
+    expect(result.modelName).toBe("voyage-4-large");
+    db.close();
+  });
+
+  it("excludes suppressed by default; includes when excludeSuppressed=false", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_v", 1, [0.1, 0.2, 0.3], "visible");
+    insertLeafWithEmbedding(db, "leaf_h", 1, [0.1, 0.2, 0.3], "hidden", /*suppressed*/ true);
+    // The suppression-trigger setup means UPDATE summaries.suppressed_at
+    // would mirror to vec0; but recordEmbedding directly sets it true,
+    // so both layers agree. Belt-and-suspenders also caught by the JOIN
+    // filter.
+    db.prepare(`UPDATE summaries SET suppressed_at = ? WHERE summary_id = ?`).run(
+      "2026-05-05",
+      "leaf_h",
+    );
+
+    const visibleOnly = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      k: 5,
+    });
+    expect(visibleOnly.hits.map((h) => h.summaryId)).toEqual(["leaf_v"]);
+
+    const includeAll = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      k: 5,
+      excludeSuppressed: false,
+    });
+    expect(includeAll.hits.map((h) => h.summaryId).sort()).toEqual(["leaf_h", "leaf_v"]);
+    db.close();
+  });
+
+  it("session_keys filter restricts to matching sessions", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3]); // sk1
+    insertLeafWithEmbedding(db, "leaf_b", 2, [0.1, 0.2, 0.3]); // sk2
+
+    const result = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      sessionKeys: ["sk1"],
+      k: 5,
+    });
+    expect(result.hits.map((h) => h.summaryId)).toEqual(["leaf_a"]);
+    db.close();
+  });
+
+  it("conversation_ids filter restricts to matching conversations", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3]);
+    insertLeafWithEmbedding(db, "leaf_b", 2, [0.1, 0.2, 0.3]);
+
+    const result = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      conversationIds: [1],
+      k: 5,
+    });
+    expect(result.hits.map((h) => h.summaryId)).toEqual(["leaf_a"]);
+    db.close();
+  });
+
+  it("time filters (since, before) restrict by created_at", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_old", 1, [0.1, 0.2, 0.3]);
+    insertLeafWithEmbedding(db, "leaf_new", 1, [0.1, 0.2, 0.3]);
+    db.prepare(`UPDATE summaries SET created_at = '2026-01-01 00:00:00' WHERE summary_id = ?`).run("leaf_old");
+    db.prepare(`UPDATE summaries SET created_at = '2026-05-01 00:00:00' WHERE summary_id = ?`).run("leaf_new");
+
+    const recent = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      since: new Date("2026-04-01"),
+      k: 5,
+    });
+    expect(recent.hits.map((h) => h.summaryId)).toEqual(["leaf_new"]);
+
+    const ancient = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      before: new Date("2026-04-01"),
+      k: 5,
+    });
+    expect(ancient.hits.map((h) => h.summaryId)).toEqual(["leaf_old"]);
+    db.close();
+  });
+
+  it("calls Voyage when queryVector not provided; voyageTokensConsumed reflects usage", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.5, 0.5, 0.5]);
+
+    const fetchMock = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { input: string[]; input_type?: string };
+      // Verify input_type is 'query' (asymmetric retrieval)
+      expect(body.input_type).toBe("query");
+      return new Response(
+        JSON.stringify({
+          data: [{ embedding: [0.5, 0.5, 0.5], index: 0 }],
+          usage: { total_tokens: 17 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await runSemanticSearch(db, {
+      query: "test",
+      voyageApiKey: "k",
+      voyageFetch: fetchMock,
+      voyageMaxRetries: 0,
+      k: 5,
+    });
+    expect(result.voyageTokensConsumed).toBe(17);
+    expect(result.hits[0].summaryId).toBe("leaf_a");
+    db.close();
+  });
+
+  // P1 harness fix (2026-05-06): when filters are present, vec0's nearest-K
+  // didn't know about them. Top-K globally could all live OUTSIDE the filter
+  // window, causing 0 hits when many matching docs existed. Fix: over-fetch
+  // 10× from vec0 (cap 500) when filters are active, then trim after JOIN.
+  it("filtered KNN over-fetches so post-filter survivors aren't crowded out", async () => {
+    const db = setupDb();
+    // 30 leaves, all very close to query vector. 5 are in the time window;
+    // 25 are outside. With over-fetch we should get all 5 in-window survivors.
+    for (let i = 1; i <= 30; i++) {
+      insertLeafWithEmbedding(db, `leaf_${i}`, 1, [0.1, 0.2, 0.3]);
+    }
+    // Move 25 leaves OUT of the time window
+    for (let i = 6; i <= 30; i++) {
+      db.prepare(`UPDATE summaries SET created_at = '2026-01-01 00:00:00' WHERE summary_id = ?`)
+        .run(`leaf_${i}`);
+    }
+    // The 5 in-window leaves stay at the default created_at (~now)
+    // Pre-fix: k=5 would request 5 candidates — almost certainly NOT the 5
+    // in-window. Post-fix: k=5 requests 50 from vec0, all 30 survive,
+    // then post-filter keeps the 5 in-window ones.
+    const result = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      since: new Date("2026-04-01"),
+      k: 5,
+    });
+    expect(result.hits.length).toBe(5);
+    expect(result.candidateCount).toBeGreaterThanOrEqual(30);
+    db.close();
+  });
+
+  // P2 harness fix: cosineSimilarity field added to each hit. Voyage embeddings
+  // are unit-normalized; vec0 default metric is L2. cos = 1 - L²/2.
+  it("each hit exposes cosineSimilarity derived from L2 distance", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_identical", 1, [1.0, 0.0, 0.0]);
+    const result = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([1.0, 0.0, 0.0]),
+      k: 1,
+    });
+    expect(result.hits[0]).toHaveProperty("cosineSimilarity");
+    // Identical unit vectors → distance ≈ 0 → cosine ≈ 1
+    expect(result.hits[0].distance).toBeCloseTo(0, 5);
+    expect(result.hits[0].cosineSimilarity).toBeCloseTo(1.0, 5);
+    db.close();
+  });
+
+  it("summary_kinds filter restricts to leaf vs condensed", async () => {
+    const db = setupDb();
+    insertLeafWithEmbedding(db, "leaf_a", 1, [0.1, 0.2, 0.3]);
+    // Insert a 'condensed' summary
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+       VALUES (?, 1, 'condensed', 'sum', 1, 'sk1')`,
+    ).run("cond_a");
+    recordEmbedding(db, {
+      modelName: "voyage-4-large",
+      embeddedId: "cond_a",
+      embeddedKind: "summary",
+      vector: [0.1, 0.2, 0.3],
+      sourceTokenCount: 1,
+    });
+
+    const leavesOnly = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      summaryKinds: ["leaf"],
+      k: 5,
+    });
+    expect(leavesOnly.hits.map((h) => h.summaryId)).toEqual(["leaf_a"]);
+
+    const both = await runSemanticSearch(db, {
+      query: "x",
+      queryVector: new Float32Array([0.1, 0.2, 0.3]),
+      k: 5,
+    });
+    expect(both.hits.map((h) => h.summaryId).sort()).toEqual(["cond_a", "leaf_a"]);
+    db.close();
+  });
+});

--- a/test/v41-data-cleanup.test.ts
+++ b/test/v41-data-cleanup.test.ts
@@ -1,0 +1,197 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+describe("v4.1 conversation session_key backfill (A.09)", () => {
+  it("backfills NULL session_keys to 'legacy:conv_<id>' AND writes audit rows", () => {
+    const db = new DatabaseSync(":memory:");
+    // Pre-populate conversations BEFORE running migrations (simulating
+    // existing DB with legacy NULL session_keys)
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', NULL)`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s2', NULL)`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s3', 'agent:main:main')`).run();
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const rows = db
+      .prepare(`SELECT conversation_id, session_key FROM conversations ORDER BY conversation_id`)
+      .all() as Array<{ conversation_id: number; session_key: string }>;
+    expect(rows[0]).toEqual({ conversation_id: 1, session_key: "legacy:conv_1" });
+    expect(rows[1]).toEqual({ conversation_id: 2, session_key: "legacy:conv_2" });
+    expect(rows[2]).toEqual({ conversation_id: 3, session_key: "agent:main:main" }); // unchanged
+
+    // Audit rows recorded for the 2 backfilled
+    const audits = db
+      .prepare(`SELECT conversation_id, original_session_key, new_session_key FROM lcm_session_key_audit ORDER BY conversation_id`)
+      .all() as Array<{ conversation_id: number; original_session_key: string | null; new_session_key: string }>;
+    expect(audits).toEqual([
+      { conversation_id: 1, original_session_key: null, new_session_key: "legacy:conv_1" },
+      { conversation_id: 2, original_session_key: null, new_session_key: "legacy:conv_2" },
+    ]);
+    db.close();
+  });
+
+  it("is idempotent — re-running migration does not duplicate audit rows or re-key existing", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', NULL)`).run();
+    runLcmMigrations(db, { fts5Available: false });
+
+    const auditCountAfterFirstRun = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_session_key_audit`).get() as { n: number }
+    ).n;
+
+    // Re-run
+    runLcmMigrations(db, { fts5Available: false });
+    const auditCountAfterSecondRun = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_session_key_audit`).get() as { n: number }
+    ).n;
+    expect(auditCountAfterSecondRun).toBe(auditCountAfterFirstRun);
+    db.close();
+  });
+});
+
+describe("v4.1 summaries session_key backfill (A.09)", () => {
+  it("populates summaries.session_key from conversations.session_key via JOIN", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'agent:main:main')`).run();
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s2', NULL)`).run(); // → legacy:conv_2
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Now insert some summaries (they'll get session_key='' default from A.02)
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 1)`,
+    ).run("sum_a", 1, "x");
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 1)`,
+    ).run("sum_b", 2, "y");
+
+    // Verify they have session_key='' before re-running migration
+    const before = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    expect(before[0].session_key).toBe(""); // A.02 default
+    expect(before[1].session_key).toBe("");
+
+    // Run migration again — should backfill summaries.session_key from conv
+    runLcmMigrations(db, { fts5Available: false });
+
+    const after = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    expect(after[0].session_key).toBe("agent:main:main");
+    expect(after[1].session_key).toBe("legacy:conv_2");
+    db.close();
+  });
+
+  it("does NOT overwrite already-set summaries.session_key", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s', 'conv-key-A')`).run();
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key) VALUES (?, ?, 'leaf', ?, 1, ?)`,
+    ).run("sum_explicit", 1, "x", "summary-key-A-different-from-conv");
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const row = db
+      .prepare(`SELECT session_key FROM summaries WHERE summary_id = ?`)
+      .get("sum_explicit") as { session_key: string };
+    // Backfill condition is `WHERE session_key = ''` — the explicit value
+    // 'summary-key-A-different-from-conv' is preserved.
+    expect(row.session_key).toBe("summary-key-A-different-from-conv");
+    db.close();
+  });
+});
+
+describe("v4.1 lcm_rollups forward-compat (A.09)", () => {
+  it("no-op on a fresh upstream install (lcm_rollups table doesn't exist)", () => {
+    const db = new DatabaseSync(":memory:");
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    const tables = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name = 'lcm_rollups'`)
+      .all();
+    expect(tables.length).toBe(0); // table never created
+    db.close();
+  });
+
+  it("backfills lcm_rollups.session_key when the fork-side table exists with the column", () => {
+    const db = new DatabaseSync(":memory:");
+    // Simulate Eva's DB having lcm_rollups (from PR #516 work that's
+    // not in upstream src but is on her live DB)
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.exec(`
+      CREATE TABLE lcm_rollups (
+        rollup_id TEXT PRIMARY KEY,
+        conversation_id INTEGER NOT NULL,
+        session_key TEXT NOT NULL DEFAULT '',
+        period_kind TEXT NOT NULL,
+        period_key TEXT NOT NULL
+      )
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s', 'conv-key-A')`).run();
+    db.prepare(
+      `INSERT INTO lcm_rollups (rollup_id, conversation_id, period_kind, period_key) VALUES (?, ?, ?, ?)`,
+    ).run("r1", 1, "day", "2026-04-01");
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const row = db
+      .prepare(`SELECT session_key FROM lcm_rollups WHERE rollup_id = ?`)
+      .get("r1") as { session_key: string };
+    expect(row.session_key).toBe("conv-key-A");
+    db.close();
+  });
+});

--- a/test/v41-embedding-meta-tables.test.ts
+++ b/test/v41-embedding-meta-tables.test.ts
@@ -1,0 +1,118 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = { name: string; notnull: number; pk: number; dflt_value: string | null };
+type FkInfo = { from: string; table: string; on_delete: string };
+
+describe("lcm_embedding_profile (v4.1 §1)", () => {
+  it("creates table with model_name PK + active default 1", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_embedding_profile)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("model_name")?.pk).toBe(1);
+    expect(byName.get("dim")?.notnull).toBe(1);
+    expect(byName.get("active")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("supports registering voyage-4-large + future model in parallel for cutover", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const ins = db.prepare(
+      `INSERT INTO lcm_embedding_profile (model_name, dim, active) VALUES (?, ?, ?)`,
+    );
+    ins.run("voyage-4-large", 1024, 1);
+    ins.run("voyage-5-large", 1536, 0); // not yet active
+    const rows = db
+      .prepare(`SELECT model_name, dim, active FROM lcm_embedding_profile ORDER BY model_name`)
+      .all() as Array<{ model_name: string; dim: number; active: number }>;
+    expect(rows).toEqual([
+      { model_name: "voyage-4-large", dim: 1024, active: 1 },
+      { model_name: "voyage-5-large", dim: 1536, active: 0 },
+    ]);
+    db.close();
+  });
+});
+
+describe("lcm_embedding_meta (v4.1 §1)", () => {
+  it("creates table with composite PK enabling parallel-rows during cutover", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_embedding_meta)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    // PK is composite (embedded_id, embedded_kind, embedding_model)
+    expect(byName.get("embedded_id")?.pk).toBe(1);
+    expect(byName.get("embedded_kind")?.pk).toBe(2);
+    expect(byName.get("embedding_model")?.pk).toBe(3);
+    db.close();
+  });
+
+  it("FK to lcm_embedding_profile prevents orphan model references", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+        )
+        .run("e1", "summary", "voyage-99-bogus", 100),
+    ).toThrow();
+
+    db.prepare(`INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`).run(
+      "voyage-4-large",
+      1024,
+    );
+    db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+    ).run("e1", "summary", "voyage-4-large", 100);
+    db.close();
+  });
+
+  it("CHECK constraint enforces embedded_kind enum", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    db.prepare(`INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`).run(
+      "voyage-4-large",
+      1024,
+    );
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+        )
+        .run("x", "bogus-kind", "voyage-4-large", 100),
+    ).toThrow();
+
+    // Valid kinds
+    for (const kind of ["summary", "entity", "theme"]) {
+      db.prepare(
+        `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+      ).run(`x_${kind}`, kind, "voyage-4-large", 100);
+    }
+    db.close();
+  });
+
+  it("composite PK allows same summary embedded under multiple models (cutover scenario)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const insProfile = db.prepare(
+      `INSERT INTO lcm_embedding_profile (model_name, dim) VALUES (?, ?)`,
+    );
+    insProfile.run("voyage-4-large", 1024);
+    insProfile.run("voyage-5-large", 1536);
+
+    const insMeta = db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count) VALUES (?, ?, ?, ?)`,
+    );
+    insMeta.run("sum_a", "summary", "voyage-4-large", 100);
+    insMeta.run("sum_a", "summary", "voyage-5-large", 100); // same id, different model — allowed
+
+    const rows = db
+      .prepare(`SELECT embedding_model FROM lcm_embedding_meta WHERE embedded_id = ?`)
+      .all("sum_a") as Array<{ embedding_model: string }>;
+    expect(rows.length).toBe(2);
+    db.close();
+  });
+});

--- a/test/v41-entity-layer-tables.test.ts
+++ b/test/v41-entity-layer-tables.test.ts
@@ -1,0 +1,130 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = { name: string; notnull: number; pk: number; dflt_value: string | null };
+type FkInfo = { from: string; table: string; on_delete: string };
+type IndexInfo = { name: string };
+
+function setupDb(): { db: DatabaseSync; sumA: string; sumB: string } {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  db.prepare(`INSERT INTO conversations (session_id) VALUES ('s')`).run();
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+  ).run("sum_a");
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'y', 1)`,
+  ).run("sum_b");
+  return { db, sumA: "sum_a", sumB: "sum_b" };
+}
+
+describe("lcm_entity_type_registry (v4.1 §7.2 + v4.1.1 §C)", () => {
+  it("creates table with type_name PK + occurrence_count default 1", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_entity_type_registry)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("type_name")?.pk).toBe(1);
+    expect(byName.get("occurrence_count")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("supports freeform Eva-domain types (no CHECK constraint)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const insert = db.prepare(`INSERT INTO lcm_entity_type_registry (type_name) VALUES (?)`);
+    insert.run("session_key");
+    insert.run("config_flag");
+    insert.run("R-agent-id");
+    insert.run("error_code");
+    insert.run("pr");
+    const types = db
+      .prepare(`SELECT type_name FROM lcm_entity_type_registry ORDER BY type_name`)
+      .all() as Array<{ type_name: string }>;
+    expect(types.length).toBe(5);
+    db.close();
+  });
+});
+
+describe("lcm_entities (v4.1 §7.2 + v4.1.1 B4/B5/B6)", () => {
+  it("creates table with simplified schema (alternate_surfaces JSON, no separate aliases table)", () => {
+    const { db } = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_entities)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("entity_id")?.pk).toBe(1);
+    expect(byName.get("canonical_text")?.notnull).toBe(1);
+    expect(byName.get("entity_type")?.notnull).toBe(1);
+    expect(byName.get("alternate_surfaces")).toBeDefined();
+    db.close();
+  });
+
+  it("UNIQUE index on (session_key, canonical_text COLLATE NOCASE) enables case-insensitive single-flight (v4.1.1 B4)", () => {
+    const { db } = setupDb();
+    const insert = db.prepare(
+      `INSERT OR IGNORE INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    );
+    expect(insert.run("e1", "agent:main:main", "openclaw-gateway", "tool").changes).toBe(1);
+    // Same canonical text different case → CONFLICT (NOCASE collation)
+    expect(insert.run("e2", "agent:main:main", "OpenClaw-Gateway", "tool").changes).toBe(0);
+    // Same canonical text different session → no conflict (different session_key)
+    expect(insert.run("e3", "agent:other", "openclaw-gateway", "tool").changes).toBe(1);
+    db.close();
+  });
+
+  it("supports ON DELETE SET NULL on first_seen_in_summary_id when source leaf deleted", () => {
+    const { db, sumA } = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at, first_seen_in_summary_id) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
+    ).run("e1", "s", "x", "concept", sumA);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run(sumA);
+    const row = db
+      .prepare(`SELECT first_seen_in_summary_id FROM lcm_entities WHERE entity_id = ?`)
+      .get("e1") as { first_seen_in_summary_id: string | null };
+    expect(row.first_seen_in_summary_id).toBeNull(); // SET NULL fired
+    db.close();
+  });
+});
+
+describe("lcm_entity_mentions (v4.1 §7.2)", () => {
+  it("creates table with cascade-delete on both entity_id and summary_id", () => {
+    const { db } = setupDb();
+    const fks = db
+      .prepare(`PRAGMA foreign_key_list(lcm_entity_mentions)`)
+      .all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "entity_id")?.on_delete).toBe("CASCADE");
+    expect(fks.find((fk) => fk.from === "summary_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+
+  it("deletes mentions when leaf is deleted (cascade — basis for v4.1.1 §C suppression cascade)", () => {
+    const { db, sumA } = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_entities (entity_id, session_key, canonical_text, entity_type, first_seen_at, last_seen_at) VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+    ).run("e1", "s", "gateway", "tool");
+    db.prepare(
+      `INSERT INTO lcm_entity_mentions (mention_id, entity_id, summary_id, surface_form, mentioned_at) VALUES (?, ?, ?, ?, datetime('now'))`,
+    ).run("m1", "e1", sumA, "the gateway");
+
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM lcm_entity_mentions WHERE entity_id = ?`).get("e1") as {
+        n: number;
+      }).n,
+    ).toBe(1);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run(sumA);
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM lcm_entity_mentions WHERE entity_id = ?`).get("e1") as {
+        n: number;
+      }).n,
+    ).toBe(0);
+    db.close();
+  });
+});
+
+// lcm_procedures tests REMOVED in first-principles pass (2026-05-06).
+// Schema + tests preserved in deferred-features draft PR (#616).
+
+// lcm_intentions tests REMOVED in first-principles pass (2026-05-06).
+// Schema + tests preserved in deferred-features draft PR (#616).

--- a/test/v41-eval-tables.test.ts
+++ b/test/v41-eval-tables.test.ts
@@ -1,0 +1,159 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  notnull: number;
+  pk: number;
+  dflt_value: string | null;
+};
+type FkInfo = { from: string; table: string; on_delete: string };
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  return db;
+}
+
+describe("lcm_eval_query_set (v4.1 §11)", () => {
+  it("creates table with PK and required columns", () => {
+    const db = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_eval_query_set)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("query_set_id")?.pk).toBe(1);
+    expect(byName.get("version")?.notnull).toBe(1);
+    db.close();
+  });
+
+  it("supports inserting a baseline query set ('eva-baseline-v2')", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version, description) VALUES (?, ?, ?)`,
+    ).run("eva-baseline-v2", 1, "100-query stratified eval set");
+    const row = db
+      .prepare("SELECT * FROM lcm_eval_query_set WHERE query_set_id = ?")
+      .get("eva-baseline-v2") as { description: string };
+    expect(row.description).toContain("stratified");
+    db.close();
+  });
+});
+
+describe("lcm_eval_query (v4.1 §11)", () => {
+  it("rejects invalid stratum values via CHECK", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`,
+    ).run("test", 1);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, rubric) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("q1", "test", "what?", "bogus-stratum", "[]", "{}"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("supports the 3 valid strata + must_not_regress flag", () => {
+    const db = setupDb();
+    db.prepare(
+      `INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`,
+    ).run("eva-baseline-v2", 1);
+
+    const insert = db.prepare(
+      `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, must_not_regress, rubric) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run("q1", "eva-baseline-v2", "What did we decide about gbrain bridge?", "fts-easy", "[]", 1, "{}");
+    insert.run("q2", "eva-baseline-v2", "Tell me about context collapsing", "paraphrastic", "[]", 0, "{}");
+    insert.run("q3", "eva-baseline-v2", "What were April blockers?", "fts-medium", "[]", 0, "{}");
+
+    const counts = db
+      .prepare(`SELECT stratum, COUNT(*) AS n FROM lcm_eval_query GROUP BY stratum ORDER BY stratum`)
+      .all() as Array<{ stratum: string; n: number }>;
+    expect(counts).toEqual([
+      { stratum: "fts-easy", n: 1 },
+      { stratum: "fts-medium", n: 1 },
+      { stratum: "paraphrastic", n: 1 },
+    ]);
+
+    const must = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_eval_query WHERE must_not_regress = 1`)
+      .get() as { n: number };
+    expect(must.n).toBe(1);
+    db.close();
+  });
+
+  it("CASCADE on query_set delete removes queries", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("x", 1);
+    db.prepare(
+      `INSERT INTO lcm_eval_query (query_id, query_set_id, query_text, stratum, expected_topics, rubric) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("q1", "x", "?", "fts-easy", "[]", "{}");
+    db.prepare(`DELETE FROM lcm_eval_query_set WHERE query_set_id = 'x'`).run();
+    const remaining = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_eval_query WHERE query_set_id = 'x'`)
+      .get() as { n: number };
+    expect(remaining.n).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_eval_run (v4.1 §11)", () => {
+  it("rejects invalid trigger values", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("s", 1);
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_eval_run (run_id, query_set_id, prompt_bundle_version, retrieval_recall_score, synthesis_quality_score, per_query_scores, judge_models, trigger) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("r1", "s", 1, 0.8, 8.5, "[]", "[]", "bogus-trigger"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("supports recording a run with both recall + quality metrics (separate per v4.1.1)", () => {
+    const db = setupDb();
+    db.prepare(`INSERT INTO lcm_eval_query_set (query_set_id, version) VALUES (?, ?)`).run("s", 1);
+    db.prepare(
+      `INSERT INTO lcm_eval_run (run_id, query_set_id, prompt_bundle_version, retrieval_recall_score, synthesis_quality_score, per_query_scores, judge_models, noise_floor_sd, trigger) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "r1",
+      "s",
+      1,
+      0.78,
+      8.4,
+      JSON.stringify({ q1: 9, q2: 8, q3: 7 }),
+      JSON.stringify(["gpt-5.5", "claude-sonnet-X", "voyage-judge"]),
+      0.5,
+      "ci",
+    );
+    const row = db
+      .prepare(`SELECT retrieval_recall_score, synthesis_quality_score, noise_floor_sd FROM lcm_eval_run WHERE run_id = ?`)
+      .get("r1") as {
+      retrieval_recall_score: number;
+      synthesis_quality_score: number;
+      noise_floor_sd: number;
+    };
+    expect(row.retrieval_recall_score).toBeCloseTo(0.78);
+    expect(row.synthesis_quality_score).toBeCloseTo(8.4);
+    expect(row.noise_floor_sd).toBeCloseTo(0.5);
+    db.close();
+  });
+});
+
+describe("lcm_eval_drift (v4.1 §11.5)", () => {
+  it("creates table for cumulative-regression drift index", () => {
+    const db = setupDb();
+    const cols = db.prepare("PRAGMA table_info(lcm_eval_drift)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("drift_id")?.pk).toBe(1);
+    expect(byName.get("cumulative_delta")?.notnull).toBe(1);
+    expect(byName.get("window_runs")?.notnull).toBe(1);
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_eval_drift)").all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "query_set_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+});

--- a/test/v41-indexes.test.ts
+++ b/test/v41-indexes.test.ts
@@ -1,0 +1,73 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type IndexInfo = { name: string; tbl_name: string; sql: string };
+
+function getIndexNames(db: DatabaseSync, tableName: string): string[] {
+  const rows = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name = ?`)
+    .all(tableName) as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+describe("v4.1 summaries indexes (A.08)", () => {
+  it("creates session_key + kind + latest_at index for retrieval", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "summaries")).toContain("summaries_session_key_kind_latest_idx");
+    db.close();
+  });
+
+  it("creates partial suppressed_at index (small footprint, fast filter)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const sql = db
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type='index' AND name = 'summaries_suppressed_idx'`,
+      )
+      .get() as { sql: string };
+    expect(sql.sql).toContain("WHERE suppressed_at IS NOT NULL");
+    db.close();
+  });
+
+  it("creates partial contains_suppressed_leaves index for idle-rebuild candidate scan", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const sql = db
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type='index' AND name = 'summaries_contains_suppressed_idx'`,
+      )
+      .get() as { sql: string };
+    expect(sql.sql).toContain("contains_suppressed_leaves = 1");
+    expect(sql.sql).toContain("superseded_by IS NULL");
+    db.close();
+  });
+
+  it("creates messages.suppressed_at partial index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "messages")).toContain("messages_suppressed_idx");
+    db.close();
+  });
+
+  it("creates conversations.session_key index for v4.1 read patterns", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(getIndexNames(db, "conversations")).toContain("conversations_session_key_v41_idx");
+    db.close();
+  });
+
+  // Note: EXPLAIN QUERY PLAN testing was attempted here but removed — SQLite's
+  // optimizer correctly picks full-table scan over index for tiny test
+  // datasets (3 rows). Verifying actual index USE requires production-scale
+  // data; verifying index PRESENCE is what these unit tests cover. End-to-end
+  // verification on Eva's live DB copy in A.09's run-script handles the rest.
+
+  it("is idempotent — re-running migration does not fail on existing indexes", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+});

--- a/test/v41-leaf-cap.test.ts
+++ b/test/v41-leaf-cap.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("v4.1 leaf-summarizer cap fix (A.10)", () => {
+  it("DEFAULT_LEAF_TARGET_TOKENS is 4000 in src/summarize.ts (was 2400; raised per v4.1)", () => {
+    const src = readFileSync("src/summarize.ts", "utf-8");
+    // The constant declaration line should set 4000
+    const match = src.match(/const DEFAULT_LEAF_TARGET_TOKENS = (\d+);/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("4000");
+  });
+
+  it("config.ts default is 4000 (was 2400; raised per v4.1)", () => {
+    const src = readFileSync("src/db/config.ts", "utf-8");
+    // The fallback default for pc.leafTargetTokens
+    const match = src.match(/toNumber\(pc\.leafTargetTokens\) \?\? (\d+),/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("4000");
+  });
+
+  it("v4.1 doc rationale present in source comment (so future readers see why)", () => {
+    const src = readFileSync("src/summarize.ts", "utf-8");
+    expect(src).toContain("v4.1 (A.10)");
+    expect(src).toContain("2,415");
+  });
+});

--- a/test/v41-pre-existing-schema-migration.test.ts
+++ b/test/v41-pre-existing-schema-migration.test.ts
@@ -1,0 +1,233 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+/**
+ * v4.1 B.fix — Gap 9: live-DB-shape regression test.
+ *
+ * All other v41-*.test.ts files start from a fresh `:memory:` and run the
+ * full migration on an empty DB. This test instead seeds the upstream
+ * pre-v4.1 schema by hand (conversations + summaries + messages with rows
+ * but NO lcm_* tables yet) and runs the v4.1 migration against it. This
+ * is the shape Eva's live DB had at the start of the v4.1 rollout.
+ *
+ * If this test ever fails, that's a SIGNAL — investigate before "fixing"
+ * the test. The migration IS being live-DB-verified after each commit;
+ * if a fresh-:memory:-with-pre-existing-data run breaks, something is
+ * wrong with assumptions baked into the migration steps.
+ */
+
+/** v4.1 tables that the migration is expected to create. */
+const EXPECTED_V41_TABLES = [
+  "lcm_worker_lock",
+  "lcm_extraction_queue",
+  "lcm_session_key_audit",
+  "lcm_prompt_registry",
+  "lcm_synthesis_cache",
+  "lcm_cache_leaf_refs",
+  "lcm_synthesis_audit",
+  "lcm_eval_query_set",
+  "lcm_eval_query",
+  "lcm_eval_run",
+  "lcm_eval_drift",
+  "lcm_entity_type_registry",
+  "lcm_entities",
+  "lcm_entity_mentions",
+  "lcm_embedding_profile",
+  "lcm_embedding_meta",
+  "lcm_feature_flags",
+] as const;
+
+function seedUpstreamPreV41Schema(db: DatabaseSync): void {
+  // Upstream pre-v4.1 baseline shape (the schema Eva's live DB had right
+  // before v4.1 column additions). This must match the CREATE TABLE
+  // statements at the top of runLcmMigrations — those are themselves
+  // CREATE TABLE IF NOT EXISTS, so the migration accepts any DB whose
+  // baseline matches this shape and proceeds to layer v4.1 changes onto it.
+  db.exec(`
+    CREATE TABLE conversations (
+      conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      active INTEGER NOT NULL DEFAULT 1,
+      archived_at TEXT,
+      title TEXT,
+      bootstrapped_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  db.exec(`
+    CREATE TABLE messages (
+      message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      identity_hash TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (conversation_id, seq)
+    )
+  `);
+  db.exec(`
+    CREATE TABLE summaries (
+      summary_id TEXT PRIMARY KEY,
+      conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+      kind TEXT NOT NULL CHECK (kind IN ('leaf', 'condensed')),
+      depth INTEGER NOT NULL DEFAULT 0,
+      content TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      earliest_at TEXT,
+      latest_at TEXT,
+      descendant_count INTEGER NOT NULL DEFAULT 0,
+      descendant_token_count INTEGER NOT NULL DEFAULT 0,
+      source_message_token_count INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      file_ids TEXT NOT NULL DEFAULT '[]'
+    )
+  `);
+}
+
+function listTableNames(db: DatabaseSync): Set<string> {
+  const rows = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table'`)
+    .all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+describe("v4.1 migration against a partially pre-existing schema (B.fix Gap 9)", () => {
+  it("runs end-to-end without throwing and produces the expected DB shape", () => {
+    const db = new DatabaseSync(":memory:");
+    seedUpstreamPreV41Schema(db);
+
+    // 3 conversations: 2 with NULL session_key (should be backfilled), 1 set.
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_a");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_b");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, ?)`,
+    ).run("s_set", "agent:main:main");
+
+    // Summaries pointing into the conversations.
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_a", 1, "leaf", "x", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_b", 2, "leaf", "y", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_c", 3, "leaf", "z", 1);
+
+    // Run the v4.1 migration — must not throw.
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+
+    // ── Conversations: NULL session_keys were backfilled to legacy:conv_<id>
+    const convs = db
+      .prepare(
+        `SELECT conversation_id, session_key FROM conversations ORDER BY conversation_id`,
+      )
+      .all() as Array<{ conversation_id: number; session_key: string }>;
+    for (const c of convs) {
+      expect(c.session_key).not.toBeNull();
+      expect(typeof c.session_key).toBe("string");
+      expect(c.session_key.length).toBeGreaterThan(0);
+    }
+    expect(convs[0].session_key).toBe("legacy:conv_1");
+    expect(convs[1].session_key).toBe("legacy:conv_2");
+    expect(convs[2].session_key).toBe("agent:main:main");
+
+    // ── Audit rows for the NULL-backfilled conversations
+    const audits = db
+      .prepare(
+        `SELECT conversation_id, original_session_key, new_session_key
+         FROM lcm_session_key_audit ORDER BY conversation_id`,
+      )
+      .all() as Array<{
+      conversation_id: number;
+      original_session_key: string | null;
+      new_session_key: string;
+    }>;
+    expect(audits).toEqual([
+      { conversation_id: 1, original_session_key: null, new_session_key: "legacy:conv_1" },
+      { conversation_id: 2, original_session_key: null, new_session_key: "legacy:conv_2" },
+    ]);
+
+    // ── Summaries.session_key populated via the JOIN backfill
+    const sums = db
+      .prepare(`SELECT summary_id, session_key FROM summaries ORDER BY summary_id`)
+      .all() as Array<{ summary_id: string; session_key: string }>;
+    for (const s of sums) {
+      expect(typeof s.session_key).toBe("string");
+      expect(s.session_key.length).toBeGreaterThan(0);
+    }
+    expect(sums.find((s) => s.summary_id === "sum_a")?.session_key).toBe("legacy:conv_1");
+    expect(sums.find((s) => s.summary_id === "sum_b")?.session_key).toBe("legacy:conv_2");
+    expect(sums.find((s) => s.summary_id === "sum_c")?.session_key).toBe("agent:main:main");
+
+    // ── All v4.1 tables present in sqlite_master
+    const tables = listTableNames(db);
+    for (const expected of EXPECTED_V41_TABLES) {
+      expect(tables.has(expected), `table ${expected} should exist after migration`).toBe(true);
+    }
+
+    // ── Gap 2 fix is in place: lcm_prompt_registry_uniq_lookup index exists
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type='index' AND tbl_name='lcm_prompt_registry'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("lcm_prompt_registry_uniq_lookup");
+
+    db.close();
+  });
+
+  it("re-running migration is idempotent (no row count changes, no errors)", () => {
+    const db = new DatabaseSync(":memory:");
+    seedUpstreamPreV41Schema(db);
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, NULL)`,
+    ).run("s_null_a");
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key) VALUES (?, ?)`,
+    ).run("s_set", "agent:main:main");
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_a", 1, "leaf", "x", 1);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, ?, ?, ?)`,
+    ).run("sum_b", 2, "leaf", "y", 1);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Snapshot the row counts of every user-visible table after first run
+    const tableNames = [...listTableNames(db)].filter((n) => !n.startsWith("sqlite_"));
+    const countsAfterFirst = new Map<string, number>();
+    for (const t of tableNames) {
+      const n = (
+        db.prepare(`SELECT COUNT(*) AS n FROM ${t}`).get() as { n: number }
+      ).n;
+      countsAfterFirst.set(t, n);
+    }
+
+    // Re-run migration — must not throw and must not change row counts
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+
+    for (const t of tableNames) {
+      const n = (
+        db.prepare(`SELECT COUNT(*) AS n FROM ${t}`).get() as { n: number }
+      ).n;
+      expect(n, `table ${t} row count should be stable across re-runs`).toBe(
+        countsAfterFirst.get(t),
+      );
+    }
+
+    db.close();
+  });
+});

--- a/test/v41-prompt-registry-null-uniq.test.ts
+++ b/test/v41-prompt-registry-null-uniq.test.ts
@@ -1,0 +1,159 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+/**
+ * v4.1 B.fix — Gap 2: lcm_prompt_registry NULL tier_label deduplication.
+ *
+ * The original UNIQUE(memory_type, tier_label, pass_kind, version) constraint
+ * admits multiple rows where tier_label IS NULL because SQLite treats NULLs
+ * as distinct in UNIQUE. The synthesis spec wants singletons-per-version, so
+ * a follow-up migration step adds a COALESCE-based UNIQUE INDEX that catches
+ * NULL collisions. Same pattern is used for lcm_synthesis_cache_lookup_uniq.
+ */
+describe("lcm_prompt_registry NULL-safe UNIQUE index (v4.1 B.fix Gap 2)", () => {
+  const insertRegistryRow = (
+    db: DatabaseSync,
+    args: {
+      prompt_id: string;
+      memory_type: string;
+      tier_label: string | null;
+      pass_kind: string;
+      version: number;
+    },
+  ): void => {
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry
+         (prompt_id, memory_type, tier_label, pass_kind, version, template)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      args.prompt_id,
+      args.memory_type,
+      args.tier_label,
+      args.pass_kind,
+      args.version,
+      "tmpl-body",
+    );
+  };
+
+  it("creates the lcm_prompt_registry_uniq_lookup index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type='index' AND tbl_name='lcm_prompt_registry'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("lcm_prompt_registry_uniq_lookup");
+    db.close();
+  });
+
+  it("rejects a second row with the same memory_type + NULL tier_label + pass_kind + version", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+
+    expect(() =>
+      insertRegistryRow(db, {
+        prompt_id: "p_2",
+        memory_type: "episodic-leaf",
+        tier_label: null,
+        pass_kind: "single",
+        version: 1,
+      }),
+    ).toThrow(/UNIQUE/i);
+    db.close();
+  });
+
+  it("allows two NULL-tier_label rows that differ only in version", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+    insertRegistryRow(db, {
+      prompt_id: "p_2",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 2,
+    });
+
+    const count = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_prompt_registry`).get() as { n: number }
+    ).n;
+    expect(count).toBe(2);
+    db.close();
+  });
+
+  it("treats NULL and 'monthly' as distinct (different tier_label values)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_null",
+      memory_type: "episodic-leaf",
+      tier_label: null,
+      pass_kind: "single",
+      version: 1,
+    });
+    insertRegistryRow(db, {
+      prompt_id: "p_monthly",
+      memory_type: "episodic-leaf",
+      tier_label: "monthly",
+      pass_kind: "single",
+      version: 1,
+    });
+
+    const count = (
+      db.prepare(`SELECT COUNT(*) AS n FROM lcm_prompt_registry`).get() as { n: number }
+    ).n;
+    expect(count).toBe(2);
+    db.close();
+  });
+
+  it("the original UNIQUE constraint still catches non-NULL collisions", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+    insertRegistryRow(db, {
+      prompt_id: "p_1",
+      memory_type: "episodic-leaf",
+      tier_label: "monthly",
+      pass_kind: "single",
+      version: 1,
+    });
+
+    expect(() =>
+      insertRegistryRow(db, {
+        prompt_id: "p_2",
+        memory_type: "episodic-leaf",
+        tier_label: "monthly",
+        pass_kind: "single",
+        version: 1,
+      }),
+    ).toThrow(/UNIQUE/i);
+    db.close();
+  });
+
+  it("is idempotent — running migrations twice does not fail", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false })).not.toThrow();
+    db.close();
+  });
+});

--- a/test/v41-summaries-columns.test.ts
+++ b/test/v41-summaries-columns.test.ts
@@ -1,0 +1,196 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+describe("v4.1 summaries column additions (v3.1 A1/A3 + v4.1.1 A2)", () => {
+  it("adds session_key with NOT NULL DEFAULT '' (v3.1 A1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sk = cols.find((c) => c.name === "session_key");
+    expect(sk).toBeDefined();
+    expect(sk?.notnull).toBe(1);
+    expect(sk?.dflt_value).toBe("''");
+    db.close();
+  });
+
+  it("adds suppressed_at as nullable TEXT (v3.1 A3)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sa = cols.find((c) => c.name === "suppressed_at");
+    expect(sa).toBeDefined();
+    expect(sa?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds entity_index as nullable TEXT (v3.1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const ei = cols.find((c) => c.name === "entity_index");
+    expect(ei).toBeDefined();
+    expect(ei?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds contains_suppressed_leaves with NOT NULL DEFAULT 0 (v3.1 A3)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const csl = cols.find((c) => c.name === "contains_suppressed_leaves");
+    expect(csl).toBeDefined();
+    expect(csl?.notnull).toBe(1);
+    expect(csl?.dflt_value).toBe("0");
+    db.close();
+  });
+
+  it("adds suppress_reason as nullable TEXT (v4.1.1 A2)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sr = cols.find((c) => c.name === "suppress_reason");
+    expect(sr).toBeDefined();
+    expect(sr?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("adds superseded_by as FK to summaries(summary_id) ON DELETE SET NULL (v4.1.1 A2/A4)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const sb = cols.find((c) => c.name === "superseded_by");
+    expect(sb).toBeDefined();
+    expect(sb?.notnull).toBe(0); // nullable per SQLite ADD COLUMN+FK rule
+
+    // Verify the FK is actually declared
+    const fks = db.prepare("PRAGMA foreign_key_list(summaries)").all() as Array<{
+      from: string;
+      to: string;
+      table: string;
+      on_delete: string;
+    }>;
+    const sbFk = fks.find((fk) => fk.from === "superseded_by");
+    expect(sbFk).toBeDefined();
+    expect(sbFk?.table).toBe("summaries");
+    expect(sbFk?.to).toBe("summary_id");
+    expect(sbFk?.on_delete).toBe("SET NULL");
+    db.close();
+  });
+
+  it("adds leaf_summarizer_cap_was as nullable INTEGER (v4.1)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(summaries)").all() as ColumnInfo[];
+    const lcw = cols.find((c) => c.name === "leaf_summarizer_cap_was");
+    expect(lcw).toBeDefined();
+    expect(lcw?.notnull).toBe(0);
+    db.close();
+  });
+
+  it("is idempotent — running migrations twice does not fail", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+    db.close();
+  });
+
+  // Forward-compat upgrade test (against a partial pre-existing schema) is
+  // deferred to Group A.10 — that step covers the full live-DB-shaped
+  // verification including all v3-era tables and indexes that the migration
+  // assumes are present.
+});
+
+describe("messages.suppressed_at column (v3.1 A3 extension)", () => {
+  it("adds suppressed_at to messages table", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(messages)").all() as ColumnInfo[];
+    const sa = cols.find((c) => c.name === "suppressed_at");
+    expect(sa).toBeDefined();
+    expect(sa?.notnull).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_feature_flags table (v4.1.1 A8 — clean new table)", () => {
+  it("creates lcm_feature_flags with (flag PK, value NOT NULL, updated_at NOT NULL)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_feature_flags)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+
+    expect(byName.get("flag")?.pk).toBe(1);
+    expect(byName.get("flag")?.notnull).toBe(1); // PRIMARY KEY → NOT NULL
+    expect(byName.get("value")?.notnull).toBe(1);
+    expect(byName.get("updated_at")?.notnull).toBe(1);
+    db.close();
+  });
+
+  it("supports basic feature-flag pattern (set + read)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(
+      `INSERT INTO lcm_feature_flags (flag, value) VALUES (?, ?)`,
+    ).run("v4_section_1_enabled", "true");
+
+    const row = db
+      .prepare(`SELECT value FROM lcm_feature_flags WHERE flag = ?`)
+      .get("v4_section_1_enabled") as { value: string } | undefined;
+    expect(row?.value).toBe("true");
+
+    // Update flips value
+    db.prepare(
+      `UPDATE lcm_feature_flags SET value = ?, updated_at = datetime('now') WHERE flag = ?`,
+    ).run("false", "v4_section_1_enabled");
+    const row2 = db
+      .prepare(`SELECT value FROM lcm_feature_flags WHERE flag = ?`)
+      .get("v4_section_1_enabled") as { value: string } | undefined;
+    expect(row2?.value).toBe("false");
+
+    db.close();
+  });
+
+  it("does NOT collide with Eva's legacy lcm_migration_flags table (separate concern)", () => {
+    const db = new DatabaseSync(":memory:");
+    // Pre-create the legacy table (simulating Eva's live DB shape)
+    db.exec(`
+      CREATE TABLE lcm_migration_flags (
+        flag TEXT PRIMARY KEY,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.prepare(`INSERT INTO lcm_migration_flags (flag) VALUES (?)`).run(
+      "tool-call-columns-backfilled-v1",
+    );
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    // Both tables should coexist
+    const tables = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('lcm_migration_flags', 'lcm_feature_flags')`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name).sort()).toEqual([
+      "lcm_feature_flags",
+      "lcm_migration_flags",
+    ]);
+
+    // Legacy table content untouched
+    const legacy = db
+      .prepare(`SELECT flag FROM lcm_migration_flags`)
+      .all() as Array<{ flag: string }>;
+    expect(legacy.map((r) => r.flag)).toContain("tool-call-columns-backfilled-v1");
+    db.close();
+  });
+});

--- a/test/v41-support-tables.test.ts
+++ b/test/v41-support-tables.test.ts
@@ -1,0 +1,142 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+type IndexInfo = { name: string };
+
+describe("lcm_extraction_queue (v4.1.1 A3)", () => {
+  it("creates the table with expected schema + indexes", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    const cols = db.prepare("PRAGMA table_info(lcm_extraction_queue)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("queue_id")?.pk).toBe(1);
+    expect(byName.get("queue_id")?.notnull).toBe(1);
+    expect(byName.get("leaf_id")?.notnull).toBe(1);
+    expect(byName.get("kind")?.notnull).toBe(1);
+    expect(byName.get("attempts")?.notnull).toBe(1);
+    expect(byName.get("attempts")?.dflt_value).toBe("0");
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_extraction_queue)").all() as Array<{
+      from: string;
+      table: string;
+      on_delete: string;
+    }>;
+    const leafFk = fks.find((fk) => fk.from === "leaf_id");
+    expect(leafFk?.table).toBe("summaries");
+    expect(leafFk?.on_delete).toBe("CASCADE");
+
+    const indexes = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_extraction_queue'`)
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_extraction_queue_pending_idx");
+    expect(indexes.map((i) => i.name)).toContain("lcm_extraction_queue_dead_letter_idx");
+    db.close();
+  });
+
+  it("rejects unknown kinds via CHECK constraint", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    // Need a real summary to satisfy FK
+    db.prepare(`INSERT INTO conversations (session_id) VALUES ('s1')`).run();
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+    ).run("sum_1");
+
+    expect(() =>
+      db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+        "q1",
+        "sum_1",
+        "bogus-kind",
+      ),
+    ).toThrow();
+
+    // Real kinds work
+    db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+      "q2",
+      "sum_1",
+      "entity",
+    );
+    db.prepare(`INSERT INTO lcm_extraction_queue (queue_id, leaf_id, kind) VALUES (?, ?, ?)`).run(
+      "q3",
+      "sum_1",
+      "procedure-recheck",
+    );
+
+    db.close();
+  });
+});
+
+// lcm_purge_rebuild_queue + lcm_voyage_rate_state tests REMOVED in
+// first-principles pass (2026-05-06). Schema + tests preserved in
+// deferred-features draft PR (#616).
+
+describe("lcm_session_key_audit (v4.1.1 §C reversibility log)", () => {
+  it("creates the audit table with FK + index", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_session_key_audit)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+
+    expect(byName.get("audit_id")?.pk).toBe(1);
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("new_session_key")?.notnull).toBe(1);
+    expect(byName.get("reason")?.notnull).toBe(1);
+    expect(byName.get("applied_at")?.notnull).toBe(1);
+    expect(byName.get("applied_by")?.notnull).toBe(1);
+    expect(byName.get("original_session_key")?.notnull).toBe(0); // nullable; legacy convs had NULL
+
+    const fks = db
+      .prepare("PRAGMA foreign_key_list(lcm_session_key_audit)")
+      .all() as Array<{ from: string; table: string; on_delete: string }>;
+    expect(fks.find((fk) => fk.from === "conversation_id")?.on_delete).toBe("CASCADE");
+
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_session_key_audit'`,
+      )
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_session_key_audit_conv_idx");
+    db.close();
+  });
+
+  it("supports recording a re-key with NULL original_session_key (legacy conv case)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.prepare(`INSERT INTO conversations (session_id) VALUES ('s1')`).run();
+
+    db.prepare(
+      `INSERT INTO lcm_session_key_audit (audit_id, conversation_id, original_session_key, new_session_key, reason)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      "audit_1",
+      1,
+      null, // legacy conv had NULL session_key
+      "agent:main:main",
+      "v4.1 cleanup: legacy leaf-bearing conv re-keyed to true main thread",
+    );
+
+    const row = db
+      .prepare("SELECT * FROM lcm_session_key_audit WHERE audit_id = ?")
+      .get("audit_1") as {
+      original_session_key: string | null;
+      new_session_key: string;
+      reason: string;
+    };
+    expect(row.original_session_key).toBeNull();
+    expect(row.new_session_key).toBe("agent:main:main");
+    expect(row.reason).toContain("legacy leaf-bearing");
+
+    db.close();
+  });
+});

--- a/test/v41-suppression-cascade-trigger.test.ts
+++ b/test/v41-suppression-cascade-trigger.test.ts
@@ -1,0 +1,303 @@
+import { existsSync } from "node:fs";
+import { arch, platform } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  dropEmbeddingsTriggers,
+  embeddingsTableName,
+  ensureEmbeddingsTable,
+  isEmbedded,
+  recordEmbedding,
+  registerEmbeddingProfile,
+  searchSimilar,
+  tryLoadSqliteVec,
+} from "../src/embeddings/store.js";
+
+/**
+ * B.03 — suppression + deletion cascade triggers.
+ *
+ * Two layers being verified here:
+ *
+ *   1. Per-model vec0 triggers (created by ensureEmbeddingsTable):
+ *      - AFTER UPDATE OF suppressed_at ON summaries → mirror to vec0.suppressed
+ *      - AFTER DELETE ON summaries → DELETE matching vec0 row
+ *
+ *   2. Shared meta-table cleanup trigger (created by migration):
+ *      - AFTER DELETE ON summaries → DELETE matching lcm_embedding_meta row
+ *        (filtered to kind='summary' to leave entity/theme meta alone)
+ */
+
+const VEC0_PATH =
+  process.env.LCM_TEST_VEC0_PATH?.trim() ||
+  (() => {
+    const realHome = process.env.REAL_HOME?.trim() || "/Users/lume";
+    const ext = platform() === "win32" ? "dll" : platform() === "darwin" ? "dylib" : "so";
+    const platformPkg = `sqlite-vec-${platform() === "win32" ? "windows" : platform()}-${arch()}`;
+    return `${realHome}/.openclaw/extensions/node_modules/${platformPkg}/vec0.${ext}`;
+  })();
+const VEC0_AVAILABLE = existsSync(VEC0_PATH);
+
+function newDbWithExtAllowed(): DatabaseSync {
+  return new DatabaseSync(":memory:", { allowExtension: true });
+}
+
+function setupDb(): DatabaseSync {
+  const db = newDbWithExtAllowed();
+  tryLoadSqliteVec(db, { path: VEC0_PATH });
+  runLcmMigrations(db, { fts5Available: false });
+  // Conversation row required because summaries.conversation_id has FK
+  db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+  registerEmbeddingProfile(db, "voyage-4-large", 3);
+  ensureEmbeddingsTable(db, "voyage-4-large", 3);
+  return db;
+}
+
+function insertSummary(db: DatabaseSync, summaryId: string, conversationId = 1): void {
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+     VALUES (?, ?, 'leaf', 'x', 1, 'sk1')`,
+  ).run(summaryId, conversationId);
+}
+
+function insertEmbeddingFor(db: DatabaseSync, summaryId: string, suppressed = false): void {
+  recordEmbedding(db, {
+    modelName: "voyage-4-large",
+    embeddedId: summaryId,
+    embeddedKind: "summary",
+    vector: [0.1, 0.2, 0.3],
+    suppressed,
+    sourceTokenCount: 1,
+  });
+}
+
+describe("v4.1 B.03 — meta-table cleanup trigger (always-on, no vec0)", () => {
+  it("AFTER DELETE on summaries cascades to lcm_embedding_meta (kind='summary' rows only)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES ('s1', 'sk1')`).run();
+    registerEmbeddingProfile(db, "voyage-4-large", 3);
+    db.prepare(
+      `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count, session_key)
+       VALUES (?, 1, 'leaf', 'x', 1, 'sk1')`,
+    ).run("leaf_a");
+    db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count)
+       VALUES (?, 'summary', 'voyage-4-large', 100)`,
+    ).run("leaf_a");
+    // Also an entity-kind meta row that should NOT be touched
+    db.prepare(
+      `INSERT INTO lcm_embedding_meta (embedded_id, embedded_kind, embedding_model, source_token_count)
+       VALUES ('ent_x', 'entity', 'voyage-4-large', 50)`,
+    ).run();
+
+    expect(
+      (
+        db.prepare(`SELECT COUNT(*) AS n FROM lcm_embedding_meta`).get() as { n: number }
+      ).n,
+    ).toBe(2);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run("leaf_a");
+
+    const remaining = db
+      .prepare(`SELECT embedded_id, embedded_kind FROM lcm_embedding_meta`)
+      .all() as Array<{ embedded_id: string; embedded_kind: string }>;
+    expect(remaining).toEqual([{ embedded_id: "ent_x", embedded_kind: "entity" }]);
+    db.close();
+  });
+
+  it("trigger is idempotent — re-running migration does not duplicate it", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false });
+    runLcmMigrations(db, { fts5Available: false }); // again — IF NOT EXISTS keeps this safe
+    const triggers = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='trigger' AND name = 'lcm_embedding_meta_cleanup_summary'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(triggers.length).toBe(1);
+    db.close();
+  });
+});
+
+describe.skipIf(!VEC0_AVAILABLE)("v4.1 B.03 — vec0 suppression cascade trigger", () => {
+  it("AFTER UPDATE OF suppressed_at on summaries flips vec0.suppressed; KNN search excludes the row", () => {
+    const db = setupDb();
+    insertSummary(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_a");
+
+    const before = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(before.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+
+    // Mark suppressed via UPDATE — trigger should mirror to vec0
+    db.prepare(`UPDATE summaries SET suppressed_at = ? WHERE summary_id = ?`).run(
+      "2026-05-05 00:00:00",
+      "leaf_a",
+    );
+
+    const after = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(after).toEqual([]); // suppressed by metadata pre-filter
+    db.close();
+  });
+
+  it("un-suppression cascade works too (suppressed_at → NULL)", () => {
+    const db = setupDb();
+    insertSummary(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_a", /*suppressed*/ true);
+
+    db.prepare(`UPDATE summaries SET suppressed_at = ? WHERE summary_id = ?`).run(
+      "2026-05-05 00:00:00",
+      "leaf_a",
+    );
+    const stillHidden = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(stillHidden).toEqual([]);
+
+    db.prepare(`UPDATE summaries SET suppressed_at = NULL WHERE summary_id = ?`).run("leaf_a");
+
+    const restored = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(restored.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+    db.close();
+  });
+
+  it("trigger fires only on suppressed_at column change, not on other column updates", () => {
+    // The trigger uses `WHEN (NEW.suppressed_at IS NULL) != (OLD.suppressed_at IS NULL)`
+    // to avoid running on every other UPDATE. Verifies that AFTER UPDATE OF
+    // is column-scoped AND that the WHEN clause skips no-op transitions.
+    const db = setupDb();
+    insertSummary(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_a");
+
+    // Update an unrelated column — should not flip vec0.suppressed
+    db.prepare(`UPDATE summaries SET content = 'updated' WHERE summary_id = ?`).run("leaf_a");
+    const stillVisible = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(stillVisible.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+
+    // Update suppressed_at to the SAME value (NULL → NULL) — trigger WHEN
+    // clause should skip
+    db.prepare(`UPDATE summaries SET suppressed_at = NULL WHERE summary_id = ?`).run("leaf_a");
+    const stillVisible2 = searchSimilar(db, {
+      modelName: "voyage-4-large",
+      queryVector: [0.1, 0.2, 0.3],
+      k: 5,
+    });
+    expect(stillVisible2.map((h) => h.embeddedId)).toEqual(["leaf_a"]);
+    db.close();
+  });
+
+  it("AFTER DELETE on summaries removes the vec0 row", () => {
+    const db = setupDb();
+    insertSummary(db, "leaf_a");
+    insertSummary(db, "leaf_b");
+    insertEmbeddingFor(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_b");
+
+    const tableName = embeddingsTableName("voyage-4-large");
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM ${tableName}`).get() as { n: number }).n,
+    ).toBe(2);
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run("leaf_a");
+
+    const remaining = db
+      .prepare(`SELECT embedded_id FROM ${tableName} ORDER BY embedded_id`)
+      .all() as Array<{ embedded_id: string }>;
+    expect(remaining).toEqual([{ embedded_id: "leaf_b" }]);
+
+    // And meta should be cleaned up too (separate trigger)
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_a", embeddedKind: "summary" })).toBe(false);
+    expect(isEmbedded(db, { modelName: "voyage-4-large", embeddedId: "leaf_b", embeddedKind: "summary" })).toBe(true);
+    db.close();
+  });
+
+  it("two embedding models — both vec0 tables get cleaned up by the cascade", () => {
+    const db = setupDb();
+    registerEmbeddingProfile(db, "voyage-3-lite", 3);
+    ensureEmbeddingsTable(db, "voyage-3-lite", 3);
+
+    insertSummary(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_a");
+    recordEmbedding(db, {
+      modelName: "voyage-3-lite",
+      embeddedId: "leaf_a",
+      embeddedKind: "summary",
+      vector: [0.5, 0.5, 0.5],
+      sourceTokenCount: 1,
+    });
+
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run("leaf_a");
+
+    // Both models' vec0 tables should be empty
+    expect(
+      (
+        db
+          .prepare(`SELECT COUNT(*) AS n FROM ${embeddingsTableName("voyage-4-large")}`)
+          .get() as { n: number }
+      ).n,
+    ).toBe(0);
+    expect(
+      (
+        db
+          .prepare(`SELECT COUNT(*) AS n FROM ${embeddingsTableName("voyage-3-lite")}`)
+          .get() as { n: number }
+      ).n,
+    ).toBe(0);
+    db.close();
+  });
+
+  it("dropEmbeddingsTriggers removes per-model triggers (used during model archival)", () => {
+    const db = setupDb();
+    insertSummary(db, "leaf_a");
+    insertEmbeddingFor(db, "leaf_a");
+
+    dropEmbeddingsTriggers(db, "voyage-4-large");
+
+    // After dropping triggers, suppression cascade no longer happens
+    db.prepare(`UPDATE summaries SET suppressed_at = ? WHERE summary_id = ?`).run(
+      "2026-05-05 00:00:00",
+      "leaf_a",
+    );
+    // vec0.suppressed should still be 0 — trigger no longer firing
+    const tableName = embeddingsTableName("voyage-4-large");
+    const row = db
+      .prepare(`SELECT suppressed FROM ${tableName} WHERE embedded_id = ?`)
+      .get("leaf_a") as { suppressed: number };
+    expect(row.suppressed).toBe(0);
+    db.close();
+  });
+
+  it("triggers are idempotent — calling ensureEmbeddingsTable twice doesn't error", () => {
+    const db = setupDb();
+    // Already called once in setupDb; call again — IF NOT EXISTS keeps it safe
+    ensureEmbeddingsTable(db, "voyage-4-large", 3);
+    const triggers = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'lcm_embed_%_voyage4large'`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(triggers.map((t) => t.name).sort()).toEqual([
+      "lcm_embed_delete_voyage4large",
+      "lcm_embed_suppress_voyage4large",
+    ]);
+    db.close();
+  });
+});

--- a/test/v41-synthesis-tables.test.ts
+++ b/test/v41-synthesis-tables.test.ts
@@ -1,0 +1,440 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+type IndexInfo = { name: string };
+type FkInfo = {
+  from: string;
+  to: string;
+  table: string;
+  on_delete: string;
+};
+
+function setupDbWithRequiredFixtures(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+
+  // Seed a conversation + summary so FK references work
+  db.prepare(`INSERT INTO conversations (session_id) VALUES ('test-session')`).run();
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'x', 1)`,
+  ).run("sum_a");
+  db.prepare(
+    `INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, 1, 'leaf', 'y', 1)`,
+  ).run("sum_b");
+
+  // Seed a prompt registry row so cache + audit FKs work
+  db.prepare(
+    `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run("prompt_v1", "episodic-condensed", "single", 1, "Summarize: {input}");
+
+  return db;
+}
+
+describe("lcm_prompt_registry (v4.1 §3)", () => {
+  it("creates table with memory_type + pass_kind CHECK constraints", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const cols = db.prepare("PRAGMA table_info(lcm_prompt_registry)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("prompt_id")?.pk).toBe(1);
+    expect(byName.get("memory_type")?.notnull).toBe(1);
+    expect(byName.get("pass_kind")?.notnull).toBe(1);
+    expect(byName.get("template")?.notnull).toBe(1);
+    expect(byName.get("active")?.dflt_value).toBe("1");
+    expect(byName.get("bundle_version")?.dflt_value).toBe("1");
+    db.close();
+  });
+
+  it("rejects invalid memory_type values", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("p1", "bogus-type", "single", 1, "x"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("rejects invalid pass_kind values", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, pass_kind, version, template) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("p2", "episodic-leaf", "critique-revise", 1, "x"),
+    ).toThrow();
+    db.close();
+  });
+
+  it("UNIQUE constraint prevents duplicate (memory_type, tier_label, pass_kind, version)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("pa", "episodic-condensed", "monthly", "single", 1, "v1");
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("pb", "episodic-condensed", "monthly", "single", 1, "v1-dup"),
+    ).toThrow();
+    // Different version is fine
+    db.prepare(
+      `INSERT INTO lcm_prompt_registry (prompt_id, memory_type, tier_label, pass_kind, version, template) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("pc", "episodic-condensed", "monthly", "single", 2, "v2");
+    db.close();
+  });
+});
+
+describe("lcm_synthesis_cache (v3.1 A8 + v4.1.1 B4)", () => {
+  it("creates table with status CHECK + tier_label CHECK + prompt_id FK", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_synthesis_cache)").all() as ColumnInfo[];
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.get("cache_id")?.pk).toBe(1);
+    expect(byName.get("status")?.dflt_value).toBe("'ready'");
+    expect(byName.get("content")?.notnull).toBe(0); // NULL while building
+    expect(byName.get("entity_index")?.dflt_value).toBe("'{}'");
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_synthesis_cache)").all() as FkInfo[];
+    const promptFk = fks.find((fk) => fk.from === "prompt_id");
+    expect(promptFk?.table).toBe("lcm_prompt_registry");
+
+    db.close();
+  });
+
+  it("UNIQUE lookup index enables INSERT OR IGNORE single-flight (v4.1.1 B4)", () => {
+    const db = setupDbWithRequiredFixtures();
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO lcm_synthesis_cache (
+        cache_id, session_key, range_start, range_end, leaf_fingerprint,
+        model_used, prompt_id, tier_label, source_leaf_ids,
+        source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized,
+        status, building_started_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'building', datetime('now'))
+    `);
+
+    // First INSERT wins
+    const r1 = insert.run(
+      "cache_A",
+      "agent:main:main",
+      "2026-04-01T00:00:00Z",
+      "2026-04-30T23:59:59Z",
+      "fp_xyz",
+      "voyage-4-large",
+      "prompt_v1",
+      "custom",
+      "[]",
+      0,
+      0,
+      "2026-04-01T00:00:00Z..2026-04-30T23:59:59Z",
+      0,
+    );
+    expect(r1.changes).toBe(1);
+
+    // Second INSERT with same lookup key conflicts → DO NOTHING
+    const r2 = insert.run(
+      "cache_B", // different cache_id, but same lookup composite
+      "agent:main:main",
+      "2026-04-01T00:00:00Z",
+      "2026-04-30T23:59:59Z",
+      "fp_xyz",
+      "voyage-4-large",
+      "prompt_v1",
+      "custom",
+      "[]",
+      0,
+      0,
+      "2026-04-01T00:00:00Z..2026-04-30T23:59:59Z",
+      0,
+    );
+    expect(r2.changes).toBe(0); // ON CONFLICT DO NOTHING fired
+
+    // Verify the winner is cache_A
+    const winner = db
+      .prepare(
+        `SELECT cache_id FROM lcm_synthesis_cache
+         WHERE session_key = ? AND range_start = ? AND range_end = ?
+           AND leaf_fingerprint = ? AND COALESCE(grep_filter, '') = ''`,
+      )
+      .get(
+        "agent:main:main",
+        "2026-04-01T00:00:00Z",
+        "2026-04-30T23:59:59Z",
+        "fp_xyz",
+      ) as { cache_id: string };
+    expect(winner.cache_id).toBe("cache_A");
+    db.close();
+  });
+
+  it("rejects invalid status / tier_label values", () => {
+    const db = setupDbWithRequiredFixtures();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c1", "sk", "s", "e", "fp", "m", "prompt_v1", "year", "[]", 0, 0, "x", 0, "bogus-status"),
+    ).toThrow();
+
+    // Final.review.3 fix (Loop 4 Bug 4.4): the cache CHECK constraint was
+    // widened to include all dispatch tiers ('daily', 'weekly', 'monthly',
+    // 'yearly', 'year', 'custom', 'filtered'). 'monthly' is now ACCEPTED.
+    // Verify with 'bogus-tier' instead, which is still rejected.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c2", "sk", "s", "e", "fp", "m", "prompt_v1", "bogus-tier", "[]", 0, 0, "x", 0),
+    ).toThrow();
+
+    // 'monthly' should now succeed (post-widen fix); verify it was a real change.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run("c3", "sk", "s2", "e2", "fp2", "m", "prompt_v1", "monthly", "[]", 0, 0, "x", 0),
+    ).not.toThrow();
+
+    db.close();
+  });
+});
+
+describe("lcm_cache_leaf_refs (v3.1 A3 inverse index)", () => {
+  it("creates table with composite PK + cascade both directions", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_cache_leaf_refs)").all() as ColumnInfo[];
+    expect(cols.find((c) => c.name === "cache_id")?.pk).toBe(1);
+    expect(cols.find((c) => c.name === "leaf_summary_id")?.pk).toBe(2);
+
+    const fks = db.prepare("PRAGMA foreign_key_list(lcm_cache_leaf_refs)").all() as FkInfo[];
+    expect(fks.find((fk) => fk.from === "cache_id")?.on_delete).toBe("CASCADE");
+    expect(fks.find((fk) => fk.from === "leaf_summary_id")?.on_delete).toBe("CASCADE");
+    db.close();
+  });
+
+  it("CASCADE on leaf delete removes refs (cleans up after leaf is purged)", () => {
+    const db = setupDbWithRequiredFixtures();
+    // Build a cache row + ref
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("c1", "sk", "s", "e", "fp", "m", "prompt_v1", "custom", "[]", 0, 0, "x", 0);
+    db.prepare(`INSERT INTO lcm_cache_leaf_refs (cache_id, leaf_summary_id) VALUES (?, ?)`).run(
+      "c1",
+      "sum_a",
+    );
+
+    // Delete the leaf — ref should cascade
+    db.prepare(`DELETE FROM summaries WHERE summary_id = ?`).run("sum_a");
+    const refs = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_cache_leaf_refs WHERE cache_id = 'c1'`)
+      .get() as { n: number };
+    expect(refs.n).toBe(0);
+    db.close();
+  });
+
+  it("CASCADE on cache delete removes refs", () => {
+    const db = setupDbWithRequiredFixtures();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache (cache_id, session_key, range_start, range_end, leaf_fingerprint, model_used, prompt_id, tier_label, source_leaf_ids, source_token_count, output_token_count, actual_range_covered, leaf_count_synthesized) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("c2", "sk", "s", "e", "fp2", "m", "prompt_v1", "custom", "[]", 0, 0, "x", 0);
+    db.prepare(`INSERT INTO lcm_cache_leaf_refs (cache_id, leaf_summary_id) VALUES (?, ?)`).run(
+      "c2",
+      "sum_b",
+    );
+
+    db.prepare(`DELETE FROM lcm_synthesis_cache WHERE cache_id = ?`).run("c2");
+    const refs = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_cache_leaf_refs WHERE leaf_summary_id = 'sum_b'`)
+      .get() as { n: number };
+    expect(refs.n).toBe(0);
+    db.close();
+  });
+});
+
+describe("lcm_synthesis_audit (v4.1.1 B1)", () => {
+  it("pass_output is NULLable so audit row can be inserted before LLM call returns", () => {
+    const db = setupDbWithRequiredFixtures();
+    const cols = db.prepare("PRAGMA table_info(lcm_synthesis_audit)").all() as ColumnInfo[];
+    const passOutput = cols.find((c) => c.name === "pass_output");
+    expect(passOutput?.notnull).toBe(0);
+
+    const status = cols.find((c) => c.name === "status");
+    expect(status?.notnull).toBe(1);
+    expect(status?.dflt_value).toBe("'started'");
+    db.close();
+  });
+
+  it("CHECK constraint requires either target_summary_id OR target_cache_id", () => {
+    const db = setupDbWithRequiredFixtures();
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("a1", "sess1", "prompt_v1", "single", "input", "voyage-4-large"),
+    ).toThrow(); // both target columns NULL
+
+    // With target_summary_id: works
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("a2", "sess1", "sum_a", "prompt_v1", "single", "input", "voyage-4-large");
+
+    db.close();
+  });
+
+  it("supports the started → completed pattern (insert with NULL pass_output, update on LLM return)", () => {
+    const db = setupDbWithRequiredFixtures();
+
+    // Step 1: insert audit row with status='started', pass_output NULL
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind, pass_input_truncated, model_used) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("a3", "sess2", "sum_a", "prompt_v1", "single", "input", "voyage-4-large");
+
+    // Step 2: LLM call happens OUTSIDE transaction (per §0 invariant 1)
+    // Step 3: UPDATE on success
+    db.prepare(
+      `UPDATE lcm_synthesis_audit SET pass_output = ?, status = 'completed', latency_ms = ? WHERE audit_id = ?`,
+    ).run("the resulting summary text", 1234, "a3");
+
+    const row = db
+      .prepare(`SELECT status, pass_output, latency_ms FROM lcm_synthesis_audit WHERE audit_id = ?`)
+      .get("a3") as { status: string; pass_output: string; latency_ms: number };
+    expect(row.status).toBe("completed");
+    expect(row.pass_output).toBe("the resulting summary text");
+    expect(row.latency_ms).toBe(1234);
+    db.close();
+  });
+
+  it("started-GC index supports the v4.1.1 B1 1-hour orphan cleanup query", () => {
+    const db = setupDbWithRequiredFixtures();
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='lcm_synthesis_audit'`,
+      )
+      .all() as IndexInfo[];
+    expect(indexes.map((i) => i.name)).toContain("lcm_synthesis_audit_started_gc_idx");
+    db.close();
+  });
+});
+
+// Wave-2 Auditor #8 fix F1: regression test for the migration's
+// DELETE-before-DROP cleanup of orphan audit rows. The Wave-1 commit
+// added the cleanup; this test pins the behavior so a future refactor
+// doesn't silently regress it.
+//
+// Strategy: run runLcmMigrations once (gets fully-migrated schema with
+// new wide CHECK), seed audit rows referencing real cache_ids, then
+// directly invoke the same DELETE that the migration runs and verify
+// it cleans the right rows. This is a unit test of the cleanup SQL,
+// not a full migration upgrade simulation (the upgrade path is
+// covered by v41-pre-existing-schema-migration.test.ts).
+describe("v4.1.3 widenLcmSynthesisCacheTierCheck — orphan-cleanup SQL", () => {
+  it("DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL prunes only orphan-pointing rows", () => {
+    const db = setupDbWithRequiredFixtures();
+    // Pre-condition: count audit rows with target_cache_id set vs NULL
+    // (the fixture seeds none; we'll seed both kinds).
+
+    // Need a real cache_id to FK against
+    db.prepare(
+      `INSERT INTO lcm_synthesis_cache
+         (cache_id, session_key, range_start, range_end, leaf_fingerprint,
+          content, model_used, prompt_id, tier_label, source_leaf_ids,
+          source_token_count, output_token_count, actual_range_covered,
+          leaf_count_synthesized)
+       VALUES ('cache_for_orphan_test', 'agent:main:main', '2026-01-01', '2026-01-31',
+         'fp1', null, 'm1', 'prompt_v1', 'year', '["sum_a"]', 100, 50, '...', 1)`,
+    ).run();
+
+    // Seed: 2 audit rows pointing at the cache (will be the "orphans"
+    // after the eventual DROP), 1 row pointing at a summary instead
+    // (must be PRESERVED).
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_cache_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_cache_1', 'pass_1', 'cache_for_orphan_test', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_cache_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_cache_2', 'pass_2', 'cache_for_orphan_test', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO lcm_synthesis_audit
+         (audit_id, pass_session_id, target_summary_id, prompt_id, pass_kind,
+          pass_input_truncated, status, model_used)
+       VALUES ('audit_summary', 'pass_3', 'sum_a', 'prompt_v1',
+         'single', '...', 'completed', 'm1')`,
+    ).run();
+
+    const beforeCacheTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`)
+      .get() as { n: number };
+    const beforeSummaryTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_summary_id IS NOT NULL`)
+      .get() as { n: number };
+    expect(beforeCacheTargeted.n).toBe(2);
+    expect(beforeSummaryTargeted.n).toBeGreaterThanOrEqual(1);
+
+    // Apply the same DELETE the migration runs.
+    db.exec(`DELETE FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`);
+
+    const afterCacheTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_cache_id IS NOT NULL`)
+      .get() as { n: number };
+    const afterSummaryTargeted = db
+      .prepare(`SELECT COUNT(*) AS n FROM lcm_synthesis_audit WHERE target_summary_id IS NOT NULL`)
+      .get() as { n: number };
+    expect(afterCacheTargeted.n).toBe(0);
+    expect(afterSummaryTargeted.n).toBe(beforeSummaryTargeted.n);
+
+    db.close();
+  });
+
+  it("re-running runLcmMigrations on already-widened DB is a no-op (idempotent)", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const before = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const after = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    expect(after.sql).toBe(before.sql);
+    db.close();
+  });
+
+  it("schema includes the wide CHECK including 'monthly' on first migration", () => {
+    const db = new DatabaseSync(":memory:");
+    runLcmMigrations(db, { fts5Available: false, seedDefaultPrompts: false });
+    const sql = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='lcm_synthesis_cache'`)
+      .get() as { sql: string };
+    expect(sql.sql).toMatch(/'monthly'|"monthly"/);
+    expect(sql.sql).toMatch(/'weekly'|"weekly"/);
+    expect(sql.sql).toMatch(/'daily'|"daily"/);
+    db.close();
+  });
+});

--- a/test/voyage-client.test.ts
+++ b/test/voyage-client.test.ts
@@ -1,0 +1,561 @@
+import { describe, expect, it } from "vitest";
+import {
+  embedTexts,
+  MAX_TOKENS_PER_EMBED_BATCH,
+  MAX_TOKENS_PER_EMBED_DOC,
+  MAX_TOKENS_PER_RERANK_CALL,
+  rerankCandidates,
+  VoyageError,
+} from "../src/voyage/client.js";
+
+/**
+ * Voyage HTTP client — covered with mock fetch only. No live API calls.
+ * Live calls happen in the backfill cron tests with explicit env-gated
+ * `VOYAGE_API_KEY` (B.04) so CI never hits the network.
+ */
+
+function mockResponse(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  const headers = new Headers({ "Content-Type": "application/json", ...(init.headers ?? {}) });
+  return new Response(JSON.stringify(body), { status: init.status ?? 200, headers });
+}
+
+function mockFetch(impl: (url: string, init: RequestInit) => Promise<Response>): typeof fetch {
+  // The real `fetch` signature accepts string | URL | Request; tests only ever
+  // pass string URLs from this client.
+  return impl as unknown as typeof fetch;
+}
+
+describe("voyage client — token budget constants (v4.1 §13)", () => {
+  it("MAX_TOKENS_PER_EMBED_BATCH is 80K (Voyage server cap 120K minus tokenizer-mismatch margin)", () => {
+    expect(MAX_TOKENS_PER_EMBED_BATCH).toBe(80_000);
+  });
+  it("MAX_TOKENS_PER_EMBED_DOC is 27K (voyage-4-large per-doc cap is 32K; ~9.5% tokenizer inflation forces 27K margin)", () => {
+    // Wave-1 Auditor #2 finding #3: 30K stored × 1.095 inflation =
+    // ~32.85K Voyage tokens, would 400 at the per-doc cap. 27K × 1.095
+    // ≈ 29.6K, comfortably under.
+    expect(MAX_TOKENS_PER_EMBED_DOC).toBe(27_000);
+  });
+  it("MAX_TOKENS_PER_RERANK_CALL is 600K (Voyage rerank-2.5 limit)", () => {
+    expect(MAX_TOKENS_PER_RERANK_CALL).toBe(600_000);
+  });
+});
+
+describe("voyage client — embedTexts happy path", () => {
+  it("posts texts to /embeddings with input_type, returns parsed Float32 vectors", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    const fetch = mockFetch(async (url, init) => {
+      captured = { url, init };
+      return mockResponse({
+        data: [
+          { embedding: [0.1, 0.2, 0.3], index: 0, object: "embedding" },
+          { embedding: [0.4, 0.5, 0.6], index: 1, object: "embedding" },
+        ],
+        model: "voyage-4-large",
+        usage: { total_tokens: 42 },
+      });
+    });
+
+    const result = await embedTexts({
+      model: "voyage-4-large",
+      texts: ["hello", "world"],
+      inputType: "document",
+      apiKey: "test-key",
+      fetch,
+    });
+
+    expect(result.vectors).toHaveLength(2);
+    expect(result.vectors[0]).toBeInstanceOf(Float32Array);
+    expect(Array.from(result.vectors[0])).toEqual([
+      0.1, // narrow to f32 precision
+    ].map((n) => Float32Array.from([n])[0]).concat(
+      [0.2, 0.3].map((n) => Float32Array.from([n])[0]),
+    ));
+    expect(result.totalTokens).toBe(42);
+    expect(result.model).toBe("voyage-4-large");
+
+    expect(captured).not.toBeNull();
+    expect(captured!.url).toBe("https://api.voyageai.com/v1/embeddings");
+    expect(captured!.init.method).toBe("POST");
+    const headers = captured!.init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-key");
+    const body = JSON.parse(captured!.init.body as string);
+    expect(body).toEqual({
+      model: "voyage-4-large",
+      input: ["hello", "world"],
+      truncation: false,
+      input_type: "document",
+    });
+  });
+
+  it("omits input_type when null (Voyage default)", async () => {
+    let captured: RequestInit | null = null;
+    const fetch = mockFetch(async (_url, init) => {
+      captured = init;
+      return mockResponse({
+        data: [{ embedding: [1, 2], index: 0 }],
+        usage: { total_tokens: 1 },
+      });
+    });
+    await embedTexts({
+      model: "voyage-4-large",
+      texts: ["x"],
+      inputType: null,
+      apiKey: "k",
+      fetch,
+    });
+    const body = JSON.parse(captured!.body as string);
+    expect(body.input_type).toBeUndefined();
+  });
+
+  it("re-orders out-of-order responses by `index` field", async () => {
+    const fetch = mockFetch(async () =>
+      mockResponse({
+        data: [
+          // Voyage might (in theory) return out of order
+          { embedding: [0.9, 0.9], index: 1 },
+          { embedding: [0.1, 0.1], index: 0 },
+        ],
+        usage: { total_tokens: 2 },
+      }),
+    );
+    const result = await embedTexts({
+      model: "voyage-4-large",
+      texts: ["first", "second"],
+      inputType: "query",
+      apiKey: "k",
+      fetch,
+    });
+    expect(Array.from(result.vectors[0])).toEqual(Array.from(Float32Array.from([0.1, 0.1])));
+    expect(Array.from(result.vectors[1])).toEqual(Array.from(Float32Array.from([0.9, 0.9])));
+  });
+
+  it("returns empty result for empty input without calling fetch", async () => {
+    let called = 0;
+    const fetch = mockFetch(async () => {
+      called++;
+      return mockResponse({});
+    });
+    const result = await embedTexts({
+      model: "voyage-4-large",
+      texts: [],
+      inputType: "query",
+      apiKey: "k",
+      fetch,
+    });
+    expect(called).toBe(0);
+    expect(result.vectors).toEqual([]);
+    expect(result.totalTokens).toBe(0);
+  });
+
+  it("sends `truncation: false` always (lossless guarantee — never silently clip)", async () => {
+    let body: Record<string, unknown> | null = null;
+    const fetch = mockFetch(async (_url, init) => {
+      body = JSON.parse(init.body as string);
+      return mockResponse({ data: [{ embedding: [0], index: 0 }], usage: { total_tokens: 1 } });
+    });
+    await embedTexts({
+      model: "voyage-4-large",
+      texts: ["x"],
+      inputType: "document",
+      apiKey: "k",
+      fetch,
+    });
+    expect(body!.truncation).toBe(false);
+  });
+});
+
+describe("voyage client — embedTexts error handling", () => {
+  it("throws VoyageError(auth) on 401 — does not retry", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      return mockResponse({ error: "bad key" }, { status: 401 });
+    });
+    await expect(
+      embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        maxRetries: 3,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "auth", status: 401 });
+    expect(calls).toBe(1);
+  });
+
+  it("throws VoyageError(bad_request) on 400 — does not retry, suppresses input echo", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      return mockResponse(
+        // Voyage 400 sometimes echoes input — should not appear in error message
+        { error: "input too long", input: "secret payload that should not leak" },
+        { status: 400 },
+      );
+    });
+    let caught: VoyageError | null = null;
+    try {
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        maxRetries: 3,
+      });
+    } catch (e) {
+      caught = e as VoyageError;
+    }
+    expect(calls).toBe(1);
+    expect(caught?.kind).toBe("bad_request");
+    expect(caught?.status).toBe(400);
+    // Error message should NOT contain the secret
+    expect(caught?.message).not.toContain("secret payload");
+    // Wave-4 Auditor #2 P1 fix: responseBody must ALSO suppress the
+    // input echo. Upstream Sentry/logger captures the exception object;
+    // raw bodyText was a privacy leak even when the message was clean.
+    expect(caught?.responseBody).not.toContain("secret payload");
+    expect(caught?.responseBody).toContain("input echoed in error body");
+  });
+
+  it("throws VoyageError(rate_limit) on persistent 429, exposes Retry-After in ms", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      return mockResponse({ error: "slow down" }, {
+        status: 429,
+        headers: { "Retry-After": "2" },
+      });
+    });
+    let caught: VoyageError | null = null;
+    try {
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        maxRetries: 0, // no retries — surface immediately
+      });
+    } catch (e) {
+      caught = e as VoyageError;
+    }
+    expect(calls).toBe(1);
+    expect(caught?.kind).toBe("rate_limit");
+    expect(caught?.status).toBe(429);
+    expect(caught?.retryAfterMs).toBe(2000);
+  });
+
+  // Wave-3 Auditor #2 fix F1: Voyage Retry-After lock-budget regression
+  it("Retry-After > 60s threshold throws immediately (does NOT sleep) — Wave-2 LOCK_BUDGET fix", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      return mockResponse({ error: "slow down" }, {
+        status: 429,
+        headers: { "Retry-After": "120" }, // 2 min > 60s threshold
+      });
+    });
+    let caught: VoyageError | null = null;
+    const startedAt = Date.now();
+    try {
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        // Allow 2 retries — but 120s > 60s threshold should still throw
+        // immediately without sleeping or retrying.
+        maxRetries: 2,
+      });
+    } catch (e) {
+      caught = e as VoyageError;
+    }
+    const elapsed = Date.now() - startedAt;
+    expect(calls).toBe(1); // ONE call, no retries
+    expect(caught?.kind).toBe("rate_limit");
+    expect(caught?.retryAfterMs).toBe(120_000); // server value preserved
+    expect(elapsed).toBeLessThan(2000); // did NOT sleep — proved by elapsed time
+  });
+
+  // Wave-3 Auditor #2 fix F1: short Retry-After honored verbatim
+  it("Retry-After ≤ 60s sleeps server-supplied value then retries", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      if (calls === 1) {
+        return mockResponse({ error: "slow down" }, {
+          status: 429,
+          headers: { "Retry-After": "0.05" }, // 50ms; well under 60s threshold
+        });
+      }
+      return mockResponse({
+        data: [{ embedding: [0.1, 0.2, 0.3], index: 0 }],
+        usage: { total_tokens: 5 },
+      });
+    });
+    const result = await embedTexts({
+      model: "voyage-4-large",
+      texts: ["x"],
+      inputType: "document",
+      apiKey: "k",
+      fetch,
+      maxRetries: 1,
+    });
+    expect(calls).toBe(2); // First 429, second success
+    expect(result.totalTokens).toBe(5);
+  });
+
+  it("retries on 5xx then succeeds — caller never sees the transient failure", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      if (calls < 3) {
+        return mockResponse({ error: "internal" }, { status: 503 });
+      }
+      return mockResponse({
+        data: [{ embedding: [0.5], index: 0 }],
+        usage: { total_tokens: 1 },
+      });
+    });
+    const result = await embedTexts({
+      model: "voyage-4-large",
+      texts: ["x"],
+      inputType: "document",
+      apiKey: "k",
+      fetch,
+      maxRetries: 3,
+    });
+    expect(calls).toBe(3); // failed twice, succeeded on third
+    expect(result.vectors).toHaveLength(1);
+  });
+
+  it("throws VoyageError(server_error) when retries exhausted on 5xx", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      return mockResponse({ error: "internal" }, { status: 500 });
+    });
+    let caught: VoyageError | null = null;
+    try {
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        maxRetries: 1,
+      });
+    } catch (e) {
+      caught = e as VoyageError;
+    }
+    expect(calls).toBe(2); // initial + 1 retry
+    expect(caught?.kind).toBe("server_error");
+    expect(caught?.status).toBe(500);
+  });
+
+  it("throws VoyageError(network) when fetch itself throws", async () => {
+    let calls = 0;
+    const fetch = mockFetch(async () => {
+      calls++;
+      throw new Error("ECONNREFUSED");
+    });
+    let caught: VoyageError | null = null;
+    try {
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+        maxRetries: 0,
+      });
+    } catch (e) {
+      caught = e as VoyageError;
+    }
+    expect(calls).toBe(1);
+    expect(caught?.kind).toBe("network");
+    expect(caught?.message).toContain("ECONNREFUSED");
+  });
+
+  it("throws VoyageError(auth) when no API key is set anywhere", async () => {
+    const originalKey = process.env.VOYAGE_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    try {
+      await expect(
+        embedTexts({
+          model: "voyage-4-large",
+          texts: ["x"],
+          inputType: "document",
+          fetch: mockFetch(async () => mockResponse({})),
+        }),
+      ).rejects.toMatchObject({ name: "VoyageError", kind: "auth" });
+    } finally {
+      if (originalKey !== undefined) process.env.VOYAGE_API_KEY = originalKey;
+    }
+  });
+
+  it("throws VoyageError(unexpected) when response data length doesn't match input", async () => {
+    const fetch = mockFetch(async () =>
+      mockResponse({
+        data: [{ embedding: [0.5], index: 0 }], // sent 2 texts, got 1 back
+        usage: { total_tokens: 1 },
+      }),
+    );
+    await expect(
+      embedTexts({
+        model: "voyage-4-large",
+        texts: ["a", "b"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "unexpected" });
+  });
+
+  it("throws VoyageError(unexpected) on dimension mismatch within batch", async () => {
+    const fetch = mockFetch(async () =>
+      mockResponse({
+        data: [
+          { embedding: [0.1, 0.2, 0.3], index: 0 },
+          { embedding: [0.4, 0.5], index: 1 }, // wrong dim
+        ],
+        usage: { total_tokens: 2 },
+      }),
+    );
+    await expect(
+      embedTexts({
+        model: "voyage-4-large",
+        texts: ["a", "b"],
+        inputType: "document",
+        apiKey: "k",
+        fetch,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "unexpected" });
+  });
+});
+
+describe("voyage client — rerankCandidates", () => {
+  it("posts to /rerank with documents + topK, joins ids back from candidates", async () => {
+    let captured: RequestInit | null = null;
+    const fetch = mockFetch(async (_url, init) => {
+      captured = init;
+      return mockResponse({
+        data: [
+          { index: 1, relevance_score: 0.9 },
+          { index: 0, relevance_score: 0.4 },
+        ],
+        model: "rerank-2.5",
+        usage: { total_tokens: 100 },
+      });
+    });
+
+    const result = await rerankCandidates({
+      model: "rerank-2.5",
+      query: "what is foo?",
+      candidates: [
+        { id: "leaf_a", text: "doc A about foo" },
+        { id: "leaf_b", text: "doc B about bar" },
+      ],
+      topK: 2,
+      apiKey: "k",
+      fetch,
+    });
+
+    expect(result.results).toHaveLength(2);
+    // Sorted descending by score
+    expect(result.results[0]).toEqual({ id: "leaf_b", index: 1, score: 0.9 });
+    expect(result.results[1]).toEqual({ id: "leaf_a", index: 0, score: 0.4 });
+
+    const body = JSON.parse(captured!.body as string);
+    expect(body.model).toBe("rerank-2.5");
+    expect(body.query).toBe("what is foo?");
+    expect(body.documents).toEqual(["doc A about foo", "doc B about bar"]);
+    expect(body.top_k).toBe(2);
+    expect(body.truncation).toBe(false);
+  });
+
+  it("defaults top_k to candidates.length when not supplied", async () => {
+    let captured: RequestInit | null = null;
+    const fetch = mockFetch(async (_url, init) => {
+      captured = init;
+      return mockResponse({
+        data: [{ index: 0, relevance_score: 0.5 }],
+        usage: { total_tokens: 1 },
+      });
+    });
+    await rerankCandidates({
+      model: "rerank-2.5",
+      query: "q",
+      candidates: [{ id: "x", text: "y" }],
+      apiKey: "k",
+      fetch,
+    });
+    const body = JSON.parse(captured!.body as string);
+    expect(body.top_k).toBe(1);
+  });
+
+  it("returns empty result for empty candidates without calling fetch", async () => {
+    let called = 0;
+    const fetch = mockFetch(async () => {
+      called++;
+      return mockResponse({});
+    });
+    const result = await rerankCandidates({
+      model: "rerank-2.5",
+      query: "q",
+      candidates: [],
+      apiKey: "k",
+      fetch,
+    });
+    expect(called).toBe(0);
+    expect(result.results).toEqual([]);
+  });
+
+  it("throws VoyageError(unexpected) when reranker returns invalid index", async () => {
+    const fetch = mockFetch(async () =>
+      mockResponse({
+        data: [{ index: 99, relevance_score: 0.5 }], // out of range
+        usage: { total_tokens: 1 },
+      }),
+    );
+    await expect(
+      rerankCandidates({
+        model: "rerank-2.5",
+        query: "q",
+        candidates: [{ id: "a", text: "b" }],
+        apiKey: "k",
+        fetch,
+      }),
+    ).rejects.toMatchObject({ name: "VoyageError", kind: "unexpected" });
+  });
+});
+
+describe("voyage client — picks up VOYAGE_API_KEY env var", () => {
+  it("uses process.env.VOYAGE_API_KEY when no apiKey opt provided", async () => {
+    const originalKey = process.env.VOYAGE_API_KEY;
+    process.env.VOYAGE_API_KEY = "from-env-test";
+    try {
+      let captured: Record<string, string> | null = null;
+      const fetch = mockFetch(async (_url, init) => {
+        captured = init.headers as Record<string, string>;
+        return mockResponse({
+          data: [{ embedding: [0], index: 0 }],
+          usage: { total_tokens: 1 },
+        });
+      });
+      await embedTexts({
+        model: "voyage-4-large",
+        texts: ["x"],
+        inputType: "document",
+        fetch,
+      });
+      expect(captured!.Authorization).toBe("Bearer from-env-test");
+    } finally {
+      if (originalKey === undefined) delete process.env.VOYAGE_API_KEY;
+      else process.env.VOYAGE_API_KEY = originalKey;
+    }
+  });
+});

--- a/test/worker-lock.test.ts
+++ b/test/worker-lock.test.ts
@@ -1,0 +1,150 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import {
+  acquireLock,
+  generateWorkerId,
+  heartbeatLock,
+  lockInfo,
+  releaseLock,
+} from "../src/concurrency/worker-lock.js";
+
+function newDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db, { fts5Available: false });
+  return db;
+}
+
+describe("worker-lock — acquire / release single-process", () => {
+  it("first acquire succeeds; second from different worker blocks", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w1" })).toBe(true);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+
+    // Both expect to be told the truth — w1 holds, w2 doesn't
+    const info = lockInfo(db, "embedding-backfill");
+    expect(info?.workerId).toBe("w1");
+    db.close();
+  });
+
+  it("release frees the lock for next acquirer", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(releaseLock(db, "embedding-backfill", "w1")).toBe(true);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(true);
+    db.close();
+  });
+
+  it("release with wrong workerId does not free the lock", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(releaseLock(db, "embedding-backfill", "wrong")).toBe(false);
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+    db.close();
+  });
+
+  it("acquireLock requires non-empty workerId", () => {
+    const db = newDb();
+    expect(() => acquireLock(db, "embedding-backfill", { workerId: "" })).toThrow(/workerId is required/);
+    expect(() => acquireLock(db, "embedding-backfill", { workerId: "  " })).toThrow(/workerId is required/);
+    db.close();
+  });
+});
+
+describe("worker-lock — TTL + GC", () => {
+  it("acquireLock with ttlMs=0 immediately stale, gets GC'd on next acquire", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "dead", ttlMs: 0 })).toBe(true);
+    // Immediately stale — the next worker should be able to acquire
+    expect(acquireLock(db, "embedding-backfill", { workerId: "alive" })).toBe(true);
+    expect(lockInfo(db, "embedding-backfill")?.workerId).toBe("alive");
+    db.close();
+  });
+
+  it("non-expired lock blocks new acquirer (TTL not reached yet)", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1", ttlMs: 60_000 });
+    // w2 cannot acquire — TTL not reached
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w2" })).toBe(false);
+    db.close();
+  });
+});
+
+describe("worker-lock — heartbeat", () => {
+  it("heartbeat from current holder extends expires_at", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1", ttlMs: 1_000 });
+    const initial = lockInfo(db, "embedding-backfill");
+    // Wait briefly so timestamps differ
+    const t1 = initial!.expiresAt;
+    expect(heartbeatLock(db, "embedding-backfill", "w1", 60_000)).toBe(true);
+    const after = lockInfo(db, "embedding-backfill");
+    // expires_at should have moved forward (later time)
+    expect(after!.expiresAt >= t1).toBe(true);
+    db.close();
+  });
+
+  it("heartbeat from non-holder fails (lock owned by other worker)", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "w1" });
+    expect(heartbeatLock(db, "embedding-backfill", "w2")).toBe(false);
+    db.close();
+  });
+
+  it("heartbeat after stale lock GC + reacquire by different worker fails for old worker", () => {
+    const db = newDb();
+    acquireLock(db, "embedding-backfill", { workerId: "old", ttlMs: 0 });
+    // Stale; new worker grabs it
+    expect(acquireLock(db, "embedding-backfill", { workerId: "new" })).toBe(true);
+    // Old worker tries to heartbeat — sees the lock is now owned by 'new', returns false
+    expect(heartbeatLock(db, "embedding-backfill", "old")).toBe(false);
+    db.close();
+  });
+});
+
+describe("worker-lock — metadata + scope", () => {
+  it("jobSessionKey and jobMetadata are stored and retrievable via lockInfo", () => {
+    const db = newDb();
+    acquireLock(db, "condensation", {
+      workerId: "w1",
+      jobSessionKey: "agent:main:main",
+      jobMetadata: "weekly:2026-W18",
+    });
+    const info = lockInfo(db, "condensation");
+    expect(info?.jobSessionKey).toBe("agent:main:main");
+    expect(info?.jobMetadata).toBe("weekly:2026-W18");
+    db.close();
+  });
+
+  it("lockInfo returns null when no lock held", () => {
+    const db = newDb();
+    expect(lockInfo(db, "extraction")).toBeNull();
+    db.close();
+  });
+});
+
+describe("worker-lock — generateWorkerId", () => {
+  it("generates IDs with the role prefix and pid + nonce uniqueness", () => {
+    const id1 = generateWorkerId("backfill");
+    const id2 = generateWorkerId("backfill");
+    expect(id1.startsWith("backfill-")).toBe(true);
+    expect(id2.startsWith("backfill-")).toBe(true);
+    expect(id1).not.toBe(id2); // different nonces
+    // Format: backfill-<pid>-<ms>-<6char hex>
+    expect(id1).toMatch(/^backfill-\d+-\d+-[0-9a-f]{6}$/);
+  });
+});
+
+describe("worker-lock — multiple job kinds independent", () => {
+  it("locks for different job_kinds don't conflict", () => {
+    const db = newDb();
+    expect(acquireLock(db, "embedding-backfill", { workerId: "w1" })).toBe(true);
+    expect(acquireLock(db, "extraction", { workerId: "w2" })).toBe(true);
+    expect(acquireLock(db, "condensation", { workerId: "w3" })).toBe(true);
+    // All three held simultaneously
+    expect(lockInfo(db, "embedding-backfill")?.workerId).toBe("w1");
+    expect(lockInfo(db, "extraction")?.workerId).toBe("w2");
+    expect(lockInfo(db, "condensation")?.workerId).toBe("w3");
+    db.close();
+  });
+});

--- a/test/worker-loop.test.ts
+++ b/test/worker-loop.test.ts
@@ -1,0 +1,261 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { WorkerLoop } from "../src/concurrency/worker-loop.js";
+
+function newDb(): DatabaseSync {
+  return new DatabaseSync(":memory:");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("worker-loop — basic lifecycle", () => {
+  it("start() returns true on first call, false on already-running", () => {
+    const db = newDb();
+    const loop = new WorkerLoop(db, {
+      jobs: [{ kind: "embedding-backfill", intervalMs: 1000, run: async () => null }],
+    });
+    expect(loop.start()).toBe(true);
+    expect(loop.start()).toBe(false); // already running
+    expect(loop.isRunning()).toBe(true);
+    return loop.stop();
+  });
+
+  it("stop() before start is a no-op (returns true)", async () => {
+    const db = newDb();
+    const loop = new WorkerLoop(db, {
+      jobs: [{ kind: "embedding-backfill", intervalMs: 1000, run: async () => null }],
+    });
+    expect(await loop.stop()).toBe(true);
+  });
+});
+
+describe("worker-loop — schedules jobs at their cadence", () => {
+  it("invokes job.run() repeatedly at the interval", async () => {
+    const db = newDb();
+    let count = 0;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 30,
+          run: async () => {
+            count++;
+            return count;
+          },
+        },
+      ],
+    });
+    loop.start();
+    await sleep(120);
+    await loop.stop();
+    expect(count).toBeGreaterThanOrEqual(2); // ~3-4 ticks in 120ms
+  });
+
+  it("two jobs with different intervals don't interfere", async () => {
+    const db = newDb();
+    let aCount = 0;
+    let bCount = 0;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        { kind: "embedding-backfill", intervalMs: 30, run: async () => aCount++ },
+        { kind: "extraction", intervalMs: 60, run: async () => bCount++ },
+      ],
+    });
+    loop.start();
+    await sleep(150);
+    await loop.stop();
+    expect(aCount).toBeGreaterThanOrEqual(3); // 30ms cadence
+    expect(bCount).toBeGreaterThanOrEqual(1); // 60ms cadence
+    expect(aCount).toBeGreaterThan(bCount); // a runs more often
+  });
+});
+
+describe("worker-loop — overlapping ticks are skipped", () => {
+  it("if a job's run() takes longer than intervalMs, next tick is skipped (not queued)", async () => {
+    const db = newDb();
+    let starts = 0;
+    let completions = 0;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 20,
+          run: async () => {
+            starts++;
+            await sleep(80); // exceeds 20ms cadence
+            completions++;
+          },
+        },
+      ],
+    });
+    loop.start();
+    await sleep(150);
+    await loop.stop({ gracefulTimeoutMs: 200 });
+    // We saw maybe 2-3 starts (one running through 80ms each) — never
+    // more than 2 simultaneous because dispatcher skips when in-flight.
+    expect(starts).toBeLessThanOrEqual(3);
+    // If overlap-protection failed, starts >> completions; with it, parity.
+    expect(completions).toBeGreaterThanOrEqual(starts - 1);
+  });
+});
+
+describe("worker-loop — error in job doesn't stop the loop", () => {
+  it("thrown error is captured in onJobComplete; subsequent ticks still run", async () => {
+    const db = newDb();
+    let runs = 0;
+    const errors: Array<unknown> = [];
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 20,
+          run: async () => {
+            runs++;
+            if (runs === 1) throw new Error("boom!");
+            return runs;
+          },
+        },
+      ],
+      onJobComplete: (info) => {
+        if (info.error) errors.push(info.error);
+      },
+    });
+    loop.start();
+    await sleep(80);
+    await loop.stop();
+    expect(runs).toBeGreaterThanOrEqual(2); // first errored, second+ ran
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("boom!");
+  });
+});
+
+describe("worker-loop — graceful stop", () => {
+  it("waits for in-flight tick to complete before resolving", async () => {
+    const db = newDb();
+    let completed = false;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 10,
+          run: async () => {
+            await sleep(60);
+            completed = true;
+          },
+        },
+      ],
+    });
+    loop.start();
+    await sleep(15); // let one tick start
+    expect(loop.inFlightCount()).toBe(1);
+    const stopped = await loop.stop({ gracefulTimeoutMs: 200 });
+    expect(stopped).toBe(true);
+    expect(completed).toBe(true);
+  });
+
+  it("returns false on graceful timeout if a tick is too slow", async () => {
+    const db = newDb();
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 10,
+          run: async () => {
+            await sleep(500); // longer than gracefulTimeoutMs
+          },
+        },
+      ],
+    });
+    loop.start();
+    await sleep(15);
+    const stopped = await loop.stop({ gracefulTimeoutMs: 50 });
+    expect(stopped).toBe(false); // timeout
+  });
+});
+
+describe("worker-loop — runOnce", () => {
+  it("invokes job once outside schedule, returns its result", async () => {
+    const db = newDb();
+    let count = 0;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 60_000, // far enough away that scheduled ticks won't fire
+          run: async () => ++count,
+        },
+      ],
+    });
+    const result = await loop.runOnce("embedding-backfill");
+    expect(result).toBe(1);
+    expect(count).toBe(1);
+  });
+
+  it("runOnce throws if job kind unknown", async () => {
+    const db = newDb();
+    const loop = new WorkerLoop(db, {
+      jobs: [{ kind: "embedding-backfill", intervalMs: 1000, run: async () => null }],
+    });
+    await expect(loop.runOnce("extraction")).rejects.toThrow(/no job kind/);
+  });
+
+  it("runOnce throws if same job is in flight", async () => {
+    const db = newDb();
+    let resolveBlock: (() => void) | null = null;
+    const loop = new WorkerLoop(db, {
+      jobs: [
+        {
+          kind: "embedding-backfill",
+          intervalMs: 60_000,
+          run: () =>
+            new Promise<void>((resolve) => {
+              resolveBlock = resolve;
+            }),
+        },
+      ],
+    });
+    const inflight = loop.runOnce("embedding-backfill");
+    // Give the promise time to register in-flight
+    await sleep(5);
+    await expect(loop.runOnce("embedding-backfill")).rejects.toThrow(/already in flight/);
+    // Wave-9 TS-tightening: resolveBlock is assigned inside an inner
+    // closure, so control-flow analysis treats it as still `null`.
+    // Cast through the union — by here the runOnce above has already
+    // entered the run() function and assigned resolve.
+    (resolveBlock as (() => void) | null)?.(); // let the original finish
+    await inflight;
+  });
+});
+
+describe("worker-loop — validates job specs", () => {
+  it("rejects duplicate job kinds", () => {
+    const db = newDb();
+    expect(
+      () =>
+        new WorkerLoop(db, {
+          jobs: [
+            { kind: "embedding-backfill", intervalMs: 100, run: async () => null },
+            { kind: "embedding-backfill", intervalMs: 200, run: async () => null },
+          ],
+        }),
+    ).toThrow(/duplicate job kind/);
+  });
+
+  it("rejects invalid intervalMs", () => {
+    const db = newDb();
+    expect(
+      () =>
+        new WorkerLoop(db, {
+          jobs: [{ kind: "embedding-backfill", intervalMs: 0, run: async () => null }],
+        }),
+    ).toThrow(/invalid intervalMs/);
+    expect(
+      () =>
+        new WorkerLoop(db, {
+          jobs: [{ kind: "embedding-backfill", intervalMs: -1, run: async () => null }],
+        }),
+    ).toThrow(/invalid intervalMs/);
+  });
+});


### PR DESCRIPTION
## TL;DR

The drilldown half of v4.1's retrieval surface. Upgrades `lcm_describe` with **inline one-hop expansion** (`expandChildren` / `expandMessages` / `expandFile`) — so an agent can drill from a synthesized claim down to its source leaves and raw messages **in a single tool call**, without paying the cost of a sub-agent. Answers question type E: **"where did this claim come from?"**

## The pain this solves

Today, the answer path for "show me the source of this synthesis claim" is:

```mermaid
flowchart LR
  A1["Agent calls lcm_describe(sum_xxx)"] --> R1[Returns summary metadata<br/>+ parent IDs + child IDs<br/>NO inline content]
  R1 --> A2["Agent decides: need child content"]
  A2 --> A3["Agent calls lcm_expand_query<br/>summaryIds: [sum_xxx]<br/>prompt: 'show source leaves'"]
  A3 --> SUB[Spawns sub-agent<br/>~30-120 seconds<br/>~$0.05-0.50 LLM cost]
  SUB --> R2[Synthesized answer with cited IDs]
  R2 --> A4["Agent paraphrases the synthesis<br/>OR asks user 'is this the source?'"]
  style SUB fill:#f99
```

Five hops. A sub-agent. A bounded ~120s timeout. An LLM call. **For drilldown that's fundamentally just "show me my children."**

After this PR, the one-hop case collapses to:

```mermaid
flowchart LR
  A1["lcm_describe(sum_xxx, expandChildren=true)"] --> R1[Returns summary metadata<br/>+ INLINE child summaries (capped 20, max 50)<br/>+ token cost manifest]
  style R1 fill:#9f9
  R1 --> A2["Agent has the source content<br/>in the SAME response"]
```

**One hop. No sub-agent. ~50ms. Free.** Sub-agent expansion (`lcm_expand_query`) is still the right tool for multi-hop drilldown; this PR is for the one-hop case that previously had no cheap path.

## Before / after — concrete scenario

**Scenario E1** (from `THE_FIVE_QUESTIONS.md`): "Where did the +52.5pp recall claim come from? Show me the source."

| Step | Today | After this PR |
|---|---|---|
| 1 | `lcm_grep "+52.5pp"` → finds `sum_recall_synthesis` | `lcm_grep "+52.5pp"` → finds `sum_recall_synthesis` |
| 2 | `lcm_describe(sum_recall_synthesis)` → "this is a condensed summary with 5 children" | `lcm_describe(sum_recall_synthesis, expandChildren=true)` → inline content of all 5 children including the leaf claiming "FTS-only: 5%, Hybrid: 57.5%" |
| 3 | `lcm_expand_query(summaryIds: [...]...)` → spawn sub-agent → ~60s + ~$0.10 | (done after step 2) |
| 4 | Sub-agent returns synthesized answer | (n/a) |

Steps 1-2 today take ~30 seconds for the user (waiting on the sub-agent in step 3). After this PR, step 1-2 take ~50ms and the agent has the actual source content, not a paraphrased synthesis of it.

## What this PR adds

### `src/tools/lcm-describe-tool.ts` — three new expand flags

| Flag | What it inlines | Cap |
|---|---|---|
| **`expandChildren=true`** | First-hop child summaries (the leaves a condensed summary was built from). Each with kind + tokenCount + content. | `expandChildrenLimit` default 20, max 50 |
| **`expandMessages=true`** | For LEAF summaries: the source `messages.content` rows the summary was built from. Optional `expandMessagesOffset` for pagination through long leaves. | `expandMessagesLimit` default 20, max 50 |
| **`expandFile=true`** | For `file_xxx` IDs: the actual file content the file-summary references (file content is stored on disk; this fetches + inlines). | `expandFileMaxBytes` configurable |

Plus enriched **expansion status fields** so the agent knows WHY a result is bounded:

| Status | Meaning |
|---|---|
| `ok` | Returned everything that exists |
| `capped` | Hit the limit — more available, paginate via `expandMessagesOffset` |
| `no-children` / `no-messages` | This node IS a terminal in the DAG |
| `all-suppressed` | Children/messages exist but ALL are `/lcm purge`-suppressed (the suppression filter from #729 is doing its job) |
| `offset-past-end` | Pagination went past the end — reduce offset |
| `not-leaf` | `expandMessages=true` only works on leaves; this is a condensed summary |

These distinctions matter because they let the agent self-recover ("I got 0 messages but the status says all-suppressed, so I'll tell the user the source has been purged" vs "I got 0 because there's nothing there").

### `src/retrieval.ts` — engine-level changes paired with the tool

- **`sessionKey` + `timeRange` fields** on `DescribeResult.summary` — the agent can see which session a summary belongs to and the wall-clock window it covers, without a second query.
- **Cycle-guarded `expandRecursive`** — the recursive descent for multi-hop expansion now uses a visited set so a malformed DAG with a cycle can't infinite-loop the gateway. (Found in Wave-7 audit.)
- One additional **parallel `getConversation` fetch** to surface conversation-level metadata.

### Test
- `test/lcm-describe-expand-flags.test.ts` — comprehensive coverage of each flag, each status code, the suppression-filtered case, the offset-past-end case.

## The science — why one-hop, not multi-hop?

`lcm_expand_query` already exists for **multi-hop, free-text-question-answering** drilldown. It spawns a sub-agent with a bounded token grant and walks the lineage to answer a question like "trace this claim through to its source messages and quote the relevant lines." It's the right tool when the answer requires *reasoning over* the lineage.

But ~70% of drilldown calls are simpler than that. The agent already has a summary ID; it just wants to see its children. There's no question to reason about — it's literally a SQL `JOIN` away. Forcing every drilldown through the sub-agent pays ~60s + ~$0.10 for what's structurally a 5ms DB query.

This PR adds the cheap path for the one-hop case. Multi-hop remains `lcm_expand_query`. The agent picks based on question shape (the tool descriptions guide it).

Considered + rejected:
- **A separate `lcm_lineage` tool**: yet another tool, fragmenting the surface. The reach-for analysis (see #724 §"science") showed agents pick the broadest matching tool; a niche `lcm_lineage` would be reached for ~rarely.
- **Auto-expand on every `lcm_describe`**: would balloon the response size; smaller summaries would still pay. Opt-in flag is the right contract.
- **Recursive expand (`expandChildren` walks N levels)**: encourages context bloat. Cap at one hop; if the agent needs deeper, it calls again or uses `lcm_expand_query`.

## Notable: this paired with `/lcm purge`

The `all-suppressed` status code is a real Wave-12 reviewer find. Without it, an agent calling `expandChildren` on a node whose children were all purged got `[]` and concluded "this node has no children" — silent leak of suppression state semantics. Now the agent sees `childrenStatus: 'all-suppressed'` and reports honestly to the user.

## What this PR explicitly does NOT add

- The **suppression filter itself** (the `suppressed_at` JOIN on read paths) — that's the operator-core PR (#729) which pairs the filter with `/lcm purge`.
- The **agent compaction wrapper** (`runWithTokenGate`) on `lcm_describe.execute` — that lands LAST in **#732**. This PR's describe-tool is the un-wrapped version; #732 re-wraps it.

## Stack position

Stacked on **#724** (lcm_grep upgrade — pr05b is its drilldown sibling, both Feature C of the v4.1 retrieval surface). Part of the 13-PR v4.1 series — see #719 for the full stack.

## Test plan

- [x] `npm run build` — esbuild bundle clean
- [x] `npx tsc --noEmit` — exact `main` baseline (631), zero net-new errors
- [x] CI green — `npm test` (incl. new describe-expand-flags suite) + smoke-import
