### PR TITLE
fix(engine): demote ENOENT during afterTurn checkpoint refresh to debug

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7095,6 +7095,12 @@ export class LcmContextEngine implements ContextEngine {
           sessionFile: params.sessionFile,
         });
       } catch (err) {
+        if (isMissingFileError(err)) {
+          this.deps.log.debug(
+            `[lcm] afterTurn: bootstrap checkpoint refresh skipped (session file missing) for ${sessionLabel} sessionFile=${params.sessionFile}`,
+          );
+          return;
+        }
         this.deps.log.warn(
           `[lcm] afterTurn: bootstrap checkpoint refresh failed for ${sessionLabel}: ${describeLogError(err)}`,
         );


### PR DESCRIPTION
## Summary

Demote the `[lcm] afterTurn: bootstrap checkpoint refresh failed` warn to debug when the underlying failure is ENOENT/ENOTDIR (the session jsonl file is not where lossless-claw expects it). Other failure modes (DB writes, unexpected stat errors) continue to surface as warn.

## Why this matters

#609 reports the warn firing once per turn under OpenClaw `2026.5.3+`, `lossless-claw@0.9.2` through `0.9.4`. @holgergruenhagen's follow-ups confirm reproductions on `2026.5.7` and `2026.5.12`, including a six-warning sequence triggered by `/new` and an Active Memory variant. The issue's own description calls it cosmetic: compaction and summary handle the missing transcript on their own, so the only effect is log noise.

`isMissingFileError` already exists at `src/engine.ts:232` and is used by the bootstrap path one screen up to short-circuit identical "session file not where we expect" cases without warning. Reusing it inside `refreshAfterTurnBootstrapState`'s catch keeps the demotion logic consistent with the surrounding code: ENOENT/ENOTDIR falls to a debug line that names the missing path so operators can still trace it if they crank log verbosity up, and any other thrown error continues through the existing warn path.

No behaviour change beyond log level: `refreshBootstrapState` was already a fail-open call from the afterTurn perspective (the catch swallows the error either way), so demoting the missing-file branch does not change which followups run.

## Testing

- `npm test` reports 923/923 passing.
- `npm run build` succeeds (the change touches only the afterTurn catch block).

Closes #609
