### PR TITLE
fix: declare context engine host requirements

### DIFF
--- a/.changeset/host-capability-crash.md
+++ b/.changeset/host-capability-crash.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare the OpenClaw context-engine host capability requirement so unsupported CLI harnesses fail with a descriptive error.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,15 @@
 
 Lossless-claw reads plugin configuration from `plugins.entries.lossless-claw.config`.
 
+Lossless-claw requires OpenClaw `2026.5.19` or newer so the host can enforce
+context-engine runtime capabilities before an agent run starts. Agent runs need
+a native host that provides the full context-engine lifecycle: session bootstrap,
+pre-prompt assembly, after-turn ingestion, maintenance, compaction, and runtime
+LLM completion. Native Codex and Pi embedded runs provide those capabilities;
+generic CLI harnesses such as `claude-cli` and `codex-cli` do not. If you must
+use a generic CLI harness, set `plugins.slots.contextEngine` to `legacy` for
+that run instead of `lossless-claw`.
+
 Configuration precedence is:
 
 1. Environment variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Lossless-claw reads plugin configuration from `plugins.entries.lossless-claw.config`.
 
-Lossless-claw requires OpenClaw `2026.5.19` or newer so the host can enforce
+Lossless-claw requires OpenClaw `2026.5.22` or newer so the host can enforce
 context-engine runtime capabilities before an agent run starts. Agent runs need
 a native host that provides the full context-engine lifecycle: session bootstrap,
 pre-prompt assembly, after-turn ingestion, maintenance, compaction, and runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.10.0",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.10.0",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": ">=0.74 <1",
@@ -22,7 +22,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.12"
+        "openclaw": ">=2026.5.19"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.19"
+        "openclaw": ">=2026.5.22"
       },
       "peerDependenciesMeta": {
         "openclaw": {
@@ -3116,7 +3116,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3687,7 +3687,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -3961,7 +3961,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4153,7 +4153,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -4373,7 +4373,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -4389,7 +4389,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -4427,7 +4427,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4459,7 +4459,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4950,14 +4950,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5317,7 +5317,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-algebra": {
@@ -6035,14 +6035,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.19"
+    "openclaw": ">=2026.5.22"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -61,14 +61,14 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.19",
-      "minGatewayVersion": "2026.5.19",
+      "pluginApi": ">=2026.5.22",
+      "minGatewayVersion": "2026.5.22",
       "tested": [
-        "2026.5.19"
+        "2026.5.22"
       ]
     },
     "build": {
-      "openclawVersion": "2026.5.19"
+      "openclawVersion": "2026.5.22"
     }
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.12"
+    "openclaw": ">=2026.5.19"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -61,14 +61,14 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.12",
-      "minGatewayVersion": "2026.5.12",
+      "pluginApi": ">=2026.5.19",
+      "minGatewayVersion": "2026.5.19",
       "tested": [
-        "2026.5.12"
+        "2026.5.19"
       ]
     },
     "build": {
-      "openclawVersion": "2026.5.12"
+      "openclawVersion": "2026.5.19"
     }
   },
   "repository": {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
   ContextEngine,
   ContextEngineInfo,
+  ContextEngineHostCapability,
   AssembleResult,
   BootstrapResult,
   CompactResult,
@@ -78,6 +79,15 @@ import {
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
+
+const LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
+  "bootstrap",
+  "assemble-before-prompt",
+  "after-turn",
+  "maintain",
+  "compact",
+  "runtime-llm-complete",
+];
 type AssemblePrefixSnapshot = {
   serializedMessages: string[];
   messageSummaries: string[];
@@ -2896,6 +2906,15 @@ export class LcmContextEngine implements ContextEngine {
       version: "0.1.0",
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
+      hostRequirements: {
+        "agent-run": {
+          requiredCapabilities: LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
+          unsupportedMessage: [
+            "lossless-claw requires a native OpenClaw runtime with the full context-engine agent-run lifecycle.",
+            "Use the native Codex or Pi embedded runtime, or switch plugins.slots.contextEngine to legacy for CLI harness runs.",
+          ].join(" "),
+        },
+      },
     } as ContextEngineInfo;
 
     this.conversationStore = new ConversationStore(this.db, {

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -58,6 +58,23 @@ export type ContextEngineInfo = {
   version: string;
   ownsCompaction?: boolean;
   turnMaintenanceMode?: "background" | "inline" | string;
+  hostRequirements?: Partial<Record<ContextEngineOperation, ContextEngineHostRequirements>>;
+};
+
+export type ContextEngineOperation = "agent-run" | "manual-compact" | "subagent-spawn";
+
+export type ContextEngineHostCapability =
+  | "bootstrap"
+  | "assemble-before-prompt"
+  | "after-turn"
+  | "maintain"
+  | "compact"
+  | "runtime-llm-complete"
+  | "thread-bootstrap-projection";
+
+export type ContextEngineHostRequirements = {
+  requiredCapabilities: ContextEngineHostCapability[];
+  unsupportedMessage?: string;
 };
 
 export type PluginCommandContext = {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -340,6 +340,21 @@ describe("LcmContextEngine metadata", () => {
     expect(engine.info.ownsCompaction).toBe(true);
   });
 
+  it("requires the full native host lifecycle for agent runs", () => {
+    const engine = createEngine();
+    expect(engine.info.hostRequirements?.["agent-run"]).toEqual({
+      requiredCapabilities: [
+        "bootstrap",
+        "assemble-before-prompt",
+        "after-turn",
+        "maintain",
+        "compact",
+        "runtime-llm-complete",
+      ],
+      unsupportedMessage: expect.stringContaining("native Codex or Pi embedded runtime"),
+    });
+  });
+
   it("configures file-backed sqlite connections with WAL and busy_timeout", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-db-"));
     tempDirs.push(tempDir);

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import packageJson from "../package.json" with { type: "json" };
 
 describe("package OpenClaw compatibility metadata", () => {
-  it("declares the runtime.llm.complete minimum OpenClaw version without an upper bound", () => {
-    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.12");
-    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.12");
-    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.12");
-    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.12"]);
-    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.12");
+  it("declares the context-engine host requirements minimum OpenClaw version without an upper bound", () => {
+    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.19");
+    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.19");
+    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.19");
+    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.19"]);
+    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.19");
   });
 });

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -3,10 +3,10 @@ import packageJson from "../package.json" with { type: "json" };
 
 describe("package OpenClaw compatibility metadata", () => {
   it("declares the context-engine host requirements minimum OpenClaw version without an upper bound", () => {
-    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.19");
-    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.19");
-    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.19");
-    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.19"]);
-    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.19");
+    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.22");
+    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.22");
+    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.22");
+    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.22"]);
+    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.22");
   });
 });


### PR DESCRIPTION
## What
Declares that lossless-claw requires OpenClaw agent runtimes that assemble context before prompt construction, and updates package metadata/docs to require the first stable OpenClaw release that contains that host-compatibility contract.

## Why
Generic CLI harnesses like claude-cli and legacy codex-cli do not project lossless-claw assembled context into the model prompt, so they should fail with a descriptive compatibility error instead of silently running with degraded context.

## Changes
- Added agent-run host requirement
- Required OpenClaw 2026.5.22
- Updated OpenClaw compatibility metadata
- Documented CLI harness fallback
- Added regression coverage
- Added patch changeset

## Release Verification
- OpenClaw PR `openclaw/openclaw#84994` merged as `cff5244a5b25a8e9fc76fb51dd5915a5a8f3eda6`.
- `git merge-base --is-ancestor cff5244a5b25a8e9fc76fb51dd5915a5a8f3eda6 v2026.5.22` passed.
- `git merge-base --is-ancestor cff5244a5b25a8e9fc76fb51dd5915a5a8f3eda6 v2026.5.20` failed, confirming 2026.5.20 does not contain it.
- GitHub Releases lists `v2026.5.22` as stable and published.
- npm `openclaw` latest is `2026.5.22`.

## Testing
- `npx vitest run test/engine.test.ts test/package-metadata.test.ts` - passed, 2 files / 234 tests.
- `npm run build` - passed.
- `npm install --package-lock-only` - passed.
- `npm ci --package-lock-only --ignore-scripts` - passed.
- `git diff --check` - passed.

## Real Behavior Proof
- Scenario: lossless-claw declares `agent-run.requiredCapabilities = ["assemble-before-prompt"]`.
- Command/path exercised: package metadata regression coverage and OpenClaw live gateway startup on the companion host-compatibility PR branch.
- Observed result: OpenClaw 2026.5.22 includes the host contract that accepts native Codex and Pi embedded runtimes, rejects unsupported CLI-style hosts with a descriptive missing-capability error, and lets lossless-claw require that behavior in published package metadata.
