### PR TITLE
fix: populate systemPromptAddition from host memory supplements in context engine assemble()

### DIFF
--- a/.changeset/context-engine-memory-supplements.md
+++ b/.changeset/context-engine-memory-supplements.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Require OpenClaw 2026.5.28 so context-engine assembly can include host memory supplements.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The bundled skill focuses on configuration, diagnostics, architecture, and recal
 - Node.js 22+
 - An LLM provider configured in OpenClaw (used for summarization)
 
-> **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer. These releases call OpenClaw's `api.runtime.llm.complete` capability for summarization, which is unavailable in older OpenClaw builds. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
+> **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer for OpenClaw's `api.runtime.llm.complete` summarization capability. Releases that include context-engine memory supplement support require OpenClaw `2026.5.28` or newer for `buildMemorySystemPromptAddition`. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
 
 ### Install the plugin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.11.3",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": ">=0.74 <1",
@@ -22,7 +22,7 @@
         "vitest": "^3.0.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.22"
+        "openclaw": ">=2026.5.28"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vitest": "^3.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.22"
+    "openclaw": ">=2026.5.28"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -63,14 +63,14 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.5.22",
-      "minGatewayVersion": "2026.5.22",
+      "pluginApi": ">=2026.5.28",
+      "minGatewayVersion": "2026.5.28",
       "tested": [
-        "2026.5.22"
+        "2026.5.28"
       ]
     },
     "build": {
-      "openclawVersion": "2026.5.22"
+      "openclawVersion": "2026.5.28"
     }
   },
   "repository": {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -7,7 +7,12 @@
 import { join } from "node:path";
 import { writeFile } from "node:fs/promises";
 import type { DatabaseSync } from "node:sqlite";
-import type { ContextEngineFactory, OpenClawPluginApi } from "../openclaw-bridge.js";
+import type {
+  AssembleResult,
+  ContextEngine,
+  ContextEngineFactory,
+  OpenClawPluginApi,
+} from "../openclaw-bridge.js";
 import { resolveLcmConfigWithDiagnostics, resolveOpenclawStateDir } from "../db/config.js";
 import type { LcmConfig } from "../db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection, normalizePath } from "../db/connection.js";
@@ -28,7 +33,7 @@ import type {
   StartupSessionFileCandidate,
 } from "../types.js";
 
-const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.22";
+const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.28";
 
 type ContextEngineCapableOpenClawPluginApi = OpenClawPluginApi & {
   registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
@@ -90,6 +95,122 @@ type RuntimeConfigSnapshotApi = {
   current?: () => unknown;
   loadConfig?: () => unknown;
 };
+
+type MemorySupplementAssembleParams = Parameters<ContextEngine["assemble"]>[0] & {
+  availableTools?: Set<string>;
+  citationsMode?: string;
+};
+
+type BuildMemorySystemPromptAddition = (params: {
+  availableTools: Set<string>;
+  citationsMode?: string;
+}) => string | undefined;
+
+type MemorySupplementModule = {
+  buildMemorySystemPromptAddition?: unknown;
+};
+
+let buildMemorySystemPromptAdditionPromise:
+  | Promise<BuildMemorySystemPromptAddition>
+  | undefined;
+
+/** Return the OpenClaw helper that renders active memory supplements for context engines. */
+async function loadBuildMemorySystemPromptAddition(): Promise<BuildMemorySystemPromptAddition> {
+  buildMemorySystemPromptAdditionPromise ??= loadBuildMemorySystemPromptAdditionModule();
+  return buildMemorySystemPromptAdditionPromise;
+}
+
+/** Import the memory prompt helper from the supported OpenClaw SDK surface. */
+async function loadBuildMemorySystemPromptAdditionModule(): Promise<BuildMemorySystemPromptAddition> {
+  const importErrors: unknown[] = [];
+  for (const modulePath of ["openclaw/plugin-sdk/core", "openclaw/plugin-sdk"]) {
+    try {
+      const mod = (await import(modulePath)) as MemorySupplementModule;
+      if (typeof mod.buildMemorySystemPromptAddition === "function") {
+        return mod.buildMemorySystemPromptAddition as BuildMemorySystemPromptAddition;
+      }
+    } catch (error) {
+      importErrors.push(error);
+    }
+  }
+  throw new Error(
+    "[lcm] OpenClaw buildMemorySystemPromptAddition is unavailable; install OpenClaw >=2026.5.28.",
+    { cause: importErrors[0] },
+  );
+}
+
+/** Delegate to the LCM engine while adding host memory supplements to assemble() results. */
+class MemorySupplementContextEngine implements ContextEngine {
+  readonly info: ContextEngine["info"];
+  readonly ingestBatch: ContextEngine["ingestBatch"];
+  readonly prepareSubagentSpawn: ContextEngine["prepareSubagentSpawn"];
+  readonly onSubagentEnded: ContextEngine["onSubagentEnded"];
+
+  constructor(private readonly inner: ContextEngine) {
+    const ingestBatch = inner.ingestBatch?.bind(inner);
+    const prepareSubagentSpawn = inner.prepareSubagentSpawn?.bind(inner);
+    const onSubagentEnded = inner.onSubagentEnded?.bind(inner);
+    this.info = inner.info;
+    this.ingestBatch = ingestBatch ? (params) => ingestBatch(params) : undefined;
+    this.prepareSubagentSpawn = prepareSubagentSpawn
+      ? (params) => prepareSubagentSpawn(params)
+      : undefined;
+    this.onSubagentEnded = onSubagentEnded ? (params) => onSubagentEnded(params) : undefined;
+  }
+
+  get config(): unknown {
+    return (this.inner as unknown as { config?: unknown }).config;
+  }
+
+  get deps(): unknown {
+    return (this.inner as unknown as { deps?: unknown }).deps;
+  }
+
+  getConversationStore(): unknown {
+    const getConversationStore = (this.inner as unknown as {
+      getConversationStore?: () => unknown;
+    }).getConversationStore;
+    if (!getConversationStore) {
+      throw new TypeError("getConversationStore is not available on the wrapped context engine");
+    }
+    return getConversationStore.call(this.inner);
+  }
+
+  getSummaryStore(): unknown {
+    const getSummaryStore = (this.inner as unknown as {
+      getSummaryStore?: () => unknown;
+    }).getSummaryStore;
+    if (!getSummaryStore) {
+      throw new TypeError("getSummaryStore is not available on the wrapped context engine");
+    }
+    return getSummaryStore.call(this.inner);
+  }
+
+  bootstrap(params: Parameters<ContextEngine["bootstrap"]>[0]) {
+    return this.inner.bootstrap(params);
+  }
+
+  ingest(params: Parameters<ContextEngine["ingest"]>[0]) {
+    return this.inner.ingest(params);
+  }
+
+  compact(params: Parameters<ContextEngine["compact"]>[0]) {
+    return this.inner.compact(params);
+  }
+
+  async assemble(params: MemorySupplementAssembleParams): Promise<AssembleResult> {
+    const result = await this.inner.assemble(params);
+    if (result.systemPromptAddition) {
+      return result;
+    }
+    const buildMemorySystemPromptAddition = await loadBuildMemorySystemPromptAddition();
+    const systemPromptAddition = buildMemorySystemPromptAddition({
+      availableTools: params.availableTools ?? new Set(),
+      citationsMode: params.citationsMode,
+    });
+    return systemPromptAddition ? { ...result, systemPromptAddition } : result;
+  }
+}
 
 /** Read the host runtime config snapshot without using deprecated APIs on newer hosts. */
 function readRuntimeConfigSnapshot(api: OpenClawPluginApi): unknown {
@@ -1461,55 +1582,11 @@ function wirePluginHandlers(
     });
   });
 
-  // Fix: Ensure host memory supplements (wiki digest, etc.) are included in assembled context.
-  // When lossless-claw is the active context engine, OpenClaw delegates prompt assembly entirely
-  // to the engine. Without this wrapper, buildMemorySystemPromptAddition() is never called and
-  // registered memory supplements are silently dropped from the prompt.
   api.registerContextEngine("lossless-claw", () => {
-    type BuildMemoryFn = (params: { availableTools: Set<string>; citationsMode?: string }) => string | undefined;
-    let _buildMemoryAddition: BuildMemoryFn | false | null = null;
-
-    async function ensureBuildMemoryAddition(): Promise<BuildMemoryFn | false> {
-      if (_buildMemoryAddition !== null) return _buildMemoryAddition;
-      try {
-        // openclaw is a peer dependency; plugin-sdk/core exports buildMemorySystemPromptAddition
-        const mod = await import("openclaw/plugin-sdk/core");
-        _buildMemoryAddition = (mod as any).buildMemorySystemPromptAddition ?? false;
-      } catch {
-        try {
-          const mod = await import("openclaw/plugin-sdk");
-          _buildMemoryAddition = (mod as any).buildMemorySystemPromptAddition ?? false;
-        } catch {
-          _buildMemoryAddition = false;
-        }
-      }
-      return _buildMemoryAddition;
-    }
-
-    function wrapEngineWithMemorySupplements<T extends { assemble: (...args: any[]) => any }>(engine: T): T {
-      if ((engine as any)._lcmMemorySupplementPatched) return engine;
-      const originalAssemble = engine.assemble.bind(engine);
-      (engine as any).assemble = async (params: any) => {
-        const result = await originalAssemble(params);
-        if (!result.systemPromptAddition) {
-          const builder = await ensureBuildMemoryAddition();
-          if (builder) {
-            const addition = builder({
-              availableTools: params.availableTools ?? new Set(),
-              citationsMode: params.citationsMode,
-            });
-            if (addition) result.systemPromptAddition = addition;
-          }
-        }
-        return result;
-      };
-      (engine as any)._lcmMemorySupplementPatched = true;
-      return engine;
-    }
-
-    const cached = shared.getCachedEngine();
-    if (cached) return wrapEngineWithMemorySupplements(cached);
-    return shared.waitForEngine().then(wrapEngineWithMemorySupplements);
+    const engine = shared.getCachedEngine();
+    return engine
+      ? new MemorySupplementContextEngine(engine)
+      : shared.waitForEngine().then((nextEngine) => new MemorySupplementContextEngine(nextEngine));
   });
 
   api.registerTool(

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1461,7 +1461,56 @@ function wirePluginHandlers(
     });
   });
 
-  api.registerContextEngine("lossless-claw", () => shared.getCachedEngine() ?? shared.waitForEngine());
+  // Fix: Ensure host memory supplements (wiki digest, etc.) are included in assembled context.
+  // When lossless-claw is the active context engine, OpenClaw delegates prompt assembly entirely
+  // to the engine. Without this wrapper, buildMemorySystemPromptAddition() is never called and
+  // registered memory supplements are silently dropped from the prompt.
+  api.registerContextEngine("lossless-claw", () => {
+    type BuildMemoryFn = (params: { availableTools: Set<string>; citationsMode?: string }) => string | undefined;
+    let _buildMemoryAddition: BuildMemoryFn | false | null = null;
+
+    async function ensureBuildMemoryAddition(): Promise<BuildMemoryFn | false> {
+      if (_buildMemoryAddition !== null) return _buildMemoryAddition;
+      try {
+        // openclaw is a peer dependency; plugin-sdk/core exports buildMemorySystemPromptAddition
+        const mod = await import("openclaw/plugin-sdk/core");
+        _buildMemoryAddition = (mod as any).buildMemorySystemPromptAddition ?? false;
+      } catch {
+        try {
+          const mod = await import("openclaw/plugin-sdk");
+          _buildMemoryAddition = (mod as any).buildMemorySystemPromptAddition ?? false;
+        } catch {
+          _buildMemoryAddition = false;
+        }
+      }
+      return _buildMemoryAddition;
+    }
+
+    function wrapEngineWithMemorySupplements<T extends { assemble: (...args: any[]) => any }>(engine: T): T {
+      if ((engine as any)._lcmMemorySupplementPatched) return engine;
+      const originalAssemble = engine.assemble.bind(engine);
+      (engine as any).assemble = async (params: any) => {
+        const result = await originalAssemble(params);
+        if (!result.systemPromptAddition) {
+          const builder = await ensureBuildMemoryAddition();
+          if (builder) {
+            const addition = builder({
+              availableTools: params.availableTools ?? new Set(),
+              citationsMode: params.citationsMode,
+            });
+            if (addition) result.systemPromptAddition = addition;
+          }
+        }
+        return result;
+      };
+      (engine as any)._lcmMemorySupplementPatched = true;
+      return engine;
+    }
+
+    const cached = shared.getCachedEngine();
+    if (cached) return wrapEngineWithMemorySupplements(cached);
+    return shared.waitForEngine().then(wrapEngineWithMemorySupplements);
+  });
 
   api.registerTool(
     (ctx) => createLcmGrepTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import packageJson from "../package.json" with { type: "json" };
 
 describe("package OpenClaw compatibility metadata", () => {
-  it("declares the context-engine host requirements minimum OpenClaw version without an upper bound", () => {
-    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.22");
-    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.22");
-    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.22");
-    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.22"]);
-    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.22");
+  it("declares the memory supplement context-engine minimum OpenClaw version without an upper bound", () => {
+    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.28");
+    expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.28");
+    expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.28");
+    expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.28"]);
+    expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.28");
   });
 });

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -9,6 +9,12 @@ import { closeLcmConnection } from "../src/db/connection.js";
 import { clearAllSharedInit } from "../src/plugin/shared-init.js";
 import { resetStartupBannerLogsForTests } from "../src/startup-banner-log.js";
 
+const buildMemorySystemPromptAdditionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/core", () => ({
+  buildMemorySystemPromptAddition: buildMemorySystemPromptAdditionMock,
+}));
+
 type RegisteredEngineFactory = (() => unknown) | undefined;
 type HookHandler = (event: unknown, context: unknown) => unknown;
 type RegisteredContextEngine = { id: string; factory: () => unknown };
@@ -228,6 +234,7 @@ describe("lcm plugin registration", () => {
     dbPaths.clear();
     clearAllSharedInit();
     resetStartupBannerLogsForTests();
+    buildMemorySystemPromptAdditionMock.mockReset();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     for (const dir of tempDirs) {
@@ -278,12 +285,53 @@ describe("lcm plugin registration", () => {
     delete (api as unknown as { registerContextEngine?: unknown }).registerContextEngine;
 
     expect(() => lcmPlugin.register(api)).toThrow(
-      /requires OpenClaw >=2026\.5\.22 with api\.registerContextEngine/,
+      /requires OpenClaw >=2026\.5\.28 with api\.registerContextEngine/,
     );
     expect(createSpy).not.toHaveBeenCalled();
     expect(api.registerCommand).not.toHaveBeenCalled();
     expect(api.registerTool).not.toHaveBeenCalled();
     expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("detectedHost=2026.5.1"));
+  });
+
+  it("adds registered host memory supplements to context engine assembly", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    const availableTools = new Set(["memory_search"]);
+    dbPaths.add(dbPath);
+    buildMemorySystemPromptAdditionMock.mockReturnValue(
+      "## Compiled Wiki Snapshot\nUse the current project glossary.",
+    );
+
+    const { api, getFactory } = buildApi({
+      enabled: true,
+      dbPath,
+    });
+    lcmPlugin.register(api);
+
+    const factory = getFactory();
+    expect(factory).toBeTypeOf("function");
+
+    const engine = factory!() as {
+      assemble: (params: {
+        sessionId: string;
+        messages: unknown[];
+        availableTools?: Set<string>;
+        citationsMode?: string;
+      }) => Promise<{ systemPromptAddition?: string }>;
+    };
+    const result = await engine.assemble({
+      sessionId: "missing-session",
+      messages: [],
+      availableTools,
+      citationsMode: "inline",
+    });
+
+    expect(buildMemorySystemPromptAdditionMock).toHaveBeenCalledWith({
+      availableTools,
+      citationsMode: "inline",
+    });
+    expect(result.systemPromptAddition).toBe(
+      "## Compiled Wiki Snapshot\nUse the current project glossary.",
+    );
   });
 
   it("uses api.pluginConfig values during register", { timeout: 20000 }, () => {


### PR DESCRIPTION
## Summary

Fixes #741

When lossless-claw registers as OpenClaw's context engine, the host delegates prompt assembly entirely to the engine. The engine's `assemble()` method did not call `buildMemorySystemPromptAddition()`, causing all registered memory supplements (wiki digest, compiled knowledge snapshots, etc.) to be silently dropped from the assembled prompt.

## Changes

Modified `src/plugin/index.ts` — the `registerContextEngine` factory now wraps the engine to call `buildMemorySystemPromptAddition()` after the original `assemble()` returns, populating `result.systemPromptAddition` when it is not already set by the engine itself.

### Behavior:
- If `assemble()` already sets `systemPromptAddition` (future-proof), the wrapper is a no-op
- `buildMemorySystemPromptAddition` is lazily imported from the `openclaw` peer dependency (`openclaw/plugin-sdk/core` with fallback to `openclaw/plugin-sdk`)
- If the import fails (older OpenClaw versions without this export), the wrapper gracefully degrades — no error, no supplement injection
- Engine wrapping is idempotent (guarded by `_lcmMemorySupplementPatched` flag)

## Reproduction

1. Install lossless-claw on OpenClaw >= 2026.5.12
2. Enable a wiki/memory supplement via `api.registerMemorySupplement()`
3. Observe that `## Compiled Wiki Snapshot` (or equivalent) is missing from the assembled prompt
4. With this fix, the wiki digest appears correctly in the prompt

## Side Effects

- **Token cost:** ~400 tokens/turn for the wiki digest system prompt addition (< 0.3% of 200k context window)
- **No extra API calls:** `buildMemorySystemPromptAddition` only reads already-registered in-memory supplements
- **No cache invalidation:** The supplement content is deterministic per-turn based on registered supplements

## Notes for Maintainers

The dynamic import path (`openclaw/plugin-sdk/core`) may need adjustment depending on OpenClaw's actual package exports configuration. The fallback to `openclaw/plugin-sdk` is included for compatibility. If there's a preferred way to access `buildMemorySystemPromptAddition` from within a plugin (e.g., via the `api` object), I'm happy to refactor accordingly.