### PR TITLE
fix(plugin): forward reasoning param to runtime LLM complete call

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1108,6 +1108,7 @@ function createLcmDependencies(
           // agentId. Plugin-wide api.runtime.llm.complete is gateway-scoped and rejects
           // target-agent overrides unless OpenClaw is explicitly configured otherwise.
           ...(isBoundRuntimeLlm && agentId?.trim() ? { agentId: agentId.trim() } : {}),
+          ...(reasoning !== undefined ? { reasoning } : {}),
         });
         const text = typeof result.text === "string" ? result.text : "";
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type RuntimeLlmCompleteFn = (params: {
   systemPrompt?: string;
   purpose?: string;
   agentId?: string;
+  reasoning?: string;
 }) => Promise<{
   text: string;
   provider: string;


### PR DESCRIPTION
## Problem

The `complete()` function in the plugin bridge destructures `reasoning` from its input params but **never forwards it** to the underlying `runtimeLlm()` call. This means:

- Any `reasoning` / `reasoningIfSupported` override (e.g. `reasoningIfSupported: "low"` from the summarizer in `summarize.ts`) gets **silently dropped**
- When OpenClaw's `runtime.llm.complete`  is the backing implementation, the host provider (e.g. DeepSeek) always uses its default thinking mode regardless of what the caller requested
- The `reasoning` value is logged in metadata (`request_reasoning`) but never actually sent to the model

## Fix

Two changes in two files:

1. **`src/types.ts`** — Add `reasoning?: string` to `RuntimeLlmCompleteFn`
2. **`src/plugin/index.ts`** — Forward `reasoning` to the `runtimeLlm()` invocation:
   ```ts
   ...(reasoning !== undefined ? { reasoning } : {}),
   ```

## How it works end-to-end

```
summarize.ts → deps.complete({reasoningIfSupported: "low", ...})
  → plugin/index.ts complete() receives {reasoning, reasoningIfSupported, ...}
    → forwards {reasoning} to runtimeLlm()
      → OpenClaw runtime.llm.complete (with companion fix)
        → pi-ai provider sends thinking: {type: "disabled"} to DeepSeek
```

## Testing

- Verified in local deployment: LCM compaction summary model (`deepseek/deepseek-v4-flash-fast` with `reasoning: true`, no effort) now correctly disables thinking mode
- No breaking changes — existing calls without `reasoning` are unaffected
- Companion fix: https://github.com/openclaw/openclaw/pull/86443 (adds `reasoning` to `LlmCompleteParams` in OpenClaw core)