### PR TITLE
fix: forward runtime context through lossless commands

### DIFF
--- a/.changeset/runtime-auth-profile-forwarding.md
+++ b/.changeset/runtime-auth-profile-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Forward host runtime auth profile context through Lossless summary and doctor repair calls.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1060,6 +1060,7 @@ function createLcmDependencies(
       runtimeModelOverride,
       runtimeLlmComplete,
       agentId,
+      authProfileId,
       messages,
       system,
       maxTokens,
@@ -1104,6 +1105,7 @@ function createLcmDependencies(
             : {}),
           ...(typeof system === "string" && system.trim() ? { systemPrompt: system.trim() } : {}),
           purpose: "lossless-claw compaction summarization",
+          ...(authProfileId?.trim() ? { authProfileId: authProfileId.trim() } : {}),
           // Only context-engine supplied runtime LLM capabilities may carry an explicit
           // agentId. Plugin-wide api.runtime.llm.complete is gateway-scoped and rejects
           // target-agent overrides unless OpenClaw is explicitly configured otherwise.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -116,6 +116,10 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function readCommandRuntimeContext(ctx: PluginCommandContext): Record<string, unknown> | undefined {
+  return asRecord(asRecord(ctx)?.runtimeContext);
+}
+
 function formatBoolean(value: boolean): string {
   return value ? "yes" : "no";
 }
@@ -2119,6 +2123,8 @@ async function buildDoctorApplyText(params: {
       deps: params.deps,
       summarize: params.summarize,
       runtimeConfig: params.ctx.config,
+      runtimeContext: readCommandRuntimeContext(params.ctx),
+      sessionKey: current.stats.sessionKey ?? normalizeIdentity(params.ctx.sessionKey),
     });
   } catch (error) {
     return [

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -53,6 +53,8 @@ export async function applyScopedDoctorRepair(params: {
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
   runtimeConfig?: unknown;
+  runtimeContext?: Record<string, unknown>;
+  sessionKey?: string;
 }): Promise<DoctorApplyResult> {
   const targets = loadDoctorTargets(params.db, params.conversationId);
   if (targets.length === 0) {
@@ -174,6 +176,8 @@ async function resolveDoctorApplySummarize(params: {
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
   runtimeConfig?: unknown;
+  runtimeContext?: Record<string, unknown>;
+  sessionKey?: string;
 }): Promise<LcmSummarizeFn | undefined> {
   if (typeof params.summarize === "function") {
     return params.summarize;
@@ -186,6 +190,8 @@ async function resolveDoctorApplySummarize(params: {
     deps: params.deps,
     legacyParams: {
       config: params.runtimeConfig,
+      ...(params.runtimeContext ?? {}),
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
     },
     customInstructions: params.config.customInstructions || undefined,
   });

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -27,6 +27,7 @@ export type LcmSummarizerLegacyParams = {
   llm?: unknown;
   agentId?: unknown;
   sessionKey?: unknown;
+  authProfileId?: unknown;
 };
 
 type SummaryResolutionCandidate = {
@@ -1316,6 +1317,10 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       ? params.deps.parseAgentSessionKey(params.legacyParams.sessionKey)?.agentId
       : undefined;
   const agentId = explicitAgentId || sessionAgentId;
+  const authProfileId =
+    typeof params.legacyParams.authProfileId === "string" && params.legacyParams.authProfileId.trim()
+      ? params.legacyParams.authProfileId.trim()
+      : undefined;
   const runtimeLlmComplete = readRuntimeLlmComplete(params.legacyParams);
   // OpenClaw only permits agentId override on host-bound/context-engine runtime LLM
   // capabilities. Plugin-wide api.runtime.llm.complete is already scoped by the
@@ -1393,6 +1398,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           ...(runtimeModelOverride ? { runtimeModelOverride } : {}),
           ...(runtimeLlmComplete ? { runtimeLlmComplete } : {}),
           ...(shouldPassAgentId ? { agentId } : {}),
+          ...(authProfileId ? { authProfileId } : {}),
           system: LCM_SUMMARIZER_SYSTEM_PROMPT,
           messages: [
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type RuntimeLlmCompleteFn = (params: {
   purpose?: string;
   agentId?: string;
   reasoning?: string;
+  authProfileId?: string;
 }) => Promise<{
   text: string;
   provider: string;
@@ -65,6 +66,7 @@ export type CompleteFn = (params: {
   runtimeModelOverride?: RuntimeLlmModelOverride;
   runtimeLlmComplete?: RuntimeLlmCompleteFn;
   agentId?: string;
+  authProfileId?: string;
   messages: Array<{ role: string; content: unknown }>;
   system?: string;
   maxTokens: number;

--- a/test/index-runtime-llm-complete.test.ts
+++ b/test/index-runtime-llm-complete.test.ts
@@ -97,6 +97,7 @@ function getRegisteredEngine(api: OpenClawPluginApi, getFactory: () => Registere
         };
         runtimeLlmComplete?: RuntimeLlmComplete;
         agentId?: string;
+        authProfileId?: string;
         system?: string;
         messages: Array<{ role: string; content: unknown }>;
         maxTokens: number;
@@ -143,6 +144,7 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         messages: [{ role: "user", content: "Summarize this." }],
         maxTokens: 256,
         temperature: 0.2,
+        authProfileId: "openai-codex:work",
         reasoningIfSupported: "low",
       });
 
@@ -154,6 +156,7 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         temperature: 0.2,
         systemPrompt: "System summary policy.",
         purpose: "lossless-claw compaction summarization",
+        authProfileId: "openai-codex:work",
       });
       expect(result).toMatchObject({
         content: [{ type: "text", text: "summary output" }],

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1631,6 +1631,9 @@ describe("lcm command", () => {
   });
 
   it("uses the normal runtime model chain for doctor apply when no explicit summary model is set", async () => {
+    const hostBoundComplete = vi.fn(async () => ({
+      text: "HOST BOUND REPAIR",
+    }));
     const runtimeComplete = vi.fn(async () => ({
       content: [{ type: "text", text: "RUNTIME REPAIR" }],
     }));
@@ -1691,6 +1694,11 @@ describe("lcm command", () => {
     const result = await fixture.command.handler(
       createCommandContext("doctor apply", {
         sessionKey: "agent:main:telegram:direct:doctor-apply-runtime-config",
+        runtimeContext: {
+          llm: {
+            complete: hostBoundComplete,
+          },
+        },
         config: {
           agents: {
             defaults: {
@@ -1716,6 +1724,11 @@ describe("lcm command", () => {
     expect(result.text).toContain("repaired summaries: 1");
     expect(result.text).not.toContain("could not resolve a summarizer");
     expect(runtimeComplete).toHaveBeenCalled();
+    expect(runtimeComplete.mock.calls[0]?.[0]).toMatchObject({
+      agentId: "main",
+      runtimeLlmComplete: hostBoundComplete,
+    });
+    expect(hostBoundComplete).not.toHaveBeenCalled();
     expect(repaired?.content).toContain("RUNTIME REPAIR");
     expect(repaired?.content).not.toContain("[Truncated from 111 tokens]");
   });

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1695,6 +1695,7 @@ describe("lcm command", () => {
       createCommandContext("doctor apply", {
         sessionKey: "agent:main:telegram:direct:doctor-apply-runtime-config",
         runtimeContext: {
+          authProfileId: "openai-codex:work",
           llm: {
             complete: hostBoundComplete,
           },
@@ -1726,6 +1727,7 @@ describe("lcm command", () => {
     expect(runtimeComplete).toHaveBeenCalled();
     expect(runtimeComplete.mock.calls[0]?.[0]).toMatchObject({
       agentId: "main",
+      authProfileId: "openai-codex:work",
       runtimeLlmComplete: hostBoundComplete,
     });
     expect(hostBoundComplete).not.toHaveBeenCalled();


### PR DESCRIPTION
## What
Fixes two runtime-context forwarding gaps in Lossless command flows.

## Why
Doctor repair and host-provided LLM calls should use the same runtime context OpenClaw gives the command, including host-bound LLM capability and selected auth profile. Without this, doctor apply can fall back to the wrong summarizer route and runtime LLM calls can lose the intended auth profile.

## Changes
- Use command runtime for doctor apply
- Forward runtime auth profile to host LLM
- Cover both paths with focused tests
- Add patch changeset

## Testing
- `npx vitest run test/lcm-command.test.ts test/index-runtime-llm-complete.test.ts` - passed, 2 files / 47 tests.
- `npm run build` - passed.
- `git diff --check` - passed.

## Notes
This branch intentionally excludes the SQLite transcript-scope compatibility stack. Its diff is limited to runtime/command forwarding files, focused tests, and a changeset.
