### PR TITLE
fix(compaction): consult leaf trigger in evaluate() so under-threshold conversations still compact

### DIFF
--- a/.changeset/leaf-trigger-evaluate-gate.md
+++ b/.changeset/leaf-trigger-evaluate-gate.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+`compaction.evaluate()` now consults the leaf trigger when the token-budget threshold has not been crossed. Conversations that stay under the context threshold but accumulate raw messages outside the protected fresh tail past `leafChunkTokens` will now correctly schedule deferred compaction with `reason: "leaf-trigger"` instead of being silently skipped on every turn. Fixes the case where conversations under the context threshold accumulated tens of thousands of raw tokens for weeks without ever being compacted.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -17,13 +17,22 @@ import { LcmProviderAuthError } from "./summarize.js";
 
 export interface CompactionDecision {
   shouldCompact: boolean;
-  reason: "threshold" | "manual" | "none";
+  reason: "threshold" | "leaf-trigger" | "manual" | "none";
   /** Persisted Lossless context tokens before runtime prompt overhead. */
   storedTokens: number;
   /** Runtime-observed prompt tokens, when supplied by the host. */
   observedTokens?: number;
   currentTokens: number;
   threshold: number;
+  /**
+   * Raw message tokens accumulated outside the protected fresh tail, when
+   * the leaf trigger was consulted. Populated when `reason === "leaf-trigger"`
+   * or when the threshold path also crossed the leaf trigger threshold; left
+   * unset otherwise so existing consumers see no behavioural change.
+   */
+  rawTokensOutsideTail?: number;
+  /** Leaf-trigger threshold (`leafChunkTokens`) used during evaluation. */
+  leafTriggerThreshold?: number;
 }
 
 export interface CompactionResult {
@@ -577,6 +586,10 @@ export class CompactionEngine {
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
 
     if (currentTokens > threshold) {
+      // Token-budget threshold path: also surface leaf-trigger telemetry so
+      // callers can see when both gates would fire on the same turn. Reason
+      // stays `"threshold"` to preserve the existing debt-routing contract.
+      const leafTrigger = await this.evaluateLeafTrigger(conversationId);
       return {
         shouldCompact: true,
         reason: "threshold",
@@ -584,6 +597,34 @@ export class CompactionEngine {
         ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
         currentTokens,
         threshold,
+        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
+        leafTriggerThreshold: leafTrigger.threshold,
+      };
+    }
+
+    // Threshold not crossed. Conversations that stay under the token-budget
+    // threshold can still accumulate raw messages indefinitely; without a
+    // leaf-trigger gate here, automatic compaction is never scheduled and
+    // the fresh-tail-protected raw tail grows unboundedly. Consult the leaf
+    // trigger so afterTurn can enqueue deferred debt before the threshold
+    // ever fires.
+    const leafTrigger = await this.evaluateLeafTrigger(conversationId);
+    if (leafTrigger.shouldCompact) {
+      this.log.debug(
+        `[lcm] compaction.evaluate: leaf-trigger fired conversation=${conversationId} ` +
+          `rawTokensOutsideTail=${leafTrigger.rawTokensOutsideTail} ` +
+          `leafTriggerThreshold=${leafTrigger.threshold} ` +
+          `currentTokens=${currentTokens} threshold=${threshold}`,
+      );
+      return {
+        shouldCompact: true,
+        reason: "leaf-trigger",
+        storedTokens,
+        ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
+        currentTokens,
+        threshold,
+        rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
+        leafTriggerThreshold: leafTrigger.threshold,
       };
     }
 
@@ -594,6 +635,8 @@ export class CompactionEngine {
       ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
       currentTokens,
       threshold,
+      rawTokensOutsideTail: leafTrigger.rawTokensOutsideTail,
+      leafTriggerThreshold: leafTrigger.threshold,
     };
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7162,6 +7162,15 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget,
         observedCurrentTokenCount,
       );
+      // Preserve the decision's actual reason so leaf-trigger compaction is
+      // visible in the maintenance row and is correctly re-validated by the
+      // legacy-debt clear path in consumeDeferredCompactionDebt (which keys
+      // off `reason === "threshold"`). Reasons other than `"threshold"`
+      // re-evaluate before clearing, and our updated evaluate() now returns
+      // `shouldCompact:true` for leaf-trigger so the row will not be
+      // prematurely cleared while the trigger remains hot.
+      const decisionReason: string =
+        thresholdDecision.reason === "leaf-trigger" ? "leaf-trigger" : "threshold";
       if (this.config.proactiveThresholdCompactionMode === "inline") {
         if (thresholdDecision.shouldCompact) {
           const compactResult = await this.compact({
@@ -7175,20 +7184,20 @@ export class LcmContextEngine implements ContextEngine {
           });
           if (!compactResult.ok) {
             shouldRefreshBootstrapState = false;
-            await recordAfterTurnCompactionRetry("threshold");
+            await recordAfterTurnCompactionRetry(decisionReason);
           }
         }
       } else if (thresholdDecision.shouldCompact) {
         await this.recordDeferredCompactionDebt({
           conversationId: conversation.conversationId,
-          reason: "threshold",
+          reason: decisionReason,
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
         });
         deferredCompactionDrain = {
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
-          reason: "threshold",
+          reason: decisionReason,
         };
       }
     } catch (err) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -10645,6 +10645,154 @@ describe("LcmContextEngine compaction telemetry", () => {
 
 });
 
+// ── Compaction.evaluate leaf-trigger gate (issue #639) ──────────────────────
+
+describe("LcmContextEngine.compact evaluate leaf-trigger gate", () => {
+  it("returns shouldCompact=true with reason=leaf-trigger when raw tokens exceed leafChunkTokens but stay under context threshold", async () => {
+    // Tiny leaf chunk so a single short turn pair already exceeds the leaf
+    // threshold, while a generous tokenBudget keeps `currentTokens <= contextThreshold * tokenBudget`.
+    const engine = createEngineWithConfig({
+      freshTailCount: 1,
+      leafChunkTokens: 1,
+      contextThreshold: 0.95,
+    });
+    const sessionId = "evaluate-leaf-trigger-under-threshold";
+
+    await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "some accumulated raw history that is outside the fresh tail" }),
+        makeMessage({ role: "assistant", content: "more accumulated raw history that is outside the fresh tail" }),
+        makeMessage({ role: "user", content: "still in the fresh tail" }),
+      ],
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<{
+          shouldCompact: boolean;
+          reason: string;
+          rawTokensOutsideTail?: number;
+          leafTriggerThreshold?: number;
+          currentTokens: number;
+          threshold: number;
+        }>;
+      };
+    };
+
+    const decision = await privateEngine.compaction.evaluate(
+      conversation!.conversationId,
+      1_000_000,
+    );
+
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.reason).toBe("leaf-trigger");
+    expect(decision.rawTokensOutsideTail).toBeGreaterThan(0);
+    expect(decision.leafTriggerThreshold).toBe(1);
+    expect(decision.currentTokens).toBeLessThanOrEqual(decision.threshold);
+  });
+
+  it("returns shouldCompact=false with reason=none when neither threshold nor leaf trigger fires", async () => {
+    const engine = createEngineWithConfig({
+      freshTailCount: 4,
+      leafChunkTokens: 50_000,
+      contextThreshold: 0.95,
+    });
+    const sessionId = "evaluate-none";
+
+    await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "hi" }),
+        makeMessage({ role: "assistant", content: "hello" }),
+      ],
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<{ shouldCompact: boolean; reason: string }>;
+      };
+    };
+
+    const decision = await privateEngine.compaction.evaluate(
+      conversation!.conversationId,
+      1_000_000,
+    );
+
+    expect(decision.shouldCompact).toBe(false);
+    expect(decision.reason).toBe("none");
+  });
+
+  it("afterTurn enqueues deferred compaction debt with reason=leaf-trigger when only the leaf gate fires", async () => {
+    const engine = createEngineWithConfig({
+      freshTailCount: 1,
+      leafChunkTokens: 1,
+      contextThreshold: 0.95,
+      proactiveThresholdCompactionMode: "deferred",
+    });
+    const sessionId = "after-turn-leaf-trigger-deferred";
+
+    // Seed enough raw history outside the fresh tail to trip the leaf trigger.
+    await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "older raw turn that lives outside the fresh tail" }),
+        makeMessage({ role: "assistant", content: "older raw turn that lives outside the fresh tail" }),
+      ],
+    });
+
+    const privateEngine = engine as unknown as {
+      scheduleDeferredCompactionDebtDrain: (params: { reason: string }) => void;
+    };
+    const scheduleSpy = vi
+      .spyOn(privateEngine, "scheduleDeferredCompactionDebtDrain")
+      .mockImplementation(() => {
+        // Don't actually drain; we just want to observe the queue handoff.
+      });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-leaf-trigger-deferred"),
+      messages: [makeMessage({ role: "user", content: "newest fresh-tail turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 1_000_000,
+      runtimeContext: { currentTokenCount: 100 },
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.reason).toBe("leaf-trigger");
+
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "leaf-trigger" }),
+    );
+  });
+});
+
 // ── Compact token budget plumbing ───────────────────────────────────────────
 
 describe("LcmContextEngine.compact token budget plumbing", () => {


### PR DESCRIPTION
## Problem

`compaction.evaluate()` (in `src/compaction.ts`) only returns `shouldCompact:true` when the live context tokens cross the budget threshold (`contextThreshold * tokenBudget`). Two related leaf-level mechanisms exist but are not consulted from `evaluate()`:

- `evaluateLeafTrigger()` measures raw message tokens outside the protected fresh tail against `leafChunkTokens`.
- The comment on `evaluateLeafTrigger` explicitly says: *"Automatic compaction no longer uses this as a trigger, but it remains useful for diagnostics and explicit maintenance commands."*

The result is that a conversation can stay forever under `contextThreshold * tokenBudget` and accumulate unbounded raw messages outside the fresh tail without ever being compacted. `afterTurn`'s threshold gate never fires, so neither `inline` nor `deferred` mode ever schedules anything for these conversations.

## Real-world evidence (one heavy install)

* 310 conversations, only 27 with any summaries (≈9%).
* 14 conversations with `pending=1` in `conversation_compaction_maintenance`, with reasons including `leaf-trigger` and `cold-cache-catchup` (written by older code paths). 9 of those had `last_started_at` NULL — never picked up.
* Several conversations sitting at 200K–269K raw tokens and `tokenBudget=500000` had been under the 75% threshold for the whole period, so `evaluate()` returned `shouldCompact:false` on every turn.
* `consumeDeferredCompactionDebt` would also clear those legacy-reason debts on the next maintain pass, because it re-checks `evaluate()` and clears when `shouldCompact === false`.

## Fix

Single, narrow behavioural change in `evaluate()`:

1. Keep the existing token-budget threshold gate behaviour as the primary trigger (still returns `reason: "threshold"`).
2. When the threshold gate does not fire, also call `evaluateLeafTrigger()`. If the leaf trigger is hot, return `shouldCompact: true` with `reason: "leaf-trigger"`.
3. `CompactionDecision` gains optional `rawTokensOutsideTail` and `leafTriggerThreshold` telemetry fields (always populated when leaf trigger was consulted) so callers can see what each gate observed.
4. `afterTurn` forwards the decision's actual reason to `recordDeferredCompactionDebt` and `scheduleDeferredCompactionDebtDrain`, so the maintenance row reflects which gate fired.
5. A `debug` log fires inside `evaluate()` when the leaf-trigger gate fires, so this is observable in the field without changing the existing log shape.

The existing `consumeDeferredCompactionDebt` legacy-clear path (which re-evaluates non-`"threshold"` debts and clears them when `shouldCompact === false`) now correctly *retains* `leaf-trigger` debt as long as the leaf trigger remains hot.

This also handles the staleness escape hatch implicitly: a conversation that has grown to many multiples of `leafChunkTokens` outside the fresh tail is by definition over the leaf trigger and is now picked up automatically. No new config knob is added.

## Test coverage

Added in `test/engine.test.ts` under `LcmContextEngine.compact evaluate leaf-trigger gate`:

1. `evaluate()` returns `shouldCompact:true` with `reason: "leaf-trigger"` when raw tokens exceed `leafChunkTokens` but stay under the context threshold.
2. `evaluate()` returns `shouldCompact:false` with `reason: "none"` when neither gate fires.
3. `afterTurn` enqueues deferred compaction debt with `reason: "leaf-trigger"` (in `conversation_compaction_maintenance`) and forwards the same reason to `scheduleDeferredCompactionDebtDrain`, when only the leaf gate fires.

`npm test` results on this branch: **48 files passed, 927 tests passed, 0 failed** (was 924 before this change).

## Risk / scope

* `CompactionDecision.reason` adds `"leaf-trigger"` to its union — additive type change. Consumers that switch on `reason` keep working; the only place that pattern-matches on it is `consumeDeferredCompactionDebt` (`reason === "threshold"`), and the new value flows through the non-threshold branch correctly.
* Existing `afterTurn` test "afterTurn ignores raw leaf pressure below the context threshold" still passes — it mocks `evaluate()` directly, and our behavioural change is inside `evaluate()`.
* No new config flags. No new dependencies. No DB migration.

## Related

This is a real fix for the long-tail "permanently-hot, sub-threshold conversation never compacts" failure mode that lossless-claw users hit on any conversation small enough to live under `contextThreshold * tokenBudget` but long-running enough to accumulate raw messages.
