### PR TITLE
Fix stale session-key rollover replay

### DIFF
--- a/.changeset/stale-session-key-rollover.md
+++ b/.changeset/stale-session-key-rollover.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Rotate stale active conversations before assemble/afterTurn when a stable session key resumes after its tracked transcript file was pruned.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5411,6 +5411,15 @@ export class LcmContextEngine implements ContextEngine {
     return await this.withSessionQueue(
       queueKey,
       async () => {
+        await this.conversationStore.withTransaction(async () => {
+          await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+            phase: "afterTurn",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+            createReplacement: false,
+          });
+        });
         const conversation = await this.conversationStore.getConversationForSession({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
@@ -5727,6 +5736,71 @@ export class LcmContextEngine implements ContextEngine {
     });
   }
 
+  /**
+   * Recover lifecycle splits that the host missed when it pruned a transcript
+   * file before Lossless saw a reset/session_end hook. Without this, stable
+   * session keys can reattach a new runtime UUID to a stale active conversation
+   * and assemble old assistant tails as if they belonged to the new turn.
+   */
+  private async rotateStaleSessionKeyConversationIfTrackedTranscriptMissing(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile?: string;
+    createReplacement?: boolean;
+  }): Promise<boolean> {
+    const normalizedSessionKey = params.sessionKey?.trim();
+    if (!normalizedSessionKey) {
+      return false;
+    }
+
+    const activeByKey = await this.conversationStore.getConversationBySessionKey(
+      normalizedSessionKey,
+    );
+    if (!activeByKey || activeByKey.sessionId === params.sessionId) {
+      return false;
+    }
+
+    const activeBootstrapState = await this.summaryStore.getConversationBootstrapState(
+      activeByKey.conversationId,
+    );
+    const trackedSessionFile = activeBootstrapState?.sessionFilePath;
+    if (typeof trackedSessionFile !== "string" || trackedSessionFile.length === 0) {
+      return false;
+    }
+
+    const transcriptRotated =
+      params.sessionFile === undefined || trackedSessionFile !== params.sessionFile;
+    if (!transcriptRotated) {
+      return false;
+    }
+
+    try {
+      await stat(trackedSessionFile);
+      return false;
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        this.deps.log.warn(
+          `[lcm] ${params.phase}: could not verify tracked transcript path conversation=${activeByKey.conversationId} file=${trackedSessionFile} error=${describeLogError(err)}`,
+        );
+        return false;
+      }
+    }
+
+    this.deps.log.warn(
+      `[lcm] ${params.phase}: detected reset/rollover without prior lifecycle split; rotating conversation=${activeByKey.conversationId} session=${params.sessionId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} oldFile=${trackedSessionFile}${params.sessionFile ? ` newFile=${params.sessionFile}` : ""}`,
+    );
+    await this.applySessionReplacement({
+      reason: `${params.phase} session-file rollover fallback`,
+      sessionId: activeByKey.sessionId,
+      sessionKey: normalizedSessionKey,
+      nextSessionId: params.sessionId,
+      nextSessionKey: normalizedSessionKey,
+      createReplacement: params.createReplacement ?? true,
+    });
+    return true;
+  }
+
   async bootstrap(params: {
     sessionId: string;
     sessionFile: string;
@@ -5781,52 +5855,12 @@ export class LcmContextEngine implements ContextEngine {
             });
           };
 
-          // Guard: when a sessionKey resumes on a new sessionId and the tracked
-          // transcript file has disappeared, treat it as a missed /reset and
-          // rotate the conversation before getOrCreate would re-attach to it.
-          const normalizedSessionKey = params.sessionKey?.trim();
-          if (normalizedSessionKey) {
-            const activeByKey = await this.conversationStore.getConversationBySessionKey(normalizedSessionKey);
-            if (activeByKey && activeByKey.sessionId !== params.sessionId) {
-              const activeBootstrapState = await this.summaryStore.getConversationBootstrapState(
-                activeByKey.conversationId,
-              );
-              const trackedSessionFile = activeBootstrapState?.sessionFilePath;
-              let trackedSessionFileMissing = false;
-              if (typeof trackedSessionFile === "string" && trackedSessionFile.length > 0) {
-                try {
-                  await stat(trackedSessionFile);
-                } catch (err) {
-                  const code = getErrorCode(err);
-                  if (code === "ENOENT" || code === "ENOTDIR") {
-                    trackedSessionFileMissing = true;
-                  } else {
-                    this.deps.log.warn(
-                      `[lcm] bootstrap: could not verify tracked transcript path conversation=${activeByKey.conversationId} file=${trackedSessionFile} error=${describeLogError(err)}`,
-                    );
-                  }
-                }
-              }
-              const transcriptRotated =
-                typeof trackedSessionFile === "string" &&
-                trackedSessionFile.length > 0 &&
-                trackedSessionFile !== params.sessionFile;
-
-              if (transcriptRotated && trackedSessionFileMissing) {
-                this.deps.log.warn(
-                  `[lcm] bootstrap: detected reset/rollover without prior lifecycle split; rotating conversation=${activeByKey.conversationId} session=${params.sessionId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} oldFile=${trackedSessionFile} newFile=${params.sessionFile}`,
-                );
-                await this.applySessionReplacement({
-                  reason: "bootstrap session-file rollover fallback",
-                  sessionId: activeByKey.sessionId,
-                  sessionKey: normalizedSessionKey,
-                  nextSessionId: params.sessionId,
-                  nextSessionKey: normalizedSessionKey,
-                  createReplacement: true,
-                });
-              }
-            }
-          }
+          await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+            phase: "bootstrap",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+          });
 
           const conversation = await this.conversationStore.getOrCreateConversation(params.sessionId, {
             sessionKey: params.sessionKey,
@@ -7246,6 +7280,22 @@ export class LcmContextEngine implements ContextEngine {
         `session=${params.sessionId}`,
         ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
       ].join(" ");
+
+      await this.withSessionQueue(
+        this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+        async () =>
+          this.conversationStore.withTransaction(async () => {
+            await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+              phase: "assemble",
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            });
+          }),
+        {
+          operationName: "assembleLifecycleGuard",
+          context: sessionLabel,
+        },
+      );
 
       const conversation = await this.conversationStore.getConversationForSession({
         sessionId: params.sessionId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5406,6 +5406,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionId: string;
     sessionKey?: string;
     sessionFile: string;
+    isHeartbeat?: boolean;
   }): Promise<TranscriptReconcileResult> {
     const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     return await this.withSessionQueue(
@@ -5425,10 +5426,43 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
         });
         if (!conversation) {
-          // No persisted conversation exists yet; afterTurn's own ingest batch
-          // will create the initial frontier, so refreshing after that ingest is
-          // safe and preserves the normal first-turn checkpoint behavior.
-          return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+          if (params.isHeartbeat) {
+            return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+          }
+          // No persisted conversation exists yet. Prefer the transcript over
+          // the runtime delta so foreground prompts that are omitted from
+          // afterTurn's messages array are not lost.
+          const historicalMessages = await readLeafPathMessages(params.sessionFile);
+          let importedMessages = 0;
+          for (const message of historicalMessages) {
+            const result = await this.ingestSingle({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              message,
+              skipReplayTimestampFloodGuard: true,
+            });
+            if (result.ingested) {
+              importedMessages += 1;
+            }
+          }
+          if (importedMessages > 0) {
+            const activeConversation = await this.conversationStore.getConversationForSession({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            });
+            if (activeConversation) {
+              this.recordRecentBootstrapImport(
+                activeConversation.conversationId,
+                importedMessages,
+                "imported initial afterTurn transcript",
+              );
+              await this.refreshBootstrapState({
+                conversationId: activeConversation.conversationId,
+                sessionFile: params.sessionFile,
+              });
+            }
+          }
+          return { importedMessages, blockedByImportCap: false, hasOverlap: true };
         }
 
         // OpenClaw can submit the foreground prompt outside the mutable
@@ -6963,6 +6997,7 @@ export class LcmContextEngine implements ContextEngine {
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         sessionFile: params.sessionFile,
+        isHeartbeat: params.isHeartbeat,
       });
     } catch (err) {
       this.deps.log.warn(
@@ -7289,6 +7324,7 @@ export class LcmContextEngine implements ContextEngine {
               phase: "assemble",
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
+              createReplacement: false,
             });
           }),
         {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7358,22 +7358,24 @@ export class LcmContextEngine implements ContextEngine {
         ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
       ].join(" ");
 
-      await this.withSessionQueue(
-        this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
-        async () =>
-          this.conversationStore.withTransaction(async () => {
-            await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
-              phase: "assemble",
-              sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
-              createReplacement: false,
-            });
-          }),
-        {
-          operationName: "assembleLifecycleGuard",
-          context: sessionLabel,
-        },
-      );
+      if (params.sessionKey?.trim()) {
+        await this.withSessionQueue(
+          this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+          async () =>
+            this.conversationStore.withTransaction(async () => {
+              await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+                phase: "assemble",
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                createReplacement: false,
+              });
+            }),
+          {
+            operationName: "assembleLifecycleGuard",
+            context: sessionLabel,
+          },
+        );
+      }
 
       const conversation = await this.conversationStore.getConversationForSession({
         sessionId: params.sessionId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5432,9 +5432,39 @@ export class LcmContextEngine implements ContextEngine {
           // No persisted conversation exists yet. Prefer the transcript over
           // the runtime delta so foreground prompts that are omitted from
           // afterTurn's messages array are not lost.
+          let sessionFileState: { size: number } | undefined;
+          try {
+            const sessionFileStats = await stat(params.sessionFile);
+            sessionFileState = { size: sessionFileStats.size };
+          } catch {
+            // Missing files are common for brand-new live sessions; allow the
+            // runtime batch to seed the conversation in that case.
+          }
           const historicalMessages = await readLeafPathMessages(params.sessionFile);
+          if (historicalMessages.length === 0) {
+            if ((sessionFileState?.size ?? 0) > 0) {
+              this.deps.log.warn(
+                `[lcm] afterTurn: initial transcript read returned no messages from non-empty file; skipping live afterTurn persistence to avoid anchoring past unreadable history session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} sessionFile=${params.sessionFile}`,
+              );
+              return { importedMessages: 0, blockedByImportCap: false, hasOverlap: false };
+            }
+            return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+          }
+          if (batchLooksLikeHeartbeatAckTurn(historicalMessages)) {
+            return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+          }
+          const bootstrapMessages = trimBootstrapMessagesToBudget(
+            historicalMessages,
+            resolveBootstrapMaxTokens(this.config),
+          );
+          if (bootstrapMessages.length === 0) {
+            this.deps.log.warn(
+              `[lcm] afterTurn: initial transcript import exceeded bootstrap budget; skipping live afterTurn persistence to avoid anchoring past unreconciled history session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} sessionFile=${params.sessionFile} sourceMessages=${historicalMessages.length}`,
+            );
+            return { importedMessages: 0, blockedByImportCap: true, hasOverlap: false };
+          }
           let importedMessages = 0;
-          for (const message of historicalMessages) {
+          for (const message of bootstrapMessages) {
             const result = await this.ingestSingle({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
@@ -5462,7 +5492,11 @@ export class LcmContextEngine implements ContextEngine {
               });
             }
           }
-          return { importedMessages, blockedByImportCap: false, hasOverlap: true };
+          return {
+            importedMessages,
+            blockedByImportCap: bootstrapMessages.length < historicalMessages.length,
+            hasOverlap: true,
+          };
         }
 
         // OpenClaw can submit the foreground prompt outside the mutable

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3481,6 +3481,11 @@ describe("LcmContextEngine.bootstrap", () => {
 
     rmSync(firstSessionFile, { force: true });
 
+    const newSessionFile = createSessionFilePath("assemble-missed-reset-fallback-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new live prompt" },
+      { role: "assistant", content: "new assistant reply" },
+    ]);
     const liveMessages = [makeMessage({ role: "user", content: "new live prompt" })];
     const assembled = await engine.assemble({
       sessionId: secondSessionId,
@@ -3494,6 +3499,27 @@ describe("LcmContextEngine.bootstrap", () => {
       assembled.messages.some((message) => message.content === "openai-codex/gpt-5.5"),
     ).toBe(false);
 
+    const activeConversationBeforeAfterTurn = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversationBeforeAfterTurn).toBeNull();
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.active).toBe(false);
+    expect(archivedConversation?.archivedAt).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "new assistant reply" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
     const activeConversation = await engine.getConversationStore().getConversationForSession({
       sessionId: secondSessionId,
       sessionKey,
@@ -3503,11 +3529,13 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(activeConversation!.sessionId).toBe(secondSessionId);
     expect(activeConversation!.active).toBe(true);
 
-    const archivedConversation = await engine.getConversationStore().getConversation(
-      originalConversation!.conversationId,
+    const storedActiveMessages = await engine.getConversationStore().getMessages(
+      activeConversation!.conversationId,
     );
-    expect(archivedConversation?.active).toBe(false);
-    expect(archivedConversation?.archivedAt).not.toBeNull();
+    expect(storedActiveMessages.map((message) => message.content)).toEqual([
+      "new live prompt",
+      "new assistant reply",
+    ]);
   });
 
   it("preserves the active conversation when the tracked transcript stat fails for a non-missing reason", async () => {
@@ -8773,10 +8801,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       sessionId: secondSessionId,
       sessionKey,
       sessionFile: newSessionFile,
-      messages: [
-        makeMessage({ role: "user", content: "new turn user" }),
-        makeMessage({ role: "assistant", content: "new turn assistant" }),
-      ],
+      messages: [makeMessage({ role: "assistant", content: "new turn assistant" })],
       prePromptMessageCount: 0,
       tokenBudget: 4_096,
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -8830,6 +8830,92 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ]);
   });
 
+  it("afterTurn skips assistant-only rollover when the replacement transcript is unreadable", async () => {
+    const engine = createEngine();
+    const firstSessionId = "after-turn-missed-reset-unreadable-1";
+    const secondSessionId = "after-turn-missed-reset-unreadable-2";
+    const sessionKey = "agent:main:test:after-turn-missed-reset-unreadable";
+    const oldSessionFile = createSessionFilePath("after-turn-missed-reset-unreadable-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old unreadable user" },
+      { role: "assistant", content: "old unreadable assistant" },
+    ]);
+
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    rmSync(oldSessionFile, { force: true });
+    const unreadableSessionFile = createSessionFilePath("after-turn-missed-reset-unreadable-new");
+    writeFileSync(unreadableSessionFile, '{"message":', "utf8");
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: unreadableSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "new unreadable assistant delta" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.active).toBe(false);
+    expect(archivedConversation?.archivedAt).not.toBeNull();
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).toBeNull();
+  });
+
+  it("afterTurn bounds initial transcript imports to the bootstrap budget", async () => {
+    const engine = createEngineWithConfig({ bootstrapMaxTokens: 120 });
+    const sessionId = "after-turn-initial-transcript-budget";
+    const sessionKey = "agent:main:test:after-turn-initial-transcript-budget";
+    const sessionFile = createSessionFilePath("after-turn-initial-transcript-budget");
+    const transcriptMessages = Array.from({ length: 60 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `initial afterTurn bulk transcript ${index} ${"x".repeat(200)}`,
+    })) as Array<{ role: AgentMessage["role"]; content: string }>;
+    writeLeafTranscript(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({
+          role: "assistant",
+          content: transcriptMessages[transcriptMessages.length - 1]!.content,
+        }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.length).toBeGreaterThan(0);
+    expect(stored.length).toBeLessThan(10);
+    expect(stored.map((message) => message.content)).toContain(
+      transcriptMessages[transcriptMessages.length - 1]!.content,
+    );
+  });
+
   it("afterTurn skips persistence when full reread finds no anchor and imports nothing", async () => {
     const engine = createEngineWithDeps({}, {
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -10189,29 +10275,32 @@ describe("LcmContextEngine fidelity and token budget", () => {
     });
     const sessionId = "after-turn-heartbeat-prune";
     const sessionKey = "agent:main:test:after-turn-heartbeat-prune";
+    const heartbeatMessages = [
+      makeMessage({
+        role: "user",
+        content:
+          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+      }),
+      makeMessage({
+        role: "tool",
+        content: "# HEARTBEAT.md\n\n## Worker heartbeat (minimal)",
+      }),
+      makeMessage({
+        role: "tool",
+        content: '{\n  "active_session_ids": []\n}',
+      }),
+      makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+    ];
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-prune");
+    writeLeafTranscriptMessages(sessionFile, heartbeatMessages);
 
     const evaluateLeafTriggerSpy = vi.spyOn(engine, "evaluateLeafTrigger");
     const compactSpy = vi.spyOn(engine, "compact");
     await engine.afterTurn({
       sessionId,
       sessionKey,
-      sessionFile: createSessionFilePath("after-turn-heartbeat-prune"),
-      messages: [
-        makeMessage({
-          role: "user",
-          content:
-            "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
-        }),
-        makeMessage({
-          role: "tool",
-          content: "# HEARTBEAT.md\n\n## Worker heartbeat (minimal)",
-        }),
-        makeMessage({
-          role: "tool",
-          content: '{\n  "active_session_ids": []\n}',
-        }),
-        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
-      ],
+      sessionFile,
+      messages: heartbeatMessages,
       prePromptMessageCount: 0,
       tokenBudget: 4096,
     });
@@ -10228,6 +10317,33 @@ describe("LcmContextEngine fidelity and token budget", () => {
         `heartbeat ack messages for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey}`,
       ),
     );
+  });
+
+  it("afterTurn heartbeat flag skips non-empty transcript imports", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-flag-transcript-skip";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-flag-transcript-skip";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-flag-transcript-skip");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "heartbeat transcript user" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).toBeNull();
   });
 });
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3452,6 +3452,64 @@ describe("LcmContextEngine.bootstrap", () => {
     ]);
   });
 
+  it("rotates before assemble when a stable sessionKey points at a pruned transcript", async () => {
+    const engine = createEngine();
+    const firstSessionId = "assemble-missed-reset-fallback-1";
+    const secondSessionId = "assemble-missed-reset-fallback-2";
+    const sessionKey = "agent:main:test:assemble-missed-reset-fallback";
+    const firstSessionFile = createSessionFilePath("assemble-missed-reset-fallback-old");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "what model produced this response?" },
+      { role: "assistant", content: "openai-codex/gpt-5.5" },
+    ]);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    rmSync(firstSessionFile, { force: true });
+
+    const liveMessages = [makeMessage({ role: "user", content: "new live prompt" })];
+    const assembled = await engine.assemble({
+      sessionId: secondSessionId,
+      sessionKey,
+      messages: liveMessages,
+      tokenBudget: 4_096,
+    });
+
+    expect(assembled.messages).toEqual(liveMessages);
+    expect(
+      assembled.messages.some((message) => message.content === "openai-codex/gpt-5.5"),
+    ).toBe(false);
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).not.toBeNull();
+    expect(activeConversation!.conversationId).not.toBe(originalConversation!.conversationId);
+    expect(activeConversation!.sessionId).toBe(secondSessionId);
+    expect(activeConversation!.active).toBe(true);
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.active).toBe(false);
+    expect(archivedConversation?.archivedAt).not.toBeNull();
+  });
+
   it("preserves the active conversation when the tracked transcript stat fails for a non-missing reason", async () => {
     const engine = createEngine();
     const firstSessionId = "bootstrap-stat-failure-fallback-1";
@@ -8674,6 +8732,77 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getConversationBootstrapState(conversation!.conversationId);
     expect(checkpoint?.sessionFilePath).toBe(newSessionFile);
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
+  });
+
+  it("afterTurn archives a stale active conversation when the prior keyed transcript was pruned", async () => {
+    const engine = createEngine();
+    const firstSessionId = "after-turn-missed-reset-fallback-1";
+    const secondSessionId = "after-turn-missed-reset-fallback-2";
+    const sessionKey = "agent:main:test:after-turn-missed-reset-fallback";
+    const oldSessionFile = createSessionFilePath("after-turn-missed-reset-fallback-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old turn user" },
+      { role: "assistant", content: "openai-codex/gpt-5.5" },
+    ]);
+
+    const first = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+    expect(first).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    rmSync(oldSessionFile, { force: true });
+
+    const newSessionFile = createSessionFilePath("after-turn-missed-reset-fallback-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new turn user" },
+      { role: "assistant", content: "new turn assistant" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "new turn user" }),
+        makeMessage({ role: "assistant", content: "new turn assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).not.toBeNull();
+    expect(activeConversation!.conversationId).not.toBe(originalConversation!.conversationId);
+    expect(activeConversation!.sessionId).toBe(secondSessionId);
+    expect(activeConversation!.active).toBe(true);
+
+    const archivedConversation = await engine.getConversationStore().getConversation(
+      originalConversation!.conversationId,
+    );
+    expect(archivedConversation?.active).toBe(false);
+    expect(archivedConversation?.archivedAt).not.toBeNull();
+
+    const activeMessages = await engine.getConversationStore().getMessages(
+      activeConversation!.conversationId,
+    );
+    expect(activeMessages.map((message) => message.content)).toEqual([
+      "new turn user",
+      "new turn assistant",
+    ]);
   });
 
   it("afterTurn skips persistence when full reread finds no anchor and imports nothing", async () => {


### PR DESCRIPTION
## Summary

Fixes a stale replay path for stable session keys when the host prunes a tracked transcript file before Lossless observes a lifecycle split.

When `agent:main:main` resumed on a new runtime session id after OpenClaw session cleanup, Lossless could still resolve the active conversation by `sessionKey` and assemble the prior DB tail. In production this repeatedly reintroduced an old assistant message whose content was exactly `openai-codex/gpt-5.5`.

This PR extracts the existing bootstrap-only missing-transcript guard and applies the same lifecycle repair before:

- `assemble()`, so stale context is not returned to a new runtime UUID.
- `afterTurn` transcript reconciliation, so a new transcript is not imported into the archived conversation.

## Evidence

Observed OpenClaw/Lossless logs:

- `assemble: done conversation=838 session=8dea0efd... sessionKey=agent:main:main ... inputMessages=0 outputMessages=40`
- immediately followed by `afterTurn: transcript reconcile slow path could not stat/read transcript; preserving existing checkpoint ... sessionFile=.../8dea0efd....jsonl`
- then `afterTurn: transcript reconcile slow path (full re-read) conversation=838 reason=path-mismatch ... historicalMessages=2 importedMessages=0`

The LCM DB had one historical assistant row with the repeated visible content:

```text
conversation=838 sessionKey=agent:main:main seq=46 role=assistant content=openai-codex/gpt-5.5
```

So the repeated Discord output was stale context replay, not a new model fallback.

## Validation

- `npm test -- --run test/engine.test.ts -t 'rotates before assemble|prior keyed transcript was pruned|stable sessionKey resumes on a new transcript after the old file disappears'`
- `npm test -- --run test/engine.test.ts`
- `npm run build`
