### PR TITLE
feat: add explicit exact-key recall tool

### DIFF
--- a/.changeset/lcm-recall-keys-tool.md
+++ b/.changeset/lcm-recall-keys-tool.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add `lcm_recall_keys` for explicit exact-key recall from stored raw messages without mutating assembled context.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ When a conversation grows beyond the model's context window, OpenClaw (just like
 2. **Summarizes chunks** of older messages into summaries using your configured LLM
 3. **Condenses summaries** into higher-level nodes as they accumulate, forming a DAG (directed acyclic graph)
 4. **Assembles context** each turn by combining summaries + recent raw messages
-5. **Provides tools** (`lcm_grep`, `lcm_describe`, `lcm_expand`) so agents can search and recall details from compacted history
+5. **Provides tools** (`lcm_recall_keys`, `lcm_grep`, `lcm_describe`, `lcm_expand_query`, `lcm_expand`) so agents can search and recall details from compacted history
 
 Nothing is lost. Raw messages stay in the database. Summaries link back to their source messages. Agents can drill into any summary to recover the original detail.
 
@@ -478,6 +478,7 @@ src/
     fts5-sanitize.ts        # FTS5 query sanitization
   tools/
     lcm-grep-tool.ts        # lcm_grep tool implementation
+    lcm-recall-keys-tool.ts # lcm_recall_keys exact-identifier recall tool
     lcm-describe-tool.ts    # lcm_describe tool implementation
     lcm-expand-tool.ts      # lcm_expand tool (sub-agent only)
     lcm-expand-query-tool.ts # lcm_expand_query tool (main agent wrapper)

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -1,6 +1,6 @@
 # Agent tools
 
-LCM provides four tools for agents to search, inspect, and recall information from compacted conversation history.
+LCM provides tools for agents to search, inspect, and recall information from compacted conversation history.
 
 ## Usage patterns
 
@@ -13,6 +13,10 @@ Most recall tasks follow this escalation:
 3. **`lcm_expand_query`** — Deep recall: spawn a sub-agent to expand the DAG and answer a focused question
 
 Start with grep. If the snippet is enough, stop. If you need full summary content, use describe. If you need details that were compressed away, use expand_query.
+
+### Exact-key shortcut: recall_keys
+
+When the user asks for an exact all-caps identifier whose value is missing from active context, use `lcm_recall_keys` before broad grep/expand. It searches stored raw messages on demand and returns bounded evidence snippets with source message IDs. It does not mutate assembled context and refuses secret-shaped keys or snippets.
 
 ### When to expand
 
@@ -27,6 +31,36 @@ Summaries are lossy by design. The "Expand for details about:" footer at the end
 `lcm_expand_query` is bounded (~120s, scoped sub-agent) and relatively cheap. Don't ration it, but use `lcm_grep` first when you need broad discovery across many sessions.
 
 ## Tool reference
+
+### lcm_recall_keys
+
+Recover exact all-caps identifier facts from stored raw messages without injecting anything into assembled context.
+
+Use this for durable fact handles such as `CRABPOT_LCM_FACT`, `DEPLOYMENT_WINDOW_ID`, or `RELEASE_NOTE_TAG` when a prompt asks for the key and the active summary/tail does not show its value. Do not use it for secrets; keys like `API_KEY`, `TOKEN`, or `PRIVATE_KEY` are refused.
+
+**Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `keys` | string[] | ✅ | — | Exact all-caps identifiers to recover, max 4 |
+| `conversationId` | number | | current session family | Specific physical conversation to search |
+| `allConversations` | boolean | | `false` | Search all conversations |
+| `limitPerKey` | number | | 2 | Max evidence snippets per key, 1–5 |
+
+**Returns:**
+- `matches` — Evidence snippets with `key`, `messageId`, `conversationId`, `role`, `createdAt`, and `snippet`
+- `skippedKeys` — Keys refused as duplicates, invalid exact-key shapes, or secret-shaped identifiers
+- `conversationScope` — Scope used for the lookup
+
+**Examples:**
+
+```
+# Recover a named fact from the current session family
+lcm_recall_keys(keys: ["CRABPOT_LCM_FACT"])
+
+# Recover up to three snippets for two exact keys
+lcm_recall_keys(keys: ["RELEASE_NOTE_TAG", "DEPLOYMENT_WINDOW_ID"], limitPerKey: 3)
+```
 
 ### lcm_grep
 
@@ -181,9 +215,10 @@ Add instructions to your agent's system prompt so it knows when to use LCM tools
 ## Memory & Context
 
 Use LCM tools for recall:
-1. `lcm_grep` — Search all conversations by keyword/regex. Prefer `mode: "full_text"` for short topic terms, use `mode: "regex"` for alternation or other regex syntax, quote exact phrases, use `sort: "relevance"` for older-topic lookups, and `sort: "hybrid"` when recency should still matter.
-2. `lcm_describe` — Inspect a specific summary (cheap, no sub-agent)
-3. `lcm_expand_query` — Deep recall with bounded sub-agent expansion
+1. `lcm_recall_keys` — Recover exact all-caps identifier facts from raw message evidence without changing assembled context.
+2. `lcm_grep` — Search all conversations by keyword/regex. Prefer `mode: "full_text"` for short topic terms, use `mode: "regex"` for alternation or other regex syntax, quote exact phrases, use `sort: "relevance"` for older-topic lookups, and `sort: "hybrid"` when recency should still matter.
+3. `lcm_describe` — Inspect a specific summary (cheap, no sub-agent)
+4. `lcm_expand_query` — Deep recall with bounded sub-agent expansion
 
 When summaries in context have an "Expand for details about:" footer
 listing something you need, use `lcm_expand_query` to get the full detail.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,6 +10,7 @@
   "contracts": {
     "tools": [
       "lcm_grep",
+      "lcm_recall_keys",
       "lcm_describe",
       "lcm_expand",
       "lcm_expand_query"

--- a/skills/lossless-claw/references/recall-tools.md
+++ b/skills/lossless-claw/references/recall-tools.md
@@ -15,6 +15,18 @@ Do not use it for:
 
 - answering detail-heavy questions by itself
 
+### `lcm_recall_keys`
+
+Use for:
+
+- recovering exact all-caps identifier facts from raw message evidence
+- post-rotation cases where a prompt asks for a key but active summaries/tail omit the value
+
+Do not use it for:
+
+- secrets or secret-shaped identifiers such as `API_KEY`, `TOKEN`, or `PRIVATE_KEY`
+- broad topical discovery; use `lcm_grep` for that
+
 ### `lcm_describe`
 
 Use for:
@@ -46,9 +58,10 @@ Treat as a specialized sub-agent flow, not the default first step.
 
 ## Recommended workflow
 
-1. Start with `lcm_grep` to find likely evidence.
-2. Use `lcm_describe` when you have a summary or file ID.
-3. Use `lcm_expand_query` when the answer requires precise recovery rather than a high-level summary.
+1. Use `lcm_recall_keys` first when the prompt asks for an exact all-caps identifier key.
+2. Start with `lcm_grep` to find likely evidence for broader topics.
+3. Use `lcm_describe` when you have a summary or file ID.
+4. Use `lcm_expand_query` when the answer requires precise recovery rather than a high-level summary.
 
 ## Conversation scope
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { createLcmDescribeTool } from "../tools/lcm-describe-tool.js";
 import { createLcmExpandQueryTool } from "../tools/lcm-expand-query-tool.js";
 import { createLcmExpandTool } from "../tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
+import { createLcmRecallKeysTool } from "../tools/lcm-recall-keys-tool.js";
 import { createLcmCommand } from "./lcm-command.js";
 import type {
   LcmDependencies,
@@ -245,12 +246,16 @@ const LOSSLESS_RECALL_POLICY_PROMPT = [
   "**Contradictions/uncertainty:** If facts seem contradictory or uncertain, verify with lossless-claw recall tools before answering instead of trusting the summary at face value.",
   "",
   "**Tool escalation:**",
+  "For exact all-caps identifiers that look like durable fact handles (for example `PROJECT_FLAG`), call `lcm_recall_keys` first. It returns bounded raw-message evidence with source IDs without changing assembled context.",
+  "",
   "Recall order for compacted conversation history:",
-  "1. `lcm_grep` — search by regex or full-text across messages and summaries",
-  "2. `lcm_describe` — inspect a specific summary (cheap, no sub-agent)",
-  "3. `lcm_expand_query` — deep recall: spawns bounded sub-agent, expands DAG, and returns answer plus cited summary IDs in tool output for follow-up (~120s, don't ration it)",
+  "1. `lcm_recall_keys` — recover exact all-caps identifier facts from raw message evidence",
+  "2. `lcm_grep` — search by regex or full-text across messages and summaries",
+  "3. `lcm_describe` — inspect a specific summary (cheap, no sub-agent)",
+  "4. `lcm_expand_query` — deep recall: spawns bounded sub-agent, expands DAG, and returns answer plus cited summary IDs in tool output for follow-up (~120s, don't ration it)",
   "",
   "**`lcm_grep` routing guidance:**",
+  "- Use `lcm_recall_keys` instead of broad grep when the prompt asks for a specific all-caps identifier key whose value is missing from active context.",
   '- Prefer `mode: "full_text"` for keyword or topical recall; keep `mode: "regex"` for regular expressions and literal patterns that use regex syntax.',
   '- Full-text queries are not regexes. Alternation (`A|B`), regex wildcards (`.*`), character classes (`[abc]`), and anchors (`^foo`, `foo$`) require `mode: "regex"`.',
   '- Full-text queries use FTS5 semantics, and FTS5 defaults to AND matching, so extra terms make matching stricter rather than broader.',
@@ -289,9 +294,10 @@ const LOSSLESS_RECALL_POLICY_PROMPT = [
   "State uncertainty instead of guessing from compacted summaries.",
   "",
   "**Precision flow:**",
-  "1. `lcm_grep` to find the relevant summaries or messages",
-  "2. `lcm_expand_query` when you need exact evidence before answering",
-  "3. Answer from the retrieved evidence instead of summary paraphrase",
+  "1. `lcm_recall_keys` for exact all-caps identifier keys.",
+  "2. `lcm_grep` to find the relevant summaries or messages.",
+  "3. `lcm_expand_query` when you need richer evidence before answering.",
+  "4. Answer from the retrieved evidence instead of summary paraphrase",
   "",
   "**Uncertainty checklist:**",
   "- Am I making an exact factual claim from compacted context?",
@@ -1391,6 +1397,10 @@ function wirePluginHandlers(
   api.registerTool(
     (ctx) => createLcmGrepTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
     { name: "lcm_grep" },
+  );
+  api.registerTool(
+    (ctx) => createLcmRecallKeysTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    { name: "lcm_recall_keys" },
   );
   api.registerTool(
     (ctx) => createLcmDescribeTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -117,6 +117,15 @@ export type MessageSearchInput = {
   sort?: SearchSort;
 };
 
+export type LiteralMessageSearchInput = {
+  conversationId?: ConversationId;
+  conversationIds?: ConversationId[];
+  literal: string;
+  roles?: MessageRole[];
+  limit?: number;
+  offset?: number;
+};
+
 export type MessageSearchResult = {
   messageId: MessageId;
   conversationId: ConversationId;
@@ -929,6 +938,47 @@ export class ConversationStore {
     );
   }
 
+  async findMessagesContainingLiteral(input: LiteralMessageSearchInput): Promise<MessageRecord[]> {
+    const literal = input.literal.trim();
+    if (!literal) {
+      return [];
+    }
+
+    const limit = Math.max(1, Math.min(500, Math.trunc(input.limit ?? 50)));
+    const offset = Math.max(0, Math.trunc(input.offset ?? 0));
+    const where: string[] = [];
+    const args: Array<string | number> = [];
+    appendConversationScopeConstraint({
+      where,
+      args,
+      columnExpr: "conversation_id",
+      conversationId: input.conversationId,
+      conversationIds: input.conversationIds,
+    });
+
+    const roles = [...new Set(input.roles ?? [])];
+    if (roles.length > 0) {
+      where.push(`role IN (${roles.map(() => "?").join(", ")})`);
+      args.push(...roles);
+    }
+
+    where.push("instr(content, ?) > 0");
+    args.push(literal);
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+    const rows = this.db
+      .prepare(
+        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content
+         FROM messages
+         ${whereClause}
+         ORDER BY created_at DESC, message_id DESC
+         LIMIT ? OFFSET ?`,
+      )
+      .all(...args, limit, offset) as unknown as MessageRow[];
+
+    return rows.map(toMessageRecord);
+  }
+
   private indexMessageForFullText(messageId: MessageId, content: string): void {
     if (!this.fts5Available) {
       return;
@@ -1128,7 +1178,7 @@ export class ConversationStore {
       .all(...args) as unknown as MessageRow[];
 
     return rows
-      .map((row) => {
+      .map((row): MessageSearchResult | null => {
         const normalizedContent = normalizeMessageContentForFullTextIndex(row.content) ?? row.content;
         const haystack = normalizedContent.toLowerCase();
         const matchesAllTerms = plan.terms.every((term) => haystack.includes(term));

--- a/src/tools/lcm-recall-keys-tool.ts
+++ b/src/tools/lcm-recall-keys-tool.ts
@@ -1,0 +1,361 @@
+import { Type } from "@sinclair/typebox";
+import type { LcmContextEngine } from "../engine.js";
+import type { LiteralMessageSearchInput, MessageRecord } from "../store/conversation-store.js";
+import type { LcmDependencies } from "../types.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult } from "./common.js";
+import {
+  resolveLcmConversationScope,
+  type LcmConversationScope,
+} from "./lcm-conversation-scope.js";
+
+const EXACT_KEY_PATTERN = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
+const MAX_EXACT_KEYS = 4;
+const DEFAULT_LIMIT_PER_KEY = 2;
+const MAX_LIMIT_PER_KEY = 5;
+const CANDIDATE_BATCH_SIZE = 50;
+const MAX_CANDIDATES_PER_KEY = 500;
+const MAX_SNIPPET_CHARS = 800;
+const SENSITIVE_KEY_IDENTIFIER_PATTERN =
+  /(?:^|[^A-Za-z0-9])(?:ACCESS_?KEY|API_?KEY|AUTH|CREDENTIALS?|DEPLOY_?KEY|KEY|PASS(?:WORD)?|PRIVATE_?KEY|SECRET|TOKEN)(?=$|[^A-Za-z0-9])/i;
+const SENSITIVE_SNIPPET_IDENTIFIER_PATTERN =
+  /(?:^|[^A-Za-z0-9])(?:ACCESS_?KEY|API_?KEY|AUTH|CREDENTIALS?|DEPLOY_?KEY|PASS(?:WORD)?|PRIVATE_?KEY|SECRET|TOKEN)(?=$|[^A-Za-z0-9])/i;
+const SENSITIVE_VALUE_PATTERN =
+  /(?:-----BEGIN [A-Z ]*PRIVATE KEY-----|\bAKIA[0-9A-Z]{16}\b|\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{10,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bxox[baprs]-[A-Za-z0-9-]{10,}\b|\b(?:sk|rk|pk)[_-][A-Za-z0-9_-]{10,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b)/i;
+const ELIGIBLE_MESSAGE_ROLES: MessageRecord["role"][] = ["user", "assistant"];
+
+type RecallCandidateStore = ReturnType<LcmContextEngine["getConversationStore"]> & {
+  findMessagesContainingLiteral?: (input: LiteralMessageSearchInput) => Promise<MessageRecord[]>;
+};
+
+const LcmRecallKeysSchema = Type.Object({
+  keys: Type.Array(
+    Type.String({
+      description:
+        "Exact all-caps identifier to recover from stored raw messages, for example CRABPOT_LCM_FACT. Secret-shaped identifiers such as API_KEY or TOKEN are refused.",
+    }),
+    {
+      description: `Exact identifier keys to recall. At most ${MAX_EXACT_KEYS} keys are searched per call.`,
+      minItems: 1,
+      maxItems: MAX_EXACT_KEYS,
+    },
+  ),
+  conversationId: Type.Optional(
+    Type.Number({
+      description:
+        "Physical conversation ID to search within. If omitted, defaults to the current session family.",
+    }),
+  ),
+  allConversations: Type.Optional(
+    Type.Boolean({
+      description:
+        "Set true to explicitly search across all conversations. Ignored when conversationId is provided.",
+    }),
+  ),
+  limitPerKey: Type.Optional(
+    Type.Number({
+      description: `Maximum evidence snippets per key. Default: ${DEFAULT_LIMIT_PER_KEY}.`,
+      minimum: 1,
+      maximum: MAX_LIMIT_PER_KEY,
+    }),
+  ),
+});
+
+type RecallKeysMatch = {
+  key: string;
+  messageId: number;
+  conversationId: number;
+  role: MessageRecord["role"];
+  createdAt: string;
+  snippet: string;
+};
+
+type SkippedKey = {
+  key: string;
+  reason: "duplicate" | "not_exact_key" | "sensitive_identifier";
+};
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exactKeyRegex(key: string): string {
+  return `(^|[^A-Za-z0-9_])${escapeRegexLiteral(key)}($|[^A-Za-z0-9_])`;
+}
+
+function isSensitiveIdentifier(value: string): boolean {
+  return SENSITIVE_KEY_IDENTIFIER_PATTERN.test(value);
+}
+
+function containsSensitiveMaterial(value: string): boolean {
+  return SENSITIVE_SNIPPET_IDENTIFIER_PATTERN.test(value) || SENSITIVE_VALUE_PATTERN.test(value);
+}
+
+function findExactKeyIndex(content: string, key: string): number {
+  const match = new RegExp(exactKeyRegex(key)).exec(content);
+  return match ? match.index + (match[1]?.length ?? 0) : -1;
+}
+
+function lineBounds(content: string, keyIndex: number): { start: number; end: number } {
+  const searchStart = Math.max(0, keyIndex - 1);
+  const previousLineBreak = Math.max(
+    content.lastIndexOf("\n", searchStart),
+    content.lastIndexOf("\r", searchStart),
+  );
+  const start = previousLineBreak >= 0 ? previousLineBreak + 1 : 0;
+  const nextLineFeed = content.indexOf("\n", keyIndex);
+  const nextCarriageReturn = content.indexOf("\r", keyIndex);
+  let end = content.length;
+  if (nextLineFeed >= 0 && nextCarriageReturn >= 0) {
+    end = Math.min(nextLineFeed, nextCarriageReturn);
+  } else if (nextLineFeed >= 0) {
+    end = nextLineFeed;
+  } else if (nextCarriageReturn >= 0) {
+    end = nextCarriageReturn;
+  }
+  return { start, end };
+}
+
+function sentenceStart(line: string, keyIndex: number): number {
+  let start = 0;
+  for (const match of line.slice(0, keyIndex).matchAll(/[.!?](?:\s+|$)/g)) {
+    start = (match.index ?? 0) + match[0].length;
+  }
+  return start;
+}
+
+function sentenceEnd(line: string, keyIndex: number, keyLength: number): number {
+  const afterKey = keyIndex + keyLength;
+  const match = /[.!?](?:\s|$)/.exec(line.slice(afterKey));
+  return match ? afterKey + match.index + 1 : line.length;
+}
+
+function clipSnippet(snippet: string, key: string): string {
+  if (snippet.length <= MAX_SNIPPET_CHARS) {
+    return snippet;
+  }
+  const keyIndex = findExactKeyIndex(snippet, key);
+  if (keyIndex < 0) {
+    return snippet.slice(0, MAX_SNIPPET_CHARS);
+  }
+  const contextBeforeKey = Math.floor(MAX_SNIPPET_CHARS * 0.75);
+  const start = Math.max(0, keyIndex - contextBeforeKey);
+  const end = Math.min(snippet.length, start + MAX_SNIPPET_CHARS);
+  return `${start > 0 ? "..." : ""}${snippet.slice(start, end)}${end < snippet.length ? "..." : ""}`;
+}
+
+function normalizeSnippet(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function extractExactKeySnippet(content: string, key: string): string | null {
+  const keyIndex = findExactKeyIndex(content, key);
+  if (keyIndex < 0) {
+    return null;
+  }
+  const bounds = lineBounds(content, keyIndex);
+  const line = content.slice(bounds.start, bounds.end);
+  const relativeKeyIndex = keyIndex - bounds.start;
+  const rawSnippet = clipSnippet(
+    line.slice(sentenceStart(line, relativeKeyIndex), sentenceEnd(line, relativeKeyIndex, key.length)),
+    key,
+  );
+  if (containsSensitiveMaterial(rawSnippet)) {
+    return null;
+  }
+  const snippet = normalizeSnippet(rawSnippet);
+  return snippet.length > 0 ? snippet : null;
+}
+
+function isEligibleMessageRole(role: MessageRecord["role"]): boolean {
+  return ELIGIBLE_MESSAGE_ROLES.includes(role);
+}
+
+function normalizeKeys(rawKeys: unknown): {
+  keys: string[];
+  skippedKeys: SkippedKey[];
+} {
+  const inputKeys = Array.isArray(rawKeys) ? rawKeys : [];
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  const skippedKeys: SkippedKey[] = [];
+
+  for (const rawKey of inputKeys.slice(0, MAX_EXACT_KEYS)) {
+    const key = typeof rawKey === "string" ? rawKey.trim() : "";
+    if (!EXACT_KEY_PATTERN.test(key)) {
+      skippedKeys.push({ key, reason: "not_exact_key" });
+      continue;
+    }
+    if (isSensitiveIdentifier(key)) {
+      skippedKeys.push({ key, reason: "sensitive_identifier" });
+      continue;
+    }
+    if (seen.has(key)) {
+      skippedKeys.push({ key, reason: "duplicate" });
+      continue;
+    }
+    seen.add(key);
+    keys.push(key);
+  }
+  return { keys, skippedKeys };
+}
+
+async function loadCandidateMessages(input: {
+  store: RecallCandidateStore;
+  conversationScope: LcmConversationScope;
+  key: string;
+  limit: number;
+  offset: number;
+}): Promise<MessageRecord[]> {
+  if (typeof input.store.findMessagesContainingLiteral === "function") {
+    return input.store.findMessagesContainingLiteral({
+      conversationId: input.conversationScope.conversationId,
+      conversationIds: input.conversationScope.conversationIds,
+      literal: input.key,
+      roles: ELIGIBLE_MESSAGE_ROLES,
+      limit: input.limit,
+      offset: input.offset,
+    });
+  }
+
+  if (input.offset > 0) {
+    return [];
+  }
+
+  const candidates = await input.store.searchMessages({
+    conversationId: input.conversationScope.conversationId,
+    conversationIds: input.conversationScope.conversationIds,
+    query: exactKeyRegex(input.key),
+    mode: "regex",
+    limit: MAX_CANDIDATES_PER_KEY,
+    sort: "recency",
+  });
+  const storedMessages: MessageRecord[] = [];
+  for (const candidate of candidates) {
+    const stored = await input.store.getMessageById(candidate.messageId);
+    if (stored) {
+      storedMessages.push(stored);
+    }
+  }
+  return storedMessages;
+}
+
+export function createLcmRecallKeysTool(input: {
+  deps: LcmDependencies;
+  lcm?: LcmContextEngine;
+  getLcm?: () => Promise<LcmContextEngine>;
+  sessionId?: string;
+  sessionKey?: string;
+}): AnyAgentTool {
+  return {
+    name: "lcm_recall_keys",
+    label: "LCM Recall Keys",
+    description:
+      "Recover exact all-caps identifier facts from stored raw LCM messages without mutating assembled context. " +
+      "Use this before broader grep/expand when the user asks for a named key such as PROJECT_FLAG or RELEASE_NOTE_ID and the active summary/tail does not show the value. " +
+      "Returns bounded evidence snippets with source message IDs. Refuses secret-shaped keys and snippets.",
+    parameters: LcmRecallKeysSchema,
+    async execute(_toolCallId: string, params: unknown) {
+      const lcm = input.lcm ?? (await input.getLcm?.());
+      if (!lcm) {
+        throw new Error("LCM engine is unavailable.");
+      }
+
+      const p = params as Record<string, unknown>;
+      const { keys, skippedKeys } = normalizeKeys(p.keys);
+      if (keys.length === 0) {
+        return jsonResult({
+          error: "No usable exact recall keys were provided.",
+          skippedKeys,
+          matches: [],
+          matchCount: 0,
+        });
+      }
+
+      const limitPerKey = Math.max(
+        1,
+        Math.min(
+          MAX_LIMIT_PER_KEY,
+          typeof p.limitPerKey === "number" && Number.isFinite(p.limitPerKey)
+            ? Math.trunc(p.limitPerKey)
+            : DEFAULT_LIMIT_PER_KEY,
+        ),
+      );
+      const conversationScope = await resolveLcmConversationScope({
+        lcm,
+        deps: input.deps,
+        sessionId: input.sessionId,
+        sessionKey: input.sessionKey,
+        params: p,
+      });
+      if (!conversationScope.allConversations && conversationScope.conversationId == null) {
+        return jsonResult({
+          error:
+            "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
+          keys,
+          skippedKeys,
+          matches: [],
+          matchCount: 0,
+        });
+      }
+
+      const store = lcm.getConversationStore() as RecallCandidateStore;
+      const matches: RecallKeysMatch[] = [];
+      const seenMatches = new Set<string>();
+      for (const key of keys) {
+        let acceptedForKey = 0;
+        let scannedForKey = 0;
+        let offset = 0;
+        while (acceptedForKey < limitPerKey && scannedForKey < MAX_CANDIDATES_PER_KEY) {
+          const candidates = await loadCandidateMessages({
+            store,
+            conversationScope,
+            key,
+            limit: Math.min(CANDIDATE_BATCH_SIZE, MAX_CANDIDATES_PER_KEY - scannedForKey),
+            offset,
+          });
+          if (candidates.length === 0) {
+            break;
+          }
+          scannedForKey += candidates.length;
+          offset += candidates.length;
+          for (const stored of candidates) {
+            if (acceptedForKey >= limitPerKey) {
+              break;
+            }
+            const seenKey = `${key}:${stored.messageId}`;
+            if (seenMatches.has(seenKey) || !isEligibleMessageRole(stored.role)) {
+              continue;
+            }
+            const snippet = extractExactKeySnippet(stored.content, key);
+            if (!snippet) {
+              continue;
+            }
+            seenMatches.add(seenKey);
+            acceptedForKey++;
+            matches.push({
+              key,
+              messageId: stored.messageId,
+              conversationId: stored.conversationId,
+              role: stored.role,
+              createdAt: stored.createdAt.toISOString(),
+              snippet,
+            });
+          }
+        }
+      }
+
+      return jsonResult({
+        keys,
+        skippedKeys,
+        conversationScope: {
+          allConversations: conversationScope.allConversations,
+          conversationId: conversationScope.conversationId,
+          conversationIds: conversationScope.conversationIds,
+        },
+        matches,
+        matchCount: matches.length,
+      });
+    },
+  };
+}

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -1,12 +1,17 @@
+import { DatabaseSync } from "node:sqlite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDelegatedExpansionGrant,
   resetDelegatedExpansionGrantsForTests,
 } from "../src/expansion-auth.js";
 import { formatTimestamp } from "../src/compaction.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
 import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
 import { createLcmExpandTool } from "../src/tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
+import { createLcmRecallKeysTool } from "../src/tools/lcm-recall-keys-tool.js";
 import type { LcmDependencies } from "../src/types.js";
 
 function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
@@ -80,6 +85,17 @@ function makeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
     },
     ...overrides,
   } as LcmDependencies;
+}
+
+function createTestDb(): { db: DatabaseSync; conversationStore: ConversationStore } {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+  return {
+    db,
+    conversationStore: new ConversationStore(db, { fts5Available }),
+  };
 }
 
 function buildLcmEngine(params: {
@@ -412,6 +428,314 @@ describe("LCM tools session scoping", () => {
     );
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("session family rooted at 42 (3 segments)");
+  });
+
+  it("lcm_recall_keys returns exact-key raw evidence with source message IDs", async () => {
+    const createdAt = new Date("2026-01-04T00:00:00.000Z");
+    const searchMessages = vi.fn(async () => [
+      {
+        messageId: 101,
+        conversationId: 42,
+        role: "user",
+        snippet: "CRABPOT_LCM_FACT",
+        createdAt,
+        rank: 0,
+      },
+    ]);
+    const getMessageById = vi.fn(async () => ({
+      messageId: 101,
+      conversationId: 42,
+      seq: 7,
+      role: "user",
+      content: "Remember blue-lantern-42 as CRABPOT_LCM_FACT.",
+      tokenCount: 8,
+      createdAt,
+      largeContent: null,
+    }));
+    const tool = createLcmRecallKeysTool({
+      deps: makeDeps(),
+      lcm: {
+        getConversationStore: () => ({
+          getConversationBySessionKey: vi.fn(async () => ({
+            conversationId: 42,
+            sessionId: "legacy-session",
+            sessionKey: "agent:main:main",
+            active: true,
+            archivedAt: null,
+            title: null,
+            bootstrappedAt: null,
+            createdAt,
+            updatedAt: createdAt,
+          })),
+          getConversationFamilyIds: vi.fn(async () => [42, 21]),
+          searchMessages,
+          getMessageById,
+        }),
+      } as never,
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-recall-key", {
+      keys: ["CRABPOT_LCM_FACT"],
+    });
+
+    expect(searchMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 42,
+        conversationIds: [42, 21],
+        mode: "regex",
+        query: expect.stringContaining("CRABPOT_LCM_FACT"),
+      }),
+    );
+    expect(result.details).toMatchObject({
+      keys: ["CRABPOT_LCM_FACT"],
+      matchCount: 1,
+      matches: [
+        {
+          key: "CRABPOT_LCM_FACT",
+          messageId: 101,
+          conversationId: 42,
+          role: "user",
+          createdAt: createdAt.toISOString(),
+          snippet: "Remember blue-lantern-42 as CRABPOT_LCM_FACT.",
+        },
+      ],
+    });
+  });
+
+  it("lcm_recall_keys rejects secret-shaped keys and sensitive snippets", async () => {
+    const createdAt = new Date("2026-01-05T00:00:00.000Z");
+    const stripeLikeSecret = ["sk", "live", "1234567890abcdefghijklmnopqrstuvwxyz"].join("_");
+    const searchMessages = vi.fn(async () => [
+      {
+        messageId: 201,
+        conversationId: 42,
+        role: "user",
+        snippet: "PROJECT_ID",
+        createdAt,
+        rank: 0,
+      },
+    ]);
+    const getMessageById = vi.fn(async () => ({
+      messageId: 201,
+      conversationId: 42,
+      seq: 3,
+      role: "user",
+      content: `PROJECT_ID is launch-alpha; Stripe value ${stripeLikeSecret}.`,
+      tokenCount: 8,
+      createdAt,
+      largeContent: null,
+    }));
+    const tool = createLcmRecallKeysTool({
+      deps: makeDeps(),
+      lcm: {
+        getConversationStore: () => ({
+          getConversationBySessionId: vi.fn(async () => ({
+            conversationId: 42,
+            sessionId: "session-1",
+            sessionKey: null,
+            active: true,
+            archivedAt: null,
+            title: null,
+            bootstrappedAt: null,
+            createdAt,
+            updatedAt: createdAt,
+          })),
+          getConversationFamilyIds: vi.fn(async () => [42]),
+          searchMessages,
+          getMessageById,
+        }),
+      } as never,
+      sessionId: "session-1",
+    });
+
+    const result = await tool.execute("call-sensitive-recall", {
+      keys: ["API_KEY", "PROJECT_ID"],
+    });
+
+    expect(searchMessages).toHaveBeenCalledTimes(1);
+    expect(searchMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.stringContaining("PROJECT_ID") }),
+    );
+    expect(result.details).toMatchObject({
+      keys: ["PROJECT_ID"],
+      skippedKeys: [{ key: "API_KEY", reason: "sensitive_identifier" }],
+      matches: [],
+      matchCount: 0,
+    });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).not.toContain(stripeLikeSecret);
+  });
+
+  it("lcm_recall_keys allows ordinary key wording in safe snippets", async () => {
+    const createdAt = new Date("2026-01-05T01:00:00.000Z");
+    const tool = createLcmRecallKeysTool({
+      deps: makeDeps(),
+      lcm: {
+        getConversationStore: () => ({
+          getConversationBySessionId: vi.fn(async () => ({
+            conversationId: 42,
+            sessionId: "session-1",
+            sessionKey: null,
+            active: true,
+            archivedAt: null,
+            title: null,
+            bootstrappedAt: null,
+            createdAt,
+            updatedAt: createdAt,
+          })),
+          getConversationFamilyIds: vi.fn(async () => [42]),
+          searchMessages: vi.fn(async () => [
+            {
+              messageId: 251,
+              conversationId: 42,
+              role: "user",
+              snippet: "CRABPOT_LCM_FACT",
+              createdAt,
+              rank: 0,
+            },
+          ]),
+          getMessageById: vi.fn(async () => ({
+            messageId: 251,
+            conversationId: 42,
+            seq: 4,
+            role: "user",
+            content: "The key CRABPOT_LCM_FACT is blue-lantern-42.",
+            tokenCount: 8,
+            createdAt,
+            largeContent: null,
+          })),
+        }),
+      } as never,
+      sessionId: "session-1",
+    });
+
+    const result = await tool.execute("call-key-wording-recall", {
+      keys: ["CRABPOT_LCM_FACT"],
+    });
+
+    expect(result.details).toMatchObject({
+      keys: ["CRABPOT_LCM_FACT"],
+      matchCount: 1,
+      matches: [
+        {
+          key: "CRABPOT_LCM_FACT",
+          snippet: "The key CRABPOT_LCM_FACT is blue-lantern-42.",
+        },
+      ],
+    });
+  });
+
+  it("lcm_recall_keys scans past recent ineligible candidates with the real store", async () => {
+    const { db, conversationStore } = createTestDb();
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+      });
+      const [validMessage] = await conversationStore.createMessagesBulk([
+        {
+          conversationId: conversation.conversationId,
+          seq: 0,
+          role: "user",
+          content: "Remember blue-lantern-42 as CRABPOT_LCM_FACT.",
+          tokenCount: 8,
+        },
+        ...Array.from({ length: 6 }, (_, index) => ({
+          conversationId: conversation.conversationId,
+          seq: index + 1,
+          role: "tool" as const,
+          content: `Tool echo ${index}: CRABPOT_LCM_FACT should not be returned.`,
+          tokenCount: 9,
+        })),
+      ]);
+      db.prepare(
+        `UPDATE messages
+         SET created_at = datetime('2026-01-01 00:00:00', printf('+%d seconds', seq))
+         WHERE conversation_id = ?`,
+      ).run(conversation.conversationId);
+
+      const tool = createLcmRecallKeysTool({
+        deps: makeDeps(),
+        lcm: {
+          getConversationStore: () => conversationStore,
+        } as never,
+        sessionKey: "agent:main:main",
+      });
+
+      const result = await tool.execute("call-real-store-starvation", {
+        keys: ["CRABPOT_LCM_FACT"],
+      });
+
+      expect(result.details).toMatchObject({
+        keys: ["CRABPOT_LCM_FACT"],
+        matchCount: 1,
+        matches: [
+          {
+            key: "CRABPOT_LCM_FACT",
+            messageId: validMessage?.messageId,
+            role: "user",
+            snippet: "Remember blue-lantern-42 as CRABPOT_LCM_FACT.",
+          },
+        ],
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("lcm_recall_keys does not accept substring matches as evidence", async () => {
+    const createdAt = new Date("2026-01-06T00:00:00.000Z");
+    const tool = createLcmRecallKeysTool({
+      deps: makeDeps(),
+      lcm: {
+        getConversationStore: () => ({
+          getConversationBySessionId: vi.fn(async () => ({
+            conversationId: 42,
+            sessionId: "session-1",
+            sessionKey: null,
+            active: true,
+            archivedAt: null,
+            title: null,
+            bootstrappedAt: null,
+            createdAt,
+            updatedAt: createdAt,
+          })),
+          getConversationFamilyIds: vi.fn(async () => [42]),
+          searchMessages: vi.fn(async () => [
+            {
+              messageId: 301,
+              conversationId: 42,
+              role: "user",
+              snippet: "CRABPOT_LCM_FACT_BACKUP",
+              createdAt,
+              rank: 0,
+            },
+          ]),
+          getMessageById: vi.fn(async () => ({
+            messageId: 301,
+            conversationId: 42,
+            seq: 3,
+            role: "user",
+            content: "CRABPOT_LCM_FACT_BACKUP is red-lantern-99.",
+            tokenCount: 7,
+            createdAt,
+            largeContent: null,
+          })),
+        }),
+      } as never,
+      sessionId: "session-1",
+    });
+
+    const result = await tool.execute("call-boundary-recall", {
+      keys: ["CRABPOT_LCM_FACT"],
+    });
+
+    expect(result.details).toMatchObject({
+      keys: ["CRABPOT_LCM_FACT"],
+      matches: [],
+      matchCount: 0,
+    });
   });
 
   it("lcm_describe blocks cross-conversation lookup unless allConversations=true", async () => {

--- a/test/plugin-prompt-hook.test.ts
+++ b/test/plugin-prompt-hook.test.ts
@@ -124,8 +124,14 @@ describe("lcm plugin prompt hook", () => {
     expect(result.prependSystemContext).toContain(
       "If facts seem contradictory or uncertain, verify with lossless-claw recall tools before answering",
     );
+    expect(result.prependSystemContext).toContain(
+      "call `lcm_recall_keys` first",
+    );
     expect(result.prependSystemContext).toContain("Recall order for compacted conversation history:");
-    expect(result.prependSystemContext).toContain("1. `lcm_grep` — search by regex or full-text");
+    expect(result.prependSystemContext).toContain(
+      "1. `lcm_recall_keys` — recover exact all-caps identifier facts from raw message evidence",
+    );
+    expect(result.prependSystemContext).toContain("2. `lcm_grep` — search by regex or full-text");
     expect(result.prependSystemContext).toContain("`lcm_grep` routing guidance");
     expect(result.prependSystemContext).toContain('Prefer `mode: "full_text"` for keyword or topical recall');
     expect(result.prependSystemContext).toContain("Full-text queries are not regexes");
@@ -135,9 +141,9 @@ describe("lcm plugin prompt hook", () => {
     expect(result.prependSystemContext).toContain('Wrap exact multi-word phrases in quotes');
     expect(result.prependSystemContext).toContain('Use `sort: "relevance"` when hunting for the best older match');
     expect(result.prependSystemContext).toContain('Use `sort: "hybrid"` when relevance matters but newer context should still get a boost');
-    expect(result.prependSystemContext).toContain("2. `lcm_describe` — inspect a specific summary");
+    expect(result.prependSystemContext).toContain("3. `lcm_describe` — inspect a specific summary");
     expect(result.prependSystemContext).toContain(
-      "3. `lcm_expand_query` — deep recall: spawns bounded sub-agent",
+      "4. `lcm_expand_query` — deep recall: spawns bounded sub-agent",
     );
     expect(result.prependSystemContext).toContain(
       "`lcm_expand_query` usage",
@@ -165,8 +171,10 @@ describe("lcm plugin prompt hook", () => {
       "For exact commands, SHAs, paths, timestamps, config values, or causal chains, expand for details before answering.",
     );
     expect(result.prependSystemContext).toContain("**Precision flow:**");
-    expect(result.prependSystemContext).toContain("1. `lcm_grep` to find the relevant summaries or messages");
-    expect(result.prependSystemContext).toContain("2. `lcm_expand_query` when you need exact evidence before answering");
+    expect(result.prependSystemContext).toContain("1. `lcm_recall_keys` for exact all-caps identifier keys.");
+    expect(result.prependSystemContext).toContain("2. `lcm_grep` to find the relevant summaries or messages.");
+    expect(result.prependSystemContext).toContain("3. `lcm_expand_query` when you need richer evidence before answering.");
+    expect(result.prependSystemContext).toContain("4. Answer from the retrieved evidence instead of summary paraphrase");
     expect(result.prependSystemContext).toContain("**Uncertainty checklist:**");
     expect(result.prependSystemContext).toContain("Could compaction have omitted a crucial detail?");
     expect(result.prependSystemContext).toContain(


### PR DESCRIPTION
## Summary

Alternative implementation for the architecture option proposed in this comment:
https://github.com/Martian-Engineering/lossless-claw/pull/765#issuecomment-4577449530

This adds an explicit `lcm_recall_keys` tool for exact all-caps identifier recall from stored raw messages. It avoids changing `assemble()` or injecting prompt-matched recall into every runtime turn.

## Why this PR exists

PR #765 is a tactical fix for prompt-matched recall after rotation, but it touches the canonical context assembly path. That is high blast radius because `assemble()` runs for normal runtime context, not just a crabbox/test-only path.

This PR is the compatibility-first alternative:

- no `engine.ts` changes
- no `assembler.ts` changes
- no database migrations
- no automatic prompt scanning during context assembly
- no mutation of assembled context
- explicit agent action when a user asks for a durable exact key

## Architecture

```mermaid
flowchart LR
  A["User asks for exact key\nCRABPOT_LCM_FACT"] --> B["Agent sees active context\nvalue missing"]
  B --> C["Call lcm_recall_keys"]
  C --> D["Session-family scoped raw-message search"]
  D --> E["Exact boundary validation"]
  E --> F["Secret-shaped key/snippet filter"]
  F --> G["Bounded evidence snippets\nmessageId + conversationId"]

  H["Normal assemble()"] -. "unchanged" .- B
  H -. "no prompt recall injection" .- C
```

## Behavior

`lcm_recall_keys` accepts up to four exact all-caps identifiers such as `CRABPOT_LCM_FACT` and returns bounded evidence snippets with source IDs. By default it searches the current session family, while still allowing explicit `conversationId` or `allConversations`.

The tool refuses broad fuzzy searches and secret-shaped identifiers such as `API_KEY`, `TOKEN`, and `PRIVATE_KEY`. It also re-reads candidate messages by ID and validates exact key boundaries before returning evidence, so `CRABPOT_LCM_FACT_BACKUP` is not accepted as evidence for `CRABPOT_LCM_FACT`.

## Compatibility Notes

This should be easier to merge safely than an assemble-time fix because the new behavior is isolated behind one registered tool and one manifest contract entry. Existing context assembly, compaction, summaries, and engine rotation behavior remain canonical.

Prompt guidance is limited to instructing agents when to choose the explicit tool. The recall itself happens only when the agent calls `lcm_recall_keys`.

## Validation

Ran locally from `/Volumes/LEXAR/repos/lossless-claw-exact-key-recall-tool`:

- `npm test -- --run test/lcm-tools.test.ts test/plugin-prompt-hook.test.ts test/manifest.test.ts`
- `npm run build`
- `git diff --check`
- `npm test -- --maxWorkers=1`

Result: 48 test files passed, 928 tests passed.

I also tried `npx tsc --noEmit`; that is not a repo script/gate and current `main` reports many existing type-environment/strictness diagnostics. After typing the new tool's `execute` signature, no `src/tools/lcm-recall-keys-tool.ts` diagnostics remain in that output.

## Draft Status

Opening as a draft alternative to #765 for review. Do not merge until maintainers choose between the tactical #765 path and this explicit-tool architecture.
