### PR TITLE
fix: enforce delegated LCM retrieval scopes

### DIFF
--- a/.changeset/delegated-retrieval-scope.md
+++ b/.changeset/delegated-retrieval-scope.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Restrict delegated sub-agent retrieval tools to the conversation IDs in their expansion grant. Sub-agents can no longer use `allConversations=true` or an explicit foreign `conversationId` to bypass the grant scope in `lcm_grep`, `lcm_describe`, `lcm_expand`, or `lcm_expand_query`.

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -1,10 +1,16 @@
 import type { LcmContextEngine } from "../engine.js";
+import {
+  getRuntimeExpansionAuthManager,
+  resolveDelegatedExpansionGrantId,
+} from "../expansion-auth.js";
 import type { LcmDependencies } from "../types.js";
 
 export type LcmConversationScope = {
   conversationId?: number;
   conversationIds?: number[];
   allConversations: boolean;
+  delegated: boolean;
+  error?: string;
 };
 
 type ConversationScopeStore = ReturnType<LcmContextEngine["getConversationStore"]> & {
@@ -87,31 +93,126 @@ export async function resolveLcmConversationScope(input: {
   params: Record<string, unknown>;
   sessionId?: string;
   sessionKey?: string;
-  deps?: Pick<LcmDependencies, "resolveSessionIdFromSessionKey">;
+  deps?: Pick<LcmDependencies, "isSubagentSessionKey" | "resolveSessionIdFromSessionKey">;
 }): Promise<LcmConversationScope> {
   const { lcm, params } = input;
+  const explicitSessionKey = input.sessionKey?.trim();
+  const normalizedInputSessionId = input.sessionId?.trim();
+  const sessionIdAsSessionKey =
+    !explicitSessionKey
+    && normalizedInputSessionId
+    && input.deps?.isSubagentSessionKey(normalizedInputSessionId)
+      ? normalizedInputSessionId
+      : undefined;
+  const normalizedSessionKey = explicitSessionKey || sessionIdAsSessionKey;
+  const isDelegatedSession =
+    Boolean(normalizedSessionKey) && Boolean(input.deps?.isSubagentSessionKey(normalizedSessionKey!));
+  let allowedConversationIds: number[] = [];
 
   const explicitConversationId =
     typeof params.conversationId === "number" && Number.isFinite(params.conversationId)
       ? Math.trunc(params.conversationId)
       : undefined;
+
+  if (isDelegatedSession) {
+    const delegatedGrantId = resolveDelegatedExpansionGrantId(normalizedSessionKey!);
+    const authManager = getRuntimeExpansionAuthManager();
+    const delegatedGrant =
+      delegatedGrantId != null
+        ? authManager.getGrant(delegatedGrantId)
+        : null;
+    if (!delegatedGrant) {
+      if (delegatedGrantId) {
+        const validation = authManager.validateExpansion(delegatedGrantId, {
+          conversationId: explicitConversationId ?? 0,
+          summaryIds: [],
+          depth: 1,
+          tokenCap: 1,
+        });
+        return {
+          allConversations: false,
+          delegated: true,
+          error: `Expansion authorization failed: ${validation.reason ?? "Grant is unavailable"}`,
+        };
+      }
+      return {
+        allConversations: false,
+        delegated: true,
+        error:
+          "Delegated LCM retrieval requires a valid grant. This sub-agent session has no propagated expansion grant.",
+      };
+    }
+
+    allowedConversationIds = Array.from(
+      new Set(
+        delegatedGrant.allowedConversationIds
+          .map((conversationId) => Math.trunc(conversationId))
+          .filter((conversationId) => Number.isInteger(conversationId)),
+      ),
+    );
+    if (allowedConversationIds.length === 0) {
+      return {
+        allConversations: false,
+        delegated: true,
+        error: "Delegated LCM retrieval grant has no allowed conversation scope.",
+      };
+    }
+
+    if (explicitConversationId != null) {
+      if (!allowedConversationIds.includes(explicitConversationId)) {
+        return {
+          allConversations: false,
+          delegated: true,
+          error: `Conversation ${explicitConversationId} is outside delegated conversation scope.`,
+        };
+      }
+      return {
+        conversationId: explicitConversationId,
+        conversationIds: [explicitConversationId],
+        allConversations: false,
+        delegated: true,
+      };
+    }
+
+    if (params.allConversations === true) {
+      return {
+        conversationId: allowedConversationIds.length === 1 ? allowedConversationIds[0] : undefined,
+        conversationIds: allowedConversationIds,
+        allConversations: false,
+        delegated: true,
+      };
+    }
+  }
+
   if (explicitConversationId != null) {
     return {
       conversationId: explicitConversationId,
       conversationIds: [explicitConversationId],
       allConversations: false,
+      delegated: false,
     };
   }
 
   if (params.allConversations === true) {
-    return { conversationId: undefined, conversationIds: undefined, allConversations: true };
+    return {
+      conversationId: undefined,
+      conversationIds: undefined,
+      allConversations: true,
+      delegated: false,
+    };
   }
 
-  const normalizedSessionKey = input.sessionKey?.trim();
   if (normalizedSessionKey) {
     const bySessionKey =
       await lcm.getConversationStore().getConversationBySessionKey(normalizedSessionKey);
     if (bySessionKey) {
+      if (isDelegatedSession && !allowedConversationIds.includes(bySessionKey.conversationId)) {
+        return {
+          allConversations: false,
+          delegated: true,
+          error: `Conversation ${bySessionKey.conversationId} is outside delegated conversation scope.`,
+        };
+      }
       const familyIds =
         typeof (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds === "function"
           ? await (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds({
@@ -119,20 +220,33 @@ export async function resolveLcmConversationScope(input: {
               sessionKey: normalizedSessionKey,
             })
           : [bySessionKey.conversationId];
+      const scopedFamilyIds = familyIds.length > 0 ? familyIds : [bySessionKey.conversationId];
+      const conversationIds = isDelegatedSession
+        ? scopedFamilyIds.filter((conversationId) => allowedConversationIds.includes(conversationId))
+        : scopedFamilyIds;
       return {
         conversationId: bySessionKey.conversationId,
-        conversationIds: familyIds.length > 0 ? familyIds : [bySessionKey.conversationId],
+        conversationIds: conversationIds.length > 0 ? conversationIds : [bySessionKey.conversationId],
         allConversations: false,
+        delegated: isDelegatedSession,
       };
     }
   }
 
-  let normalizedSessionId = input.sessionId?.trim();
+  let normalizedSessionId = sessionIdAsSessionKey ? undefined : normalizedInputSessionId;
   if (!normalizedSessionId && normalizedSessionKey && input.deps) {
     normalizedSessionId = await input.deps.resolveSessionIdFromSessionKey(normalizedSessionKey);
   }
   if (!normalizedSessionId && !input.sessionKey?.trim()) {
-    return { conversationId: undefined, conversationIds: undefined, allConversations: false };
+    return {
+      conversationId:
+        isDelegatedSession && allowedConversationIds.length === 1
+          ? allowedConversationIds[0]
+          : undefined,
+      conversationIds: isDelegatedSession ? allowedConversationIds : undefined,
+      allConversations: false,
+      delegated: isDelegatedSession,
+    };
   }
 
   const conversation = await lookupConversationForSession({
@@ -141,7 +255,15 @@ export async function resolveLcmConversationScope(input: {
     sessionKey: input.sessionKey,
   });
   if (!conversation) {
-    return { conversationId: undefined, conversationIds: undefined, allConversations: false };
+    return {
+      conversationId:
+        isDelegatedSession && allowedConversationIds.length === 1
+          ? allowedConversationIds[0]
+          : undefined,
+      conversationIds: isDelegatedSession ? allowedConversationIds : undefined,
+      allConversations: false,
+      delegated: isDelegatedSession,
+    };
   }
 
   const store = lcm.getConversationStore() as ConversationScopeStore;
@@ -154,9 +276,22 @@ export async function resolveLcmConversationScope(input: {
         })
       : [conversation.conversationId];
 
+  const scopedFamilyIds = familyIds.length > 0 ? familyIds : [conversation.conversationId];
+  const conversationIds = isDelegatedSession
+    ? scopedFamilyIds.filter((conversationId) => allowedConversationIds.includes(conversationId))
+    : scopedFamilyIds;
+  if (isDelegatedSession && !allowedConversationIds.includes(conversation.conversationId)) {
+    return {
+      allConversations: false,
+      delegated: true,
+      error: `Conversation ${conversation.conversationId} is outside delegated conversation scope.`,
+    };
+  }
+
   return {
     conversationId: conversation.conversationId,
-    conversationIds: familyIds.length > 0 ? familyIds : [conversation.conversationId],
+    conversationIds: conversationIds.length > 0 ? conversationIds : [conversation.conversationId],
     allConversations: false,
+    delegated: isDelegatedSession,
   };
 }

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -137,7 +137,14 @@ export function createLcmDescribeTool(input: {
         sessionKey: input.sessionKey,
         params: p,
       });
-      if (!conversationScope.allConversations && conversationScope.conversationId == null) {
+      if (conversationScope.error) {
+        return jsonResult({ error: conversationScope.error });
+      }
+      if (
+        !conversationScope.allConversations
+        && conversationScope.conversationId == null
+        && (conversationScope.conversationIds?.length ?? 0) === 0
+      ) {
         return jsonResult({
           error:
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",
@@ -165,7 +172,10 @@ export function createLcmDescribeTool(input: {
           hint: "Check the ID format (sum_xxx for summaries, file_xxx for files).",
         });
       }
-      if (conversationScope.conversationId != null) {
+      if (
+        conversationScope.conversationId != null
+        || (conversationScope.conversationIds?.length ?? 0) > 0
+      ) {
         const itemConversationId =
           result.type === "summary" ? result.summary?.conversationId : result.file?.conversationId;
         const allowedConversationIds = new Set(
@@ -177,7 +187,9 @@ export function createLcmDescribeTool(input: {
         );
         if (itemConversationId != null && !allowedConversationIds.has(itemConversationId)) {
           return jsonResult({
-            error: `Not found in this session scope: ${id}`,
+            error: conversationScope.delegated
+              ? `Not found in delegated conversation scope: ${id}`
+              : `Not found in this session scope: ${id}`,
             hint: "Use allConversations=true for cross-conversation lookup.",
           });
         }

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -1089,6 +1089,9 @@ export function createLcmExpandQueryTool(input: {
           sessionKey: input.sessionKey,
           params: p,
         });
+        if (conversationScope.error) {
+          return jsonResult({ error: conversationScope.error });
+        }
         const familyScopedConversationId =
           (conversationScope.conversationIds?.length ?? 0) > 1
             ? undefined

--- a/src/tools/lcm-expand-tool.ts
+++ b/src/tools/lcm-expand-tool.ts
@@ -189,6 +189,15 @@ export function createLcmExpandTool(input: {
         sessionKey: input.sessionKey,
         params: p,
       });
+      if (conversationScope.error) {
+        return jsonResult({ error: conversationScope.error });
+      }
+      if (isDelegatedSession && conversationScope.conversationId == null) {
+        return jsonResult({
+          error:
+            "lcm_expand requires a single delegated conversation scope. Provide conversationId within the delegated grant.",
+        });
+      }
 
       const runExpand = async (input: {
         summaryIds: string[];

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -206,7 +206,14 @@ export function createLcmGrepTool(input: {
         sessionKey: input.sessionKey,
         params: p,
       });
-      if (!conversationScope.allConversations && conversationScope.conversationId == null) {
+      if (conversationScope.error) {
+        return jsonResult({ error: conversationScope.error });
+      }
+      if (
+        !conversationScope.allConversations
+        && conversationScope.conversationId == null
+        && (conversationScope.conversationIds?.length ?? 0) === 0
+      ) {
         return jsonResult({
           error:
             "No LCM conversation found for this session. Provide conversationId or set allConversations=true.",

--- a/test/lcm-expand-tool.test.ts
+++ b/test/lcm-expand-tool.test.ts
@@ -362,6 +362,59 @@ describe("createLcmExpandTool expansion limits", () => {
     expect(mockRetrieval.expand).not.toHaveBeenCalled();
   });
 
+  it("fails closed for delegated explicit expansion with multiple allowed conversations", async () => {
+    const mockRetrieval = makeMockRetrieval();
+
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: "agent:main:subagent:multi-conversation",
+      issuerSessionId: "main",
+      allowedConversationIds: [7, 11],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmExpandTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval: mockRetrieval }),
+      sessionId: "agent:main:subagent:multi-conversation",
+    });
+    const result = await tool.execute("call-multi-conversation", {
+      summaryIds: ["sum_a", "sum_b"],
+      allConversations: true,
+    });
+
+    expect(result.details).toMatchObject({
+      error: expect.stringContaining("requires a single delegated conversation scope"),
+    });
+    expect(mockRetrieval.expand).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for delegated query expansion with multiple allowed conversations", async () => {
+    const mockRetrieval = makeMockRetrieval();
+
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: "agent:main:subagent:multi-query",
+      issuerSessionId: "main",
+      allowedConversationIds: [7, 11],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmExpandTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval: mockRetrieval }),
+      sessionId: "agent:main:subagent:multi-query",
+    });
+    const result = await tool.execute("call-multi-query", {
+      query: "private",
+      allConversations: true,
+    });
+
+    expect(result.details).toMatchObject({
+      error: expect.stringContaining("requires a single delegated conversation scope"),
+    });
+    expect(mockRetrieval.grep).not.toHaveBeenCalled();
+    expect(mockRetrieval.expand).not.toHaveBeenCalled();
+  });
+
   it("clamps delegated expansion tokenCap to grant budget", async () => {
     const mockRetrieval = makeMockRetrieval();
     mockRetrieval.expand.mockResolvedValue({

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -414,6 +414,154 @@ describe("LCM tools session scoping", () => {
     expect(text).toContain("session family rooted at 42 (3 segments)");
   });
 
+  it("lcm_grep rejects allConversations from a sub-agent without a delegated grant", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+      sessionKey: "agent:main:subagent:session-1",
+    });
+    const result = await tool.execute("call-subagent-all", {
+      pattern: "private",
+      allConversations: true,
+    });
+
+    expect(retrieval.grep).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain(
+      "Delegated LCM retrieval requires a valid grant",
+    );
+  });
+
+  it("lcm_grep rejects allConversations when a sub-agent key is passed as sessionId", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+      sessionId: "agent:main:subagent:session-1",
+    });
+    const result = await tool.execute("call-subagent-session-id-all", {
+      pattern: "private",
+      allConversations: true,
+    });
+
+    expect(retrieval.grep).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain(
+      "Delegated LCM retrieval requires a valid grant",
+    );
+  });
+
+  it("lcm_grep scopes delegated allConversations to the granted conversation IDs", async () => {
+    const retrieval = {
+      grep: vi.fn(async (request: { conversationIds?: number[] }) => {
+        const scoped = request.conversationIds?.includes(42);
+        return {
+          messages: [],
+          summaries: scoped
+            ? [
+                {
+                  summaryId: "sum_allowed",
+                  conversationId: 42,
+                  kind: "leaf",
+                  snippet: "allowed summary",
+                  createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                },
+              ]
+            : [
+                {
+                  summaryId: "sum_foreign",
+                  conversationId: 99,
+                  kind: "leaf",
+                  snippet: "foreign summary",
+                  createdAt: new Date("2026-01-02T00:00:00.000Z"),
+                },
+              ],
+          totalMatches: 1,
+        };
+      }),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: "agent:main:subagent:session-1",
+      issuerSessionId: "main",
+      allowedConversationIds: [42],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+      sessionKey: "agent:main:subagent:session-1",
+    });
+    const result = await tool.execute("call-subagent-granted-all", {
+      pattern: "summary",
+      allConversations: true,
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 42,
+        conversationIds: [42],
+      }),
+    );
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("allowed summary");
+    expect(text).not.toContain("foreign summary");
+  });
+
+  it("lcm_grep rejects explicit foreign conversationId outside a delegated grant", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: "agent:main:subagent:session-1",
+      issuerSessionId: "main",
+      allowedConversationIds: [42],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+      sessionKey: "agent:main:subagent:session-1",
+    });
+    const result = await tool.execute("call-subagent-foreign", {
+      pattern: "private",
+      conversationId: 99,
+    });
+
+    expect(retrieval.grep).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain(
+      "outside delegated conversation scope",
+    );
+  });
+
   it("lcm_describe blocks cross-conversation lookup unless allConversations=true", async () => {
     const timezone = "America/Los_Angeles";
     const retrieval = {
@@ -489,5 +637,56 @@ describe("LCM tools session scoping", () => {
     });
     expect(JSON.stringify(cross.details)).not.toContain("foreign summary");
     expect(JSON.stringify(cross.details)).not.toContain("subtree");
+  });
+
+  it("lcm_describe rejects allConversations results outside a delegated grant", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "sum_foreign",
+        type: "summary",
+        summary: {
+          conversationId: 99,
+          kind: "leaf",
+          content: "foreign summary",
+          depth: 0,
+          tokenCount: 12,
+          descendantCount: 0,
+          descendantTokenCount: 0,
+          sourceMessageTokenCount: 12,
+          fileIds: [],
+          parentIds: [],
+          childIds: [],
+          messageIds: [],
+          earliestAt: new Date("2026-01-01T00:00:00.000Z"),
+          latestAt: new Date("2026-01-01T00:00:00.000Z"),
+          subtree: [],
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: "agent:main:subagent:session-1",
+      issuerSessionId: "main",
+      allowedConversationIds: [42],
+      tokenCap: 120,
+    });
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+      sessionKey: "agent:main:subagent:session-1",
+    });
+    const result = await tool.execute("call-subagent-describe-foreign", {
+      id: "sum_foreign",
+      allConversations: true,
+    });
+
+    expect((result.details as { error?: string }).error).toContain(
+      "Not found in delegated conversation scope",
+    );
+    expect(JSON.stringify(result.details)).not.toContain("foreign summary");
   });
 });


### PR DESCRIPTION
## Summary
- Enforce delegated expansion grants before LCM retrieval tools can read conversation state.
- Reject sub-agent retrieval without a propagated grant, reject explicit foreign conversation IDs, and downgrade delegated `allConversations` to the grant's allowed conversation IDs.
- Fail closed for delegated `lcm_expand` when the grant spans multiple conversations, since expansion requires a single concrete conversation.

Fixes #70.

## Validation
- `git diff --check`
- `npm exec vitest run test/lcm-tools.test.ts test/lcm-expand-tool.test.ts test/lcm-expand-query-tool.test.ts -- --pool=threads --maxWorkers=1 --minWorkers=1`
- `npm run build`

## Review Notes
- Two adversarial rereviews cleared the original cross-session leak and the follow-up `sessionId`-as-subagent-key bypass.
- The review also cleared delegated `allConversations` scoping and multi-conversation delegated expansion fail-closed coverage.
