### PR TITLE
fix: scrub reasoning fields from compaction summaries

### DIFF
--- a/.changeset/qwen-reasoning-fields.md
+++ b/.changeset/qwen-reasoning-fields.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Normalize ChatCompletion-style summarizer responses from reasoning-capable providers by reading `choices[].message.content` without storing or logging reasoning/thinking fields as summary text.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -262,7 +262,7 @@ const MEDIA_PATH_RE = /^MEDIA:\/.+$/;
 const EMBEDDED_DATA_URL_RE = /data:[^;\s"'`]+;base64,[A-Za-z0-9+/=\s]+/gi;
 const MEDIA_ATTACHMENT_PART_TYPES = new Set(["file", "snapshot"]);
 const MEDIA_ATTACHMENT_RAW_TYPES = new Set(["file", "image", "snapshot"]);
-const PROVIDER_REASONING_RAW_TYPES = new Set(["reasoning", "thinking"]);
+const PROVIDER_REASONING_RAW_TYPES = new Set(["reasoning", "thinking", "redacted_thinking"]);
 const STRUCTURED_MEDIA_TEXT_KEYS = ["text", "caption", "alt", "title", "summary"] as const;
 const STRUCTURED_MEDIA_NESTED_KEYS = [
   "content",
@@ -466,6 +466,10 @@ function extractMeaningfulStructuredText(value: unknown): string {
 
 /** Extract a readable fallback from one structured message part. */
 function extractMessagePartSummaryText(part: MessagePartRecord): string {
+  if (part.partType === "reasoning") {
+    return "";
+  }
+
   const sections: string[] = [];
   const text = extractMeaningfulStructuredText(part.textContent);
   if (text) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -596,10 +596,14 @@ const TOOL_RAW_TYPES: ReadonlySet<string> = new Set([
   ...TOOL_CALL_RAW_TYPES,
   ...TOOL_RESULT_RAW_TYPES,
 ]);
+const REASONING_RAW_TYPES: ReadonlySet<string> = new Set([
+  "thinking",
+  "redacted_thinking",
+  "reasoning",
+]);
 const REPLAY_CRITICAL_RAW_TYPES: ReadonlySet<string> = new Set([
   ...TOOL_RAW_TYPES,
-  "thinking",
-  "reasoning",
+  ...REASONING_RAW_TYPES,
 ]);
 const RAW_PAYLOAD_EXTERNALIZATION_REASON = "large_raw_message";
 
@@ -648,6 +652,10 @@ function extractStructuredText(value: unknown, depth: number = 0): string | unde
   }
 
   const record = value as Record<string, unknown>;
+
+  if (typeof record.type === "string" && REASONING_RAW_TYPES.has(record.type)) {
+    return undefined;
+  }
 
   // Skip tool call/result objects — their structured data belongs in the parts table, not content
   if (typeof record.type === "string" && TOOL_RAW_TYPES.has(record.type)) {
@@ -795,6 +803,7 @@ function toPartType(type: string): MessagePartType {
     case "text":
       return "text";
     case "thinking":
+    case "redacted_thinking":
     case "reasoning":
       return "reasoning";
     case "tool_use":
@@ -851,12 +860,15 @@ function extractMessageContent(content: unknown): string {
   if (Array.isArray(content) && content.length === 0) {
     return "";
   }
-  // If content is an array of only tool call/result objects, store as empty
+  // If content is an array of only tool call/result/reasoning objects, store as empty
   // (structured data is preserved in the message parts table)
   if (Array.isArray(content) && content.length > 0 && content.every(
     (item) => typeof item === "object" && item !== null && !Array.isArray(item) &&
       typeof (item as Record<string, unknown>).type === "string" &&
-      TOOL_RAW_TYPES.has((item as Record<string, unknown>).type as string)
+      (
+        TOOL_RAW_TYPES.has((item as Record<string, unknown>).type as string) ||
+        REASONING_RAW_TYPES.has((item as Record<string, unknown>).type as string)
+      )
   )) {
     return "";
   }

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -274,6 +274,15 @@ function isReasoningLikeType(type: unknown): boolean {
   return normalized.includes("reasoning") || normalized.includes("thinking");
 }
 
+function isReasoningLikeKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return normalized.includes("reasoning") || normalized.includes("thinking");
+}
+
+function shouldAppendDirectTextField(key: string): boolean {
+  return key === "content" || key === "summary";
+}
+
 /** Collect text payloads from common provider response shapes. */
 function collectTextLikeFields(value: unknown, out: string[]): void {
   if (Array.isArray(value)) {
@@ -293,9 +302,19 @@ function collectTextLikeFields(value: unknown, out: string[]): void {
   for (const key of ["text", "output_text"]) {
     appendTextValue(value[key], out);
   }
-  for (const key of ["content", "summary", "output", "message", "response"]) {
+  for (const key of ["content", "summary", "output", "message", "response", "choices", "delta"]) {
     if (key in value) {
-      collectTextLikeFields(value[key], out);
+      if (isReasoningLikeKey(key)) {
+        continue;
+      }
+      const nested = value[key];
+      if (typeof nested === "string") {
+        if (shouldAppendDirectTextField(key)) {
+          out.push(nested);
+        }
+        continue;
+      }
+      collectTextLikeFields(nested, out);
     }
   }
 }
@@ -393,10 +412,17 @@ function sanitizeForDiagnostics(value: unknown, depth = 0): unknown {
     return String(value);
   }
 
+  if (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType)) {
+    return {
+      type: typeof value.type === "string" ? value.type : typeof value.rawType === "string" ? value.rawType : "reasoning",
+      content: "[redacted]",
+    };
+  }
+
   const out: Record<string, unknown> = {};
   const entries = Object.entries(value);
   for (const [key, entry] of entries.slice(0, DIAGNOSTIC_MAX_OBJECT_KEYS)) {
-    out[key] = DIAGNOSTIC_SENSITIVE_KEY_PATTERN.test(key)
+    out[key] = DIAGNOSTIC_SENSITIVE_KEY_PATTERN.test(key) || isReasoningLikeKey(key)
       ? "[redacted]"
       : sanitizeForDiagnostics(entry, depth + 1);
   }
@@ -440,7 +466,14 @@ function collectAuthFailureText(value: unknown, out: string[], depth = 0): void 
     return;
   }
 
-  for (const entry of Object.values(value).slice(0, DIAGNOSTIC_MAX_OBJECT_KEYS)) {
+  if (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType)) {
+    return;
+  }
+
+  for (const [key, entry] of Object.entries(value).slice(0, DIAGNOSTIC_MAX_OBJECT_KEYS)) {
+    if (isReasoningLikeKey(key)) {
+      continue;
+    }
     collectAuthFailureText(entry, out, depth + 1);
   }
 }
@@ -599,6 +632,17 @@ function getProviderResponseFinishReason(value: Record<string, unknown>): string
     }
   }
   return undefined;
+}
+
+function isIncompleteFinishReason(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === "length" ||
+    normalized === "max_tokens" ||
+    normalized === "max_output_tokens" ||
+    normalized === "model_length" ||
+    normalized === "incomplete"
+  );
 }
 
 function getProviderResponseErrorCode(value: Record<string, unknown>): string | undefined {
@@ -877,8 +921,12 @@ function collectIncompleteResponseSignals(
       out.add(`${label}.reason=${reason}`);
     }
   }
+  const finishReason = getProviderResponseFinishReason(value);
+  if (finishReason && isIncompleteFinishReason(finishReason)) {
+    out.add(`${label}.finish=${finishReason}`);
+  }
 
-  for (const key of ["content", "output", "message", "response", "items"] as const) {
+  for (const key of ["content", "output", "message", "response", "items", "choices"] as const) {
     if (key in value) {
       collectIncompleteResponseSignals(value[key], out, `${label}.${key}`, depth + 1);
     }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1723,6 +1723,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
         .getMessages(conversation!.conversationId);
       expect(messages).toHaveLength(1);
       expect(messages[0].content).not.toContain("[LCM Raw Payload:");
+      expect(messages[0].content).not.toContain("protected reasoning");
 
       const largeFiles = await engine
         .getSummaryStore()
@@ -10768,6 +10769,115 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 });
 
 describe("LcmContextEngine compaction telemetry", () => {
+  it("does not feed engine-ingested reasoning parts into compaction summarizer input", async () => {
+    const privateReasoning = "PRIVATE_STORED_REASONING_TRACE";
+    let summarizerInput = "";
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 0,
+        leafMinFanout: 2,
+        leafChunkTokens: 1_000,
+        incrementalMaxDepth: 0,
+      },
+      {
+        complete: vi.fn(async (request) => {
+          const message = request.messages?.[0];
+          summarizerInput =
+            message && typeof message === "object" && "content" in message
+              ? String((message as { content?: unknown }).content ?? "")
+              : "";
+          return { content: [{ type: "text", text: "Safe compacted summary." }] };
+        }),
+        resolveModel: vi.fn(() => ({ provider: "vllm", model: "qwen3.5-122b" })),
+      },
+    );
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "reasoning", summary: [{ text: privateReasoning }] },
+          { type: "text", text: "Visible assistant answer." },
+        ],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "user",
+        content: `Follow-up ${"x".repeat(400)}`,
+      }),
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("reasoning-parts-compact"),
+      tokenBudget: 10_000,
+      force: true,
+      legacyParams: { provider: "vllm", model: "qwen3.5-122b" },
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summarizerInput).toContain("Visible assistant answer.");
+    expect(summarizerInput).not.toContain(privateReasoning);
+  });
+
+  it("does not feed redacted-thinking-only ingested parts into compaction summarizer input", async () => {
+    const privateReasoning = "PRIVATE_REDACTED_THINKING_ONLY_TRACE";
+    let summarizerInput = "";
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 0,
+        leafMinFanout: 2,
+        leafChunkTokens: 1_000,
+        incrementalMaxDepth: 0,
+      },
+      {
+        complete: vi.fn(async (request) => {
+          const message = request.messages?.[0];
+          summarizerInput =
+            message && typeof message === "object" && "content" in message
+              ? String((message as { content?: unknown }).content ?? "")
+              : "";
+          return { content: [{ type: "text", text: "Safe compacted summary." }] };
+        }),
+        resolveModel: vi.fn(() => ({ provider: "vllm", model: "qwen3.5-122b" })),
+      },
+    );
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", text: privateReasoning },
+        ],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "user",
+        content: `Follow-up ${"x".repeat(400)}`,
+      }),
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("redacted-thinking-only-compact"),
+      tokenBudget: 10_000,
+      force: true,
+      legacyParams: { provider: "vllm", model: "qwen3.5-122b" },
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summarizerInput).toContain("Follow-up");
+    expect(summarizerInput).not.toContain(privateReasoning);
+  });
+
   it("does not append synthetic system messages for compaction passes", async () => {
     const infoLog = vi.fn();
     const debugLog = vi.fn();

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -9,7 +9,8 @@ import type {
 import { ContextAssembler } from "../src/assembler.js";
 import { CompactionEngine, type CompactionConfig } from "../src/compaction.js";
 import { RetrievalEngine } from "../src/retrieval.js";
-import { LcmProviderAuthError } from "../src/summarize.js";
+import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "../src/summarize.js";
+import type { LcmDependencies } from "../src/types.js";
 
 // ── Mock Store Factories ─────────────────────────────────────────────────────
 
@@ -369,6 +370,7 @@ function createMockSummaryStore() {
         descendantCount?: number;
         descendantTokenCount?: number;
         sourceMessageTokenCount?: number;
+        model?: string;
       }): Promise<SummaryRecord> => {
         const summary: SummaryRecord = {
           summaryId: input.summaryId,
@@ -383,6 +385,7 @@ function createMockSummaryStore() {
           descendantCount: input.descendantCount ?? 0,
           descendantTokenCount: input.descendantTokenCount ?? 0,
           sourceMessageTokenCount: input.sourceMessageTokenCount ?? 0,
+          model: input.model ?? "",
           createdAt: new Date(),
         };
         summaries.push(summary);
@@ -690,6 +693,69 @@ const defaultCompactionConfig: CompactionConfig = {
   maxRounds: 10,
   summaryMaxOverageFactor: 3,
 };
+
+function makeSummarizeDeps(overrides?: Partial<LcmDependencies>): LcmDependencies {
+  return {
+    config: {
+      enabled: true,
+      databasePath: ":memory:",
+      ignoreSessionPatterns: [],
+      statelessSessionPatterns: [],
+      skipStatelessSessions: true,
+      contextThreshold: 0.75,
+      freshTailCount: 8,
+      newSessionRetainDepth: 2,
+      leafMinFanout: 8,
+      condensedMinFanout: 4,
+      condensedMinFanoutHard: 2,
+      incrementalMaxDepth: 0,
+      leafChunkTokens: 20_000,
+      leafTargetTokens: 600,
+      condensedTargetTokens: 900,
+      maxExpandTokens: 120,
+      largeFileTokenThreshold: 25_000,
+      summaryProvider: "",
+      summaryModel: "",
+      largeFileSummaryProvider: "",
+      largeFileSummaryModel: "",
+      timezone: "UTC",
+      pruneHeartbeatOk: false,
+      transcriptGcEnabled: false,
+      proactiveThresholdCompactionMode: "deferred",
+      autoRotateSessionFiles: {
+        enabled: true,
+        createBackups: false,
+        sizeBytes: 2 * 1024 * 1024,
+        startup: "rotate",
+        runtime: "rotate",
+      },
+      summaryMaxOverageFactor: 3,
+    },
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "summary output" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+    })),
+    parseAgentSessionKey: vi.fn(() => null),
+    isSubagentSessionKey: vi.fn(() => false),
+    normalizeAgentId: vi.fn(() => "main"),
+    buildSubagentSystemPrompt: vi.fn(() => ""),
+    readLatestAssistantReply: vi.fn(() => undefined),
+    resolveAgentDir: vi.fn(() => "/tmp/openclaw-agent"),
+    resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
+    agentLaneSubagent: "subagent",
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    ...overrides,
+  } as LcmDependencies;
+}
 
 // ═════════════════════════════════════════════════════════════════════════════
 // Test Suite: Ingest -> Assemble
@@ -1356,6 +1422,10 @@ describe("LCM integration: compaction", () => {
       { type: "reasoning", text: "PRIVATE_REASONING_TEXT" },
       { type: "text", text: "Visible reply after reasoning text." },
     ]);
+    const redactedThinkingTextContent = JSON.stringify([
+      { type: "redacted_thinking", text: "PRIVATE_REDACTED_THINKING_TEXT" },
+      { type: "text", text: "Visible reply after redacted thinking text." },
+    ]);
     const thinkingSummaryContent = JSON.stringify([
       { type: "thinking", summary: "PRIVATE_THINKING_SUMMARY" },
       { type: "text", text: "Visible reply after thinking summary." },
@@ -1379,6 +1449,11 @@ describe("LCM integration: compaction", () => {
     });
     await ingestMessages(convStore, sumStore, 1, {
       contentFn: () => reasoningTextContent,
+      roleFn: () => "assistant",
+      tokenCountFn: (_i, c) => estimateTokens(c),
+    });
+    await ingestMessages(convStore, sumStore, 1, {
+      contentFn: () => redactedThinkingTextContent,
       roleFn: () => "assistant",
       tokenCountFn: (_i, c) => estimateTokens(c),
     });
@@ -1415,15 +1490,130 @@ describe("LCM integration: compaction", () => {
     expect(capturedSourceText).not.toContain("ANOTHER_ENCRYPTED");
     expect(capturedSourceText).not.toContain('"type":"thinking"');
     expect(capturedSourceText).not.toContain("PRIVATE_REASONING_TEXT");
+    expect(capturedSourceText).not.toContain("PRIVATE_REDACTED_THINKING_TEXT");
     expect(capturedSourceText).not.toContain("PRIVATE_THINKING_SUMMARY");
 
     // The visible text from the mixed-content message must still be present
     expect(capturedSourceText).toContain("Visible assistant reply.");
     expect(capturedSourceText).toContain("Visible reply after reasoning text.");
+    expect(capturedSourceText).toContain("Visible reply after redacted thinking text.");
     expect(capturedSourceText).toContain("Visible reply after thinking summary.");
 
     // The plain user message must still be present
     expect(capturedSourceText).toContain("A plain user message.");
+  });
+
+  it("leaf compaction strips redacted_thinking blocks from structured message parts", async () => {
+    const structuredPartEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafChunkTokens: 1_000,
+    });
+    await convStore.createConversation({ sessionId: "redacted-thinking-session" });
+
+    const assistant = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 1,
+      role: "assistant",
+      content: "",
+      tokenCount: 120,
+    });
+    await convStore.createMessageParts(assistant.messageId, [
+      {
+        sessionId: "redacted-thinking-session",
+        partType: "reasoning",
+        ordinal: 0,
+        textContent: JSON.stringify({
+          type: "redacted_thinking",
+          text: "PRIVATE_PART_REDACTED_THINKING",
+          summary: [{ text: "PRIVATE_PART_SUMMARY" }],
+        }),
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          rawType: "redacted_thinking",
+        }),
+      },
+      {
+        sessionId: "redacted-thinking-session",
+        partType: "text",
+        ordinal: 1,
+        textContent: "Visible answer after redacted thinking.",
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          rawType: "text",
+        }),
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, assistant.messageId);
+
+    let capturedSourceText = "";
+    const summarize = vi.fn(async (text: string) => {
+      capturedSourceText = text;
+      return "Structured redacted thinking summary.";
+    });
+
+    const result = await structuredPartEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 10_000,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(capturedSourceText).toContain("Visible answer after redacted thinking.");
+    expect(capturedSourceText).not.toContain("PRIVATE_PART_REDACTED_THINKING");
+    expect(capturedSourceText).not.toContain("PRIVATE_PART_SUMMARY");
+  });
+
+  it("persists vLLM message content rather than reasoning as a leaf summary", async () => {
+    const qwenCompactionEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafMinFanout: 2,
+      leafChunkTokens: 1_000,
+    });
+    await ingestMessages(convStore, sumStore, 4, {
+      contentFn: (i) => `Conversation turn ${i}: weather and follow-up details ${"x".repeat(200)}`,
+      roleFn: (i) => (i % 2 === 0 ? "user" : "assistant"),
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    const summarizeResult = await createLcmSummarizeFromLegacyParams({
+      deps: makeSummarizeDeps({
+        resolveModel: vi.fn(() => ({ provider: "vllm", model: "qwen3.5-122b" })),
+        complete: vi.fn(async () => ({
+          content: [],
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "User asked for weather; assistant answered sunny and 25C.",
+                reasoning: "Thinking Process: PRIVATE_QWEN_REASONING",
+                reasoning_content: "PRIVATE_QWEN_REASONING_CONTENT",
+              },
+            },
+          ],
+        })),
+      }),
+      legacyParams: { provider: "vllm", model: "qwen3.5-122b" },
+    });
+
+    expect(summarizeResult).toBeDefined();
+
+    await qwenCompactionEngine.compact({
+      conversationId: CONV_ID,
+      tokenBudget: 10_000,
+      summarize: summarizeResult!.fn,
+      summaryModel: "qwen3.5-122b",
+      force: true,
+    });
+
+    const leaf = sumStore._summaries.find((summary) => summary.kind === "leaf");
+    expect(leaf?.content).toBe("User asked for weather; assistant answered sunny and 25C.");
+    expect(leaf?.content).not.toContain("Thinking Process");
+    expect(leaf?.content).not.toContain("PRIVATE_QWEN_REASONING");
+    expect(leaf?.content).not.toContain("PRIVATE_QWEN_REASONING_CONTENT");
+    expect(leaf?.model).toBe("qwen3.5-122b");
   });
 
   it("leaf compaction summarizes structured message parts when stored content is empty", async () => {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -713,6 +713,159 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(summary).not.toContain("Reasoning summary line.");
   });
 
+  it("uses chat-completion message content instead of vLLM reasoning fields", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [],
+        id: "chatcmpl_reasoning",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "User asked for weather; assistant answered sunny and 25C.",
+              reasoning: "Thinking Process: summarize the weather exchange verbatim.",
+              reasoning_content: "PRIVATE_QWEN_REASONING",
+            },
+            finish_reason: "stop",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      },
+    });
+
+    const summary = await summarize!("Weather conversation segment", false);
+
+    expect(summary).toBe("User asked for weather; assistant answered sunny and 25C.");
+    expect(summary).not.toContain("Thinking Process");
+    expect(summary).not.toContain("PRIVATE_QWEN_REASONING");
+    expect(getDepsLogText(deps)).toContain("source=envelope");
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses streaming delta content without reasoning_content", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [],
+        choices: [
+          {
+            delta: {
+              content: "Final streamed summary.",
+              reasoning_content: "PRIVATE_STREAM_REASONING",
+            },
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      },
+    });
+
+    const summary = await summarize!("Streaming segment", false);
+
+    expect(summary).toBe("Final streamed summary.");
+    expect(summary).not.toContain("PRIVATE_STREAM_REASONING");
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries chat-completion summaries truncated by finish_reason length", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      })),
+      complete: vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            content: [],
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: "Partial visible summary",
+                },
+                finish_reason: "length",
+              },
+            ],
+          };
+        }
+        return {
+          content: [{ type: "text", text: "Recovered complete summary." }],
+        };
+      }),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      },
+    });
+
+    const summary = await summarize!("Long segment", false);
+
+    expect(summary).toBe("Recovered complete summary.");
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(deps.complete).mock.calls[1]?.[0]?.reasoning).toBe("low");
+
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).toContain("incomplete summary response on first attempt");
+    expect(diagnostics).toContain("response.choices[0].finish=length");
+  });
+
+  it("does not persist untyped provider error strings as summaries", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [],
+        message: "upstream timeout while acquiring provider connection",
+        response: "provider overloaded",
+        error: { code: "provider_timeout" },
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      },
+    });
+
+    const summary = await summarize!("I".repeat(8_000), false);
+
+    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+    expect(summary).not.toContain("upstream timeout");
+    expect(summary).not.toContain("provider overloaded");
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(2);
+  });
+
   it("logs provider/model/block diagnostics when normalized summary is empty", async () => {
     const deps = makeDeps({
       resolveModel: vi.fn(() => ({
@@ -740,6 +893,45 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(diagnostics).toContain("model=gpt-5.3-codex");
     expect(diagnostics).toContain("block_types=reasoning");
     expect(diagnostics).toContain("content_preview=");
+  });
+
+  it("redacts typed reasoning blocks from diagnostic previews", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "reasoning",
+            summary: [
+              {
+                type: "summary_text",
+                text: "PRIVATE_TYPED_REASONING_TRACE",
+              },
+            ],
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "vllm",
+        model: "qwen3.5-122b",
+      },
+    });
+
+    const summary = await summarize!("H".repeat(8_000), false);
+
+    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).toContain("block_types=reasoning");
+    expect(diagnostics).toContain("content_preview=");
+    expect(diagnostics).not.toContain("PRIVATE_TYPED_REASONING_TRACE");
   });
 
   it("does not treat thinking-only completions as summary content", async () => {
@@ -1641,6 +1833,44 @@ describe("createLcmSummarizeFromLegacyParams", () => {
       expect(diagnostics).toContain("error_preview=");
     });
 
+    it("redacts reasoning fields from provider error warning details", async () => {
+      const deps = makeDeps({
+        resolveModel: vi.fn(() => ({
+          provider: "vllm",
+          model: "qwen3.5-122b",
+        })),
+        complete: vi.fn(async () => ({
+          content: [],
+          stopReason: "error",
+          error: {
+            kind: "provider_error",
+            message: "provider failed before returning a summary",
+            reasoning_content: "PRIVATE_ERROR_REASONING",
+            details: [
+              {
+                type: "reasoning",
+                summary: [{ text: "PRIVATE_TYPED_ERROR_REASONING" }],
+              },
+            ],
+          },
+        })),
+      });
+
+      const summarize = await createSummarizeFn({
+        deps,
+        legacyParams: { provider: "vllm", model: "qwen3.5-122b" },
+      });
+
+      const summary = await summarize!("J".repeat(8_000), false);
+
+      expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+
+      const diagnostics = getDepsLogText(deps);
+      expect(diagnostics).toContain("provider failed before returning a summary");
+      expect(diagnostics).not.toContain("PRIVATE_ERROR_REASONING");
+      expect(diagnostics).not.toContain("PRIVATE_TYPED_ERROR_REASONING");
+    });
+
     it("redacts sensitive keys from diagnostic content previews", async () => {
       const deps = makeDeps({
         resolveModel: vi.fn(() => ({
@@ -1652,6 +1882,8 @@ describe("createLcmSummarizeFromLegacyParams", () => {
             {
               type: "tool_use",
               name: "http",
+              reasoning: "PRIVATE_DIAGNOSTIC_REASONING",
+              reasoning_content: "PRIVATE_DIAGNOSTIC_REASONING_CONTENT",
               input: { authorization: "Bearer super-secret-token", body: "x".repeat(1500) },
             },
           ],
@@ -1669,6 +1901,8 @@ describe("createLcmSummarizeFromLegacyParams", () => {
       expect(diagnostics).toContain("content_preview=");
       expect(diagnostics).toContain('"authorization":"[redacted]"');
       expect(diagnostics).not.toContain("super-secret-token");
+      expect(diagnostics).not.toContain("PRIVATE_DIAGNOSTIC_REASONING");
+      expect(diagnostics).not.toContain("PRIVATE_DIAGNOSTIC_REASONING_CONTENT");
       expect(diagnostics).toContain("[truncated:");
     });
 


### PR DESCRIPTION
## Summary
- Fixes #471 by keeping provider reasoning/thinking fields out of compaction summaries and diagnostics.
- Preserves visible `message.content`, `summary`, and streaming `delta.content` text for vLLM/Qwen-style responses while ignoring sibling `reasoning`, `reasoning_content`, `thinking`, and `redacted_thinking` payloads.
- Prevents fallback warning/detail paths and engine-stored message content from serializing private reasoning text back into summarizer input.

## Validation
- `pwd` confirmed `/Volumes/LEXAR/repos/lossless-claw-p0-reasoning-fields` before local validation.
- `npm exec vitest run test/summarize.test.ts test/engine.test.ts test/lcm-integration.test.ts -- --pool=threads --maxWorkers=1 --minWorkers=1` → 391 tests passed.
- `git diff --check` → no whitespace errors.
- `npm run build` → succeeded.

## Triage note
This is the P0 privacy/data-retention fix for #471. I am opening the PR for review and CI, not merging it from the agent side.
