### PR TITLE
Fix projected raw backlog threshold compaction

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -22,6 +22,10 @@ export interface CompactionDecision {
   storedTokens: number;
   /** Runtime-observed prompt tokens, when supplied by the host. */
   observedTokens?: number;
+  /** Raw message tokens outside the protected fresh tail, when live prompt pressure is known. */
+  rawTokensOutsideTail?: number;
+  /** Projected prompt pressure after adding unsummarized raw backlog to observed tokens. */
+  projectedTokens?: number;
   currentTokens: number;
   threshold: number;
 }
@@ -573,7 +577,11 @@ export class CompactionEngine {
       observedTokenCount > 0
         ? Math.floor(observedTokenCount)
         : 0;
-    const currentTokens = Math.max(storedTokens, liveTokens);
+    const rawTokensOutsideTail =
+      liveTokens > 0 ? await this.countRawTokensOutsideFreshTail(conversationId) : undefined;
+    const projectedTokens =
+      liveTokens > 0 ? liveTokens + (rawTokensOutsideTail ?? 0) : undefined;
+    const currentTokens = Math.max(storedTokens, projectedTokens ?? liveTokens);
     const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
 
     if (currentTokens > threshold) {
@@ -582,6 +590,8 @@ export class CompactionEngine {
         reason: "threshold",
         storedTokens,
         ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
+        ...(rawTokensOutsideTail !== undefined ? { rawTokensOutsideTail } : {}),
+        ...(projectedTokens !== undefined ? { projectedTokens } : {}),
         currentTokens,
         threshold,
       };
@@ -592,6 +602,8 @@ export class CompactionEngine {
       reason: "none",
       storedTokens,
       ...(liveTokens > 0 ? { observedTokens: liveTokens } : {}),
+      ...(rawTokensOutsideTail !== undefined ? { rawTokensOutsideTail } : {}),
+      ...(projectedTokens !== undefined ? { projectedTokens } : {}),
       currentTokens,
       threshold,
     };

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -168,6 +168,25 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
 }
 
+function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
+  const maintenanceColumns = db
+    .prepare(`PRAGMA table_info(conversation_compaction_maintenance)`)
+    .all() as SummaryColumnInfo[];
+  const hasProjectedTokenCount = maintenanceColumns.some(
+    (col) => col.name === "projected_token_count",
+  );
+  const hasRawTokensOutsideTail = maintenanceColumns.some(
+    (col) => col.name === "raw_tokens_outside_tail",
+  );
+
+  if (!hasProjectedTokenCount) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
+  }
+  if (!hasRawTokensOutsideTail) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN raw_tokens_outside_tail INTEGER`);
+  }
+}
+
 function ensureFocusBriefTables(db: DatabaseSync): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS focus_briefs (
@@ -1040,6 +1059,8 @@ export function runLcmMigrations(
       last_failure_summary TEXT,
       token_budget INTEGER,
       current_token_count INTEGER,
+      projected_token_count INTEGER,
+      raw_tokens_outside_tail INTEGER,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -1167,6 +1188,9 @@ export function runLcmMigrations(
     );
     runMigrationStep("ensureCompactionTelemetryColumns", log, () =>
       ensureCompactionTelemetryColumns(db),
+    );
+    runMigrationStep("ensureCompactionMaintenanceColumns", log, () =>
+      ensureCompactionMaintenanceColumns(db),
     );
     runMigrationStep("ensureFocusBriefTables", log, () => ensureFocusBriefTables(db));
     runVersionedBackfillStep(db, "backfillSummaryDepths", log, () => backfillSummaryDepths(db));

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3366,15 +3366,19 @@ export class LcmContextEngine implements ContextEngine {
     reason: string;
     tokenBudget: number;
     currentTokenCount?: number;
+    projectedTokenCount?: number;
+    rawTokensOutsideTail?: number;
   }): Promise<void> {
     await this.compactionMaintenanceStore.requestProactiveCompactionDebt({
       conversationId: params.conversationId,
       reason: params.reason,
       tokenBudget: params.tokenBudget,
       currentTokenCount: params.currentTokenCount ?? null,
+      projectedTokenCount: params.projectedTokenCount ?? null,
+      rawTokensOutsideTail: params.rawTokensOutsideTail ?? null,
     });
     this.deps.log.debug(
-      `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"}`,
+      `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"} projectedTokenCount=${params.projectedTokenCount ?? "null"} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"}`,
     );
   }
 
@@ -3504,6 +3508,9 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedCurrentTokenCount = this.normalizeObservedTokenCount(
         params.currentTokenCount ?? maintenance.currentTokenCount ?? undefined,
       );
+      const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
+        maintenance.projectedTokenCount ?? undefined,
+      );
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
@@ -3553,7 +3560,7 @@ export class LcmContextEngine implements ContextEngine {
         keepPending: !result.ok,
       });
       this.deps.log.debug(
-        `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"}`,
+        `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"} currentTokenCount=${resolvedCurrentTokenCount ?? "null"} projectedTokenCount=${resolvedProjectedTokenCount ?? "null"} rawTokensOutsideTail=${maintenance.rawTokensOutsideTail ?? "null"}`,
       );
       return {
         changed: result.compacted,
@@ -3705,29 +3712,56 @@ export class LcmContextEngine implements ContextEngine {
         : await this.compaction.evaluate(conversationId, tokenBudget);
     const targetTokens =
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
-    const liveContextStillExceedsTarget =
-      observedTokens !== undefined && observedTokens >= targetTokens;
     // Codex can report a live prompt count that includes runtime framing,
-    // tool schemas, and other overhead not present in Lossless's stored count.
-    // If that live count crosses the threshold, compact stored context far
-    // enough that stored tokens plus the observed overhead should fit.
+    // tool schemas, and other overhead not present in Lossless's compactable
+    // stored count. Raw backlog is different: it can force a sweep, but once
+    // swept it should not be carried forward as permanent runtime overhead.
     const decisionStoredTokens =
       typeof decision.storedTokens === "number"
       && Number.isFinite(decision.storedTokens)
       && decision.storedTokens >= 0
         ? Math.floor(decision.storedTokens)
         : decision.currentTokens;
+    const decisionProjectedTokens =
+      typeof decision.projectedTokens === "number" &&
+      Number.isFinite(decision.projectedTokens) &&
+      decision.projectedTokens >= 0
+        ? Math.floor(decision.projectedTokens)
+        : undefined;
+    const decisionRawTokensOutsideTail =
+      typeof decision.rawTokensOutsideTail === "number" &&
+      Number.isFinite(decision.rawTokensOutsideTail) &&
+      decision.rawTokensOutsideTail >= 0
+        ? Math.floor(decision.rawTokensOutsideTail)
+        : undefined;
     const observedRuntimeOverhead =
       params.compactionTarget === "threshold" && observedTokens !== undefined
         ? Math.max(0, observedTokens - decisionStoredTokens)
         : 0;
     const runtimeAdjustedSweepTargetTokens =
-      observedRuntimeOverhead > 0 && observedTokens !== undefined && observedTokens > targetTokens
+      observedRuntimeOverhead > 0 &&
+      observedTokens !== undefined &&
+      observedTokens > targetTokens
         ? Math.max(1, targetTokens - observedRuntimeOverhead)
         : undefined;
+    const projectedRawBacklogPressure =
+      params.compactionTarget === "threshold" &&
+      decisionProjectedTokens !== undefined &&
+      decisionProjectedTokens > targetTokens &&
+      (decisionRawTokensOutsideTail ?? 0) > 0;
+    const thresholdPressureTokens =
+      params.compactionTarget === "threshold"
+        ? Math.max(
+            decision.currentTokens,
+            observedTokens ?? 0,
+            decisionProjectedTokens ?? 0,
+          )
+        : observedTokens;
+    const liveContextStillExceedsTarget =
+      thresholdPressureTokens !== undefined && thresholdPressureTokens >= targetTokens;
 
     this.deps.log.info(
-      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
+      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
     );
 
     if (!forceCompaction && !decision.shouldCompact) {
@@ -3748,11 +3782,15 @@ export class LcmContextEngine implements ContextEngine {
     // overflow counts can drive recovery even when persisted context is already small.
     const useSweep = manualCompactionRequested || params.compactionTarget === "threshold";
     if (useSweep) {
+      const forceThresholdSweep =
+        forceCompaction ||
+        runtimeAdjustedSweepTargetTokens !== undefined ||
+        projectedRawBacklogPressure;
       const sweepResult = await this.compaction.compact({
         conversationId,
         tokenBudget,
         summarize,
-        force: forceCompaction || runtimeAdjustedSweepTargetTokens !== undefined,
+        force: forceThresholdSweep,
         hardTrigger: false,
         summaryModel,
         ...(runtimeAdjustedSweepTargetTokens !== undefined
@@ -3773,7 +3811,8 @@ export class LcmContextEngine implements ContextEngine {
           ? sweepResult.tokensAfter
           : undefined;
       const projectedTokensAfterSweep =
-        sweepTokensAfter !== undefined && runtimeAdjustedSweepTargetTokens !== undefined
+        sweepTokensAfter !== undefined &&
+        (runtimeAdjustedSweepTargetTokens !== undefined || projectedRawBacklogPressure)
           ? sweepTokensAfter + observedRuntimeOverhead
           : sweepTokensAfter;
       const isThresholdSweep = params.compactionTarget === "threshold";
@@ -3815,10 +3854,16 @@ export class LcmContextEngine implements ContextEngine {
           details: {
             rounds: sweepResult.actionTaken ? 1 : 0,
             targetTokens: runtimeAdjustedSweepTargetTokens ?? targetTokens,
-            ...(runtimeAdjustedSweepTargetTokens !== undefined
+            ...(runtimeAdjustedSweepTargetTokens !== undefined || projectedRawBacklogPressure
               ? {
                   observedOverheadTokens: observedRuntimeOverhead,
                   projectedTokensAfter: projectedTokensAfterSweep,
+                  ...(decisionProjectedTokens !== undefined
+                    ? { projectedTokensBefore: decisionProjectedTokens }
+                    : {}),
+                  ...(decisionRawTokensOutsideTail !== undefined
+                    ? { rawTokensOutsideTail: decisionRawTokensOutsideTail }
+                    : {}),
                 }
               : {}),
           },
@@ -7127,13 +7172,18 @@ export class LcmContextEngine implements ContextEngine {
         );
       }
     };
-    const recordAfterTurnCompactionRetry = async (reason: string): Promise<void> => {
+    const recordAfterTurnCompactionRetry = async (
+      reason: string,
+      diagnostics?: { projectedTokenCount?: number; rawTokensOutsideTail?: number },
+    ): Promise<void> => {
       try {
         await this.recordDeferredCompactionDebt({
           conversationId: conversation.conversationId,
           reason,
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
+          projectedTokenCount: diagnostics?.projectedTokenCount,
+          rawTokensOutsideTail: diagnostics?.rawTokensOutsideTail,
         });
       } catch (err) {
         this.deps.log.warn(
@@ -7170,6 +7220,10 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget,
         observedCurrentTokenCount,
       );
+      const thresholdDiagnostics = {
+        projectedTokenCount: thresholdDecision.projectedTokens,
+        rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+      };
       if (this.config.proactiveThresholdCompactionMode === "inline") {
         if (thresholdDecision.shouldCompact) {
           const compactResult = await this.compact({
@@ -7183,7 +7237,7 @@ export class LcmContextEngine implements ContextEngine {
           });
           if (!compactResult.ok) {
             shouldRefreshBootstrapState = false;
-            await recordAfterTurnCompactionRetry("threshold");
+            await recordAfterTurnCompactionRetry("threshold", thresholdDiagnostics);
           }
         }
       } else if (thresholdDecision.shouldCompact) {
@@ -7192,6 +7246,8 @@ export class LcmContextEngine implements ContextEngine {
           reason: "threshold",
           tokenBudget,
           currentTokenCount: observedCurrentTokenCount,
+          projectedTokenCount: thresholdDecision.projectedTokens,
+          rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
         });
         deferredCompactionDrain = {
           tokenBudget,
@@ -7281,13 +7337,20 @@ export class LcmContextEngine implements ContextEngine {
         const recordedContextTokens = this.normalizeObservedTokenCount(
           maintenance.currentTokenCount ?? undefined,
         );
-        const emergencyContextTokens = Math.max(
+        const recordedProjectedTokens = this.normalizeObservedTokenCount(
+          maintenance.projectedTokenCount ?? undefined,
+        );
+        const observedEmergencyContextTokens = Math.max(
           liveContextTokens,
           recordedContextTokens ?? 0,
         );
+        const emergencyContextTokens = Math.max(
+          observedEmergencyContextTokens,
+          recordedProjectedTokens ?? 0,
+        );
         if (emergencyContextTokens > tokenBudget) {
           this.deps.log.warn(
-            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${emergencyContextTokens} tokenBudget=${tokenBudget} reason=over-budget`,
+            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${observedEmergencyContextTokens} projectedTokenCount=${recordedProjectedTokens ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
           );
           try {
             await this.maybeConsumeDeferredCompactionDebtForAssemble({
@@ -7295,7 +7358,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               tokenBudget,
-              currentTokenCount: emergencyContextTokens,
+              currentTokenCount: observedEmergencyContextTokens,
             });
           } catch (error) {
             this.deps.log.warn(
@@ -7304,7 +7367,7 @@ export class LcmContextEngine implements ContextEngine {
           }
         } else {
           this.deps.log.debug(
-            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${emergencyContextTokens} tokenBudget=${tokenBudget} reason=not-over-budget`,
+            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${observedEmergencyContextTokens} projectedTokenCount=${recordedProjectedTokens ?? "null"} tokenBudget=${tokenBudget} reason=not-over-budget`,
           );
         }
       }

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -859,6 +859,14 @@ async function buildStatusText(params: {
           "observed token count",
           maintenance?.currentTokenCount != null ? formatNumber(maintenance.currentTokenCount) : "unknown",
         ),
+        buildStatLine(
+          "projected token count",
+          maintenance?.projectedTokenCount != null ? formatNumber(maintenance.projectedTokenCount) : "unknown",
+        ),
+        buildStatLine(
+          "raw tokens outside tail",
+          maintenance?.rawTokensOutsideTail != null ? formatNumber(maintenance.rawTokensOutsideTail) : "unknown",
+        ),
         buildStatLine("last api call", formatMaintenanceTime(telemetry?.lastApiCallAt ?? null)),
         buildStatLine("last cache touch", formatMaintenanceTime(telemetry?.lastCacheTouchAt ?? null)),
         buildStatLine("cache retention", telemetry?.retention ?? "unknown"),

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -13,6 +13,8 @@ export type ConversationCompactionMaintenanceRecord = {
   lastFailureSummary: string | null;
   tokenBudget: number | null;
   currentTokenCount: number | null;
+  projectedTokenCount: number | null;
+  rawTokensOutsideTail: number | null;
   updatedAt: Date;
 };
 
@@ -27,6 +29,8 @@ type ConversationCompactionMaintenanceRow = {
   last_failure_summary: string | null;
   token_budget: number | null;
   current_token_count: number | null;
+  projected_token_count: number | null;
+  raw_tokens_outside_tail: number | null;
   updated_at: string;
 };
 
@@ -44,6 +48,8 @@ function toMaintenanceRecord(
     lastFailureSummary: row.last_failure_summary,
     tokenBudget: row.token_budget,
     currentTokenCount: row.current_token_count,
+    projectedTokenCount: row.projected_token_count,
+    rawTokensOutsideTail: row.raw_tokens_outside_tail,
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -70,6 +76,14 @@ function mergeMaintenanceRecord(
     tokenBudget: patch.tokenBudget !== undefined ? patch.tokenBudget : existing?.tokenBudget ?? null,
     currentTokenCount:
       patch.currentTokenCount !== undefined ? patch.currentTokenCount : existing?.currentTokenCount ?? null,
+    projectedTokenCount:
+      patch.projectedTokenCount !== undefined
+        ? patch.projectedTokenCount
+        : existing?.projectedTokenCount ?? null,
+    rawTokensOutsideTail:
+      patch.rawTokensOutsideTail !== undefined
+        ? patch.rawTokensOutsideTail
+        : existing?.rawTokensOutsideTail ?? null,
     updatedAt: new Date(),
   };
 }
@@ -106,6 +120,8 @@ export class CompactionMaintenanceStore {
            last_failure_summary,
            token_budget,
            current_token_count,
+           projected_token_count,
+           raw_tokens_outside_tail,
            updated_at
          FROM conversation_compaction_maintenance
          WHERE conversation_id = ?`,
@@ -130,8 +146,10 @@ export class CompactionMaintenanceStore {
          last_failure_summary,
          token_budget,
          current_token_count,
+         projected_token_count,
+         raw_tokens_outside_tail,
          updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -142,6 +160,8 @@ export class CompactionMaintenanceStore {
            last_failure_summary = excluded.last_failure_summary,
            token_budget = excluded.token_budget,
            current_token_count = excluded.current_token_count,
+           projected_token_count = excluded.projected_token_count,
+           raw_tokens_outside_tail = excluded.raw_tokens_outside_tail,
            updated_at = datetime('now')`,
       )
       .run(
@@ -155,6 +175,8 @@ export class CompactionMaintenanceStore {
         record.lastFailureSummary ?? null,
         record.tokenBudget ?? null,
         record.currentTokenCount ?? null,
+        record.projectedTokenCount ?? null,
+        record.rawTokensOutsideTail ?? null,
       );
   }
 
@@ -165,6 +187,8 @@ export class CompactionMaintenanceStore {
     requestedAt?: Date;
     tokenBudget?: number | null;
     currentTokenCount?: number | null;
+    projectedTokenCount?: number | null;
+    rawTokensOutsideTail?: number | null;
   }): Promise<void> {
     const existing = await this.getConversationCompactionMaintenance(input.conversationId);
     await this.saveConversationCompactionMaintenance(
@@ -175,6 +199,8 @@ export class CompactionMaintenanceStore {
         running: false,
         tokenBudget: input.tokenBudget ?? existing?.tokenBudget ?? null,
         currentTokenCount: input.currentTokenCount ?? existing?.currentTokenCount ?? null,
+        projectedTokenCount: input.projectedTokenCount ?? existing?.projectedTokenCount ?? null,
+        rawTokensOutsideTail: input.rawTokensOutsideTail ?? existing?.rawTokensOutsideTail ?? null,
       }),
     );
   }

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -62,4 +62,34 @@ describe("CompactionMaintenanceStore", () => {
     expect(record?.pending).toBe(false);
     expect(record?.running).toBe(false);
   });
+
+  it("persists projected token diagnostics for deferred threshold debt", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-projected-session",
+      sessionKey: "agent:main:maintenance-store:2",
+    });
+    const store = new CompactionMaintenanceStore(db);
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 600,
+      currentTokenCount: 300,
+      projectedTokenCount: 620,
+      rawTokensOutsideTail: 320,
+    });
+
+    const record = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(record).toMatchObject({
+      pending: true,
+      reason: "threshold",
+      tokenBudget: 600,
+      currentTokenCount: 300,
+      projectedTokenCount: 620,
+      rawTokensOutsideTail: 320,
+    });
+  });
 });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -250,6 +250,29 @@ function makeMessage(params: { role?: string; content: unknown }): AgentMessage 
   } as AgentMessage;
 }
 
+async function seedBacklogContext(
+  engine: LcmContextEngine,
+  sessionId: string,
+  tokenCounts: number[],
+): Promise<void> {
+  const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+    sessionKey: undefined,
+  });
+  const messages = await engine.getConversationStore().createMessagesBulk(
+    tokenCounts.map((tokenCount, index) => ({
+      conversationId: conversation.conversationId,
+      seq: index,
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `backlog turn ${index}`,
+      tokenCount,
+      skipReplayTimestampFloodGuard: true,
+    })),
+  );
+  await engine
+    .getSummaryStore()
+    .appendContextMessages(conversation.conversationId, messages.map((message) => message.messageId));
+}
+
 function readSessionMessages(sessionFile: string): AgentMessage[] {
   return SessionManager.open(sessionFile)
     .getBranch()
@@ -7645,6 +7668,105 @@ describe("LcmContextEngine fidelity and token budget", () => {
     );
   });
 
+  it("afterTurn runs inline threshold compaction when projected raw backlog crosses threshold", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+      freshTailCount: 1,
+    });
+    const sessionId = "after-turn-inline-projected-raw-backlog-threshold";
+    await seedBacklogContext(engine, sessionId, [100, 100, 100]);
+    const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-inline-projected-raw-backlog-threshold"),
+      messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 600,
+      runtimeContext: { currentTokenCount: 300 },
+    });
+
+    expect(compactSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId,
+        tokenBudget: 600,
+        currentTokenCount: 300,
+        compactionTarget: "threshold",
+      }),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await expect(
+      engine.getSummaryStore().getContextTokenCount(conversation!.conversationId),
+    ).resolves.toBeLessThan(450);
+  });
+
+  it("afterTurn records deferred threshold debt when projected raw backlog crosses threshold", async () => {
+    const debugLog = vi.fn();
+    const engine = createEngineWithDeps(
+      { freshTailCount: 1 },
+      {
+        log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: debugLog },
+      },
+    );
+    const sessionId = "after-turn-deferred-projected-raw-backlog-threshold";
+    const privateEngine = engine as unknown as {
+      scheduleDeferredCompactionDebtDrain: (params: unknown) => void;
+    };
+    await seedBacklogContext(engine, sessionId, [100, 100, 100]);
+    const scheduleSpy = vi
+      .spyOn(privateEngine, "scheduleDeferredCompactionDebtDrain")
+      .mockImplementation(() => undefined);
+    const compactSpy = vi.spyOn(engine, "compact");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-deferred-projected-raw-backlog-threshold"),
+      messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 600,
+      runtimeContext: { currentTokenCount: 300 },
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(compactSpy).not.toHaveBeenCalled();
+    expect(scheduleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId,
+        tokenBudget: 600,
+        currentTokenCount: 300,
+        reason: "threshold",
+      }),
+    );
+    expect(maintenance).toMatchObject({
+      pending: true,
+      running: false,
+      reason: "threshold",
+      tokenBudget: 600,
+      currentTokenCount: 300,
+      projectedTokenCount: expect.any(Number),
+      rawTokensOutsideTail: expect.any(Number),
+    });
+    await expect(
+      engine.getSummaryStore().getContextTokenCount(conversation!.conversationId),
+    ).resolves.toBeLessThan(450);
+    const deferredDebtLog = debugLog.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes("deferred compaction debt recorded"));
+    expect(deferredDebtLog).toContain("projectedTokenCount=");
+    expect(deferredDebtLog).not.toContain("projectedTokenCount=null");
+    expect(deferredDebtLog).toContain("rawTokensOutsideTail=");
+    expect(deferredDebtLog).not.toContain("rawTokensOutsideTail=null");
+  });
+
   it("afterTurn ignores raw leaf pressure below the context threshold", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-below-threshold-ignores-leaf-pressure";
@@ -9899,6 +10021,55 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
+  it("assemble() uses projected deferred pressure for emergency drain without passing it as observed tokens", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-threshold-debt-projected-over-budget-drains";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 300,
+      projectedTokenCount: 5_000,
+      rawTokensOutsideTail: 4_700,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: conversation.conversationId,
+        sessionId,
+        tokenBudget: 4_096,
+        currentTokenCount: 300,
+        compactionTarget: "threshold",
+      }),
+    );
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(assembleResult.messages).toHaveLength(1);
+  });
+
   it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
@@ -11428,6 +11599,90 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         projectedTokensAfter: 8_200,
       }),
     );
+  });
+
+  it("forces threshold sweeps to account for projected raw backlog pressure", async () => {
+    const infoLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: infoLog, warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 300,
+      observedTokens: 300,
+      rawTokensOutsideTail: 200,
+      projectedTokens: 500,
+      currentTokens: 500,
+      threshold: 450,
+    });
+    const compactFullSweepSpy = vi
+      .spyOn(privateEngine.compaction, "compactFullSweep")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 300,
+        tokensAfter: 240,
+        condensed: false,
+      });
+
+    await engine.ingest({
+      sessionId: "threshold-projected-raw-backlog-session",
+      message: { role: "user", content: "trigger projected threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-projected-raw-backlog-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 600,
+      currentTokenCount: 300,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(compactFullSweepSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 600,
+        summarize: expect.any(Function),
+        force: true,
+        hardTrigger: false,
+      }),
+    );
+    expect(result.result?.tokensBefore).toBe(500);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 450,
+        observedOverheadTokens: 0,
+        projectedTokensBefore: 500,
+        projectedTokensAfter: 240,
+        rawTokensOutsideTail: 200,
+      }),
+    );
+    expect(
+      infoLog.mock.calls
+        .map((call) => String(call[0]))
+        .some(
+          (message) =>
+            message.includes("projectedTokens=500") &&
+            message.includes("rawTokensOutsideTail=200") &&
+            message.includes("thresholdPressureTokens=500"),
+        ),
+    ).toBe(true);
   });
 
   it("does not clear threshold pressure when persisted tokens are under target but runtime tokens remain over", async () => {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -3004,6 +3004,75 @@ describe("LCM integration: compaction", () => {
     expect(decision.threshold).toBe(450);
   });
 
+  it("evaluate compacts when observed tokens plus raw backlog exceed the threshold", async () => {
+    const backlogEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 1,
+    });
+    await ingestMessages(convStore, sumStore, 3, {
+      contentFn: (i) => `Backlog ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const decision = await backlogEngine.evaluate(CONV_ID, 600, 300);
+    expect(decision).toMatchObject({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 300,
+      observedTokens: 300,
+      rawTokensOutsideTail: 200,
+      projectedTokens: 500,
+      currentTokens: 500,
+      threshold: 450,
+    });
+  });
+
+  it("evaluate stays below threshold when projected raw backlog still fits", async () => {
+    const backlogEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 1,
+    });
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Small backlog ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const decision = await backlogEngine.evaluate(CONV_ID, 600, 250);
+    expect(decision).toMatchObject({
+      shouldCompact: false,
+      reason: "none",
+      storedTokens: 200,
+      observedTokens: 250,
+      rawTokensOutsideTail: 100,
+      projectedTokens: 350,
+      currentTokens: 350,
+      threshold: 450,
+    });
+  });
+
+  it("evaluate does not count fresh-tail raw messages as backlog pressure", async () => {
+    const freshTailEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 3,
+    });
+    await ingestMessages(convStore, sumStore, 3, {
+      contentFn: (i) => `Fresh tail ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const decision = await freshTailEngine.evaluate(CONV_ID, 600, 300);
+    expect(decision).toMatchObject({
+      shouldCompact: false,
+      reason: "none",
+      storedTokens: 300,
+      observedTokens: 300,
+      rawTokensOutsideTail: 0,
+      projectedTokens: 300,
+      currentTokens: 300,
+      threshold: 450,
+    });
+  });
+
   it("compactUntilUnder uses currentTokens when stored tokens are stale", async () => {
     await ingestMessages(convStore, sumStore, 10, {
       contentFn: (i) => `Turn ${i}: ${"x".repeat(200)}`,


### PR DESCRIPTION
## Summary
- include raw backlog outside the fresh tail in threshold compaction decisions when runtime observed tokens are available
- persist projected/raw-backlog diagnostics for deferred threshold debt and emergency assemble decisions
- force threshold sweeps for projected raw backlog without treating compactable raw tokens as permanent runtime overhead
- surface projected/raw backlog maintenance diagnostics in `lcm status`

Refs #603

## Validation
- `npm test -- test/compaction-maintenance-store.test.ts test/lcm-integration.test.ts -t "projected|evaluate"`
- `npm test -- test/engine.test.ts -t "projected raw backlog|projected raw backlog pressure|projected deferred pressure|recorded runtime tokens are over budget"`
- `npm test -- test/engine.test.ts test/lcm-integration.test.ts test/compaction-maintenance-store.test.ts test/lcm-command.test.ts`
- `npm run build`
- `git diff --check`

## Notes
Adversarial review initially found two semantic hazards: deferred debt lost projected pressure, and compactable raw backlog was being treated like permanent runtime overhead. This version persists projected pressure separately and uses it only to decide when debt is urgent, while compaction still receives the non-projected observed prompt count.