### PR TITLE
Fix missing session file afterTurn reread

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5436,13 +5436,15 @@ export class LcmContextEngine implements ContextEngine {
           conversation.conversationId,
         );
         let sessionFileState: { size: number; mtimeMs: number } | undefined;
+        let sessionFileStatError: unknown;
         try {
           const sessionFileStats = await stat(params.sessionFile);
           sessionFileState = {
             size: sessionFileStats.size,
             mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
           };
-        } catch {
+        } catch (error) {
+          sessionFileStatError = error;
           // Leave undefined: without stat proof, do not use append-only guards or slow-read caps.
         }
         const transcriptEpochShrank = checkpointIsPastTranscriptEof(
@@ -5569,6 +5571,37 @@ export class LcmContextEngine implements ContextEngine {
           this.afterTurnReconcileFullReadStates.set(fullReadKey, sessionFileState);
         };
         const slowPathStartedAt = Date.now();
+
+        if (isMissingFileError(sessionFileStatError)) {
+          if (!checkpoint) {
+            try {
+              await this.summaryStore.upsertConversationBootstrapState({
+                conversationId: conversation.conversationId,
+                sessionFilePath: params.sessionFile,
+                lastSeenSize: 0,
+                lastSeenMtimeMs: 0,
+                lastProcessedOffset: 0,
+                lastProcessedEntryHash: null,
+              });
+            } catch (seedError) {
+              this.deps.log.warn(
+                `[lcm] afterTurn: transcript reconcile slow path failed to seed placeholder bootstrap_state conversation=${conversation.conversationId} sessionFile=${params.sessionFile} error=${seedError instanceof Error ? seedError.message : String(seedError)}`,
+              );
+            }
+            this.deps.log.warn(
+              `[lcm] afterTurn: session file missing; skipping transcript reconcile full reread; could not stat/read transcript; allowing live afterTurn persistence and seeding placeholder bootstrap_state at offset=0 to unblock next-turn recovery conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+            );
+          } else {
+            this.deps.log.warn(
+              `[lcm] afterTurn: session file missing; skipping transcript reconcile full reread; preserving existing checkpoint (offset=${checkpoint.lastProcessedOffset}) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+            );
+          }
+          return {
+            importedMessages: 0,
+            blockedByImportCap: false,
+            hasOverlap: true,
+          };
+        }
 
         // Distinguish empty-file from read/parse error: stat the file and
         // only treat it as "actually empty" when size is 0. A non-zero file

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -8420,6 +8420,85 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(secondSlowPathWarns.length).toBe(0);
   });
 
+  it("afterTurn treats missing tracked transcripts as a cheap degraded path without full reread", async () => {
+    const warnLog = vi.fn();
+    const debugLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: debugLog },
+      },
+    );
+    const sessionId = "after-turn-missing-transcript-cheap-skip";
+    const sessionKey = "agent:main:test:missing-transcript-cheap-skip";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey,
+    });
+    const bulkMessages = await engine.getConversationStore().createMessagesBulk(
+      Array.from({ length: 120 }, (_, index) => ({
+        conversationId: conversation.conversationId,
+        seq: index,
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `persisted historical message ${index}`,
+        tokenCount: 5,
+        skipReplayTimestampFloodGuard: true,
+      })),
+    );
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(
+        conversation.conversationId,
+        bulkMessages.map((message) => message.messageId),
+      );
+    const missingSessionFile = createSessionFilePath("after-turn-missing-transcript-cheap-skip");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: missingSessionFile,
+      lastSeenSize: 24_000,
+      lastSeenMtimeMs: 1_700_000_000_000,
+      lastProcessedOffset: 24_000,
+      lastProcessedEntryHash: "checkpoint-hash",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: missingSessionFile,
+      messages: [
+        makeMessage({ role: "assistant", content: "persisted historical message 119" }),
+        makeMessage({ role: "user", content: "live user after missing transcript" }),
+        makeMessage({ role: "assistant", content: "live assistant after missing transcript" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation.conversationId);
+    expect(stored.slice(-2).map((message) => message.content)).toEqual([
+      "live user after missing transcript",
+      "live assistant after missing transcript",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation.conversationId);
+    expect(checkpoint).toMatchObject({
+      sessionFilePath: missingSessionFile,
+      lastSeenSize: 24_000,
+      lastProcessedOffset: 24_000,
+      lastProcessedEntryHash: "checkpoint-hash",
+    });
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("session file missing; skipping transcript reconcile full reread")),
+    ).toBe(true);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("transcript reconcile slow path (full re-read)")),
+    ).toBe(false);
+  });
+
   it("seeds placeholder bootstrap_state when afterTurn stat-fail fallback runs (#649 follow-up)", async () => {
     // #649 added a permissive stat-fail fallback in the slow path that
     // returns hasOverlap:true to allow live afterTurn ingest even when the


### PR DESCRIPTION
## Summary
- short-circuit afterTurn transcript reconciliation when the tracked session file is missing (`ENOENT`/`ENOTDIR`)
- preserve an existing bootstrap checkpoint, or seed the existing placeholder checkpoint path when no checkpoint exists
- allow live afterTurn persistence to continue while logging an explicit degraded missing-file diagnostic
- add a regression for a large persisted conversation whose tracked transcript has disappeared

Refs #699

## Validation
- `npm test -- test/engine.test.ts -t "missing tracked transcripts|stat-fail fallback"`
- `npm test -- test/engine.test.ts -t "transcript reconcile slow path|stat-fail fallback|missing tracked transcripts|path-mismatched|no-anchor|same-path shrink|capped reconcile|retries a capped reconcile|checkpoint refresh"`
- `npm test -- test/engine.test.ts`
- `npm run build`
- `git diff --check`

## Notes
This keeps #699 open until review/CI/merge. The fix targets the missing-file/orphan transcript path only; path-mismatch and same-path-shrink full reconciliation remain unchanged when the current transcript is readable.