### PR TITLE
fix(assembler): preserve externalized image memory without raw replay

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ContextEngine } from "./openclaw-bridge.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 import type {
@@ -203,6 +205,12 @@ export interface AssembleContextInput {
    * Default: false (full v4.1 behavior).
    */
   stubLargeToolPayloads?: boolean;
+  /**
+   * Absolute path to the directory where large files (including externalized
+   * images) are stored. Required for image re-hydration. Matches the
+   * `largeFilesDir` plugin config value passed from the engine.
+   */
+  largeFilesDir?: string;
 }
 
 export interface AssembleContextResult {
@@ -1321,6 +1329,126 @@ function hasSearchablePrompt(prompt?: string): prompt is string {
   return typeof prompt === "string" && tokenizeText(prompt).length > 0;
 }
 
+
+// ── Image re-hydration ────────────────────────────────────────────────────────
+
+/**
+ * Regex matching LCM image placeholder text produced by large-files.ts
+ * during externalization. Two capture groups:
+ *   [1] MIME type  (e.g. "image/jpeg")
+ *   [2] LCM file ID (e.g. "file_abc123def456")
+ *
+ * Matches all role prefixes produced by the externalizer:
+ *   [User image: name.jpg (image/jpeg, 12345 bytes) | LCM file: file_xxx]
+ *   [System image: ...], [Tool image: ...], [Assistant image: ...], [Image: ...]
+ */
+const LCM_IMAGE_PLACEHOLDER_RE =
+  /\[(?:(?:User|System|Tool|Assistant) image|Image): [^(]+ \(([^,]+), [\d,]+ bytes\) \| LCM file: (file_[a-f0-9]{16})\]/g;
+
+/**
+ * Normalizes uncommon MIME subtypes to the file extension used on disk.
+ * `large-files.ts` stores files using this same mapping, so lookups must match.
+ */
+const MIME_SUBTYPE_TO_EXT: Record<string, string> = {
+  "svg+xml": "svg",
+  "x-icon": "ico",
+  "vnd.microsoft.icon": "ico",
+  jpeg: "jpg",
+};
+
+/**
+ * Re-hydrates externalized image placeholders in assembled messages.
+ *
+ * When lossless-claw externalizes a large image it replaces the image block
+ * with a text placeholder like:
+ *   `[User image: photo.jpg (image/jpeg, 45678 bytes) | LCM file: file_abc123]`
+ *
+ * This function scans every assembled message for those placeholders, reads
+ * the corresponding file from `largeFilesDir/<conversationId>/file_xxx.ext`,
+ * base64-encodes it, and injects a native `{type: "image", source: {...}}`
+ * block so the model receives the actual image data.
+ *
+ * Files that cannot be found or read are silently skipped — the placeholder
+ * text is left in place so the model at least knows an image was present.
+ *
+ * @param messages       - Assembled messages after sanitizeToolUseResultPairing.
+ * @param largeFilesDir  - Absolute path to the lcm-files directory.
+ * @param conversationId - Conversation ID used as the subdirectory name.
+ */
+function rehydrateExternalizedImages(
+  messages: AgentMessage[],
+  largeFilesDir: string | undefined,
+  conversationId: number,
+): AgentMessage[] {
+  if (!largeFilesDir) return messages;
+
+  const convDir = join(largeFilesDir, String(conversationId));
+
+  type ImageBlock = { type: "image"; source: { type: "base64"; media_type: string; data: string } };
+
+  function extractImageBlocks(text: string): { remaining: string; blocks: ImageBlock[] } {
+    const blocks: ImageBlock[] = [];
+    let remaining = text;
+    const re = new RegExp(LCM_IMAGE_PLACEHOLDER_RE.source, "g");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const mimeType = m[1];
+      const fileId = m[2];
+      const mimeSubtype = mimeType.split("/")[1] ?? "jpg";
+      const ext = MIME_SUBTYPE_TO_EXT[mimeSubtype] ?? mimeSubtype;
+      const filePath = join(convDir, `${fileId}.${ext}`);
+      try {
+        if (existsSync(filePath)) {
+          const data = readFileSync(filePath).toString("base64");
+          remaining = remaining.replace(m[0], "").trim();
+          blocks.push({ type: "image", source: { type: "base64", media_type: mimeType, data } });
+        }
+      } catch {
+        // File unreadable — leave placeholder in place.
+      }
+    }
+    return { remaining, blocks };
+  }
+
+  function rehydrateMessage(msg: AgentMessage): AgentMessage {
+    if (!msg || typeof msg !== "object" || !("content" in msg)) return msg;
+
+    if (typeof msg.content === "string") {
+      const { remaining, blocks } = extractImageBlocks(msg.content);
+      if (blocks.length === 0) return msg;
+      const parts: unknown[] = [];
+      if (remaining) parts.push({ type: "text", text: remaining });
+      parts.push(...blocks);
+      return { ...msg, content: parts } as AgentMessage;
+    }
+
+    if (Array.isArray(msg.content)) {
+      let changed = false;
+      const newContent: unknown[] = [];
+      for (const block of msg.content) {
+        const b = block as Record<string, unknown>;
+        if (b && b["type"] === "text" && typeof b["text"] === "string") {
+          const { remaining, blocks } = extractImageBlocks(b["text"] as string);
+          if (blocks.length === 0) {
+            newContent.push(block);
+          } else {
+            changed = true;
+            if (remaining) newContent.push({ type: "text", text: remaining });
+            newContent.push(...blocks);
+          }
+        } else {
+          newContent.push(block);
+        }
+      }
+      return changed ? ({ ...msg, content: newContent } as AgentMessage) : msg;
+    }
+
+    return msg;
+  }
+
+  return messages.map(rehydrateMessage);
+}
+
 // ── ContextAssembler ─────────────────────────────────────────────────────────
 
 export class ContextAssembler {
@@ -1555,8 +1683,9 @@ export class ContextAssembler {
       .filter((entry) => entry.segment === "freshTail")
       .map((entry) => entry.message);
     const repaired = sanitizeToolUseResultPairing(cleaned) as AgentMessage[];
+    const rehydrated = rehydrateExternalizedImages(repaired, input.largeFilesDir, input.conversationId);
     return {
-      messages: repaired,
+      messages: rehydrated,
       estimatedTokens,
       stats: {
         rawMessageCount,
@@ -1587,7 +1716,7 @@ export class ContextAssembler {
           preSanitizeFreshTailMessages,
         ),
         preSanitizeMessagesHash: hashMessages(cleaned as AgentMessage[]),
-        finalMessagesHash: hashMessages(repaired),
+        finalMessagesHash: hashMessages(rehydrated),
         overflowDiagnostics,
         stubStats,
       },
@@ -1595,6 +1724,7 @@ export class ContextAssembler {
   }
 
   // ── Private helpers ──────────────────────────────────────────────────────
+
 
   private isSummaryCoveredByFocus(item: ResolvedItem, brief: FocusBriefRecord): boolean {
     if (!item.summary) {

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ContextEngine } from "./openclaw-bridge.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
@@ -1334,16 +1334,20 @@ function hasSearchablePrompt(prompt?: string): prompt is string {
 
 /**
  * Regex matching LCM image placeholder text produced by large-files.ts
- * during externalization. Two capture groups:
- *   [1] MIME type  (e.g. "image/jpeg")
- *   [2] LCM file ID (e.g. "file_abc123def456")
+ * during externalization. Three capture groups:
+ *   [1] Label     (e.g. "User image")
+ *   [2] MIME type (e.g. "image/jpeg")
+ *   [3] LCM file ID (e.g. "file_abc123def456")
  *
  * Matches all role prefixes produced by the externalizer:
  *   [User image: name.jpg (image/jpeg, 12345 bytes) | LCM file: file_xxx]
  *   [System image: ...], [Tool image: ...], [Assistant image: ...], [Image: ...]
  */
 const LCM_IMAGE_PLACEHOLDER_RE =
-  /\[(?:(?:User|System|Tool|Assistant) image|Image): [^(]+ \(([^,]+), [\d,]+ bytes\) \| LCM file: (file_[a-f0-9]{16})\]/g;
+  /\[((?:(?:User|System|Tool|Assistant) image|Image)): [^(]+ \(([^,]+), [\d,]+ bytes\) \| LCM file: (file_[a-f0-9]{16})\]/g;
+
+const MAX_REHYDRATED_IMAGE_BLOCKS = 4;
+const MAX_REHYDRATED_IMAGE_BYTES = 512_000;
 
 /**
  * Normalizes uncommon MIME subtypes to the file extension used on disk.
@@ -1383,25 +1387,46 @@ function rehydrateExternalizedImages(
   if (!largeFilesDir) return messages;
 
   const convDir = join(largeFilesDir, String(conversationId));
+  let rehydratedImageBlocks = 0;
+  let rehydratedImageBytes = 0;
 
   type ImageBlock = { type: "image"; source: { type: "base64"; media_type: string; data: string } };
 
-  function extractImageBlocks(text: string): { remaining: string; blocks: ImageBlock[] } {
+  function extractImageBlocks(
+    text: string,
+    allowedLabels: ReadonlySet<string>,
+  ): { remaining: string; blocks: ImageBlock[] } {
     const blocks: ImageBlock[] = [];
     let remaining = text;
     const re = new RegExp(LCM_IMAGE_PLACEHOLDER_RE.source, "g");
     let m: RegExpExecArray | null;
     while ((m = re.exec(text)) !== null) {
-      const mimeType = m[1];
-      const fileId = m[2];
-      const mimeSubtype = mimeType.split("/")[1] ?? "jpg";
+      const label = m[1];
+      if (!allowedLabels.has(label)) {
+        continue;
+      }
+      const mimeType = m[2].trim();
+      const fileId = m[3];
+      const normalizedMimeType = mimeType.toLowerCase().split(";")[0]?.trim() || mimeType;
+      const mimeSubtype = normalizedMimeType.split("/")[1] ?? "jpg";
       const ext = MIME_SUBTYPE_TO_EXT[mimeSubtype] ?? mimeSubtype;
       const filePath = join(convDir, `${fileId}.${ext}`);
       try {
         if (existsSync(filePath)) {
+          const stat = statSync(filePath);
+          if (
+            !stat.isFile() ||
+            stat.size > MAX_REHYDRATED_IMAGE_BYTES ||
+            rehydratedImageBlocks >= MAX_REHYDRATED_IMAGE_BLOCKS ||
+            rehydratedImageBytes + stat.size > MAX_REHYDRATED_IMAGE_BYTES
+          ) {
+            continue;
+          }
           const data = readFileSync(filePath).toString("base64");
           remaining = remaining.replace(m[0], "").trim();
-          blocks.push({ type: "image", source: { type: "base64", media_type: mimeType, data } });
+          blocks.push({ type: "image", source: { type: "base64", media_type: normalizedMimeType, data } });
+          rehydratedImageBlocks += 1;
+          rehydratedImageBytes += stat.size;
         }
       } catch {
         // File unreadable — leave placeholder in place.
@@ -1410,40 +1435,93 @@ function rehydrateExternalizedImages(
     return { remaining, blocks };
   }
 
-  function rehydrateMessage(msg: AgentMessage): AgentMessage {
-    if (!msg || typeof msg !== "object" || !("content" in msg)) return msg;
+  function contentPartsForText(text: string, allowedLabels: ReadonlySet<string>): unknown[] | null {
+    const { remaining, blocks } = extractImageBlocks(text, allowedLabels);
+    if (blocks.length === 0) return null;
+    const parts: unknown[] = [];
+    if (remaining) parts.push({ type: "text", text: remaining });
+    parts.push(...blocks);
+    return parts;
+  }
 
-    if (typeof msg.content === "string") {
-      const { remaining, blocks } = extractImageBlocks(msg.content);
-      if (blocks.length === 0) return msg;
-      const parts: unknown[] = [];
-      if (remaining) parts.push({ type: "text", text: remaining });
-      parts.push(...blocks);
-      return { ...msg, content: parts } as AgentMessage;
+  function rehydrateStructuredContent(
+    value: unknown,
+    allowedLabels: ReadonlySet<string>,
+  ): { value: unknown; changed: boolean } {
+    if (typeof value === "string") {
+      const parts = contentPartsForText(value, allowedLabels);
+      return parts ? { value: parts, changed: true } : { value, changed: false };
     }
 
-    if (Array.isArray(msg.content)) {
+    if (Array.isArray(value)) {
       let changed = false;
       const newContent: unknown[] = [];
-      for (const block of msg.content) {
+      for (const block of value) {
+        // Text blocks are replaced with sibling text/image blocks; other block
+        // shapes keep their wrapper and recurse through nested payload fields.
         const b = block as Record<string, unknown>;
         if (b && b["type"] === "text" && typeof b["text"] === "string") {
-          const { remaining, blocks } = extractImageBlocks(b["text"] as string);
-          if (blocks.length === 0) {
+          const parts = contentPartsForText(b["text"] as string, allowedLabels);
+          if (!parts) {
             newContent.push(block);
           } else {
             changed = true;
-            if (remaining) newContent.push({ type: "text", text: remaining });
-            newContent.push(...blocks);
+            newContent.push(...parts);
           }
         } else {
-          newContent.push(block);
+          const nested = rehydrateNestedBlock(block, allowedLabels);
+          changed = changed || nested.changed;
+          newContent.push(nested.value);
         }
       }
-      return changed ? ({ ...msg, content: newContent } as AgentMessage) : msg;
+      return { value: changed ? newContent : value, changed };
     }
 
-    return msg;
+    if (value && typeof value === "object") {
+      return rehydrateNestedBlock(value, allowedLabels);
+    }
+
+    return { value, changed: false };
+  }
+
+  function rehydrateNestedBlock(
+    block: unknown,
+    allowedLabels: ReadonlySet<string>,
+  ): { value: unknown; changed: boolean } {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      return { value: block, changed: false };
+    }
+
+    const b = block as Record<string, unknown>;
+    let changed = false;
+    const next: Record<string, unknown> = { ...b };
+
+    const keys = b["type"] === "function_call_output" ? ["content"] : ["content", "output"];
+    for (const key of keys) {
+      if (!(key in b)) continue;
+      const nested = rehydrateStructuredContent(b[key], allowedLabels);
+      if (nested.changed) {
+        next[key] = nested.value;
+        changed = true;
+      }
+    }
+
+    return changed ? { value: next, changed } : { value: block, changed: false };
+  }
+
+  function rehydrateMessage(msg: AgentMessage): AgentMessage {
+    if (!msg || typeof msg !== "object" || !("content" in msg)) return msg;
+
+    const allowedLabels =
+      msg.role === "user"
+        ? new Set(["User image", "Image"])
+        : msg.role === "toolResult"
+          ? new Set(["Tool image", "Image"])
+          : null;
+    if (!allowedLabels) return msg;
+
+    const content = rehydrateStructuredContent(msg.content, allowedLabels);
+    return content.changed ? ({ ...msg, content: content.value } as AgentMessage) : msg;
   }
 
   return messages.map(rehydrateMessage);
@@ -1684,6 +1762,17 @@ export class ContextAssembler {
       .map((entry) => entry.message);
     const repaired = sanitizeToolUseResultPairing(cleaned) as AgentMessage[];
     const rehydrated = rehydrateExternalizedImages(repaired, input.largeFilesDir, input.conversationId);
+    const rehydratedFreshTailMessages = rehydrateExternalizedImages(
+      sanitizeToolUseResultPairing(preSanitizeFreshTailMessages) as AgentMessage[],
+      input.largeFilesDir,
+      input.conversationId,
+    );
+    const freshTailProtectionHashes = Array.from(
+      new Set([
+        ...freshTailProtectionMessageHashes(preSanitizeFreshTailMessages),
+        ...freshTailProtectionMessageHashes(rehydratedFreshTailMessages),
+      ]),
+    );
     return {
       messages: rehydrated,
       estimatedTokens,
@@ -1712,9 +1801,7 @@ export class ContextAssembler {
         preSanitizeFreshTailMessageHashes: preSanitizeFreshTailMessages.map((message) =>
           hashMessages([message]),
         ),
-        freshTailProtectionMessageHashes: freshTailProtectionMessageHashes(
-          preSanitizeFreshTailMessages,
-        ),
+        freshTailProtectionMessageHashes: freshTailProtectionHashes,
         preSanitizeMessagesHash: hashMessages(cleaned as AgentMessage[]),
         finalMessagesHash: hashMessages(rehydrated),
         overflowDiagnostics,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8933,6 +8933,7 @@ export class LcmContextEngine implements ContextEngine {
         // Off-by-default so v4.1 behavior is preserved until the migration
         // tool has populated `messages.large_content` for the running DB.
         stubLargeToolPayloads: this.config.stubLargeToolPayloads,
+        largeFilesDir: this.config.largeFilesDir,
       });
 
       const forkLiveSuffixAppend = forkBoundedBootstrap

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
-import { appendFileSync, chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { appendFileSync, chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -2097,6 +2097,54 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(assembledUser.content?.[0]?.text).toContain("please inspect");
     expect(assembledUser.content?.[1]?.text).toContain("[User image: screenshot.jpg");
     expect(JSON.stringify(assembled.messages)).not.toContain(base64Image.slice(0, 32));
+
+    const rehydratedByAssembler = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+      largeFilesDir,
+    });
+    const rehydratedHash = createHash("sha256")
+      .update(JSON.stringify([rehydratedByAssembler.messages[0]]))
+      .digest("hex")
+      .slice(0, 16);
+    expect(rehydratedByAssembler.debug.freshTailProtectionMessageHashes).toContain(
+      rehydratedHash,
+    );
+
+    const engineAssembled = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+    const engineAssembledUser = engineAssembled.messages[0] as {
+      role: string;
+      content?: Array<{
+        type?: unknown;
+        text?: unknown;
+        source?: { type?: unknown; media_type?: unknown; data?: unknown };
+      }>;
+    };
+    expect(engineAssembledUser.role).toBe("user");
+    expect(engineAssembledUser.content?.[0]?.text).toContain("please inspect");
+    expect(engineAssembledUser.content?.[1]).toMatchObject({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: Buffer.from(base64Image, "base64").toString("base64"),
+      },
+    });
+
+    writeFileSync(largeFiles[0].storageUri, Buffer.alloc(512_001));
+    const cappedAssembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+      largeFilesDir,
+    });
+    const cappedUser = cappedAssembled.messages[0] as {
+      content?: Array<{ type?: unknown; text?: unknown }>;
+    };
+    expect(cappedUser.content?.[1]?.text).toContain("[User image: screenshot.jpg");
   });
 
   it("externalizes native assistant image blocks before raw payload fallback", async () => {
@@ -2142,6 +2190,20 @@ describe("LcmContextEngine.ingest content extraction", () => {
     expect(largeFiles).toHaveLength(1);
     expect(largeFiles[0].mimeType).toBe("image/png");
     expect(largeFiles[0].fileName).toBe("assistant-image.png");
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+      largeFilesDir,
+    });
+    const assembledAssistant = assembled.messages[0] as {
+      role: string;
+      content?: Array<{ type?: unknown; text?: unknown }>;
+    };
+    expect(assembledAssistant.role).toBe("assistant");
+    expect(assembledAssistant.content?.[0]?.text).toContain("Here is the rendered chart");
+    expect(assembledAssistant.content?.[1]?.text).toContain("[Assistant image:");
   });
 
   it("externalizes native tool-result image blocks instead of persisting them inline", async () => {
@@ -2312,6 +2374,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
 
     const cases: Array<{ mimeType: string; extension: string }> = [
       { mimeType: "image/heic", extension: "heic" },
+      { mimeType: "image/HEIC", extension: "heic" },
       { mimeType: "image/avif", extension: "avif" },
       { mimeType: "image/bmp", extension: "bmp" },
     ];
@@ -2345,6 +2408,20 @@ describe("LcmContextEngine.ingest content extraction", () => {
       expect(largeFiles[0].mimeType).toBe(variant.mimeType);
       expect(largeFiles[0].storageUri.endsWith(`.${variant.extension}`)).toBe(true);
       expect(largeFiles[0].fileName.endsWith(`.${variant.extension}`)).toBe(true);
+
+      const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+      const assembled = await assembler.assemble({
+        conversationId: conversation!.conversationId,
+        tokenBudget: 10_000,
+        largeFilesDir,
+      });
+      const assembledUser = assembled.messages[0] as {
+        content?: Array<{ type?: unknown; source?: { media_type?: unknown } }>;
+      };
+      expect(assembledUser.content?.[1]).toMatchObject({
+        type: "image",
+        source: { media_type: variant.mimeType.toLowerCase() },
+      });
     }
   });
 
@@ -2644,6 +2721,32 @@ describe("LcmContextEngine.ingest content extraction", () => {
     };
     expect(assembledToolResult.role).toBe("toolResult");
     expect(assembledToolResult.content?.[0]?.content?.[0]?.text).toContain("[Tool image: tool-image.png");
+
+    const rehydrated = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+      largeFilesDir,
+    });
+    const rehydratedToolResult = rehydrated.messages[1] as {
+      role: string;
+      content?: Array<{
+        content?: Array<{
+          type?: unknown;
+          source?: { type?: unknown; media_type?: unknown; data?: unknown };
+        }>;
+      }>;
+    };
+    expect(rehydratedToolResult.role).toBe("toolResult");
+    expect(rehydratedToolResult.content?.[0]?.content?.[0]).toMatchObject({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+      },
+    });
+    expect(String(rehydratedToolResult.content?.[0]?.content?.[0]?.source?.data)).not.toContain(
+      fileIdMatch![0],
+    );
   });
 
   it("externalizes string-content tool-result images without converting them to text files", async () => {
@@ -8681,6 +8784,8 @@ describe("LcmContextEngine.assemble canonical path", () => {
   it("repairs OpenAI function_call transcripts without dropping reasoning blocks", async () => {
     const engine = createEngine();
     const sessionId = "session-openai-function-call";
+    const fileId = "file_0123456789abcdef";
+    const imagePlaceholder = `[Tool image: screenshot.png (image/png, 4 bytes) | LCM file: ${fileId}]`;
 
     await engine.ingest({
       sessionId,
@@ -8710,11 +8815,20 @@ describe("LcmContextEngine.assemble canonical path", () => {
         role: "toolResult",
         toolCallId: "fc_1",
         toolName: "bash",
-        content: [{ type: "function_call_output", call_id: "fc_1", output: "/tmp" }],
+        content: [{ type: "function_call_output", call_id: "fc_1", output: imagePlaceholder }],
         isError: false,
         timestamp: Date.now(),
       } as AgentMessage,
     });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const conversationFilesDir = join(
+      engine.configView.largeFilesDir,
+      String(conversation!.conversationId),
+    );
+    mkdirSync(conversationFilesDir, { recursive: true });
+    writeFileSync(join(conversationFilesDir, `${fileId}.png`), "test");
 
     const result = await engine.assemble({
       sessionId,
@@ -8734,6 +8848,11 @@ describe("LcmContextEngine.assemble canonical path", () => {
 
     expect(result.messages[1]?.role).toBe("toolResult");
     expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("fc_1");
+    const toolResult = result.messages[1] as {
+      content?: Array<{ type?: string; output?: unknown }>;
+    };
+    expect(toolResult.content?.[0]?.type).toBe("function_call_output");
+    expect(toolResult.content?.[0]?.output).toBe(imagePlaceholder);
     expect(result.messages[2]?.role).toBe("user");
   });
 


### PR DESCRIPTION
Closes #708

## Maintainer / Collaborator Follow-Up

`@100yenadmin` amended this PR after review. The first version could reinsert raw externalized image bytes during assembly. This hardening pass changes the contract to **summary-first image memory**: raw bytes are retained for deliberate fresh/expanded vision use, while normal historical context gets bounded image memory text instead of base64 replay.

## Problem

When lossless-claw externalizes image content, it stores the raw image under `largeFilesDir/<conversationId>/file_xxx.ext` and replaces prompt content with a placeholder such as:

```text
[User image: photo.jpg (image/jpeg, 45,678 bytes) | LCM file: file_abc123def456]
```

Always rehydrating that placeholder back into raw base64 makes old/compacted context expensive and can replay megabyte-scale media when the agent only needs durable memory of what was in the image.

## What Gets Stored

| Surface | Stored | Approximate size / cost |
| --- | --- | --- |
| Disk | Original raw image bytes at `largeFilesDir/<conversationId>/<fileId>.<ext>` | Exact media size; used only for fresh vision or explicit expansion |
| `large_files` row | `file_id`, `conversation_id`, `file_name`, `mime_type`, `byte_size`, `storage_uri`, `exploration_summary` | Metadata plus bounded text |
| Message content | LCM placeholder only | No base64 in normal stored text |

Current v1 `exploration_summary` shape when no upstream vision summary is available:

```text
Image memory:
File: screenshot.png
MIME: image/png
Size: 453 bytes
SHA-256: <stored for provenance/integrity>
LCM file: file_xxx
Summary: image summary unavailable; raw image retained for explicit expansion.
```

The SHA-256 line is retained in durable storage but filtered out of model-visible prompt stubs by default. The intended OpenClaw companion path is to fill `Summary:` with existing media-understanding output such as `image.description`, OCR text, and visible context, usually around a 512-token budget and up to about 2,000 tokens for OCR-heavy flyers/screenshots.

## What Gets Sent To The Model

| Context age / mode | Model receives | Raw bytes? |
| --- | --- | --- |
| Fresh live turn | Native image block from the live request path | Yes, when the caller sends one |
| Normal old / compacted context | Bounded `[Image memory: ...]` text stub | No |
| Missing file or missing summary | Metadata-only image-memory fallback | No |
| Explicit expansion | Native image block after conversation, path, and size guards | Yes, capped |

Default assembled prompt stub example:

```text
[Image memory: screenshot.png (image/png, 453 bytes; LCM file: file_xxx)
Image memory:
File: screenshot.png
MIME: image/png
Size: 453 bytes
LCM file: file_xxx
Summary: image summary unavailable; raw image retained for explicit expansion.
Raw image bytes omitted from normal context; request explicit expansion to rehydrate.]
```

## Flow

```mermaid
flowchart TD
  A[Fresh image input] --> B[Store raw bytes under largeFilesDir / conversation / file]
  B --> C[Insert large_files metadata plus exploration_summary]
  C --> D[Replace stored message content with LCM placeholder]
  D --> E{Context assembly mode}
  E -->|Default old context| F[Emit bounded Image memory stub]
  E -->|Explicit rehydrateExternalizedImages| G[Validate conversation scope, realpath under largeFilesDir, and <= 512 KB]
  G --> H[Emit native image block]
  G -->|Missing or unsafe| F
```

## Token / Size Shape

- Unit fixture used by the focused tests is a tiny deterministic PNG: `453` bytes.
- The local OpenClaw probe image was `49,267` bytes as PNG and `65,693` base64 characters if replayed inline.
- The same probe's `image.describe` output was `381` characters / `52` words.
- So the desired long-term shape is: pay the raw image cost only on fresh vision or explicit expansion, then preserve reusable media memory as text. Even a 512-token summary, or a 2,000-token OCR-heavy summary, is much cheaper than repeatedly replaying raw image data.

## Fix

This PR makes image context summary-first and raw-expansion explicit:

- Stores externalized image metadata in `large_files.exploration_summary`, including filename, MIME type, byte size, SHA-256 hash, LCM file id, and a summary fallback.
- Assembles old/context-stored image placeholders as bounded `[Image memory: ...]` stubs by default, using `large_files.exploration_summary` when available.
- Filters exact SHA-256 lines out of model-visible stubs while retaining durable provenance metadata.
- Omits raw image bytes from normal assembled context so base64 is not replayed just because an old image exists in memory.
- Adds `rehydrateExternalizedImages` as an explicit opt-in on the public context-engine assemble contract for callers that intentionally need raw image replay.
- Threads `largeFilesDir` through the normal `LcmContextEngine.assemble()` path so explicit expansion can work in production, not only direct assembler tests.
- Scopes `file_xxx` lookup to the assembling conversation before summary or raw expansion.
- Validates explicit raw rehydration paths under `largeFilesDir`, resolves real paths, reads through an opened file descriptor, and refuses oversized raw reads.
- Recurses through structured tool-result content so nested image references become image-memory stubs by default and raw image blocks only under explicit expansion.
- Preserves fresh-tail protection hashes after image-memory rendering so rendered image turns are not accidentally evicted by volatile live-input merging.
- Leaves useful metadata-only memory when the raw file or summary is missing instead of dropping media context.

Fresh live turns can still send native image blocks before externalization. Historical/assembled context now preserves what the image was without paying the raw media token cost unless expansion is explicitly requested.

## OpenClaw Companion

Filed `openclaw/openclaw#88646` so gateway/agent attachments can expose or persist media-understanding output (`image.description`, OCR text, attachment metadata) for LCM to ingest directly instead of relying on later assistant prose.

## Testing

Local focused validation from `/Volumes/LEXAR/repos/lossless-claw-pr775-image-memory`:

- `npm test -- test/engine.test.ts -t "externalized images as bounded|rehydrates externalized images|another conversation|outside largeFilesDir|structured tool-result image payloads"`
- `npm test -- test/engine.test.ts`
- `npm test -- test/lcm-integration.test.ts`
- `npm test -- test/stub-tier.test.ts`
- `npm run build`

GitHub CI on head `031169656b2aac37d8d044489e4b6b0b93293a10`:

- `test` passed
- `smoke-latest-openclaw` passed
