### PR TITLE
fix: gate doctor apply on hot conversations

### DIFF
--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -37,6 +37,9 @@ import { FocusBriefStore, hashFocusSourceContext } from "../store/focus-brief-st
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
 const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
+const DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD = 1_000;
+const DOCTOR_APPLY_LARGE_TARGET_THRESHOLD = 25;
+const DOCTOR_APPLY_BUDGET_PRESSURE_RATIO = 0.75;
 
 type LcmStatusStats = {
   conversationCount: number;
@@ -71,6 +74,9 @@ type CurrentConversationResolution =
       kind: "unavailable";
       reason: string;
     };
+type DoctorApplyOptions = {
+  confirmOffline: boolean;
+};
 
 type ParsedLcmCommand =
   | { kind: "status" }
@@ -80,7 +86,7 @@ type ParsedLcmCommand =
   | { kind: "focus_generate"; prompt: string }
   | { kind: "refocus" }
   | { kind: "unfocus" }
-  | { kind: "doctor"; apply: boolean }
+  | { kind: "doctor"; apply: boolean; applyOptions?: DoctorApplyOptions }
   | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
   | { kind: "help"; error?: string };
 
@@ -229,6 +235,37 @@ function parseDoctorCleanerApplyArgs(tokens: string[]):
   return { ok: true, filterId, vacuum };
 }
 
+function parseDoctorApplyArgs(tokens: string[]):
+  | { ok: true; options: DoctorApplyOptions }
+  | { ok: false; error: string } {
+  if (tokens.length === 0) {
+    return { ok: true, options: { confirmOffline: false } };
+  }
+
+  let confirmOffline = false;
+  for (const token of tokens) {
+    const normalized = token.toLowerCase();
+    if (
+      normalized === "confirm-offline" ||
+      normalized === "confirm-large" ||
+      normalized === "offline" ||
+      normalized === "--offline" ||
+      normalized === "--confirm-large"
+    ) {
+      confirmOffline = true;
+      continue;
+    }
+
+    return {
+      ok: false,
+      error:
+        `\`${VISIBLE_COMMAND} doctor apply\` accepts optional \`confirm-offline\` for large/hot repair overrides.`,
+    };
+  }
+
+  return { ok: true, options: { confirmOffline } };
+}
+
 function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
   const raw = (rawArgs ?? "").trim();
   if (raw === "") {
@@ -283,13 +320,16 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
             }
           : { kind: "help", error: parsedApply.error };
       }
-      if (rest.length === 1 && rest[0]?.toLowerCase() === "apply") {
-        return { kind: "doctor", apply: true };
+      if (rest[0]?.toLowerCase() === "apply") {
+        const parsedApply = parseDoctorApplyArgs(rest.slice(1));
+        return parsedApply.ok
+          ? { kind: "doctor", apply: true, applyOptions: parsedApply.options }
+          : { kind: "help", error: parsedApply.error };
       }
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply\` for the scoped summary repair path.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [confirm-offline]\` for the scoped summary repair path.`,
       };
     case "help":
       return { kind: "help" };
@@ -560,6 +600,58 @@ function resolveLifecycleCompactionTokenBudget(config: LcmConfig): number {
     : 128_000;
 }
 
+function buildDoctorApplySafetyPreflight(params: {
+  config: LcmConfig;
+  stats: LcmConversationStatusStats;
+  doctor: DoctorSummaryStats;
+  maintenance: ConversationCompactionMaintenanceRecord | null;
+}): { blocked: boolean; reasons: string[]; tokenBudget: number; tokenThreshold: number } {
+  const tokenBudget = resolveLifecycleCompactionTokenBudget(params.config);
+  const tokenThreshold = Math.floor(tokenBudget * DOCTOR_APPLY_BUDGET_PRESSURE_RATIO);
+  const reasons: string[] = [];
+  const maintenanceObservedTokens = Math.max(
+    params.maintenance?.currentTokenCount ?? 0,
+    params.maintenance?.projectedTokenCount ?? 0,
+  );
+  const observedTokens = Math.max(
+    params.stats.contextTokenCount,
+    params.stats.summarizedSourceTokens,
+    params.stats.compressedTokenCount,
+    maintenanceObservedTokens,
+  );
+
+  if (params.doctor.total > DOCTOR_APPLY_LARGE_TARGET_THRESHOLD) {
+    reasons.push(
+      `doctor target count ${formatNumber(params.doctor.total)} exceeds safe inline limit ${formatNumber(DOCTOR_APPLY_LARGE_TARGET_THRESHOLD)}`,
+    );
+  }
+  if (params.stats.messageCount > DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD) {
+    reasons.push(
+      `message count ${formatNumber(params.stats.messageCount)} exceeds safe inline limit ${formatNumber(DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD)}`,
+    );
+  }
+  if (observedTokens > tokenThreshold) {
+    reasons.push(
+      `observed token count ${formatNumber(observedTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of repair budget ${formatNumber(tokenBudget)}`,
+    );
+  }
+  if (params.maintenance?.pending) {
+    reasons.push(
+      `compaction maintenance is pending (${params.maintenance.reason ?? "reason unknown"})`,
+    );
+  }
+  if (params.maintenance?.running) {
+    reasons.push("compaction maintenance is already running");
+  }
+
+  return {
+    blocked: reasons.length > 0,
+    reasons,
+    tokenBudget,
+    tokenThreshold,
+  };
+}
+
 // Run the cache-aware focus lifecycle sweep. Focus and unfocus both mutate the
 // prompt prefix, so they explicitly take the manual full-sweep path and bypass
 // threshold skips instead of leaving compaction to normal background policy.
@@ -722,6 +814,10 @@ function buildHelpText(error?: string): string {
         "Delete approved high-confidence cleaner matches after creating a DB backup.",
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor apply`), "Repair broken summaries in the current conversation."),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor apply confirm-offline`),
+        "Override large/hot-session repair preflight after isolating the active channel path.",
+      ),
     ]),
     "",
     buildSection("🧭 Notes", [
@@ -2104,6 +2200,7 @@ async function buildDoctorApplyText(params: {
   config: LcmConfig;
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
+  options?: DoctorApplyOptions;
 }): Promise<string> {
   const current = await resolveCurrentConversation(params);
 
@@ -2122,6 +2219,46 @@ async function buildDoctorApplyText(params: {
   }
 
   const stats = getDoctorSummaryStats(params.db, current.stats.conversationId);
+  const maintenance = await getConversationCompactionMaintenanceByConversationId(
+    params.db,
+    current.stats.conversationId,
+  );
+  const preflight = buildDoctorApplySafetyPreflight({
+    config: params.config,
+    stats: current.stats,
+    doctor: stats,
+    maintenance,
+  });
+  if (preflight.blocked && params.options?.confirmOffline !== true) {
+    return [
+      ...buildHeaderLines(),
+      "",
+      "🩺 Lossless Claw Doctor Apply",
+      "",
+      buildSection("📍 Current conversation", [
+        buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
+        buildStatLine(
+          "session key",
+          current.stats.sessionKey ? formatCommand(truncateMiddle(current.stats.sessionKey, 44)) : "missing",
+        ),
+        buildStatLine("scope", "this conversation only"),
+      ]),
+      "",
+      buildSection("🧯 Safety preflight", [
+        buildStatLine("status", "blocked"),
+        buildStatLine("mode", "read-only; no summary rewrites ran"),
+        buildStatLine("messages", formatNumber(current.stats.messageCount)),
+        buildStatLine("tokens in context", formatNumber(current.stats.contextTokenCount)),
+        buildStatLine("detected summaries", formatNumber(stats.total)),
+        buildStatLine("token threshold", formatNumber(preflight.tokenThreshold)),
+        ...preflight.reasons.map((reason) => buildStatLine("reason", reason)),
+      ]),
+      "",
+      buildSection("🛠️ Next step", [
+        `Run ${formatCommand(`${VISIBLE_COMMAND} doctor apply confirm-offline`)} only from an isolated/offline maintenance lane after active channel delivery is paused or moved away from this conversation.`,
+      ]),
+    ].join("\n");
+  }
   let result: Awaited<ReturnType<typeof applyScopedDoctorRepair>>;
   try {
     result = await applyScopedDoctorRepair({
@@ -2187,6 +2324,9 @@ async function buildDoctorApplyText(params: {
   lines.push(
     buildSection("🛠️ Apply", [
       buildStatLine("mode", "in-place summary rewrite"),
+      ...(params.options?.confirmOffline === true
+        ? [buildStatLine("safety override", "confirm-offline")]
+        : []),
       buildStatLine("detected summaries", formatNumber(stats.total)),
       buildStatLine("old-marker summaries", formatNumber(stats.old)),
       buildStatLine("truncated-marker summaries", formatNumber(stats.truncated)),
@@ -2310,6 +2450,7 @@ export function createLcmCommand(params: {
                   config: params.config,
                   deps: params.deps,
                   summarize: params.summarize,
+                  options: parsed.applyOptions,
                 }),
               }
             : { text: await buildDoctorText({ ctx, db: await getDb() }) };

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1513,6 +1513,221 @@ describe("lcm command", () => {
     expect(summarize).not.toHaveBeenCalled();
   });
 
+  it("blocks doctor apply for large scoped repairs before summarizer or writes run", async () => {
+    const summarize = vi.fn(async () => "should not run");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-large-targets",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-large-targets",
+    });
+
+    for (let index = 0; index < 26; index += 1) {
+      await fixture.summaryStore.insertSummary({
+        summaryId: `sum_large_target_${index}`,
+        conversationId: currentConversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: `broken leaf ${index}\n${"[Truncated from 512 tokens]"}`,
+        tokenCount: 11,
+      });
+    }
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-large-targets",
+      }),
+    );
+
+    const unchanged = await fixture.summaryStore.getSummary("sum_large_target_0");
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
+    expect(result.text).toContain("**🧯 Safety preflight**");
+    expect(result.text).toContain("status: blocked");
+    expect(result.text).toContain("mode: read-only; no summary rewrites ran");
+    expect(result.text).toContain("detected summaries: 26");
+    expect(result.text).toContain("doctor target count 26 exceeds safe inline limit 25");
+    expect(result.text).toContain("`/lossless doctor apply confirm-offline`");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(unchanged?.content).toContain("[Truncated from 512 tokens]");
+  });
+
+  it("blocks doctor apply when compaction maintenance is pending for the active conversation", async () => {
+    const summarize = vi.fn(async () => "should not run");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-pending-maintenance",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-pending-maintenance",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "pending maintenance source",
+        tokenCount: 7,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_pending_maintenance",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `broken leaf\n${"[Truncated from 512 tokens]"}`,
+      tokenCount: 11,
+      sourceMessageTokenCount: 7,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_pending_maintenance", [message.messageId]);
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           token_budget,
+           current_token_count,
+           projected_token_count,
+           updated_at
+         ) VALUES (?, 1, ?, ?, 0, ?, ?, ?, datetime('now'))`,
+      )
+      .run(
+        currentConversation.conversationId,
+        "2026-04-12T00:00:00.000Z",
+        "budget-trigger",
+        128_000,
+        96_001,
+        96_001,
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-pending-maintenance",
+      }),
+    );
+
+    const unchanged = await fixture.summaryStore.getSummary("sum_pending_maintenance");
+    expect(result.text).toContain("status: blocked");
+    expect(result.text).toContain("compaction maintenance is pending (budget-trigger)");
+    expect(result.text).toContain("observed token count 96,001 exceeds 75% of repair budget 128,000");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(unchanged?.content).toContain("[Truncated from 512 tokens]");
+  });
+
+  it("blocks doctor apply when a broken leaf summary points at oversized raw source tokens", async () => {
+    const summarize = vi.fn(async () => "should not run");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-raw-source-tokens",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-raw-source-tokens",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "oversized raw repair source",
+        tokenCount: 120_000,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_raw_source_tokens",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `broken leaf\n${"[Truncated from 512 tokens]"}`,
+      tokenCount: 11,
+      sourceMessageTokenCount: 120_000,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_raw_source_tokens", [message.messageId]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-raw-source-tokens",
+      }),
+    );
+
+    const unchanged = await fixture.summaryStore.getSummary("sum_raw_source_tokens");
+    expect(result.text).toContain("status: blocked");
+    expect(result.text).toContain("detected summaries: 1");
+    expect(result.text).toContain("observed token count 120,000 exceeds 75% of repair budget 128,000");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(unchanged?.content).toContain("[Truncated from 512 tokens]");
+  });
+
+  it("allows an explicit offline confirmation to run doctor apply despite pending maintenance", async () => {
+    const summarize = vi.fn(async () => "OFFLINE REPAIR");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-confirm-offline",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-confirm-offline",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "offline repair source",
+        tokenCount: 7,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_confirm_offline",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `broken leaf\n${"[Truncated from 512 tokens]"}`,
+      tokenCount: 11,
+      sourceMessageTokenCount: 7,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_confirm_offline", [message.messageId]);
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           token_budget,
+           current_token_count,
+           updated_at
+         ) VALUES (?, 1, ?, ?, 0, ?, ?, datetime('now'))`,
+      )
+      .run(
+        currentConversation.conversationId,
+        "2026-04-12T00:00:00.000Z",
+        "budget-trigger",
+        128_000,
+        96_001,
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply confirm-offline", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-confirm-offline",
+      }),
+    );
+
+    const repaired = await fixture.summaryStore.getSummary("sum_confirm_offline");
+    expect(result.text).toContain("safety override: confirm-offline");
+    expect(result.text).toContain("repaired summaries: 1");
+    expect(result.text).not.toContain("status: blocked");
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(repaired?.content).toContain("OFFLINE REPAIR");
+    expect(repaired?.content).not.toContain("[Truncated from 512 tokens]");
+  });
+
   it("repairs scoped doctor summaries in place and feeds repaired children into parents", async () => {
     const summarize = vi.fn(async (text: string, _aggressive?: boolean, options?: Parameters<LcmSummarizeFn>[2]) => {
       if (options?.isCondensed) {
@@ -2352,6 +2567,11 @@ describe("lcm command helpers", () => {
     expect(__testing.parseLcmCommand("focus")).toEqual({ kind: "focus_status" });
     expect(__testing.parseLcmCommand("refocus")).toEqual({ kind: "refocus" });
     expect(__testing.parseLcmCommand("unfocus")).toEqual({ kind: "unfocus" });
+    expect(__testing.parseLcmCommand("doctor apply confirm-offline")).toEqual({
+      kind: "doctor",
+      apply: true,
+      applyOptions: { confirmOffline: true },
+    });
   });
 
   it("treats only the canonical engine id and empty slot state as selected", () => {


### PR DESCRIPTION
## Summary
- Add a safe-by-default doctor apply preflight for large/hot current conversations.
- Block inline repair before summarizer calls when target count, message count, observed token pressure, or pending/running maintenance indicates active-channel risk.
- Add explicit `doctor apply confirm-offline` override for isolated/offline maintenance lanes.
- Add regressions proving large repairs and pending maintenance do not call the summarizer or mutate summaries, while explicit confirmation still repairs.

Refs #491.

## Validation
- `npm test -- test/lcm-command.test.ts -t "doctor apply|parses focus command forms"`
- `npm test -- test/lcm-command.test.ts`
- `npm test` (49 files, 1012 tests)
- `npm run build`
- `git diff --check`
- `npm pack --dry-run`

## Notes
- I am not closing #491 from this PR alone until CI and adversarial rereview complete and reporter/maintainer confirmation decides whether additional degraded assembly/status work is still required.