### PR TITLE
fix: guard missing context engine API at startup

### DIFF
--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -96,7 +96,7 @@ export type OpenClawPluginApi = {
   logger?: any;
   log?: any;
   registerCommand: (definition: OpenClawPluginCommandDefinition) => void;
-  registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
+  registerContextEngine?: (id: string, factory: ContextEngineFactory) => void;
   [key: string]: any;
 };
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -7,7 +7,7 @@
 import { join } from "node:path";
 import { writeFile } from "node:fs/promises";
 import type { DatabaseSync } from "node:sqlite";
-import type { OpenClawPluginApi } from "../openclaw-bridge.js";
+import type { ContextEngineFactory, OpenClawPluginApi } from "../openclaw-bridge.js";
 import { resolveLcmConfigWithDiagnostics, resolveOpenclawStateDir } from "../db/config.js";
 import type { LcmConfig } from "../db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection, normalizePath } from "../db/connection.js";
@@ -27,6 +27,12 @@ import type {
   RuntimeLlmModelOverride,
   StartupSessionFileCandidate,
 } from "../types.js";
+
+const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.22";
+
+type ContextEngineCapableOpenClawPluginApi = OpenClawPluginApi & {
+  registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
+};
 
 /** Parse `agent:<agentId>:<suffix...>` session keys. */
 function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
@@ -332,6 +338,67 @@ function toPluginConfig(value: unknown): Record<string, unknown> | undefined {
 /** Narrow unknown values to plain object records. */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Return a host version label from known runtime/API version surfaces when available. */
+function readOpenClawHostVersion(api: OpenClawPluginApi): string {
+  const runtime = isRecord(api.runtime) ? api.runtime : undefined;
+  const runtimeGateway = isRecord(runtime?.gateway) ? runtime.gateway : undefined;
+  const apiRecord = api as Record<string, unknown>;
+  const candidates = [
+    runtime?.openclawVersion,
+    runtime?.hostVersion,
+    runtime?.gatewayVersion,
+    runtime?.version,
+    runtimeGateway?.version,
+    apiRecord.openclawVersion,
+    apiRecord.hostVersion,
+    apiRecord.gatewayVersion,
+    apiRecord.version,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "unknown";
+}
+
+/** Log compatibility failures without relying on the newer context-engine API. */
+function logOpenClawCompatibilityError(api: OpenClawPluginApi, message: string): void {
+  const runtime = isRecord(api.runtime) ? api.runtime : undefined;
+  const logging = isRecord(runtime?.logging) ? runtime.logging : undefined;
+  if (typeof logging?.getChildLogger === "function") {
+    const childLogger = logging.getChildLogger({ plugin: "lossless-claw" });
+    if (isRecord(childLogger) && typeof childLogger.error === "function") {
+      childLogger.error(message);
+      return;
+    }
+  }
+
+  if (isRecord(api.logger) && typeof api.logger.error === "function") {
+    api.logger.error(message);
+  }
+}
+
+/** Fail before DB init when the host lacks the required context-engine API. */
+function assertContextEngineRegistrationAvailable(
+  api: OpenClawPluginApi,
+): asserts api is ContextEngineCapableOpenClawPluginApi {
+  if (typeof api.registerContextEngine === "function") {
+    return;
+  }
+
+  const message =
+    `[lcm] Unsupported OpenClaw plugin API: lossless-claw requires OpenClaw >=${MIN_CONTEXT_ENGINE_OPENCLAW_VERSION} ` +
+    `with api.registerContextEngine; detectedHost=${readOpenClawHostVersion(api)}; ` +
+    "upgrade OpenClaw or disable lossless-claw.";
+  logOpenClawCompatibilityError(api, message);
+  throw new Error(message);
 }
 
 /** Resolve plugin config from direct runtime injection or the root OpenClaw config fallback. */
@@ -1363,7 +1430,7 @@ function createLcmDependencies(
  * OpenClaw plugin API using shared init closures.
  */
 function wirePluginHandlers(
-  api: OpenClawPluginApi,
+  api: ContextEngineCapableOpenClawPluginApi,
   deps: LcmDependencies,
   shared: SharedLcmInit,
 ): void {
@@ -1440,6 +1507,7 @@ const lcmPlugin = {
   },
 
   register(api: OpenClawPluginApi) {
+    assertContextEngineRegistrationAvailable(api);
     const registrationConfig = resolveRegistrationConfig(api);
     const deps = createLcmDependencies(api, registrationConfig);
     const dbPath = deps.config.databasePath;

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -244,6 +244,23 @@ describe("lcm plugin registration", () => {
     ]);
   });
 
+  it("fails fast with a compatibility diagnostic when context-engine registration is unavailable", () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, errorLog } = buildApi({ enabled: true, dbPath });
+    (api.runtime as Record<string, unknown>).openclawVersion = "2026.5.1";
+    delete (api as unknown as { registerContextEngine?: unknown }).registerContextEngine;
+
+    expect(() => lcmPlugin.register(api)).toThrow(
+      /requires OpenClaw >=2026\.5\.22 with api\.registerContextEngine/,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(api.registerCommand).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("detectedHost=2026.5.1"));
+  });
+
   it("uses api.pluginConfig values during register", { timeout: 20000 }, () => {
     const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
     dbPaths.add(dbPath);


### PR DESCRIPTION
## Summary
- fail fast when the OpenClaw host API lacks `registerContextEngine`
- include detected host version details in the compatibility diagnostic
- reflect optional context-engine registration in the local bridge type
- add a regression proving no DB/tool/command setup runs before the compatibility failure

Closes part of #693.

## Validation
- `npm test -- test/plugin-config-registration.test.ts -t "context-engine registration is unavailable"` (red before fix, green after)
- `npm test -- test/plugin-config-registration.test.ts`
- `npm test`
- `npm run build`
- `git diff --check`
- `npm pack --dry-run`
