### PR TITLE
docs: add vulnerability disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Lossless Context Management plugin for [OpenClaw](https://github.com/openclaw/op
 - [Commands And Skill](#commands-and-skill)
 - [Documentation](#documentation)
 - [Development](#development)
+- [Security](#security)
 - [License](#license)
 
 ## What it does
@@ -496,6 +497,11 @@ tui/                        # Interactive terminal UI (Go)
   prompts/                  # Depth-aware prompt templates
 .goreleaser.yml             # GoReleaser config for TUI binary releases
 ```
+
+## Security
+
+Please report suspected vulnerabilities privately. See [SECURITY.md](SECURITY.md)
+for the supported disclosure process and response expectations.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are handled on the `main` branch and the latest published
+`@martian-engineering/lossless-claw` release line.
+
+Older release lines are not guaranteed to receive security fixes unless a
+maintainer explicitly announces support for that line in a release note or
+advisory.
+
+## Reporting A Vulnerability
+
+Please do not report suspected vulnerabilities in public GitHub issues,
+discussions, pull requests, or social channels.
+
+Use GitHub's private vulnerability reporting flow for this repository:
+
+1. Open the repository's **Security** tab.
+2. Select **Report a vulnerability**.
+3. Include affected versions, reproduction steps, impact, and any proof of
+   concept details that are safe to share privately.
+
+If the private reporting flow is unavailable, contact a repository maintainer
+through an existing trusted private channel and include only a high-level,
+non-sensitive request for security coordination in any public follow-up.
+
+## Response Expectations
+
+Maintainers aim to acknowledge new reports within 5 business days. After
+triage, maintainers will coordinate validation, remediation, release timing,
+and public disclosure through the private advisory thread when possible.
+
+## Safe Harbor
+
+Good-faith security research is welcome when it avoids privacy violations,
+service disruption, data destruction, and access to data that does not belong
+to you. Reports should include only the minimum sensitive detail needed to
+validate the issue.


### PR DESCRIPTION
## Summary
- add root `SECURITY.md` with supported versions, private reporting guidance, response expectations, and safe harbor language
- link the disclosure policy from the README

Part of #191.

## Validation
- `git diff --check`
- Verified current GitHub private vulnerability reporting state remains `enabled: false`; attempted API enablement returned HTTP 404 for this token/session, so a repository admin or security manager still needs to enable the setting.
