### PR TITLE
fix: preserve continuity for delivery-only transcript rotation

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1212,6 +1212,8 @@ const PROMPT_RECALL_MAX_MESSAGES = 4;
 const PROMPT_RECALL_MAX_MESSAGE_CHARS = 1200;
 const PROMPT_RECALL_SEARCH_LIMIT = PROMPT_RECALL_MAX_MESSAGES * 2;
 const PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT = PROMPT_RECALL_SEARCH_LIMIT * 4;
+const DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES = 4;
+const INJECTED_DELIVERY_TRANSCRIPT_PATTERN = /\b(?:delivery[-_\s]?mirror|config[-_\s]?audit)\b/i;
 const PROMPT_RECALL_SENSITIVE_IDENTIFIER_PATTERN =
   /(?:^|[^A-Za-z0-9])(?:ACCESS_?KEY|API_?KEY|AUTH|CREDENTIALS?|DEPLOY_?KEY|KEY|PASS(?:WORD)?|PRIVATE_?KEY|SECRET|TOKEN)(?=$|[^A-Za-z0-9])/i;
 const PROMPT_RECALL_SENSITIVE_VALUE_PATTERN =
@@ -1249,6 +1251,19 @@ function toStoredMessage(message: AgentMessage): StoredMessage {
     content,
     tokenCount,
   };
+}
+
+function isLikelyInjectedDeliveryMessage(message: AgentMessage): boolean {
+  const stored = toStoredMessage(message);
+  return stored.role === "system" && INJECTED_DELIVERY_TRANSCRIPT_PATTERN.test(stored.content);
+}
+
+function isLikelyInjectedDeliveryOnlyTranscript(messages: AgentMessage[]): boolean {
+  return (
+    messages.length > 0 &&
+    messages.length <= DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES &&
+    messages.every(isLikelyInjectedDeliveryMessage)
+  );
 }
 
 function escapeRegexLiteral(value: string): string {
@@ -5431,6 +5446,19 @@ export class LcmContextEngine implements ContextEngine {
 
       if (anchorIndex < 0) {
         if (params.allowNoAnchorImport) {
+          if (
+            params.noAnchorImportReason === "path-mismatch" &&
+            isLikelyInjectedDeliveryOnlyTranscript(historicalMessages)
+          ) {
+            this.deps.log.warn(
+              `[lcm] reconcileSessionTail: blocked delivery-only path-mismatched transcript for ${sessionContext}; preserving existing checkpoint because the rotated transcript contains only injected delivery/config traffic`,
+            );
+            this.deps.log.debug(
+              `[lcm] reconcileSessionTail: blocked delivery-only path mismatch for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} overlap=false`,
+            );
+            return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
+          }
+
           const replayAnalysis = await this.analyzePersistedTranscriptIdentityOverlaps({
             conversationId,
             messages: historicalMessages,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -10475,6 +10475,127 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
   });
 
+  it("bootstrap preserves a long-lived checkpoint when a rotated transcript is only delivery audit traffic", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "bootstrap-delivery-only-path-mismatch";
+    const sessionKey = "agent:main:signal:direct:delivery-only";
+
+    const oldSessionFile = createSessionFilePath("bootstrap-delivery-only-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "long-lived DM question" },
+      { role: "assistant", content: "long-lived DM answer" },
+    ]);
+    await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(oldSessionFile);
+
+    const newSessionFile = createSessionFilePath("bootstrap-delivery-only-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "system", content: "delivery-mirror config-audit: refreshed host policy" },
+      { role: "system", content: "config-audit delivery-mirror: no user turn" },
+    ]);
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result).toEqual({
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: "already bootstrapped",
+    });
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("delivery-only path-mismatched transcript")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "long-lived DM question",
+      "long-lived DM answer",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toEqual(oldCheckpoint);
+  });
+
+  it("bootstrap imports real path-mismatched user turns that mention config audit", async () => {
+    const engine = createEngine();
+    const sessionId = "bootstrap-real-config-audit-path-mismatch";
+    const sessionKey = "agent:main:test:direct:real-config-audit";
+
+    const oldSessionFile = createSessionFilePath("bootstrap-real-config-audit-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old config-audit setup question" },
+      { role: "assistant", content: "old config-audit setup answer" },
+    ]);
+    await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const newSessionFile = createSessionFilePath("bootstrap-real-config-audit-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "please run a config audit for this deployment" },
+      { role: "assistant", content: "config audit result: deployment policy is current" },
+    ]);
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old config-audit setup question",
+      "old config-audit setup answer",
+      "please run a config audit for this deployment",
+      "config audit result: deployment policy is current",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.sessionFilePath).toBe(newSessionFile);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
+  });
+
   it("afterTurn reconciles a path-mismatched no-anchor transcript before oversized delta dedup", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-transcript-epoch-no-anchor";
@@ -10558,6 +10679,99 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getConversationBootstrapState(conversation!.conversationId);
     expect(checkpoint?.sessionFilePath).toBe(newSessionFile);
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
+  });
+
+  it("afterTurn preserves continuity when a path-mismatched transcript is only delivery audit traffic", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-delivery-only-path-mismatch";
+    const sessionKey = "agent:main:signal:direct:after-turn-delivery-only";
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    });
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 0,
+      threshold: 3_072,
+    });
+
+    const oldSessionFile = createSessionFilePath("after-turn-delivery-only-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "long-lived afterTurn DM question" },
+      { role: "assistant", content: "long-lived afterTurn DM answer" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "long-lived afterTurn DM question" }),
+        makeMessage({ role: "assistant", content: "long-lived afterTurn DM answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(oldSessionFile);
+
+    const newSessionFile = createSessionFilePath("after-turn-delivery-only-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "system", content: "delivery-mirror config-audit: refreshed host policy" },
+      { role: "system", content: "config-audit delivery-mirror: no user turn" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "assistant delta without foreground user" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("delivery-only path-mismatched transcript")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "long-lived afterTurn DM question",
+      "long-lived afterTurn DM answer",
+    ]);
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toEqual(oldCheckpoint);
   });
 
   it("afterTurn archives a stale active conversation when the prior keyed transcript was pruned", async () => {


### PR DESCRIPTION
## Summary
- block `path-mismatch` + no-anchor epoch imports when the rotated transcript is tiny and contains only delivery/config-audit traffic
- preserve the previous long-lived checkpoint instead of anchoring the conversation to injected system delivery messages
- cover both bootstrap and afterTurn paths while keeping real user/assistant rotated transcripts importable

Fixes part of #769 and narrows one concrete #556 identity-integrity slice.

## Validation
- `npm test -- test/engine.test.ts -t "delivery audit traffic|afterTurn preserves continuity|bounded path-mismatched transcript|path-mismatched no-anchor transcript before oversized"` (red/green for the new bootstrap regression; green with afterTurn and existing real-rotation tests)
- `npm test -- test/engine.test.ts -t "path-mismatched|same-path shrink|tracked transcript|heartbeat flag skips|heartbeat-shaped"`
- `npm test -- test/engine.test.ts`
- `npm test`
- `git diff --check`
- `npm run build`
- `npm pack --dry-run`
