### PR TITLE
fix: avoid archived conversation reattachment

### DIFF
--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -341,7 +341,7 @@ export class ConversationStore {
           const existing = await this.getConversationBySessionKey(input.sessionKey);
           if (existing) return existing;
         }
-        const existing = await this.getConversationBySessionId(input.sessionId);
+        const existing = await this.getActiveConversationBySessionId(input.sessionId);
         if (existing) return existing;
       }
       throw err;
@@ -366,6 +366,23 @@ export class ConversationStore {
        FROM conversations
        WHERE session_id = ?
        ORDER BY active DESC, created_at DESC
+       LIMIT 1`,
+      )
+      .get(sessionId) as unknown as ConversationRow | undefined;
+
+    return row ? toConversationRecord(row) : null;
+  }
+
+  private async getActiveConversationBySessionId(
+    sessionId: string,
+  ): Promise<ConversationRecord | null> {
+    const row = this.db
+      .prepare(
+        `SELECT conversation_id, session_id, session_key, active, archived_at, title, bootstrapped_at, created_at, updated_at
+       FROM conversations
+       WHERE session_id = ?
+         AND active = 1
+       ORDER BY created_at DESC
        LIMIT 1`,
       )
       .get(sessionId) as unknown as ConversationRow | undefined;
@@ -446,7 +463,7 @@ export class ConversationStore {
       return null;
     }
 
-    return this.getConversationBySessionId(normalizedSessionId);
+    return this.getActiveConversationBySessionId(normalizedSessionId);
   }
 
   /** List active conversations that may own live session storage. */
@@ -489,7 +506,7 @@ export class ConversationStore {
       }
     }
 
-    const existing = await this.getConversationBySessionId(sessionId);
+    const existing = await this.getActiveConversationBySessionId(sessionId);
     if (existing) {
       if (!normalizedSessionKey) {
         return existing;

--- a/src/tools/lcm-expand-tool.delegation.ts
+++ b/src/tools/lcm-expand-tool.delegation.ts
@@ -262,6 +262,13 @@ export async function resolveRequesterConversationScopeId(params: {
     if (!runtimeSessionId) {
       return undefined;
     }
+    if (typeof store.getConversationForSession === "function") {
+      const conversation = await store.getConversationForSession({
+        sessionId: runtimeSessionId,
+        sessionKey: requesterSessionKey,
+      });
+      return conversation?.conversationId;
+    }
     const conversation = await store.getConversationBySessionId(runtimeSessionId);
     return conversation?.conversationId;
   } catch {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1003,6 +1003,28 @@ describe("ConversationStore session reuse", () => {
     const refreshed = await store.getConversation(conv1.conversationId);
     expect(refreshed?.sessionId).toBe("uuid-2");
   });
+
+  it("does not resolve archived conversations through active session lookup", async () => {
+    const engine = createEngine();
+    (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+    const store = engine.getConversationStore();
+    const sessionId = "archived-lookup-session";
+    const sessionKey = "agent:main:test:archived-lookup";
+
+    const archived = await store.getOrCreateConversation(sessionId, { sessionKey });
+    await store.archiveConversation(archived.conversationId);
+
+    expect(
+      await store.getConversationForSession({
+        sessionId,
+        sessionKey,
+      }),
+    ).toBeNull();
+
+    const replacement = await store.getOrCreateConversation(sessionId, { sessionKey });
+    expect(replacement.conversationId).not.toBe(archived.conversationId);
+    expect(replacement.active).toBe(true);
+  });
 });
 
 describe("LcmContextEngine before_reset lifecycle", () => {

--- a/test/lcm-expand-tool.delegation.test.ts
+++ b/test/lcm-expand-tool.delegation.test.ts
@@ -5,7 +5,10 @@ import {
   resetExpansionDelegationGuardForTests,
   stampDelegatedExpansionContext,
 } from "../src/tools/lcm-expansion-recursion-guard.js";
-import { runDelegatedExpansionLoop } from "../src/tools/lcm-expand-tool.delegation.js";
+import {
+  resolveRequesterConversationScopeId,
+  runDelegatedExpansionLoop,
+} from "../src/tools/lcm-expand-tool.delegation.js";
 import type { LcmDependencies } from "../src/types.js";
 
 const callGatewayMock = vi.fn();
@@ -87,6 +90,34 @@ describe("runDelegatedExpansionLoop recursion guard", () => {
     callGatewayMock.mockReset();
     resetDelegatedExpansionGrantsForTests();
     resetExpansionDelegationGuardForTests();
+  });
+
+  it("does not resolve requester scope from archived runtime-session rows", async () => {
+    const getConversationForSession = vi.fn(async () => null);
+    const getConversationBySessionId = vi.fn(async () => ({ conversationId: 42 }));
+
+    const result = await resolveRequesterConversationScopeId({
+      deps: {
+        resolveSessionIdFromSessionKey: vi.fn(async () => "archived-runtime-session"),
+      },
+      requesterSessionKey: "agent:main:main",
+      lcm: {
+        getConversationStore: () => ({
+          getConversationForSession,
+          getConversationBySessionId,
+        }),
+      } as never,
+    });
+
+    expect(result).toBeUndefined();
+    expect(getConversationForSession).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+    });
+    expect(getConversationForSession).toHaveBeenCalledWith({
+      sessionId: "archived-runtime-session",
+      sessionKey: "agent:main:main",
+    });
+    expect(getConversationBySessionId).not.toHaveBeenCalled();
   });
 
   it("runs delegated expansion when not in delegated context", async () => {


### PR DESCRIPTION
## Summary
- make active session resolution ignore archived conversations when falling back by runtime `sessionId`
- keep `getConversationBySessionId()` available for audit/history lookups while using an active-only path for live session resolution and get-or-create flows
- route delegated expansion requester fallback through active session resolution after runtime-session-id lookup
- add regressions for archived-row active lookup and delegated expansion requester scope

Fixes part of #556. This does not close the full identity-integrity umbrella.

## Validation
- `npm test -- test/engine.test.ts -t "archived conversations"` (red before fix, green after)
- `npm test -- test/lcm-expand-tool.delegation.test.ts -t "archived runtime-session"` (red before fix, green after)
- `npm test -- test/engine.test.ts -t "ConversationStore session reuse|before_reset lifecycle|session_end lifecycle"`
- `npm test -- test/engine.test.ts`
- `npm test` (49 files / 1019 tests)
- `npm run build`
- `git diff --check`
- `npm pack --dry-run`

Local validation ran from `/Volumes/LEXAR/repos/lossless-claw-pr556-identity-invariants`.