### PR TITLE
fix(db): allow SQLite extension-capable LCM connections

### DIFF
--- a/.changeset/sqlite-extension-loading.md
+++ b/.changeset/sqlite-extension-loading.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Allow LCM SQLite handles to explicitly enable extension loading for sqlite-vec on node:sqlite hosts.

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -60,7 +60,20 @@ function configureConnection(db: DatabaseSync): DatabaseSync {
   db.exec("PRAGMA synchronous = NORMAL");
   // Keep temp tables/indexes in RAM (helps ordinal resequencing).
   db.exec("PRAGMA temp_store = MEMORY");
+  // Keep extension loading disabled by default, while still allowing explicit
+  // enablement later on handles created with allowExtension: true.
+  if (typeof db.enableLoadExtension === "function") {
+    db.enableLoadExtension(false);
+  }
   return db;
+}
+
+function createDatabaseSync(dbPath: string): DatabaseSync {
+  const supportsExtensionLoading =
+    typeof DatabaseSync.prototype.enableLoadExtension === "function";
+  return supportsExtensionLoading
+    ? new DatabaseSync(dbPath, { allowExtension: true })
+    : new DatabaseSync(dbPath);
 }
 
 function trackConnection(dbPath: string, db: DatabaseSync): void {
@@ -112,7 +125,7 @@ function closeDatabase(db: DatabaseSync | undefined): void {
  */
 export function createLcmDatabaseConnection(dbPath: string): DatabaseSync {
   ensureDbDirectory(dbPath);
-  const db = new DatabaseSync(dbPath);
+  const db = createDatabaseSync(dbPath);
   try {
     configureConnection(db);
   } catch (err) {

--- a/test/db-connection.test.ts
+++ b/test/db-connection.test.ts
@@ -1,11 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  closeLcmConnection,
+  createLcmDatabaseConnection,
   getFileBackedDatabasePath,
   isInMemoryPath,
   normalizePath,
 } from "../src/db/connection.js";
 
 describe("db connection path helpers", () => {
+  afterEach(() => {
+    closeLcmConnection();
+  });
+
   it("treats non-string runtime values as non-memory paths", () => {
     expect(isInMemoryPath(123 as unknown as string)).toBe(false);
     expect(isInMemoryPath({} as unknown as string)).toBe(false);
@@ -24,5 +33,13 @@ describe("db connection path helpers", () => {
   it("preserves file-backed paths for valid strings", () => {
     expect(getFileBackedDatabasePath(" ./tmp/lcm.db ")).toMatch(/tmp\/lcm\.db$/);
     expect(normalizePath(" ./tmp/lcm.db ")).toMatch(/tmp\/lcm\.db$/);
+  });
+
+  it("creates connections that can explicitly enable SQLite extensions", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-db-"));
+    const db = createLcmDatabaseConnection(join(tempDir, "extensions.db"));
+
+    expect(() => db.enableLoadExtension(true)).not.toThrow();
+    db.enableLoadExtension(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #402.

This makes LCM-owned `DatabaseSync` handles extension-capable at construction time by passing `{ allowExtension: true }`, which is required by node:sqlite before callers can explicitly enable/load SQLite extensions such as sqlite-vec.

The connection configuration immediately disables extension loading at rest with `enableLoadExtension(false)`, so the handle has the capability but does not leave extension loading open by default.

## Validation

- `npm test -- test/db-connection.test.ts`
- `npm run build`
- `npm test` (49 files / 1020 tests)
- `git diff --check`
- `npm pack --dry-run`

## Notes

This PR does not add sqlite-vec loading itself; it removes the node:sqlite construction-time blocker so explicit extension loading can work safely where the host/runtime needs it.