### PR TITLE
fix(assembler): strip foreign thinking signatures

### DIFF
--- a/.changeset/strip-foreign-thinking-signature.md
+++ b/.changeset/strip-foreign-thinking-signature.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Strip stale foreign thinking signatures from DB-sourced thinking blocks during assembly.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -500,7 +500,17 @@ export function blockFromPart(part: MessagePartRecord): unknown {
     // arguments (stringify if object) and format for the target provider.
     // Returning raw here causes arguments to be passed as a JS object instead
     // of a JSON string, which breaks xAI/OpenAI Chat Completions API (422).
-    const rawType = (metadata.raw as Record<string, unknown>).type as string | undefined;
+    const rawRecord = metadata.raw as Record<string, unknown>;
+    const rawType =
+      typeof rawRecord.type === "string" ? rawRecord.type : metadata.rawType;
+    if (
+      rawType === "thinking" &&
+      typeof rawRecord.thinkingSignature === "string"
+    ) {
+      const { thinkingSignature: _thinkingSignature, ...cleaned } = rawRecord;
+      return cleaned;
+    }
+
     const isToolBlock =
       rawType === "toolCall" ||
       rawType === "tool_use" ||
@@ -520,7 +530,6 @@ export function blockFromPart(part: MessagePartRecord): unknown {
     // from the DB columns.  For rows stored as part_type='text' those columns are
     // often NULL — the values only live inside metadata.raw.  Backfill them here
     // so the reconstructed block keeps the original id/name.
-    const rawRecord = metadata.raw as Record<string, unknown>;
     const rawToolCallId =
       typeof rawRecord.id === "string" && rawRecord.id.length > 0
         ? rawRecord.id

--- a/test/assembler-blocks.test.ts
+++ b/test/assembler-blocks.test.ts
@@ -392,6 +392,47 @@ describe("blockFromPart", () => {
     expect(block.id).toBe("rs_abc123");
   });
 
+  it("strips foreign thinkingSignature from DB-sourced thinking blocks", () => {
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "provider-specific thinking text",
+      metadata: JSON.stringify({
+        raw: {
+          type: "thinking",
+          thinking: "provider-specific thinking text",
+          thinkingSignature: "dashscope-signature-for-a-different-provider",
+        },
+      }),
+    });
+    const block = blockFromPart(part) as Record<string, unknown>;
+
+    expect(block).toEqual({
+      type: "thinking",
+      thinking: "provider-specific thinking text",
+    });
+    expect(block).not.toHaveProperty("thinkingSignature");
+  });
+
+  it("strips foreign thinkingSignature when only rawType identifies the thinking block", () => {
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "legacy thinking text",
+      metadata: JSON.stringify({
+        rawType: "thinking",
+        raw: {
+          thinking: "legacy thinking text",
+          thinkingSignature: "legacy-provider-signature",
+        },
+      }),
+    });
+    const block = blockFromPart(part) as Record<string, unknown>;
+
+    expect(block).toEqual({
+      thinking: "legacy thinking text",
+    });
+    expect(block).not.toHaveProperty("thinkingSignature");
+  });
+
   it("routes tool result parts correctly", () => {
     const part = makePart({
       partType: "tool",


### PR DESCRIPTION
## Summary

Fixes #365.

This keeps OpenAI reasoning restoration intact, but strips stale foreign `thinkingSignature` metadata from DB-sourced `type: "thinking"` blocks before assembly returns the raw block. That prevents provider-specific signatures from being replayed after a provider/model switch.

## Validation

- `npm test -- test/assembler-blocks.test.ts`
- `npm run build`
- `npm test` (49 files / 1020 tests)
- `git diff --check`
- `npm pack --dry-run`

## Notes

This is intentionally narrow: it only removes `thinkingSignature` after the existing OpenAI JSON reasoning-signature restoration path has had a chance to convert valid OpenAI reasoning metadata back to `{ type: "reasoning", id: ... }`.