### PR TITLE
fix: degrade LCM assembly when maintenance is hot

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -58,6 +58,7 @@ import {
 } from "./store/compaction-telemetry-store.js";
 import {
   CompactionMaintenanceStore,
+  type ConversationCompactionMaintenanceRecord,
 } from "./store/compaction-maintenance-store.js";
 import {
   ConversationStore,
@@ -108,6 +109,7 @@ type BootstrapImportObservation = {
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
+const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
   failures: number;
   openSince: number | null;
@@ -3049,6 +3051,68 @@ function trimMessagesToBudget(messages: AgentMessage[], tokenBudget: number): Ag
   return stripTrailingAssistantPrefill(
     trimBootstrapMessagesToBudget(messages, Math.max(0, Math.floor(tokenBudget))),
   );
+}
+
+function isProtectedLeadingLiveContextMessage(message: AgentMessage): boolean {
+  const role = typeof message.role === "string" ? message.role.toLowerCase() : "";
+  return role === "system" || role === "developer";
+}
+
+function buildDegradedLiveAssembleResult(params: {
+  liveMessages: AgentMessage[];
+  tokenBudget: number;
+}): AssembleResult {
+  const withoutAssistantPrefill = stripTrailingAssistantPrefill(params.liveMessages.slice());
+  const protectedPrefix: AgentMessage[] = [];
+  while (
+    protectedPrefix.length < withoutAssistantPrefill.length &&
+    isProtectedLeadingLiveContextMessage(withoutAssistantPrefill[protectedPrefix.length]!)
+  ) {
+    protectedPrefix.push(withoutAssistantPrefill[protectedPrefix.length]!);
+  }
+  const liveTail = withoutAssistantPrefill.slice(protectedPrefix.length);
+  const remainingBudget = Math.max(
+    0,
+    Math.floor(params.tokenBudget) - estimateAgentMessageTokens(protectedPrefix),
+  );
+  let liveTailMessages = trimMessagesToBudget(liveTail, remainingBudget);
+  if (liveTailMessages.length === 0 && liveTail.length > 0) {
+    liveTailMessages = [liveTail[liveTail.length - 1]!];
+  }
+  const messages = [...protectedPrefix, ...liveTailMessages];
+  return {
+    messages,
+    estimatedTokens: estimateAgentMessageTokens(messages),
+  };
+}
+
+function resolveDeferredAssemblyPressure(params: {
+  liveContextTokens: number;
+  maintenance: ConversationCompactionMaintenanceRecord | null;
+}): {
+  observedContextTokens: number;
+  projectedTokenCount: number | null;
+  pressureTokenCount: number;
+} {
+  const recordedContextTokens = normalizeNonNegativeInteger(
+    params.maintenance?.currentTokenCount,
+  );
+  const recordedProjectedTokens = normalizeNonNegativeInteger(
+    params.maintenance?.projectedTokenCount,
+  );
+  const observedContextTokens = Math.max(
+    params.liveContextTokens,
+    recordedContextTokens ?? 0,
+  );
+  const pressureTokenCount = Math.max(
+    observedContextTokens,
+    recordedProjectedTokens ?? 0,
+  );
+  return {
+    observedContextTokens,
+    projectedTokenCount: recordedProjectedTokens ?? null,
+    pressureTokenCount,
+  };
 }
 
 function buildForkBoundedLiveFallback(params: {
@@ -8174,24 +8238,23 @@ export class LcmContextEngine implements ContextEngine {
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
+      let deferredAssemblyDegradation:
+        | {
+            reason: "near-budget" | "emergency-debt-still-pending";
+            pressure: ReturnType<typeof resolveDeferredAssemblyPressure>;
+          }
+        | null = null;
       if (maintenance?.pending || maintenance?.running) {
-        const recordedContextTokens = this.normalizeObservedTokenCount(
-          maintenance.currentTokenCount ?? undefined,
+        const pressureThreshold = Math.floor(
+          tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO,
         );
-        const recordedProjectedTokens = this.normalizeObservedTokenCount(
-          maintenance.projectedTokenCount ?? undefined,
-        );
-        const observedEmergencyContextTokens = Math.max(
+        let pressure = resolveDeferredAssemblyPressure({
           liveContextTokens,
-          recordedContextTokens ?? 0,
-        );
-        const emergencyContextTokens = Math.max(
-          observedEmergencyContextTokens,
-          recordedProjectedTokens ?? 0,
-        );
-        if (emergencyContextTokens > tokenBudget) {
+          maintenance,
+        });
+        if (pressure.pressureTokenCount > tokenBudget) {
           this.deps.log.warn(
-            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${observedEmergencyContextTokens} projectedTokenCount=${recordedProjectedTokens ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
+            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
           );
           try {
             await this.maybeConsumeDeferredCompactionDebtForAssemble({
@@ -8199,18 +8262,49 @@ export class LcmContextEngine implements ContextEngine {
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               tokenBudget,
-              currentTokenCount: observedEmergencyContextTokens,
+              currentTokenCount: pressure.observedContextTokens,
             });
           } catch (error) {
             this.deps.log.warn(
               `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
             );
           }
+          const latestMaintenance =
+            await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+              conversation.conversationId,
+            );
+          if (latestMaintenance?.pending || latestMaintenance?.running) {
+            pressure = resolveDeferredAssemblyPressure({
+              liveContextTokens,
+              maintenance: latestMaintenance,
+            });
+            if (pressure.pressureTokenCount > pressureThreshold) {
+              deferredAssemblyDegradation = {
+                reason: "emergency-debt-still-pending",
+                pressure,
+              };
+            }
+          }
+        } else if (pressure.pressureTokenCount > pressureThreshold) {
+          deferredAssemblyDegradation = {
+            reason: "near-budget",
+            pressure,
+          };
         } else {
           this.deps.log.debug(
-            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${observedEmergencyContextTokens} projectedTokenCount=${recordedProjectedTokens ?? "null"} tokenBudget=${tokenBudget} reason=not-over-budget`,
+            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=not-over-budget`,
           );
         }
+      }
+      if (deferredAssemblyDegradation) {
+        const degraded = buildDegradedLiveAssembleResult({
+          liveMessages: params.messages,
+          tokenBudget,
+        });
+        this.deps.log.warn(
+          `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} currentTokenCount=${deferredAssemblyDegradation.pressure.observedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
+        );
+        return degraded;
       }
 
       const bootstrapState = await this.summaryStore.getConversationBootstrapState(

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -652,6 +652,61 @@ function buildDoctorApplySafetyPreflight(params: {
   };
 }
 
+function buildLcmHealthSummary(params: {
+  config: LcmConfig;
+  stats: LcmConversationStatusStats;
+  maintenance: ConversationCompactionMaintenanceRecord | null;
+}): { state: "healthy" | "warning" | "degraded"; reasons: string[] } {
+  const tokenBudget = resolveLifecycleCompactionTokenBudget(params.config);
+  const warningThreshold = Math.floor(tokenBudget * DOCTOR_APPLY_BUDGET_PRESSURE_RATIO);
+  const activeMaintenance = params.maintenance?.pending || params.maintenance?.running;
+  const assemblyObservedTokens = Math.max(
+    params.stats.contextTokenCount,
+    activeMaintenance ? params.maintenance?.currentTokenCount ?? 0 : 0,
+    activeMaintenance ? params.maintenance?.projectedTokenCount ?? 0 : 0,
+  );
+  const repairSurfaceTokens = Math.max(
+    params.stats.summarizedSourceTokens,
+    params.stats.compressedTokenCount,
+  );
+  const degradedReasons: string[] = [];
+  const warningReasons: string[] = [];
+
+  if (params.maintenance?.running) {
+    degradedReasons.push("compaction maintenance is running");
+  }
+  if (params.maintenance?.pending) {
+    degradedReasons.push(
+      `compaction maintenance is pending (${params.maintenance.reason ?? "reason unknown"})`,
+    );
+  }
+  if (assemblyObservedTokens > tokenBudget) {
+    degradedReasons.push(
+      `observed token count ${formatNumber(assemblyObservedTokens)} exceeds assembly budget ${formatNumber(tokenBudget)}`,
+    );
+  } else if (assemblyObservedTokens > warningThreshold) {
+    warningReasons.push(
+      `observed token count ${formatNumber(assemblyObservedTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of assembly budget ${formatNumber(tokenBudget)}`,
+    );
+  }
+  if (repairSurfaceTokens > warningThreshold) {
+    warningReasons.push(
+      `repair source token count ${formatNumber(repairSurfaceTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of assembly budget ${formatNumber(tokenBudget)}`,
+    );
+  }
+  if (params.maintenance?.lastFailureSummary) {
+    warningReasons.push(`last maintenance failure: ${params.maintenance.lastFailureSummary}`);
+  }
+
+  if (degradedReasons.length > 0) {
+    return { state: "degraded", reasons: [...degradedReasons, ...warningReasons] };
+  }
+  if (warningReasons.length > 0) {
+    return { state: "warning", reasons: warningReasons };
+  }
+  return { state: "healthy", reasons: [] };
+}
+
 // Run the cache-aware focus lifecycle sweep. Focus and unfocus both mutate the
 // prompt prefix, so they explicitly take the manual full-sweep path and bypass
 // threshold skips instead of leaving compaction to normal background policy.
@@ -896,6 +951,11 @@ async function buildStatusText(params: {
       params.db,
       current.stats.conversationId,
     );
+    const lcmHealth = buildLcmHealthSummary({
+      config: params.config,
+      stats: current.stats,
+      maintenance,
+    });
     const focusLines = await buildFocusSummaryLines({
       store: new FocusBriefStore(params.db),
       conversationId: current.stats.conversationId,
@@ -922,6 +982,9 @@ async function buildStatusText(params: {
           "compression ratio",
           formatCompressionRatio(current.stats.contextTokenCount, current.stats.compressedTokenCount),
         ),
+        buildStatLine("lcm health", lcmHealth.state),
+        buildStatLine("transport health", "not assessed by Lossless Claw"),
+        ...lcmHealth.reasons.map((reason) => buildStatLine("lcm reason", reason)),
         buildStatLine(
           "doctor",
           conversationDoctor.total > 0

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12166,6 +12166,176 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
+  it("assemble() uses bounded live context when pending maintenance is near budget", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-threshold-debt-near-budget-degrades";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context should be skipped while maintenance is pending",
+        tokenCount: 20,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 90,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(privateEngine, "executeCompactionCore");
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current delivery turn" })],
+      tokenBudget: 100,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(assembleResult.messages.map((message) => message.content)).toEqual([
+      "current delivery turn",
+    ]);
+    expect(assembleResult.estimatedTokens).toBeLessThanOrEqual(100);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
+  });
+
+  it("assemble() preserves leading system context when degraded live context is bounded", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const sessionId = "assemble-degraded-preserves-system";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 30,
+      currentTokenCount: 29,
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [
+        makeMessage({ role: "system", content: "critical runtime policy" }),
+        makeMessage({ role: "user", content: "current delivery turn" }),
+      ],
+      tokenBudget: 10,
+    });
+
+    expect(assembleResult.messages.map((message) => message.content)).toEqual([
+      "critical runtime policy",
+      "current delivery turn",
+    ]);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+  });
+
+  it("assemble() degrades to bounded live context if emergency compaction leaves debt pending", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-threshold-debt-emergency-failed-degrades";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context should not be used after failed emergency compaction",
+        tokenCount: 20,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 150,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: false,
+      compacted: false,
+      reason: "provider timeout",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current emergency turn" })],
+      tokenBudget: 100,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: conversation.conversationId,
+        sessionId,
+        tokenBudget: 100,
+        compactionTarget: "threshold",
+      }),
+    );
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.lastFailureSummary).toBe("provider timeout");
+    expect(assembleResult.messages.map((message) => message.content)).toEqual([
+      "current emergency turn",
+    ]);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[lcm] assemble: emergency deferred compaction debt draining pre-assembly",
+      ),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("reason=emergency-debt-still-pending"),
+    );
+  });
+
   it("assemble() drains pending threshold debt as an emergency when already over budget", async () => {
     const log = {
       info: vi.fn(),

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -227,6 +227,8 @@ describe("lcm command", () => {
     expect(result.text).toContain("summarized source tokens: 21");
     expect(result.text).toContain("tokens in context: 5");
     expect(result.text).toContain("compression ratio: 1:6");
+    expect(result.text).toContain("lcm health: healthy");
+    expect(result.text).toContain("transport health: not assessed by Lossless Claw");
     expect(result.text).toContain("doctor: 1 issue(s) in this conversation");
   });
 
@@ -886,11 +888,179 @@ describe("lcm command", () => {
     );
 
     expect(result.text).toContain("**🛠️ Maintenance**");
+    expect(result.text).toContain("lcm health: degraded");
+    expect(result.text).toContain("transport health: not assessed by Lossless Claw");
+    expect(result.text).toContain("lcm reason: compaction maintenance is pending (budget-trigger)");
+    expect(result.text).toContain("lcm reason: last maintenance failure: provider timeout");
     expect(result.text).toContain("state: pending");
     expect(result.text).toContain("reason: budget-trigger");
     expect(result.text).toContain("last failure: provider timeout");
     expect(result.text).toContain("requested token budget: 128,000");
     expect(result.text).toContain("observed token count: 96,000");
+  });
+
+  it("reports LCM token pressure separately from transport health in status output", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    fixture.config.maxAssemblyTokenBudget = 100;
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "status-token-pressure-session",
+      sessionKey: "agent:main:telegram:pressure:1",
+      title: "Token pressure fixture",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "large active context",
+        tokenCount: 130,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "status_pressure_leaf",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "pressure summary",
+      tokenCount: 130,
+      sourceMessageTokenCount: 130,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("status_pressure_leaf", [message.messageId]);
+    await fixture.summaryStore.replaceContextRangeWithSummary({
+      conversationId: conversation.conversationId,
+      startOrdinal: 0,
+      endOrdinal: 0,
+      summaryId: "status_pressure_leaf",
+    });
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        sessionKey: "agent:main:telegram:pressure:1",
+        sessionId: "status-token-pressure-session",
+      }),
+    );
+
+    expect(result.text).toContain("lcm health: degraded");
+    expect(result.text).toContain("transport health: not assessed by Lossless Claw");
+    expect(result.text).toContain(
+      "lcm reason: observed token count 130 exceeds assembly budget 100",
+    );
+  });
+
+  it("warns when repair-source pressure would block doctor apply even if active context is small", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    fixture.config.maxAssemblyTokenBudget = 128_000;
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "status-repair-pressure-session",
+      sessionKey: "agent:main:telegram:repair-pressure:1",
+      title: "Repair pressure fixture",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "oversized raw repair source",
+        tokenCount: 120_000,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "status_repair_pressure_leaf",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "small active summary",
+      tokenCount: 8,
+      sourceMessageTokenCount: 120_000,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("status_repair_pressure_leaf", [message.messageId]);
+    await fixture.summaryStore.replaceContextRangeWithSummary({
+      conversationId: conversation.conversationId,
+      startOrdinal: 0,
+      endOrdinal: 0,
+      summaryId: "status_repair_pressure_leaf",
+    });
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        sessionKey: "agent:main:telegram:repair-pressure:1",
+        sessionId: "status-repair-pressure-session",
+      }),
+    );
+
+    expect(result.text).toContain("tokens in context: 8");
+    expect(result.text).toContain("lcm health: warning");
+    expect(result.text).toContain(
+      "lcm reason: repair source token count 120,000 exceeds 75% of assembly budget 128,000",
+    );
+  });
+
+  it("does not treat stale idle maintenance token counts as degraded status", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    fixture.config.maxAssemblyTokenBudget = 100;
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "status-idle-stale-maintenance-session",
+      sessionKey: "agent:main:telegram:idle-maintenance:1",
+      title: "Idle maintenance fixture",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "small active context",
+        tokenCount: 8,
+      },
+    ]);
+    await fixture.summaryStore.appendContextMessages(conversation.conversationId, [message.messageId]);
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           last_started_at,
+           last_finished_at,
+           token_budget,
+           current_token_count,
+           projected_token_count,
+           updated_at
+         ) VALUES (?, 0, ?, ?, 0, ?, ?, ?, ?, ?, datetime('now'))`,
+      )
+      .run(
+        conversation.conversationId,
+        "2026-04-12T00:00:00.000Z",
+        "threshold",
+        "2026-04-12T00:05:00.000Z",
+        "2026-04-12T00:07:00.000Z",
+        100,
+        150,
+        150,
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        sessionKey: "agent:main:telegram:idle-maintenance:1",
+        sessionId: "status-idle-stale-maintenance-session",
+      }),
+    );
+
+    expect(result.text).toContain("tokens in context: 8");
+    expect(result.text).toContain("state: idle");
+    expect(result.text).toContain("observed token count: 150");
+    expect(result.text).toContain("lcm health: healthy");
+    expect(result.text).not.toContain("lcm reason: observed token count 150");
   });
 
   it("falls back to the active session id when the current session key is not stored yet", async () => {


### PR DESCRIPTION
## Summary
- Add a high-pressure maintenance guard in assemble() so active delivery falls back to bounded live context instead of replaying stored LCM history when deferred compaction debt is pending/running near the assembly budget.
- Keep the emergency over-budget drain path first, but degrade if emergency maintenance remains pending or fails.
- Extend /lossless status with LCM health vs transport-health diagnostics, including the same 75% repair-source pressure warning used by doctor apply.

Refs #491.

## Validation
- `npx vitest run test/lcm-command.test.ts -t "repair-source pressure|token pressure|deferred compaction maintenance state"`
- `npx vitest run test/engine.test.ts -t "pending maintenance is near budget|emergency compaction leaves debt pending"`
- `npx vitest run test/lcm-command.test.ts`
- `npx vitest run test/engine.test.ts -t "deferred threshold debt|pending maintenance is near budget|emergency compaction leaves debt pending|assemble\(\) drains pending threshold debt|assemble\(\) does not wait|assemble\(\) waits"`
- `npx vitest run test/engine.test.ts`
- `npm test` (49 files, 1029 tests)
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`

## Notes
- This covers the remaining degraded delivery/status lane after #777. Issue #491 should remain open until reporter/maintainer confirmation on the original channel-unresponsive symptom.
- Full required checks are expected to run in GitHub Actions on this PR.