### PR TITLE
fix: filter leaked OpenClaw runtime context

### DIFF
--- a/.changeset/filter-runtime-context-leaks.md
+++ b/.changeset/filter-runtime-context-leaks.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip leaked OpenClaw runtime context assistant messages before LCM persistence.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1221,6 +1221,8 @@ const PROMPT_RECALL_SEARCH_LIMIT = PROMPT_RECALL_MAX_MESSAGES * 2;
 const PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT = PROMPT_RECALL_SEARCH_LIMIT * 4;
 const DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES = 4;
 const INJECTED_DELIVERY_TRANSCRIPT_PATTERN = /\b(?:delivery[-_\s]?mirror|config[-_\s]?audit)\b/i;
+const OPENCLAW_RUNTIME_CONTEXT_SENTINEL =
+  "OpenClaw runtime context for the immediately preceding user message. This context is runtime-generated, not user-author.";
 const PROMPT_RECALL_SENSITIVE_IDENTIFIER_PATTERN =
   /(?:^|[^A-Za-z0-9])(?:ACCESS_?KEY|API_?KEY|AUTH|CREDENTIALS?|DEPLOY_?KEY|KEY|PASS(?:WORD)?|PRIVATE_?KEY|SECRET|TOKEN)(?=$|[^A-Za-z0-9])/i;
 const PROMPT_RECALL_SENSITIVE_VALUE_PATTERN =
@@ -1263,6 +1265,13 @@ function toStoredMessage(message: AgentMessage): StoredMessage {
 function isLikelyInjectedDeliveryMessage(message: AgentMessage): boolean {
   const stored = toStoredMessage(message);
   return stored.role === "system" && INJECTED_DELIVERY_TRANSCRIPT_PATTERN.test(stored.content);
+}
+
+function isOpenClawRuntimeContextLeak(stored: StoredMessage): boolean {
+  return (
+    stored.role === "assistant" &&
+    stored.content.trimStart().startsWith(OPENCLAW_RUNTIME_CONTEXT_SENTINEL)
+  );
 }
 
 function isLikelyInjectedDeliveryOnlyTranscript(messages: AgentMessage[]): boolean {
@@ -7541,6 +7550,9 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     let stored = toStoredMessage(message);
+    if (isOpenClawRuntimeContextLeak(stored)) {
+      return { ingested: false };
+    }
 
     // Get or create conversation for this session
     const conversation = await this.conversationStore.getOrCreateConversation(sessionId, {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -686,6 +686,202 @@ describe("LcmContextEngine ignored sessions", () => {
   });
 });
 
+describe("LcmContextEngine OpenClaw runtime context leak filter", () => {
+  const leakedRuntimeContext =
+    "OpenClaw runtime context for the immediately preceding user message. This context is runtime-generated, not user-author. Keep internal details private.";
+
+  it("skips leaked assistant runtime context messages through direct ingest", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-direct";
+
+    const result = await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "assistant", content: leakedRuntimeContext }),
+    });
+
+    expect(result.ingested).toBe(false);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).toBeNull();
+  });
+
+  it("skips leaked assistant runtime context messages without creating a conversation", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-only";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [makeMessage({ role: "assistant", content: leakedRuntimeContext })],
+    });
+
+    expect(result.ingestedCount).toBe(0);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).toBeNull();
+  });
+
+  it("keeps real assistant replies after skipping leaked runtime context", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-with-reply";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "assistant", content: leakedRuntimeContext }),
+        makeMessage({ role: "assistant", content: "Real assistant reply." }),
+      ],
+    });
+
+    expect(result.ingestedCount).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["Real assistant reply."]);
+  });
+
+  it("skips leaked runtime context content blocks during afterTurn", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-after-turn";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("runtime-context-leak-after-turn"),
+      messages: [
+        makeMessage({
+          role: "assistant",
+          content: [{ type: "text", text: leakedRuntimeContext }],
+        }),
+        makeMessage({ role: "assistant", content: "Visible answer." }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["Visible answer."]);
+  });
+
+  it("skips leaked runtime context imported from bootstrap transcripts", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-bootstrap";
+    const sessionFile = createSessionFilePath("runtime-context-leak-bootstrap");
+    writeLeafTranscriptMessages(sessionFile, [
+      makeMessage({ role: "assistant", content: leakedRuntimeContext }),
+      makeMessage({ role: "assistant", content: "Bootstrapped answer." }),
+    ]);
+
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+
+    expect(result.importedMessages).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual(["Bootstrapped answer."]);
+  });
+
+  it("skips leaked runtime context in append-only bootstrap transcript recovery", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-leak-append-only-bootstrap";
+    const sessionFile = createSessionFilePath("runtime-context-leak-append-only-bootstrap");
+    writeLeafTranscriptMessages(sessionFile, [
+      makeMessage({ role: "user", content: "Initial question." }),
+      makeMessage({ role: "assistant", content: "Initial answer." }),
+    ]);
+
+    await engine.bootstrap({ sessionId, sessionFile });
+    writeLeafTranscriptMessages(sessionFile, [
+      makeMessage({ role: "user", content: "Initial question." }),
+      makeMessage({ role: "assistant", content: "Initial answer." }),
+      makeMessage({ role: "assistant", content: leakedRuntimeContext }),
+      makeMessage({ role: "assistant", content: "Recovered answer." }),
+    ]);
+
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+
+    expect(result.importedMessages).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "Initial question.",
+      "Initial answer.",
+      "Recovered answer.",
+    ]);
+  });
+
+  it("keeps user-authored messages even when they quote the runtime context prefix", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-user-quote";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: leakedRuntimeContext })],
+    });
+
+    expect(result.ingestedCount).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([leakedRuntimeContext]);
+  });
+
+  it("keeps system and tool messages even when they contain the runtime context sentinel", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-non-assistant-roles";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "system", content: leakedRuntimeContext }),
+        makeMessage({ role: "tool", content: leakedRuntimeContext }),
+      ],
+    });
+
+    expect(result.ingestedCount).toBe(2);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.role)).toEqual(["system", "tool"]);
+    expect(stored.map((m) => m.content)).toEqual([leakedRuntimeContext, leakedRuntimeContext]);
+  });
+
+  it("keeps ordinary assistant messages that mention the runtime context phrase later", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-assistant-explanation";
+    const content =
+      "I found the leak: OpenClaw runtime context for the immediately preceding user message was persisted even though it is runtime-generated, not user-author.";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [makeMessage({ role: "assistant", content })],
+    });
+
+    expect(result.ingestedCount).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([content]);
+  });
+
+  it("keeps assistant messages that start with runtime context wording without the full sentinel", async () => {
+    const engine = createEngine();
+    const sessionId = "runtime-context-generic-assistant";
+    const content =
+      "OpenClaw runtime context for the immediately preceding user message can refer to host-provided fields; this answer is not the private per-turn context block.";
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [makeMessage({ role: "assistant", content })],
+    });
+
+    expect(result.ingestedCount).toBe(1);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([content]);
+  });
+});
+
 describe("LcmContextEngine stateless sessions", () => {
   const statelessSessionKey = "agent:main:subagent:worker-preview";
   const statefulSessionKey = "agent:main:main";


### PR DESCRIPTION
## Summary
- skip assistant messages that begin with the leaked OpenClaw runtime-context sentinel before creating an LCM conversation/message row
- keep user/system/tool messages and ordinary assistant explanations intact
- add regression coverage for direct ingest, batch ingest, afterTurn, first bootstrap, and append-only bootstrap recovery

Issue context: https://github.com/Martian-Engineering/lossless-claw/issues/528. This is defensive persistence hardening only; it does not close the stale-check issue without reporter confirmation and does not clean already-persisted contaminated rows.

## Validation
- `npm test -- --run test/engine.test.ts -t "OpenClaw runtime context leak filter"`
- `npm test -- --run test/engine.test.ts`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`

## Review notes
- Sidecar coverage review found production persistence routes funnel through `ingestSingle()` before `createMessage()`.
- Sidecar false-positive review recommended assistant-only scope and a tightened exact sentinel predicate; the final patch follows that recommendation.
