### PR TITLE
fix: bound summarization spend

### DIFF
--- a/.changeset/backoff-deferred-compaction.md
+++ b/.changeset/backoff-deferred-compaction.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add a per-session summarization spend guard and back off failed deferred compaction retries to avoid repeated non-auth model spend.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
           "summaryModel": "openai/gpt-5.4-mini",
           "expansionModel": "openai/gpt-5.4-mini",
           "delegationTimeoutMs": 300000,
-          "summaryTimeoutMs": 60000
+          "summaryTimeoutMs": 60000,
+          "summaryCallWindowMs": 600000,
+          "summaryMaxCallsPerWindow": 24,
+          "summarySpendBackoffMs": 1800000
         }
       }
     }
@@ -161,7 +164,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 }
 ```
 
-`leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
+`leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). `summaryMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs` bound repeated non-auth summarization spend per session. When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
 
 ### Environment variables
 
@@ -193,6 +196,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 | `LCM_EXPANSION_PROVIDER` | *(from OpenClaw)* | Provider override for `lcm_expand_query` sub-agent |
 | `LCM_DELEGATION_TIMEOUT_MS` | `120000` | Max time to wait for delegated `lcm_expand_query` sub-agent completion |
 | `LCM_SUMMARY_TIMEOUT_MS` | `60000` | Max time to wait for a single model-backed LCM summarizer call |
+| `LCM_SUMMARY_CALL_WINDOW_MS` | `600000` | Rolling window used by the per-session summarization spend guard |
+| `LCM_SUMMARY_MAX_CALLS_PER_WINDOW` | `24` | Max model-backed summarization calls per session/window before spend backoff opens |
+| `LCM_SUMMARY_SPEND_BACKOFF_MS` | `1800000` | Cooldown after the summarization spend guard opens |
 | `LCM_PRUNE_HEARTBEAT_OK` | `false` | Retroactively delete `HEARTBEAT_OK` turn cycles from LCM storage |
 | `LCM_TRANSCRIPT_GC_ENABLED` | `false` | Enable transcript rewrite GC during `maintain()` |
 | `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | `deferred` | Choose whether proactive threshold compaction is deferred into maintenance debt or kept inline for legacy behavior |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,9 @@ Most installations only need to override a handful of keys. If you want a comple
   "expansionModel": "",
   "delegationTimeoutMs": 120000,
   "summaryTimeoutMs": 60000,
+  "summaryCallWindowMs": 600000,
+  "summaryMaxCallsPerWindow": 24,
+  "summarySpendBackoffMs": 1800000,
   "timezone": "America/Los_Angeles",
   "pruneHeartbeatOk": false,
   "transcriptGcEnabled": false,
@@ -205,6 +208,9 @@ the raw copied transcript.
 | `expansionProvider` | `string` | `""` | `LCM_EXPANSION_PROVIDER` | `lcm_expand_query` sub-agent provider hint for bare model names. |
 | `delegationTimeoutMs` | `integer` | `120000` | `LCM_DELEGATION_TIMEOUT_MS` | Maximum time to wait for delegated expansion work. `lcm_expand_query` advertises a dynamic tool `timeoutMs` default with 30 seconds of extra RPC headroom so OpenClaw's tool watchdog does not fire before this wait completes. |
 | `summaryTimeoutMs` | `integer` | `60000` | `LCM_SUMMARY_TIMEOUT_MS` | Maximum time to wait for one model-backed summarizer call. |
+| `summaryCallWindowMs` | `integer` | `600000` | `LCM_SUMMARY_CALL_WINDOW_MS` | Rolling window for the per-session summarization spend guard. |
+| `summaryMaxCallsPerWindow` | `integer` | `24` | `LCM_SUMMARY_MAX_CALLS_PER_WINDOW` | Maximum model-backed summarization calls per session/window before Lossless opens a non-auth spend backoff. |
+| `summarySpendBackoffMs` | `integer` | `1800000` | `LCM_SUMMARY_SPEND_BACKOFF_MS` | Cooldown after the summarization spend guard opens. |
 | `customInstructions` | `string` | `""` | `LCM_CUSTOM_INSTRUCTIONS` | Extra natural-language instructions injected into every summarization prompt. |
 
 Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capability. If you configure an explicit Lossless summary model (`summaryModel`, `largeFileSummaryModel`, or `fallbackProviders`), OpenClaw must allow that runtime LLM override under `plugins.entries.lossless-claw.llm.allowModelOverride` and `plugins.entries.lossless-claw.llm.allowedModels`. `openclaw doctor --fix` can add the minimal policy entries for configured Lossless summary models. Delegated expansion calls use OpenClaw's runtime sub-agent layer; explicit `expansionModel` values require `plugins.entries.lossless-claw.subagent.allowModelOverride` and a matching `subagent.allowedModels` entry, or `"*"` if you intentionally trust any expansion target. `openclaw doctor --fix` can add the minimal subagent policy, and `lcm_expand_query` retries once without the override if the host rejects it.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -168,6 +168,18 @@
       "label": "Summary Timeout (ms)",
       "help": "Maximum time to wait for a single model-backed LCM summarizer call before timing out"
     },
+    "summaryCallWindowMs": {
+      "label": "Summary Call Window (ms)",
+      "help": "Rolling window used by the summarization spend guard"
+    },
+    "summaryMaxCallsPerWindow": {
+      "label": "Summary Max Calls Per Window",
+      "help": "Maximum model-backed summarization calls per session/window before Lossless opens a non-auth spend backoff"
+    },
+    "summarySpendBackoffMs": {
+      "label": "Summary Spend Backoff (ms)",
+      "help": "Cooldown after the summarization spend guard opens"
+    },
     "maxAssemblyTokenBudget": {
       "label": "Max Assembly Token Budget",
       "help": "Hard ceiling for assembly token budget — caps runtime-provided and fallback budgets. Set for smaller context-window models (e.g., 30000 for 32k models)"
@@ -407,6 +419,18 @@
         "minimum": 1
       },
       "summaryTimeoutMs": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "summaryCallWindowMs": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "summaryMaxCallsPerWindow": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "summarySpendBackoffMs": {
         "type": "integer",
         "minimum": 1
       },

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -623,6 +623,28 @@ Why it matters:
 - guards against runaway summaries that are much larger than their target budget
 - useful when summary models are verbose or unstable
 
+### `summaryMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs`
+
+Bounds model-backed compaction and large-file summarization calls per session.
+
+Defaults:
+
+- `summaryMaxCallsPerWindow`: `24`
+- `summaryCallWindowMs`: `600000`
+- `summarySpendBackoffMs`: `1800000`
+
+Env overrides:
+
+- `LCM_SUMMARY_MAX_CALLS_PER_WINDOW`
+- `LCM_SUMMARY_CALL_WINDOW_MS`
+- `LCM_SUMMARY_SPEND_BACKOFF_MS`
+
+Why they matter:
+
+- prevents non-auth provider failures, ineffective compaction, or repeated deferred debt from spending unbounded summarization calls
+- keeps provider-auth failures on the separate auth circuit breaker path
+- direct deterministic fallbacks remain available when model-backed large-file summaries are throttled
+
 ### `customInstructions`
 
 Natural-language instructions injected into summarization prompts.

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -24,6 +24,9 @@ export function resolveOpenclawStateDir(env: NodeJS.ProcessEnv = process.env): s
  */
 export const DEFAULT_CRITICAL_BUDGET_PRESSURE_RATIO = 0.90;
 export const DEFAULT_AUTO_ROTATE_SESSION_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+export const DEFAULT_SUMMARY_CALL_WINDOW_MS = 10 * 60 * 1000;
+export const DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW = 24;
+export const DEFAULT_SUMMARY_SPEND_BACKOFF_MS = 30 * 60 * 1000;
 
 export type CacheAwareCompactionConfig = {
   enabled: boolean;
@@ -126,6 +129,12 @@ export type LcmConfig = {
   delegationTimeoutMs: number;
   /** Max time to wait for a single model-backed LCM summarizer call. */
   summaryTimeoutMs: number;
+  /** Rolling window for model-backed summarization call budgets. */
+  summaryCallWindowMs?: number;
+  /** Maximum model-backed summarization calls per session/window before backoff. */
+  summaryMaxCallsPerWindow?: number;
+  /** Cooldown after a summarization spend guard opens. */
+  summarySpendBackoffMs?: number;
   /** IANA timezone for timestamps in summaries (from TZ env or system default) */
   timezone: string;
   /** When true, retroactively delete HEARTBEAT_OK turn cycles from LCM storage. */
@@ -417,6 +426,21 @@ export function resolveLcmConfigWithDiagnostics(
       parseFiniteInt(env.LCM_COMPACT_UNTIL_UNDER_DEADLINE_MS)
         ?? toNumber(pc.compactUntilUnderDeadlineMs),
     ) ?? 300_000;
+  const resolvedSummaryCallWindowMs =
+    toPositiveInteger(
+      parseFiniteInt(env.LCM_SUMMARY_CALL_WINDOW_MS)
+        ?? toNumber(pc.summaryCallWindowMs),
+    ) ?? DEFAULT_SUMMARY_CALL_WINDOW_MS;
+  const resolvedSummaryMaxCallsPerWindow =
+    toPositiveInteger(
+      parseFiniteInt(env.LCM_SUMMARY_MAX_CALLS_PER_WINDOW)
+        ?? toNumber(pc.summaryMaxCallsPerWindow),
+    ) ?? DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW;
+  const resolvedSummarySpendBackoffMs =
+    toPositiveInteger(
+      parseFiniteInt(env.LCM_SUMMARY_SPEND_BACKOFF_MS)
+        ?? toNumber(pc.summarySpendBackoffMs),
+    ) ?? DEFAULT_SUMMARY_SPEND_BACKOFF_MS;
   const envDelegationTimeoutMs =
     env.LCM_DELEGATION_TIMEOUT_MS !== undefined
       ? toNumber(env.LCM_DELEGATION_TIMEOUT_MS)
@@ -563,6 +587,9 @@ export function resolveLcmConfigWithDiagnostics(
       summaryTimeoutMs:
         parseFiniteInt(env.LCM_SUMMARY_TIMEOUT_MS)
           ?? toNumber(pc.summaryTimeoutMs) ?? 60000,
+      summaryCallWindowMs: resolvedSummaryCallWindowMs,
+      summaryMaxCallsPerWindow: resolvedSummaryMaxCallsPerWindow,
+      summarySpendBackoffMs: resolvedSummarySpendBackoffMs,
       timezone: env.TZ ?? toStr(pc.timezone) ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
       pruneHeartbeatOk:
         env.LCM_PRUNE_HEARTBEAT_OK !== undefined

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -178,12 +178,26 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   const hasRawTokensOutsideTail = maintenanceColumns.some(
     (col) => col.name === "raw_tokens_outside_tail",
   );
+  const hasRetryAttempts = maintenanceColumns.some(
+    (col) => col.name === "retry_attempts",
+  );
+  const hasNextAttemptAfter = maintenanceColumns.some(
+    (col) => col.name === "next_attempt_after",
+  );
 
   if (!hasProjectedTokenCount) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
   }
   if (!hasRawTokensOutsideTail) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN raw_tokens_outside_tail INTEGER`);
+  }
+  if (!hasRetryAttempts) {
+    db.exec(
+      `ALTER TABLE conversation_compaction_maintenance ADD COLUMN retry_attempts INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+  if (!hasNextAttemptAfter) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN next_attempt_after TEXT`);
   }
 }
 
@@ -1082,6 +1096,8 @@ export function runLcmMigrations(
       current_token_count INTEGER,
       projected_token_count INTEGER,
       raw_tokens_outside_tail INTEGER,
+      retry_attempts INTEGER NOT NULL DEFAULT 0,
+      next_attempt_after TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -70,8 +70,14 @@ import {
 import { buildMessageIdentityHash } from "./store/message-identity.js";
 import { FocusBriefStore, type FocusBriefRecord } from "./store/focus-brief-store.js";
 import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
-import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "./summarize.js";
-import type { LcmDependencies, StartupSessionFileCandidate } from "./types.js";
+import {
+  createLcmSummarizeFromLegacyParams,
+  extractProviderAuthFailure,
+  LcmProviderAuthError,
+  LcmSummarySpendLimitError,
+  type LcmSummarizeFn,
+} from "./summarize.js";
+import type { CompleteFn, LcmDependencies, StartupSessionFileCandidate } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 import { createLcmDatabaseBackup } from "./plugin/lcm-db-backup.js";
 import {
@@ -113,6 +119,13 @@ const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
   failures: number;
   openSince: number | null;
+};
+
+type SummarySpendGuardState = {
+  windowStartedAt: number;
+  calls: number;
+  backoffUntil: number | null;
+  lastReason: string | null;
 };
 type PromptCacheSnapshot = {
   lastObservedCacheRead?: number;
@@ -3274,8 +3287,6 @@ export class LcmContextEngine implements ContextEngine {
   private previousAssembledMessagesByConversation = new Map<number, AssemblePrefixSnapshot>();
   private recentBootstrapImportsByConversation = new Map<number, BootstrapImportObservation>();
   private oversizedAutoRotateCheckpointByQueueKey = new Map<string, number>();
-  private largeFileTextSummarizerResolved = false;
-  private largeFileTextSummarizer?: (prompt: string) => Promise<string | null>;
   private deps: LcmDependencies;
 
   /**
@@ -3288,6 +3299,9 @@ export class LcmContextEngine implements ContextEngine {
 
   // ── Circuit breaker for compaction auth failures ──
   private circuitBreakerStates = new Map<string, CircuitBreakerState>();
+
+  // ── Non-auth spend guard for model-backed summarization calls ───────────
+  private summarySpendGuardStates = new Map<string, SummarySpendGuardState>();
 
   /** Last file state successfully covered by `reconcileTranscriptTailForAfterTurn`
    *  slow-path full re-reads, keyed by `${sessionQueueKey}\u0000${sessionFile}`
@@ -3538,6 +3552,198 @@ export class LcmContextEngine implements ContextEngine {
 
   private resetCircuitBreaker(key: string): void {
     this.circuitBreakerStates.delete(key);
+  }
+
+  private resolvePositiveConfigInteger(value: unknown, fallback: number): number {
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+      ? Math.floor(value)
+      : fallback;
+  }
+
+  private resolveSummarySpendGuardConfig(): {
+    windowMs: number;
+    maxCalls: number;
+    backoffMs: number;
+  } {
+    return {
+      windowMs: this.resolvePositiveConfigInteger(
+        this.config.summaryCallWindowMs,
+        10 * 60 * 1000,
+      ),
+      maxCalls: this.resolvePositiveConfigInteger(
+        this.config.summaryMaxCallsPerWindow,
+        24,
+      ),
+      backoffMs: this.resolvePositiveConfigInteger(
+        this.config.summarySpendBackoffMs,
+        30 * 60 * 1000,
+      ),
+    };
+  }
+
+  private resolveSummarySpendScope(params: {
+    kind: "compaction" | "large-file" | "custom";
+    scope: string | undefined;
+  }): string {
+    const scope = params.scope?.trim() || "global";
+    return `${params.kind}:${scope}`;
+  }
+
+  private openSummarySpendBackoff(params: {
+    scopeKey: string;
+    reason: string;
+    now?: number;
+  }): Date {
+    const now = params.now ?? Date.now();
+    const { backoffMs } = this.resolveSummarySpendGuardConfig();
+    const state = this.summarySpendGuardStates.get(params.scopeKey) ?? {
+      windowStartedAt: now,
+      calls: 0,
+      backoffUntil: null,
+      lastReason: null,
+    };
+    state.backoffUntil = now + backoffMs;
+    state.lastReason = params.reason;
+    this.summarySpendGuardStates.set(params.scopeKey, state);
+    return new Date(state.backoffUntil);
+  }
+
+  private assertSummarySpendCallAllowed(params: {
+    scopeKey: string;
+    reason: string;
+  }): void {
+    const now = Date.now();
+    const { windowMs, maxCalls } = this.resolveSummarySpendGuardConfig();
+    let state = this.summarySpendGuardStates.get(params.scopeKey);
+    if (state?.backoffUntil !== null && state?.backoffUntil !== undefined) {
+      if (now < state.backoffUntil) {
+        throw new LcmSummarySpendLimitError({
+          scopeKey: params.scopeKey,
+          backoffUntil: new Date(state.backoffUntil),
+        });
+      }
+      state.windowStartedAt = now;
+      state.calls = 0;
+      state.backoffUntil = null;
+      state.lastReason = null;
+    }
+
+    if (!state || now - state.windowStartedAt >= windowMs) {
+      state = {
+        windowStartedAt: now,
+        calls: 0,
+        backoffUntil: null,
+        lastReason: null,
+      };
+      this.summarySpendGuardStates.set(params.scopeKey, state);
+    }
+
+    if (state.calls >= maxCalls) {
+      const backoffUntil = this.openSummarySpendBackoff({
+        scopeKey: params.scopeKey,
+        reason: params.reason,
+        now,
+      });
+      this.deps.log.warn(
+        `[lcm] summary spend guard opened scope=${params.scopeKey} calls=${state.calls}/${maxCalls} reason=${params.reason.replaceAll(" ", "_")} backoffUntil=${backoffUntil.toISOString()}`,
+      );
+      throw new LcmSummarySpendLimitError({
+        scopeKey: params.scopeKey,
+        backoffUntil,
+      });
+    }
+
+    state.lastReason = params.reason;
+  }
+
+  private recordSummarySpendCall(params: {
+    scopeKey: string;
+    reason: string;
+  }): void {
+    const now = Date.now();
+    const { windowMs } = this.resolveSummarySpendGuardConfig();
+    let state = this.summarySpendGuardStates.get(params.scopeKey);
+    if (!state || now - state.windowStartedAt >= windowMs) {
+      state = {
+        windowStartedAt: now,
+        calls: 0,
+        backoffUntil: null,
+        lastReason: null,
+      };
+      this.summarySpendGuardStates.set(params.scopeKey, state);
+    }
+    state.calls += 1;
+    state.lastReason = params.reason;
+  }
+
+  private getSummarySpendBackoffUntil(scopeKey: string): Date | null {
+    const state = this.summarySpendGuardStates.get(scopeKey);
+    if (!state?.backoffUntil) {
+      return null;
+    }
+    return state.backoffUntil > Date.now() ? new Date(state.backoffUntil) : null;
+  }
+
+  private buildSummarySpendGuardedDeps(params: {
+    scopeKey: string;
+    reason: string;
+  }): LcmDependencies {
+    const complete: CompleteFn = async (input) => {
+      this.assertSummarySpendCallAllowed({
+        scopeKey: params.scopeKey,
+        reason: params.reason,
+      });
+      try {
+        const result = await this.deps.complete(input);
+        if (!extractProviderAuthFailure(result, { requireStructuralSignal: true })) {
+          this.recordSummarySpendCall({
+            scopeKey: params.scopeKey,
+            reason: params.reason,
+          });
+        }
+        return result;
+      } catch (err) {
+        if (!extractProviderAuthFailure(err)) {
+          this.recordSummarySpendCall({
+            scopeKey: params.scopeKey,
+            reason: params.reason,
+          });
+        }
+        throw err;
+      }
+    };
+    return {
+      ...this.deps,
+      complete,
+    };
+  }
+
+  private guardCustomSummarize(params: {
+    summarize: LcmSummarizeFn;
+    scopeKey: string;
+  }): LcmSummarizeFn {
+    return async (text, aggressive, options) => {
+      this.assertSummarySpendCallAllowed({
+        scopeKey: params.scopeKey,
+        reason: "custom summarizer call",
+      });
+      try {
+        const result = await params.summarize(text, aggressive, options);
+        this.recordSummarySpendCall({
+          scopeKey: params.scopeKey,
+          reason: "custom summarizer call",
+        });
+        return result;
+      } catch (err) {
+        if (!(err instanceof LcmProviderAuthError)) {
+          this.recordSummarySpendCall({
+            scopeKey: params.scopeKey,
+            reason: "custom summarizer call",
+          });
+        }
+        throw err;
+      }
+    };
   }
 
   /** Ensure DB schema is up-to-date. Called lazily on first bootstrap/ingest/assemble/compact. */
@@ -3869,6 +4075,10 @@ export class LcmContextEngine implements ContextEngine {
       `session=${params.sessionId}`,
       ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
     ].join(" ");
+    const summarySpendScopeKey = this.resolveSummarySpendScope({
+      kind: "compaction",
+      scope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+    });
     if (this.sessionOperationQueues.has(params.queueKey)) {
       this.deps.log.debug(
         `[lcm] background deferred compaction skipped conversation=${params.conversationId} ${sessionLabel} reason=session-queue-busy debtReason=${params.reason}`,
@@ -3947,6 +4157,25 @@ export class LcmContextEngine implements ContextEngine {
       `session=${params.sessionId}`,
       ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
     ].join(" ");
+    const summarySpendScopeKey = this.resolveSummarySpendScope({
+      kind: "compaction",
+      scope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+    });
+
+    if (
+      maintenance.nextAttemptAfter !== null &&
+      maintenance.nextAttemptAfter.getTime() > Date.now()
+    ) {
+      this.deps.log.debug(
+        `[lcm] maintain: deferred compaction backoff active conversation=${params.conversationId} ${sessionLabel} retryAttempts=${maintenance.retryAttempts} nextAttemptAfter=${maintenance.nextAttemptAfter.toISOString()} debtReason=${maintenance.reason ?? "null"}`,
+      );
+      return {
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "deferred compaction backoff active",
+      };
+    }
 
     await this.compactionMaintenanceStore.markProactiveCompactionRunning({
       conversationId: params.conversationId,
@@ -4011,11 +4240,22 @@ export class LcmContextEngine implements ContextEngine {
         runtimeContext: params.runtimeContext,
         legacyParams: params.legacyParams,
       });
+      const blockedByAuthCircuitBreaker = result.reason === "circuit breaker open";
+      const keepPending = !result.ok || blockedByAuthCircuitBreaker;
+      const failureSummary = blockedByAuthCircuitBreaker
+        ? "summary provider circuit breaker is open"
+        : result.ok
+          ? null
+          : result.reason ?? "deferred compaction failed";
+      const summarySpendBackoffUntil = keepPending
+        ? this.getSummarySpendBackoffUntil(summarySpendScopeKey)
+        : null;
       await this.compactionMaintenanceStore.markProactiveCompactionFinished({
         conversationId: params.conversationId,
         finishedAt: new Date(),
-        failureSummary: result.ok ? null : result.reason ?? "deferred compaction failed",
-        keepPending: !result.ok,
+        failureSummary,
+        keepPending,
+        ...(summarySpendBackoffUntil ? { nextAttemptAfter: summarySpendBackoffUntil } : {}),
       });
       this.deps.log.debug(
         `[lcm] maintain: deferred compaction ${result.compacted ? "completed" : "skipped"} conversation=${params.conversationId} ${sessionLabel} changed=${result.compacted} ok=${result.ok} reason=${result.reason ?? "none"} currentTokenCount=${resolvedCurrentTokenCount ?? "null"} projectedTokenCount=${resolvedProjectedTokenCount ?? "null"} rawTokensOutsideTail=${maintenance.rawTokensOutsideTail ?? "null"}`,
@@ -4139,13 +4379,18 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
 
+    const compactionScope = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
+    const summarySpendScopeKey = this.resolveSummarySpendScope({
+      kind: "compaction",
+      scope: compactionScope,
+    });
     const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
       legacyParams: this.buildSummarizerLegacyParams({
         legacyParams,
         sessionKey: params.sessionKey,
       }),
       customInstructions: params.customInstructions,
-      breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+      breakerScope: compactionScope,
     });
     if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
       return {
@@ -4244,17 +4489,32 @@ export class LcmContextEngine implements ContextEngine {
         forceCompaction ||
         runtimeAdjustedSweepTargetTokens !== undefined ||
         projectedRawBacklogPressure;
-      const sweepResult = await this.compaction.compact({
-        conversationId,
-        tokenBudget,
-        summarize,
-        force: forceThresholdSweep,
-        hardTrigger: false,
-        summaryModel,
-        ...(runtimeAdjustedSweepTargetTokens !== undefined
-          ? { stopAtTokens: runtimeAdjustedSweepTargetTokens }
-          : {}),
-      });
+      let sweepResult: Awaited<ReturnType<CompactionEngine["compact"]>>;
+      try {
+        sweepResult = await this.compaction.compact({
+          conversationId,
+          tokenBudget,
+          summarize,
+          force: forceThresholdSweep,
+          hardTrigger: false,
+          summaryModel,
+          ...(runtimeAdjustedSweepTargetTokens !== undefined
+            ? { stopAtTokens: runtimeAdjustedSweepTargetTokens }
+            : {}),
+        });
+      } catch (err) {
+        if (err instanceof LcmSummarySpendLimitError) {
+          this.deps.log.warn(
+            `[lcm] compact: summary spend guard blocked conversation=${conversationId} ${sessionLabel} scope=${err.scopeKey} backoffUntil=${err.backoffUntil.toISOString()}`,
+          );
+          return {
+            ok: false,
+            compacted: false,
+            reason: "summary spend backoff open",
+          };
+        }
+        throw err;
+      }
 
       if (sweepResult.authFailure && breakerKey) {
         this.recordCompactionAuthFailure(breakerKey);
@@ -4298,6 +4558,12 @@ export class LcmContextEngine implements ContextEngine {
             : manualCompactionRequested
               ? "nothing to compact"
               : "live context still exceeds target";
+      if (thresholdSweepStillOverTarget && !sweepResult.authFailure) {
+        this.openSummarySpendBackoff({
+          scopeKey: summarySpendScopeKey,
+          reason: sweepReason,
+        });
+      }
       this.deps.log.info(
         `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${sweepOk} compacted=${sweepResult.actionTaken} reason=${sweepReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${sweepResult.tokensAfter} createdSummaryId=${sweepResult.createdSummaryId ?? "none"} duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
@@ -4346,14 +4612,29 @@ export class LcmContextEngine implements ContextEngine {
         : forceCompaction
           ? tokenBudget
           : undefined;
-    const compactResult = await this.compaction.compactUntilUnder({
-      conversationId,
-      tokenBudget,
-      targetTokens: convergenceTargetTokens,
-      ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
-      summarize,
-      summaryModel,
-    });
+    let compactResult: Awaited<ReturnType<CompactionEngine["compactUntilUnder"]>>;
+    try {
+      compactResult = await this.compaction.compactUntilUnder({
+        conversationId,
+        tokenBudget,
+        targetTokens: convergenceTargetTokens,
+        ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
+        summarize,
+        summaryModel,
+      });
+    } catch (err) {
+      if (err instanceof LcmSummarySpendLimitError) {
+        this.deps.log.warn(
+          `[lcm] compact: summary spend guard blocked conversation=${conversationId} ${sessionLabel} scope=${err.scopeKey} backoffUntil=${err.backoffUntil.toISOString()}`,
+        );
+        return {
+          ok: false,
+          compacted: false,
+          reason: "summary spend backoff open",
+        };
+      }
+      throw err;
+    }
 
     if (compactResult.authFailure && breakerKey) {
       this.recordCompactionAuthFailure(breakerKey);
@@ -4375,6 +4656,12 @@ export class LcmContextEngine implements ContextEngine {
           ? "compacted"
           : "already under target"
         : "could not reach target";
+    if (!compactResult.success && !compactResult.authFailure) {
+      this.openSummarySpendBackoff({
+        scopeKey: summarySpendScopeKey,
+        reason: compactUntilReason,
+      });
+    }
     this.deps.log.info(
       `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${compactResult.success} compacted=${didCompact} reason=${compactUntilReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${compactResult.finalTokens} rounds=${compactResult.rounds} duration=${formatDurationMs(Date.now() - startedAt)}`,
     );
@@ -4462,16 +4749,24 @@ export class LcmContextEngine implements ContextEngine {
     customInstructions?: string;
     breakerScope: string;
   }): Promise<{
-    summarize: (text: string, aggressive?: boolean) => Promise<string>;
+    summarize: LcmSummarizeFn;
     summaryModel: string;
     breakerKey?: string;
   }> {
     const lp = params.legacyParams ?? {};
+    const breakerScope = params.breakerScope || "global";
+    const scopeKey = this.resolveSummarySpendScope({
+      kind: "compaction",
+      scope: breakerScope,
+    });
     if (typeof lp.summarize === "function") {
       return {
-        summarize: lp.summarize as (text: string, aggressive?: boolean) => Promise<string>,
+        summarize: this.guardCustomSummarize({
+          summarize: lp.summarize as LcmSummarizeFn,
+          scopeKey,
+        }),
         summaryModel: "unknown",
-        breakerKey: `custom:${params.breakerScope}`,
+        breakerKey: `custom:${breakerScope}`,
       };
     }
     try {
@@ -4480,7 +4775,10 @@ export class LcmContextEngine implements ContextEngine {
           ? params.customInstructions
           : (this.config.customInstructions || undefined);
       const runtimeSummarizer = await createLcmSummarizeFromLegacyParams({
-        deps: this.deps,
+        deps: this.buildSummarySpendGuardedDeps({
+          scopeKey,
+          reason: "compaction summarizer call",
+        }),
         legacyParams: lp,
         customInstructions,
       });
@@ -4507,14 +4805,9 @@ export class LcmContextEngine implements ContextEngine {
    * This is opt-in via env so ingest remains deterministic and lightweight when
    * no summarization model is configured.
    */
-  private async resolveLargeFileTextSummarizer(): Promise<
+  private async resolveLargeFileTextSummarizer(params?: { conversationId?: number }): Promise<
     ((prompt: string) => Promise<string | null>) | undefined
   > {
-    if (this.largeFileTextSummarizerResolved) {
-      return this.largeFileTextSummarizer;
-    }
-    this.largeFileTextSummarizerResolved = true;
-
     const provider = this.deps.config.largeFileSummaryProvider;
     const model = this.deps.config.largeFileSummaryModel;
     if (!provider || !model) {
@@ -4522,8 +4815,18 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     try {
+      const scopeKey = this.resolveSummarySpendScope({
+        kind: "large-file",
+        scope:
+          typeof params?.conversationId === "number"
+            ? String(params.conversationId)
+            : "global",
+      });
       const result = await createLcmSummarizeFromLegacyParams({
-        deps: this.deps,
+        deps: this.buildSummarySpendGuardedDeps({
+          scopeKey,
+          reason: "large-file summarizer call",
+        }),
         legacyParams: {
           provider,
           model,
@@ -4536,12 +4839,12 @@ export class LcmContextEngine implements ContextEngine {
         return undefined;
       }
 
-      this.largeFileTextSummarizer = async (prompt: string): Promise<string | null> => {
+      return async (prompt: string): Promise<string | null> => {
         let summary: string;
         try {
           summary = await result.fn(prompt, false);
         } catch (err) {
-          if (err instanceof LcmProviderAuthError) {
+          if (err instanceof LcmProviderAuthError || err instanceof LcmSummarySpendLimitError) {
             return null;
           }
           throw err;
@@ -4552,7 +4855,6 @@ export class LcmContextEngine implements ContextEngine {
         const trimmed = summary.trim();
         return trimmed.length > 0 ? trimmed : null;
       };
-      return this.largeFileTextSummarizer;
     } catch {
       return undefined;
     }
@@ -5140,7 +5442,9 @@ export class LcmContextEngine implements ContextEngine {
     mimeType?: string;
     formatReference: (input: { fileId: string; byteSize: number; summary: string }) => string;
   }): Promise<{ fileId: string; byteSize: number; summary: string; reference: string }> {
-    const summarizeText = await this.resolveLargeFileTextSummarizer();
+    const summarizeText = await this.resolveLargeFileTextSummarizer({
+      conversationId: params.conversationId,
+    });
     const fileId = `file_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
     const extension = extensionFromNameOrMime(params.fileName, params.mimeType);
     const storageUri = await this.storeLargeFileContent({
@@ -9924,7 +10228,7 @@ export class LcmContextEngine implements ContextEngine {
 
     const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
       legacyParams: this.buildSummarizerLegacyParams({ sessionKey: params.sessionKey }),
-      breakerScope: "rotate",
+      breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
     });
     if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
       return {
@@ -9936,14 +10240,26 @@ export class LcmContextEngine implements ContextEngine {
     let leafPasses = 0;
 
     while (leafPasses <= maxLeafPasses) {
-      const result = await this.compaction.compactLeaf({
-        conversationId: current.conversationId,
-        tokenBudget,
-        summarize,
-        force: true,
-        allowCondensedPasses: false,
-        summaryModel,
-      });
+      let result: Awaited<ReturnType<CompactionEngine["compactLeaf"]>>;
+      try {
+        result = await this.compaction.compactLeaf({
+          conversationId: current.conversationId,
+          tokenBudget,
+          summarize,
+          force: true,
+          allowCondensedPasses: false,
+          summaryModel,
+        });
+      } catch (err) {
+        if (err instanceof LcmSummarySpendLimitError) {
+          return {
+            kind: "unavailable",
+            reason:
+              `Lossless Claw could not summarize raw context before rotate because summary spend backoff is open until ${err.backoffUntil.toISOString()}.`,
+          };
+        }
+        throw err;
+      }
       if (!result.actionTaken) {
         if (result.authFailure) {
           if (breakerKey) {

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -15,6 +15,8 @@ export type ConversationCompactionMaintenanceRecord = {
   currentTokenCount: number | null;
   projectedTokenCount: number | null;
   rawTokensOutsideTail: number | null;
+  retryAttempts: number;
+  nextAttemptAfter: Date | null;
   updatedAt: Date;
 };
 
@@ -31,8 +33,28 @@ type ConversationCompactionMaintenanceRow = {
   current_token_count: number | null;
   projected_token_count: number | null;
   raw_tokens_outside_tail: number | null;
+  retry_attempts: number;
+  next_attempt_after: string | null;
   updated_at: string;
 };
+
+const DEFERRED_COMPACTION_RETRY_BASE_MS = 5 * 60 * 1000;
+const DEFERRED_COMPACTION_RETRY_MAX_MS = 30 * 60 * 1000;
+
+function computeDeferredCompactionRetryDelayMs(attempts: number): number {
+  const safeAttempts = Number.isFinite(attempts) ? Math.max(1, Math.floor(attempts)) : 1;
+  const multiplier = Math.min(2 ** (safeAttempts - 1), 64);
+  return Math.min(DEFERRED_COMPACTION_RETRY_BASE_MS * multiplier, DEFERRED_COMPACTION_RETRY_MAX_MS);
+}
+
+function shouldBackOffDeferredCompactionFailure(failureSummary: string | null | undefined): boolean {
+  if (failureSummary == null) {
+    return false;
+  }
+  return !/\b(provider auth failure|summary provider circuit breaker is open)\b/i.test(
+    failureSummary,
+  );
+}
 
 function toMaintenanceRecord(
   row: ConversationCompactionMaintenanceRow,
@@ -50,6 +72,11 @@ function toMaintenanceRecord(
     currentTokenCount: row.current_token_count,
     projectedTokenCount: row.projected_token_count,
     rawTokensOutsideTail: row.raw_tokens_outside_tail,
+    retryAttempts:
+      typeof row.retry_attempts === "number" && Number.isFinite(row.retry_attempts)
+        ? Math.max(0, Math.floor(row.retry_attempts))
+        : 0,
+    nextAttemptAfter: parseUtcTimestampOrNull(row.next_attempt_after),
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -84,6 +111,14 @@ function mergeMaintenanceRecord(
       patch.rawTokensOutsideTail !== undefined
         ? patch.rawTokensOutsideTail
         : existing?.rawTokensOutsideTail ?? null,
+    retryAttempts:
+      patch.retryAttempts !== undefined
+        ? Math.max(0, Math.floor(patch.retryAttempts))
+        : existing?.retryAttempts ?? 0,
+    nextAttemptAfter:
+      patch.nextAttemptAfter !== undefined
+        ? patch.nextAttemptAfter
+        : existing?.nextAttemptAfter ?? null,
     updatedAt: new Date(),
   };
 }
@@ -122,6 +157,8 @@ export class CompactionMaintenanceStore {
            current_token_count,
            projected_token_count,
            raw_tokens_outside_tail,
+           retry_attempts,
+           next_attempt_after,
            updated_at
          FROM conversation_compaction_maintenance
          WHERE conversation_id = ?`,
@@ -139,17 +176,19 @@ export class CompactionMaintenanceStore {
            conversation_id,
            pending,
            requested_at,
-         reason,
-         running,
-         last_started_at,
-         last_finished_at,
-         last_failure_summary,
-         token_budget,
-         current_token_count,
-         projected_token_count,
-         raw_tokens_outside_tail,
-         updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+           reason,
+           running,
+           last_started_at,
+           last_finished_at,
+           last_failure_summary,
+           token_budget,
+           current_token_count,
+           projected_token_count,
+           raw_tokens_outside_tail,
+           retry_attempts,
+           next_attempt_after,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -162,6 +201,8 @@ export class CompactionMaintenanceStore {
            current_token_count = excluded.current_token_count,
            projected_token_count = excluded.projected_token_count,
            raw_tokens_outside_tail = excluded.raw_tokens_outside_tail,
+           retry_attempts = excluded.retry_attempts,
+           next_attempt_after = excluded.next_attempt_after,
            updated_at = datetime('now')`,
       )
       .run(
@@ -177,6 +218,8 @@ export class CompactionMaintenanceStore {
         record.currentTokenCount ?? null,
         record.projectedTokenCount ?? null,
         record.rawTokensOutsideTail ?? null,
+        record.retryAttempts,
+        record.nextAttemptAfter?.toISOString() ?? null,
       );
   }
 
@@ -226,10 +269,19 @@ export class CompactionMaintenanceStore {
     finishedAt?: Date;
     failureSummary?: string | null;
     keepPending?: boolean;
+    nextAttemptAfter?: Date | null;
   }): Promise<void> {
     const existing = await this.getConversationCompactionMaintenance(input.conversationId);
     const finishedAt = input.finishedAt ?? new Date();
     const isFailure = input.failureSummary != null;
+    const shouldBackOff = shouldBackOffDeferredCompactionFailure(input.failureSummary);
+    const retryAttempts = shouldBackOff ? (existing?.retryAttempts ?? 0) + 1 : 0;
+    const nextAttemptAfter =
+      input.nextAttemptAfter !== undefined
+        ? input.nextAttemptAfter
+        : shouldBackOff
+          ? new Date(finishedAt.getTime() + computeDeferredCompactionRetryDelayMs(retryAttempts))
+          : null;
     await this.saveConversationCompactionMaintenance(
       mergeMaintenanceRecord(input.conversationId, existing, {
         pending: input.keepPending ?? isFailure,
@@ -239,6 +291,8 @@ export class CompactionMaintenanceStore {
           input.failureSummary === undefined
             ? existing?.lastFailureSummary ?? null
             : input.failureSummary,
+        retryAttempts,
+        nextAttemptAfter,
       }),
     );
   }

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -199,6 +199,26 @@ export class LcmRuntimeLlmUnavailableError extends Error {
   }
 }
 
+/** Signals that Lossless has opened its non-auth summarization spend guard. */
+export class LcmSummarySpendLimitError extends Error {
+  readonly scopeKey: string;
+  readonly backoffUntil: Date;
+
+  constructor(params: {
+    scopeKey: string;
+    backoffUntil: Date;
+    message?: string;
+  }) {
+    super(
+      params.message ??
+        `summary spend backoff open for ${params.scopeKey} until ${params.backoffUntil.toISOString()}`,
+    );
+    this.name = "LcmSummarySpendLimitError";
+    this.scopeKey = params.scopeKey;
+    this.backoffUntil = params.backoffUntil;
+  }
+}
+
 /** Signals that a provider returned an explicit non-auth error response. */
 class LcmProviderResponseError extends Error {
   readonly provider: string;
@@ -1578,6 +1598,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           if (
             err instanceof LcmRuntimeLlmPolicyError ||
             err instanceof LcmRuntimeLlmUnavailableError ||
+            err instanceof LcmSummarySpendLimitError ||
             err instanceof LcmProviderAuthError ||
             err instanceof LcmProviderResponseError
           ) {
@@ -1601,6 +1622,10 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         }
         if (err instanceof LcmRuntimeLlmUnavailableError) {
           params.deps.log.error(err.message);
+          throw err;
+        }
+        if (err instanceof LcmSummarySpendLimitError) {
+          params.deps.log.warn(err.message);
           throw err;
         }
         if (err instanceof LcmProviderAuthError) {
@@ -1739,6 +1764,10 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           }
           if (retryErr instanceof LcmRuntimeLlmUnavailableError) {
             params.deps.log.error(retryErr.message);
+            throw retryErr;
+          }
+          if (retryErr instanceof LcmSummarySpendLimitError) {
+            params.deps.log.warn(retryErr.message);
             throw retryErr;
           }
           if (retryErr instanceof LcmProviderAuthError) {

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -206,6 +206,68 @@ describe("Circuit Breaker", () => {
     expect(blocked.compacted).toBe(false);
   });
 
+  it("does not reclassify repeated auth failures as summary spend failures", async () => {
+    const authConfig = createTestConfig({
+      circuitBreakerThreshold: 3,
+      summaryMaxCallsPerWindow: 1,
+      summaryCallWindowMs: 10 * 60 * 1000,
+      summarySpendBackoffMs: 30 * 60 * 1000,
+    });
+    const authDb = new DatabaseSync(":memory:");
+    const authEngine = new LcmContextEngine(createTestDeps(authConfig), authDb);
+    const authSessionFile = join(tmpDir, `auth-spend-${randomUUID()}.jsonl`);
+    writeFileSync(
+      authSessionFile,
+      Array.from({ length: 8 }, (_, index) =>
+        JSON.stringify({
+          message: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: [{ type: "text", text: `auth spend message ${index} ${"x".repeat(200)}` }],
+          },
+        }),
+      ).join("\n") + "\n",
+    );
+    await authEngine.bootstrap({
+      sessionId: "auth-spend-session",
+      sessionKey: "agent:main:auth-spend",
+      sessionFile: authSessionFile,
+    });
+
+    let callCount = 0;
+    const failingSummarizer = async () => {
+      callCount++;
+      throw makeAuthError();
+    };
+
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        const result = await authEngine.compact({
+          sessionId: "auth-spend-session",
+          sessionKey: "agent:main:auth-spend",
+          sessionFile: authSessionFile,
+          tokenBudget: 5000,
+          force: true,
+          legacyParams: { summarize: failingSummarizer },
+        });
+        expect(result.reason).toContain("provider auth failure");
+      }
+
+      const blocked = await authEngine.compact({
+        sessionId: "auth-spend-session",
+        sessionKey: "agent:main:auth-spend",
+        sessionFile: authSessionFile,
+        tokenBudget: 5000,
+        force: true,
+        legacyParams: { summarize: failingSummarizer },
+      });
+
+      expect(callCount).toBe(3);
+      expect(blocked.reason).toBe("circuit breaker open");
+    } finally {
+      try { authDb.close(); } catch {}
+    }
+  });
+
   it("should auto-reset after cooldown", async () => {
     await engine.bootstrap({ sessionId, sessionFile, sessionKey });
     

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -92,4 +92,110 @@ describe("CompactionMaintenanceStore", () => {
       rawTokensOutsideTail: 320,
     });
   });
+
+  it("records retry backoff after failures and clears it after success", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-retry-session",
+      sessionKey: "agent:main:maintenance-store:3",
+    });
+    const store = new CompactionMaintenanceStore(db);
+    const firstFinishedAt = new Date("2026-05-31T12:00:00.000Z");
+    const secondFinishedAt = new Date("2026-05-31T12:05:00.000Z");
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+    await store.markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await store.markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: "provider timeout",
+      finishedAt: firstFinishedAt,
+    });
+
+    const failed = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(failed?.pending).toBe(true);
+    expect(failed?.running).toBe(false);
+    expect(failed?.retryAttempts).toBe(1);
+    expect(failed?.nextAttemptAfter?.toISOString()).toBe("2026-05-31T12:05:00.000Z");
+
+    await store.markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await store.markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: "provider timeout",
+      finishedAt: secondFinishedAt,
+    });
+
+    const failedAgain = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(failedAgain?.retryAttempts).toBe(2);
+    expect(failedAgain?.nextAttemptAfter?.toISOString()).toBe("2026-05-31T12:15:00.000Z");
+
+    for (let attempt = 3; attempt <= 8; attempt += 1) {
+      await store.markProactiveCompactionRunning({
+        conversationId: conversation.conversationId,
+      });
+      await store.markProactiveCompactionFinished({
+        conversationId: conversation.conversationId,
+        failureSummary: "provider timeout",
+        finishedAt: new Date(`2026-05-31T12:${String(10 + attempt).padStart(2, "0")}:00.000Z`),
+      });
+    }
+
+    const capped = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(capped?.retryAttempts).toBe(8);
+    expect(capped?.nextAttemptAfter?.getTime()).toBe(
+      new Date("2026-05-31T12:18:00.000Z").getTime() + 30 * 60 * 1000,
+    );
+
+    await store.markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await store.markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: null,
+      keepPending: false,
+    });
+
+    const recovered = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(recovered?.pending).toBe(false);
+    expect(recovered?.running).toBe(false);
+    expect(recovered?.retryAttempts).toBe(0);
+    expect(recovered?.nextAttemptAfter).toBeNull();
+  });
+
+  it("does not add deferred retry backoff for provider auth failures", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-auth-session",
+      sessionKey: "agent:main:maintenance-store:4",
+    });
+    const store = new CompactionMaintenanceStore(db);
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+    await store.markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await store.markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: "provider auth failure",
+    });
+
+    const record = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(record?.pending).toBe(true);
+    expect(record?.running).toBe(false);
+    expect(record?.retryAttempts).toBe(0);
+    expect(record?.nextAttemptAfter).toBeNull();
+  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,6 +5,9 @@ import manifest from "../openclaw.plugin.json" with { type: "json" };
 import {
   DEFAULT_AUTO_ROTATE_SESSION_FILE_SIZE_BYTES,
   DEFAULT_CRITICAL_BUDGET_PRESSURE_RATIO,
+  DEFAULT_SUMMARY_CALL_WINDOW_MS,
+  DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW,
+  DEFAULT_SUMMARY_SPEND_BACKOFF_MS,
   resolveLcmConfig,
   resolveLcmConfigWithDiagnostics,
   resolveOpenclawStateDir,
@@ -45,6 +48,9 @@ describe("resolveLcmConfig", () => {
     expect(config.leafTargetTokens).toBe(2400);
     expect(config.summaryProvider).toBe("");
     expect(config.summaryModel).toBe("");
+    expect(config.summaryCallWindowMs).toBe(DEFAULT_SUMMARY_CALL_WINDOW_MS);
+    expect(config.summaryMaxCallsPerWindow).toBe(DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW);
+    expect(config.summarySpendBackoffMs).toBe(DEFAULT_SUMMARY_SPEND_BACKOFF_MS);
     expect(config.pruneHeartbeatOk).toBe(false);
     expect(config.transcriptGcEnabled).toBe(false);
     expect(config.proactiveThresholdCompactionMode).toBe("deferred");
@@ -84,6 +90,9 @@ describe("resolveLcmConfig", () => {
       maxSweepIterations: 6,
       sweepDeadlineMs: 45000,
       compactUntilUnderDeadlineMs: 90000,
+      summaryCallWindowMs: 120000,
+      summaryMaxCallsPerWindow: 7,
+      summarySpendBackoffMs: 240000,
       ignoreSessionPatterns: ["agent:*:cron:*", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:ephemeral:**"],
       skipStatelessSessions: false,
@@ -132,6 +141,9 @@ describe("resolveLcmConfig", () => {
     expect(config.maxSweepIterations).toBe(6);
     expect(config.sweepDeadlineMs).toBe(45000);
     expect(config.compactUntilUnderDeadlineMs).toBe(90000);
+    expect(config.summaryCallWindowMs).toBe(120000);
+    expect(config.summaryMaxCallsPerWindow).toBe(7);
+    expect(config.summarySpendBackoffMs).toBe(240000);
     expect(config.leafMinFanout).toBe(4);
     expect(config.condensedMinFanout).toBe(2);
     expect(config.pruneHeartbeatOk).toBe(true);
@@ -191,6 +203,9 @@ describe("resolveLcmConfig", () => {
       LCM_MAX_SWEEP_ITERATIONS: "8",
       LCM_SWEEP_DEADLINE_MS: "90000",
       LCM_COMPACT_UNTIL_UNDER_DEADLINE_MS: "150000",
+      LCM_SUMMARY_CALL_WINDOW_MS: "180000",
+      LCM_SUMMARY_MAX_CALLS_PER_WINDOW: "9",
+      LCM_SUMMARY_SPEND_BACKOFF_MS: "360000",
     } as NodeJS.ProcessEnv;
     const pluginConfig = {
       contextThreshold: 0.5,
@@ -203,6 +218,9 @@ describe("resolveLcmConfig", () => {
       maxSweepIterations: 4,
       sweepDeadlineMs: 30000,
       compactUntilUnderDeadlineMs: 60000,
+      summaryCallWindowMs: 120000,
+      summaryMaxCallsPerWindow: 7,
+      summarySpendBackoffMs: 240000,
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
@@ -260,6 +278,9 @@ describe("resolveLcmConfig", () => {
     expect(config.maxSweepIterations).toBe(8); // env wins
     expect(config.sweepDeadlineMs).toBe(90000); // env wins
     expect(config.compactUntilUnderDeadlineMs).toBe(150000); // env wins
+    expect(config.summaryCallWindowMs).toBe(180000); // env wins
+    expect(config.summaryMaxCallsPerWindow).toBe(9); // env wins
+    expect(config.summarySpendBackoffMs).toBe(360000); // env wins
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
       cacheTTLSeconds: 600,
@@ -786,6 +807,18 @@ describe("resolveLcmConfig", () => {
   it("ships a manifest with schema entries for runtime-only toggles and model overrides", () => {
     expect(manifest.configSchema.properties.largeFileSummaryModel).toEqual({ type: "string" });
     expect(manifest.configSchema.properties.largeFileSummaryProvider).toEqual({ type: "string" });
+    expect(manifest.configSchema.properties.summaryCallWindowMs).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(manifest.configSchema.properties.summaryMaxCallsPerWindow).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(manifest.configSchema.properties.summarySpendBackoffMs).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
     expect(manifest.configSchema.properties.timezone).toEqual({ type: "string" });
     expect(manifest.configSchema.properties.pruneHeartbeatOk).toEqual({ type: "boolean" });
   });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -10,7 +10,7 @@ import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateTokens } from "../src/estimate-tokens.js";
-import { LcmProviderAuthError } from "../src/summarize.js";
+import { LcmProviderAuthError, LcmSummarySpendLimitError } from "../src/summarize.js";
 import {
   createDelegatedExpansionGrant,
   getRuntimeExpansionAuthManager,
@@ -4308,6 +4308,91 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(secondRotate.kind).toBe("unavailable");
     expect(secondRotate.reason).toContain("summary provider circuit breaker is open");
     expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("scopes rotate summarization spend guards per session", async () => {
+    const complete = vi.fn(async () => ({
+      content: [{ type: "text", text: "rotate summary" }],
+    }));
+    const engine = createEngineWithDeps(
+      {
+        summaryProvider: "test-provider",
+        summaryModel: "test-model",
+        freshTailCount: 2,
+        leafChunkTokens: 1,
+        leafMinFanout: 1,
+        summaryMaxCallsPerWindow: 1,
+        summaryCallWindowMs: 10 * 60 * 1000,
+        summarySpendBackoffMs: 30 * 60 * 1000,
+      },
+      { complete },
+    );
+
+    for (const suffix of ["one", "two"]) {
+      const sessionFile = createSessionFilePath(`lcm-rotate-spend-scope-${suffix}`);
+      const sessionKey = `agent:main:rotate-spend-scope-${suffix}`;
+      const sessionId = `rotate-spend-scope-${suffix}-session`;
+      const sm = SessionManager.open(sessionFile);
+      for (const message of [
+        { role: "user", content: [{ type: "text", text: `older detail ${suffix}` }] },
+        { role: "assistant", content: [{ type: "text", text: `tail assistant ${suffix}` }] },
+        { role: "user", content: [{ type: "text", text: `tail user ${suffix}` }] },
+      ] as AgentMessage[]) {
+        sm.appendMessage(message);
+      }
+
+      await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+
+      const rotate = await engine.rotateSessionStorage({
+        sessionId,
+        sessionKey,
+        sessionFile,
+      });
+      expect(rotate).toMatchObject({ kind: "rotated" });
+    }
+
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns rotate unavailable when summarization spend backoff opens", async () => {
+    const sessionFile = createSessionFilePath("lcm-rotate-storage-spend-backoff");
+    const sessionKey = "agent:main:rotate-spend-backoff";
+    const sessionId = "rotate-spend-backoff-session";
+    const sm = SessionManager.open(sessionFile);
+    for (const message of [
+      { role: "user", content: [{ type: "text", text: "older detail before rotate" }] },
+      { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
+      { role: "user", content: [{ type: "text", text: "tail user" }] },
+    ] as AgentMessage[]) {
+      sm.appendMessage(message);
+    }
+
+    const engine = createEngineWithConfig({
+      freshTailCount: 2,
+      leafChunkTokens: 1,
+      leafMinFanout: 1,
+    });
+    const privateEngine = engine as unknown as {
+      compaction: {
+        compactLeaf: (input: unknown) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "compactLeaf").mockRejectedValue(
+      new LcmSummarySpendLimitError({
+        scopeKey: "compaction:rotate-spend-backoff-session",
+        backoffUntil: new Date("2026-05-31T13:00:00.000Z"),
+      }),
+    );
+
+    await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+
+    const rotate = await engine.rotateSessionStorage({
+      sessionId,
+      sessionKey,
+      sessionFile,
+    });
+    expect(rotate.kind).toBe("unavailable");
+    expect(rotate.reason).toContain("summary spend backoff is open");
   });
 
   it("reconciles unimported transcript messages before rotate summary coverage", async () => {
@@ -12264,8 +12349,127 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getConversationCompactionMaintenance(conversation.conversationId);
     expect(maintenance?.pending).toBe(true);
     expect(maintenance?.running).toBe(false);
+    expect(maintenance?.retryAttempts).toBe(0);
+    expect(maintenance?.nextAttemptAfter).toBeNull();
     expect(result.changed).toBe(false);
     expect(result.reason).toBe("provider auth failure");
+  });
+
+  it("maintain() keeps threshold debt pending when the auth circuit breaker is open", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-deferred-compaction-circuit-open";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 3_500,
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine, "executeCompactionCore").mockResolvedValue({
+      ok: true,
+      compacted: false,
+      reason: "circuit breaker open",
+    });
+
+    const result = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-compaction-circuit-open"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 4_096,
+        currentTokenCount: 3_500,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.lastFailureSummary).toBe("summary provider circuit breaker is open");
+    expect(maintenance?.retryAttempts).toBe(0);
+    expect(maintenance?.nextAttemptAfter).toBeNull();
+    expect(result.changed).toBe(false);
+    expect(result.reason).toBe("circuit breaker open");
+  });
+
+  it("maintain() backs off deferred threshold debt after non-auth compaction failures", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:00:00.000Z"));
+    try {
+      const engine = createEngine();
+      const sessionId = "maintain-deferred-compaction-provider-timeout-backoff";
+      const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+        sessionKey: undefined,
+      });
+      await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        reason: "threshold",
+        tokenBudget: 4_096,
+        currentTokenCount: 3_500,
+      });
+      const privateEngine = engine as unknown as {
+        executeCompactionCore: (params: unknown) => Promise<unknown>;
+      };
+      const executeSpy = vi.spyOn(privateEngine, "executeCompactionCore");
+      executeSpy.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason: "provider timeout",
+      });
+      executeSpy.mockResolvedValueOnce({
+        ok: true,
+        compacted: true,
+        reason: "compacted",
+      });
+
+      const first = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-deferred-provider-timeout-backoff"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(first.changed).toBe(false);
+      expect(first.reason).toBe("provider timeout");
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+
+      const second = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-deferred-provider-timeout-backoff-retry"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(second.changed).toBe(false);
+      expect(second.reason).toBe("deferred compaction backoff active");
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      const third = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-deferred-provider-timeout-after-backoff"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(third.changed).toBe(true);
+      expect(third.reason).toBe("compacted");
+      expect(executeSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("maintain() keeps threshold debt pending when partial compaction remains over target", async () => {
@@ -12321,6 +12525,304 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(maintenance?.lastFailureSummary).toBe("compacted but still over target");
     expect(result.changed).toBe(true);
     expect(result.reason).toBe("compacted but still over target");
+  });
+
+  it("maintain() backs off after partial deferred compaction still exceeds target", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:10:00.000Z"));
+    try {
+      const engine = createEngine();
+      const sessionId = "maintain-deferred-partial-still-over-backoff";
+      const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+        sessionKey: undefined,
+      });
+      await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        reason: "threshold",
+        tokenBudget: 4_096,
+        currentTokenCount: 3_500,
+      });
+      const privateEngine = engine as unknown as {
+        compaction: {
+          compactFullSweep: (input: unknown) => Promise<unknown>;
+        };
+      };
+      const compactFullSweepSpy = vi
+        .spyOn(privateEngine.compaction, "compactFullSweep")
+        .mockResolvedValue({
+          actionTaken: true,
+          tokensBefore: 3_500,
+          tokensAfter: 3_200,
+          condensed: false,
+        });
+
+      const first = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-deferred-partial-over-backoff"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(first.changed).toBe(true);
+      expect(first.reason).toBe("compacted but still over target");
+      expect(compactFullSweepSpy).toHaveBeenCalledTimes(1);
+
+      const second = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-deferred-partial-over-backoff-retry"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(second.changed).toBe(false);
+      expect(second.reason).toBe("deferred compaction backoff active");
+      expect(compactFullSweepSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maintain() stops model-backed deferred compaction at the summary call cap", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:20:00.000Z"));
+    try {
+      const complete = vi.fn(async () => ({
+        content: [{ type: "text", text: "short summary" }],
+      }));
+      const engine = createEngineWithDeps(
+        {
+          summaryProvider: "anthropic",
+          summaryModel: "claude-opus-4-5",
+          summaryMaxCallsPerWindow: 1,
+          summaryCallWindowMs: 10 * 60 * 1000,
+          summarySpendBackoffMs: 20 * 60 * 1000,
+        },
+        { complete },
+      );
+      const sessionId = "maintain-summary-spend-call-cap";
+      const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+        sessionKey: undefined,
+      });
+      await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        reason: "threshold",
+        tokenBudget: 4_096,
+        currentTokenCount: 3_500,
+      });
+      const privateEngine = engine as unknown as {
+        compaction: {
+          compactFullSweep: (input: {
+            summarize: (text: string, aggressive?: boolean) => Promise<string>;
+          }) => Promise<unknown>;
+        };
+      };
+      vi.spyOn(privateEngine.compaction, "compactFullSweep").mockImplementation(async (input) => {
+        await input.summarize("first chunk ".repeat(200));
+        await input.summarize("second chunk ".repeat(200));
+        return {
+          actionTaken: true,
+          tokensBefore: 3_500,
+          tokensAfter: 2_000,
+          condensed: false,
+        };
+      });
+
+      const first = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-summary-spend-call-cap"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(first.changed).toBe(false);
+      expect(first.reason).toBe("summary spend backoff open");
+      expect(complete).toHaveBeenCalledTimes(1);
+
+      const maintenance = await engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation.conversationId);
+      expect(maintenance?.pending).toBe(true);
+      expect(maintenance?.retryAttempts).toBe(1);
+      expect(maintenance?.nextAttemptAfter?.toISOString()).toBe("2026-05-31T12:40:00.000Z");
+
+      const second = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-summary-spend-call-cap-retry"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 3_500,
+        },
+      });
+      expect(second.changed).toBe(false);
+      expect(second.reason).toBe("deferred compaction backoff active");
+      expect(complete).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("compact() is not blocked by deferred-maintenance retry backoff", async () => {
+    const engine = createEngine();
+    const sessionId = "manual-compact-ignores-maintenance-backoff";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 3_500,
+    });
+    await engine.getCompactionMaintenanceStore().markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await engine.getCompactionMaintenanceStore().markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: "provider timeout",
+      keepPending: true,
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi.spyOn(privateEngine, "executeCompactionCore").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("manual-compact-ignores-maintenance-backoff"),
+      tokenBudget: 4_096,
+      force: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("poor-reduction spend backoff blocks custom summarizers in the same compaction scope", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:35:00.000Z"));
+    try {
+      const engine = createEngineWithConfig({
+        summarySpendBackoffMs: 10 * 60 * 1000,
+      });
+      const sessionId = "custom-summarizer-poor-reduction-backoff";
+      await engine.ingest({
+        sessionId,
+        message: { role: "user", content: "custom summarize poor reduction" } as AgentMessage,
+      });
+      const summarize = vi.fn(async () => "custom summary");
+      const privateEngine = engine as unknown as {
+        compaction: {
+          compactUntilUnder: (input: {
+            summarize: (text: string, aggressive?: boolean) => Promise<string>;
+          }) => Promise<unknown>;
+        };
+      };
+      vi.spyOn(privateEngine.compaction, "compactUntilUnder").mockImplementation(async (input) => {
+        await input.summarize("source text for custom summarizer");
+        return {
+          success: false,
+          rounds: 1,
+          finalTokens: 3_500,
+        };
+      });
+
+      const first = await engine.compact({
+        sessionId,
+        sessionFile: createSessionFilePath("custom-summarizer-poor-reduction-backoff"),
+        tokenBudget: 4_096,
+        currentTokenCount: 4_096,
+        force: true,
+        legacyParams: { summarize },
+      });
+      expect(first.reason).toBe("could not reach target");
+      expect(summarize).toHaveBeenCalledTimes(1);
+
+      const second = await engine.compact({
+        sessionId,
+        sessionFile: createSessionFilePath("custom-summarizer-poor-reduction-backoff-retry"),
+        tokenBudget: 4_096,
+        currentTokenCount: 4_096,
+        force: true,
+        legacyParams: { summarize },
+      });
+      expect(second.reason).toBe("summary spend backoff open");
+      expect(summarize).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("afterTurn refreshes threshold debt while retry backoff is active without compacting", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:30:00.000Z"));
+    try {
+      const engine = createEngineWithConfig({ freshTailCount: 1 });
+      const sessionId = "after-turn-records-debt-during-backoff";
+      await seedBacklogContext(engine, sessionId, [100, 100, 100]);
+      const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+      await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+        conversationId: conversation!.conversationId,
+        reason: "threshold",
+        tokenBudget: 600,
+        currentTokenCount: 300,
+      });
+      await engine.getCompactionMaintenanceStore().markProactiveCompactionRunning({
+        conversationId: conversation!.conversationId,
+      });
+      await engine.getCompactionMaintenanceStore().markProactiveCompactionFinished({
+        conversationId: conversation!.conversationId,
+        failureSummary: "provider timeout",
+        keepPending: true,
+      });
+      const before = await engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation!.conversationId);
+      const privateEngine = engine as unknown as {
+        scheduleDeferredCompactionDebtDrain: (params: unknown) => void;
+      };
+      const scheduleSpy = vi
+        .spyOn(privateEngine, "scheduleDeferredCompactionDebtDrain")
+        .mockImplementation(() => undefined);
+      const compactSpy = vi.spyOn(engine, "compact");
+
+      await engine.afterTurn({
+        sessionId,
+        sessionFile: createSessionFilePath("after-turn-records-debt-during-backoff"),
+        messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
+        prePromptMessageCount: 0,
+        tokenBudget: 600,
+        runtimeContext: { currentTokenCount: 300 },
+      });
+
+      const after = await engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation!.conversationId);
+      expect(compactSpy).not.toHaveBeenCalled();
+      expect(scheduleSpy).toHaveBeenCalled();
+      expect(after?.pending).toBe(true);
+      expect(after?.running).toBe(false);
+      expect(after?.nextAttemptAfter?.toISOString()).toBe(
+        before?.nextAttemptAfter?.toISOString(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("assemble() leaves pending threshold debt for post-turn maintenance while under budget", async () => {
@@ -12780,6 +13282,45 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     expect(consumeSpy).toHaveBeenCalledTimes(1);
     expect(assembleResult.messages).toHaveLength(1);
+  });
+
+  it("assemble() degrades instead of spending during active deferred retry backoff", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-deferred-compaction-backoff-degrades";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 3_500,
+    });
+    await engine.getCompactionMaintenanceStore().markProactiveCompactionRunning({
+      conversationId: conversation.conversationId,
+    });
+    await engine.getCompactionMaintenanceStore().markProactiveCompactionFinished({
+      conversationId: conversation.conversationId,
+      failureSummary: "provider timeout",
+      keepPending: true,
+    });
+    const executeSpy = vi.spyOn(privateEngine, "executeCompactionCore");
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "hello ".repeat(200) })],
+      tokenBudget: 10,
+    });
+
+    expect(executeSpy).not.toHaveBeenCalled();
+    expect(assembleResult.messages).toHaveLength(1);
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(true);
   });
 
   it("maintain() uses the stricter current token budget for deferred threshold debt", async () => {
@@ -13880,6 +14421,52 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         },
       }),
     );
+  });
+
+  it("caps model-backed large-file summarization calls per spend window", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:40:00.000Z"));
+    try {
+      const completeSpy = vi.fn(async () => ({
+        content: [{ type: "text", text: "large-file summary" }],
+      }));
+      const engine = createEngineWithDeps(
+        {
+          largeFileSummaryProvider: "openai-codex",
+          largeFileSummaryModel: "gpt-5.4",
+          summaryMaxCallsPerWindow: 1,
+          summaryCallWindowMs: 1_000,
+          summarySpendBackoffMs: 30 * 60 * 1000,
+        },
+        {
+          complete: completeSpy,
+          resolveModel: vi.fn((modelRef?: string, providerHint?: string) => ({
+            provider: providerHint ?? "openai-codex",
+            model: modelRef ?? "gpt-5.4",
+          })),
+        },
+      );
+      const privateEngine = engine as unknown as {
+        resolveLargeFileTextSummarizer: (params?: {
+          conversationId?: number;
+        }) => Promise<((prompt: string) => Promise<string | null>) | undefined>;
+      };
+
+      const summarizeText = await privateEngine.resolveLargeFileTextSummarizer({
+        conversationId: 123,
+      });
+      expect(summarizeText).toBeTypeOf("function");
+
+      await expect(summarizeText!("Large file prompt 1")).resolves.toBe("large-file summary");
+      await expect(summarizeText!("Large file prompt 2")).resolves.toBeNull();
+      vi.advanceTimersByTime(1_001);
+      await expect(summarizeText!("Large file prompt 3")).resolves.toBeNull();
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      await expect(summarizeText!("Large file prompt 4")).resolves.toBe("large-file summary");
+      expect(completeSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes context-engine runtime llm and session identity to compaction summaries", async () => {

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -104,6 +104,91 @@ function seedLegacySummaryGraph(db: ReturnType<typeof getLcmConnection>): void {
 }
 
 describe("runLcmMigrations summary depth backfill", () => {
+  it("adds deferred compaction retry columns to legacy maintenance rows", () => {
+    const db = createTestDb("legacy-maintenance.db");
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE conversation_compaction_maintenance (
+        conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        pending INTEGER NOT NULL DEFAULT 0,
+        requested_at TEXT,
+        reason TEXT,
+        running INTEGER NOT NULL DEFAULT 0,
+        last_started_at TEXT,
+        last_finished_at TEXT,
+        last_failure_summary TEXT,
+        token_budget INTEGER,
+        current_token_count INTEGER,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      1,
+      "legacy-maintenance-session",
+    );
+    db.prepare(
+      `INSERT INTO conversation_compaction_maintenance (
+         conversation_id,
+         pending,
+         requested_at,
+         reason,
+         running,
+         last_failure_summary,
+         token_budget,
+         current_token_count
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      1,
+      1,
+      "2026-05-31T12:00:00.000Z",
+      "threshold",
+      0,
+      "provider timeout",
+      4096,
+      3500,
+    );
+
+    runLcmMigrations(db);
+
+    const columns = db
+      .prepare(`PRAGMA table_info(conversation_compaction_maintenance)`)
+      .all() as Array<{ name?: string }>;
+    expect(columns.some((column) => column.name === "projected_token_count")).toBe(true);
+    expect(columns.some((column) => column.name === "raw_tokens_outside_tail")).toBe(true);
+    expect(columns.some((column) => column.name === "retry_attempts")).toBe(true);
+    expect(columns.some((column) => column.name === "next_attempt_after")).toBe(true);
+
+    const row = db
+      .prepare(
+        `SELECT pending, reason, token_budget, current_token_count, retry_attempts, next_attempt_after
+         FROM conversation_compaction_maintenance
+         WHERE conversation_id = 1`,
+      )
+      .get() as {
+      pending: number;
+      reason: string;
+      token_budget: number;
+      current_token_count: number;
+      retry_attempts: number;
+      next_attempt_after: string | null;
+    };
+    expect(row).toEqual({
+      pending: 1,
+      reason: "threshold",
+      token_budget: 4096,
+      current_token_count: 3500,
+      retry_attempts: 0,
+      next_attempt_after: null,
+    });
+  });
+
   it("adds depth and metadata from summary lineage", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-migration-"));
     tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary

Issue: #74

Adds a bounded non-auth summarization spend guard for model-backed Lossless summarization:

- caps compaction and large-file summarization calls per session/window (`summaryMaxCallsPerWindow`, `summaryCallWindowMs`, `summarySpendBackoffMs`)
- throws a dedicated spend-limit error so provider fallback/retry paths do not silently keep spending once the guard opens
- backs off ineffective or failed deferred threshold compaction debt while preserving pending debt for later retry
- keeps provider auth failures on the existing auth circuit breaker path instead of double-throttling them through deferred retry backoff
- documents and schemas the new config surface

I intentionally did not use a closing keyword for #74 yet. This should be reviewed as the concrete cost-circuit-breaker fix candidate; if maintainers want a separate global cross-session limiter or ratio-threshold follow-up, #74 can either close after this merge with a split follow-up or remain open for that narrower remainder.

## Validation

Local validation from `/Volumes/LEXAR/repos/lossless-claw-issue-74-compaction-backoff`:

- `npm test -- --run test/config.test.ts test/compaction-maintenance-store.test.ts test/migration.test.ts`
- `npm test -- --run test/engine.test.ts`
- `npm run build`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`

Note: `npm exec tsc -- --noEmit` was also sampled, but this repository currently has pre-existing type-check failures unrelated to this branch, including missing `openclaw/plugin-sdk` declarations and existing test fixture type errors. The supported repo validation path above is green.
