### PR TITLE
Preserve top-level assistant reasoning content

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -283,6 +283,9 @@ function getPartMetadata(part: MessagePartRecord): {
   originalRole?: string;
   rawType?: string;
   raw?: unknown;
+  topLevelReasoningField?: string;
+  topLevelReasoningContent?: string;
+  topLevelReasoningOnly?: boolean;
 } {
   const decoded = parseJson(part.metadata);
   if (!decoded || typeof decoded !== "object") {
@@ -293,6 +296,9 @@ function getPartMetadata(part: MessagePartRecord): {
     originalRole?: unknown;
     rawType?: unknown;
     raw?: unknown;
+    topLevelReasoningField?: unknown;
+    topLevelReasoningContent?: unknown;
+    topLevelReasoningOnly?: unknown;
   };
   return {
     originalRole:
@@ -304,6 +310,20 @@ function getPartMetadata(part: MessagePartRecord): {
         ? record.rawType
         : undefined,
     raw: record.raw,
+    topLevelReasoningField:
+      typeof record.topLevelReasoningField === "string" &&
+      record.topLevelReasoningField.length > 0
+        ? record.topLevelReasoningField
+        : undefined,
+    topLevelReasoningContent:
+      typeof record.topLevelReasoningContent === "string" &&
+      record.topLevelReasoningContent.length > 0
+        ? record.topLevelReasoningContent
+        : undefined,
+    topLevelReasoningOnly:
+      typeof record.topLevelReasoningOnly === "boolean"
+        ? record.topLevelReasoningOnly
+        : undefined,
   };
 }
 
@@ -618,7 +638,8 @@ export function contentFromParts(
   role: "user" | "assistant" | "toolResult",
   fallbackContent: string,
 ): unknown {
-  if (parts.length === 0) {
+  const contentParts = parts.filter((part) => !getPartMetadata(part).topLevelReasoningOnly);
+  if (contentParts.length === 0) {
     if (role === "assistant") {
       return fallbackContent ? [{ type: "text", text: fallbackContent }] : [];
     }
@@ -628,7 +649,7 @@ export function contentFromParts(
     return fallbackContent;
   }
 
-  const blocks = parts.map(blockFromPart);
+  const blocks = contentParts.map(blockFromPart);
   if (
     role === "user" &&
     blocks.length === 1 &&
@@ -640,6 +661,20 @@ export function contentFromParts(
     return (blocks[0] as { text: string }).text;
   }
   return blocks;
+}
+
+function pickTopLevelAssistantReasoning(parts: MessagePartRecord[]): Record<string, string> {
+  for (const part of parts) {
+    const metadata = getPartMetadata(part);
+    if (
+      metadata.topLevelReasoningField === "reasoning_content" &&
+      typeof metadata.topLevelReasoningContent === "string" &&
+      metadata.topLevelReasoningContent.length > 0
+    ) {
+      return { reasoning_content: metadata.topLevelReasoningContent };
+    }
+  }
+  return {};
 }
 
 /** @internal Exported for transcript-maintenance reconstruction. */
@@ -1689,9 +1724,14 @@ export class ContextAssembler {
     const role: "user" | "assistant" | "toolResult" =
       isToolResult && !toolCallId ? "assistant" : roleFromStore;
     const content = contentFromParts(parts, role, msg.content);
+    const topLevelAssistantReasoning =
+      role === "assistant" ? pickTopLevelAssistantReasoning(parts) : {};
     const contentText =
       typeof content === "string" ? content : (JSON.stringify(content) ?? msg.content);
-    const tokenCount = estimateTokens(contentText);
+    const topLevelReasoningText = Object.values(topLevelAssistantReasoning).join("\n");
+    const tokenCount = estimateTokens(
+      [contentText, topLevelReasoningText].filter(Boolean).join("\n"),
+    );
 
     // v4.2 §B (Option C) — `messages.large_content` now stores the
     // externalized `file_xxx` id, not a content copy. When present, look
@@ -1722,6 +1762,7 @@ export class ContextAssembler {
           ? ({
               role,
               content,
+              ...topLevelAssistantReasoning,
               usage: {
                 input: 0,
                 output: tokenCount,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -819,6 +819,33 @@ function normalizeUnknownBlock(value: unknown): {
   };
 }
 
+function extractTopLevelReasoningContent(
+  role: string,
+  topLevel: Record<string, unknown>,
+): { field: "reasoning_content"; content: string } | null {
+  if (role !== "assistant") {
+    return null;
+  }
+  const content = safeString(topLevel.reasoning_content);
+  return content && content.trim().length > 0
+    ? { field: "reasoning_content", content }
+    : null;
+}
+
+function topLevelReasoningMetadata(
+  reasoning: { field: "reasoning_content"; content: string } | null,
+  only = false,
+): Record<string, unknown> {
+  if (!reasoning) {
+    return {};
+  }
+  return {
+    topLevelReasoningField: reasoning.field,
+    topLevelReasoningContent: reasoning.content,
+    topLevelReasoningOnly: only || undefined,
+  };
+}
+
 function toPartType(type: string): MessagePartType {
   switch (type) {
     case "text":
@@ -1032,6 +1059,7 @@ function buildMessageParts(params: {
   const topLevelIsError =
     safeBoolean(topLevel.isError) ??
     safeBoolean(topLevel.is_error);
+  const topLevelReasoning = extractTopLevelReasoningContent(role, topLevel);
   const rawPayloadExternalized = safeBoolean(topLevel.rawPayloadExternalized);
   const externalizedFileId = safeString(topLevel.externalizedFileId);
   const originalByteSize =
@@ -1085,6 +1113,7 @@ function buildMessageParts(params: {
           toolCallId: topLevelToolCallId,
           toolName: topLevelToolName,
           isError: topLevelIsError,
+          ...topLevelReasoningMetadata(topLevelReasoning),
           rawPayloadExternalized: rawPayloadExternalized || undefined,
           externalizedFileId,
           originalByteSize,
@@ -1105,12 +1134,26 @@ function buildMessageParts(params: {
           originalRole: role,
           source: "non-array-content",
           raw: message.content,
+          ...topLevelReasoningMetadata(topLevelReasoning),
         }),
       },
     ];
   }
 
   const parts: CreateMessagePartInput[] = [];
+  if (message.content.length === 0 && topLevelReasoning) {
+    parts.push({
+      sessionId,
+      partType: "reasoning",
+      ordinal: 0,
+      textContent: null,
+      metadata: toJson({
+        originalRole: role,
+        rawType: topLevelReasoning.field,
+        ...topLevelReasoningMetadata(topLevelReasoning, true),
+      }),
+    });
+  }
   for (let ordinal = 0; ordinal < message.content.length; ordinal++) {
     const block = normalizeUnknownBlock(message.content[ordinal]);
     const metadataRecord = block.metadata.raw as Record<string, unknown> | undefined;
@@ -1162,6 +1205,7 @@ function buildMessageParts(params: {
         toolCallId: topLevelToolCallId,
         toolName: topLevelToolName,
         isError: topLevelIsError,
+        ...(ordinal === 0 ? topLevelReasoningMetadata(topLevelReasoning) : {}),
         externalizedFileId: safeString(metadataRecord?.externalizedFileId),
         originalByteSize:
           typeof metadataRecord?.originalByteSize === "number"
@@ -1267,11 +1311,15 @@ function toStoredMessage(message: AgentMessage): StoredMessage {
           fallbackContent: content,
         })
       : estimateTokens(content);
+  const topLevelReasoning = extractTopLevelReasoningContent(
+    typeof message.role === "string" ? message.role : "",
+    message as unknown as Record<string, unknown>,
+  );
 
   return {
     role: toDbRole(message.role),
     content,
-    tokenCount,
+    tokenCount: tokenCount + (topLevelReasoning ? estimateTokens(topLevelReasoning.content) : 0),
   };
 }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9295,6 +9295,71 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(result.content).toEqual([{ type: "text", text: "/tmp/project" }]);
   });
 
+  it("preserves top-level reasoning_content for assistant tool-call replay", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+    const privateReasoning = "PRIVATE_KIMI_REASONING_CONTENT";
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        reasoning_content: privateReasoning,
+        content: [
+          {
+            type: "function_call",
+            call_id: "fc_kimi_1",
+            name: "bash",
+            arguments: '{"cmd":"pwd"}',
+          },
+        ],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "fc_kimi_1",
+        toolName: "bash",
+        content: [{ type: "function_call_output", call_id: "fc_kimi_1", output: "/tmp/project" }],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const storedMessages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const assistantParts = await engine
+      .getConversationStore()
+      .getMessageParts(storedMessages[0].messageId);
+    expect(storedMessages[0].tokenCount).toBeGreaterThanOrEqual(estimateTokens(privateReasoning));
+    expect(assistantParts.map((part) => part.partType)).toEqual(["tool"]);
+    expect(JSON.parse(assistantParts[0].metadata ?? "{}")).toMatchObject({
+      topLevelReasoningField: "reasoning_content",
+      topLevelReasoningContent: privateReasoning,
+    });
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+
+    const assistant = assembled.messages[0] as {
+      role: string;
+      reasoning_content?: string;
+      content?: Array<{ type?: string; call_id?: string; arguments?: unknown }>;
+    };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.reasoning_content).toBe(privateReasoning);
+    expect(JSON.stringify(assistant.content)).not.toContain(privateReasoning);
+    expect(assistant.content?.[0]?.type).toBe("function_call");
+    expect(assistant.content?.[0]?.call_id).toBe("fc_kimi_1");
+    expect(assistant.content?.[0]?.arguments).toBe('{"cmd":"pwd"}');
+  });
+
   it("reconstructs OpenAI reasoning and function call blocks when raw metadata is missing", async () => {
     const engine = createEngine();
     const sessionId = randomUUID();
@@ -14171,6 +14236,59 @@ describe("LcmContextEngine compaction telemetry", () => {
     const result = await engine.compact({
       sessionId,
       sessionFile: createSessionFilePath("reasoning-parts-compact"),
+      tokenBudget: 10_000,
+      force: true,
+      legacyParams: { provider: "vllm", model: "qwen3.5-122b" },
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summarizerInput).toContain("Visible assistant answer.");
+    expect(summarizerInput).not.toContain(privateReasoning);
+  });
+
+  it("does not feed top-level reasoning_content into compaction summarizer input", async () => {
+    const privateReasoning = "PRIVATE_TOP_LEVEL_REASONING_CONTENT";
+    let summarizerInput = "";
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 0,
+        leafMinFanout: 2,
+        leafChunkTokens: 1_000,
+        incrementalMaxDepth: 0,
+      },
+      {
+        complete: vi.fn(async (request) => {
+          const message = request.messages?.[0];
+          summarizerInput =
+            message && typeof message === "object" && "content" in message
+              ? String((message as { content?: unknown }).content ?? "")
+              : "";
+          return { content: [{ type: "text", text: "Safe compacted summary." }] };
+        }),
+        resolveModel: vi.fn(() => ({ provider: "vllm", model: "qwen3.5-122b" })),
+      },
+    );
+    const sessionId = randomUUID();
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        reasoning_content: privateReasoning,
+        content: [{ type: "text", text: "Visible assistant answer." }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({
+        role: "user",
+        content: `Follow-up ${"x".repeat(400)}`,
+      }),
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("top-level-reasoning-content-compact"),
       tokenBudget: 10_000,
       force: true,
       legacyParams: { provider: "vllm", model: "qwen3.5-122b" },


### PR DESCRIPTION
## Summary
- Preserve assistant top-level `reasoning_content` during ingest/replay, including tool-call-only messages.
- Restore that data as a top-level assistant field instead of converting it into visible `content` blocks.
- Keep top-level private reasoning out of compaction summarizer inputs while still accounting for it in token estimates.

Refs #488.

## Validation
- `npm test -- --run test/engine.test.ts -t 'reasoning_content|reasoning parts|OpenAI reasoning'`
- `npm test -- --run test/engine.test.ts`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`

## Review notes
- Read-only blocker sweep by subagent Bernoulli found no blockers at >=95% confidence.
