### PR TITLE
chore: add changeset for reasoning content preservation

### DIFF
--- a/.changeset/preserve-top-level-reasoning-content.md
+++ b/.changeset/preserve-top-level-reasoning-content.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve assistant top-level `reasoning_content` during LCM ingest and replay,
+including tool-call-only assistant messages from Kimi/DeepSeek-style thinking
+providers. The field is restored as top-level assistant metadata, kept out of
+visible `content` blocks and compaction summarizer input, and still included in
+token accounting.


### PR DESCRIPTION
## Summary
- Add the missing patch changeset for PR #789 / issue #488.
- Ensure the generated release PR includes the top-level `reasoning_content` preservation fix.

Refs #488.

## Validation
- `git diff --check`
- `npm pack --dry-run`
