### PR TITLE
fix: fail closed on ambiguous session rollover

### DIFF
--- a/.changeset/fail-closed-ambiguous-runtime-rollover.md
+++ b/.changeset/fail-closed-ambiguous-runtime-rollover.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fail closed when a stable session key resumes under a new runtime session and transcript while the prior tracked transcript still exists.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -114,6 +114,8 @@ type BootstrapImportObservation = {
 
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
+const AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON =
+  "ambiguous session-key runtime rollover";
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
@@ -3288,9 +3290,20 @@ function appendForkBoundedLiveSuffixWithinBudget(params: {
 
 type TranscriptReconcileResult = {
   blockedByImportCap: boolean;
-  blockedReason?: "import-cap" | "cross-conversation-raw-id" | "duplicate-transcript-replay";
+  blockedReason?:
+    | "import-cap"
+    | "cross-conversation-raw-id"
+    | "duplicate-transcript-replay"
+    | "ambiguous-session-key-runtime-rollover";
   importedMessages: number;
   hasOverlap: boolean;
+};
+
+type AmbiguousSessionKeyRuntimeRollover = {
+  conversationId: number;
+  activeSessionId: string;
+  sessionKey: string;
+  trackedSessionFile: string;
 };
 
 export class LcmContextEngine implements ContextEngine {
@@ -6677,6 +6690,41 @@ export class LcmContextEngine implements ContextEngine {
         // processed, otherwise future afterTurns will skip reconciliation
         // and we lose messages.
         const historicalMessages = await readLeafPathMessages(params.sessionFile);
+        if (reason === "path-mismatch") {
+          const ambiguousRollover =
+            await this.findAmbiguousSessionKeyRuntimeRollover({
+              phase: "afterTurn",
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              sessionFile: params.sessionFile,
+            });
+          if (ambiguousRollover) {
+            const activeBootstrapState =
+              await this.summaryStore.getConversationBootstrapState(
+                ambiguousRollover.conversationId,
+              );
+            const hasFrontierAnchor =
+              await this.transcriptContainsCurrentConversationTailAnchor({
+                conversationId: ambiguousRollover.conversationId,
+                historicalMessages,
+                checkpointEntryHash: activeBootstrapState?.lastProcessedEntryHash,
+              });
+            if (!hasFrontierAnchor) {
+              this.logAmbiguousSessionKeyRuntimeRollover({
+                phase: "afterTurn",
+                rollover: ambiguousRollover,
+                sessionId: params.sessionId,
+                sessionFile: params.sessionFile,
+              });
+              return {
+                importedMessages: 0,
+                blockedByImportCap: false,
+                blockedReason: "ambiguous-session-key-runtime-rollover",
+                hasOverlap: false,
+              };
+            }
+          }
+        }
         if (historicalMessages.length === 0) {
           if (!sessionFileState) {
             // #649 added this permissive stat-fail fallback expecting the
@@ -6919,6 +6967,111 @@ export class LcmContextEngine implements ContextEngine {
     return true;
   }
 
+  private async findAmbiguousSessionKeyRuntimeRollover(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile?: string;
+  }): Promise<AmbiguousSessionKeyRuntimeRollover | null> {
+    const normalizedSessionKey = params.sessionKey?.trim();
+    if (!normalizedSessionKey) {
+      return null;
+    }
+
+    const activeByKey = await this.conversationStore.getConversationBySessionKey(
+      normalizedSessionKey,
+    );
+    if (!activeByKey || activeByKey.sessionId === params.sessionId) {
+      return null;
+    }
+
+    const activeBootstrapState = await this.summaryStore.getConversationBootstrapState(
+      activeByKey.conversationId,
+    );
+    const trackedSessionFile = activeBootstrapState?.sessionFilePath;
+    if (typeof trackedSessionFile !== "string" || trackedSessionFile.length === 0) {
+      return null;
+    }
+
+    if (params.sessionFile !== undefined && trackedSessionFile === params.sessionFile) {
+      return null;
+    }
+
+    try {
+      await stat(trackedSessionFile);
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        this.deps.log.warn(
+          `[lcm] ${params.phase}: could not verify tracked transcript path for ambiguous runtime rollover guard conversation=${activeByKey.conversationId} file=${trackedSessionFile} error=${describeLogError(err)}`,
+        );
+      }
+      return null;
+    }
+
+    return {
+      conversationId: activeByKey.conversationId,
+      activeSessionId: activeByKey.sessionId,
+      sessionKey: normalizedSessionKey,
+      trackedSessionFile,
+    };
+  }
+
+  private logAmbiguousSessionKeyRuntimeRollover(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    rollover: AmbiguousSessionKeyRuntimeRollover;
+    sessionId: string;
+    sessionFile?: string;
+  }): void {
+    this.deps.log.warn(
+      `[lcm] ${params.phase}: ${AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON}; preserving conversation=${params.rollover.conversationId} session=${params.sessionId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} oldFile=${params.rollover.trackedSessionFile}${params.sessionFile ? ` newFile=${params.sessionFile}` : ""}`,
+    );
+  }
+
+  private async transcriptContainsCurrentConversationTailAnchor(params: {
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+    checkpointEntryHash?: string | null;
+  }): Promise<boolean> {
+    if (params.historicalMessages.length === 0) {
+      return false;
+    }
+
+    const persistedMessages = await this.conversationStore.getMessages(params.conversationId);
+    if (persistedMessages.length < 2 || !params.checkpointEntryHash) {
+      return false;
+    }
+
+    const storedHistoricalMessages = params.historicalMessages.map((message) =>
+      toStoredMessage(message),
+    );
+    const tailLength = Math.min(3, persistedMessages.length);
+    const persistedTail = persistedMessages.slice(-tailLength);
+    for (let index = tailLength - 1; index < storedHistoricalMessages.length; index += 1) {
+      if (
+        createBootstrapEntryHash(storedHistoricalMessages[index]!) !==
+        params.checkpointEntryHash
+      ) {
+        continue;
+      }
+      const historicalTail = storedHistoricalMessages.slice(index - tailLength + 1, index + 1);
+      // A single common tail like "Done" is not enough to bind a new runtime to
+      // an existing keyed conversation. Require a contiguous persisted suffix.
+      const tailsMatch = persistedTail.every((persistedMessage, tailIndex) => {
+        const historical = historicalTail[tailIndex];
+        return (
+          historical !== undefined &&
+          messageIdentity(persistedMessage.role, persistedMessage.content) ===
+            messageIdentity(historical.role, historical.content)
+        );
+      });
+      if (tailsMatch) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   async bootstrap(params: {
     sessionId: string;
     sessionFile: string;
@@ -6979,6 +7132,7 @@ export class LcmContextEngine implements ContextEngine {
               mtimeMs: sessionFileMtimeMs,
             });
           };
+          let preloadedHistoricalMessages: AgentMessage[] | undefined;
 
           await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
             phase: "bootstrap",
@@ -6986,6 +7140,39 @@ export class LcmContextEngine implements ContextEngine {
             sessionKey: params.sessionKey,
             sessionFile: params.sessionFile,
           });
+          const ambiguousRollover =
+            await this.findAmbiguousSessionKeyRuntimeRollover({
+              phase: "bootstrap",
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              sessionFile: params.sessionFile,
+            });
+          if (ambiguousRollover) {
+            preloadedHistoricalMessages = await readLeafPathMessages(params.sessionFile);
+            const activeBootstrapState =
+              await this.summaryStore.getConversationBootstrapState(
+                ambiguousRollover.conversationId,
+              );
+            const hasFrontierAnchor =
+              await this.transcriptContainsCurrentConversationTailAnchor({
+                conversationId: ambiguousRollover.conversationId,
+                historicalMessages: preloadedHistoricalMessages,
+                checkpointEntryHash: activeBootstrapState?.lastProcessedEntryHash,
+              });
+            if (!hasFrontierAnchor) {
+              this.logAmbiguousSessionKeyRuntimeRollover({
+                phase: "bootstrap",
+                rollover: ambiguousRollover,
+                sessionId: params.sessionId,
+                sessionFile: params.sessionFile,
+              });
+              return {
+                bootstrapped: false,
+                importedMessages: 0,
+                reason: AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON,
+              };
+            }
+          }
 
           const conversation = await this.conversationStore.getOrCreateConversation(params.sessionId, {
             sessionKey: params.sessionKey,
@@ -7039,7 +7226,8 @@ export class LcmContextEngine implements ContextEngine {
               await this.conversationStore.markConversationBootstrapped(conversationId);
             }
             if (parentSessionReference !== null && !bootstrapState.forkBounded) {
-              const historicalMessages = await readLeafPathMessages(params.sessionFile);
+              const historicalMessages =
+                preloadedHistoricalMessages ?? (await readLeafPathMessages(params.sessionFile));
               await persistBootstrapState(conversationId, bootstrapState.lastProcessedEntryHash, {
                 forkBounded: true,
                 forkSourceMessageCount: historicalMessages.length,
@@ -7187,7 +7375,8 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
 
-          const historicalMessages = await readLeafPathMessages(params.sessionFile);
+          const historicalMessages =
+            preloadedHistoricalMessages ?? (await readLeafPathMessages(params.sessionFile));
           this.deps.log.debug(
             `[lcm] bootstrap: full transcript read conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} historicalMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
@@ -8154,12 +8343,18 @@ export class LcmContextEngine implements ContextEngine {
     const transcriptReconcileUnsafeToAdvance =
       transcriptReconcileResult.blockedByImportCap ||
       (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
+    const transcriptReconcileBlockedByAmbiguousRollover =
+      transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover";
     let dedupedNewMessages: AgentMessage[] = [];
     if (transcriptReconcileUnsafeToAdvance) {
       if (newMessages.length > 0 || params.autoCompactionSummary) {
         this.deps.log.warn(
           `[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`,
         );
+      }
+      if (transcriptReconcileBlockedByAmbiguousRollover) {
+        await runRuntimeAutoRotate();
+        return;
       }
     } else {
       dedupedNewMessages = await this.deduplicateAfterTurnBatch(
@@ -8588,6 +8783,20 @@ export class LcmContextEngine implements ContextEngine {
         this.deps.log.debug(
           `[lcm] assemble: conversation lookup missed ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
         );
+        return safeFallback();
+      }
+      const ambiguousRollover =
+        await this.findAmbiguousSessionKeyRuntimeRollover({
+          phase: "assemble",
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+        });
+      if (ambiguousRollover) {
+        this.logAmbiguousSessionKeyRuntimeRollover({
+          phase: "assemble",
+          rollover: ambiguousRollover,
+          sessionId: params.sessionId,
+        });
         return safeFallback();
       }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11106,6 +11106,242 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(newSessionFile).size);
   });
 
+  it("bootstrap fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const firstSessionId = "bootstrap-ambiguous-rollover-old-runtime";
+    const secondSessionId = "bootstrap-ambiguous-rollover-new-runtime";
+    const sessionKey = "agent:main:test:ambiguous-runtime-rollover";
+
+    const oldSessionFile = createSessionFilePath("bootstrap-ambiguous-rollover-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old long-lived question" },
+      { role: "assistant", content: "Done" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(oldSessionFile);
+
+    const newSessionFile = createSessionFilePath("bootstrap-ambiguous-rollover-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new unrelated first turn" },
+      { role: "assistant", content: "Done" },
+    ]);
+
+    const result = await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result).toEqual({
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: "ambiguous session-key runtime rollover",
+    });
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old long-lived question",
+      "Done",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toEqual(oldCheckpoint);
+    const active = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(active?.conversationId).toBe(conversation!.conversationId);
+    expect(active?.sessionId).toBe(firstSessionId);
+    await expect(
+      engine.getConversationStore().getConversationBySessionId(secondSessionId),
+    ).resolves.toBeNull();
+  });
+
+  it("afterTurn fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluateLeafTrigger: (conversationId: number) => Promise<unknown>;
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateLeafTriggerSpy = vi.spyOn(privateEngine.compaction, "evaluateLeafTrigger").mockResolvedValue({
+      shouldCompact: false,
+      rawTokensOutsideTail: 0,
+      threshold: 20_000,
+    } as unknown as Record<string, unknown>);
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "above threshold",
+      currentTokens: 10_000,
+      threshold: 3_072,
+      projectedTokens: 10_000,
+      rawTokensOutsideTail: 6_000,
+    });
+    const firstSessionId = "after-turn-ambiguous-rollover-old-runtime";
+    const secondSessionId = "after-turn-ambiguous-rollover-new-runtime";
+    const sessionKey = "agent:main:test:after-turn-ambiguous-runtime-rollover";
+
+    const oldSessionFile = createSessionFilePath("after-turn-ambiguous-rollover-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old afterTurn long-lived question" },
+      { role: "assistant", content: "Done" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const oldCheckpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(oldCheckpoint?.sessionFilePath).toBe(oldSessionFile);
+
+    const newSessionFile = createSessionFilePath("after-turn-ambiguous-rollover-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new afterTurn unrelated first turn" },
+      { role: "assistant", content: "Done" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "Done" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover")),
+    ).toBe(true);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old afterTurn long-lived question",
+      "Done",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toEqual(oldCheckpoint);
+    const activeByKey = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeByKey?.conversationId).toBe(conversation!.conversationId);
+    expect(activeByKey?.sessionId).toBe(firstSessionId);
+    await expect(
+      engine.getConversationStore().getConversationBySessionId(secondSessionId),
+    ).resolves.toBeNull();
+    await expect(
+      engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation!.conversationId),
+    ).resolves.toBeNull();
+    expect(evaluateLeafTriggerSpy).not.toHaveBeenCalled();
+    expect(evaluateSpy).not.toHaveBeenCalled();
+  });
+
+  it("assemble falls back to live messages on ambiguous runtime rollover while the old transcript still exists", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const firstSessionId = "assemble-ambiguous-rollover-old-runtime";
+    const secondSessionId = "assemble-ambiguous-rollover-new-runtime";
+    const sessionKey = "agent:main:test:assemble-ambiguous-runtime-rollover";
+
+    const oldSessionFile = createSessionFilePath("assemble-ambiguous-rollover-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "what model produced the stale answer?" },
+      { role: "assistant", content: "openai-codex/gpt-5.5" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const originalConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(originalConversation).not.toBeNull();
+
+    const liveMessages = [makeMessage({ role: "user", content: "new live user prompt" })];
+    const assembled = await engine.assemble({
+      sessionId: secondSessionId,
+      sessionKey,
+      messages: liveMessages,
+      tokenBudget: 4_096,
+    });
+
+    expect(assembled.messages).toEqual(liveMessages);
+    expect(
+      assembled.messages.some((message) => message.content === "openai-codex/gpt-5.5"),
+    ).toBe(false);
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover")),
+    ).toBe(true);
+    const activeByKey = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeByKey?.conversationId).toBe(originalConversation!.conversationId);
+    expect(activeByKey?.sessionId).toBe(firstSessionId);
+    await expect(
+      engine.getConversationStore().getConversationBySessionId(secondSessionId),
+    ).resolves.toBeNull();
+  });
+
   it("afterTurn reconciles a path-mismatched no-anchor transcript before oversized delta dedup", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-transcript-epoch-no-anchor";


### PR DESCRIPTION
## Summary
- fail closed when a stable session key appears under a new runtime session and new transcript while the prior tracked transcript still exists
- require a contiguous persisted tail/checkpoint anchor before allowing runtime-session rollover continuity
- prevent afterTurn from writing assistant-only deltas or compaction maintenance debt into the preserved old conversation on ambiguous rollover
- add regression coverage for bootstrap, afterTurn, assemble, and common-tail messages like `Done`
- add a patch changeset

Fixes the remaining implementable P1 slice of #556.

## Validation
- `npm test -- --run test/engine.test.ts -t 'ambiguous runtime rollover'`\n- `npm test -- --run test/engine.test.ts -t 'ambiguous runtime rollover|preserves conversation history when the session file rotates across a stable sessionKey|bootstrap imports a bounded path-mismatched transcript|bootstrap imports real path-mismatched user turns|afterTurn reconciles a path-mismatched no-anchor transcript|rotates before assemble when a stable sessionKey points at a pruned transcript|deduplicates replay when runtime sessionId changes but stable sessionKey continues'`\n- `npm test -- --run test/engine.test.ts` passed 314/314; earlier full-file run had two unrelated local 5s timeout flakes that passed individually\n- `npm test` passed 1057/1061 with four unrelated local 5s timeout flakes; all four passed individually by exact test name\n- `npm run build`\n- `npm pack --dry-run`\n- `git diff --check`\n\n## Adversarial review\n- subagent review found and we fixed the common-tail bypass (`Done`)\n- subagent review found and we fixed the afterTurn compaction-maintenance write path\n- final subagent check reported no blockers for those two risks