### PR TITLE
fix: inherit summary provider for env model override

### DIFF
--- a/.changeset/summary-provider-env-model.md
+++ b/.changeset/summary-provider-env-model.md
@@ -1,0 +1,6 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Inherit the configured summary provider when `LCM_SUMMARY_MODEL` overrides the
+summary model without also setting `LCM_SUMMARY_PROVIDER`.

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1346,29 +1346,26 @@ function resolveSummaryCandidates(params: {
   };
   const nestedPluginConfig =
     runtimeConfig?.plugins?.entries?.["lossless-claw"]?.config ?? directPluginConfig;
+  const envSummaryProvider = process.env.LCM_SUMMARY_PROVIDER?.trim() ?? "";
+  const pluginSummaryProvider =
+    typeof nestedPluginConfig?.summaryProvider === "string"
+      ? nestedPluginConfig.summaryProvider.trim()
+      : "";
 
   const resolutionCandidates: SummaryResolutionCandidate[] = [
     {
       levelName: "environment variables",
       modelRef: process.env.LCM_SUMMARY_MODEL?.trim() ?? "",
-      providerHint:
-        process.env.LCM_SUMMARY_PROVIDER?.trim() ||
-        (providerHint || undefined),
-      hasExplicitProvider: Boolean(process.env.LCM_SUMMARY_PROVIDER?.trim()),
+      providerHint: envSummaryProvider || pluginSummaryProvider || (providerHint || undefined),
+      hasExplicitProvider: Boolean(envSummaryProvider || pluginSummaryProvider),
       runtimeModelOverrideField: "LCM_SUMMARY_MODEL",
       runtimeModelOverrideConfigPath: "LCM_SUMMARY_MODEL",
     },
     {
       levelName: "plugin config (lossless-claw)",
       modelRef: readModelRef(nestedPluginConfig?.summaryModel),
-      providerHint:
-        (typeof nestedPluginConfig?.summaryProvider === "string"
-          ? nestedPluginConfig.summaryProvider.trim()
-          : "") || (providerHint || undefined),
-      hasExplicitProvider: Boolean(
-        typeof nestedPluginConfig?.summaryProvider === "string" &&
-          nestedPluginConfig.summaryProvider.trim(),
-      ),
+      providerHint: pluginSummaryProvider || (providerHint || undefined),
+      hasExplicitProvider: Boolean(pluginSummaryProvider),
       runtimeModelOverrideField: "summaryModel",
       runtimeModelOverrideConfigPath: "plugins.entries.lossless-claw.config.summaryModel",
     },

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -365,6 +365,39 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(vi.mocked(deps.log.warn)).toHaveBeenCalledWith(expect.stringContaining("gpt-4o-mini"));
   });
 
+  it("env summaryModel without summaryProvider inherits plugin summaryProvider before the legacy provider hint", async () => {
+    vi.stubEnv("LCM_SUMMARY_MODEL", "gpt-5.4-mini");
+    const deps = makeDeps();
+
+    await createLcmSummarizeFromLegacyParams({
+      deps,
+      legacyParams: {
+        provider: "openrouter",
+        model: "openrouter/z-ai/glm-5.1",
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                config: {
+                  summaryProvider: "openai-codex",
+                  summaryModel: "gpt-5.4-mini",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(vi.mocked(deps.resolveModel).mock.calls[0]).toEqual([
+      "gpt-5.4-mini",
+      "openai-codex",
+    ]);
+    expect(vi.mocked(deps.log.warn)).not.toHaveBeenCalledWith(
+      expect.stringContaining("gpt-5.4-mini"),
+    );
+  });
+
   it("falls back to legacy providerHint when no summary overrides exist", async () => {
     const deps = makeDeps();
 


### PR DESCRIPTION
## Summary
- Fixes #738
- When `LCM_SUMMARY_MODEL` is set without `LCM_SUMMARY_PROVIDER`, inherit the configured plugin `summaryProvider` before falling back to the legacy/session provider hint.
- Adds a regression test covering the reported openai-codex vs openrouter precedence failure.

## Validation
- `npx vitest run test/summarize.test.ts -t "inherits plugin summaryProvider"`
- `npx vitest run test/summarize.test.ts`
- `npm run build`
