### PR TITLE
chore: backfill release audit changeset

### DIFF
--- a/.changeset/release-audit-backfill.md
+++ b/.changeset/release-audit-backfill.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Backfill release-note coverage for recent safety and reliability fixes that shipped without individual changesets.
+
+This release includes additional hardening for threshold raw-backlog projection, hot-maintenance assembly degradation, OpenClaw context-engine compatibility checks, doctor apply preflight safety, archived conversation reattachment avoidance, rotate/reconcile idempotency, and prompt-recall behavior after transcript rotation.


### PR DESCRIPTION
## Summary

- add a patch changeset that backfills release-note coverage for material fixes merged since `v0.11.3`
- leave generated files untouched so the changesets workflow updates PR #762

Closes #794.

## Validation

- `npx changeset status --since martian/main`
