### PR TITLE
fix: fail closed on compaction fallback summaries

### DIFF
--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -11,7 +11,7 @@ import type { SummaryStore, SummaryRecord, ContextItemRecord } from "./store/sum
 import { estimateTokens, truncateTextToEstimatedTokens } from "./estimate-tokens.js";
 import { extractFileIdsFromContent } from "./large-files.js";
 import { NOOP_LCM_LOGGER, type LcmLogger } from "./lcm-log.js";
-import { LcmProviderAuthError } from "./summarize.js";
+import { isLcmDeterministicFallbackSummary, LcmProviderAuthError } from "./summarize.js";
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
@@ -44,6 +44,8 @@ export interface CompactionResult {
   level?: CompactionLevel;
   /** Whether compaction was blocked by a provider auth failure */
   authFailure?: boolean;
+  /** Whether compaction was blocked by non-auth provider failure/degraded model fallback */
+  providerFailure?: boolean;
 }
 
 export interface CompactionConfig {
@@ -103,6 +105,7 @@ export interface CompactionConfig {
 }
 
 type CompactionLevel = "normal" | "aggressive" | "fallback" | "capped";
+type CompactionFailure = "auth" | "provider";
 type CompactionPass = "leaf" | "condensed";
 type CompactionSummarizeOptions = {
   previousSummary?: string;
@@ -122,6 +125,10 @@ type PassResult = {
   /** Token count of the newly created summary. */
   addedTokens: number;
 };
+type PassFailure = { failure: CompactionFailure };
+type SummaryEscalationResult =
+  | { content: string; level: CompactionLevel }
+  | PassFailure;
 type LeafChunkSelection = {
   items: ContextItemRecord[];
   rawTokensOutsideTail: number;
@@ -753,13 +760,13 @@ export class CompactionEngine {
       previousSummaryContent,
       input.summaryModel,
     );
-    if (!leafResult) {
+    if (!leafResult || "failure" in leafResult) {
       return {
         actionTaken: false,
         tokensBefore,
         tokensAfter: tokensBefore,
         condensed: false,
-        authFailure: true,
+        ...(leafResult?.failure === "provider" ? { providerFailure: true } : { authFailure: true }),
       };
     }
     // Delta tracking: compute token change from pass results instead of re-querying DB
@@ -798,7 +805,29 @@ export class CompactionEngine {
           summarize,
           input.summaryModel,
         );
-        if (!condenseResult) {
+        if (!condenseResult || "failure" in condenseResult) {
+          if (condenseResult?.failure === "provider") {
+            return {
+              actionTaken: true,
+              tokensBefore,
+              tokensAfter,
+              createdSummaryId,
+              condensed,
+              level,
+              providerFailure: true,
+            };
+          }
+          if (condenseResult?.failure === "auth") {
+            return {
+              actionTaken: true,
+              tokensBefore,
+              tokensAfter,
+              createdSummaryId,
+              condensed,
+              level,
+              authFailure: true,
+            };
+          }
           break;
         }
         const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
@@ -899,6 +928,7 @@ export class CompactionEngine {
     let previousSummaryContent: string | undefined;
     let previousTokens = tokensBefore;
     let hadAuthFailure = false;
+    let hadProviderFailure = false;
     let stoppedForNoProgress = false;
 
     // Sweep bounds: a single full sweep must not run an unbounded number of
@@ -979,8 +1009,12 @@ export class CompactionEngine {
         previousSummaryContent,
         input.summaryModel,
       );
-      if (!leafResult) {
-        hadAuthFailure = true;
+      if (!leafResult || "failure" in leafResult) {
+        if (leafResult?.failure === "provider") {
+          hadProviderFailure = true;
+        } else {
+          hadAuthFailure = true;
+        }
         break;
       }
       const passTokensAfter = passTokensBefore - leafResult.removedTokens + leafResult.addedTokens;
@@ -1022,7 +1056,13 @@ export class CompactionEngine {
       enforcePreferredDepth: boolean;
       useHardFanout: boolean;
     }): Promise<
-      "progress" | "no-candidate" | "depth-cap" | "budget" | "auth-failure" | "no-progress"
+      | "progress"
+      | "no-candidate"
+      | "depth-cap"
+      | "budget"
+      | "auth-failure"
+      | "provider-failure"
+      | "no-progress"
     > => {
       const candidate = await this.selectShallowestCondensationCandidate({
         conversationId,
@@ -1047,7 +1087,11 @@ export class CompactionEngine {
         summarize,
         input.summaryModel,
       );
-      if (!condenseResult) {
+      if (!condenseResult || "failure" in condenseResult) {
+        if (condenseResult?.failure === "provider") {
+          hadProviderFailure = true;
+          return "provider-failure";
+        }
         hadAuthFailure = true;
         return "auth-failure";
       }
@@ -1102,6 +1146,7 @@ export class CompactionEngine {
 
     while (
       !hadAuthFailure &&
+      !hadProviderFailure &&
       !stoppedForNoProgress &&
       !stoppedAtBudget &&
       await hasCondensationPressure()
@@ -1133,6 +1178,7 @@ export class CompactionEngine {
       condensed,
       level,
       ...(hadAuthFailure ? { authFailure: true } : {}),
+      ...(hadProviderFailure ? { providerFailure: true } : {}),
     };
   }
 
@@ -1146,7 +1192,13 @@ export class CompactionEngine {
     currentTokens?: number;
     summarize: CompactionSummarizeFn;
     summaryModel?: string;
-  }): Promise<{ success: boolean; rounds: number; finalTokens: number; authFailure?: boolean }> {
+  }): Promise<{
+    success: boolean;
+    rounds: number;
+    finalTokens: number;
+    authFailure?: boolean;
+    providerFailure?: boolean;
+  }> {
     return this.withContextCache(() => this._compactUntilUnderImpl(input));
   }
 
@@ -1157,7 +1209,13 @@ export class CompactionEngine {
     currentTokens?: number;
     summarize: CompactionSummarizeFn;
     summaryModel?: string;
-  }): Promise<{ success: boolean; rounds: number; finalTokens: number; authFailure?: boolean }> {
+  }): Promise<{
+    success: boolean;
+    rounds: number;
+    finalTokens: number;
+    authFailure?: boolean;
+    providerFailure?: boolean;
+  }> {
     const { conversationId, tokenBudget, summarize } = input;
     const targetTokens =
       typeof input.targetTokens === "number" &&
@@ -1224,6 +1282,14 @@ export class CompactionEngine {
           rounds: round,
           finalTokens: result.tokensAfter,
           authFailure: true,
+        };
+      }
+      if (result.providerFailure) {
+        return {
+          success: false,
+          rounds: round,
+          finalTokens: result.tokensAfter,
+          providerFailure: true,
         };
       }
 
@@ -1797,7 +1863,7 @@ export class CompactionEngine {
     options?: CompactionSummarizeOptions;
     /** Target token count for this summary kind (leaf or condensed). Used for hard-cap enforcement. */
     targetTokens: number;
-  }): Promise<{ content: string; level: CompactionLevel } | null> {
+  }): Promise<SummaryEscalationResult> {
     const sourceText = typeof params.sourceText === "string" ? params.sourceText.trim() : "";
     if (!sourceText) {
       return {
@@ -1818,10 +1884,11 @@ export class CompactionEngine {
       };
     };
     const authFailure = Symbol("authFailure");
+    const providerFailure = Symbol("providerFailure");
 
     const runSummarizer = async (
       aggressiveMode: boolean,
-    ): Promise<string | null | typeof authFailure> => {
+    ): Promise<string | null | typeof authFailure | typeof providerFailure> => {
       let output: string;
       try {
         output = await params.summarize(sourceText, aggressiveMode, params.options);
@@ -1832,12 +1899,18 @@ export class CompactionEngine {
         throw err;
       }
       const trimmed = output.trim();
+      if (isLcmDeterministicFallbackSummary(trimmed)) {
+        return providerFailure;
+      }
       return trimmed || null;
     };
 
     const initialSummary = await runSummarizer(false);
     if (initialSummary === authFailure) {
-      return null;
+      return { failure: "auth" };
+    }
+    if (initialSummary === providerFailure) {
+      return { failure: "provider" };
     }
     if (initialSummary === null) {
       // Empty provider output should still compact deterministically so a
@@ -1850,7 +1923,10 @@ export class CompactionEngine {
     if (estimateTokens(summaryText) >= inputTokens) {
       const aggressiveSummary = await runSummarizer(true);
       if (aggressiveSummary === authFailure) {
-        return null;
+        return { failure: "auth" };
+      }
+      if (aggressiveSummary === providerFailure) {
+        return { failure: "provider" };
       }
       if (aggressiveSummary === null) {
         return buildDeterministicFallback();
@@ -1977,7 +2053,11 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn,
     previousSummaryContent?: string,
     summaryModel?: string,
-  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number } | null> {
+  ): Promise<
+    | { summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number }
+    | PassFailure
+    | null
+  > {
     // Fetch full message content for each context item
     const messageContents: { messageId: number; content: string; createdAt: Date; tokenCount: number }[] =
       [];
@@ -2020,11 +2100,11 @@ export class CompactionEngine {
       },
       targetTokens: this.config.leafTargetTokens,
     });
-    if (!summary) {
+    if ("failure" in summary) {
       this.log.warn(
-        `[lcm] leaf compaction skipped summary write; conversationId=${conversationId}; chunkMessages=${messageContents.length}`,
+        `[lcm] leaf compaction skipped summary write after ${summary.failure} failure; conversationId=${conversationId}; chunkMessages=${messageContents.length}`,
       );
-      return null;
+      return summary;
     }
 
     // Persist the leaf summary
@@ -2096,7 +2176,7 @@ export class CompactionEngine {
     targetDepth: number,
     summarize: CompactionSummarizeFn,
     summaryModel?: string,
-  ): Promise<PassResult | null> {
+  ): Promise<PassResult | PassFailure | null> {
     // Fetch full summary records
     const summaryRecords: SummaryRecord[] = [];
     for (const item of summaryItems) {
@@ -2138,11 +2218,11 @@ export class CompactionEngine {
       },
       targetTokens: this.config.condensedTargetTokens,
     });
-    if (!condensed) {
+    if ("failure" in condensed) {
       this.log.warn(
-        `[lcm] condensed compaction skipped summary write; conversationId=${conversationId}; depth=${targetDepth}; chunkSummaries=${summaryRecords.length}`,
+        `[lcm] condensed compaction skipped summary write after ${condensed.failure} failure; conversationId=${conversationId}; depth=${targetDepth}; chunkSummaries=${summaryRecords.length}`,
       );
-      return null;
+      return condensed;
     }
 
     // Persist the condensed summary

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4579,7 +4579,7 @@ export class LcmContextEngine implements ContextEngine {
 
       if (sweepResult.authFailure && breakerKey) {
         this.recordCompactionAuthFailure(breakerKey);
-      } else if (sweepResult.actionTaken && breakerKey) {
+      } else if (sweepResult.actionTaken && !sweepResult.providerFailure && breakerKey) {
         this.recordCompactionSuccess(breakerKey);
       }
       if (sweepResult.actionTaken) {
@@ -4605,11 +4605,16 @@ export class LcmContextEngine implements ContextEngine {
         isThresholdSweep && sweepResult.actionTaken && !isUnderTargetAfterSweep;
       const sweepOk =
         !sweepResult.authFailure &&
+        !sweepResult.providerFailure &&
         (isUnderTargetAfterSweep || (sweepResult.actionTaken && !isThresholdSweep));
       const sweepReason = sweepResult.authFailure
         ? (sweepResult.actionTaken
             ? "provider auth failure after partial compaction"
             : "provider auth failure")
+        : sweepResult.providerFailure
+          ? (sweepResult.actionTaken
+              ? "provider failure after partial compaction"
+              : "provider failure")
         : thresholdSweepStillOverTarget
           ? "compacted but still over target"
         : sweepResult.actionTaken
@@ -4619,7 +4624,10 @@ export class LcmContextEngine implements ContextEngine {
             : manualCompactionRequested
               ? "nothing to compact"
               : "live context still exceeds target";
-      if (thresholdSweepStillOverTarget && !sweepResult.authFailure) {
+      if (
+        (thresholdSweepStillOverTarget && !sweepResult.authFailure) ||
+        sweepResult.providerFailure
+      ) {
         this.openSummarySpendBackoff({
           scopeKey: summarySpendScopeKey,
           reason: sweepReason,
@@ -4699,7 +4707,7 @@ export class LcmContextEngine implements ContextEngine {
 
     if (compactResult.authFailure && breakerKey) {
       this.recordCompactionAuthFailure(breakerKey);
-    } else if (compactResult.rounds > 0 && breakerKey) {
+    } else if (compactResult.rounds > 0 && !compactResult.providerFailure && breakerKey) {
       this.recordCompactionSuccess(breakerKey);
     }
 
@@ -4712,6 +4720,10 @@ export class LcmContextEngine implements ContextEngine {
       ? (didCompact
           ? "provider auth failure after partial compaction"
           : "provider auth failure")
+      : compactResult.providerFailure
+        ? (didCompact
+            ? "provider failure after partial compaction"
+            : "provider failure")
       : compactResult.success
         ? didCompact
           ? "compacted"
@@ -10525,6 +10537,12 @@ export class LcmContextEngine implements ContextEngine {
           return {
             kind: "unavailable",
             reason: "Lossless Claw could not summarize raw context before rotate because the summary provider rejected authentication.",
+          };
+        }
+        if (result.providerFailure) {
+          return {
+            kind: "unavailable",
+            reason: "Lossless Claw could not summarize raw context before rotate because the summary provider failed.",
           };
         }
         if (leafPasses > 0) {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1275,6 +1275,10 @@ function buildDeterministicFallbackSummary(text: string, targetTokens: number): 
   return `${summaryText}\n${fallbackNote}`;
 }
 
+export function isLcmDeterministicFallbackSummary(text: string): boolean {
+  return text.includes("[LCM fallback summary;");
+}
+
 /** Normalize model refs from string or `{ primary }` config shapes. */
 function readModelRef(value: unknown): string {
   if (typeof value === "string") {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -15222,6 +15222,49 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(compactUntilUnderSpy).not.toHaveBeenCalled();
   });
 
+  it("keeps threshold debt failed when the sweep reports provider fallback failure", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (conversationId: number, tokenBudget: number) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 380,
+      threshold: 300,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 380,
+      tokensAfter: 380,
+      condensed: false,
+      providerFailure: true,
+    });
+    const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder");
+
+    await engine.ingest({
+      sessionId: "threshold-provider-failure-session",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "threshold-provider-failure-session",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 400,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe("provider failure");
+    expect(compactUntilUnderSpy).not.toHaveBeenCalled();
+  });
+
   it("passes currentTokenCount through to compaction evaluation and loop", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1957,6 +1957,78 @@ describe("LCM integration: compaction", () => {
     expect(condensedSummaries).toHaveLength(0);
   });
 
+  it("compactLeaf preserves its leaf result when a follow-on condensed pass hits model-backed fallback", async () => {
+    const leafEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafMinFanout: 2,
+      condensedMinFanout: 2,
+      leafChunkTokens: 500,
+      condensedTargetTokens: 10,
+      incrementalMaxDepth: 1,
+    });
+
+    await convStore.createConversation({ sessionId: "incremental-depth-provider-failure" });
+
+    await sumStore.insertSummary({
+      summaryId: "sum_provider_failure_leaf_a",
+      conversationId: CONV_ID,
+      kind: "leaf",
+      depth: 0,
+      content: "Depth zero leaf A",
+      tokenCount: 60,
+    });
+    await sumStore.insertSummary({
+      summaryId: "sum_provider_failure_leaf_b",
+      conversationId: CONV_ID,
+      kind: "leaf",
+      depth: 0,
+      content: "Depth zero leaf B",
+      tokenCount: 60,
+    });
+    await sumStore.appendContextSummary(CONV_ID, "sum_provider_failure_leaf_a");
+    await sumStore.appendContextSummary(CONV_ID, "sum_provider_failure_leaf_b");
+
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Leaf source turn ${i}: ${"q".repeat(160)}`,
+      tokenCountFn: () => 120,
+    });
+
+    const summarize = vi.fn(
+      async (
+        _text: string,
+        _aggressive?: boolean,
+        options?: { isCondensed?: boolean; depth?: number },
+      ) => {
+        return options?.isCondensed
+          ? "[LCM fallback summary; truncated for context management]"
+          : "Leaf summary";
+      },
+    );
+
+    const result = await leafEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 1_200,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(result.providerFailure).toBe(true);
+    expect(result.condensed).toBe(false);
+    expect(result.level).toBe("normal");
+    expect(result.createdSummaryId).toBeDefined();
+    expect(Number.isNaN(result.tokensAfter)).toBe(false);
+
+    const condensedSummaries = sumStore._summaries.filter(
+      (summary) => summary.kind === "condensed",
+    );
+    expect(condensedSummaries).toHaveLength(0);
+    expect(
+      summarize.mock.calls.some((call) => call[2]?.isCondensed === true),
+    ).toBe(true);
+  });
+
   it("compactLeaf cascades to depth two when incrementalMaxDepth is two", async () => {
     const leafEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
@@ -3107,6 +3179,107 @@ describe("LCM integration: compaction", () => {
     expect(result.actionTaken).toBe(false);
     expect(result.level).toBeUndefined();
     expect(sumStore._summaries.find((s) => s.kind === "leaf")).toBeUndefined();
+  });
+
+  it("skips summary persistence when the model-backed summarizer exhausts providers into deterministic fallback", async () => {
+    await ingestMessages(convStore, sumStore, 8, {
+      contentFn: (i) => `Content ${i}: ${"e".repeat(200)}`,
+      tokenCountFn: (_i, content) => estimateTokens(content),
+    });
+
+    const deps = makeSummarizeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      })),
+      complete: vi.fn(async () => {
+        throw new Error("ChatGPT prolite plan, try again in 61 min");
+      }),
+    });
+    const summarizeResult = await createLcmSummarizeFromLegacyParams({
+      deps,
+      legacyParams: {
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+
+    const result = await compactionEngine.compact({
+      conversationId: CONV_ID,
+      tokenBudget: 10_000,
+      summarize: summarizeResult!.fn,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(false);
+    expect((result as { providerFailure?: boolean }).providerFailure).toBe(true);
+    expect(result.level).toBeUndefined();
+    expect(sumStore._summaries.find((s) => s.kind === "leaf")).toBeUndefined();
+
+    const contextItems = await sumStore.getContextItems(CONV_ID);
+    expect(contextItems.filter((item) => item.itemType === "summary")).toHaveLength(0);
+    expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(8);
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips condensed summary persistence when a model-backed summarizer falls back deterministically", async () => {
+    const sourceSummaries: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      await sumStore.insertSummary({
+        summaryId: `source_leaf_${i}`,
+        conversationId: CONV_ID,
+        kind: "leaf",
+        depth: 0,
+        content: `Leaf ${i}: ${"already summarized content ".repeat(80)}`,
+        tokenCount: 500,
+        descendantCount: 0,
+        descendantTokenCount: 0,
+        sourceMessageTokenCount: 500,
+      });
+      sourceSummaries.push(`source_leaf_${i}`);
+    }
+    for (const summaryId of sourceSummaries) {
+      await sumStore.appendContextSummary(CONV_ID, summaryId);
+    }
+
+    const deps = makeSummarizeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      })),
+      complete: vi.fn(async () => {
+        throw new Error("ChatGPT prolite plan, try again in 61 min");
+      }),
+    });
+    const summarizeResult = await createLcmSummarizeFromLegacyParams({
+      deps,
+      legacyParams: {
+        provider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+    const pressureEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      contextThreshold: 0.1,
+      summaryPrefixTargetTokens: 100,
+      sweepMaxDepth: 1,
+    });
+
+    const result = await pressureEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      summarize: summarizeResult!.fn,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(false);
+    expect(result.providerFailure).toBe(true);
+    expect(result.condensed).toBe(false);
+    expect(sumStore._summaries.filter((summary) => summary.kind === "condensed")).toHaveLength(0);
+
+    const contextItems = await sumStore.getContextItems(CONV_ID);
+    expect(contextItems.filter((item) => item.itemType === "summary")).toHaveLength(4);
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
   });
 
   it("compactUntilUnder loops until under budget", async () => {


### PR DESCRIPTION
## Summary
- Fixes #605
- Treat model-backed `[LCM fallback summary...]` output as a non-auth provider failure inside compaction instead of persisting it into the summary DAG.
- Propagate `providerFailure` through threshold sweeps and budget recovery so deferred debt remains pending/backed off without recording an auth failure.
- Cover both the leaf write path and the depth-1 condensed write path that caused sticky context collapse.

## Validation
- `npx vitest run test/lcm-integration.test.ts -t "model-backed summarizer|condensed summary persistence"`
- `npx vitest run test/lcm-integration.test.ts`
- `npx vitest run test/summarize.test.ts`
- `npx vitest run test/engine.test.ts -t "provider fallback failure|uses threshold target for proactive threshold compaction mode"`
- `npx vitest run test/engine.test.ts`
- `npm run build`
- `git diff --check`
