### PR TITLE
fix: preserve rotate summarizer context

### DIFF
--- a/.changeset/rotate-summary-runtime.md
+++ b/.changeset/rotate-summary-runtime.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use live runtime model context or stored compaction telemetry when rotate summarizes raw context before rewriting transcripts, avoiding emergency truncation when no explicit summary model is configured.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10457,6 +10457,8 @@ export class LcmContextEngine implements ContextEngine {
   private async compactRawContextOutsideFreshTailForRotate(params: {
     sessionId: string;
     sessionKey: string;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
   }): Promise<
     | { kind: "ready"; conversationId: number; leafPasses: number }
     | { kind: "unavailable"; reason: string }
@@ -10483,8 +10485,23 @@ export class LcmContextEngine implements ContextEngine {
       return { kind: "ready", conversationId: current.conversationId, leafPasses: 0 };
     }
 
+    const telemetry = await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+      current.conversationId,
+    );
+    const telemetryLegacyParams =
+      telemetry?.provider || telemetry?.model
+        ? {
+            ...(telemetry.provider ? { provider: telemetry.provider } : {}),
+            ...(telemetry.model ? { model: telemetry.model } : {}),
+          }
+        : undefined;
+    const legacyParams =
+      asRecord(params.runtimeContext) ?? params.legacyParams ?? telemetryLegacyParams;
     const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
-      legacyParams: this.buildSummarizerLegacyParams({ sessionKey: params.sessionKey }),
+      legacyParams: this.buildSummarizerLegacyParams({
+        legacyParams,
+        sessionKey: params.sessionKey,
+      }),
       breakerScope: this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
     });
     if (breakerKey && this.isCircuitBreakerOpen(breakerKey)) {
@@ -10602,6 +10619,8 @@ export class LcmContextEngine implements ContextEngine {
     sessionId?: string;
     sessionKey?: string;
     sessionFile: string;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
   }): Promise<RotateSessionStorageResult> {
     const sessionId = params.sessionId?.trim();
     const sessionKey = params.sessionKey?.trim();
@@ -10641,6 +10660,8 @@ export class LcmContextEngine implements ContextEngine {
         const coverage = await this.compactRawContextOutsideFreshTailForRotate({
           sessionId,
           sessionKey,
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
         });
         if (coverage.kind === "unavailable") {
           return coverage;
@@ -10730,6 +10751,8 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     sessionFile: string;
     lockTimeoutMs: number;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
   }): Promise<RotateSessionStorageWithBackupResult> {
     const sessionId = params.sessionId?.trim();
     const sessionKey = params.sessionKey?.trim();
@@ -10786,6 +10809,8 @@ export class LcmContextEngine implements ContextEngine {
         const coverage = await this.compactRawContextOutsideFreshTailForRotate({
           sessionId,
           sessionKey,
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
         });
         if (coverage.kind === "unavailable") {
           return {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -96,6 +96,7 @@ type RotateCommandEngine = {
     sessionKey?: string;
     sessionFile: string;
     lockTimeoutMs: number;
+    runtimeContext?: Record<string, unknown>;
   }): Promise<RotateSessionStorageWithBackupResult>;
 };
 
@@ -1359,11 +1360,13 @@ async function buildRotateText(params: {
 
   let result: RotateSessionStorageWithBackupResult;
   try {
+    const runtimeContext = readCommandRuntimeContext(params.ctx);
     result = await (await params.getLcm()).rotateSessionStorageWithBackup({
       sessionId,
       sessionKey,
       sessionFile: transcriptPath,
       lockTimeoutMs: ROTATE_DATABASE_LOCK_TIMEOUT_MS,
+      ...(runtimeContext ? { runtimeContext } : {}),
     });
   } catch (error) {
     lines.push(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4660,6 +4660,68 @@ describe("LcmContextEngine.bootstrap", () => {
     ]);
   });
 
+  it("uses stored compaction telemetry to summarize raw context before automatic rotate", async () => {
+    const sessionFile = createSessionFilePath("lcm-rotate-storage-telemetry-model");
+    const sessionKey = "agent:main:rotate-telemetry-model";
+    const sessionId = "rotate-storage-telemetry-model-session";
+    const transcriptMessages = [
+      { role: "user", content: [{ type: "text", text: "older fact before telemetry rotate" }] },
+      { role: "assistant", content: [{ type: "text", text: "older answer before telemetry rotate" }] },
+      { role: "user", content: [{ type: "text", text: "tail user" }] },
+      { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
+    ] as AgentMessage[];
+    const sm = SessionManager.open(sessionFile);
+    for (const message of transcriptMessages.slice(0, 2)) {
+      sm.appendMessage(message);
+    }
+
+    const complete = vi.fn(async () => ({
+      content: [{ type: "text", text: "telemetry backed summary" }],
+    }));
+    const resolveModel = vi.fn((modelRef?: string, providerHint?: string) => ({
+      provider: providerHint ?? "fallback",
+      model: modelRef ?? "fallback-model",
+    }));
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 2,
+        leafChunkTokens: 1,
+        leafMinFanout: 1,
+      },
+      {
+        complete,
+        resolveModel,
+      },
+    );
+    await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    for (const message of transcriptMessages.slice(2)) {
+      sm.appendMessage(message);
+    }
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation!.conversationId,
+      cacheState: "unknown",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    const rotate = await engine.rotateSessionStorageWithBackup({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      lockTimeoutMs: 1_000,
+    });
+
+    expect(rotate).toMatchObject({ kind: "rotated" });
+    expect(resolveModel).toHaveBeenCalledWith("gpt-5.5", "openai");
+    expect(complete).toHaveBeenCalled();
+  });
+
   it("waits for an in-flight managed transaction before backing up and rotating", async () => {
     const sessionFile = createSessionFilePath("lcm-rotate-storage-wait");
     const sessionManager = SessionManager.inMemory(process.cwd());

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -2233,6 +2233,75 @@ describe("lcm command", () => {
     });
   });
 
+  it("passes command runtime context through to rotate", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-rotate-runtime-context-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");
+    tempDirs.add(transcriptPath);
+
+    let currentConversationId = 0;
+    const mockedBackupPath = join(tmpdir(), `lcm-rotate-runtime-context-${Date.now()}.bak`);
+    tempDirs.add(mockedBackupPath);
+    writeFileSync(mockedBackupPath, "backup");
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 1,
+      backupPath: mockedBackupPath,
+      preservedTailMessageCount: 1,
+      checkpointSize: 111,
+      bytesRemoved: 222,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const fixture = createCommandFixture({
+      deps,
+      getLcm: async () => ({
+        rotateSessionStorageWithBackup,
+      }),
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "rotate-runtime-context-session",
+      sessionKey: "agent:main:main",
+    });
+    currentConversationId = currentConversation.conversationId;
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+    const runtimeContext = {
+      provider: "openai",
+      model: "gpt-5.5",
+      config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+    };
+
+    const result = await fixture.command.handler(
+      createCommandContext("rotate", {
+        sessionId: "rotate-runtime-context-session",
+        sessionKey: "agent:main:main",
+        runtimeContext,
+      }),
+    );
+
+    expect(result.text).toContain("status: rotated");
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
+      sessionId: "rotate-runtime-context-session",
+      sessionKey: "agent:main:main",
+      sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
+      runtimeContext,
+    });
+  });
+
   it("renders engine-reported rotate stats after waiting for other DB work", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-backup-fail-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");


### PR DESCRIPTION
## Summary
- pass live command runtime context into `/lossless rotate` so pre-rewrite coverage compaction can resolve the configured summarizer
- fall back to stored per-conversation compaction telemetry for automatic/runtime rotate paths that do not have a live command context
- add regression coverage for both command runtime context forwarding and telemetry-backed automatic rotate summarization

## Why
Production logs showed rotate creating emergency fallback summaries during transcript rewrite because summarizer resolution had zero candidates:

- `[lcm] createLcmSummarize: no summary model candidates resolved`
- `[lcm] resolveSummarize: FALLING BACK TO EMERGENCY TRUNCATION`

The rotate coverage path was only passing `sessionKey` into summarizer resolution, while normal compaction retained model context through runtime/legacy params. This meant installations without an explicit `summaryModel` config could rotate using truncation even though normal compaction had a working runtime model.

## Verification
- `npm test -- test/engine.test.ts test/lcm-command.test.ts`
- `npm run build`
- `env -u OPENCLAW_STATE_DIR npm test`
- `git diff --check`
- `git verify-commit HEAD`
