### PR TITLE
fix: mark emergency fallback summaries

### DIFF
--- a/.changeset/doctor-emergency-fallback.md
+++ b/.changeset/doctor-emergency-fallback.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Mark engine emergency fallback summaries with the normal fallback marker and teach `/lossless doctor` to flag legacy unmarked emergency truncation summaries for repair.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -71,8 +71,10 @@ import { buildMessageIdentityHash } from "./store/message-identity.js";
 import { FocusBriefStore, type FocusBriefRecord } from "./store/focus-brief-store.js";
 import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
 import {
+  buildDeterministicFallbackSummary,
   createLcmSummarizeFromLegacyParams,
   extractProviderAuthFailure,
+  FALLBACK_SUMMARY_MARKER,
   LcmProviderAuthError,
   LcmSummarySpendLimitError,
   type LcmSummarizeFn,
@@ -4857,7 +4859,7 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
     this.deps.log.error(`[lcm] resolveSummarize: FALLING BACK TO EMERGENCY TRUNCATION`);
-    return { summarize: createEmergencyFallbackSummarize(), summaryModel: "unknown" };
+    return { summarize: createEmergencyFallbackSummarize(), summaryModel: "emergency-fallback" };
   }
 
   /**
@@ -11070,11 +11072,14 @@ function createEmergencyFallbackSummarize(): (
   aggressive?: boolean,
 ) => Promise<string> {
   return async (text: string, aggressive?: boolean): Promise<string> => {
-    const maxChars = aggressive ? 600 * 4 : 900 * 4;
-    if (text.length <= maxChars) {
-      return text;
+    const targetTokens = aggressive ? 600 : 900;
+    const fallbackSummary = buildDeterministicFallbackSummary(text, targetTokens).trim();
+    if (!fallbackSummary) {
+      return FALLBACK_SUMMARY_MARKER;
     }
-    return text.slice(0, maxChars) + "\n[Truncated for context management]";
+    return fallbackSummary.includes(FALLBACK_SUMMARY_MARKER)
+      ? fallbackSummary
+      : `${fallbackSummary}\n${FALLBACK_SUMMARY_MARKER}`;
   };
 }
 

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -943,6 +943,7 @@ async function buildStatusText(params: {
         old: 0,
         truncated: 0,
         fallback: 0,
+        emergency: 0,
       };
     const maintenance = await getConversationCompactionMaintenanceByConversationId(
       params.db,
@@ -1087,6 +1088,7 @@ async function buildDoctorText(params: {
       buildStatLine("old-marker summaries", formatNumber(stats.old)),
       buildStatLine("truncated-marker summaries", formatNumber(stats.truncated)),
       buildStatLine("fallback-marker summaries", formatNumber(stats.fallback)),
+      buildStatLine("emergency-fallback summaries", formatNumber(stats.emergency)),
       buildStatLine("result", stats.total === 0 ? "clean" : "issues found"),
     ]),
   ];
@@ -2397,6 +2399,7 @@ async function buildDoctorApplyText(params: {
       buildStatLine("old-marker summaries", formatNumber(stats.old)),
       buildStatLine("truncated-marker summaries", formatNumber(stats.truncated)),
       buildStatLine("fallback-marker summaries", formatNumber(stats.fallback)),
+      buildStatLine("emergency-fallback summaries", formatNumber(stats.emergency)),
       buildStatLine("repaired summaries", formatNumber(result.repaired)),
       buildStatLine("unchanged summaries", formatNumber(result.unchanged)),
       buildStatLine("skipped summaries", formatNumber(result.skipped.length)),

--- a/src/plugin/lcm-doctor-shared.ts
+++ b/src/plugin/lcm-doctor-shared.ts
@@ -1,11 +1,14 @@
 import type { DatabaseSync } from "node:sqlite";
+import { FALLBACK_SUMMARY_MARKER } from "../summarize.js";
 
-export const FALLBACK_SUMMARY_MARKER = "[LCM fallback summary; truncated for context management]";
+export { FALLBACK_SUMMARY_MARKER };
 export const TRUNCATED_SUMMARY_PREFIX = "[Truncated from ";
+export const BARE_EMERGENCY_TRUNCATION_MARKER = "[Truncated for context management]";
+export const EMERGENCY_FALLBACK_MODEL = "emergency-fallback";
 export const TRUNCATED_SUMMARY_WINDOW = 40;
 export const FALLBACK_SUMMARY_WINDOW = 80;
 
-export type DoctorMarkerKind = "old" | "new" | "fallback";
+export type DoctorMarkerKind = "old" | "new" | "fallback" | "emergency";
 
 export type DoctorSummaryCandidate = {
   conversationId: number;
@@ -18,6 +21,7 @@ export type DoctorConversationCounts = {
   old: number;
   truncated: number;
   fallback: number;
+  emergency: number;
 };
 
 export type DoctorSummaryStats = {
@@ -26,6 +30,7 @@ export type DoctorSummaryStats = {
   old: number;
   truncated: number;
   fallback: number;
+  emergency: number;
   byConversation: Map<number, DoctorConversationCounts>;
 };
 
@@ -36,6 +41,7 @@ export type DoctorTargetRecord = {
   depth: number;
   tokenCount: number;
   content: string;
+  model: string;
   createdAt: string;
   childCount: number;
   markerKind: DoctorMarkerKind;
@@ -48,6 +54,7 @@ type DoctorTargetRow = {
   depth: number;
   token_count: number;
   content: string;
+  model: string;
   created_at: string;
   child_count: number | null;
 };
@@ -73,6 +80,23 @@ export function detectDoctorMarker(content: string): DoctorMarkerKind | null {
   return null;
 }
 
+function detectDoctorMarkerForRow(row: { content: string; model?: string }): DoctorMarkerKind | null {
+  const markerKind = detectDoctorMarker(row.content);
+  if (markerKind) {
+    return markerKind;
+  }
+
+  const model = row.model?.trim();
+  if (model === EMERGENCY_FALLBACK_MODEL) {
+    return "emergency";
+  }
+  if (model === "unknown" && row.content.includes(BARE_EMERGENCY_TRUNCATION_MARKER)) {
+    return "emergency";
+  }
+
+  return null;
+}
+
 /**
  * Load doctor targets for one conversation or the whole DB.
  */
@@ -89,6 +113,7 @@ export function loadDoctorTargets(
            COALESCE(s.depth, 0) AS depth,
            COALESCE(s.token_count, 0) AS token_count,
            COALESCE(s.content, '') AS content,
+           COALESCE(s.model, '') AS model,
            COALESCE(s.created_at, '') AS created_at,
            COALESCE(spc.child_count, 0) AS child_count
          FROM summaries s
@@ -99,6 +124,11 @@ export function loadDoctorTargets(
          ) spc ON spc.summary_id = s.summary_id
          WHERE INSTR(COALESCE(s.content, ''), ?) > 0
             OR INSTR(COALESCE(s.content, ''), ?) > 0
+            OR COALESCE(s.model, '') = ?
+            OR (
+              COALESCE(s.model, '') = 'unknown'
+              AND INSTR(COALESCE(s.content, ''), ?) > 0
+            )
          ORDER BY s.conversation_id ASC, COALESCE(s.depth, 0) ASC, s.created_at ASC, s.summary_id ASC`,
       )
     : db.prepare(
@@ -109,6 +139,7 @@ export function loadDoctorTargets(
            COALESCE(s.depth, 0) AS depth,
            COALESCE(s.token_count, 0) AS token_count,
            COALESCE(s.content, '') AS content,
+           COALESCE(s.model, '') AS model,
            COALESCE(s.created_at, '') AS created_at,
            COALESCE(spc.child_count, 0) AS child_count
          FROM summaries s
@@ -121,17 +152,33 @@ export function loadDoctorTargets(
            AND (
              INSTR(COALESCE(s.content, ''), ?) > 0
              OR INSTR(COALESCE(s.content, ''), ?) > 0
+             OR COALESCE(s.model, '') = ?
+             OR (
+               COALESCE(s.model, '') = 'unknown'
+               AND INSTR(COALESCE(s.content, ''), ?) > 0
+             )
            )
          ORDER BY COALESCE(s.depth, 0) ASC, s.created_at ASC, s.summary_id ASC`,
       );
 
   const rows = (conversationId === undefined
-    ? statement.all(FALLBACK_SUMMARY_MARKER, TRUNCATED_SUMMARY_PREFIX)
-    : statement.all(conversationId, FALLBACK_SUMMARY_MARKER, TRUNCATED_SUMMARY_PREFIX)) as DoctorTargetRow[];
+    ? statement.all(
+        FALLBACK_SUMMARY_MARKER,
+        TRUNCATED_SUMMARY_PREFIX,
+        EMERGENCY_FALLBACK_MODEL,
+        BARE_EMERGENCY_TRUNCATION_MARKER,
+      )
+    : statement.all(
+        conversationId,
+        FALLBACK_SUMMARY_MARKER,
+        TRUNCATED_SUMMARY_PREFIX,
+        EMERGENCY_FALLBACK_MODEL,
+        BARE_EMERGENCY_TRUNCATION_MARKER,
+      )) as DoctorTargetRow[];
 
   const targets: DoctorTargetRecord[] = [];
   for (const row of rows) {
-    const markerKind = detectDoctorMarker(row.content);
+    const markerKind = detectDoctorMarkerForRow(row);
     if (!markerKind) {
       continue;
     }
@@ -142,6 +189,7 @@ export function loadDoctorTargets(
       depth: Math.max(0, Math.floor(row.depth ?? 0)),
       tokenCount: Math.max(0, Math.floor(row.token_count ?? 0)),
       content: row.content,
+      model: row.model,
       createdAt: row.created_at,
       childCount:
         typeof row.child_count === "number" && Number.isFinite(row.child_count)
@@ -166,6 +214,7 @@ export function getDoctorSummaryStats(
   let old = 0;
   let truncated = 0;
   let fallback = 0;
+  let emergency = 0;
 
   for (const target of targets) {
     const current = byConversation.get(target.conversationId) ?? {
@@ -173,6 +222,7 @@ export function getDoctorSummaryStats(
       old: 0,
       truncated: 0,
       fallback: 0,
+      emergency: 0,
     };
     current.total += 1;
 
@@ -188,6 +238,10 @@ export function getDoctorSummaryStats(
       case "fallback":
         fallback += 1;
         current.fallback += 1;
+        break;
+      case "emergency":
+        emergency += 1;
+        current.emergency += 1;
         break;
     }
 
@@ -205,6 +259,7 @@ export function getDoctorSummaryStats(
     old,
     truncated,
     fallback,
+    emergency,
     byConversation,
   };
 }

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -78,6 +78,7 @@ type SummaryMode = "normal" | "aggressive";
 
 const DEFAULT_LEAF_TARGET_TOKENS = 2400;
 const DEFAULT_CONDENSED_TARGET_TOKENS = 2000;
+export const FALLBACK_SUMMARY_MARKER = "[LCM fallback summary; truncated for context management]";
 const FALLBACK_DIRECTIVE_OMISSION =
   "[LCM fallback summary omitted directive-shaped untrusted content].";
 const FALLBACK_DIRECTIVE_SHAPED_PATTERN = new RegExp(
@@ -1249,7 +1250,7 @@ function sanitizeDeterministicFallbackText(text: string): {
  * Keeps compaction progress monotonic instead of throwing and aborting the
  * whole compaction pass.
  */
-function buildDeterministicFallbackSummary(text: string, targetTokens: number): string {
+export function buildDeterministicFallbackSummary(text: string, targetTokens: number): string {
   if (typeof text !== "string") return "";
   const trimmed = text.trim();
   if (!trimmed) {
@@ -1260,7 +1261,7 @@ function buildDeterministicFallbackSummary(text: string, targetTokens: number): 
     sanitizeDeterministicFallbackText(trimmed);
   const fallbackNote = omittedDirectiveShapedContent
     ? "[LCM fallback summary; directive-shaped untrusted content omitted]"
-    : "[LCM fallback summary; truncated for context management]";
+    : FALLBACK_SUMMARY_MARKER;
   if (!sanitizedText) {
     return fallbackNote;
   }

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1157,6 +1157,15 @@ describe("lcm command", () => {
       tokenCount: 11,
     });
     await fixture.summaryStore.insertSummary({
+      summaryId: "sum_current_emergency",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `raw transcript fallback\n${"[Truncated for context management]"}`,
+      tokenCount: 12,
+      model: "unknown",
+    });
+    await fixture.summaryStore.insertSummary({
       summaryId: "sum_other_new",
       conversationId: otherConversation.conversationId,
       kind: "leaf",
@@ -1174,11 +1183,12 @@ describe("lcm command", () => {
     expect(result.text).toContain("🩺 Lossless Claw Doctor");
     expect(result.text).toContain(`conversation id: ${currentConversation.conversationId}`);
     expect(result.text).toContain("scope: this conversation only");
-    expect(result.text).toContain("detected summaries: 2");
+    expect(result.text).toContain("detected summaries: 3");
     expect(result.text).toContain("old-marker summaries: 1");
     expect(result.text).toContain("truncated-marker summaries: 1");
+    expect(result.text).toContain("emergency-fallback summaries: 1");
     expect(result.text).toContain("result: issues found");
-    expect(result.text).toContain("sum_current_new (new), sum_current_old (old)");
+    expect(result.text).toContain("sum_current_emergency (emergency), sum_current_new (new), sum_current_old (old)");
     expect(result.text).toContain("**🛠️ Next step**");
     expect(result.text).toContain("`/lossless doctor apply` repairs these in place for the current conversation.");
     expect(result.text).not.toContain("sum_other_new");
@@ -1208,6 +1218,15 @@ describe("lcm command", () => {
       tokenCount: 9,
     });
     await fixture.summaryStore.insertSummary({
+      summaryId: "sum_unknown_clean",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "healthy custom summarizer output",
+      tokenCount: 8,
+      model: "unknown",
+    });
+    await fixture.summaryStore.insertSummary({
       summaryId: "sum_dirty",
       conversationId: otherConversation.conversationId,
       kind: "leaf",
@@ -1229,6 +1248,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("result: clean");
     expect(result.text).not.toContain("🧷 Affected summaries");
     expect(result.text).not.toContain("sum_dirty");
+    expect(result.text).not.toContain("sum_unknown_clean");
   });
 
   it("reports doctor as unavailable when the current conversation cannot be resolved", async () => {
@@ -1913,7 +1933,7 @@ describe("lcm command", () => {
       sessionId: "doctor-apply-current",
       sessionKey: "agent:main:telegram:direct:doctor-apply-current",
     });
-    const [firstMessage, secondMessage] = await fixture.conversationStore.createMessagesBulk([
+    const [firstMessage, secondMessage, thirdMessage] = await fixture.conversationStore.createMessagesBulk([
       {
         conversationId: currentConversation.conversationId,
         seq: 0,
@@ -1927,6 +1947,13 @@ describe("lcm command", () => {
         role: "assistant",
         content: "second broken message",
         tokenCount: 7,
+      },
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 2,
+        role: "user",
+        content: "third emergency fallback source",
+        tokenCount: 8,
       },
     ]);
 
@@ -1943,6 +1970,17 @@ describe("lcm command", () => {
       firstMessage.messageId,
       secondMessage.messageId,
     ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_emergency_fix",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `raw emergency fallback\n${"[Truncated for context management]"}`,
+      tokenCount: 10,
+      sourceMessageTokenCount: 8,
+      model: "unknown",
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_emergency_fix", [thirdMessage.messageId]);
 
     await fixture.summaryStore.insertSummary({
       summaryId: "sum_parent_fix",
@@ -1961,15 +1999,19 @@ describe("lcm command", () => {
     );
 
     const repairedLeaf = await fixture.summaryStore.getSummary("sum_leaf_fix");
+    const repairedEmergency = await fixture.summaryStore.getSummary("sum_emergency_fix");
     const repairedParent = await fixture.summaryStore.getSummary("sum_parent_fix");
 
-    expect(result.text).toContain("detected summaries: 2");
-    expect(result.text).toContain("repaired summaries: 2");
-    expect(result.text).toContain("result: repaired 2 summary(s) in place");
-    expect(result.text).toContain("sum_leaf_fix, sum_parent_fix");
-    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(result.text).toContain("detected summaries: 3");
+    expect(result.text).toContain("emergency-fallback summaries: 1");
+    expect(result.text).toContain("repaired summaries: 3");
+    expect(result.text).toContain("result: repaired 3 summary(s) in place");
+    expect(result.text).toContain("sum_emergency_fix, sum_leaf_fix, sum_parent_fix");
+    expect(summarize).toHaveBeenCalledTimes(3);
     expect(repairedLeaf?.content).toContain("LEAF REPAIR");
     expect(repairedLeaf?.content).not.toContain("[Truncated from");
+    expect(repairedEmergency?.content).toContain("LEAF REPAIR");
+    expect(repairedEmergency?.content).not.toContain("[Truncated for context management]");
     expect(repairedParent?.content).toContain("CONDENSED REPAIR");
     expect(repairedParent?.content).toContain("LEAF REPAIR");
     expect(repairedParent?.content).not.toContain("[LCM fallback summary");


### PR DESCRIPTION
## Summary
- mark engine emergency fallback summaries with the standard fallback marker and `emergency-fallback` model label
- teach `/lossless doctor` and `doctor apply` to detect legacy unmarked emergency truncation rows
- add regression coverage that unknown-model custom summaries stay clean while emergency fallback summaries are repairable

## Verification
- `npm test -- test/lcm-command.test.ts test/summarize.test.ts`
- `npm run build`
- `env -u OPENCLAW_STATE_DIR npm test`
- `git diff --check`
- `git verify-commit HEAD`