### PR TITLE
fix(transcript-repair): dedupe duplicate assistant tool_use blocks at assemble time

### DIFF
--- a/.changeset/dedupe-assistant-tool-use.md
+++ b/.changeset/dedupe-assistant-tool-use.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Sanitize duplicate assistant tool-use blocks during context assembly so replayed history cannot produce provider-invalid tool call payloads.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -14,6 +14,7 @@ import { formatToolOutputReference } from "./large-files.js";
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type AssemblySegment = "evictable" | "freshTail";
 type FocusBriefLookup = Pick<FocusBriefStore, "getActiveFocusBrief">;
+type RepairLogger = { warn: (message: string) => void };
 
 export interface AssemblyOverflowContributor {
   /** Context item ordinal in the persisted conversation window. */
@@ -1336,6 +1337,7 @@ export class ContextAssembler {
     private summaryStore: SummaryStore,
     private timezone?: string,
     private focusBriefStore?: FocusBriefLookup,
+    private log?: RepairLogger,
   ) {}
 
   /**
@@ -1561,7 +1563,7 @@ export class ContextAssembler {
     const preSanitizeFreshTailMessages = cleanedEntries
       .filter((entry) => entry.segment === "freshTail")
       .map((entry) => entry.message);
-    const repaired = sanitizeToolUseResultPairing(cleaned) as AgentMessage[];
+    const repaired = sanitizeToolUseResultPairing(cleaned, this.log) as AgentMessage[];
     return {
       messages: repaired,
       estimatedTokens,

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -184,6 +184,32 @@ function freshTailProtectionMessageHashes(messages: AgentMessage[]): string[] {
   return hashes;
 }
 
+const FRESH_TAIL_PROTECTION_MARKER = Symbol("freshTailProtection");
+
+type FreshTailProtectionMarkedMessage = AgentMessage & {
+  [FRESH_TAIL_PROTECTION_MARKER]?: true;
+};
+
+function repairedFreshTailProtectionMessageHashes(
+  entries: Array<{ message: AgentMessage; segment: AssemblySegment }>
+): string[] {
+  const markedMessages = entries.map((entry): FreshTailProtectionMarkedMessage => {
+    if (entry.segment !== "freshTail") {
+      return entry.message as FreshTailProtectionMarkedMessage;
+    }
+    return {
+      ...entry.message,
+      [FRESH_TAIL_PROTECTION_MARKER]: true,
+    } as FreshTailProtectionMarkedMessage;
+  });
+  const repaired = sanitizeToolUseResultPairing(
+    markedMessages
+  ) as FreshTailProtectionMarkedMessage[];
+  return repaired
+    .filter((message) => message[FRESH_TAIL_PROTECTION_MARKER])
+    .map((message) => hashMessages([message]));
+}
+
 // ── Public types ─────────────────────────────────────────────────────────────
 
 export interface AssembleContextInput {
@@ -1564,6 +1590,10 @@ export class ContextAssembler {
       .filter((entry) => entry.segment === "freshTail")
       .map((entry) => entry.message);
     const repaired = sanitizeToolUseResultPairing(cleaned, this.log) as AgentMessage[];
+    const protectionHashes = new Set([
+      ...freshTailProtectionMessageHashes(preSanitizeFreshTailMessages),
+      ...repairedFreshTailProtectionMessageHashes(cleanedEntries),
+    ]);
     return {
       messages: repaired,
       estimatedTokens,
@@ -1592,9 +1622,7 @@ export class ContextAssembler {
         preSanitizeFreshTailMessageHashes: preSanitizeFreshTailMessages.map((message) =>
           hashMessages([message]),
         ),
-        freshTailProtectionMessageHashes: freshTailProtectionMessageHashes(
-          preSanitizeFreshTailMessages,
-        ),
+        freshTailProtectionMessageHashes: [...protectionHashes],
         preSanitizeMessagesHash: hashMessages(cleaned as AgentMessage[]),
         finalMessagesHash: hashMessages(repaired),
         overflowDiagnostics,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -89,6 +89,7 @@ import {
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
+type RepairLogger = { warn: (message: string) => void };
 
 const LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
   "bootstrap",
@@ -2731,6 +2732,7 @@ function buildVolatileLiveInputMergedOutput(params: {
   retained: RetainedAssembledEntry[];
   appendedEntries: VolatileLiveInputEntry[];
   liveSortIndexes: Map<number, number>;
+  log?: RepairLogger;
 }): AgentMessage[] {
   const output: AgentMessage[] = [];
   const appendedEntries = params.appendedEntries
@@ -2754,7 +2756,7 @@ function buildVolatileLiveInputMergedOutput(params: {
     output.push((appendedEntries[appendedCursor] as VolatileLiveInputEntry).message);
     appendedCursor++;
   }
-  return sanitizeToolUseResultPairing(output) as AgentMessage[];
+  return sanitizeToolUseResultPairing(output, params.log) as AgentMessage[];
 }
 
 function matchVolatileLiveInputsToCoverageSlots(params: {
@@ -2930,6 +2932,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
   liveMessages: AgentMessage[];
   protectedAssembledIndexes?: Set<number>;
   tokenBudget: number;
+  log?: RepairLogger;
 }): {
   messages: AgentMessage[];
   estimatedTokens: number;
@@ -2984,6 +2987,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
     retained,
     appendedEntries,
     liveSortIndexes,
+    log: params.log,
   });
   let estimatedTokens = estimateAgentMessageTokens(output);
 
@@ -3022,6 +3026,7 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
         retained: candidateRetained,
         appendedEntries: candidateAppendedEntries,
         liveSortIndexes,
+        log: params.log,
       });
       const candidateEstimatedTokens = estimateAgentMessageTokens(candidateOutput);
       const candidateFits = candidateEstimatedTokens <= params.tokenBudget;
@@ -3491,6 +3496,7 @@ export class LcmContextEngine implements ContextEngine {
       this.summaryStore,
       this.config.timezone,
       this.focusBriefStore,
+      this.deps.log,
     );
 
     const compactionConfig: CompactionConfig = {
@@ -9054,6 +9060,7 @@ export class LcmContextEngine implements ContextEngine {
         liveMessages: params.messages,
         protectedAssembledIndexes,
         tokenBudget,
+        log: this.deps.log,
       });
       if (
         budgetedPromptRecallCue &&
@@ -9079,6 +9086,7 @@ export class LcmContextEngine implements ContextEngine {
           liveMessages: params.messages,
           protectedAssembledIndexes,
           tokenBudget,
+          log: this.deps.log,
         });
       }
       if (volatileLiveInputAppend.appendedMessages > 0) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2987,7 +2987,6 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
     retained,
     appendedEntries,
     liveSortIndexes,
-    log: params.log,
   });
   let estimatedTokens = estimateAgentMessageTokens(output);
 
@@ -3026,7 +3025,6 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
         retained: candidateRetained,
         appendedEntries: candidateAppendedEntries,
         liveSortIndexes,
-        log: params.log,
       });
       const candidateEstimatedTokens = estimateAgentMessageTokens(candidateOutput);
       const candidateFits = candidateEstimatedTokens <= params.tokenBudget;
@@ -3066,6 +3064,13 @@ function appendUncoveredVolatileLiveInputsWithinBudget(params: {
     output = bestCandidate.output;
     estimatedTokens = bestCandidate.estimatedTokens;
   }
+  output = buildVolatileLiveInputMergedOutput({
+    retained,
+    appendedEntries,
+    liveSortIndexes,
+    log: params.log,
+  });
+  estimatedTokens = estimateAgentMessageTokens(output);
   const appendedMessages = materializeVolatileLiveInputEntries(appendedEntries);
 
   return {

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -16,6 +16,7 @@ type AgentMessageLike = {
   toolUseId?: string;
   toolName?: string;
   stopReason?: string;
+  stop_reason?: string;
   isError?: boolean;
   timestamp?: number;
 };
@@ -26,6 +27,8 @@ type ToolCallLike = {
 };
 
 type WarnLogger = { warn: (message: string) => void };
+type ToolUseDropReason = "duplicate" | "terminal";
+type DroppedToolUse = ToolCallLike & { reason: ToolUseDropReason };
 
 // -- Extraction helpers (from tool-call-id.ts) --
 
@@ -150,6 +153,46 @@ function extractToolResultId(msg: AgentMessageLike): string | null {
   return null;
 }
 
+function getTerminalStopReason(msg: AgentMessageLike): "error" | "aborted" | null {
+  const stopReason =
+    typeof msg.stopReason === "string"
+      ? msg.stopReason
+      : typeof msg.stop_reason === "string"
+        ? msg.stop_reason
+        : undefined;
+  return stopReason === "error" || stopReason === "aborted" ? stopReason : null;
+}
+
+function isThinkingLikeBlock(block: unknown): boolean {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    ["thinking", "redacted_thinking", "reasoning"].includes(
+      String((block as { type?: unknown }).type ?? "")
+    )
+  );
+}
+
+function isBlankTextBlock(block: unknown): boolean {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string" &&
+    !(block as { text: string }).text.trim()
+  );
+}
+
+function isEmptyAfterToolUseDrop(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return (
+    content.length === 0 ||
+    content.every((block) => isThinkingLikeBlock(block) || isBlankTextBlock(block))
+  );
+}
+
 /**
  * Remove duplicate assistant `tool_use` blocks during assembly.
  *
@@ -169,13 +212,13 @@ function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
   msg: T,
   seenToolUseIds: Set<string>,
   options: { dropAll?: boolean; record?: boolean } = {}
-): { message: T; dropped: ToolCallLike[] } {
+): { message: T; dropped: DroppedToolUse[] } {
   const { dropAll = false, record = true } = options;
   const content = msg.content;
   if (!Array.isArray(content)) {
     return { message: msg, dropped: [] };
   }
-  const dropped: ToolCallLike[] = [];
+  const dropped: DroppedToolUse[] = [];
   const kept: unknown[] = [];
   for (const block of content) {
     if (block && typeof block === "object") {
@@ -193,6 +236,7 @@ function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
           dropped.push({
             id,
             name: typeof rec.name === "string" ? rec.name : undefined,
+            reason: dropAll ? "terminal" : "duplicate",
           });
           continue;
         }
@@ -248,9 +292,20 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
   const seenToolUseIds = new Set<string>();
   let droppedDuplicateCount = 0;
   let droppedDuplicateAssistantToolUseCount = 0;
+  let droppedTerminalAssistantToolUseCount = 0;
   let droppedOrphanCount = 0;
   let moved = false;
   let changed = false;
+
+  const recordAssistantToolUseDrops = (dropped: DroppedToolUse[]) => {
+    for (const drop of dropped) {
+      if (drop.reason === "terminal") {
+        droppedTerminalAssistantToolUseCount += 1;
+      } else {
+        droppedDuplicateAssistantToolUseCount += 1;
+      }
+    }
+  };
 
   const pushToolResult = (msg: T) => {
     const id = extractToolResultId(msg);
@@ -290,8 +345,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
 
     // Drop duplicate assistant tool_use blocks (keep-first). Two assistant
     // tool_use blocks sharing an id cause the Anthropic API to reject the turn.
-    const stopReason = normalizedAssistant.stopReason;
-    const terminal = stopReason === "error" || stopReason === "aborted";
+    const terminal = getTerminalStopReason(normalizedAssistant) !== null;
     const deduped = filterAssistantToolUseBlocks(
       normalizedAssistant,
       seenToolUseIds,
@@ -302,11 +356,8 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     const assistantMsg = deduped.message;
     if (deduped.dropped.length > 0) {
       changed = true;
-      droppedDuplicateAssistantToolUseCount += deduped.dropped.length;
-      const remaining = Array.isArray(assistantMsg.content)
-        ? assistantMsg.content
-        : [];
-      if (remaining.length === 0) {
+      recordAssistantToolUseDrops(deduped.dropped);
+      if (isEmptyAfterToolUseDrop(assistantMsg.content)) {
         // Nothing left after removing duplicate tool_use blocks; drop the message.
         continue;
       }
@@ -341,13 +392,27 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
 
       const nextRole = next.role;
       if (nextRole === "assistant") {
-        const nextToolCalls = extractToolCallsFromAssistant(
-          normalizeAssistantReasoningBlocks(next)
+        const normalizedNext = normalizeAssistantReasoningBlocks(next);
+        const nextTerminal = getTerminalStopReason(normalizedNext) !== null;
+        const preview = filterAssistantToolUseBlocks(
+          normalizedNext,
+          new Set(seenToolUseIds),
+          nextTerminal ? { dropAll: true, record: false } : {}
         );
+        const nextToolCalls = nextTerminal
+          ? []
+          : extractToolCallsFromAssistant(preview.message);
         if (nextToolCalls.length > 0) {
           break;
         }
-        remainder.push(next);
+        if (preview.dropped.length > 0) {
+          changed = true;
+          recordAssistantToolUseDrops(preview.dropped);
+          if (isEmptyAfterToolUseDrop(preview.message.content)) {
+            continue;
+          }
+        }
+        remainder.push(preview.message as T);
         continue;
       }
 
@@ -402,6 +467,11 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
   if (droppedDuplicateAssistantToolUseCount > 0 && log) {
     log.warn(
       `[lossless-claw] sanitizeToolUseResultPairing dropped ${droppedDuplicateAssistantToolUseCount} duplicate assistant tool_use block(s)`
+    );
+  }
+  if (droppedTerminalAssistantToolUseCount > 0 && log) {
+    log.warn(
+      `[lossless-claw] sanitizeToolUseResultPairing stripped ${droppedTerminalAssistantToolUseCount} non-pairable terminal assistant tool_use block(s)`
     );
   }
 

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -290,6 +290,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
   const out: T[] = [];
   const seenToolResultIds = new Set<string>();
   const seenToolUseIds = new Set<string>();
+  const movedToolResultIndexes = new Set<number>();
   let droppedDuplicateCount = 0;
   let droppedDuplicateAssistantToolUseCount = 0;
   let droppedTerminalAssistantToolUseCount = 0;
@@ -322,6 +323,9 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
 
   for (let i = 0; i < messages.length; i += 1) {
     const msg = messages[i];
+    if (movedToolResultIndexes.has(i)) {
+      continue;
+    }
     if (!msg || typeof msg !== "object") {
       out.push(msg);
       continue;
@@ -385,6 +389,9 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     let j = i + 1;
     for (; j < messages.length; j += 1) {
       const next = messages[j];
+      if (movedToolResultIndexes.has(j)) {
+        continue;
+      }
       if (!next || typeof next !== "object") {
         remainder.push(next);
         continue;
@@ -403,6 +410,57 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
           ? []
           : extractToolCallsFromAssistant(preview.message);
         if (nextToolCalls.length > 0) {
+          if (preview.dropped.length > 0) {
+            const lookaheadToolUseIds = new Set(seenToolUseIds);
+            for (const call of nextToolCalls) {
+              lookaheadToolUseIds.add(call.id);
+            }
+            // The next assistant may mix stale duplicate calls from this span
+            // with new calls. Keep that assistant for its own pass, but look
+            // past it for delayed results that still belong to the current span.
+            for (let k = j + 1; k < messages.length; k += 1) {
+              if (movedToolResultIndexes.has(k)) {
+                continue;
+              }
+              const candidate = messages[k];
+              if (!candidate || typeof candidate !== "object") {
+                continue;
+              }
+              if (candidate.role === "assistant") {
+                const normalizedCandidate = normalizeAssistantReasoningBlocks(candidate);
+                const candidateTerminal =
+                  getTerminalStopReason(normalizedCandidate) !== null;
+                const candidatePreview = filterAssistantToolUseBlocks(
+                  normalizedCandidate,
+                  new Set(lookaheadToolUseIds),
+                  candidateTerminal ? { dropAll: true, record: false } : {}
+                );
+                const candidateToolCalls = candidateTerminal
+                  ? []
+                  : extractToolCallsFromAssistant(candidatePreview.message);
+                if (candidateToolCalls.length > 0) {
+                  break;
+                }
+                continue;
+              }
+              if (candidate.role !== "toolResult") {
+                continue;
+              }
+              const id = extractToolResultId(candidate);
+              if (!id || !toolCallIds.has(id)) {
+                continue;
+              }
+              movedToolResultIndexes.add(k);
+              if (seenToolResultIds.has(id) || spanResultsById.has(id)) {
+                droppedDuplicateCount += 1;
+                changed = true;
+                continue;
+              }
+              spanResultsById.set(id, candidate);
+              moved = true;
+              changed = true;
+            }
+          }
           break;
         }
         if (preview.dropped.length > 0) {

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -25,6 +25,8 @@ type ToolCallLike = {
   name?: string;
 };
 
+type WarnLogger = { warn: (message: string) => void };
+
 // -- Extraction helpers (from tool-call-id.ts) --
 
 const TOOL_CALL_TYPES = new Set([
@@ -148,6 +150,65 @@ function extractToolResultId(msg: AgentMessageLike): string | null {
   return null;
 }
 
+/**
+ * Remove duplicate assistant `tool_use` blocks during assembly.
+ *
+ * The Anthropic Messages API rejects a turn containing two assistant tool_use
+ * blocks that share an id. Duplicate-ingest can place the same tool_use id on
+ * more than one assistant message. This filters tool_use blocks whose id has
+ * already been emitted earlier in the assembled transcript (keep-first), while
+ * preserving every other block (text, distinct tool calls).
+ *
+ * - record:false leaves surviving ids out of the seen set. Used for
+ *   error/aborted turns, which are non-pairable and must not "claim" an id that
+ *   a later valid turn legitimately reuses.
+ * - dropAll:true strips every tool_use block regardless of the seen set. Also
+ *   used for error/aborted turns, whose tool_use blocks may be incomplete.
+ */
+function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
+  msg: T,
+  seenToolUseIds: Set<string>,
+  options: { dropAll?: boolean; record?: boolean } = {}
+): { message: T; dropped: ToolCallLike[] } {
+  const { dropAll = false, record = true } = options;
+  const content = msg.content;
+  if (!Array.isArray(content)) {
+    return { message: msg, dropped: [] };
+  }
+  const dropped: ToolCallLike[] = [];
+  const kept: unknown[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object") {
+      const rec = block as {
+        type?: unknown;
+        id?: unknown;
+        call_id?: unknown;
+        name?: unknown;
+      };
+      const id = extractToolCallId(rec);
+      const isToolUse =
+        !!id && typeof rec.type === "string" && TOOL_CALL_TYPES.has(rec.type);
+      if (isToolUse && id) {
+        if (dropAll || seenToolUseIds.has(id)) {
+          dropped.push({
+            id,
+            name: typeof rec.name === "string" ? rec.name : undefined,
+          });
+          continue;
+        }
+        if (record) {
+          seenToolUseIds.add(id);
+        }
+      }
+    }
+    kept.push(block);
+  }
+  if (dropped.length === 0) {
+    return { message: msg, dropped };
+  }
+  return { message: { ...msg, content: kept } as T, dropped };
+}
+
 // -- Repair logic (from session-transcript-repair.ts) --
 
 function makeMissingToolResult(params: {
@@ -179,11 +240,14 @@ function makeMissingToolResult(params: {
  * - Drops orphaned toolResults with no matching tool call
  */
 export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
-  messages: T[]
+  messages: T[],
+  log?: WarnLogger
 ): T[] {
   const out: T[] = [];
   const seenToolResultIds = new Set<string>();
+  const seenToolUseIds = new Set<string>();
   let droppedDuplicateCount = 0;
+  let droppedDuplicateAssistantToolUseCount = 0;
   let droppedOrphanCount = 0;
   let moved = false;
   let changed = false;
@@ -224,18 +288,41 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       changed = true;
     }
 
+    // Drop duplicate assistant tool_use blocks (keep-first). Two assistant
+    // tool_use blocks sharing an id cause the Anthropic API to reject the turn.
+    const stopReason = normalizedAssistant.stopReason;
+    const terminal = stopReason === "error" || stopReason === "aborted";
+    const deduped = filterAssistantToolUseBlocks(
+      normalizedAssistant,
+      seenToolUseIds,
+      // Error/aborted turns are non-pairable: strip their tool_use blocks and
+      // do not let them claim an id a later valid turn may legitimately reuse.
+      terminal ? { dropAll: true, record: false } : {}
+    );
+    const assistantMsg = deduped.message;
+    if (deduped.dropped.length > 0) {
+      changed = true;
+      droppedDuplicateAssistantToolUseCount += deduped.dropped.length;
+      const remaining = Array.isArray(assistantMsg.content)
+        ? assistantMsg.content
+        : [];
+      if (remaining.length === 0) {
+        // Nothing left after removing duplicate tool_use blocks; drop the message.
+        continue;
+      }
+    }
+
     // Skip tool call extraction for aborted or errored assistant messages.
     // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
     // and should not have synthetic tool_results created.
-    const stopReason = normalizedAssistant.stopReason;
-    if (stopReason === "error" || stopReason === "aborted") {
-      out.push(normalizedAssistant as T);
+    if (terminal) {
+      out.push(assistantMsg);
       continue;
     }
 
-    const toolCalls = extractToolCallsFromAssistant(normalizedAssistant);
+    const toolCalls = extractToolCallsFromAssistant(assistantMsg);
     if (toolCalls.length === 0) {
-      out.push(normalizedAssistant as T);
+      out.push(assistantMsg);
       continue;
     }
 
@@ -267,14 +354,12 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       if (nextRole === "toolResult") {
         const id = extractToolResultId(next);
         if (id && toolCallIds.has(id)) {
-          if (seenToolResultIds.has(id)) {
+          if (seenToolResultIds.has(id) || spanResultsById.has(id)) {
             droppedDuplicateCount += 1;
             changed = true;
             continue;
           }
-          if (!spanResultsById.has(id)) {
-            spanResultsById.set(id, next);
-          }
+          spanResultsById.set(id, next);
           continue;
         }
       }
@@ -287,7 +372,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       }
     }
 
-    out.push(normalizedAssistant as T);
+    out.push(assistantMsg);
 
     if (spanResultsById.size > 0 && remainder.length > 0) {
       moved = true;
@@ -312,6 +397,12 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       out.push(rem);
     }
     i = j - 1;
+  }
+
+  if (droppedDuplicateAssistantToolUseCount > 0 && log) {
+    log.warn(
+      `[lossless-claw] sanitizeToolUseResultPairing dropped ${droppedDuplicateAssistantToolUseCount} duplicate assistant tool_use block(s)`
+    );
   }
 
   const changedOrMoved = changed || moved;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { appendFileSync, chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -8400,6 +8400,78 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages[0]?.role).toBe("assistant");
     expect(result.messages[1]?.role).toBe("toolResult");
     expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_2");
+  });
+
+  it("protects repaired fresh-tail assistant messages after cross-message tool-use dedupe", async () => {
+    const engine = createEngineWithConfig({ freshTailCount: 3 });
+    const sessionId = "session-fresh-tail-dedupe-protection";
+
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "X", name: "bash", input: {} }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "X", name: "bash", input: {} },
+          { type: "toolCall", id: "Y", name: "grep", input: {} },
+        ],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "X",
+        content: [{ type: "text", text: "real X" }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "Y",
+        content: [{ type: "text", text: "real Y" }],
+      } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 10_000,
+    });
+    const repairedFreshTailAssistant = assembled.messages.find(
+      (message) =>
+        message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some(
+          (block) =>
+            block &&
+            typeof block === "object" &&
+            (block as { id?: unknown }).id === "Y",
+        ) &&
+        !message.content.some(
+          (block) =>
+            block &&
+            typeof block === "object" &&
+            (block as { id?: unknown }).id === "X",
+        ),
+    );
+
+    expect(repairedFreshTailAssistant).toBeDefined();
+    const repairedHash = createHash("sha256")
+      .update(JSON.stringify([repairedFreshTailAssistant]))
+      .digest("hex")
+      .slice(0, 16);
+    expect(assembled.debug?.freshTailProtectionMessageHashes).toContain(repairedHash);
   });
 
   it("drops older orphaned assistant tool calls instead of surfacing synthetic repair results", async () => {

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -135,7 +135,14 @@ describe("sanitizeToolUseResultPairing", () => {
   // -- Duplicate assistant tool_use dedup (INC-2026-03-24 class) --
 
   type Block = { type?: string; id?: string; call_id?: string; name?: string; text?: string };
-  type Msg = { role: string; content?: Block[]; toolCallId?: string; toolName?: string; stopReason?: string };
+  type Msg = {
+    role: string;
+    content?: Block[];
+    toolCallId?: string;
+    toolName?: string;
+    stopReason?: string;
+    stop_reason?: string;
+  };
 
   const assistantToolUseIds = (messages: Msg[]): string[] => {
     const ids: string[] = [];
@@ -195,6 +202,80 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.some((m) => m.stopReason === "aborted" && (m.content?.length ?? 0) > 0)).toBe(false);
   });
 
+  it("treats snake_case terminal stop reasons as non-pairable", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", stop_reason: "error", content: [{ type: "tool_use", id: "X", name: "bash" }] },
+      { role: "assistant", content: [{ type: "tool_use", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+
+    expect(assistantToolUseIds(out)).toEqual(["X"]);
+    expect(toolResultIds(out)).toEqual(["X"]);
+    expect(out.some((m) => m.stop_reason === "error" && (m.content?.length ?? 0) > 0)).toBe(false);
+  });
+
+  it("does not let a stripped terminal assistant turn block a delayed real result", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "assistant", stopReason: "aborted", content: [{ type: "toolCall", id: "Y", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+  });
+
+  it("looks past aborted non-pairable tool_use turns for delayed results", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "A", name: "bash" }] },
+      { role: "assistant", stopReason: "aborted", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "A", content: [{ type: "text", text: "real A" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "A", name: "bash" }] },
+      { role: "toolResult", toolCallId: "A", content: [{ type: "text", text: "real A" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+    ]);
+  });
+
+  it("drops duplicate assistant turns that become reasoning-only after filtering", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "stale hidden thought" },
+          { type: "toolCall", id: "X", name: "bash" },
+        ],
+      },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+  });
+
+  it("does not let a duplicate-only assistant turn block a delayed real result", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+  });
+
   it("drops duplicate tool results within a single assistant span", () => {
     const out = sanitizeToolUseResultPairing<Msg>([
       { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
@@ -219,6 +300,20 @@ describe("sanitizeToolUseResultPairing", () => {
     );
     expect(warnings.length).toBe(1);
     expect(warnings[0]).toContain("duplicate assistant tool_use");
+  });
+
+  it("logs terminal tool_use removals distinctly from duplicate removals", () => {
+    const warnings: string[] = [];
+    sanitizeToolUseResultPairing<Msg>(
+      [
+        { role: "assistant", stopReason: "aborted", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      ],
+      { warn: (m) => warnings.push(m) }
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("terminal assistant tool_use");
+    expect(warnings[0]).not.toContain("duplicate");
   });
 
 });

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -190,6 +190,57 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(toolResultIds(out).sort()).toEqual(["X", "Y"]);
   });
 
+  it("moves a delayed real result before a mixed duplicate and new tool_use turn", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "X", name: "bash" },
+          { type: "toolCall", id: "Y", name: "grep" },
+        ],
+      },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+      { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "real Y" }] },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "Y", name: "grep" }],
+      },
+      { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "real Y" }] },
+    ]);
+  });
+
+  it("looks past duplicate cascades after a mixed duplicate and new tool_use turn", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "X", name: "bash" },
+          { type: "toolCall", id: "Y", name: "grep" },
+        ],
+      },
+      { role: "assistant", content: [{ type: "toolCall", id: "Y", name: "grep" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+      { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "real Y" }] },
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real X" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "Y", name: "grep" }],
+      },
+      { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "real Y" }] },
+    ]);
+  });
+
   it("does not let an aborted turn claim an id that a later valid turn reuses", () => {
     const out = sanitizeToolUseResultPairing<Msg>([
       { role: "assistant", stopReason: "aborted", content: [{ type: "toolCall", id: "X", name: "bash" }] },

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -131,4 +131,94 @@ describe("sanitizeToolUseResultPairing", () => {
       messages[1],
     ]);
   });
+
+  // -- Duplicate assistant tool_use dedup (INC-2026-03-24 class) --
+
+  type Block = { type?: string; id?: string; call_id?: string; name?: string; text?: string };
+  type Msg = { role: string; content?: Block[]; toolCallId?: string; toolName?: string; stopReason?: string };
+
+  const assistantToolUseIds = (messages: Msg[]): string[] => {
+    const ids: string[] = [];
+    for (const m of messages) {
+      if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+      for (const b of m.content) {
+        if (b && (b.type === "toolCall" || b.type === "tool_use") && (b.id ?? b.call_id)) {
+          ids.push((b.id ?? b.call_id) as string);
+        }
+      }
+    }
+    return ids;
+  };
+  const toolResultIds = (messages: Msg[]): string[] =>
+    messages.filter((m) => m.role === "toolResult" && m.toolCallId).map((m) => m.toolCallId as string);
+
+  it("drops a duplicate assistant tool_use id repeated across two messages", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "out-1" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "out-2" }] },
+    ]);
+
+    expect(assistantToolUseIds(out)).toEqual(["X"]);
+    expect(toolResultIds(out)).toEqual(["X"]);
+  });
+
+  it("keeps a distinct tool_use in a later message while dropping the duplicate block", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "x" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "X", name: "bash" },
+          { type: "toolCall", id: "Y", name: "grep" },
+        ],
+      },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "x-dup" }] },
+      { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "y" }] },
+    ]);
+
+    expect(assistantToolUseIds(out).sort()).toEqual(["X", "Y"]);
+    expect(toolResultIds(out).sort()).toEqual(["X", "Y"]);
+  });
+
+  it("does not let an aborted turn claim an id that a later valid turn reuses", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", stopReason: "aborted", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "real" }] },
+    ]);
+
+    expect(assistantToolUseIds(out)).toEqual(["X"]);
+    expect(toolResultIds(out)).toEqual(["X"]);
+    expect(out.some((m) => m.stopReason === "aborted" && (m.content?.length ?? 0) > 0)).toBe(false);
+  });
+
+  it("drops duplicate tool results within a single assistant span", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "first" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "dup" }] },
+    ]);
+
+    expect(toolResultIds(out)).toEqual(["X"]);
+    expect(assistantToolUseIds(out)).toEqual(["X"]);
+  });
+
+  it("invokes the optional logger when duplicate assistant tool_use blocks are dropped", () => {
+    const warnings: string[] = [];
+    sanitizeToolUseResultPairing<Msg>(
+      [
+        { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+        { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "a" }] },
+        { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
+        { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "b" }] },
+      ],
+      { warn: (m) => warnings.push(m) }
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("duplicate assistant tool_use");
+  });
+
 });


### PR DESCRIPTION
# PR: dedupe duplicate assistant `tool_use` blocks at assemble time (+ same-span `tool_result` fix)

**Repo:** `Martian-Engineering/lossless-claw`
**Base:** built/verified against `4fc60c9` (npm `gitHead` for `@martian-engineering/lossless-claw@0.9.4`)
**Files:** `src/transcript-repair.ts`, `test/transcript-repair.test.ts`
**Companion patch:** `lcm-toolus-dedup.patch` (184 insertions / 11 deletions)

---

## Summary

`sanitizeToolUseResultPairing()` already de-duplicates tool **results** (`seenToolResultIds`) but has no symmetric guard for duplicate assistant **`tool_use`** blocks. When the same assistant `tool_use` id appears on more than one assembled message, the Anthropic Messages API rejects the turn (two `tool_use` blocks sharing an id can't be matched to results). This PR adds a block-level, keep-first dedup of assistant `tool_use` blocks during assembly, so a transcript that already contains duplicate `tool_use` ids still produces a valid outbound payload.

It also fixes a pre-existing correctness bug in the same function: a duplicate tool **result** appearing twice *within a single assistant span* was dropped without setting `changed`, so the function could return the original (unsanitized) array.

Read-path only — no schema, storage, or ingest changes.

## Motivation

Duplicate assistant `tool_use` ids enter the store via duplicate ingestion of the same logical message. `afterTurn()` (engine.ts) runs `reconcileTranscriptTailForAfterTurn()` (which ingests from the session file) and then `ingestBatch()`, with `deduplicateAfterTurnBatch()` in between guarding against replay. That guard matches on `(role, content)` identity, which **collapses for empty-content assistant tool-use turns** (a tool-use-only assistant message stores empty content, so every such turn is identity-equal). The result is two persisted assistant rows carrying the same `tool_use` id.

Fixing ingest idempotency is the real root cause and is proposed as a separate change below. This PR is the assemble-time safety net: it keeps the outbound payload valid regardless of how duplicates were stored, and it protects already-duplicated history.

Observed in production: duplicate `tool_use` ids formed in a live conversation across active turns; with this filter deployed, those turns assembled and sent with zero `invalid_request` rejections while the duplicate rows were still present in the DB.

## Changes

Suggested as two commits:

**1. Assistant `tool_use` block dedup (keep-first, block-level).**
New helper `filterAssistantToolUseBlocks(msg, seenToolUseIds, { dropAll, record })`. During assembly, for each assistant message:
- Drop `tool_use` blocks whose id was already emitted earlier in the assembled transcript (keep-first); preserve all other blocks (text, distinct tool calls).
- If the message has no blocks left after filtering, drop the message entirely.
- Track surviving ids in a transcript-scoped `seenToolUseIds` set.

Error/aborted turns are treated as non-pairable (consistent with the existing early-return): they use `{ dropAll: true, record: false }` — their `tool_use` blocks are stripped (they may be incomplete) and their ids are **not** recorded, so an aborted turn cannot "claim" an id that a later valid turn legitimately reuses. *This is a deliberate behavior change for error/aborted assistant turns that carry non-empty `tool_use` content* (empty ones are already skipped at ingest); previously such blocks passed through. Rationale: an incomplete/aborted `tool_use` with no matched result is itself an invalid outbound block.

**2. Same-span duplicate `tool_result` fix.**
In the span scan, a result whose id is already in `spanResultsById` (seen earlier in the same span, before being added to `seenToolResultIds`) now increments `droppedDuplicateCount` and sets `changed = true`, instead of silently falling through. Without this, a within-span duplicate could be the only change, leaving `changed === false` and causing the function to return the unsanitized input.

Optional `log?: { warn(msg): void }` second parameter emits a single warning when duplicate assistant `tool_use` blocks are dropped. Defaults to no-op; the assembler call site does not pass a logger yet (`ContextAssembler` has no logger in scope), so wiring it is a small optional follow-up.

## Edge cases covered

- Exact duplicate tool-use-only assistant message across two messages → one survives.
- Later message mixes a duplicate id with a distinct tool call / text → only the duplicate block is dropped, the rest preserved.
- Aborted turn carrying id `X` before a later valid turn with id `X` → the valid turn survives with its result; the aborted block does not poison it.
- Duplicate tool results within a single assistant span → reduced to one.

## Tests

`test/transcript-repair.test.ts` extended with the four cases above plus a logger-invocation test. Full suite passes (`vitest run --dir test`): 46 files, 859 tests. Build reproduces deterministically (`npm ci && npm run build`); pristine `4fc60c9` rebuild is byte-identical in size to the published 0.9.4 bundle.

## Note for maintainers

`transcript-repair.ts` documents itself as a temporary copy "to avoid depending on unexported internals … when the plugin SDK exports `sanitizeToolUseResultPairing`, this file can be removed." If the canonical implementation lives in openclaw core, this dedup likely belongs there too; happy to mirror it.

---

## Follow-up (separate issue/PR): ingest idempotency

The durable fix is to stop persisting the same logical message twice. Diagnosis, grounded in `4fc60c9`:

- `afterTurn()` ingests via both `reconcileTranscriptTailForAfterTurn()` and `ingestBatch()` in one pass.
- `deduplicateAfterTurnBatch()` is the intended guard but keys on `(role, content)` identity (`messageIdentity`).
- Tool-use-only assistant turns persist empty content, so `(role, content)` is identical across distinct turns — the guard can't distinguish a replay from a genuine new turn, and duplicate rows are written.

Proposed direction (for discussion, not implemented here): give ingest a stable per-message idempotency key rather than content identity — e.g. a stable source/transcript message id if one is available from the session file, or a composite of `(role, tool_use ids, ordinal/seq)` for tool-use turns — and short-circuit `ingestSingle()` when that key already exists for the conversation. `ingestSingle()` already skips empty error/aborted assistant messages; this would extend that guarding to the replay case. This needs design + tests and should not block the assemble-time fix above.
