### PR TITLE
fix: show conversation IDs in lcm_grep results

### DIFF
--- a/.changeset/lcm-grep-conversation-provenance.md
+++ b/.changeset/lcm-grep-conversation-provenance.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Include conversation IDs on each `lcm_grep` message and summary result so agents can disambiguate global recall hits.

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -262,7 +262,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const msg of result.messages) {
           const snippet = truncateSnippet(msg.snippet);
-          const line = `- [msg#${msg.messageId}] (${msg.role}, ${formatDisplayTime(msg.createdAt, timezone)}): ${snippet}`;
+          const line = `- [conv=${msg.conversationId} msg#${msg.messageId}] (${msg.role}, ${formatDisplayTime(msg.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;
@@ -278,7 +278,7 @@ export function createLcmGrepTool(input: {
         lines.push("");
         for (const sum of result.summaries) {
           const snippet = truncateSnippet(sum.snippet);
-          const line = `- [${sum.summaryId}] (${sum.kind}, ${formatDisplayTime(sum.createdAt, timezone)}): ${snippet}`;
+          const line = `- [conv=${sum.conversationId} ${sum.summaryId}] (${sum.kind}, ${formatDisplayTime(sum.createdAt, timezone)}): ${snippet}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;


### PR DESCRIPTION
## Summary

- Closes #811.
- Include `conv=<conversationId>` in each `lcm_grep` message result label.
- Include `conv=<conversationId>` in each `lcm_grep` summary result label.
- Add a patch changeset for the user-facing recall-tool output change.

## Validation

- `npx vitest run test/lcm-tools.test.ts`
- `npm run build`
- `npm test`
