### PR TITLE
fix: skip runtime init for CLI metadata

### DIFF
--- a/.changeset/quiet-cli-metadata-registration.md
+++ b/.changeset/quiet-cli-metadata-registration.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip Lossless runtime startup work during OpenClaw CLI metadata registration so help and JSON inspection commands do not emit misleading runtime LLM warnings.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -401,6 +401,11 @@ function assertContextEngineRegistrationAvailable(
   throw new Error(message);
 }
 
+/** Return true for OpenClaw's descriptor-only CLI registration pass. */
+function isCliMetadataRegistration(api: OpenClawPluginApi): boolean {
+  return (api as { registrationMode?: unknown }).registrationMode === "cli-metadata";
+}
+
 /** Resolve plugin config from direct runtime injection or the root OpenClaw config fallback. */
 function resolvePluginConfig(api: OpenClawPluginApi): Record<string, unknown> | undefined {
   const directPluginConfig = toPluginConfig(api.pluginConfig);
@@ -1507,6 +1512,10 @@ const lcmPlugin = {
   },
 
   register(api: OpenClawPluginApi) {
+    if (isCliMetadataRegistration(api)) {
+      return;
+    }
+
     assertContextEngineRegistrationAvailable(api);
     const registrationConfig = resolveRegistrationConfig(api);
     const deps = createLcmDependencies(api, registrationConfig);

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -24,6 +24,7 @@ function buildApi(
     includeRuntimeLlm?: boolean;
     agentDir?: string;
     runtimeConfig?: Record<string, unknown>;
+    registrationMode?: string;
   },
 ): {
   api: OpenClawPluginApi;
@@ -54,6 +55,7 @@ function buildApi(
     source: "/tmp/lossless-claw",
     config: {},
     pluginConfig,
+    ...(options?.registrationMode ? { registrationMode: options.registrationMode } : {}),
     runtime: {
       subagent: {
         run: vi.fn(),
@@ -242,6 +244,29 @@ describe("lcm plugin registration", () => {
     expect(getRegisteredContextEngines()).toEqual([
       expect.objectContaining({ id: "lossless-claw" }),
     ]);
+  });
+
+  it("does not initialize runtime surfaces during CLI metadata registration", () => {
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, getRegisteredContextEngines, infoLog, warnLog } = buildApi(
+      { enabled: true },
+      {
+        includeRuntimeLlm: false,
+        registrationMode: "cli-metadata",
+      },
+    );
+
+    lcmPlugin.register(api);
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(getRegisteredContextEngines()).toEqual([]);
+    expect(api.registerCommand).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(api.on).not.toHaveBeenCalled();
+    expect(infoLog).not.toHaveBeenCalled();
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("runtime.llm.complete is unavailable"),
+    );
   });
 
   it("fails fast with a compatibility diagnostic when context-engine registration is unavailable", () => {


### PR DESCRIPTION
## What

Skip Lossless runtime startup work when OpenClaw loads the plugin in `cli-metadata` mode for CLI descriptor collection.

## Why

OpenClaw issue https://github.com/openclaw/openclaw/issues/86980 shows `openclaw --help` and JSON-oriented plugin inspection paths can load Lossless without a full runtime LLM surface, producing misleading `runtime.llm.complete` warnings and startup logs. In `cli-metadata` mode Lossless does not need DB initialization, context-engine registration, hooks, tools, or runtime LLM probing.

## Changes

- Short-circuit `cli-metadata` registration
- Add regression coverage for no runtime init
- Add patch changeset

## Testing

- `npm test -- test/plugin-config-registration.test.ts`
- `npm test -- test/plugin-config-registration.test.ts test/index-runtime-llm-complete.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`
