### PR TITLE
fix: isolate stable cron session runs

### DIFF
--- a/.changeset/isolate-stable-cron-runs.md
+++ b/.changeset/isolate-stable-cron-runs.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Isolate cron scheduler runs that reuse a stable session key so prior run transcripts do not enter the new run's LCM context.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Lossless-claw applies `/new` pruning through `before_reset` and uses `session_en
 
 Use `ignoreSessionPatterns` or `LCM_IGNORE_SESSION_PATTERNS` to keep low-value sessions completely out of LCM. Matching sessions do not create conversations, do not store messages, and do not participate in compaction or delegated expansion grants.
 
+Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when OpenClaw reuses the same `sessionKey` for a new runtime `sessionId`: lossless-claw archives the prior active run and creates a fresh LCM conversation for the new run. Leave cron sessions out of `ignoreSessionPatterns` when they need in-run LCM compaction.
+
 Pattern rules:
 
 - `*` matches any characters except `:`
@@ -322,7 +324,7 @@ Pattern rules:
 
 Examples:
 
-- `agent:*:cron:**` excludes cron sessions for any agent, including isolated run sessions like `agent:main:cron:daily-digest:run:run-123`
+- `agent:*:cron:**` excludes cron sessions for any agent when you want to bypass LCM entirely
 - `agent:main:subagent:**` excludes all main-agent subagent sessions
 - `agent:ops:**` excludes every session under the `ops` agent id
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,6 +308,8 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 - `*` matches any characters except `:`
 - `**` matches anything, including `:`
 
+Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when a new runtime `sessionId` reuses the same `sessionKey`. Configure `ignoreSessionPatterns` for cron only when the run should bypass LCM entirely; leave cron sessions included when they need in-run compaction.
+
 Example:
 
 ```json

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -469,6 +469,7 @@ Why it matters:
 
 - keeps low-value automation or noisy sessions out of the DB
 - useful for excluding certain agent lanes or ephemeral traffic entirely
+- cron scheduler keys are already isolated per runtime run, so ignore them only when they should bypass LCM compaction
 
 ### `statelessSessionPatterns`
 

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -8,31 +8,36 @@ For stock `lossless-claw` on current main:
 
 - OpenClaw handles `/new` and `/reset` as session-reset operations.
 - `lossless-claw` handles `/lossless rotate` (`/lcm rotate`) as transcript maintenance on the current conversation.
-- `lossless-claw` does **not** currently register its own `before_reset` hook or a custom reset policy.
 - `lossless-claw` prefers **`sessionKey`** as the stable identity for an LCM conversation.
-- When the same `sessionKey` reappears with a new `sessionId`, `lossless-claw` updates the stored `sessionId` on the existing LCM conversation row instead of creating a brand-new LCM conversation.
+- `/reset` archives the active conversation and creates a fresh active row for the same stable `sessionKey`.
+- Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated per runtime run when a new `sessionId` reuses the same `sessionKey`.
+- For ordinary non-cron session keys, continuity still follows the stable `sessionKey`.
 
 ## What that means in practice
 
-If a user asks whether `/new` or `/reset` gives them a fresh LCM conversation, the answer is usually **no** under the current implementation.
+If a user asks whether `/new` or `/reset` gives them a fresh LCM conversation, distinguish the commands.
 
-They get a fresh OpenClaw session runtime, but LCM continuity still follows the stable `sessionKey` when one is available.
+They get a fresh OpenClaw session runtime, but LCM continuity usually still follows the stable `sessionKey` when one is available.
 
 So today:
 
-- `/new` and `/reset` can reset the runtime session
-- but LCM history may continue in the same conversation row if the chat/thread keeps the same `sessionKey`
+- `/new` prunes active context but keeps the same LCM conversation row
+- `/reset` archives the active LCM conversation row and creates a fresh active row
+- ordinary chat/thread LCM history may continue in the same row across runtime `sessionId` changes when the stable `sessionKey` continues
+- cron scheduler keys create fresh LCM rows per runtime run so prior runs do not enter the new run's assembled context
 - `/lossless rotate` keeps that same conversation row, summaries, and context items in place while compacting only the live transcript backing
 
 ## Why
 
-Current lossless-claw conversation resolution does this:
+Current lossless-claw conversation resolution generally does this:
 
 1. look up by `sessionKey` first
 2. fall back to `sessionId` only when no `sessionKey` match exists
 3. if the `sessionKey` already exists but the `sessionId` changed, update the stored `sessionId` on that same conversation
 
 That behavior preserves continuity across session resets for the same chat identity.
+
+Cron keys are the exception: when an active cron conversation exists for the same `sessionKey` but a different runtime `sessionId`, lossless-claw archives the prior active row and starts a fresh one for the new run. Prior messages remain persisted on the archived conversation.
 
 ## `/lossless rotate`
 
@@ -49,22 +54,23 @@ This makes rotate the lightweight option when the problem is transcript bloat ra
 
 ## Important limitation
 
-There is still **no plugin-specific `/new` vs `/reset` split** in stock lossless-claw docs or runtime behavior.
+There is a plugin-specific `/new` vs `/reset` split in current lossless-claw behavior.
 
 If someone is asking for semantics like:
 
 - `/new` gives them a fresh LCM conversation row
-- `/reset` archives old LCM conversation and starts a new one for the same stable `sessionKey`
 
-that is a **design/spec topic**, not current stock behavior.
+that remains a **design/spec topic**, not current stock behavior.
 
 ## Safe operator guidance
 
 When answering users:
 
-- do not promise that `/new` or `/reset` clears LCM history
+- do not promise that `/new` clears LCM history
+- explain that `/reset` archives the active LCM row and starts a fresh one for the same stable `sessionKey`
 - explain that `/lossless rotate` compacts the current transcript without splitting the LCM conversation
-- explain that current stock behavior follows `sessionKey` continuity
+- explain that ordinary current stock behavior follows `sessionKey` continuity
+- explain that cron scheduler session keys are isolated per runtime run while preserving archived prior runs
 - if they need a truly separate LCM history, use a different session key context (for example a different chat/thread/binding) or explicit non-MVP migration/surgery tools
 
 ## Relation to `/status`

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6415,6 +6415,12 @@ export class LcmContextEngine implements ContextEngine {
   }): Promise<TranscriptReconcileResult> {
     const queueKey = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     await this.conversationStore.withTransaction(async () => {
+      await this.rotateIsolatedCronConversationIfRuntimeChanged({
+        phase: "afterTurn",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        createReplacement: true,
+      });
       await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
         phase: "afterTurn",
         sessionId: params.sessionId,
@@ -6973,6 +6979,57 @@ export class LcmContextEngine implements ContextEngine {
     return true;
   }
 
+  /** Cron session keys represent isolated scheduled runs, not conversation continuity. */
+  private isIsolatedCronSessionKey(sessionKey?: string): boolean {
+    const trimmed = sessionKey?.trim();
+    if (!trimmed) {
+      return false;
+    }
+    const parts = trimmed.split(":");
+    return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
+  }
+
+  /**
+   * Archive the prior active cron run when OpenClaw reuses a scheduler
+   * sessionKey for a new isolated runtime session.
+   */
+  private async rotateIsolatedCronConversationIfRuntimeChanged(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    sessionId: string;
+    sessionKey?: string;
+    createReplacement: boolean;
+  }): Promise<boolean> {
+    const normalizedSessionId = params.sessionId.trim();
+    const normalizedSessionKey = params.sessionKey?.trim();
+    if (
+      !normalizedSessionId ||
+      !normalizedSessionKey ||
+      !this.isIsolatedCronSessionKey(normalizedSessionKey)
+    ) {
+      return false;
+    }
+
+    const activeByKey = await this.conversationStore.getConversationBySessionKey(
+      normalizedSessionKey,
+    );
+    if (!activeByKey || activeByKey.sessionId === normalizedSessionId) {
+      return false;
+    }
+
+    this.deps.log.info(
+      `[lcm] ${params.phase}: isolated cron session rollover; archiving conversation=${activeByKey.conversationId} oldSessionId=${activeByKey.sessionId} newSessionId=${normalizedSessionId} sessionKey=${normalizedSessionKey}`,
+    );
+    await this.applySessionReplacement({
+      reason: `${params.phase} isolated cron session rollover`,
+      sessionId: activeByKey.sessionId,
+      sessionKey: normalizedSessionKey,
+      nextSessionId: normalizedSessionId,
+      nextSessionKey: normalizedSessionKey,
+      createReplacement: params.createReplacement,
+    });
+    return true;
+  }
+
   private async findAmbiguousSessionKeyRuntimeRollover(params: {
     phase: "bootstrap" | "assemble" | "afterTurn";
     sessionId: string;
@@ -7140,6 +7197,12 @@ export class LcmContextEngine implements ContextEngine {
           };
           let preloadedHistoricalMessages: AgentMessage[] | undefined;
 
+          await this.rotateIsolatedCronConversationIfRuntimeChanged({
+            phase: "bootstrap",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            createReplacement: true,
+          });
           await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
             phase: "bootstrap",
             sessionId: params.sessionId,
@@ -8769,6 +8832,12 @@ export class LcmContextEngine implements ContextEngine {
           this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
           async () =>
             this.conversationStore.withTransaction(async () => {
+              await this.rotateIsolatedCronConversationIfRuntimeChanged({
+                phase: "assemble",
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                createReplacement: false,
+              });
               await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
                 phase: "assemble",
                 sessionId: params.sessionId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6419,7 +6419,7 @@ export class LcmContextEngine implements ContextEngine {
         phase: "afterTurn",
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
-        createReplacement: true,
+        createReplacement: false,
       });
       await this.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
         phase: "afterTurn",

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -56,6 +56,15 @@ async function lookupConversationForSession(input: {
   return store.getConversationBySessionId(normalizedSessionId);
 }
 
+function isIsolatedCronSessionKey(sessionKey?: string): boolean {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const parts = trimmed.split(":");
+  return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
+}
+
 /**
  * Parse an ISO-8601 timestamp tool parameter into a Date.
  *
@@ -107,6 +116,7 @@ export async function resolveLcmConversationScope(input: {
   const normalizedSessionKey = explicitSessionKey || sessionIdAsSessionKey;
   const isDelegatedSession =
     Boolean(normalizedSessionKey) && Boolean(input.deps?.isSubagentSessionKey(normalizedSessionKey!));
+  const isolateCurrentSessionFamily = isIsolatedCronSessionKey(normalizedSessionKey);
   let allowedConversationIds: number[] = [];
 
   const explicitConversationId =
@@ -213,8 +223,9 @@ export async function resolveLcmConversationScope(input: {
           error: `Conversation ${bySessionKey.conversationId} is outside delegated conversation scope.`,
         };
       }
-      const familyIds =
-        typeof (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds === "function"
+      const familyIds = isolateCurrentSessionFamily
+        ? [bySessionKey.conversationId]
+        : typeof (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds === "function"
           ? await (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds({
               conversationId: bySessionKey.conversationId,
               sessionKey: normalizedSessionKey,
@@ -267,8 +278,9 @@ export async function resolveLcmConversationScope(input: {
   }
 
   const store = lcm.getConversationStore() as ConversationScopeStore;
-  const familyIds =
-    typeof store.getConversationFamilyIds === "function"
+  const familyIds = isolateCurrentSessionFamily
+    ? [conversation.conversationId]
+    : typeof store.getConversationFamilyIds === "function"
       ? await store.getConversationFamilyIds({
           conversationId: conversation.conversationId,
           sessionId: normalizedSessionId,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11357,6 +11357,89 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).resolves.toBeNull();
   });
 
+  it("isolates cron runs that reuse a stable sessionKey while preserving prior runs", async () => {
+    const engine = createEngine();
+    const firstSessionId = "cron-isolated-stable-key-run-1";
+    const secondSessionId = "cron-isolated-stable-key-run-2";
+    const sessionKey = "agent:main:cron:nightly";
+
+    const oldSessionFile = createSessionFilePath("cron-isolated-stable-key-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "prior cron input should stay archived" },
+      { role: "assistant", content: "prior cron output should not leak" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const priorConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(priorConversation).not.toBeNull();
+
+    const newSessionFile = createSessionFilePath("cron-isolated-stable-key-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "current cron input" },
+      { role: "assistant", content: "current cron output" },
+    ]);
+
+    const result = await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+    });
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).not.toBeNull();
+    expect(activeConversation!.conversationId).not.toBe(priorConversation!.conversationId);
+    expect(activeConversation!.sessionId).toBe(secondSessionId);
+
+    const archivedPrior = await engine.getConversationStore().getConversation(
+      priorConversation!.conversationId,
+    );
+    expect(archivedPrior?.active).toBe(false);
+    const priorMessages = await engine.getConversationStore().getMessages(
+      priorConversation!.conversationId,
+    );
+    expect(priorMessages.map((message) => message.content)).toEqual([
+      "prior cron input should stay archived",
+      "prior cron output should not leak",
+    ]);
+
+    const activeMessages = await engine.getConversationStore().getMessages(
+      activeConversation!.conversationId,
+    );
+    expect(activeMessages.map((message) => message.content)).toEqual([
+      "current cron input",
+      "current cron output",
+    ]);
+
+    const assembled = await engine.assemble({
+      sessionId: secondSessionId,
+      sessionKey,
+      messages: [makeMessage({ role: "user", content: "current live cron prompt" })],
+      tokenBudget: 4_096,
+    });
+    const assembledText = assembled.messages
+      .map((message) =>
+        typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+      )
+      .join("\n");
+    expect(assembledText).toContain("current cron input");
+    expect(assembledText).not.toContain("prior cron output should not leak");
+  });
+
   it("afterTurn fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11361,7 +11361,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     const engine = createEngine();
     const firstSessionId = "cron-isolated-stable-key-run-1";
     const secondSessionId = "cron-isolated-stable-key-run-2";
-    const sessionKey = "agent:main:cron:nightly";
+    const sessionKey = "agent:main:cron:nightly:run:run-123";
 
     const oldSessionFile = createSessionFilePath("cron-isolated-stable-key-old");
     writeLeafTranscript(oldSessionFile, [
@@ -11437,7 +11437,83 @@ describe("LcmContextEngine fidelity and token budget", () => {
       )
       .join("\n");
     expect(assembledText).toContain("current cron input");
+    expect(assembledText).not.toContain("prior cron input should stay archived");
     expect(assembledText).not.toContain("prior cron output should not leak");
+  });
+
+  it("isolates cron sessionKey rollover during afterTurn transcript reconcile", async () => {
+    const engine = createEngine();
+    const firstSessionId = "cron-after-turn-isolated-run-1";
+    const secondSessionId = "cron-after-turn-isolated-run-2";
+    const sessionKey = "agent:main:cron:nightly:run:after-turn-123";
+
+    const oldSessionFile = createSessionFilePath("cron-after-turn-isolated-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "prior afterTurn cron input should stay archived" },
+      { role: "assistant", content: "prior afterTurn cron output should not leak" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const priorConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(priorConversation).not.toBeNull();
+
+    const newSessionFile = createSessionFilePath("cron-after-turn-isolated-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "current afterTurn cron input" },
+      { role: "assistant", content: "current afterTurn cron output" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [makeMessage({ role: "assistant", content: "current afterTurn cron output" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const archivedPrior = await engine.getConversationStore().getConversation(
+      priorConversation!.conversationId,
+    );
+    expect(archivedPrior?.active).toBe(false);
+
+    const activeConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: secondSessionId,
+      sessionKey,
+    });
+    expect(activeConversation).not.toBeNull();
+    expect(activeConversation!.conversationId).not.toBe(priorConversation!.conversationId);
+    expect(activeConversation!.sessionId).toBe(secondSessionId);
+
+    const activeMessages = await engine.getConversationStore().getMessages(
+      activeConversation!.conversationId,
+    );
+    expect(activeMessages.map((message) => message.content)).toEqual([
+      "current afterTurn cron input",
+      "current afterTurn cron output",
+    ]);
+
+    const assembled = await engine.assemble({
+      sessionId: secondSessionId,
+      sessionKey,
+      messages: [makeMessage({ role: "user", content: "current live afterTurn cron prompt" })],
+      tokenBudget: 4_096,
+    });
+    const assembledText = assembled.messages
+      .map((message) =>
+        typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+      )
+      .join("\n");
+    expect(assembledText).toContain("current afterTurn cron input");
+    expect(assembledText).not.toContain("prior afterTurn cron input should stay archived");
+    expect(assembledText).not.toContain("prior afterTurn cron output should not leak");
   });
 
   it("afterTurn fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -514,6 +514,41 @@ describe("LCM tools session scoping", () => {
     expect(JSON.stringify(describeResult.details)).not.toContain(summaryContent);
   });
 
+  it("lcm_grep keeps isolated cron sessionKey scope on the active run", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps({
+        resolveSessionIdFromSessionKey: vi.fn(async () => "uuid-after-reset"),
+      }),
+      lcm: buildLcmEngine({
+        retrieval,
+        conversationIdBySessionKey: 42,
+        conversationFamilyIds: [42, 21, 7],
+      }) as never,
+      sessionKey: "agent:main:cron:nightly:run:run-123",
+    });
+    const result = await tool.execute("call-cron-family", { pattern: "deployment" });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 42,
+        conversationIds: [42],
+      }),
+    );
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("**Conversation scope:** 42");
+    expect(text).not.toContain("session family rooted at 42");
+  });
+
   it("lcm_grep rejects allConversations from a sub-agent without a delegated grant", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({


### PR DESCRIPTION
## What
Isolates OpenClaw cron scheduler runs that reuse stable session keys so a new runtime session does not inherit prior-run LCM transcript context. Prior run conversations are preserved and archived rather than deleted.

## Why
Cron-style isolated runs can reuse the same sessionKey across logically independent executions. Without a separate runtime-run boundary, LCM can assemble stale prior-run context into a new run.

## Changes
- Detect stable cron key reuse
- Archive prior active run
- Create fresh run conversation
- Cover lifecycle paths
- Update docs and changeset

## Testing
- `npx vitest run test/engine.test.ts -t "isolates cron runs"`
- `npx vitest run test/engine.test.ts -t "missed reset|ambiguous runtime rollover|isolates cron runs"`
- `npx vitest run test/engine.test.ts`
- `npm run build`
- `npm test`
- `git diff --check`

Closes #810