### PR TITLE
fix: restore release typecheck gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "scripts": {
     "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
     "changeset": "changeset",
-    "release:verify": "npm run build && npm test && npm pack --dry-run",
+    "release:verify": "npm run typecheck && npm run build && npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
+    "typecheck": "tsc --noEmit --pretty false",
     "version-packages": "changeset version"
   },
   "files": [

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1444,13 +1444,14 @@ export class ContextAssembler {
       selected.push(...evictable);
       evictableTokens = evictableTotalTokens;
     } else if (input.promptAwareEviction !== false && hasSearchablePrompt(input.prompt)) {
+      const searchablePrompt = input.prompt;
       selectionMode = "prompt-aware";
       // Prompt-aware eviction: score each evictable item by relevance to the
       // prompt, then greedily fill budget from highest-scoring items down.
       // Re-sort selected items by ordinal to restore chronological order.
       const scored = evictable.map((item, idx) => ({
         item,
-        score: scoreRelevance(item.text, input.prompt),
+        score: scoreRelevance(item.text, searchablePrompt),
         idx, // original index — higher = more recent, used as tiebreaker
       }));
       // Sort: highest relevance first; most recent (higher idx) breaks ties

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { contentFromParts } from "./assembler.js";
 import type {
   ConversationStore,
@@ -206,12 +206,12 @@ function shortTzAbbr(value: Date, timezone: string): string {
   }
 }
 
-/** Generate a deterministic summary ID from content + timestamp. */
+/** Generate a collision-resistant summary ID from content and a random nonce. */
 function generateSummaryId(content: string): string {
   return (
     "sum_" +
     createHash("sha256")
-      .update(content + Date.now().toString())
+      .update(content + randomUUID())
       .digest("hex")
       .slice(0, 16)
   );

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -171,7 +171,7 @@ type CompactionExecutionParams = {
   conversationId: number;
   sessionId: string;
   sessionKey?: string;
-  tokenBudget: number;
+  tokenBudget?: number;
   currentTokenCount?: number;
   compactionTarget?: "budget" | "threshold";
   customInstructions?: string;
@@ -1297,7 +1297,7 @@ function toStoredMessage(message: AgentMessage): StoredMessage {
     "content" in message
       ? extractMessageContent(message.content)
       : "output" in message
-        ? `$ ${(message as { command: string; output: string }).command}\n${(message as { command: string; output: string }).output}`
+        ? `$ ${String(message.command ?? "")}\n${String(message.output)}`
         : "";
   const runtimeRole = toRuntimeRoleForTokenEstimate(message.role);
   const normalizedContent =
@@ -1625,14 +1625,18 @@ function extractRuntimePromptTokenCount(runtimeContext?: Record<string, unknown>
   }
 
   // 2. Sum from runtimeContext.usage (normalizeUsage output: {input, cacheRead, cacheWrite})
-  const usageSum = sumPromptTokensFromUsageRecord(asRecord(ctx["usage"]) ?? asRecord(ctx["lastCallUsage"]));
+  const usageSum = sumPromptTokensFromUsageRecord(
+    asRecord(ctx["usage"]) ?? asRecord(ctx["lastCallUsage"]) ?? null,
+  );
   if (usageSum !== undefined && usageSum > 0) {
     return usageSum;
   }
 
   // 3. Sum from promptCache.lastCallUsage (same normalized shape)
   const promptCache = asRecord(ctx["promptCache"]);
-  const promptCacheUsageSum = sumPromptTokensFromUsageRecord(asRecord(promptCache?.["lastCallUsage"]));
+  const promptCacheUsageSum = sumPromptTokensFromUsageRecord(
+    asRecord(promptCache?.["lastCallUsage"]) ?? null,
+  );
   if (promptCacheUsageSum !== undefined && promptCacheUsageSum > 0) {
     return promptCacheUsageSum;
   }
@@ -3340,7 +3344,7 @@ export class LcmContextEngine implements ContextEngine {
   private retrieval: RetrievalEngine;
   private readonly db: DatabaseSync;
   private migrated = false;
-  private readonly fts5Available: boolean;
+  private readonly fts5Available: boolean = false;
   private readonly ignoreSessionPatterns: RegExp[];
   private readonly statelessSessionPatterns: RegExp[];
   private sessionOperationQueues = new Map<
@@ -8288,6 +8292,7 @@ export class LcmContextEngine implements ContextEngine {
     autoCompactionSummary?: string;
     isHeartbeat?: boolean;
     tokenBudget?: number;
+    currentTokenCount?: number;
     /** OpenClaw runtime param name (preferred). */
     runtimeContext?: Record<string, unknown>;
     /** Back-compat param name. */
@@ -8496,6 +8501,7 @@ export class LcmContextEngine implements ContextEngine {
     const estimatedContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
     const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
     const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
       (
         (legacyParams ?? {}) as {
           currentTokenCount?: unknown;
@@ -10349,7 +10355,7 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    const entriesToKeep: Array<Record<string, unknown>> = [];
+    const entriesToKeep: Array<(typeof branch)[number]> = [];
     for (const type of ["session_info", "model_change", "thinking_level_change"] as const) {
       const entry = latestPreludeEntries.get(type);
       if (entry) {
@@ -10369,7 +10375,7 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     let previousEntryId: string | null = null;
-    const linearizedEntries = entriesToKeep.map((entry) => {
+    const linearizedEntries = entriesToKeep.map((entry): (typeof branch)[number] => {
       const nextEntry = {
         ...entry,
         parentId: previousEntryId,

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -1,13 +1,31 @@
-export type {
-  AnyAgentTool,
-} from "openclaw/plugin-sdk";
-
 /**
  * Compatibility bridge for plugin-sdk context-engine symbols.
  *
  * This module intentionally keeps the context-engine contract local because
  * older OpenClaw SDK packages do not publish these newer type symbols yet.
  */
+
+export type AnyAgentTool = {
+  name: string;
+  label?: string;
+  description?: string;
+  parameters?: unknown;
+  execute: (toolCallId: string, params: Record<string, unknown>) => any | Promise<any>;
+  [key: string]: any;
+};
+
+export type PluginLifecycleContext = {
+  sessionId?: string;
+  sessionKey?: string;
+  [key: string]: any;
+};
+
+export type PluginLifecycleEvent = {
+  reason?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  [key: string]: any;
+};
 
 export type ContextEngineProjection = {
   mode: "per_turn" | "thread_bootstrap";
@@ -34,7 +52,7 @@ export type CompactResult = {
   reason?: string;
   summaryId?: string;
   error?: string;
-  result?: unknown;
+  result?: any;
 };
 
 export type IngestResult = {
@@ -84,7 +102,7 @@ export type PluginCommandContext = {
 export type OpenClawPluginCommandDefinition = {
   name?: string;
   description?: string;
-  handler?: (ctx: PluginCommandContext) => unknown | Promise<unknown>;
+  handler: (ctx: PluginCommandContext) => any | Promise<any>;
   [key: string]: any;
 };
 
@@ -97,6 +115,14 @@ export type OpenClawPluginApi = {
   log?: any;
   registerCommand: (definition: OpenClawPluginCommandDefinition) => void;
   registerContextEngine?: (id: string, factory: ContextEngineFactory) => void;
+  registerTool?: (
+    factory: (ctx: PluginLifecycleContext) => AnyAgentTool | Promise<AnyAgentTool>,
+    options?: { name?: string; [key: string]: any },
+  ) => void;
+  on: (
+    eventName: string,
+    handler: (event: PluginLifecycleEvent, ctx: PluginLifecycleContext) => unknown | Promise<unknown>,
+  ) => void;
   [key: string]: any;
 };
 
@@ -109,6 +135,9 @@ export type AgentMessage = {
   toolName?: string;
   details?: any;
   isError?: boolean;
+  stopReason?: string;
+  command?: string;
+  output?: unknown;
 };
 
 export type ContextEngine = {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -32,6 +32,7 @@ const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.22";
 
 type ContextEngineCapableOpenClawPluginApi = OpenClawPluginApi & {
   registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
+  registerTool: NonNullable<OpenClawPluginApi["registerTool"]>;
 };
 
 /** Parse `agent:<agentId>:<suffix...>` session keys. */

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -1161,7 +1161,7 @@ export class ConversationStore {
       .all(...args) as unknown as MessageRow[];
 
     return rows
-      .map((row) => {
+      .map((row): MessageSearchResult | null => {
         const normalizedContent = normalizeMessageContentForFullTextIndex(row.content) ?? row.content;
         const haystack = normalizedContent.toLowerCase();
         const matchesAllTerms = plan.terms.every((term) => haystack.includes(term));

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -9,6 +9,7 @@ import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import { formatTimestamp } from "../compaction.js";
+import type { DescribeResult } from "../retrieval.js";
 
 function formatDisplayTime(
   value: Date | string | number | null | undefined,
@@ -74,7 +75,7 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
   return Math.max(1, Math.trunc(value));
 }
 
-function compactDescribeDetails(result: Awaited<ReturnType<LcmContextEngine["getRetrieval"]>["describe"]>) {
+function compactDescribeDetails(result: DescribeResult | null) {
   if (!result) {
     return result;
   }

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -172,7 +172,13 @@ type BucketExecutionResult =
     }
   | {
       conversationId: number;
-      status: "failed" | "skipped";
+      status: "failed";
+      candidateCount: number;
+      error: string;
+    }
+  | {
+      conversationId: number;
+      status: "skipped";
       candidateCount: number;
       error: string;
     };

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -2,32 +2,45 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
 import type { LcmDependencies } from "../src/types.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const tempDirs: string[] = [];
 
+function appendSessionMessage(manager: SessionManager, message: AgentMessage): string {
+  return manager.appendMessage(
+    message as unknown as Parameters<SessionManager["appendMessage"]>[0],
+  );
+}
+
 function createTestConfig(databasePath: string): LcmConfig {
   return {
     enabled: true,
     databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
     contextThreshold: 0.75,
     freshTailCount: 8,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
     condensedMinFanout: 4,
     condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
     incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
     leafChunkTokens: 20_000,
     leafTargetTokens: 600,
     condensedTargetTokens: 900,
@@ -52,10 +65,25 @@ function createTestConfig(databasePath: string): LcmConfig {
     customInstructions: "",
     expansionProvider: "",
     expansionModel: "",
-    pinnedFiles: [],
-    pinnedFilesPerAgent: {},
+    delegationTimeoutMs: 120_000,
+    summaryTimeoutMs: 60_000,
     circuitBreakerThreshold: 5,
     circuitBreakerCooldownMs: 1_800_000,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.90,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40_000,
+    },
+    stripInjectedContextTags: [],
   };
 }
 
@@ -86,6 +114,7 @@ function createTestDeps(config: LcmConfig): LcmDependencies {
     },
     resolveAgentDir: () => process.env.HOME ?? tmpdir(),
     resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
     agentLaneSubagent: "subagent",
     log: {
       info: vi.fn(),
@@ -119,20 +148,20 @@ function buildRepeatedPatternSession(sessionFile: string, pairCount: number): vo
   const sm = SessionManager.open(sessionFile);
   for (let i = 0; i < pairCount; i++) {
     if (i % 5 === 0) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: "ping" }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: "pong" }],
       } as AgentMessage);
     } else {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: `Question ${i}` }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: `Answer ${i}` }],
       } as AgentMessage);
@@ -307,7 +336,7 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
     // Add many new messages to the JSONL — these look "new" due to stale checkpoint
     const sm = SessionManager.open(sessionFile);
     for (let i = 0; i < 200; i++) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: `extra flood message ${i}` }],
       } as AgentMessage);
@@ -427,7 +456,7 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
     // Add enough extra messages to trigger the import cap
     const sm = SessionManager.open(sessionFile);
     for (let i = 0; i < 200; i++) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: `flood ${i}` }],
       } as AgentMessage);

--- a/test/circuit-breaker.test.ts
+++ b/test/circuit-breaker.test.ts
@@ -21,15 +21,23 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
   return {
     enabled: true,
     databasePath: ":memory:",
+    largeFilesDir: "/tmp/lcm-files",
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: false,
     contextThreshold: 0.75,
     freshTailCount: 4,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
     leafMinFanout: 4,
     condensedMinFanout: 4,
     condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
     incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
     leafChunkTokens: 2000,
     leafTargetTokens: 600,
     condensedTargetTokens: 900,
@@ -41,7 +49,6 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
     largeFileSummaryModel: "",
     expansionProvider: "",
     expansionModel: "",
-    autocompactDisabled: false,
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
@@ -72,8 +79,9 @@ function createTestConfig(overrides: Partial<LcmConfig> = {}): LcmConfig {
       enabled: true,
       max: 4_000,
     },
+    stripInjectedContextTags: [],
     ...overrides,
-  };
+  } as LcmConfig;
 }
 
 function createTestDeps(config: LcmConfig): LcmDependencies {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2,14 +2,14 @@ import { randomUUID } from "node:crypto";
 import { appendFileSync, chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ContextAssembler } from "../src/assembler.js";
 import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
-import { LcmContextEngine } from "../src/engine.js";
+import { LcmContextEngine, type RotateSessionStorageResult } from "../src/engine.js";
 import { estimateTokens } from "../src/estimate-tokens.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
 import { LcmProviderAuthError, LcmSummarySpendLimitError } from "../src/summarize.js";
 import {
   createDelegatedExpansionGrant,
@@ -22,6 +22,27 @@ import type { LcmDependencies } from "../src/types.js";
 
 const tempDirs: string[] = [];
 
+function appendSessionMessage(manager: SessionManager, message: AgentMessage): string {
+  return manager.appendMessage(
+    message as unknown as Parameters<SessionManager["appendMessage"]>[0],
+  );
+}
+
+function expectUnavailableRotate(
+  result: RotateSessionStorageResult,
+): Extract<RotateSessionStorageResult, { kind: "unavailable" }> {
+  expect(result.kind).toBe("unavailable");
+  return result as Extract<RotateSessionStorageResult, { kind: "unavailable" }>;
+}
+
+function getEngineConfig(engine: LcmContextEngine): LcmConfig {
+  return (engine as unknown as { config: LcmConfig }).config;
+}
+
+function firstCompleteCall(mock: ReturnType<typeof vi.fn>): Parameters<LcmDependencies["complete"]>[0] | undefined {
+  return (mock.mock.calls as Array<[Parameters<LcmDependencies["complete"]>[0]]>)[0]?.[0];
+}
+
 function createTestConfig(databasePath: string): LcmConfig {
   const tempDir = join(databasePath, "..", "lcm-files");
   return {
@@ -33,11 +54,17 @@ function createTestConfig(databasePath: string): LcmConfig {
     skipStatelessSessions: true,
     contextThreshold: 0.75,
     freshTailCount: 8,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
     condensedMinFanout: 4,
     condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
     incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
     leafChunkTokens: 20_000,
     leafTargetTokens: 600,
     condensedTargetTokens: 900,
@@ -80,6 +107,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       enabled: true,
       max: 40_000,
     },
+    stripInjectedContextTags: [],
   };
 }
 
@@ -289,7 +317,7 @@ function createBulkySession(sessionFile: string, messageCount: number): AgentMes
       role: index % 2 === 0 ? "user" : "assistant",
       content: [{ type: "text", text: `auto rotate payload ${index} ${"x".repeat(160)}` }],
     });
-    sm.appendMessage(message);
+    appendSessionMessage(sm, message);
     messages.push(message);
   }
   return messages;
@@ -410,11 +438,11 @@ describe("LcmContextEngine ignored sessions", () => {
   it("skips bootstrap for ignored sessions while bootstrapping included sessions", async () => {
     const sessionFile = createSessionFilePath("ignored-bootstrap");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "bootstrap me" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "bootstrap reply" }],
     } as AgentMessage);
@@ -645,7 +673,7 @@ describe("LcmContextEngine ignored sessions", () => {
     expect(included).toBeDefined();
     expect(resolveDelegatedExpansionGrantId(childSessionKey)).not.toBeNull();
 
-    included?.rollback();
+    included?.rollback?.();
     expect(resolveDelegatedExpansionGrantId(childSessionKey)).toBeNull();
   });
 
@@ -905,11 +933,11 @@ describe("LcmContextEngine stateless sessions", () => {
   it("skips bootstrap persistence for stateless session keys", async () => {
     const sessionFile = createSessionFilePath("stateless-bootstrap");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "bootstrap me" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "bootstrap reply" }],
     } as AgentMessage);
@@ -1168,7 +1196,7 @@ describe("LcmContextEngine stateless sessions", () => {
     expect(skipped).toBeUndefined();
     expect(resolveDelegatedExpansionGrantId(childSessionKey)).not.toBeNull();
 
-    included?.rollback();
+    included?.rollback?.();
     expect(resolveDelegatedExpansionGrantId(childSessionKey)).toBeNull();
   });
 
@@ -2342,9 +2370,10 @@ describe("LcmContextEngine.ingest content extraction", () => {
         .getSummaryStore()
         .getLargeFilesByConversation(conversation!.conversationId);
       expect(largeFiles).toHaveLength(1);
-      expect(largeFiles[0].mimeType).toBe(variant.mimeType);
-      expect(largeFiles[0].storageUri.endsWith(`.${variant.extension}`)).toBe(true);
-      expect(largeFiles[0].fileName.endsWith(`.${variant.extension}`)).toBe(true);
+      const largeFile = largeFiles[0]!;
+      expect(largeFile.mimeType).toBe(variant.mimeType);
+      expect(largeFile.storageUri.endsWith(`.${variant.extension}`)).toBe(true);
+      expect(largeFile.fileName?.endsWith(`.${variant.extension}`)).toBe(true);
     }
   });
 
@@ -2804,7 +2833,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
       const toolOutput = `${"tool output line\n".repeat(160)}done`;
 
       const sm = SessionManager.open(sessionFile);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [
           {
@@ -2815,7 +2844,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
           },
         ],
       } as AgentMessage);
-      const toolResultEntryId = sm.appendMessage({
+      const toolResultEntryId = appendSessionMessage(sm, {
         role: "toolResult",
         toolCallId: "call_gc_rewrite",
         toolName: "exec",
@@ -2828,7 +2857,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
           },
         ],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: "done" }],
       } as AgentMessage);
@@ -3121,22 +3150,22 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionFile = createSessionFilePath("branched");
     const sm = SessionManager.open(sessionFile);
 
-    const rootUserId = sm.appendMessage({
+    const rootUserId = appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "root user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "abandoned assistant" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "abandoned user" }],
     } as AgentMessage);
 
     // Re-branch from the first user entry so prior turns are abandoned.
     sm.branch(rootUserId);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "active assistant" }],
     } as AgentMessage);
@@ -3182,11 +3211,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("is idempotent and does not duplicate already bootstrapped sessions", async () => {
     const sessionFile = createSessionFilePath("idempotent");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "first" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "second" }],
     } as AgentMessage);
@@ -3219,11 +3248,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionId = "bootstrap-reinstantiation-replay";
 
     for (let turn = 1; turn <= 5; turn += 1) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: `question ${turn}` }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: `answer ${turn}` }],
       } as AgentMessage);
@@ -3239,7 +3268,7 @@ describe("LcmContextEngine.bootstrap", () => {
     await engineA.dispose();
 
     for (const answer of ["answer 3", "answer 4", "answer 5"]) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: answer }],
       } as AgentMessage);
@@ -3276,11 +3305,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionId = "bootstrap-reinstantiation-tool-tail";
 
     for (let turn = 1; turn <= 5; turn += 1) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: `question ${turn}` }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: `answer ${turn}` }],
       } as AgentMessage);
@@ -3296,12 +3325,12 @@ describe("LcmContextEngine.bootstrap", () => {
     await engineA.dispose();
 
     for (const answer of ["answer 3", "answer 4", "answer 5"]) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: answer }],
       } as AgentMessage);
     }
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "toolResult",
       toolCallId: "call_new",
       content: [{ type: "tool_result", tool_use_id: "call_new", output: { ok: true } }],
@@ -3337,11 +3366,11 @@ describe("LcmContextEngine.bootstrap", () => {
       ["question 2", "beta"],
       ["question 3", "gamma"],
     ] as const) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: question }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: answer }],
       } as AgentMessage);
@@ -3360,7 +3389,7 @@ describe("LcmContextEngine.bootstrap", () => {
     }
 
     for (const answer of ["alpha", "gamma", "beta"]) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: answer }],
       } as AgentMessage);
@@ -3392,11 +3421,11 @@ describe("LcmContextEngine.bootstrap", () => {
       ["question 2", "beta"],
       ["question 3", "gamma"],
     ] as const) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: question }],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [{ type: "text", text: answer }],
       } as AgentMessage);
@@ -3419,7 +3448,7 @@ describe("LcmContextEngine.bootstrap", () => {
     }
 
     for (const question of ["question 1", "question 2", "question 3"]) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "user",
         content: [{ type: "text", text: question }],
       } as AgentMessage);
@@ -3437,11 +3466,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("skips reopening the transcript when checkpoint stats match", async () => {
     const sessionFile = createSessionFilePath("unchanged-fast-path");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "first" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "second" }],
     } as AgentMessage);
@@ -3467,11 +3496,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const dbPath = join(tempDir, "lcm.db");
     const sessionFile = createSessionFilePath("missing-checkpoint");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "first" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "second" }],
     } as AgentMessage);
@@ -3509,11 +3538,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("preserves existing conversation data when the session file rotates", async () => {
     const firstSessionFile = createSessionFilePath("rotation-old");
     const firstManager = SessionManager.open(firstSessionFile);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "user",
       content: [{ type: "text", text: "old user" }],
     } as AgentMessage);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "assistant",
       content: [{ type: "text", text: "old assistant" }],
     } as AgentMessage);
@@ -3541,19 +3570,19 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const rotatedSessionFile = createSessionFilePath("rotation-new");
     const rotatedManager = SessionManager.open(rotatedSessionFile);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "user",
       content: [{ type: "text", text: "old user" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "assistant",
       content: [{ type: "text", text: "old assistant" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "user",
       content: [{ type: "text", text: "new user" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "assistant",
       content: [{ type: "text", text: "new assistant" }],
     } as AgentMessage);
@@ -3591,11 +3620,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionKey = "agent:main:test:bootstrap-rotation";
     const firstSessionFile = createSessionFilePath("rotation-session-key-old");
     const firstManager = SessionManager.open(firstSessionFile);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "user",
       content: [{ type: "text", text: "old keyed user" }],
     } as AgentMessage);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "assistant",
       content: [{ type: "text", text: "old keyed assistant" }],
     } as AgentMessage);
@@ -3629,19 +3658,19 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const rotatedSessionFile = createSessionFilePath("rotation-session-key-new");
     const rotatedManager = SessionManager.open(rotatedSessionFile);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "user",
       content: [{ type: "text", text: "old keyed user" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "assistant",
       content: [{ type: "text", text: "old keyed assistant" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "user",
       content: [{ type: "text", text: "new keyed user" }],
     } as AgentMessage);
-    rotatedManager.appendMessage({
+    appendSessionMessage(rotatedManager, {
       role: "assistant",
       content: [{ type: "text", text: "new keyed assistant" }],
     } as AgentMessage);
@@ -3691,11 +3720,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionKey = "agent:main:test:bootstrap-missed-reset-fallback";
     const firstSessionFile = createSessionFilePath("missed-reset-fallback-old");
     const firstManager = SessionManager.open(firstSessionFile);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "user",
       content: [{ type: "text", text: "old user" }],
     } as AgentMessage);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "assistant",
       content: [{ type: "text", text: "old assistant" }],
     } as AgentMessage);
@@ -3731,11 +3760,11 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const secondSessionFile = createSessionFilePath("missed-reset-fallback-new");
     const secondManager = SessionManager.open(secondSessionFile);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "user",
       content: [{ type: "text", text: "new user" }],
     } as AgentMessage);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "assistant",
       content: [{ type: "text", text: "new assistant" }],
     } as AgentMessage);
@@ -3875,11 +3904,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionKey = "agent:main:test:bootstrap-stat-failure-fallback";
     const firstSessionFile = createSessionFilePath("stat-failure-fallback-old");
     const firstManager = SessionManager.open(firstSessionFile);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "user",
       content: [{ type: "text", text: "old user" }],
     } as AgentMessage);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "assistant",
       content: [{ type: "text", text: "old assistant" }],
     } as AgentMessage);
@@ -3913,19 +3942,19 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const secondSessionFile = createSessionFilePath("stat-failure-fallback-new");
     const secondManager = SessionManager.open(secondSessionFile);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "user",
       content: [{ type: "text", text: "old user" }],
     } as AgentMessage);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "assistant",
       content: [{ type: "text", text: "old assistant" }],
     } as AgentMessage);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "user",
       content: [{ type: "text", text: "new user" }],
     } as AgentMessage);
-    secondManager.appendMessage({
+    appendSessionMessage(secondManager, {
       role: "assistant",
       content: [{ type: "text", text: "new assistant" }],
     } as AgentMessage);
@@ -3983,11 +4012,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionKey = "agent:main:test:bootstrap-rotation-full-reseed";
     const firstSessionFile = createSessionFilePath("rotation-full-reseed-old");
     const firstManager = SessionManager.open(firstSessionFile);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "user",
       content: [{ type: "text", text: "old seed user" }],
     } as AgentMessage);
-    firstManager.appendMessage({
+    appendSessionMessage(firstManager, {
       role: "assistant",
       content: [{ type: "text", text: "old seed assistant" }],
     } as AgentMessage);
@@ -4015,14 +4044,14 @@ describe("LcmContextEngine.bootstrap", () => {
       },
     ] as AgentMessage[];
     for (const message of originalMessages) {
-      rotatedManager.appendMessage(message);
+      appendSessionMessage(rotatedManager, message);
     }
     const rotatedMessages = Array.from({ length: 5 }, (_, index) => ({
       role: index % 2 === 0 ? "user" : "assistant",
       content: [{ type: "text", text: `rotated turn ${index} ${"x".repeat(396)}` }],
     })) as AgentMessage[];
     for (const message of rotatedMessages) {
-      rotatedManager.appendMessage(message);
+      appendSessionMessage(rotatedManager, message);
     }
 
     const second = await engine.bootstrap({
@@ -4064,7 +4093,7 @@ describe("LcmContextEngine.bootstrap", () => {
       { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
     ] as AgentMessage[];
     for (const message of originalMessages) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const engine = createEngineWithConfig({ freshTailCount: 2 });
@@ -4132,7 +4161,7 @@ describe("LcmContextEngine.bootstrap", () => {
     const rotatedBranchMessages = rotatedManager
       .getBranch()
       .filter((entry) => entry.type === "message")
-      .map((entry) => entry.message);
+      .map((entry) => entry.message as { content: Array<{ text: string }> });
     expect(rotatedBranchMessages.map((message) => (message.content[0] as { text: string }).text)).toEqual([
       "tail user",
       "tail assistant",
@@ -4142,11 +4171,11 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(checkpointHit.bootstrapped).toBe(false);
     expect(checkpointHit.importedMessages).toBe(0);
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "new user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "new assistant" }],
     } as AgentMessage);
@@ -4188,7 +4217,7 @@ describe("LcmContextEngine.bootstrap", () => {
       { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
     ] as AgentMessage[];
     for (const message of originalMessages) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const engine = createEngineWithConfig({
@@ -4263,7 +4292,7 @@ describe("LcmContextEngine.bootstrap", () => {
       { role: "user", content: [{ type: "text", text: "tail user" }] },
       { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
     ] as AgentMessage[]) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const complete = vi.fn(async () => {
@@ -4296,8 +4325,7 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionKey,
       sessionFile,
     });
-    expect(firstRotate.kind).toBe("unavailable");
-    expect(firstRotate.reason).toContain("summary provider rejected authentication");
+    expect(expectUnavailableRotate(firstRotate).reason).toContain("summary provider rejected authentication");
     expect(complete).toHaveBeenCalledTimes(1);
 
     const secondRotate = await engine.rotateSessionStorage({
@@ -4305,8 +4333,7 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionKey,
       sessionFile,
     });
-    expect(secondRotate.kind).toBe("unavailable");
-    expect(secondRotate.reason).toContain("summary provider circuit breaker is open");
+    expect(expectUnavailableRotate(secondRotate).reason).toContain("summary provider circuit breaker is open");
     expect(complete).toHaveBeenCalledTimes(1);
   });
 
@@ -4338,7 +4365,7 @@ describe("LcmContextEngine.bootstrap", () => {
         { role: "assistant", content: [{ type: "text", text: `tail assistant ${suffix}` }] },
         { role: "user", content: [{ type: "text", text: `tail user ${suffix}` }] },
       ] as AgentMessage[]) {
-        sm.appendMessage(message);
+        appendSessionMessage(sm, message);
       }
 
       await engine.bootstrap({ sessionId, sessionKey, sessionFile });
@@ -4364,7 +4391,7 @@ describe("LcmContextEngine.bootstrap", () => {
       { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
       { role: "user", content: [{ type: "text", text: "tail user" }] },
     ] as AgentMessage[]) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const engine = createEngineWithConfig({
@@ -4391,8 +4418,7 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionKey,
       sessionFile,
     });
-    expect(rotate.kind).toBe("unavailable");
-    expect(rotate.reason).toContain("summary spend backoff is open");
+    expect(expectUnavailableRotate(rotate).reason).toContain("summary spend backoff is open");
   });
 
   it("reconciles unimported transcript messages before rotate summary coverage", async () => {
@@ -4412,7 +4438,7 @@ describe("LcmContextEngine.bootstrap", () => {
     ] as AgentMessage[];
     const sm = SessionManager.open(sessionFile);
     for (const message of originalMessages.slice(0, 2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const engine = createEngineWithConfig({
@@ -4427,7 +4453,7 @@ describe("LcmContextEngine.bootstrap", () => {
       importedMessages: 2,
     });
     for (const message of originalMessages.slice(2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -4512,7 +4538,7 @@ describe("LcmContextEngine.bootstrap", () => {
     ] as AgentMessage[];
     const sm = SessionManager.open(sessionFile);
     for (const message of transcriptMessages) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -4582,8 +4608,7 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionFile,
     });
 
-    expect(rotate.kind).toBe("unavailable");
-    expect(rotate.reason).toContain("could not prove transcript coverage");
+    expect(expectUnavailableRotate(rotate).reason).toContain("could not prove transcript coverage");
     expect(readFileSync(sessionFile, "utf8")).toBe(originalTranscript);
   });
 
@@ -4604,7 +4629,7 @@ describe("LcmContextEngine.bootstrap", () => {
     ] as AgentMessage[];
     const sm = SessionManager.open(sessionFile);
     for (const message of transcriptMessages.slice(0, 2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const engine = createEngineWithConfig({
@@ -4618,7 +4643,7 @@ describe("LcmContextEngine.bootstrap", () => {
       importedMessages: 2,
     });
     for (const message of transcriptMessages.slice(2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -4672,7 +4697,7 @@ describe("LcmContextEngine.bootstrap", () => {
     ] as AgentMessage[];
     const sm = SessionManager.open(sessionFile);
     for (const message of transcriptMessages.slice(0, 2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const complete = vi.fn(async () => ({
@@ -4695,7 +4720,7 @@ describe("LcmContextEngine.bootstrap", () => {
     );
     await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     for (const message of transcriptMessages.slice(2)) {
-      sm.appendMessage(message);
+      appendSessionMessage(sm, message);
     }
 
     const conversation = await engine.getConversationStore().getConversationForSession({
@@ -4725,7 +4750,7 @@ describe("LcmContextEngine.bootstrap", () => {
   it("waits for an in-flight managed transaction before backing up and rotating", async () => {
     const sessionFile = createSessionFilePath("lcm-rotate-storage-wait");
     const sessionManager = SessionManager.inMemory(process.cwd());
-    sessionManager.appendMessage({
+    appendSessionMessage(sessionManager, {
       role: "user",
       content: [{ type: "text", text: "existing" }],
     } as AgentMessage);
@@ -4840,8 +4865,7 @@ describe("LcmContextEngine.bootstrap", () => {
       sessionFile: join(tmpdir(), `missing-rotate-transcript-${Date.now()}.jsonl`),
     });
 
-    expect(result.kind).toBe("unavailable");
-    expect(result.reason).toContain("could not rotate the current session transcript");
+    expect(expectUnavailableRotate(result).reason).toContain("could not rotate the current session transcript");
   });
 
   it("defers oversized session-file rewrites from afterTurn runtime hooks", async () => {
@@ -5463,11 +5487,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("reconciles missing tail messages when JSONL advanced past LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-tail");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5486,11 +5510,11 @@ describe("LcmContextEngine.bootstrap", () => {
       .getConversationBootstrapState(conversation!.conversationId);
     expect(firstBootstrapState).not.toBeNull();
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "lost user turn" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "lost assistant turn" }],
     } as AgentMessage);
@@ -5524,11 +5548,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("imports appended tail messages without replaying full reconciliation", async () => {
     const sessionFile = createSessionFilePath("append-only-tail");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5542,11 +5566,11 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const reconcileSpy = vi.spyOn(engine as any, "reconcileSessionTail");
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -5734,23 +5758,23 @@ describe("LcmContextEngine.bootstrap", () => {
   it("keeps the append-only fast path after heartbeat pruning changes the DB frontier", async () => {
     const sessionFile = createSessionFilePath("append-only-heartbeat-prune");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly." }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "tool",
       content: "# HEARTBEAT.md\n\n## Worker heartbeat (minimal)",
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "HEARTBEAT_OK" }],
     } as AgentMessage);
@@ -5770,11 +5794,11 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const reconcileSpy = vi.spyOn(engine as any, "reconcileSessionTail");
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -5799,11 +5823,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("ignores non-message envelopes in appended transcript tails without forcing reconcile", async () => {
     const sessionFile = createSessionFilePath("append-only-noncanonical-envelope");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5821,11 +5845,11 @@ describe("LcmContextEngine.bootstrap", () => {
       `${JSON.stringify({ type: "commentary", message: { role: "assistant", content: "ignore me" } })}\n`,
       "utf8",
     );
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -5842,11 +5866,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("tolerates custom bootstrap sidecar entries in append-only suffixes", async () => {
     const sessionFile = createSessionFilePath("append-only-bootstrap-sidecar");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5864,7 +5888,7 @@ describe("LcmContextEngine.bootstrap", () => {
       `${JSON.stringify({ type: "custom", customType: "openclaw:bootstrap-context:full", data: { ok: true } })}\n`,
       "utf8",
     );
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
@@ -5881,11 +5905,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("refreshes the bootstrap checkpoint after afterTurn heartbeat pruning", async () => {
     const sessionFile = createSessionFilePath("append-only-after-turn-heartbeat-prune");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5912,7 +5936,7 @@ describe("LcmContextEngine.bootstrap", () => {
       }),
     ];
     for (const message of heartbeatBatch) {
-      sm.appendMessage(message as AgentMessage);
+      appendSessionMessage(sm, message as AgentMessage);
     }
 
     await engine.afterTurn({
@@ -5924,11 +5948,11 @@ describe("LcmContextEngine.bootstrap", () => {
       tokenBudget: 4096,
     });
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -5946,11 +5970,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("refreshes the bootstrap checkpoint after a normal afterTurn before the next append-only bootstrap", async () => {
     const sessionFile = createSessionFilePath("append-only-after-turn-normal-ingest");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -5972,7 +5996,7 @@ describe("LcmContextEngine.bootstrap", () => {
       }),
     ];
     for (const message of realTurn) {
-      sm.appendMessage(message as AgentMessage);
+      appendSessionMessage(sm, message as AgentMessage);
     }
 
     await engine.afterTurn({
@@ -5983,11 +6007,11 @@ describe("LcmContextEngine.bootstrap", () => {
       tokenBudget: 4096,
     });
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -6005,11 +6029,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("reconciles foreground transcript messages before assistant-only afterTurn deltas", async () => {
     const sessionFile = createSessionFilePath("after-turn-foreground-transcript-reconcile");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "kick off workers" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "same status reply" }],
     } as AgentMessage);
@@ -6020,11 +6044,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const first = await engine.bootstrap({ sessionId, sessionFile });
     expect(first.bootstrapped).toBe(true);
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "You set up a monitor too right?" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "same status reply" }],
     } as AgentMessage);
@@ -6060,11 +6084,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const dbPath = join(tempDir, "lcm.db");
     const sessionFile = createSessionFilePath("append-only-mismatch");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -6093,11 +6117,11 @@ describe("LcmContextEngine.bootstrap", () => {
 
     const reconcileSpy = vi.spyOn(engine as any, "reconcileSessionTail");
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "tail user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "tail assistant" }],
     } as AgentMessage);
@@ -6114,19 +6138,19 @@ describe("LcmContextEngine.bootstrap", () => {
   it("reconciles missing structured tool-call tail when prior empty tool content exists", async () => {
     const sessionFile = createSessionFilePath("reconcile-tool-tail");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "toolCall", id: "call_existing", name: "read", input: { path: "a.txt" } }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "toolResult",
       toolCallId: "call_existing",
       content: [{ type: "tool_result", tool_use_id: "call_existing", output: { ok: true } }],
@@ -6139,11 +6163,11 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(first.bootstrapped).toBe(true);
     expect(first.importedMessages).toBe(4);
 
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "toolCall", id: "call_missing", name: "read", input: { path: "b.txt" } }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "toolResult",
       toolCallId: "call_missing",
       content: [{ type: "tool_result", tool_use_id: "call_missing", output: { ok: true } }],
@@ -6343,7 +6367,7 @@ describe("LcmContextEngine.bootstrap", () => {
       .getMessages(conversation!.conversationId);
     expect(firstStored).toHaveLength(1);
 
-    const rawDb = createLcmDatabaseConnection(engine.config.databasePath);
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
     try {
       rawDb
         .prepare(`UPDATE messages SET content = ?, token_count = ? WHERE message_id = ?`)
@@ -6433,11 +6457,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("does not append JSONL when no overlapping anchor exists in LCM", async () => {
     const sessionFile = createSessionFilePath("reconcile-no-overlap");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "json only user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "json only assistant" }],
     } as AgentMessage);
@@ -6471,11 +6495,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const dbPath = join(tempDir, "lcm.db");
     const sessionFile = createSessionFilePath("reconcile-import-cap");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -6528,7 +6552,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(staleBootstrapState?.lastProcessedEntryHash).toBe("mismatch");
 
     for (let index = 0; index < 60; index += 1) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: index % 2 === 0 ? "user" : "assistant",
         content: [{ type: "text", text: `missing tail ${index}` }],
       } as AgentMessage);
@@ -6565,11 +6589,11 @@ describe("LcmContextEngine.bootstrap", () => {
   it("uses the live ingest path for initial bootstrap", async () => {
     const sessionFile = createSessionFilePath("bootstrap-ingest-path");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "ingest one" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "ingest two" }],
     } as AgentMessage);
@@ -6709,7 +6733,7 @@ describe("LcmContextEngine.bootstrap", () => {
       const sessionFile = createSessionFilePath("bootstrap-tool-result-parity");
       const sm = SessionManager.open(sessionFile);
       const toolOutput = `${"bootstrap tool output\n".repeat(160)}done`;
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "assistant",
         content: [
           {
@@ -6720,7 +6744,7 @@ describe("LcmContextEngine.bootstrap", () => {
           },
         ],
       } as AgentMessage);
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: "toolResult",
         toolCallId: "call_bootstrap_externalized",
         toolName: "exec",
@@ -6772,7 +6796,7 @@ describe("LcmContextEngine.bootstrap", () => {
     const sessionFile = createSessionFilePath("bootstrap-token-cap");
     const sm = SessionManager.open(sessionFile);
     for (let index = 0; index < 5; index += 1) {
-      sm.appendMessage({
+      appendSessionMessage(sm, {
         role: index % 2 === 0 ? "user" : "assistant",
         content: [{ type: "text", text: `turn ${index} ${"x".repeat(396)}` }],
       } as AgentMessage);
@@ -6841,7 +6865,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(stored[0]?.content).not.toContain("fork parent turn 0");
     expect(stored.at(-1)?.content).toContain("fork parent turn 59");
 
-    const rawDb = createLcmDatabaseConnection(engine.config.databasePath);
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
     try {
       rawDb
         .prepare(
@@ -6857,7 +6881,7 @@ describe("LcmContextEngine.bootstrap", () => {
     const secondBootstrap = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     expect(secondBootstrap.bootstrapped).toBe(false);
 
-    const restartedEngine = createEngineAtDatabasePath(engine.config.databasePath);
+    const restartedEngine = createEngineAtDatabasePath(getEngineConfig(engine).databasePath);
     const repeatedChildPrompt = `fork parent turn 58 ${"x".repeat(240)}`;
     const liveMessages = [
       ...forkedParentBranch.map((entry) => entry.message as AgentMessage),
@@ -6883,7 +6907,7 @@ describe("LcmContextEngine.bootstrap", () => {
   it("drops an oversized singleton bootstrap tail that exceeds bootstrapMaxTokens", async () => {
     const sessionFile = createSessionFilePath("bootstrap-oversized-singleton");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "x".repeat(5000) }],
     } as AgentMessage);
@@ -7003,7 +7027,7 @@ describe("LcmContextEngine.bootstrap", () => {
     });
 
     expect(preparation).toBeDefined();
-    preparation?.rollback();
+    preparation?.rollback?.();
   });
 
   it("skips full read when file is unchanged and conversation is already bootstrapped", async () => {
@@ -7014,11 +7038,11 @@ describe("LcmContextEngine.bootstrap", () => {
     const dbPath = join(tempDir, "lcm.db");
     const sessionFile = createSessionFilePath("cache-guard");
     const sm = SessionManager.open(sessionFile);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "user",
       content: [{ type: "text", text: "one" }],
     } as AgentMessage);
-    sm.appendMessage({
+    appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "two" }],
     } as AgentMessage);
@@ -12046,7 +12070,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getMessages(conversation!.conversationId);
     expect(firstStored).toHaveLength(1);
 
-    const rawDb = createLcmDatabaseConnection(engine.config.databasePath);
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
     try {
       rawDb
         .prepare(`UPDATE messages SET content = ?, token_count = ? WHERE message_id = ?`)
@@ -14765,7 +14789,7 @@ describe("LcmContextEngine compaction telemetry", () => {
       stripInjectedContextTags: ["hindsight_memories"],
     });
     const sessionId = "compact-strip-injected-context";
-    const summarize = vi.fn(async () => "safe compacted summary");
+    const summarize = vi.fn(async (_text: string) => "safe compacted summary");
 
     await engine.ingestBatch({
       sessionId,
@@ -14833,9 +14857,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     await summarize("segment text");
 
-    const firstCall = completeSpy.mock.calls[0]?.[0] as
-      | { messages?: Array<{ content?: string }> }
-      | undefined;
+    const firstCall = firstCompleteCall(completeSpy);
     const prompt = firstCall?.messages?.[0]?.content;
     expect(typeof prompt).toBe("string");
     expect(prompt).toContain("Operator instructions: (none)");
@@ -15016,9 +15038,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     await summarizeText!("Large file prompt");
 
-    const firstCall = completeSpy.mock.calls[0]?.[0] as
-      | { messages?: Array<{ content?: string }> }
-      | undefined;
+    const firstCall = firstCompleteCall(completeSpy);
     const prompt = firstCall?.messages?.[0]?.content;
     expect(typeof prompt).toBe("string");
     expect(prompt).toContain("Operator instructions:\nUse terse factual prose.");

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -6,16 +6,23 @@ import { buildExpansionToolDefinition } from "../src/expansion.js";
 const BASE_CONFIG: LcmConfig = {
   enabled: true,
   databasePath: ":memory:",
+  largeFilesDir: "/tmp/lcm-files",
   ignoreSessionPatterns: [],
   statelessSessionPatterns: [],
   skipStatelessSessions: true,
   contextThreshold: 0.75,
   freshTailCount: 8,
+  promptAwareEviction: false,
+  stubLargeToolPayloads: false,
   newSessionRetainDepth: 2,
   leafMinFanout: 8,
   condensedMinFanout: 4,
   condensedMinFanoutHard: 2,
+  sweepMaxDepth: 1,
   incrementalMaxDepth: 0,
+  maxSweepIterations: 12,
+  sweepDeadlineMs: 120_000,
+  compactUntilUnderDeadlineMs: 300_000,
   leafChunkTokens: 20_000,
   leafTargetTokens: 600,
   condensedTargetTokens: 900,
@@ -58,6 +65,7 @@ const BASE_CONFIG: LcmConfig = {
     enabled: true,
     max: 40_000,
   },
+  stripInjectedContextTags: [],
 };
 
 function makeExpansionResult() {

--- a/test/focus-brief-overlay.test.ts
+++ b/test/focus-brief-overlay.test.ts
@@ -246,7 +246,6 @@ describe("focus brief assembly overlay", () => {
       depth: 1,
       content: "Condensed summary content that should be masked.",
       tokenCount: 8,
-      latestAt: null,
       sourceMessageTokenCount: 0,
     });
     await summaryStore.linkSummaryToParents("covered_condensed_summary", ["condensed_leaf_summary"]);

--- a/test/focus-briefs.test.ts
+++ b/test/focus-briefs.test.ts
@@ -19,7 +19,7 @@ function createDeps(
     },
     isSubagentSessionKey: (key: string) => key.includes(":subagent:"),
     normalizeAgentId: (id?: string) => id?.trim() || "main",
-    buildSubagentSystemPrompt: ({ taskSummary }) => `system: ${taskSummary ?? ""}`,
+    buildSubagentSystemPrompt: ({ taskSummary }: { taskSummary?: string }) => `system: ${taskSummary ?? ""}`,
     readLatestAssistantReply: (messages: unknown[]) => {
       const latest = messages.at(-1) as { content?: unknown } | undefined;
       return typeof latest?.content === "string" ? latest.content : undefined;
@@ -46,6 +46,7 @@ const activeSummaries: ActiveFocusSummaryRecord[] = [
     tokenCount: 1200,
     createdAt: "2026-05-16T00:00:00.000Z",
     latestAt: "2026-05-16T00:01:00.000Z",
+    maxSourceSeq: 1,
     content: "Focused alpha work, source decisions, and pending review state.",
   },
 ];

--- a/test/index-runtime-llm-complete.test.ts
+++ b/test/index-runtime-llm-complete.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
+import type { CompletionResult } from "../src/types.js";
 
 type RegisteredEngineFactory = (() => unknown) | undefined;
 type RuntimeLlmComplete = ReturnType<typeof vi.fn>;
@@ -103,7 +104,7 @@ function getRegisteredEngine(api: OpenClawPluginApi, getFactory: () => Registere
         maxTokens: number;
         temperature?: number;
         reasoningIfSupported?: string;
-      }) => Promise<Record<string, unknown>>;
+      }) => Promise<CompletionResult>;
     };
     config: { databasePath: string };
   };

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -16,10 +16,7 @@ import type { LcmDependencies } from "../src/types.js";
 function createCommandFixture(options?: {
   summarize?: LcmSummarizeFn;
   deps?: LcmDependencies;
-  getLcm?: () => Promise<{
-    rotateSessionStorageWithBackup: (...args: unknown[]) => Promise<unknown>;
-    compact?: (...args: unknown[]) => Promise<unknown>;
-  }>;
+  getLcm?: () => Promise<any>;
 }) {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-command-"));
   const dbPath = join(tempDir, "lcm.db");
@@ -2061,7 +2058,7 @@ describe("lcm command", () => {
     const hostBoundComplete = vi.fn(async () => ({
       text: "HOST BOUND REPAIR",
     }));
-    const runtimeComplete = vi.fn(async () => ({
+    const runtimeComplete = vi.fn(async (_params: Parameters<LcmDependencies["complete"]>[0]) => ({
       content: [{ type: "text", text: "RUNTIME REPAIR" }],
     }));
     const config = resolveLcmConfig({}, { dbPath: "/tmp/unused.db" });

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { MessagePartRecord, MessageRecord, MessageRole } from "../src/store/conversation-store.js";
+import type { ConversationStore, MessagePartRecord, MessageRecord, MessageRole } from "../src/store/conversation-store.js";
 import type {
   SummaryRecord,
+  SummaryStore,
   ContextItemRecord,
   SummaryKind,
   LargeFileRecord,
@@ -2670,7 +2671,7 @@ describe("LCM integration: compaction", () => {
     await sumStore.appendContextSummary(CONV_ID, "sum_depth_zero_a");
     await sumStore.appendContextSummary(CONV_ID, "sum_depth_zero_b");
 
-    const summarize = vi.fn(async () => "Depth-aware summary output");
+    const summarize = vi.fn(async (_sourceText: string) => "Depth-aware summary output");
     const result = await depthAwareEngine.compact({
       conversationId: CONV_ID,
       tokenBudget: 140,
@@ -2679,7 +2680,7 @@ describe("LCM integration: compaction", () => {
     });
 
     expect(result.actionTaken).toBe(true);
-    const firstSourceText = summarize.mock.calls[0]?.[0] as string;
+    const firstSourceText = summarize.mock.calls[0]?.[0] ?? "";
     expect(firstSourceText).toMatch(
       /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC - \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\]/,
     );
@@ -4397,8 +4398,8 @@ describe("LCM integration: media message annotation in compaction", () => {
     sumStore = createMockSummaryStore();
     wireStores(convStore, sumStore);
     compactionEngine = new CompactionEngine(
-      convStore,
-      sumStore,
+      convStore as unknown as ConversationStore,
+      sumStore as unknown as SummaryStore,
       defaultCompactionConfig,
     );
   });
@@ -4926,7 +4927,7 @@ describe("prompt-aware eviction", () => {
       contentFn: (i) => `Fresh message ${i}`,
     });
 
-    const hasSummaryInOutput = (messages: { content: unknown }[]): boolean =>
+    const hasSummaryInOutput = (messages: Array<{ content?: unknown }>): boolean =>
       messages.some((m) => extractMessageText(m.content).includes("x".repeat(10)));
 
     // Small budget: fresh tail uses ~16 tokens, remaining budget ~54; summary is ~125 tokens → dropped

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -14,7 +14,7 @@ import { LcmContextEngine } from "../src/engine.js";
 import type { LcmDependencies } from "../src/types.js";
 
 type SessionQueueEntry = { promise: Promise<void>; refCount: number };
-type QueueTestEngine = LcmContextEngine & {
+type QueueTestEngine = {
   sessionOperationQueues: Map<string, SessionQueueEntry>;
   withSessionQueue<T>(queueKey: string, operation: () => Promise<T>): Promise<T>;
 };
@@ -26,16 +26,23 @@ function createTestConfig(databasePath: string): LcmConfig {
   return {
     enabled: true,
     databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
     contextThreshold: 0.75,
     freshTailCount: 8,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
     condensedMinFanout: 4,
     condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
     incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
     leafChunkTokens: 20_000,
     leafTargetTokens: 600,
     condensedTargetTokens: 900,
@@ -78,6 +85,7 @@ function createTestConfig(databasePath: string): LcmConfig {
       enabled: true,
       max: 40_000,
     },
+    stripInjectedContextTags: [],
   };
 }
 
@@ -96,6 +104,7 @@ function createTestDeps(config: LcmConfig): LcmDependencies {
     readLatestAssistantReply: () => undefined,
     resolveAgentDir: () => process.env.HOME ?? tmpdir(),
     resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
     agentLaneSubagent: "subagent",
     log: {
       info: vi.fn(),
@@ -112,7 +121,7 @@ function createQueueTestEngine(): QueueTestEngine {
   const config = createTestConfig(join(tempDir, "lcm.db"));
   const db = createLcmDatabaseConnection(config.databasePath);
   dbs.push(db);
-  return new LcmContextEngine(createTestDeps(config), db) as QueueTestEngine;
+  return new LcmContextEngine(createTestDeps(config), db) as unknown as QueueTestEngine;
 }
 
 afterEach(() => {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -623,7 +623,7 @@ describe("createLcmSummarizeFromLegacyParams", () => {
       const deps = makeDeps({
         complete: vi.fn(
           () =>
-            new Promise(() => {
+            new Promise<Awaited<ReturnType<LcmDependencies["complete"]>>>(() => {
               // Intentionally unresolved to exercise the timeout fallback path.
             }),
         ),
@@ -1067,8 +1067,9 @@ describe("createLcmSummarizeFromLegacyParams", () => {
   });
 
     it("propagates runtime llm auth failures without direct credential retry", async () => {
+      const baseConfig = makeDeps().config;
       const deps = makeDeps({
-        config: { summaryTimeoutMs: 60_000 },
+        config: { ...baseConfig, summaryTimeoutMs: 60_000 },
         resolveModel: vi.fn(() => ({
           provider: "openai-codex",
           model: "gpt-5.4",

--- a/test/transaction-mutex.test.ts
+++ b/test/transaction-mutex.test.ts
@@ -276,10 +276,7 @@ describe("transaction-mutex", () => {
         kind: "leaf",
         content: "Summary of messages 0-1",
         tokenCount: 10,
-        messageIds: [],
-        childSummaryIds: [],
         depth: 0,
-        fileIds: [],
       });
 
       await summaryStore.insertSummary({
@@ -288,10 +285,7 @@ describe("transaction-mutex", () => {
         kind: "leaf",
         content: "Summary of messages 2-3",
         tokenCount: 10,
-        messageIds: [],
-        childSummaryIds: [],
         depth: 0,
-        fileIds: [],
       });
 
       // These are launched concurrently; without the mutex, that could
@@ -356,10 +350,7 @@ describe("transaction-mutex", () => {
         kind: "leaf",
         content: "Cross-test summary",
         tokenCount: 10,
-        messageIds: [],
-        childSummaryIds: [],
         depth: 0,
-        fileIds: [],
       });
 
       // This is the core #260 scenario: one session does withTransaction
@@ -425,7 +416,6 @@ describe("transaction-mutex", () => {
             content: "Scoped summary",
             tokenCount: 10,
             depth: 0,
-            fileIds: [],
           });
           await summaryStore.linkSummaryToMessages("sum_scope_001", contextMessageIds.slice(0, 2));
           await delay(20);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2023"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,


### PR DESCRIPTION
## What
Fixes the current TypeScript no-emit errors and adds typecheck coverage to release validation.

## Why
The release head built successfully with esbuild, but `tsc --noEmit` exposed source and test type failures that were not covered by CI.

## Changes
- Fix no-emit type errors
- Add npm typecheck script
- Gate CI and publish
- Include release verification
- Stabilize summary IDs

## Testing
- `npx tsc --noEmit --pretty false`
- `npm run typecheck`
- `npm test -- test/engine.test.ts test/lcm-integration.test.ts test/lcm-command.test.ts test/lcm-expand-tool.test.ts test/lcm-expand-query-tool.test.ts test/lcm-tools.test.ts test/summarize.test.ts test/transaction-mutex.test.ts test/focus-briefs.test.ts test/focus-brief-overlay.test.ts test/index-runtime-llm-complete.test.ts test/expansion.test.ts test/circuit-breaker.test.ts test/session-operation-queues.test.ts test/bootstrap-flood-regression.test.ts`
- `npm run build`
- `git diff --check`

Closes #798