### PR TITLE
feat: add global summary spend limiter

### DIFF
--- a/.changeset/global-summary-spend-limiter.md
+++ b/.changeset/global-summary-spend-limiter.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add optional provider/model-scoped global summarization call limiting with `summaryGlobalMaxCallsPerWindow`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "summaryTimeoutMs": 60000,
   "summaryCallWindowMs": 600000,
   "summaryMaxCallsPerWindow": 24,
+  "summaryGlobalMaxCallsPerWindow": 240,
   "summarySpendBackoffMs": 1800000,
   "timezone": "America/Los_Angeles",
   "pruneHeartbeatOk": false,
@@ -210,6 +211,7 @@ the raw copied transcript.
 | `summaryTimeoutMs` | `integer` | `60000` | `LCM_SUMMARY_TIMEOUT_MS` | Maximum time to wait for one model-backed summarizer call. |
 | `summaryCallWindowMs` | `integer` | `600000` | `LCM_SUMMARY_CALL_WINDOW_MS` | Rolling window for the per-session summarization spend guard. |
 | `summaryMaxCallsPerWindow` | `integer` | `24` | `LCM_SUMMARY_MAX_CALLS_PER_WINDOW` | Maximum model-backed summarization calls per session/window before Lossless opens a non-auth spend backoff. |
+| `summaryGlobalMaxCallsPerWindow` | `integer` | unset | `LCM_SUMMARY_GLOBAL_MAX_CALLS_PER_WINDOW` | Optional shared provider/model summarization call cap in the same rolling window. |
 | `summarySpendBackoffMs` | `integer` | `1800000` | `LCM_SUMMARY_SPEND_BACKOFF_MS` | Cooldown after the summarization spend guard opens. |
 | `customInstructions` | `string` | `""` | `LCM_CUSTOM_INSTRUCTIONS` | Extra natural-language instructions injected into every summarization prompt. |
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -176,6 +176,10 @@
       "label": "Summary Max Calls Per Window",
       "help": "Maximum model-backed summarization calls per session/window before Lossless opens a non-auth spend backoff"
     },
+    "summaryGlobalMaxCallsPerWindow": {
+      "label": "Summary Global Max Calls Per Window",
+      "help": "Optional shared provider/model cap for model-backed summarization calls in each summary call window"
+    },
     "summarySpendBackoffMs": {
       "label": "Summary Spend Backoff (ms)",
       "help": "Cooldown after the summarization spend guard opens"
@@ -427,6 +431,10 @@
         "minimum": 1
       },
       "summaryMaxCallsPerWindow": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "summaryGlobalMaxCallsPerWindow": {
         "type": "integer",
         "minimum": 1
       },

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -623,25 +623,28 @@ Why it matters:
 - guards against runaway summaries that are much larger than their target budget
 - useful when summary models are verbose or unstable
 
-### `summaryMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs`
+### `summaryMaxCallsPerWindow`, `summaryGlobalMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs`
 
-Bounds model-backed compaction and large-file summarization calls per session.
+Bounds model-backed compaction and large-file summarization calls per session. Optionally also bounds calls across sessions by provider/model.
 
 Defaults:
 
 - `summaryMaxCallsPerWindow`: `24`
+- `summaryGlobalMaxCallsPerWindow`: unset
 - `summaryCallWindowMs`: `600000`
 - `summarySpendBackoffMs`: `1800000`
 
 Env overrides:
 
 - `LCM_SUMMARY_MAX_CALLS_PER_WINDOW`
+- `LCM_SUMMARY_GLOBAL_MAX_CALLS_PER_WINDOW`
 - `LCM_SUMMARY_CALL_WINDOW_MS`
 - `LCM_SUMMARY_SPEND_BACKOFF_MS`
 
 Why they matter:
 
 - prevents non-auth provider failures, ineffective compaction, or repeated deferred debt from spending unbounded summarization calls
+- prevents many sessions from individually staying under their per-session caps while collectively exhausting a shared provider/model quota
 - keeps provider-auth failures on the separate auth circuit breaker path
 - direct deterministic fallbacks remain available when model-backed large-file summaries are throttled
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -133,6 +133,8 @@ export type LcmConfig = {
   summaryCallWindowMs?: number;
   /** Maximum model-backed summarization calls per session/window before backoff. */
   summaryMaxCallsPerWindow?: number;
+  /** Optional shared provider/model call cap for model-backed summarization. */
+  summaryGlobalMaxCallsPerWindow?: number;
   /** Cooldown after a summarization spend guard opens. */
   summarySpendBackoffMs?: number;
   /** IANA timezone for timestamps in summaries (from TZ env or system default) */
@@ -436,6 +438,11 @@ export function resolveLcmConfigWithDiagnostics(
       parseFiniteInt(env.LCM_SUMMARY_MAX_CALLS_PER_WINDOW)
         ?? toNumber(pc.summaryMaxCallsPerWindow),
     ) ?? DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW;
+  const resolvedSummaryGlobalMaxCallsPerWindow =
+    toPositiveInteger(
+      parseFiniteInt(env.LCM_SUMMARY_GLOBAL_MAX_CALLS_PER_WINDOW)
+        ?? toNumber(pc.summaryGlobalMaxCallsPerWindow),
+    );
   const resolvedSummarySpendBackoffMs =
     toPositiveInteger(
       parseFiniteInt(env.LCM_SUMMARY_SPEND_BACKOFF_MS)
@@ -589,6 +596,7 @@ export function resolveLcmConfigWithDiagnostics(
           ?? toNumber(pc.summaryTimeoutMs) ?? 60000,
       summaryCallWindowMs: resolvedSummaryCallWindowMs,
       summaryMaxCallsPerWindow: resolvedSummaryMaxCallsPerWindow,
+      summaryGlobalMaxCallsPerWindow: resolvedSummaryGlobalMaxCallsPerWindow,
       summarySpendBackoffMs: resolvedSummarySpendBackoffMs,
       timezone: env.TZ ?? toStr(pc.timezone) ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
       pruneHeartbeatOk:

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -131,6 +131,12 @@ type SummarySpendGuardState = {
   backoffUntil: number | null;
   lastReason: string | null;
 };
+
+type SummarySpendGuardLimit = {
+  scopeKey: string;
+  maxCalls: number;
+  reason: string;
+};
 type PromptCacheSnapshot = {
   lastObservedCacheRead?: number;
   lastObservedCacheWrite?: number;
@@ -3626,8 +3632,13 @@ export class LcmContextEngine implements ContextEngine {
   private resolveSummarySpendGuardConfig(): {
     windowMs: number;
     maxCalls: number;
+    globalMaxCalls?: number;
     backoffMs: number;
   } {
+    const globalMaxCalls = this.resolvePositiveConfigInteger(
+      this.config.summaryGlobalMaxCallsPerWindow,
+      0,
+    );
     return {
       windowMs: this.resolvePositiveConfigInteger(
         this.config.summaryCallWindowMs,
@@ -3637,6 +3648,7 @@ export class LcmContextEngine implements ContextEngine {
         this.config.summaryMaxCallsPerWindow,
         24,
       ),
+      ...(globalMaxCalls > 0 ? { globalMaxCalls } : {}),
       backoffMs: this.resolvePositiveConfigInteger(
         this.config.summarySpendBackoffMs,
         30 * 60 * 1000,
@@ -3650,6 +3662,43 @@ export class LcmContextEngine implements ContextEngine {
   }): string {
     const scope = params.scope?.trim() || "global";
     return `${params.kind}:${scope}`;
+  }
+
+  private resolveProviderSummarySpendScope(params: {
+    kind: "compaction" | "large-file";
+    provider?: string;
+    model?: string;
+  }): string | undefined {
+    const provider = params.provider?.trim();
+    const model = params.model?.trim();
+    if (!provider || !model) {
+      return undefined;
+    }
+    return `${params.kind}-provider:${provider}/${model}`;
+  }
+
+  private buildSummarySpendLimits(params: {
+    scopeKey: string;
+    reason: string;
+    globalScopeKey?: string;
+  }): SummarySpendGuardLimit[] {
+    const { maxCalls, globalMaxCalls } = this.resolveSummarySpendGuardConfig();
+    return [
+      {
+        scopeKey: params.scopeKey,
+        maxCalls,
+        reason: params.reason,
+      },
+      ...(params.globalScopeKey && globalMaxCalls
+        ? [
+            {
+              scopeKey: params.globalScopeKey,
+              maxCalls: globalMaxCalls,
+              reason: `${params.reason} provider/global`,
+            },
+          ]
+        : []),
+    ];
   }
 
   private openSummarySpendBackoff(params: {
@@ -3673,10 +3722,11 @@ export class LcmContextEngine implements ContextEngine {
 
   private assertSummarySpendCallAllowed(params: {
     scopeKey: string;
+    maxCalls: number;
     reason: string;
   }): void {
     const now = Date.now();
-    const { windowMs, maxCalls } = this.resolveSummarySpendGuardConfig();
+    const { windowMs } = this.resolveSummarySpendGuardConfig();
     let state = this.summarySpendGuardStates.get(params.scopeKey);
     if (state?.backoffUntil !== null && state?.backoffUntil !== undefined) {
       if (now < state.backoffUntil) {
@@ -3701,14 +3751,14 @@ export class LcmContextEngine implements ContextEngine {
       this.summarySpendGuardStates.set(params.scopeKey, state);
     }
 
-    if (state.calls >= maxCalls) {
+    if (state.calls >= params.maxCalls) {
       const backoffUntil = this.openSummarySpendBackoff({
         scopeKey: params.scopeKey,
         reason: params.reason,
         now,
       });
       this.deps.log.warn(
-        `[lcm] summary spend guard opened scope=${params.scopeKey} calls=${state.calls}/${maxCalls} reason=${params.reason.replaceAll(" ", "_")} backoffUntil=${backoffUntil.toISOString()}`,
+        `[lcm] summary spend guard opened scope=${params.scopeKey} calls=${state.calls}/${params.maxCalls} reason=${params.reason.replaceAll(" ", "_")} backoffUntil=${backoffUntil.toISOString()}`,
       );
       throw new LcmSummarySpendLimitError({
         scopeKey: params.scopeKey,
@@ -3717,6 +3767,12 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     state.lastReason = params.reason;
+  }
+
+  private assertSummarySpendCallsAllowed(limits: SummarySpendGuardLimit[]): void {
+    for (const limit of limits) {
+      this.assertSummarySpendCallAllowed(limit);
+    }
   }
 
   private recordSummarySpendCall(params: {
@@ -3750,27 +3806,36 @@ export class LcmContextEngine implements ContextEngine {
   private buildSummarySpendGuardedDeps(params: {
     scopeKey: string;
     reason: string;
+    globalKind?: "compaction" | "large-file";
   }): LcmDependencies {
-    const complete: CompleteFn = async (input) => {
-      this.assertSummarySpendCallAllowed({
+    const resolveLimits = (input: Parameters<CompleteFn>[0]): SummarySpendGuardLimit[] =>
+      this.buildSummarySpendLimits({
         scopeKey: params.scopeKey,
         reason: params.reason,
+        globalScopeKey: params.globalKind
+          ? this.resolveProviderSummarySpendScope({
+              kind: params.globalKind,
+              provider: input.provider,
+              model: input.model,
+            })
+          : undefined,
       });
+    const complete: CompleteFn = async (input) => {
+      const limits = resolveLimits(input);
+      this.assertSummarySpendCallsAllowed(limits);
       try {
         const result = await this.deps.complete(input);
         if (!extractProviderAuthFailure(result, { requireStructuralSignal: true })) {
-          this.recordSummarySpendCall({
-            scopeKey: params.scopeKey,
-            reason: params.reason,
-          });
+          for (const limit of limits) {
+            this.recordSummarySpendCall(limit);
+          }
         }
         return result;
       } catch (err) {
         if (!extractProviderAuthFailure(err)) {
-          this.recordSummarySpendCall({
-            scopeKey: params.scopeKey,
-            reason: params.reason,
-          });
+          for (const limit of limits) {
+            this.recordSummarySpendCall(limit);
+          }
         }
         throw err;
       }
@@ -3788,6 +3853,7 @@ export class LcmContextEngine implements ContextEngine {
     return async (text, aggressive, options) => {
       this.assertSummarySpendCallAllowed({
         scopeKey: params.scopeKey,
+        maxCalls: this.resolveSummarySpendGuardConfig().maxCalls,
         reason: "custom summarizer call",
       });
       try {
@@ -4841,6 +4907,7 @@ export class LcmContextEngine implements ContextEngine {
         deps: this.buildSummarySpendGuardedDeps({
           scopeKey,
           reason: "compaction summarizer call",
+          globalKind: "compaction",
         }),
         legacyParams: lp,
         customInstructions,
@@ -4889,6 +4956,7 @@ export class LcmContextEngine implements ContextEngine {
         deps: this.buildSummarySpendGuardedDeps({
           scopeKey,
           reason: "large-file summarizer call",
+          globalKind: "large-file",
         }),
         legacyParams: {
           provider,
@@ -10531,7 +10599,7 @@ export class LcmContextEngine implements ContextEngine {
           return {
             kind: "unavailable",
             reason:
-              `Lossless Claw could not summarize raw context before rotate because summary spend backoff is open until ${err.backoffUntil.toISOString()}.`,
+              `Lossless Claw could not summarize raw context before rotate because summary spend backoff is open for ${err.scopeKey} until ${err.backoffUntil.toISOString()}.`,
           };
         }
         throw err;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -50,6 +50,7 @@ describe("resolveLcmConfig", () => {
     expect(config.summaryModel).toBe("");
     expect(config.summaryCallWindowMs).toBe(DEFAULT_SUMMARY_CALL_WINDOW_MS);
     expect(config.summaryMaxCallsPerWindow).toBe(DEFAULT_SUMMARY_MAX_CALLS_PER_WINDOW);
+    expect(config.summaryGlobalMaxCallsPerWindow).toBeUndefined();
     expect(config.summarySpendBackoffMs).toBe(DEFAULT_SUMMARY_SPEND_BACKOFF_MS);
     expect(config.pruneHeartbeatOk).toBe(false);
     expect(config.transcriptGcEnabled).toBe(false);
@@ -92,6 +93,7 @@ describe("resolveLcmConfig", () => {
       compactUntilUnderDeadlineMs: 90000,
       summaryCallWindowMs: 120000,
       summaryMaxCallsPerWindow: 7,
+      summaryGlobalMaxCallsPerWindow: 70,
       summarySpendBackoffMs: 240000,
       ignoreSessionPatterns: ["agent:*:cron:*", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:ephemeral:**"],
@@ -143,6 +145,7 @@ describe("resolveLcmConfig", () => {
     expect(config.compactUntilUnderDeadlineMs).toBe(90000);
     expect(config.summaryCallWindowMs).toBe(120000);
     expect(config.summaryMaxCallsPerWindow).toBe(7);
+    expect(config.summaryGlobalMaxCallsPerWindow).toBe(70);
     expect(config.summarySpendBackoffMs).toBe(240000);
     expect(config.leafMinFanout).toBe(4);
     expect(config.condensedMinFanout).toBe(2);
@@ -205,6 +208,7 @@ describe("resolveLcmConfig", () => {
       LCM_COMPACT_UNTIL_UNDER_DEADLINE_MS: "150000",
       LCM_SUMMARY_CALL_WINDOW_MS: "180000",
       LCM_SUMMARY_MAX_CALLS_PER_WINDOW: "9",
+      LCM_SUMMARY_GLOBAL_MAX_CALLS_PER_WINDOW: "90",
       LCM_SUMMARY_SPEND_BACKOFF_MS: "360000",
     } as NodeJS.ProcessEnv;
     const pluginConfig = {
@@ -220,6 +224,7 @@ describe("resolveLcmConfig", () => {
       compactUntilUnderDeadlineMs: 60000,
       summaryCallWindowMs: 120000,
       summaryMaxCallsPerWindow: 7,
+      summaryGlobalMaxCallsPerWindow: 70,
       summarySpendBackoffMs: 240000,
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
@@ -280,6 +285,7 @@ describe("resolveLcmConfig", () => {
     expect(config.compactUntilUnderDeadlineMs).toBe(150000); // env wins
     expect(config.summaryCallWindowMs).toBe(180000); // env wins
     expect(config.summaryMaxCallsPerWindow).toBe(9); // env wins
+    expect(config.summaryGlobalMaxCallsPerWindow).toBe(90); // env wins
     expect(config.summarySpendBackoffMs).toBe(360000); // env wins
     expect(config.cacheAwareCompaction).toEqual({
       enabled: false,
@@ -812,6 +818,10 @@ describe("resolveLcmConfig", () => {
       minimum: 1,
     });
     expect(manifest.configSchema.properties.summaryMaxCallsPerWindow).toEqual({
+      type: "integer",
+      minimum: 1,
+    });
+    expect(manifest.configSchema.properties.summaryGlobalMaxCallsPerWindow).toEqual({
       type: "integer",
       minimum: 1,
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4354,6 +4354,61 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(complete).toHaveBeenCalledTimes(2);
   });
 
+  it("blocks rotate summarization when sessions exceed the shared provider spend window", async () => {
+    let summaryIndex = 0;
+    const complete = vi.fn(async () => ({
+      content: [{ type: "text", text: `rotate summary ${++summaryIndex}` }],
+    }));
+    const engine = createEngineWithDeps(
+      {
+        summaryProvider: "test-provider",
+        summaryModel: "test-model",
+        freshTailCount: 2,
+        leafChunkTokens: 1,
+        leafMinFanout: 1,
+        summaryMaxCallsPerWindow: 1,
+        summaryGlobalMaxCallsPerWindow: 2,
+        summaryCallWindowMs: 10 * 60 * 1000,
+        summarySpendBackoffMs: 30 * 60 * 1000,
+      },
+      {
+        complete,
+        resolveModel: vi.fn(() => ({ provider: "test-provider", model: "test-model" })),
+      },
+    );
+
+    for (const suffix of ["one", "two", "three"]) {
+      const sessionFile = createSessionFilePath(`lcm-rotate-global-spend-${suffix}`);
+      const sessionKey = `agent:main:rotate-global-spend-${suffix}`;
+      const sessionId = `rotate-global-spend-${suffix}-session`;
+      const sm = SessionManager.open(sessionFile);
+      for (const message of [
+        { role: "user", content: [{ type: "text", text: `older detail ${suffix}` }] },
+        { role: "assistant", content: [{ type: "text", text: `tail assistant ${suffix}` }] },
+        { role: "user", content: [{ type: "text", text: `tail user ${suffix}` }] },
+      ] as AgentMessage[]) {
+        sm.appendMessage(message);
+      }
+
+      await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+
+      const rotate = await engine.rotateSessionStorage({
+        sessionId,
+        sessionKey,
+        sessionFile,
+      });
+      if (suffix === "three") {
+        expect(rotate.kind).toBe("unavailable");
+        expect(rotate.reason).toContain("summary spend backoff is open");
+        expect(rotate.reason).toContain("compaction-provider:test-provider/test-model");
+      } else {
+        expect(rotate).toMatchObject({ kind: "rotated" });
+      }
+    }
+
+    expect(complete).toHaveBeenCalledTimes(2);
+  });
+
   it("returns rotate unavailable when summarization spend backoff opens", async () => {
     const sessionFile = createSessionFilePath("lcm-rotate-storage-spend-backoff");
     const sessionKey = "agent:main:rotate-spend-backoff";
@@ -4675,8 +4730,9 @@ describe("LcmContextEngine.bootstrap", () => {
       sm.appendMessage(message);
     }
 
+    let summaryIndex = 0;
     const complete = vi.fn(async () => ({
-      content: [{ type: "text", text: "telemetry backed summary" }],
+      content: [{ type: "text", text: `telemetry backed summary ${++summaryIndex}` }],
     }));
     const resolveModel = vi.fn((modelRef?: string, providerHint?: string) => ({
       provider: providerHint ?? "fallback",


### PR DESCRIPTION
## What
Adds an optional global/provider-scoped summarization spend limiter across sessions.

## Why
Multiple sessions can each stay within their per-session summarization budget while collectively exhausting a shared provider or account quota window.

## Changes
- Add global call window
- Scope by provider/model
- Preserve session guard
- Update config schema
- Document new option

## Testing
- `npm test -- --run test/engine.test.ts -t "shared provider spend window"`
- `npm test -- --run test/config.test.ts`
- `npm test -- --run test/engine.test.ts -t "summarization spend|summary spend|large-file summarization calls"`
- `npm test -- --run test/circuit-breaker.test.ts`
- `npm test -- --run test/engine.test.ts -t "uses stored compaction telemetry"`
- `npm test`
- `npm run build`

Closes #791