### PR TITLE
feat: add replay residue doctor diagnostic

### DIFF
--- a/.changeset/doctor-replay-residue.md
+++ b/.changeset/doctor-replay-residue.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add a read-only `/lossless doctor` diagnostic for repeated high-token transcript replay residue, including scoped conversation/session details, repeat counts, token pressure, and representative message ids.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -24,7 +24,9 @@ import {
 } from "./lcm-doctor-cleaners.js";
 import {
   detectDoctorMarker,
+  getDoctorReplayResidueStats,
   getDoctorSummaryStats,
+  type DoctorReplayResidueCluster,
   type DoctorSummaryStats,
 } from "./lcm-doctor-shared.js";
 import {
@@ -898,6 +900,31 @@ function buildDoctorCleanerExampleLine(params: {
   return `conv ${formatNumber(params.conversationId)} · session key ${sessionKey} · messages ${formatNumber(params.messageCount)}${preview}`;
 }
 
+function buildReplayResidueExampleLine(cluster: DoctorReplayResidueCluster): string {
+  const sessionKey = cluster.sessionKey
+    ? formatCommand(truncateMiddle(cluster.sessionKey, 80))
+    : "missing";
+  const sessionId = formatCommand(truncateMiddle(cluster.sessionId, 80));
+  // Report a stable identity anchor and row ids, not transcript content.
+  const identity = cluster.identityHash
+    ? `identity ${cluster.identityHash.slice(0, 12)}`
+    : "legacy content identity";
+  const ids = cluster.representativeMessageIds.length > 0
+    ? cluster.representativeMessageIds.map((id) => formatNumber(id)).join(", ")
+    : "none";
+
+  return [
+    `conv ${formatNumber(cluster.conversationId)}`,
+    `session key ${sessionKey}`,
+    `session id ${sessionId}`,
+    `role ${cluster.role}`,
+    identity,
+    `repeats ${formatNumber(cluster.repeatCount)}`,
+    `pressure ~${formatNumber(cluster.tokenPressure)} tokens`,
+    `ids ${ids}`,
+  ].join(" · ");
+}
+
 async function buildStatusText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
@@ -1069,6 +1096,7 @@ async function buildDoctorText(params: {
   }
 
   const stats = getDoctorSummaryStats(params.db, current.stats.conversationId);
+  const replayResidue = getDoctorReplayResidueStats(params.db, current.stats.conversationId);
   const lines = [
     ...buildHeaderLines(),
     "",
@@ -1091,6 +1119,17 @@ async function buildDoctorText(params: {
       buildStatLine("emergency-fallback summaries", formatNumber(stats.emergency)),
       buildStatLine("result", stats.total === 0 ? "clean" : "issues found"),
     ]),
+    "",
+    buildSection("🔁 Transcript replay residue", [
+      buildStatLine("clusters", formatNumber(replayResidue.clusterCount)),
+      buildStatLine("repeated messages", formatNumber(replayResidue.repeatedMessageCount)),
+      buildStatLine(
+        "duplicate token pressure",
+        `~${formatNumber(replayResidue.tokenPressure)} tokens`,
+      ),
+      buildStatLine("mode", "read-only diagnostics"),
+      buildStatLine("result", replayResidue.clusterCount === 0 ? "clean" : "residue found"),
+    ]),
   ];
 
   if (stats.total > 0) {
@@ -1106,6 +1145,16 @@ async function buildDoctorText(params: {
       buildSection("🛠️ Next step", [
         `${formatCommand(`${VISIBLE_COMMAND} doctor apply`)} repairs these in place for the current conversation.`,
       ]),
+    );
+  }
+
+  if (replayResidue.clusterCount > 0) {
+    lines.push(
+      "",
+      buildSection(
+        "🧷 Replay residue examples",
+        replayResidue.clusters.map((cluster) => buildReplayResidueExampleLine(cluster)),
+      ),
     );
   }
 

--- a/src/plugin/lcm-doctor-shared.ts
+++ b/src/plugin/lcm-doctor-shared.ts
@@ -34,6 +34,27 @@ export type DoctorSummaryStats = {
   byConversation: Map<number, DoctorConversationCounts>;
 };
 
+/** Repeated high-token message identity cluster reported by doctor. */
+export type DoctorReplayResidueCluster = {
+  conversationId: number;
+  sessionId: string;
+  sessionKey: string | null;
+  role: string;
+  identityHash: string | null;
+  repeatCount: number;
+  totalTokenCount: number;
+  tokenPressure: number;
+  representativeMessageIds: number[];
+};
+
+/** Aggregate stats for duplicate transcript replay residue diagnostics. */
+export type DoctorReplayResidueStats = {
+  clusters: DoctorReplayResidueCluster[];
+  clusterCount: number;
+  repeatedMessageCount: number;
+  tokenPressure: number;
+};
+
 export type DoctorTargetRecord = {
   conversationId: number;
   summaryId: string;
@@ -58,6 +79,27 @@ type DoctorTargetRow = {
   created_at: string;
   child_count: number | null;
 };
+
+type DoctorReplayResidueClusterRow = {
+  conversation_id: number;
+  session_id: string;
+  session_key: string | null;
+  role: string;
+  identity_hash: string | null;
+  content: string;
+  repeat_count: number;
+  total_token_count: number;
+  max_token_count: number;
+};
+
+type DoctorReplayResidueMessageIdRow = {
+  message_id: number;
+};
+
+const DOCTOR_REPLAY_MIN_REPEAT_COUNT = 2;
+const DOCTOR_REPLAY_MIN_MESSAGE_TOKENS = 1_000;
+const DOCTOR_REPLAY_MAX_CLUSTERS = 10;
+const DOCTOR_REPLAY_MAX_REPRESENTATIVE_IDS = 5;
 
 /**
  * Detect broken summary markers that doctor should flag or repair.
@@ -261,5 +303,96 @@ export function getDoctorSummaryStats(
     fallback,
     emergency,
     byConversation,
+  };
+}
+
+/**
+ * Scan one conversation for repeated high-token message identities.
+ */
+export function getDoctorReplayResidueStats(
+  db: DatabaseSync,
+  conversationId: number,
+): DoctorReplayResidueStats {
+  // Group by exact role/content plus the stored identity hash so hash
+  // collisions cannot merge unrelated persisted messages.
+  const rows = db
+    .prepare(
+      `SELECT
+         m.conversation_id,
+         c.session_id,
+         c.session_key,
+         m.role,
+         NULLIF(m.identity_hash, '') AS identity_hash,
+         m.content,
+         COUNT(*) AS repeat_count,
+         COALESCE(SUM(CASE WHEN m.token_count > 0 THEN m.token_count ELSE 0 END), 0) AS total_token_count,
+         COALESCE(MAX(CASE WHEN m.token_count > 0 THEN m.token_count ELSE 0 END), 0) AS max_token_count
+       FROM messages m
+       JOIN conversations c ON c.conversation_id = m.conversation_id
+       WHERE m.conversation_id = ?
+         AND LENGTH(m.content) > 0
+       GROUP BY
+         m.conversation_id,
+         c.session_id,
+         c.session_key,
+         m.role,
+         COALESCE(m.identity_hash, ''),
+         m.content
+       HAVING repeat_count >= ?
+          AND max_token_count >= ?
+       ORDER BY
+         (total_token_count - max_token_count) DESC,
+         repeat_count DESC,
+         m.conversation_id ASC
+       LIMIT ?`,
+    )
+    .all(
+      conversationId,
+      DOCTOR_REPLAY_MIN_REPEAT_COUNT,
+      DOCTOR_REPLAY_MIN_MESSAGE_TOKENS,
+      DOCTOR_REPLAY_MAX_CLUSTERS,
+    ) as DoctorReplayResidueClusterRow[];
+
+  const idStatement = db.prepare(
+    `SELECT message_id
+     FROM messages
+     WHERE conversation_id = ?
+       AND role = ?
+       AND COALESCE(identity_hash, '') = COALESCE(?, '')
+       AND content = ?
+     ORDER BY message_id ASC
+     LIMIT ?`,
+  );
+
+  const clusters = rows.map((row): DoctorReplayResidueCluster => {
+    const totalTokenCount = Math.max(0, Math.floor(row.total_token_count ?? 0));
+    const maxTokenCount = Math.max(0, Math.floor(row.max_token_count ?? 0));
+    // Keep large payloads out of the user-facing report; ids are enough for
+    // maintainers to inspect the exact rows from an offline database copy.
+    const representativeRows = idStatement.all(
+      row.conversation_id,
+      row.role,
+      row.identity_hash,
+      row.content,
+      DOCTOR_REPLAY_MAX_REPRESENTATIVE_IDS,
+    ) as DoctorReplayResidueMessageIdRow[];
+    return {
+      conversationId: row.conversation_id,
+      sessionId: row.session_id,
+      sessionKey: row.session_key ?? null,
+      role: row.role,
+      identityHash: row.identity_hash ?? null,
+      repeatCount: Math.max(0, Math.floor(row.repeat_count ?? 0)),
+      totalTokenCount,
+      tokenPressure: Math.max(0, totalTokenCount - maxTokenCount),
+      representativeMessageIds: representativeRows.map((message) => message.message_id),
+    };
+  });
+
+  return {
+    clusters,
+    clusterCount: clusters.length,
+    repeatedMessageCount: clusters.reduce((sum, cluster) => sum + cluster.repeatCount, 0),
+    tokenPressure: clusters.reduce((sum, cluster) => sum + cluster.tokenPressure, 0),
   };
 }

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1195,6 +1195,102 @@ describe("lcm command", () => {
     expect(result.text).not.toContain(`conversation id: ${otherConversation.conversationId}`);
   });
 
+  it("reports duplicate high-token transcript replay residue without mutating messages", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-replay-current",
+      sessionKey: "agent:main:telegram:direct:doctor-replay-current",
+    });
+    const otherConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-replay-other",
+      sessionKey: "agent:main:telegram:direct:doctor-replay-other",
+    });
+    const replayPayload = "historical transcript payload ".repeat(160);
+
+    const duplicates = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: replayPayload,
+        tokenCount: 1800,
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: replayPayload,
+        tokenCount: 1800,
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 2,
+        role: "assistant",
+        content: replayPayload,
+        tokenCount: 1800,
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: otherConversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: replayPayload,
+        tokenCount: 1800,
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: otherConversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: replayPayload,
+        tokenCount: 1800,
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+
+    const beforeCount = await fixture.conversationStore.countMessagesByIdentity(
+      currentConversation.conversationId,
+      "assistant",
+      replayPayload,
+    );
+    const result = await fixture.command.handler(
+      createCommandContext("doctor", {
+        sessionKey: "agent:main:telegram:direct:doctor-replay-current",
+      }),
+    );
+    const afterCount = await fixture.conversationStore.countMessagesByIdentity(
+      currentConversation.conversationId,
+      "assistant",
+      replayPayload,
+    );
+
+    expect(beforeCount).toBe(3);
+    expect(afterCount).toBe(3);
+    expect(result.text).toContain("**🔁 Transcript replay residue**");
+    expect(result.text).toContain("mode: read-only diagnostics");
+    expect(result.text).toContain("clusters: 1");
+    expect(result.text).toContain("duplicate token pressure: ~3,600 tokens");
+    expect(result.text).toContain(`conv ${currentConversation.conversationId}`);
+    expect(result.text).toContain("session key `agent:main:telegram:direct:doctor-replay-current`");
+    expect(result.text).toContain("session id `doctor-replay-current`");
+    expect(result.text).toContain("role assistant");
+    expect(result.text).toContain("repeats 3");
+    expect(result.text).toContain("pressure ~3,600 tokens");
+    expect(result.text).toContain(
+      `ids ${duplicates.map((message) => message.messageId).join(", ")}`,
+    );
+    expect(result.text).not.toContain(`conv ${otherConversation.conversationId}`);
+    expect(result.text).not.toContain("doctor-replay-other");
+    expect(result.text).not.toContain(replayPayload);
+  });
+
   it("reports a clean scoped doctor result for the resolved current conversation", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);


### PR DESCRIPTION
## What
Adds a read-only `/lossless doctor` diagnostic for duplicate high-token transcript replay residue.

## Why
Older databases can contain duplicate historical transcript payloads from replay floods before the active prevention fix. Maintainers need a safe diagnostic that identifies likely residue without mutating live data.

## Changes
- Detect duplicate clusters
- Report token pressure
- Include message samples
- Keep diagnostic read-only
- Add regression coverage

## Testing
- `npx vitest run --dir test test/lcm-command.test.ts -t "duplicate high-token transcript replay residue"`
- `npx vitest run --dir test test/lcm-command.test.ts`
- `npm run build`
- `git diff --check`

Closes #782