### PR TITLE
chore(ci): add plugin inspector gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout OpenClaw contract source
-        uses: actions/checkout@v4
-        with:
-          repository: openclaw/openclaw
-          path: openclaw
+        run: git clone --depth 1 https://github.com/openclaw/openclaw "$RUNNER_TEMP/openclaw"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -55,7 +52,7 @@ jobs:
         run: npm run build
 
       - name: Run OpenClaw plugin inspector
-        run: npm run plugin-inspector:ci -- --openclaw ./openclaw
+        run: npm run plugin-inspector:ci -- --openclaw "$RUNNER_TEMP/openclaw"
 
       - name: Upload plugin inspector reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: plugin-inspector-reports
-          path: .plugin-inspector/
+          path: plugin-inspector-reports/
           if-no-files-found: ignore
 
   # Smoke-install the plugin against the latest published openclaw to catch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,42 @@ jobs:
       - name: Run tests
         run: npm test
 
+  plugin-inspector:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout OpenClaw contract source
+        uses: actions/checkout@v4
+        with:
+          repository: openclaw/openclaw
+          path: openclaw
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package bundle
+        run: npm run build
+
+      - name: Run OpenClaw plugin inspector
+        run: npm run plugin-inspector:ci -- --openclaw ./openclaw
+
+      - name: Upload plugin inspector reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-inspector-reports
+          path: .plugin-inspector/
+          if-no-files-found: ignore
+
   # Smoke-install the plugin against the latest published openclaw to catch
   # bundle-level breakage (esbuild externals, ESM resolution, missing default
   # export) before users hit it.  Calling `plugin.register(...)` against a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Checkout OpenClaw contract source
-        run: git clone --depth 1 https://github.com/openclaw/openclaw "$RUNNER_TEMP/openclaw"
+      - name: Checkout declared OpenClaw contract source
+        run: |
+          OPENCLAW_CONTRACT_REF="v$(node -p "require('./package.json').openclaw.build.openclawVersion")"
+          git clone --depth 1 --branch "$OPENCLAW_CONTRACT_REF" https://github.com/openclaw/openclaw "$RUNNER_TEMP/openclaw"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .pebbles
 node_modules/
 dist/
-.plugin-inspector/
+plugin-inspector-reports/
 *.tsbuildinfo
 .DS_Store
 .worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pebbles
 node_modules/
 dist/
+.plugin-inspector/
 *.tsbuildinfo
 .DS_Store
 .worktrees

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "lossless-claw",
+  "name": "Lossless Context Management",
   "kind": "context-engine",
   "activation": {
     "onStartup": true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
     "changeset": "changeset",
-    "plugin-inspector:ci": "npm exec --yes --package @openclaw/plugin-inspector@0.3.11 -- plugin-inspector ci --plugin-root . --out .plugin-inspector",
+    "plugin-inspector:ci": "npm exec --yes --package @openclaw/plugin-inspector@0.3.11 -- plugin-inspector ci --plugin-root . --out plugin-inspector-reports",
     "release:verify": "npm run typecheck && npm run build && npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
     "typecheck": "tsc --noEmit --pretty false",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
     "changeset": "changeset",
+    "plugin-inspector:ci": "npm exec --yes --package @openclaw/plugin-inspector@0.3.11 -- plugin-inspector ci --plugin-root . --out .plugin-inspector",
     "release:verify": "npm run typecheck && npm run build && npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
     "typecheck": "tsc --noEmit --pretty false",

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -7273,6 +7273,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     memoryAssistantContent?: string;
     tailUserContent?: string;
     tailAssistantContent?: string;
+    tailTurns?: Array<{ userContent: string; assistantContent: string }>;
     prompt?: string;
   }): Promise<{ liveMessages: AgentMessage[]; prompt: string }> {
     const memoryUserContent =
@@ -7294,17 +7295,25 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: params.sessionId,
       message: { role: "assistant", content: memoryAssistantContent } as AgentMessage,
     });
-    await params.engine.ingest({
-      sessionId: params.sessionId,
-      message: {
-        role: "user",
-        content: params.tailUserContent ?? "Say one neutral filler response.",
-      } as AgentMessage,
-    });
-    await params.engine.ingest({
-      sessionId: params.sessionId,
-      message: { role: "assistant", content: params.tailAssistantContent ?? "ok" } as AgentMessage,
-    });
+    const tailTurns = params.tailTurns ?? [
+      {
+        userContent: params.tailUserContent ?? "Say one neutral filler response.",
+        assistantContent: params.tailAssistantContent ?? "ok",
+      },
+    ];
+    for (const tailTurn of tailTurns) {
+      await params.engine.ingest({
+        sessionId: params.sessionId,
+        message: {
+          role: "user",
+          content: tailTurn.userContent,
+        } as AgentMessage,
+      });
+      await params.engine.ingest({
+        sessionId: params.sessionId,
+        message: { role: "assistant", content: tailTurn.assistantContent } as AgentMessage,
+      });
+    }
 
     const conversation = await params.engine.getConversationStore().getConversationForSession({
       sessionId: params.sessionId,
@@ -7675,6 +7684,45 @@ describe("LcmContextEngine.assemble canonical path", () => {
       .find((entry: unknown) => typeof entry === "string" && entry.includes("[lcm] assemble: done"));
     expect(assembleDoneLog).toEqual(expect.any(String));
     expect(assembleDoneLog).not.toContain("promptRecallMatches=");
+  });
+
+  it("uses summary-backed recall when the fact is outside a realistic fresh tail", async () => {
+    const engine = createEngineWithConfig({ freshTailCount: 8 });
+    const sessionId = "session-prompt-recall-summary-backed-fresh-tail";
+    const prompt = "What is CRABPOT_LCM_FACT? Answer with only the remembered value.";
+    const { liveMessages } = await seedPromptRecallFixture({
+      engine,
+      sessionId,
+      summaryId: "sum_prompt_recall_summary_backed_fresh_tail",
+      summaryContent:
+        "Release-gate summary preserved CRABPOT_LCM_FACT is blue-lantern-42. " +
+        "It also noted neutral filler turn 3 so the summary is not a single-key stub.",
+      tailTurns: Array.from({ length: 8 }, (_, index) => ({
+        userContent: `Neutral filler turn ${index + 1}: keep the conversation moving.`,
+        assistantContent: `ack filler ${index + 1}`,
+      })),
+      prompt,
+    });
+    const searchSpy = vi.spyOn(engine.getConversationStore(), "searchMessages");
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      prompt,
+      tokenBudget: 10_000,
+    });
+
+    const rendered = result.messages.map((message) =>
+      typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+    );
+    const summaryCue = rendered.find((content) =>
+      content.includes('<summary id="sum_prompt_recall_summary_backed_fresh_tail"'),
+    );
+    expect(summaryCue).toEqual(expect.any(String));
+    expect(summaryCue).toContain("CRABPOT_LCM_FACT is blue-lantern-42");
+    expect(summaryCue).toContain("neutral filler turn 3");
+    expect(rendered.some((content) => content.includes("<lossless_claw_prompt_recall>"))).toBe(false);
+    expect(searchSpy).not.toHaveBeenCalled();
   });
 
   it("does not add prompt-recall when an active summary already mentions the requested key", async () => {

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -414,6 +414,106 @@ describe("LCM tools session scoping", () => {
     expect(text).toContain("session family rooted at 42 (3 segments)");
   });
 
+  it("supports grep-to-describe recovery for compacted summary matches", async () => {
+    const summaryId = "sum_crabpot_lcm_fact";
+    const createdAt = new Date("2026-01-02T00:00:00.000Z");
+    const summaryContent =
+      "Release-gate summary preserved CRABPOT_LCM_FACT is blue-lantern-42 after rotate.";
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [
+          {
+            summaryId,
+            conversationId: 42,
+            kind: "leaf",
+            snippet: summaryContent,
+            createdAt,
+          },
+        ],
+        totalMatches: 1,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: summaryId,
+        type: "summary",
+        summary: {
+          conversationId: 42,
+          kind: "leaf",
+          content: summaryContent,
+          depth: 0,
+          tokenCount: 16,
+          descendantCount: 0,
+          descendantTokenCount: 0,
+          sourceMessageTokenCount: 16,
+          fileIds: [],
+          parentIds: [],
+          childIds: [],
+          messageIds: [],
+          earliestAt: createdAt,
+          latestAt: createdAt,
+          subtree: [
+            {
+              summaryId,
+              parentSummaryId: null,
+              depthFromRoot: 0,
+              kind: "leaf",
+              depth: 0,
+              tokenCount: 16,
+              descendantCount: 0,
+              descendantTokenCount: 0,
+              sourceMessageTokenCount: 16,
+              earliestAt: createdAt,
+              latestAt: createdAt,
+              childCount: 0,
+              path: "",
+            },
+          ],
+          createdAt,
+        },
+      })),
+    };
+    const lcm = buildLcmEngine({ retrieval, conversationId: 42 }) as never;
+    const deps = makeDeps();
+
+    const grepTool = createLcmGrepTool({
+      deps,
+      lcm,
+      sessionId: "session-1",
+    });
+    const grepResult = await grepTool.execute("call-grep-summary", {
+      pattern: "CRABPOT_LCM_FACT",
+      scope: "summaries",
+      mode: "full_text",
+    });
+    const grepText = (grepResult.content[0] as { text: string }).text;
+    const matchedSummaryId = grepText.match(/\bsum_[a-z0-9_]+\b/)?.[0];
+
+    expect(matchedSummaryId).toBe(summaryId);
+    expect(grepText).toContain("CRABPOT_LCM_FACT is blue-lantern-42");
+
+    const describeTool = createLcmDescribeTool({
+      deps,
+      lcm,
+      sessionId: "session-1",
+    });
+    const describeResult = await describeTool.execute("call-describe-summary", {
+      id: matchedSummaryId,
+    });
+
+    expect(retrieval.describe).toHaveBeenCalledWith(
+      summaryId,
+      expect.objectContaining({
+        expandFile: false,
+      }),
+    );
+    const describeText = (describeResult.content[0] as { text: string }).text;
+    expect(describeText).toContain(`LCM_SUMMARY ${summaryId}`);
+    expect(describeText).toContain("manifest");
+    expect(describeText).toContain("CRABPOT_LCM_FACT is blue-lantern-42");
+    expect(JSON.stringify(describeResult.details)).not.toContain(summaryContent);
+  });
+
   it("lcm_grep rejects allConversations from a sub-agent without a delegated grant", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -131,6 +131,7 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
   });
 
   it("declares startup activation until OpenClaw always loads selected context-engine plugins", () => {
+    expect(manifest.name).toBe("Lossless Context Management");
     expect(manifest.kind).toBe("context-engine");
     expect(manifest.activation?.onStartup).toBe(true);
   });


### PR DESCRIPTION
## Summary

- add a pinned `plugin-inspector:ci` npm script using `@openclaw/plugin-inspector@0.3.11`
- add a CI job that builds Lossless, checks out OpenClaw, runs plugin-inspector, and uploads inspector reports
- add upstream LCM coverage for Crabpot-derived recall/tool flows: summary-backed recall beyond an 8-message fresh tail, and `lcm_grep` summary IDs flowing into `lcm_describe`
- declare the manifest display name so plugin-inspector no longer reports `manifest-name-missing`
- ignore the local `.plugin-inspector/` report directory

## Context

Refs #818.

This keeps the generic OpenClaw plugin compatibility gate in the upstream plugin repo instead of making the Crabpot-side LCM behavior eval PRs carry all of the safety coverage. The useful behavior asks from openclaw/crabpot#132 and openclaw/crabpot#134 are now represented as Lossless unit coverage. openclaw/crabpot#133 is Crabpot harness plumbing for `npm-pack:` fixtures, so it stays out of this upstream plugin PR.

I also tried the stronger plugin-inspector runtime capture mode with `--runtime --mock-sdk --allow-execute`; current mocked runtime import fails with `registration-execution-error` on a null-byte path argument, so required CI intentionally stays on the stable static inspector gate. The remaining capture/dependency rows are inspector follow-ups, not upstream metadata issues.

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test -- test/engine.test.ts test/lcm-tools.test.ts test/manifest.test.ts --maxWorkers=1` → 3 test files passed, 336 tests passed
- `npm run plugin-inspector:ci -- --openclaw <openclaw-main-worktree> --json` against OpenClaw `59366ca4208d` → pass, 0 breakages, 0 warnings, 0 P0/P1 issues, 0 upstream metadata issues
- `npm test -- --maxWorkers=1` → 49 test files passed, 1067 tests passed
- `git diff --check`
