### PR TITLE
test(lcm): cover grep-to-delegated-expansion handoff

### DIFF
--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -11,7 +11,9 @@ import {
   resetExpansionDelegationGuardForTests,
   stampDelegatedExpansionContext,
 } from "../src/tools/lcm-expansion-recursion-guard.js";
+import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
 import { createLcmExpandQueryTool } from "../src/tools/lcm-expand-query-tool.js";
+import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
 import type { LcmDependencies } from "../src/types.js";
 
 const callGatewayMock = vi.fn();
@@ -140,6 +142,7 @@ function makeEngine(params: {
 }): LcmContextEngine {
   return {
     info: { id: "lcm", name: "LCM", version: "0.0.0" },
+    timezone: "UTC",
     getRetrieval: () => params.retrieval,
     getSummaryStore: () => params.summaryStore ?? makeSummaryStore(),
     getConversationStore: () => ({
@@ -164,6 +167,12 @@ function makeEngine(params: {
       ),
     }),
   } as unknown as LcmContextEngine;
+}
+
+function readToolText(result: { content: Array<{ type?: string; text?: string }> }): string {
+  return result.content
+    .map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
+    .join("\n");
 }
 
 describe("createLcmExpandQueryTool", () => {
@@ -299,6 +308,169 @@ describe("createLcmExpandQueryTool", () => {
       block: 0,
       timeout: 0,
       success: 1,
+    });
+  });
+
+  it("expands a compacted fact from a grep-discovered summary ID", async () => {
+    const retrieval = makeRetrieval();
+    const createdAt = new Date("2026-01-02T00:00:00.000Z");
+    const summaryId = "sum_crabpot_lcm_fact";
+    const summaryContent =
+      "Release-gate summary preserved CRABPOT_LCM_FACT is blue-lantern-42 after rotate.";
+    const describedSummary = {
+      id: summaryId,
+      type: "summary",
+      summary: {
+        conversationId: 42,
+        kind: "leaf",
+        content: summaryContent,
+        depth: 0,
+        tokenCount: 16,
+        descendantCount: 0,
+        descendantTokenCount: 0,
+        sourceMessageTokenCount: 16,
+        fileIds: [],
+        parentIds: [],
+        childIds: [],
+        messageIds: [],
+        earliestAt: createdAt,
+        latestAt: createdAt,
+        createdAt,
+        subtree: [
+          {
+            summaryId,
+            parentSummaryId: null,
+            depthFromRoot: 0,
+            depth: 0,
+            kind: "leaf",
+            tokenCount: 16,
+            descendantCount: 0,
+            descendantTokenCount: 0,
+            sourceMessageTokenCount: 16,
+            childCount: 0,
+            earliestAt: createdAt,
+            latestAt: createdAt,
+            path: summaryId,
+          },
+        ],
+      },
+    };
+    retrieval.grep.mockResolvedValue({
+      messages: [],
+      summaries: [
+        {
+          summaryId,
+          conversationId: 42,
+          kind: "leaf",
+          snippet: summaryContent,
+          createdAt,
+        },
+      ],
+      totalMatches: 1,
+    });
+    retrieval.describe.mockResolvedValue(describedSummary);
+
+    const deps = makeDeps();
+    const lcm = makeEngine({ retrieval, conversationId: 42 });
+    const grepTool = createLcmGrepTool({
+      deps,
+      lcm,
+      sessionId: "agent:main:main",
+    });
+    const grepResult = await grepTool.execute("call-grep-summary", {
+      pattern: "CRABPOT_LCM_FACT",
+      mode: "regex",
+      scope: "summaries",
+      limit: 10,
+    });
+    const grepText = readToolText(grepResult);
+    const matchedSummaryId = grepText.match(/\bsum_[a-z0-9_]+\b/)?.[0];
+    if (!matchedSummaryId) {
+      throw new Error(`Expected lcm_grep output to include ${summaryId}`);
+    }
+    expect(matchedSummaryId).toBe(summaryId);
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "CRABPOT_LCM_FACT",
+        mode: "regex",
+        scope: "summaries",
+        conversationId: 42,
+      }),
+    );
+
+    const describeTool = createLcmDescribeTool({
+      deps,
+      lcm,
+      sessionId: "agent:main:main",
+    });
+    const describeResult = await describeTool.execute("call-describe-summary", {
+      id: matchedSummaryId,
+    });
+    const describeText = readToolText(describeResult);
+    expect(describeText).toContain(`LCM_SUMMARY ${summaryId}`);
+    expect(describeText).toContain("blue-lantern-42");
+
+    let delegatedMessage = "";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        delegatedMessage = String(request.params?.message ?? "");
+        return { runId: "run-crabpot-flow" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    answer: "blue-lantern-42",
+                    citedIds: [summaryId],
+                    expandedSummaryCount: 1,
+                    totalSourceTokens: 16,
+                    truncated: false,
+                  }),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const expandQueryTool = createLcmExpandQueryTool({
+      deps,
+      lcm,
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const expandResult = await expandQueryTool.execute("call-expand-query", {
+      summaryIds: [matchedSummaryId],
+      prompt: "What is CRABPOT_LCM_FACT? Answer with only the remembered value.",
+      conversationId: 42,
+      maxTokens: 400,
+      timeoutMs: 60_000,
+    });
+
+    expect(retrieval.describe.mock.calls.map(([id]) => id)).toEqual([summaryId, summaryId]);
+    expect(delegatedMessage).toContain(`Seed summary IDs: ${summaryId}`);
+    expect(delegatedMessage).toContain("What is CRABPOT_LCM_FACT?");
+    expect(expandResult.details).toMatchObject({
+      answer: "blue-lantern-42",
+      citedIds: [summaryId],
+      sourceConversationId: 42,
+      expandedSummaryCount: 1,
+      totalSourceTokens: 16,
+      truncated: false,
     });
   });
 

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -11,7 +11,6 @@ import {
   resetExpansionDelegationGuardForTests,
   stampDelegatedExpansionContext,
 } from "../src/tools/lcm-expansion-recursion-guard.js";
-import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
 import { createLcmExpandQueryTool } from "../src/tools/lcm-expand-query-tool.js";
 import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
 import type { LcmDependencies } from "../src/types.js";
@@ -169,12 +168,6 @@ function makeEngine(params: {
   } as unknown as LcmContextEngine;
 }
 
-function readToolText(result: { content: Array<{ type?: string; text?: string }> }): string {
-  return result.content
-    .map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
-    .join("\n");
-}
-
 describe("createLcmExpandQueryTool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -311,50 +304,12 @@ describe("createLcmExpandQueryTool", () => {
     });
   });
 
-  it("expands a compacted fact from a grep-discovered summary ID", async () => {
+  it("routes a grep-discovered summary ID into delegated expansion", async () => {
     const retrieval = makeRetrieval();
     const createdAt = new Date("2026-01-02T00:00:00.000Z");
     const summaryId = "sum_crabpot_lcm_fact";
     const summaryContent =
       "Release-gate summary preserved CRABPOT_LCM_FACT is blue-lantern-42 after rotate.";
-    const describedSummary = {
-      id: summaryId,
-      type: "summary",
-      summary: {
-        conversationId: 42,
-        kind: "leaf",
-        content: summaryContent,
-        depth: 0,
-        tokenCount: 16,
-        descendantCount: 0,
-        descendantTokenCount: 0,
-        sourceMessageTokenCount: 16,
-        fileIds: [],
-        parentIds: [],
-        childIds: [],
-        messageIds: [],
-        earliestAt: createdAt,
-        latestAt: createdAt,
-        createdAt,
-        subtree: [
-          {
-            summaryId,
-            parentSummaryId: null,
-            depthFromRoot: 0,
-            depth: 0,
-            kind: "leaf",
-            tokenCount: 16,
-            descendantCount: 0,
-            descendantTokenCount: 0,
-            sourceMessageTokenCount: 16,
-            childCount: 0,
-            earliestAt: createdAt,
-            latestAt: createdAt,
-            path: summaryId,
-          },
-        ],
-      },
-    };
     retrieval.grep.mockResolvedValue({
       messages: [],
       summaries: [
@@ -368,7 +323,13 @@ describe("createLcmExpandQueryTool", () => {
       ],
       totalMatches: 1,
     });
-    retrieval.describe.mockResolvedValue(describedSummary);
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: {
+        conversationId: 42,
+        latestAt: createdAt,
+      },
+    });
 
     const deps = makeDeps();
     const lcm = makeEngine({ retrieval, conversationId: 42 });
@@ -383,12 +344,13 @@ describe("createLcmExpandQueryTool", () => {
       scope: "summaries",
       limit: 10,
     });
-    const grepText = readToolText(grepResult);
+    const grepText = (grepResult.content[0] as { text: string }).text;
     const matchedSummaryId = grepText.match(/\bsum_[a-z0-9_]+\b/)?.[0];
     if (!matchedSummaryId) {
       throw new Error(`Expected lcm_grep output to include ${summaryId}`);
     }
     expect(matchedSummaryId).toBe(summaryId);
+    expect(grepText).toContain(`[conv=42 ${summaryId}]`);
     expect(retrieval.grep).toHaveBeenCalledWith(
       expect.objectContaining({
         query: "CRABPOT_LCM_FACT",
@@ -398,19 +360,9 @@ describe("createLcmExpandQueryTool", () => {
       }),
     );
 
-    const describeTool = createLcmDescribeTool({
-      deps,
-      lcm,
-      sessionId: "agent:main:main",
-    });
-    const describeResult = await describeTool.execute("call-describe-summary", {
-      id: matchedSummaryId,
-    });
-    const describeText = readToolText(describeResult);
-    expect(describeText).toContain(`LCM_SUMMARY ${summaryId}`);
-    expect(describeText).toContain("blue-lantern-42");
-
     let delegatedMessage = "";
+    // The gateway is the unit-test boundary, so prove the child receives the
+    // discovered ID plus evidence-retrieval instructions before stubbing its reply.
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: Record<string, unknown> };
       if (request.method === "agent") {
@@ -461,9 +413,13 @@ describe("createLcmExpandQueryTool", () => {
       timeoutMs: 60_000,
     });
 
-    expect(retrieval.describe.mock.calls.map(([id]) => id)).toEqual([summaryId, summaryId]);
+    expect(retrieval.describe).toHaveBeenCalledWith(summaryId);
     expect(delegatedMessage).toContain(`Seed summary IDs: ${summaryId}`);
     expect(delegatedMessage).toContain("What is CRABPOT_LCM_FACT?");
+    expect(delegatedMessage).toContain("lcm_describe");
+    expect(delegatedMessage).toContain(
+      "Synthesize the final answer from retrieved evidence, not assumptions.",
+    );
     expect(expandResult.details).toMatchObject({
       answer: "blue-lantern-42",
       citedIds: [summaryId],


### PR DESCRIPTION
## What

Adds a regression test that feeds a summary ID emitted by the public `lcm_grep` tool into `lcm_expand_query`. The test verifies the rendered grep reference, conversation scoping, delegated prompt, evidence-retrieval instructions, and parsed tool result.

The gateway supplies a deterministic child reply, so this test covers the public-tool orchestration boundary. Existing coverage in `test/lcm-tools.test.ts` verifies `lcm_grep` to `lcm_describe` content recovery. A packaged behavior eval with a real delegated child remains tracked in #818.

## Why

The Crabpot compaction-tools scenario in openclaw/crabpot#132 identified a useful interoperability contract: a summary discovered through `lcm_grep` must remain usable by the delegated expansion tool. This focused Lossless test catches regressions in that handoff without adding Crabpot eval-runner code to this repository.

## Changes

- Route rendered grep ID into delegated expansion
- Assert child evidence-retrieval prompt instructions
- Parse deterministic delegated tool result
- Add mock engine timezone for tool formatting

## Testing

- `npm test -- test/lcm-expand-query-tool.test.ts --maxWorkers=1` (36 tests passed on the exact current-main merge tree)
- `npm run typecheck`
- `npm run build`
- `npm test -- --maxWorkers=1` (1,874 tests passed across 105 files on the exact current-main merge tree)
- `/Users/phaedrus/Projects/Martian-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
- `git diff --check origin/main...HEAD`

## Changeset

None. This PR changes tests only and does not change package or user-facing behavior.
