### PR TITLE
fix(bootstrap): recover placeholder-checkpoint conversations with a non-anchoring frontier (#639 family)

### DIFF
--- a/.changeset/placeholder-checkpoint-recovery.md
+++ b/.changeset/placeholder-checkpoint-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Recover placeholder-checkpoint conversations whose persisted metadata frontier cannot anchor into the real transcript.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6120,8 +6120,7 @@ export class LcmContextEngine implements ContextEngine {
           const replayThreshold = Math.max(3, Math.ceil(historicalMessages.length * 0.5));
           const shouldDropPersistedPrefix =
             replayAnalysis.firstNonOverlappingIndex > 0 &&
-            (persistedIdentityOverlaps >= replayThreshold ||
-              params.noAnchorImportReason === "placeholder-checkpoint-recovery");
+            persistedIdentityOverlaps >= replayThreshold;
           if (
             replayAnalysis.firstNonOverlappingIndex < 0 &&
             persistedIdentityOverlaps >= replayThreshold
@@ -6192,18 +6191,21 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
 
-          let importedMessages = 0;
-          for (const message of noAnchorImportMessages) {
-            const result = await this.ingestSingle({
-              sessionId,
-              sessionKey: params.sessionKey,
-              message,
-              skipReplayTimestampFloodGuard: true,
-            });
-            if (result.ingested) {
-              importedMessages += 1;
+          const importedMessages = await this.conversationStore.withTransaction(async () => {
+            let count = 0;
+            for (const message of noAnchorImportMessages) {
+              const result = await this.ingestSingle({
+                sessionId,
+                sessionKey: params.sessionKey,
+                message,
+                skipReplayTimestampFloodGuard: true,
+              });
+              if (result.ingested) {
+                count += 1;
+              }
             }
-          }
+            return count;
+          });
           this.deps.log.warn(
             `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} overlap=false`,
           );

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -64,7 +64,6 @@ import {
   ConversationStore,
   type ConversationRecord,
   type CreateMessagePartInput,
-  type MessageRecord,
   type MessagePartRecord,
   type MessagePartType,
 } from "./store/conversation-store.js";
@@ -1283,7 +1282,7 @@ const PROMPT_RECALL_SEARCH_LIMIT = PROMPT_RECALL_MAX_MESSAGES * 2;
 const PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT = PROMPT_RECALL_SEARCH_LIMIT * 4;
 const DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES = 4;
 const INJECTED_DELIVERY_TRANSCRIPT_PATTERN = /\b(?:delivery[-_\s]?mirror|config[-_\s]?audit)\b/i;
-const INJECTED_CONVERSATION_METADATA_PREFIX = "Conversation info (untrusted metadata)";
+const PLACEHOLDER_CHECKPOINT_RECOVERY_IMPORT_CAP = 1_000;
 const OPENCLAW_RUNTIME_CONTEXT_SENTINEL =
   "OpenClaw runtime context for the immediately preceding user message. This context is runtime-generated, not user-author.";
 const PROMPT_RECALL_SENSITIVE_IDENTIFIER_PATTERN =
@@ -1346,15 +1345,6 @@ function isLikelyInjectedDeliveryOnlyTranscript(messages: AgentMessage[]): boole
     messages.length > 0 &&
     messages.length <= DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES &&
     messages.every(isLikelyInjectedDeliveryMessage)
-  );
-}
-
-function isInjectedConversationMetadataMessage(
-  message: Pick<MessageRecord, "role" | "content">,
-): boolean {
-  return (
-    message.role === "user" &&
-    message.content.trimStart().startsWith(INJECTED_CONVERSATION_METADATA_PREFIX)
   );
 }
 
@@ -5951,34 +5941,6 @@ export class LcmContextEngine implements ContextEngine {
     return { overlaps, firstNonOverlappingIndex };
   }
 
-  private async canBypassPlaceholderNoAnchorImportCap(params: {
-    conversationId: number;
-    historicalMessages: AgentMessage[];
-    persistedPrefixLength: number;
-  }): Promise<boolean> {
-    const persistedMessages = await this.conversationStore.getMessages(params.conversationId);
-    const allowedPrefix = params.historicalMessages
-      .slice(0, params.persistedPrefixLength)
-      .map((message) => toStoredMessage(message));
-    let prefixIndex = 0;
-
-    // Only the targeted recovery shape may bypass the cap: injected metadata
-    // rows, plus an already-imported prefix when a previous retry failed.
-    for (const persisted of persistedMessages) {
-      if (isInjectedConversationMetadataMessage(persisted)) {
-        continue;
-      }
-
-      const expected = allowedPrefix[prefixIndex];
-      if (!expected || persisted.role !== expected.role || persisted.content !== expected.content) {
-        return false;
-      }
-      prefixIndex += 1;
-    }
-
-    return prefixIndex === allowedPrefix.length;
-  }
-
   private async countPersistedTranscriptIdentityOverlaps(params: {
     conversationId: number;
     messages: AgentMessage[];
@@ -6185,22 +6147,14 @@ export class LcmContextEngine implements ContextEngine {
             );
           }
 
-          const placeholderRecoveryCanBypassCap =
-            params.noAnchorImportReason === "placeholder-checkpoint-recovery" &&
-            (await this.canBypassPlaceholderNoAnchorImportCap({
-              conversationId,
-              historicalMessages,
-              persistedPrefixLength: shouldDropPersistedPrefix
-                ? replayAnalysis.firstNonOverlappingIndex
-                : 0,
-            }));
           // #639: placeholder-checkpoint recovery is an initial-epoch
-          // catch-up only when the DB still contains injected metadata plus
-          // any already-imported prefix from a failed retry. Generic
-          // placeholder checkpoints keep the normal bounded cap.
-          const importCap = placeholderRecoveryCanBypassCap
-            ? Number.POSITIVE_INFINITY
-            : Math.max(Math.floor(existingDbCount * 0.2), 50);
+          // catch-up, but persisted rows do not carry durable provenance that
+          // proves they are injected metadata. Use a larger finite cap for this
+          // reason instead of disabling the flood guard.
+          const importCap =
+            params.noAnchorImportReason === "placeholder-checkpoint-recovery"
+              ? PLACEHOLDER_CHECKPOINT_RECOVERY_IMPORT_CAP
+              : Math.max(Math.floor(existingDbCount * 0.2), 50);
           if (noAnchorImportMessages.length > importCap) {
             this.deps.log.warn(
               `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6117,30 +6117,34 @@ export class LcmContextEngine implements ContextEngine {
           const persistedIdentityOverlaps = replayAnalysis.overlaps;
           let noAnchorImportMessages = historicalMessages;
           const replayThreshold = Math.max(3, Math.ceil(historicalMessages.length * 0.5));
-          if (persistedIdentityOverlaps >= replayThreshold) {
-            if (replayAnalysis.firstNonOverlappingIndex < 0) {
-              this.deps.log.warn(
-                `[lcm] reconcileSessionTail: duplicate transcript replay blocked for ${sessionContext} - ${persistedIdentityOverlaps}/${historicalMessages.length} candidate messages already exist (reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent replay flood.`,
-              );
-              this.deps.log.debug(
-                `[lcm] reconcileSessionTail: blocked duplicate transcript replay for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} persistedIdentityOverlaps=${persistedIdentityOverlaps} overlap=false`,
-              );
-              return {
-                blockedByImportCap: true,
-                blockedReason: "duplicate-transcript-replay",
-                importedMessages: 0,
-                hasOverlap: false,
-              };
-            }
-
-            if (replayAnalysis.firstNonOverlappingIndex > 0) {
-              noAnchorImportMessages = historicalMessages.slice(replayAnalysis.firstNonOverlappingIndex);
-              this.deps.log.warn(
-                `[lcm] reconcileSessionTail: duplicate transcript replay guard dropped ${replayAnalysis.firstNonOverlappingIndex}/${historicalMessages.length} already-persisted prefix messages for ${sessionContext} before no-anchor import (reason: ${params.noAnchorImportReason ?? "unspecified"})`,
-              );
-            }
+          const shouldDropPersistedPrefix =
+            replayAnalysis.firstNonOverlappingIndex > 0 &&
+            (persistedIdentityOverlaps >= replayThreshold ||
+              params.noAnchorImportReason === "placeholder-checkpoint-recovery");
+          if (
+            replayAnalysis.firstNonOverlappingIndex < 0 &&
+            persistedIdentityOverlaps >= replayThreshold
+          ) {
+            this.deps.log.warn(
+              `[lcm] reconcileSessionTail: duplicate transcript replay blocked for ${sessionContext} - ${persistedIdentityOverlaps}/${historicalMessages.length} candidate messages already exist (reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent replay flood.`,
+            );
+            this.deps.log.debug(
+              `[lcm] reconcileSessionTail: blocked duplicate transcript replay for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} persistedIdentityOverlaps=${persistedIdentityOverlaps} overlap=false`,
+            );
+            return {
+              blockedByImportCap: true,
+              blockedReason: "duplicate-transcript-replay",
+              importedMessages: 0,
+              hasOverlap: false,
+            };
           }
 
+          if (shouldDropPersistedPrefix) {
+            noAnchorImportMessages = historicalMessages.slice(replayAnalysis.firstNonOverlappingIndex);
+            this.deps.log.warn(
+              `[lcm] reconcileSessionTail: duplicate transcript replay guard dropped ${replayAnalysis.firstNonOverlappingIndex}/${historicalMessages.length} already-persisted prefix messages for ${sessionContext} before no-anchor import (reason: ${params.noAnchorImportReason ?? "unspecified"})`,
+            );
+          }
           // #639: placeholder-checkpoint recovery is an initial-epoch
           // catch-up (the conversation has only injected metadata and never
           // ingested its real transcript). The proportional cap

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6141,7 +6141,17 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
 
-          const importCap = Math.max(Math.floor(existingDbCount * 0.2), 50);
+          // #639: placeholder-checkpoint recovery is an initial-epoch
+          // catch-up (the conversation has only injected metadata and never
+          // ingested its real transcript). The proportional cap
+          // (max(existingDbCount*0.2, 50)) permanently starves large
+          // pre-existing sessions, so lift it for this reason only. The
+          // replay-duplicate guard above already aborts genuine floods; every
+          // other no-anchor reason keeps the cap.
+          const importCap =
+            params.noAnchorImportReason === "placeholder-checkpoint-recovery"
+              ? Number.POSITIVE_INFINITY
+              : Math.max(Math.floor(existingDbCount * 0.2), 50);
           if (noAnchorImportMessages.length > importCap) {
             this.deps.log.warn(
               `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,
@@ -6546,6 +6556,13 @@ export class LcmContextEngine implements ContextEngine {
                 sessionKey: params.sessionKey,
                 conversationId: conversation.conversationId,
                 historicalMessages: appended.messages,
+                // #639: a placeholder-checkpoint conversation (only injected
+                // metadata rows, never ingested its real transcript) cannot
+                // anchor that transcript, so allow importing it as a new epoch
+                // instead of giving up. The replay-duplicate guard inside
+                // reconcileSessionTail still aborts genuine floods; the import
+                // cap is lifted for this initial-epoch catch-up reason below.
+                allowNoAnchorImport: true,
                 noAnchorImportReason: "placeholder-checkpoint-recovery",
               });
               if (reconcile.importedMessages > 0) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8363,6 +8363,15 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.warn(
         `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
       );
+      // A reconcile exception can happen after partial transcript import. Do
+      // not leave the default "safe overlap" result in place, or afterTurn can
+      // refresh the checkpoint past unimported history and make the gap
+      // unrecoverable.
+      transcriptReconcileResult = {
+        importedMessages: 0,
+        blockedByImportCap: false,
+        hasOverlap: false,
+      };
     }
     const transcriptReconcileUnsafeToAdvance =
       transcriptReconcileResult.blockedByImportCap ||

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -64,6 +64,7 @@ import {
   ConversationStore,
   type ConversationRecord,
   type CreateMessagePartInput,
+  type MessageRecord,
   type MessagePartRecord,
   type MessagePartType,
 } from "./store/conversation-store.js";
@@ -1282,6 +1283,7 @@ const PROMPT_RECALL_SEARCH_LIMIT = PROMPT_RECALL_MAX_MESSAGES * 2;
 const PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT = PROMPT_RECALL_SEARCH_LIMIT * 4;
 const DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES = 4;
 const INJECTED_DELIVERY_TRANSCRIPT_PATTERN = /\b(?:delivery[-_\s]?mirror|config[-_\s]?audit)\b/i;
+const INJECTED_CONVERSATION_METADATA_PREFIX = "Conversation info (untrusted metadata)";
 const OPENCLAW_RUNTIME_CONTEXT_SENTINEL =
   "OpenClaw runtime context for the immediately preceding user message. This context is runtime-generated, not user-author.";
 const PROMPT_RECALL_SENSITIVE_IDENTIFIER_PATTERN =
@@ -1344,6 +1346,15 @@ function isLikelyInjectedDeliveryOnlyTranscript(messages: AgentMessage[]): boole
     messages.length > 0 &&
     messages.length <= DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES &&
     messages.every(isLikelyInjectedDeliveryMessage)
+  );
+}
+
+function isInjectedConversationMetadataMessage(
+  message: Pick<MessageRecord, "role" | "content">,
+): boolean {
+  return (
+    message.role === "user" &&
+    message.content.trimStart().startsWith(INJECTED_CONVERSATION_METADATA_PREFIX)
   );
 }
 
@@ -5940,6 +5951,34 @@ export class LcmContextEngine implements ContextEngine {
     return { overlaps, firstNonOverlappingIndex };
   }
 
+  private async canBypassPlaceholderNoAnchorImportCap(params: {
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+    persistedPrefixLength: number;
+  }): Promise<boolean> {
+    const persistedMessages = await this.conversationStore.getMessages(params.conversationId);
+    const allowedPrefix = params.historicalMessages
+      .slice(0, params.persistedPrefixLength)
+      .map((message) => toStoredMessage(message));
+    let prefixIndex = 0;
+
+    // Only the targeted recovery shape may bypass the cap: injected metadata
+    // rows, plus an already-imported prefix when a previous retry failed.
+    for (const persisted of persistedMessages) {
+      if (isInjectedConversationMetadataMessage(persisted)) {
+        continue;
+      }
+
+      const expected = allowedPrefix[prefixIndex];
+      if (!expected || persisted.role !== expected.role || persisted.content !== expected.content) {
+        return false;
+      }
+      prefixIndex += 1;
+    }
+
+    return prefixIndex === allowedPrefix.length;
+  }
+
   private async countPersistedTranscriptIdentityOverlaps(params: {
     conversationId: number;
     messages: AgentMessage[];
@@ -6145,17 +6184,23 @@ export class LcmContextEngine implements ContextEngine {
               `[lcm] reconcileSessionTail: duplicate transcript replay guard dropped ${replayAnalysis.firstNonOverlappingIndex}/${historicalMessages.length} already-persisted prefix messages for ${sessionContext} before no-anchor import (reason: ${params.noAnchorImportReason ?? "unspecified"})`,
             );
           }
+
+          const placeholderRecoveryCanBypassCap =
+            params.noAnchorImportReason === "placeholder-checkpoint-recovery" &&
+            (await this.canBypassPlaceholderNoAnchorImportCap({
+              conversationId,
+              historicalMessages,
+              persistedPrefixLength: shouldDropPersistedPrefix
+                ? replayAnalysis.firstNonOverlappingIndex
+                : 0,
+            }));
           // #639: placeholder-checkpoint recovery is an initial-epoch
-          // catch-up (the conversation has only injected metadata and never
-          // ingested its real transcript). The proportional cap
-          // (max(existingDbCount*0.2, 50)) permanently starves large
-          // pre-existing sessions, so lift it for this reason only. The
-          // replay-duplicate guard above already aborts genuine floods; every
-          // other no-anchor reason keeps the cap.
-          const importCap =
-            params.noAnchorImportReason === "placeholder-checkpoint-recovery"
-              ? Number.POSITIVE_INFINITY
-              : Math.max(Math.floor(existingDbCount * 0.2), 50);
+          // catch-up only when the DB still contains injected metadata plus
+          // any already-imported prefix from a failed retry. Generic
+          // placeholder checkpoints keep the normal bounded cap.
+          const importCap = placeholderRecoveryCanBypassCap
+            ? Number.POSITIVE_INFINITY
+            : Math.max(Math.floor(existingDbCount * 0.2), 50);
           if (noAnchorImportMessages.length > importCap) {
             this.deps.log.warn(
               `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11214,7 +11214,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).resolves.toBe(1);
   });
 
-  it("does not advance a placeholder checkpoint when no-anchor recovery throws mid-import (#639)", async () => {
+  it("keeps placeholder recovery retryable without duplicating a partially imported prefix (#639)", async () => {
     const engine = createEngine();
     const sessionId = "placeholder-no-anchor-import-failure";
     const sessionKey = "agent:opsos:telegram:test:direct:placeholder-failure";
@@ -11308,6 +11308,35 @@ describe("LcmContextEngine fidelity and token budget", () => {
       .getConversationStore()
       .getMessageCount(conversation!.conversationId);
     expect(count).toBe(4);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "failure assistant turn 7" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const retryCount = await engine
+      .getConversationStore()
+      .getMessageCount(conversation!.conversationId);
+    expect(retryCount).toBe(2 + entries.length);
+    await expect(
+      engine
+        .getConversationStore()
+        .countMessagesByIdentity(conversation!.conversationId, "user", "failure user turn 0"),
+    ).resolves.toBe(1);
+    await expect(
+      engine
+        .getConversationStore()
+        .countMessagesByIdentity(conversation!.conversationId, "assistant", "failure assistant turn 0"),
+    ).resolves.toBe(1);
+
+    const advanced = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advanced?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9,7 +9,7 @@ import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine, type RotateSessionStorageResult } from "../src/engine.js";
 import { estimateTokens } from "../src/estimate-tokens.js";
-import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { AgentMessage, IngestResult } from "../src/openclaw-bridge.js";
 import { LcmProviderAuthError, LcmSummarySpendLimitError } from "../src/summarize.js";
 import {
   createDelegatedExpansionGrant,
@@ -11172,18 +11172,145 @@ describe("LcmContextEngine fidelity and token budget", () => {
     const count = await engine
       .getConversationStore()
       .getMessageCount(conversation!.conversationId);
-    expect(count).toBeGreaterThan(50);
+    expect(count).toBe(2 + entries.length);
     await expect(
       engine
         .getConversationStore()
         .countMessagesByIdentity(conversation!.conversationId, "user", "real user turn 0"),
+    ).resolves.toBe(1);
+    await expect(
+      engine
+        .getConversationStore()
+        .countMessagesByIdentity(
+          conversation!.conversationId,
+          "assistant",
+          `real assistant turn ${turns - 1}`,
+        ),
     ).resolves.toBe(1);
     // Checkpoint advanced past the placeholder so future turns take the normal
     // incremental append-only path.
     const advanced = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);
-    expect(advanced?.lastProcessedOffset).toBeGreaterThan(0);
+    expect(advanced?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: `real assistant turn ${turns - 1}` })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const countAfterReplay = await engine
+      .getConversationStore()
+      .getMessageCount(conversation!.conversationId);
+    expect(countAfterReplay).toBe(count);
+    await expect(
+      engine
+        .getConversationStore()
+        .countMessagesByIdentity(
+          conversation!.conversationId,
+          "assistant",
+          `real assistant turn ${turns - 1}`,
+        ),
+    ).resolves.toBe(1);
+  });
+
+  it("does not advance a placeholder checkpoint when no-anchor recovery throws mid-import (#639)", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-no-anchor-import-failure";
+    const sessionKey = "agent:opsos:telegram:test:direct:placeholder-failure";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "Conversation info (untrusted metadata): alpha" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "Conversation info (untrusted metadata): beta" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const entries: Array<{ role: AgentMessage["role"]; content: string }> = [];
+    for (let i = 0; i < 8; i += 1) {
+      entries.push({ role: "user", content: `failure user turn ${i}` });
+      entries.push({ role: "assistant", content: `failure assistant turn ${i}` });
+    }
+    const sessionFile = createSessionFilePath("placeholder-no-anchor-import-failure");
+    writeLeafTranscript(sessionFile, entries);
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    const privateEngine = engine as unknown as {
+      ingestSingle: (params: {
+        sessionId: string;
+        sessionKey?: string;
+        message: AgentMessage;
+        isHeartbeat?: boolean;
+        skipReplayTimestampFloodGuard?: boolean;
+      }) => Promise<IngestResult>;
+    };
+    const originalIngestSingle = privateEngine.ingestSingle.bind(engine);
+    let transcriptImportAttempts = 0;
+    vi.spyOn(privateEngine, "ingestSingle").mockImplementation(async (params) => {
+      const content =
+        typeof params.message.content === "string"
+          ? params.message.content
+          : Array.isArray(params.message.content)
+            ? params.message.content
+                .map((block) =>
+                  block &&
+                  typeof block === "object" &&
+                  "text" in block &&
+                  typeof (block as { text?: unknown }).text === "string"
+                    ? (block as { text: string }).text
+                    : "",
+                )
+                .join("\n")
+            : "";
+      if (content.startsWith("failure user turn") || content.startsWith("failure assistant turn")) {
+        transcriptImportAttempts += 1;
+        if (transcriptImportAttempts === 3) {
+          throw new Error("simulated placeholder import failure");
+        }
+      }
+      return originalIngestSingle(params);
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "failure assistant turn 7" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(0);
+    expect(checkpoint?.lastSeenSize).toBe(0);
+    expect(checkpoint?.lastProcessedEntryHash).toBeNull();
+
+    const count = await engine
+      .getConversationStore()
+      .getMessageCount(conversation!.conversationId);
+    expect(count).toBe(4);
   });
 
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11214,7 +11214,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).resolves.toBe(1);
   });
 
-  it("keeps the no-anchor import cap for placeholder checkpoints with real DB rows (#639)", async () => {
+  it("keeps a bounded no-anchor import cap for placeholder checkpoints with real DB rows (#639)", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
@@ -11239,7 +11239,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(conversation).not.toBeNull();
 
     const entries: Array<{ role: AgentMessage["role"]; content: string }> = [];
-    for (let i = 0; i < 60; i += 1) {
+    for (let i = 0; i < 600; i += 1) {
       entries.push({ role: "user", content: `foreign user turn ${i}` });
       entries.push({ role: "assistant", content: `foreign assistant turn ${i}` });
     }
@@ -11259,7 +11259,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       sessionId,
       sessionKey,
       sessionFile,
-      messages: [makeMessage({ role: "assistant", content: "foreign assistant turn 59" })],
+      messages: [makeMessage({ role: "assistant", content: "foreign assistant turn 599" })],
       prePromptMessageCount: 0,
       tokenBudget: 4_096,
     });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11214,6 +11214,70 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).resolves.toBe(1);
   });
 
+  it("keeps the no-anchor import cap for placeholder checkpoints with real DB rows (#639)", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+    });
+    const sessionId = "placeholder-real-frontier-large-transcript";
+    const sessionKey = "agent:opsos:telegram:test:direct:placeholder-real-frontier";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "live real user row" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "live real assistant row" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const entries: Array<{ role: AgentMessage["role"]; content: string }> = [];
+    for (let i = 0; i < 60; i += 1) {
+      entries.push({ role: "user", content: `foreign user turn ${i}` });
+      entries.push({ role: "assistant", content: `foreign assistant turn ${i}` });
+    }
+    const sessionFile = createSessionFilePath("placeholder-real-frontier-large-transcript");
+    writeLeafTranscript(sessionFile, entries);
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "foreign assistant turn 59" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    await expect(
+      engine.getConversationStore().getMessageCount(conversation!.conversationId),
+    ).resolves.toBe(2);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(0);
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("no anchor import cap exceeded")),
+    ).toBe(true);
+  });
+
   it("keeps placeholder recovery retryable without duplicating a partially imported prefix (#639)", async () => {
     const engine = createEngine();
     const sessionId = "placeholder-no-anchor-import-failure";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11102,6 +11102,90 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
   });
 
+  it("recovers a placeholder-checkpoint conversation whose only DB rows are non-anchoring metadata by importing the full transcript as a new epoch (#639)", async () => {
+    // Repro of conv 3893 (agent:opsos:telegram): the DB frontier holds only
+    // injected "Conversation info (untrusted metadata)" preambles that do NOT
+    // appear in the real transcript, and the bootstrap checkpoint is a
+    // placeholder (all-zero, never ingested). Before the fix the
+    // placeholder-checkpoint-recovery branch called reconcileSessionTail
+    // WITHOUT allowNoAnchorImport, so with no anchor it imported 0 messages
+    // forever; and even with it, the no-anchor import cap (max(2*0.2,50)=50)
+    // would block a >50-message transcript. After the fix the full transcript
+    // is imported as a new epoch (cap lifted for this initial-epoch catch-up).
+    const engine = createEngine();
+    const sessionId = "placeholder-no-anchor-large-transcript";
+    const sessionKey = "agent:opsos:telegram:test:direct:placeholder-no-anchor";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "Conversation info (untrusted metadata): alpha" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "Conversation info (untrusted metadata): beta" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    // Large transcript (120 messages > 50-message no-anchor cap), sharing no
+    // content with the 2 metadata rows so there is no anchor.
+    const turns = 60;
+    const entries: Array<{ role: AgentMessage["role"]; content: string }> = [];
+    for (let i = 0; i < turns; i += 1) {
+      entries.push({ role: "user", content: `real user turn ${i}` });
+      entries.push({ role: "assistant", content: `real assistant turn ${i}` });
+    }
+    const sessionFile = createSessionFilePath("placeholder-no-anchor-large-transcript");
+    writeLeafTranscript(sessionFile, entries);
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: `real assistant turn ${turns - 1}` })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const contents = messages.map((m) => m.content);
+    expect(contents).toContain("real user turn 0");
+    expect(contents).toContain(`real assistant turn ${turns - 1}`);
+    // Proves BOTH the allowNoAnchorImport pass-through AND the cap bypass:
+    // 2 metadata + 120 transcript messages, far above the old 50 cap.
+    const count = await engine
+      .getConversationStore()
+      .getMessageCount(conversation!.conversationId);
+    expect(count).toBeGreaterThan(50);
+    await expect(
+      engine
+        .getConversationStore()
+        .countMessagesByIdentity(conversation!.conversationId, "user", "real user turn 0"),
+    ).resolves.toBe(1);
+    // Checkpoint advanced past the placeholder so future turns take the normal
+    // incremental append-only path.
+    const advanced = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advanced?.lastProcessedOffset).toBeGreaterThan(0);
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11278,7 +11278,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).toBe(true);
   });
 
-  it("keeps placeholder recovery retryable without duplicating a partially imported prefix (#639)", async () => {
+  it("rolls back failed placeholder recovery before retrying the full transcript (#639)", async () => {
     const engine = createEngine();
     const sessionId = "placeholder-no-anchor-import-failure";
     const sessionKey = "agent:opsos:telegram:test:direct:placeholder-failure";
@@ -11371,7 +11371,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     const count = await engine
       .getConversationStore()
       .getMessageCount(conversation!.conversationId);
-    expect(count).toBe(4);
+    expect(count).toBe(2);
 
     await engine.afterTurn({
       sessionId,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11106,12 +11106,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
     // Repro of conv 3893 (agent:opsos:telegram): the DB frontier holds only
     // injected "Conversation info (untrusted metadata)" preambles that do NOT
     // appear in the real transcript, and the bootstrap checkpoint is a
-    // placeholder (all-zero, never ingested). Before the fix the
-    // placeholder-checkpoint-recovery branch called reconcileSessionTail
-    // WITHOUT allowNoAnchorImport, so with no anchor it imported 0 messages
-    // forever; and even with it, the no-anchor import cap (max(2*0.2,50)=50)
-    // would block a >50-message transcript. After the fix the full transcript
-    // is imported as a new epoch (cap lifted for this initial-epoch catch-up).
+    // placeholder (all-zero, never ingested). This recovery path must allow a
+    // no-anchor import and bypass the normal no-anchor cap only for the
+    // initial-epoch catch-up.
     const engine = createEngine();
     const sessionId = "placeholder-no-anchor-large-transcript";
     const sessionKey = "agent:opsos:telegram:test:direct:placeholder-no-anchor";


### PR DESCRIPTION
### What

Fixes `#822`: a conversation with a placeholder `bootstrap_state` (all-zero, from #685) plus a DB frontier of only non-anchoring rows could never re-import its real transcript — the placeholder-checkpoint-recovery branch called `reconcileSessionTail` **without** `allowNoAnchorImport` (0 imports forever), and the no-anchor import cap (`max(floor(existingDbCount*0.2), 50)`, #649) blocked transcripts > ~50 messages; this PR now raises that recovery cap while keeping it finite. Result: `assemble()` falls back to the raw transcript, compaction never runs, LCM is silently a no-op for that session.

### How (2 hunks, minimal)

1. Pass `allowNoAnchorImport: true` in the placeholder-checkpoint-recovery reconcile — a placeholder checkpoint means never-ingested, so importing the transcript as a bounded new epoch is the correct recovery.
2. Use a larger finite import cap only for `noAnchorImportReason === "placeholder-checkpoint-recovery"` (initial-epoch catch-up) so large recoveries can proceed without disabling the replay-flood guard.

Safety:
- The replay-duplicate guard runs **before** the cap and is unchanged → #776's anti-flood protection is preserved; genuine duplicate floods still abort.
- Only conversations with this exact pathological shape (placeholder checkpoint + non-anchoring frontier) change behavior — and for those, prior behavior was a permanent no-op (0 imports forever), so the new behavior is strictly an improvement.
- Idempotent: after import, `refreshBootstrapState` advances the checkpoint to EOF (non-placeholder) → subsequent turns take the normal incremental append-only path. The recovery runs once.

### Repro / validation

- Deterministic unit test in `test/engine.test.ts`: seed a conversation with 2 non-anchoring metadata rows + a placeholder checkpoint + a 120-message transcript; call `afterTurn`. **Before:** only the 2 metadata rows exist (`expected [...(2)] to include 'real user turn 0'` fails). **After:** the full transcript imports once, checkpoint advances. Full suite green.
- Production: a real session stuck at 2 DB msgs / 0 summaries / placeholder checkpoint while its session file held ~764 messages. After the fix + one turn: 1999 messages, 19 summaries, checkpoint advanced, compaction healthy, no more overflow.

### Related

Regression of #685 (created the placeholder, left recovery a no-op for the no-anchor shape) · #714 edited the same branch without fixing it · refutes "possibly-resolved-by-#685" triage on #686 · cap origin #649, anti-flood #489/#776 (preserved) · part of the #639 "context lost" family but a distinct mechanism from the Mode-2 deferred-compaction exhaustion (separate PR).

Fixes `#822`. Refs #685, #686, #639.