### PR TITLE
test: cover fallback compaction recovery bounds

### DIFF
--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -17,6 +17,7 @@ import {
   resetDelegatedExpansionGrantsForTests,
   resolveDelegatedExpansionGrantId,
 } from "../src/expansion-auth.js";
+import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
 import { RetrievalEngine } from "../src/retrieval.js";
 import type { LcmDependencies } from "../src/types.js";
 
@@ -13139,6 +13140,157 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect(second.changed).toBe(false);
       expect(second.reason).toBe("deferred compaction backoff active");
       expect(complete).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maintain() bounds provider-fallback recursive sweeps with unlimited depth and repairable lineage", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-31T12:30:00.000Z"));
+    try {
+      const maxSweepIterations = 5;
+      const complete = vi.fn(async () => {
+        throw new Error("FailoverError: ChatGPT prolite plan, try again in ~61 min");
+      });
+      const engine = createEngineWithDeps(
+        {
+          summaryProvider: "openai-codex",
+          summaryModel: "gpt-5.3-codex",
+          sweepMaxDepth: -1,
+          incrementalMaxDepth: -1,
+          dynamicLeafChunkTokens: { enabled: true, max: 40_000 },
+          freshTailCount: 2,
+          leafMinFanout: 2,
+          condensedMinFanout: 2,
+          condensedMinFanoutHard: 2,
+          leafChunkTokens: 2_500,
+          leafTargetTokens: 600,
+          condensedTargetTokens: 900,
+          summaryPrefixTargetTokens: 1,
+          maxSweepIterations,
+          sweepDeadlineMs: 1_000,
+          summarySpendBackoffMs: 30 * 60 * 1000,
+        },
+        {
+          complete,
+          resolveModel: vi.fn(() => ({
+            provider: "openai-codex",
+            model: "gpt-5.3-codex",
+          })),
+        },
+      );
+      const sessionId = "maintain-provider-fallback-unlimited-depth-repairable";
+      const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+        sessionKey: undefined,
+      });
+      const summaryStore = engine.getSummaryStore();
+      await summaryStore.insertSummary({
+        summaryId: "sum_provider_fallback_old_1",
+        conversationId: conversation.conversationId,
+        kind: "condensed",
+        depth: 1,
+        content: `old provider-stress arc 1 ${"a".repeat(3_600)}`,
+        tokenCount: 1_000,
+      });
+      await summaryStore.insertSummary({
+        summaryId: "sum_provider_fallback_old_2",
+        conversationId: conversation.conversationId,
+        kind: "condensed",
+        depth: 1,
+        content: `old provider-stress arc 2 ${"b".repeat(3_600)}`,
+        tokenCount: 1_000,
+      });
+      await summaryStore.appendContextSummary(
+        conversation.conversationId,
+        "sum_provider_fallback_old_1",
+      );
+      await summaryStore.appendContextSummary(
+        conversation.conversationId,
+        "sum_provider_fallback_old_2",
+      );
+      const rawMessages = await engine.getConversationStore().createMessagesBulk(
+        Array.from({ length: 6 }, (_, index) => ({
+          conversationId: conversation.conversationId,
+          seq: index + 1,
+          role: index % 2 === 0 ? "user" as const : "assistant" as const,
+          content: `provider stress turn ${index} ${"x".repeat(5_000)}`,
+          tokenCount: 1_000,
+          skipReplayTimestampFloodGuard: true,
+        })),
+      );
+      await summaryStore.appendContextMessages(
+        conversation.conversationId,
+        rawMessages.map((message) => message.messageId),
+      );
+      const tokensBefore = await summaryStore.getContextTokenCount(conversation.conversationId);
+      await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        reason: "threshold",
+        tokenBudget: 4_096,
+        currentTokenCount: 9_000,
+      });
+
+      const first = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-provider-fallback-unlimited-depth"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 9_000,
+        },
+      });
+
+      expect(first.changed).toBe(true);
+      expect(first.reason).toBe("compacted but still over target");
+      expect(complete.mock.calls.length).toBeGreaterThan(0);
+      expect(complete.mock.calls.length).toBeLessThanOrEqual(maxSweepIterations);
+
+      const maintenance = await engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation.conversationId);
+      expect(maintenance?.pending).toBe(true);
+      expect(maintenance?.running).toBe(false);
+      expect(maintenance?.lastFailureSummary).toBe("compacted but still over target");
+      expect(maintenance?.nextAttemptAfter?.toISOString()).toBe("2026-05-31T13:00:00.000Z");
+
+      const afterFirstCallCount = complete.mock.calls.length;
+      const second = await engine.maintain({
+        sessionId,
+        sessionFile: createSessionFilePath("maintain-provider-fallback-unlimited-depth-retry"),
+        runtimeContext: {
+          allowDeferredCompactionExecution: true,
+          tokenBudget: 4_096,
+          currentTokenCount: 9_000,
+        },
+      });
+      expect(second.changed).toBe(false);
+      expect(second.reason).toBe("deferred compaction backoff active");
+      expect(complete).toHaveBeenCalledTimes(afterFirstCallCount);
+
+      const summaries = await summaryStore.getSummariesByConversation(conversation.conversationId);
+      const markerSummaries = summaries.filter(
+        (summary) => detectDoctorMarker(summary.content) !== null,
+      );
+      const markerLeaves = markerSummaries.filter((summary) => summary.kind === "leaf");
+      const markerCondensed = markerSummaries.filter((summary) => summary.kind === "condensed");
+      expect(markerLeaves.length).toBeGreaterThan(0);
+      expect(markerCondensed.length).toBeGreaterThan(0);
+
+      const contextItems = await summaryStore.getContextItems(conversation.conversationId);
+      expect(contextItems.length).toBeGreaterThan(1);
+      expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(2);
+      expect(contextItems.filter((item) => item.itemType === "summary")).not.toHaveLength(1);
+
+      for (const summary of markerLeaves) {
+        expect(await summaryStore.getSummaryMessages(summary.summaryId)).not.toHaveLength(0);
+      }
+      for (const summary of markerCondensed) {
+        expect(await summaryStore.getSummaryParents(summary.summaryId)).not.toHaveLength(0);
+      }
+      const tokensAfter = await summaryStore.getContextTokenCount(conversation.conversationId);
+      expect(Number.isFinite(tokensAfter)).toBe(true);
+      expect(tokensAfter).toBeLessThanOrEqual(tokensBefore);
     } finally {
       vi.useRealTimers();
     }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -17,6 +17,7 @@ import {
   resetDelegatedExpansionGrantsForTests,
   resolveDelegatedExpansionGrantId,
 } from "../src/expansion-auth.js";
+import { applyScopedDoctorRepair } from "../src/plugin/lcm-doctor-apply.js";
 import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
 import { RetrievalEngine } from "../src/retrieval.js";
 import type { LcmDependencies } from "../src/types.js";
@@ -13150,16 +13151,19 @@ describe("LcmContextEngine fidelity and token budget", () => {
     vi.setSystemTime(new Date("2026-05-31T12:30:00.000Z"));
     try {
       const maxSweepIterations = 5;
-      const complete = vi.fn(async () => {
+      const complete = vi.fn(async (params: Parameters<LcmDependencies["complete"]>[0]) => {
+        if (params.provider === "anthropic") {
+          throw new Error("FallbackError: secondary summarizer unavailable");
+        }
         throw new Error("FailoverError: ChatGPT prolite plan, try again in ~61 min");
       });
       const engine = createEngineWithDeps(
         {
           summaryProvider: "openai-codex",
           summaryModel: "gpt-5.3-codex",
+          fallbackProviders: [{ provider: "anthropic", model: "claude-sonnet-4-6" }],
           sweepMaxDepth: -1,
           incrementalMaxDepth: -1,
-          dynamicLeafChunkTokens: { enabled: true, max: 40_000 },
           freshTailCount: 2,
           leafMinFanout: 2,
           condensedMinFanout: 2,
@@ -13174,10 +13178,12 @@ describe("LcmContextEngine fidelity and token budget", () => {
         },
         {
           complete,
-          resolveModel: vi.fn(() => ({
-            provider: "openai-codex",
-            model: "gpt-5.3-codex",
-          })),
+          resolveModel: vi.fn((modelRef?: string, providerHint?: string) => {
+            if (providerHint === "anthropic" || modelRef === "anthropic/claude-sonnet-4-6") {
+              return { provider: "anthropic", model: "claude-sonnet-4-6" };
+            }
+            return { provider: "openai-codex", model: "gpt-5.3-codex" };
+          }),
         },
       );
       const sessionId = "maintain-provider-fallback-unlimited-depth-repairable";
@@ -13244,7 +13250,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect(first.changed).toBe(true);
       expect(first.reason).toBe("compacted but still over target");
       expect(complete.mock.calls.length).toBeGreaterThan(0);
-      expect(complete.mock.calls.length).toBeLessThanOrEqual(maxSweepIterations);
+      expect(complete.mock.calls.length).toBeLessThanOrEqual(maxSweepIterations * 2);
+      const calledProviders = new Set(
+        complete.mock.calls.map(([params]) => params.provider ?? ""),
+      );
+      expect(calledProviders).toEqual(new Set(["openai-codex", "anthropic"]));
 
       const maintenance = await engine
         .getCompactionMaintenanceStore()
@@ -13282,6 +13292,24 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect(contextItems.filter((item) => item.itemType === "message")).toHaveLength(2);
       expect(contextItems.filter((item) => item.itemType === "summary")).not.toHaveLength(1);
 
+      const reachableSummaryIds = new Set<string>();
+      const collectReachableSummaryIds = async (summaryId: string): Promise<void> => {
+        if (reachableSummaryIds.has(summaryId)) {
+          return;
+        }
+        reachableSummaryIds.add(summaryId);
+        for (const parent of await summaryStore.getSummaryParents(summaryId)) {
+          await collectReachableSummaryIds(parent.summaryId);
+        }
+      };
+      for (const item of contextItems) {
+        if (item.itemType === "summary" && item.summaryId != null) {
+          await collectReachableSummaryIds(item.summaryId);
+        }
+      }
+      expect(reachableSummaryIds).toContain("sum_provider_fallback_old_1");
+      expect(reachableSummaryIds).toContain("sum_provider_fallback_old_2");
+
       for (const summary of markerLeaves) {
         expect(await summaryStore.getSummaryMessages(summary.summaryId)).not.toHaveLength(0);
       }
@@ -13291,6 +13319,50 @@ describe("LcmContextEngine fidelity and token budget", () => {
       const tokensAfter = await summaryStore.getContextTokenCount(conversation.conversationId);
       expect(Number.isFinite(tokensAfter)).toBe(true);
       expect(tokensAfter).toBeLessThanOrEqual(tokensBefore);
+
+      const privateEngine = engine as unknown as { db: Parameters<typeof applyScopedDoctorRepair>[0]["db"] };
+      const repairSummarize = vi.fn(async (
+        text: string,
+        _aggressive?: boolean,
+        options?: Parameters<NonNullable<Parameters<typeof applyScopedDoctorRepair>[0]["summarize"]>>[2],
+      ) => {
+        if (options?.isCondensed) {
+          return `CONDENSED REPAIR\n${text}`;
+        }
+        return `LEAF REPAIR\n${text}`;
+      });
+      const repairResult = await applyScopedDoctorRepair({
+        db: privateEngine.db,
+        config: getEngineConfig(engine),
+        conversationId: conversation.conversationId,
+        summarize: repairSummarize,
+      });
+      expect(repairResult.kind).toBe("applied");
+      expect(repairResult.detected).toBe(markerSummaries.length);
+      expect(repairResult.repaired).toBe(markerSummaries.length);
+      expect(repairResult.skipped).toEqual([]);
+      expect(repairSummarize).toHaveBeenCalledTimes(markerSummaries.length);
+
+      const condensedRepairCalls = repairSummarize.mock.calls.filter(
+        ([, , options]) => options?.isCondensed === true,
+      );
+      expect(
+        repairSummarize.mock.calls.some(
+          ([text, , options]) =>
+            options?.isCondensed !== true &&
+            text.includes("provider stress turn 0"),
+        ),
+      ).toBe(true);
+      expect(
+        condensedRepairCalls.some(
+          ([text]) =>
+            text.includes("old provider-stress arc 1") &&
+            text.includes("old provider-stress arc 2"),
+        ),
+      ).toBe(true);
+
+      const repairedSummaries = await summaryStore.getSummariesByConversation(conversation.conversationId);
+      expect(repairedSummaries.every((summary) => detectDoctorMarker(summary.content) === null)).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -13338,6 +13338,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
         summarize: repairSummarize,
       });
       expect(repairResult.kind).toBe("applied");
+      if (repairResult.kind !== "applied") {
+        throw new Error(`expected doctor repair to apply: ${repairResult.reason}`);
+      }
       expect(repairResult.detected).toBe(markerSummaries.length);
       expect(repairResult.repaired).toBe(markerSummaries.length);
       expect(repairResult.skipped).toEqual([]);

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -11,6 +11,7 @@ import { ContextAssembler } from "../src/assembler.js";
 import { CompactionEngine, type CompactionConfig } from "../src/compaction.js";
 import { RetrievalEngine } from "../src/retrieval.js";
 import { createLcmSummarizeFromLegacyParams, LcmProviderAuthError } from "../src/summarize.js";
+import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
 import type { LcmDependencies } from "../src/types.js";
 
 // ── Mock Store Factories ─────────────────────────────────────────────────────
@@ -3705,6 +3706,95 @@ describe("LCM integration: compactUntilUnder bounds", () => {
     expect(result.rounds).toBeGreaterThan(1);
     expect(result.success).toBe(true);
     expect(result.finalTokens).toBeLessThanOrEqual(300);
+  });
+
+  it("bounds unlimited-depth fallback-marker compaction while preserving repair lineage", async () => {
+    const maxRounds = 3;
+    const maxSweepIterations = 10;
+    const engine = new CompactionEngine(
+      convStore as any,
+      sumStore as any,
+      multiRoundConfig({
+        freshTailCount: 0,
+        leafChunkTokens: 100,
+        leafMinFanout: 2,
+        condensedMinFanout: 2,
+        condensedMinFanoutHard: 2,
+        condensedTargetTokens: 30,
+        summaryPrefixTargetTokens: 1,
+        incrementalMaxDepth: -1,
+        maxRounds,
+        maxSweepIterations,
+        compactUntilUnderDeadlineMs: 1_000,
+      }),
+    );
+    await ingestMessages(convStore, sumStore, 8, {
+      contentFn: (i) => `Provider stress turn ${i}: ${"x".repeat(80)}`,
+      tokenCountFn: () => 80,
+    });
+
+    const fallbackSummary = "[LCM fallback summary; truncated for context management]\nrepairable fallback";
+    const summarize = vi.fn(async () => fallbackSummary);
+
+    const result = await engine.compactUntilUnder({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      targetTokens: 1,
+      summarize,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.rounds).toBeLessThanOrEqual(maxRounds);
+    expect(summarize.mock.calls.length).toBeGreaterThan(0);
+    expect(summarize.mock.calls.length).toBeLessThanOrEqual(maxRounds * maxSweepIterations);
+    expect(Number.isFinite(result.finalTokens)).toBe(true);
+
+    const summaries = sumStore._summaries;
+    expect(summaries.length).toBeGreaterThan(0);
+    expect(summaries.some((summary) => summary.kind === "condensed")).toBe(true);
+    expect(summaries.every((summary) => Number.isFinite(summary.tokenCount))).toBe(true);
+    expect(summaries.every((summary) => detectDoctorMarker(summary.content) !== null)).toBe(true);
+
+    const summaryIds = new Set(summaries.map((summary) => summary.summaryId));
+    expect(
+      sumStore._summaryParents.every(
+        (edge) => summaryIds.has(edge.summaryId) && summaryIds.has(edge.parentSummaryId),
+      ),
+    ).toBe(true);
+
+    const collectSourceMessageIds = (summaryId: string, seen = new Set<string>()): Set<number> => {
+      if (seen.has(summaryId)) {
+        return new Set();
+      }
+      seen.add(summaryId);
+
+      const messageIds = new Set(
+        sumStore._summaryMessages
+          .filter((edge) => edge.summaryId === summaryId)
+          .map((edge) => edge.messageId),
+      );
+      for (const edge of sumStore._summaryParents.filter((parent) => parent.summaryId === summaryId)) {
+        for (const messageId of collectSourceMessageIds(edge.parentSummaryId, seen)) {
+          messageIds.add(messageId);
+        }
+      }
+      return messageIds;
+    };
+
+    const coveredMessageIds = new Set<number>();
+    for (const item of await sumStore.getContextItems(CONV_ID)) {
+      if (item.itemType === "message" && item.messageId != null) {
+        coveredMessageIds.add(item.messageId);
+      }
+      if (item.itemType === "summary" && item.summaryId != null) {
+        for (const messageId of collectSourceMessageIds(item.summaryId)) {
+          coveredMessageIds.add(messageId);
+        }
+      }
+    }
+    expect([...coveredMessageIds].toSorted((a, b) => a - b)).toEqual(
+      convStore._messages.map((message) => message.messageId),
+    );
   });
 });
 

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -3715,7 +3715,7 @@ describe("LCM integration: compactUntilUnder bounds", () => {
       convStore as any,
       sumStore as any,
       multiRoundConfig({
-        freshTailCount: 0,
+        freshTailCount: 2,
         leafChunkTokens: 100,
         leafMinFanout: 2,
         condensedMinFanout: 2,
@@ -3755,6 +3755,14 @@ describe("LCM integration: compactUntilUnder bounds", () => {
     expect(summaries.every((summary) => Number.isFinite(summary.tokenCount))).toBe(true);
     expect(summaries.every((summary) => detectDoctorMarker(summary.content) !== null)).toBe(true);
 
+    const contextItems = await sumStore.getContextItems(CONV_ID);
+    expect(contextItems.length).toBeGreaterThan(1);
+    expect(
+      contextItems
+        .filter((item) => item.itemType === "message")
+        .map((item) => item.messageId),
+    ).toEqual(convStore._messages.slice(-2).map((message) => message.messageId));
+
     const summaryIds = new Set(summaries.map((summary) => summary.summaryId));
     expect(
       sumStore._summaryParents.every(
@@ -3782,7 +3790,7 @@ describe("LCM integration: compactUntilUnder bounds", () => {
     };
 
     const coveredMessageIds = new Set<number>();
-    for (const item of await sumStore.getContextItems(CONV_ID)) {
+    for (const item of contextItems) {
       if (item.itemType === "message" && item.messageId != null) {
         coveredMessageIds.add(item.messageId);
       }


### PR DESCRIPTION
## Summary

Adds focused regression coverage for #605 without changing production behavior:

- covers the current design where deterministic fallback summaries are intentional and doctor-detectable
- verifies unlimited-depth fallback-marker compaction is bounded and preserves source lineage
- verifies deferred `maintain()` under provider failure/backoff does not retry indefinitely across an immediate restart-style second maintain call
- asserts fallback leaf and condensed summaries keep repair lineage, fresh-tail messages remain, and context is not collapsed into a single fallback root

This PR does **not** close #605 by itself. It provides current-main evidence that the reported runaway/permanent-collapse path is bounded and repairable; closure should still wait for reporter/maintainer confirmation or an exact incident replay.

## Validation

Local, focused validation from `/Volumes/LEXAR/repos/lossless-claw-issue-605-regression`:

- `npx vitest run test/lcm-integration.test.ts -t "bounds unlimited-depth fallback-marker"`
- `npx vitest run test/engine.test.ts -t "bounds provider-fallback recursive sweeps"`
- `npx vitest run test/lcm-integration.test.ts -t "compactUntilUnder bounds"`
- `npx vitest run test/engine.test.ts -t "maintain\\(\\)"`
- `git diff --check`
- `npm run build`

Related issue: #605
