### PR TITLE
fix: deduplicate replayed ingest batches

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6316,6 +6316,95 @@ export class LcmContextEngine implements ContextEngine {
     return { candidateRawIds: candidateRawIds.size, matchedRawIds };
   }
 
+  /** Drop exact raw-id transcript replays while preserving content-only repeated user turns. */
+  private async filterPersistedRawIdReplayBatch(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    messages: AgentMessage[];
+  }): Promise<AgentMessage[]> {
+    const matchStmt = this.db.prepare(
+      `SELECT 1 AS found
+       FROM message_parts mp
+       JOIN messages m ON m.message_id = mp.message_id
+       WHERE m.conversation_id = ?
+         AND m.role = ?
+         AND m.identity_hash = ?
+         AND mp.metadata IS NOT NULL
+         AND json_valid(mp.metadata)
+         AND (
+           json_extract(mp.metadata, '$.raw.id') = ?
+           OR json_extract(mp.metadata, '$.raw.call_id') = ?
+           OR json_extract(mp.metadata, '$.raw.toolCallId') = ?
+           OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
+           OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
+           OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
+         )
+       LIMIT 1`,
+    );
+
+    const filtered: AgentMessage[] = [];
+    let replayedMessages = 0;
+
+    for (const message of params.messages) {
+      const stored = toStoredMessage(message);
+      const rawIds = new Set<string>();
+      for (const part of buildMessageParts({
+        sessionId: params.sessionId,
+        message,
+        fallbackContent: stored.content,
+      })) {
+        for (const rawId of extractRawIdsFromPartMetadata(part.metadata)) {
+          rawIds.add(rawId);
+        }
+      }
+
+      if (rawIds.size === 0) {
+        filtered.push(message);
+        continue;
+      }
+
+      const identityHash = buildMessageIdentityHash(stored.role, stored.content);
+      let alreadyPersisted = false;
+      for (const rawId of rawIds) {
+        const row = matchStmt.get(
+          params.conversationId,
+          stored.role,
+          identityHash,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+        ) as { found: number } | undefined;
+        if (row?.found === 1) {
+          alreadyPersisted = true;
+          break;
+        }
+      }
+
+      if (alreadyPersisted) {
+        replayedMessages += 1;
+      } else {
+        filtered.push(message);
+      }
+    }
+
+    if (replayedMessages > 0) {
+      const sessionContext = this.formatSessionLogContext({
+        conversationId: params.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      });
+      this.deps.log.warn(
+        `[lcm] ingestBatch: dropped ${replayedMessages}/${params.messages.length} raw-id replay messages for ${sessionContext}`,
+      );
+    }
+
+    return filtered;
+  }
+
   /**
    * Existing-conversation bootstrap is a rehydrate path. It may repair small
    * crash gaps, but it must not replay already persisted transcript rows as
@@ -8257,8 +8346,23 @@ export class LcmContextEngine implements ContextEngine {
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () => {
         return this.conversationStore.withTransaction(async () => {
+          let messages = params.messages;
+          if (!params.isHeartbeat) {
+            const conversation = await this.conversationStore.getConversationForSession({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            });
+            if (conversation) {
+              messages = await this.filterPersistedRawIdReplayBatch({
+                conversationId: conversation.conversationId,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                messages: params.messages,
+              });
+            }
+          }
           let ingestedCount = 0;
-          for (const message of params.messages) {
+          for (const message of messages) {
             const result = await this.ingestSingle({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream, statSync } from "node:fs";
+import { createReadStream, readFileSync, statSync } from "node:fs";
 import { mkdir, open, stat, writeFile } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { join, resolve as resolvePath } from "node:path";
@@ -457,19 +457,241 @@ function extractRawIdsFromPartMetadata(metadata: string | null | undefined): str
     return [];
   }
 
-  const raw = asRecord(asRecord(parsed)?.raw);
-  if (!raw) {
+  const record = asRecord(parsed);
+  const raw = asRecord(record?.raw);
+
+  // Replay IDs can be preserved either inside the raw transcript block or
+  // as top-level metadata for string-content tool messages.
+  return [
+    safeString(raw?.id),
+    safeString(raw?.call_id),
+    safeString(raw?.toolCallId),
+    safeString(raw?.tool_call_id),
+    safeString(raw?.toolUseId),
+    safeString(raw?.tool_use_id),
+    safeString(record?.id),
+    safeString(record?.call_id),
+    safeString(record?.toolCallId),
+    safeString(record?.tool_call_id),
+    safeString(record?.toolUseId),
+    safeString(record?.tool_use_id),
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function extractRawBlockIdsFromPartMetadata(metadata: string | null | undefined): string[] {
+  if (!metadata) {
     return [];
   }
 
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata);
+  } catch {
+    return [];
+  }
+
+  const raw = asRecord(asRecord(parsed)?.raw);
   return [
-    safeString(raw.id),
-    safeString(raw.call_id),
-    safeString(raw.toolCallId),
-    safeString(raw.tool_call_id),
-    safeString(raw.toolUseId),
-    safeString(raw.tool_use_id),
+    safeString(raw?.id),
+    safeString(raw?.call_id),
+    safeString(raw?.toolCallId),
+    safeString(raw?.tool_call_id),
+    safeString(raw?.toolUseId),
+    safeString(raw?.tool_use_id),
   ].filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function extractRawBlockSignatureFromPartMetadata(metadata: string | null | undefined): string | null {
+  if (!metadata) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata);
+  } catch {
+    return null;
+  }
+
+  const raw = asRecord(asRecord(parsed)?.raw);
+  return raw ? toJson(raw) : null;
+}
+
+function extractPlainToolReplayTextsById(message: AgentMessage): Map<string, string> {
+  const textsById = new Map<string, string>();
+  const duplicateIds = new Set<string>();
+  const addText = (replayId: string, text: string): void => {
+    if (duplicateIds.has(replayId)) {
+      return;
+    }
+    if (textsById.has(replayId)) {
+      textsById.delete(replayId);
+      duplicateIds.add(replayId);
+      return;
+    }
+    textsById.set(replayId, text);
+  };
+  if (
+    (message.role !== "toolResult" && message.role !== "tool") ||
+    !("content" in message)
+  ) {
+    return textsById;
+  }
+  const topLevel = message as unknown as Record<string, unknown>;
+  const topLevelToolCallId =
+    safeString(topLevel.toolCallId) ??
+    safeString(topLevel.tool_call_id) ??
+    safeString(topLevel.toolUseId) ??
+    safeString(topLevel.tool_use_id) ??
+    safeString(topLevel.call_id) ??
+    safeString(topLevel.id);
+  if (typeof message.content === "string") {
+    if (topLevelToolCallId) {
+      addText(topLevelToolCallId, message.content);
+    }
+    return textsById;
+  }
+  if (!Array.isArray(message.content)) {
+    return textsById;
+  }
+
+  for (const item of message.content) {
+    const record = asRecord(item);
+    if (!record) {
+      continue;
+    }
+    const rawType = safeString(record.type);
+    const replayId =
+      safeString(record.tool_use_id) ??
+      safeString(record.toolUseId) ??
+      safeString(record.tool_call_id) ??
+      safeString(record.toolCallId) ??
+      safeString(record.call_id) ??
+      safeString(record.id) ??
+      (message.content.length === 1 ? topLevelToolCallId : undefined);
+    if (!replayId) {
+      continue;
+    }
+
+    if (record.type === "text") {
+      const text = safeString(record.text);
+      if (text !== undefined) {
+        addText(replayId, text);
+      }
+      continue;
+    }
+    if (
+      rawType !== "tool_result" &&
+      rawType !== "toolResult" &&
+      rawType !== "function_call_output"
+    ) {
+      continue;
+    }
+    const textSource =
+      record.output !== undefined
+        ? record.output
+        : record.content !== undefined
+          ? record.content
+          : record;
+    const text = extractStructuredText(textSource);
+    if (text !== undefined) {
+      addText(replayId, text);
+    }
+  }
+  return textsById;
+}
+
+function stripExternalizedReplayMetadata(record: Record<string, unknown>): Record<string, unknown> {
+  const stripped = { ...record };
+  delete stripped.raw;
+  delete stripped.output;
+  delete stripped.content;
+  delete stripped.text;
+  delete stripped.externalizedFileId;
+  delete stripped.originalByteSize;
+  delete stripped.toolOutputExternalized;
+  delete stripped.externalizationReason;
+  delete stripped.rawType;
+  return stripped;
+}
+
+function canonicalizeReplayRawMetadata(record: Record<string, unknown>): Record<string, unknown> {
+  const canonical = stripExternalizedReplayMetadata(record);
+  const rawType = safeString(canonical.type);
+  if (rawType === "toolResult") {
+    canonical.type = "tool_result";
+  }
+
+  const replayId =
+    safeString(canonical.tool_use_id) ??
+    safeString(canonical.toolUseId) ??
+    safeString(canonical.tool_call_id) ??
+    safeString(canonical.toolCallId) ??
+    safeString(canonical.call_id) ??
+    safeString(canonical.id);
+  delete canonical.tool_use_id;
+  delete canonical.toolUseId;
+  delete canonical.tool_call_id;
+  delete canonical.toolCallId;
+  delete canonical.call_id;
+  delete canonical.id;
+  if (replayId) {
+    canonical[canonical.type === "function_call_output" ? "call_id" : "tool_use_id"] = replayId;
+  }
+
+  const isError = canonical.isError ?? canonical.is_error;
+  delete canonical.isError;
+  delete canonical.is_error;
+  if (typeof isError === "boolean") {
+    canonical.isError = isError;
+  }
+
+  return canonical;
+}
+
+function pickTopLevelReplayMetadata(record: Record<string, unknown>): Record<string, unknown> {
+  return {
+    originalRole: record.originalRole,
+    toolCallId: record.toolCallId,
+    toolName: record.toolName,
+    isError: record.isError,
+  };
+}
+
+function externalizedReplayMetadataMatches(
+  persistedMetadata: string | null,
+  incomingMetadata: string | null | undefined,
+): boolean {
+  let persistedParsed: unknown;
+  let incomingParsed: unknown;
+  try {
+    persistedParsed = persistedMetadata ? JSON.parse(persistedMetadata) : undefined;
+    incomingParsed = incomingMetadata ? JSON.parse(incomingMetadata) : undefined;
+  } catch {
+    return false;
+  }
+
+  const persistedRecord = asRecord(persistedParsed);
+  const incomingRecord = asRecord(incomingParsed);
+  if (!persistedRecord || !incomingRecord) {
+    return false;
+  }
+  const incomingRaw = asRecord(incomingRecord.raw);
+  if (!incomingRaw) {
+    return toJson(pickTopLevelReplayMetadata(persistedRecord)) ===
+      toJson(pickTopLevelReplayMetadata(incomingRecord));
+  }
+  if (
+    toJson(stripExternalizedReplayMetadata(persistedRecord)) !==
+    toJson(stripExternalizedReplayMetadata(incomingRecord))
+  ) {
+    return false;
+  }
+
+  const persistedRaw = asRecord(persistedRecord.raw);
+  return !!persistedRaw &&
+    toJson(canonicalizeReplayRawMetadata(persistedRaw)) ===
+      toJson(canonicalizeReplayRawMetadata(incomingRaw));
 }
 
 function formatDurationMs(durationMs: number): string {
@@ -6293,6 +6515,13 @@ export class LcmContextEngine implements ContextEngine {
            OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
            OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
            OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
+           OR mp.tool_call_id = ?
+           OR json_extract(mp.metadata, '$.id') = ?
+           OR json_extract(mp.metadata, '$.call_id') = ?
+           OR json_extract(mp.metadata, '$.toolCallId') = ?
+           OR json_extract(mp.metadata, '$.tool_call_id') = ?
+           OR json_extract(mp.metadata, '$.toolUseId') = ?
+           OR json_extract(mp.metadata, '$.tool_use_id') = ?
          )
        LIMIT 1`,
     );
@@ -6301,6 +6530,13 @@ export class LcmContextEngine implements ContextEngine {
     for (const rawId of candidateRawIds) {
       const row = matchStmt.get(
         params.conversationId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
+        rawId,
         rawId,
         rawId,
         rawId,
@@ -6323,8 +6559,33 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     messages: AgentMessage[];
   }): Promise<AgentMessage[]> {
-    const matchStmt = this.db.prepare(
-      `SELECT 1 AS found
+    const idMatchPredicate = `(
+      json_extract(mp.metadata, '$.raw.id') = ?
+      OR json_extract(mp.metadata, '$.raw.call_id') = ?
+      OR json_extract(mp.metadata, '$.raw.toolCallId') = ?
+      OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
+      OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
+      OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
+      OR mp.tool_call_id = ?
+      OR json_extract(mp.metadata, '$.id') = ?
+      OR json_extract(mp.metadata, '$.call_id') = ?
+      OR json_extract(mp.metadata, '$.toolCallId') = ?
+      OR json_extract(mp.metadata, '$.tool_call_id') = ?
+      OR json_extract(mp.metadata, '$.toolUseId') = ?
+      OR json_extract(mp.metadata, '$.tool_use_id') = ?
+    )`;
+    const rawCoverageStmt = this.db.prepare(
+      `SELECT m.message_id AS messageId
+       FROM message_parts mp
+       JOIN messages m ON m.message_id = mp.message_id
+       WHERE m.conversation_id = ?
+         AND m.role = ?
+         AND mp.metadata IS NOT NULL
+         AND json_valid(mp.metadata)
+         AND ${idMatchPredicate}`,
+    );
+    const identityCoverageStmt = this.db.prepare(
+      `SELECT m.message_id AS messageId
        FROM message_parts mp
        JOIN messages m ON m.message_id = mp.message_id
        WHERE m.conversation_id = ?
@@ -6332,15 +6593,28 @@ export class LcmContextEngine implements ContextEngine {
          AND m.identity_hash = ?
          AND mp.metadata IS NOT NULL
          AND json_valid(mp.metadata)
-         AND (
-           json_extract(mp.metadata, '$.raw.id') = ?
-           OR json_extract(mp.metadata, '$.raw.call_id') = ?
-           OR json_extract(mp.metadata, '$.raw.toolCallId') = ?
-           OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
-           OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
-           OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
-         )
-       LIMIT 1`,
+         AND ${idMatchPredicate}`,
+    );
+    const externalizedCoverageStmt = this.db.prepare(
+      `SELECT
+         m.message_id AS messageId,
+         json_extract(mp.metadata, '$.externalizedFileId') AS fileId,
+         json_extract(mp.metadata, '$.originalByteSize') AS originalByteSize,
+         mp.metadata AS metadata
+       FROM message_parts mp
+       JOIN messages m ON m.message_id = mp.message_id
+       WHERE m.conversation_id = ?
+         AND m.role = ?
+         AND mp.metadata IS NOT NULL
+         AND json_valid(mp.metadata)
+         AND json_extract(mp.metadata, '$.externalizationReason') = 'large_tool_result'
+         AND ${idMatchPredicate}`,
+    );
+    const rawBlockSignatureStmt = this.db.prepare(
+      `SELECT metadata
+       FROM message_parts
+       WHERE message_id = ?
+       ORDER BY ordinal ASC`,
     );
 
     const filtered: AgentMessage[] = [];
@@ -6348,40 +6622,237 @@ export class LcmContextEngine implements ContextEngine {
 
     for (const message of params.messages) {
       const stored = toStoredMessage(message);
-      const rawIds = new Set<string>();
-      for (const part of buildMessageParts({
+      const replayIds = new Set<string>();
+      const rawBlockIds = new Set<string>();
+      const rawBlockSignatures: string[] = [];
+      const replayIdsByPart: string[][] = [];
+      let everyPartHasRawBlockId = true;
+      const parts = buildMessageParts({
         sessionId: params.sessionId,
         message,
         fallbackContent: stored.content,
-      })) {
-        for (const rawId of extractRawIdsFromPartMetadata(part.metadata)) {
-          rawIds.add(rawId);
+      });
+      for (const part of parts) {
+        const partRawBlockIds = extractRawBlockIdsFromPartMetadata(part.metadata);
+        if (partRawBlockIds.length === 0) {
+          everyPartHasRawBlockId = false;
+        }
+        for (const rawId of partRawBlockIds) {
+          rawBlockIds.add(rawId);
+        }
+        const rawBlockSignature = extractRawBlockSignatureFromPartMetadata(part.metadata);
+        if (rawBlockSignature) {
+          rawBlockSignatures.push(rawBlockSignature);
+        }
+        const partReplayIds = extractRawIdsFromPartMetadata(part.metadata);
+        replayIdsByPart.push(partReplayIds);
+        for (const rawId of partReplayIds) {
+          replayIds.add(rawId);
         }
       }
 
-      if (rawIds.size === 0) {
+      if (replayIds.size === 0) {
         filtered.push(message);
         continue;
       }
 
-      const identityHash = buildMessageIdentityHash(stored.role, stored.content);
-      let alreadyPersisted = false;
-      for (const rawId of rawIds) {
-        const row = matchStmt.get(
-          params.conversationId,
-          stored.role,
-          identityHash,
+      const canMatchWithoutIdentity = rawBlockIds.size > 0 && everyPartHasRawBlockId;
+      const matchedIds = canMatchWithoutIdentity ? rawBlockIds : replayIds;
+      const externalizedTextsById = extractPlainToolReplayTextsById(message);
+      const coverageByMessageId = new Map<number, Set<string>>();
+      for (const rawId of matchedIds) {
+        const rawIdArgs = [
           rawId,
           rawId,
           rawId,
           rawId,
           rawId,
           rawId,
-        ) as { found: number } | undefined;
-        if (row?.found === 1) {
-          alreadyPersisted = true;
-          break;
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+          rawId,
+        ];
+        let rows: Array<{ messageId: number }>;
+        if (canMatchWithoutIdentity) {
+          rows = rawCoverageStmt.all(
+            params.conversationId,
+            stored.role,
+            ...rawIdArgs,
+          ) as Array<{ messageId: number }>;
+        } else {
+          const identityHash = buildMessageIdentityHash(stored.role, stored.content);
+          rows = identityCoverageStmt.all(
+            params.conversationId,
+            stored.role,
+            identityHash,
+            ...rawIdArgs,
+          ) as Array<{ messageId: number }>;
         }
+        for (const row of rows) {
+          const matchedRawIds = coverageByMessageId.get(row.messageId) ?? new Set<string>();
+          matchedRawIds.add(rawId);
+          coverageByMessageId.set(row.messageId, matchedRawIds);
+        }
+      }
+
+      let alreadyPersisted = false;
+      if (canMatchWithoutIdentity) {
+        for (const [messageId, rawIds] of coverageByMessageId.entries()) {
+          if (rawIds.size !== matchedIds.size) {
+            continue;
+          }
+          const rows = rawBlockSignatureStmt.all(messageId) as Array<{ metadata: string | null }>;
+          if (rows.length !== parts.length) {
+            continue;
+          }
+          let allPartsMatch = true;
+          for (let index = 0; index < rows.length; index += 1) {
+            const persistedMetadata = rows[index]!.metadata;
+            const persistedSignature = extractRawBlockSignatureFromPartMetadata(persistedMetadata);
+            if (
+              persistedSignature === rawBlockSignatures[index] &&
+              externalizedReplayMetadataMatches(persistedMetadata, parts[index]?.metadata)
+            ) {
+              continue;
+            }
+            let externalizedPartMatches = false;
+            for (const rawId of replayIdsByPart[index] ?? []) {
+              if (!extractRawIdsFromPartMetadata(persistedMetadata).includes(rawId)) {
+                continue;
+              }
+              const externalizedText = externalizedTextsById.get(rawId);
+              if (externalizedText === undefined) {
+                continue;
+              }
+              let persistedParsed: unknown;
+              try {
+                persistedParsed = persistedMetadata ? JSON.parse(persistedMetadata) : undefined;
+              } catch {
+                continue;
+              }
+              const persistedRecord = asRecord(persistedParsed);
+              const fileId = safeString(persistedRecord?.externalizedFileId);
+              const originalByteSize = persistedRecord?.originalByteSize;
+              if (
+                !fileId ||
+                Number(originalByteSize) !== Buffer.byteLength(externalizedText, "utf8")
+              ) {
+                continue;
+              }
+              const largeFile = await this.summaryStore.getLargeFile(fileId);
+              if (!largeFile) {
+                continue;
+              }
+              let storedText: string;
+              try {
+                storedText = readFileSync(largeFile.storageUri, "utf8");
+              } catch {
+                continue;
+              }
+              if (
+                storedText === externalizedText &&
+                externalizedReplayMetadataMatches(persistedMetadata, parts[index]?.metadata)
+              ) {
+                externalizedPartMatches = true;
+                break;
+              }
+            }
+            if (!externalizedPartMatches) {
+              allPartsMatch = false;
+              break;
+            }
+          }
+          if (allPartsMatch) {
+            alreadyPersisted = true;
+            break;
+          }
+        }
+      } else {
+        for (const [messageId, rawIds] of coverageByMessageId.entries()) {
+          if (rawIds.size !== matchedIds.size) {
+            continue;
+          }
+          const rows = rawBlockSignatureStmt.all(messageId) as Array<{ metadata: string | null }>;
+          if (
+            rows.length === parts.length &&
+            rows.every((row, index) => row.metadata === (parts[index]?.metadata ?? null))
+          ) {
+            alreadyPersisted = true;
+            break;
+          }
+        }
+      }
+
+      const canUseExternalizedFallback = parts.length === 1 || everyPartHasRawBlockId;
+      if (!alreadyPersisted && canUseExternalizedFallback && externalizedTextsById.size > 0) {
+        const externalizedCoverageByMessageId = new Map<number, Set<string>>();
+        for (const rawId of matchedIds) {
+          const externalizedText = externalizedTextsById.get(rawId);
+          if (externalizedText === undefined) {
+            continue;
+          }
+          const externalizedByteSize = Buffer.byteLength(externalizedText, "utf8");
+          const rawIdArgs = [
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+            rawId,
+          ];
+          const rows = externalizedCoverageStmt.all(
+            params.conversationId,
+            stored.role,
+            ...rawIdArgs,
+          ) as Array<{
+            messageId: number;
+            fileId: unknown;
+            originalByteSize: unknown;
+            metadata: string | null;
+          }>;
+          for (const row of rows) {
+            if (
+              typeof row.fileId !== "string" ||
+              Number(row.originalByteSize) !== externalizedByteSize
+            ) {
+              continue;
+            }
+            const largeFile = await this.summaryStore.getLargeFile(row.fileId);
+            if (!largeFile) {
+              continue;
+            }
+            let storedText: string;
+            try {
+              storedText = readFileSync(largeFile.storageUri, "utf8");
+            } catch {
+              continue;
+            }
+            if (
+              storedText !== externalizedText ||
+              !externalizedReplayMetadataMatches(row.metadata, parts[0]?.metadata)
+            ) {
+              continue;
+            }
+            const matchedRawIds =
+              externalizedCoverageByMessageId.get(row.messageId) ?? new Set<string>();
+            matchedRawIds.add(rawId);
+            externalizedCoverageByMessageId.set(row.messageId, matchedRawIds);
+          }
+        }
+        alreadyPersisted = Array.from(externalizedCoverageByMessageId.values()).some(
+          (rawIds) => rawIds.size === matchedIds.size,
+        );
       }
 
       if (alreadyPersisted) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9706,6 +9706,172 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).toBe(3);
   });
 
+  it("deduplicates persisted replay rows in ingestBatch", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-replay-dedup-session";
+    const replayedMessages: AgentMessage[] = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "raw-replay-user", text: "checkpoint replay user" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "raw-replay-assistant", text: "checkpoint replay assistant" }],
+      }),
+    ];
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: replayedMessages,
+    });
+    expect(first.ingestedCount).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
+    try {
+      rawDb
+        .prepare(
+          `UPDATE messages SET created_at = datetime('now', '-10 seconds') WHERE conversation_id = ?`,
+        )
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: replayedMessages,
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "checkpoint replay user",
+      "checkpoint replay assistant",
+    ]);
+    expect(
+      (await engine.getSummaryStore().getContextItems(conversation!.conversationId)).length,
+    ).toBe(2);
+  });
+
+  it("keeps content-only repeated rows in ingestBatch", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-legitimate-repeat-session";
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "hello" }),
+    });
+
+    const result = await engine.ingestBatch({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "hello" }),
+        makeMessage({ role: "assistant", content: "world" }),
+      ],
+    });
+    expect(result.ingestedCount).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["hello", "hello", "world"]);
+  });
+
+  it("deduplicates single raw-id replay rows in ingestBatch", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-single-raw-replay-session";
+    const replayedMessage = makeMessage({
+      role: "tool",
+      content: [{ type: "tool_result", tool_use_id: "raw-single-tool", output: "same output" }],
+    });
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([""]);
+    expect(
+      (await engine.getSummaryStore().getContextItems(conversation!.conversationId)).length,
+    ).toBe(1);
+  });
+
+  it("deduplicates raw-id replay prefix while keeping new ingestBatch tail", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-replay-tail-session";
+    const oldMessages: AgentMessage[] = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "raw-tail-user-a", text: "checkpoint replay old user" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "raw-tail-assistant-b", text: "checkpoint replay old assistant" }],
+      }),
+    ];
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: oldMessages,
+    });
+    expect(first.ingestedCount).toBe(2);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
+    try {
+      rawDb
+        .prepare(
+          `UPDATE messages SET created_at = datetime('now', '-10 seconds') WHERE conversation_id = ?`,
+        )
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const replayWithTail = await engine.ingestBatch({
+      sessionId,
+      messages: [
+        ...oldMessages,
+        makeMessage({
+          role: "user",
+          content: [{ type: "text", id: "raw-tail-user-c", text: "checkpoint replay new user" }],
+        }),
+        makeMessage({
+          role: "assistant",
+          content: [{ type: "text", id: "raw-tail-assistant-d", text: "checkpoint replay new assistant" }],
+        }),
+      ],
+    });
+    expect(replayWithTail.ingestedCount).toBe(2);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "checkpoint replay old user",
+      "checkpoint replay old assistant",
+      "checkpoint replay new user",
+      "checkpoint replay new assistant",
+    ]);
+    expect(
+      (await engine.getSummaryStore().getContextItems(conversation!.conversationId)).length,
+    ).toBe(4);
+  });
+
   it("skips heartbeat turn batches in ingestBatch", async () => {
     const engine = createEngine();
     const sessionId = "batch-ingest-heartbeat-session";
@@ -9774,6 +9940,37 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "[summary] compacted older history",
       "new assistant reply",
+    ]);
+  });
+
+  it("afterTurn keeps auto-compaction summary that matches stored text", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-summary-same-as-stored";
+
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "S" }),
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-summary-same-as-stored"),
+      messages: [
+        makeMessage({ role: "assistant", content: "fresh assistant reply" }),
+      ],
+      prePromptMessageCount: 0,
+      autoCompactionSummary: "S",
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "S",
+      "S",
+      "fresh assistant reply",
     ]);
   });
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -9810,6 +9810,763 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).toBe(1);
   });
 
+  it("keeps changed tool output rows that reuse a raw id", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-changed-tool-output-session";
+    const firstMessage = makeMessage({
+      role: "tool",
+      content: [{ type: "tool_result", tool_use_id: "raw-changed-tool", output: "old output" }],
+    });
+    const changedMessage = makeMessage({
+      role: "tool",
+      content: [{ type: "tool_result", tool_use_id: "raw-changed-tool", output: "new output" }],
+    });
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    const changedParts = await engine.getConversationStore().getMessageParts(stored[1]!.messageId);
+    const metadata = JSON.parse(changedParts[0]!.metadata ?? "{}") as {
+      raw?: { output?: unknown };
+    };
+    expect(metadata.raw?.output).toBe("new output");
+  });
+
+  it("keeps raw-id tool rows when top-level metadata changes but raw output matches", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-raw-id-metadata-change-session";
+    const firstMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [{ type: "tool_result", tool_use_id: "raw-metadata-change", output: "same output" }],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      role: "toolResult",
+      toolName: "shell",
+      content: [{ type: "tool_result", tool_use_id: "raw-metadata-change", output: "same output" }],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("deduplicates top-level tool-call replay rows in ingestBatch", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-top-level-tool-replay-session";
+    const replayedMessage = {
+      role: "tool",
+      content: "same output",
+      toolCallId: "call_top_level_replay",
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["same output"]);
+    expect(
+      (await engine.getSummaryStore().getContextItems(conversation!.conversationId)).length,
+    ).toBe(1);
+  });
+
+  it("keeps top-level tool rows when metadata changes but text matches", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-top-level-metadata-change-session";
+    const firstMessage = {
+      role: "tool",
+      content: "same output",
+      toolCallId: "call_metadata_change",
+      toolName: "exec",
+      isError: false,
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      ...firstMessage,
+      isError: true,
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("deduplicates replay rows when persistence rewrites stored content", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-rewritten-content-replay-session";
+    const toolOutput = `${"tool output line\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "toolResult",
+      toolCallId: "call_rewritten_replay",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_rewritten_replay",
+          name: "exec",
+          content: [{ type: "text", text: toolOutput }],
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.content).toContain("[LCM Tool Output: file_");
+    expect(
+      (await engine.getSummaryStore().getLargeFilesByConversation(conversation!.conversationId)),
+    ).toHaveLength(1);
+  });
+
+  it("deduplicates externalized tool-result replay rows with aliased ids", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-externalized-alias-replay-session";
+    const toolOutput = `${"aliased externalized output\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "toolResult",
+          toolCallId: "call_externalized_alias",
+          name: "exec",
+          output: toolOutput,
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    expect(
+      (await engine.getSummaryStore().getLargeFilesByConversation(conversation!.conversationId)),
+    ).toHaveLength(1);
+  });
+
+  it("deduplicates large string tool-call replay rows after content rewrite", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-large-string-tool-replay-session";
+    const toolOutput = `${"large string tool output\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "tool",
+      content: toolOutput,
+      toolCallId: "call_large_string_replay",
+      toolName: "exec",
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.content).toContain("[LCM Tool Output: file_");
+    expect(
+      (await engine.getSummaryStore().getLargeFilesByConversation(conversation!.conversationId)),
+    ).toHaveLength(1);
+  });
+
+  it("keeps externalized tool rows when metadata changes but output matches", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-externalized-metadata-change-session";
+    const toolOutput = `${"metadata change large output\n".repeat(160)}done`;
+    const firstMessage = {
+      role: "tool",
+      content: toolOutput,
+      toolCallId: "call_externalized_metadata",
+      toolName: "exec",
+      isError: false,
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      ...firstMessage,
+      isError: true,
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("keeps externalized tool rows when tool name changes but output matches", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-externalized-tool-name-change-session";
+    const toolOutput = `${"tool name change large output\n".repeat(160)}done`;
+    const firstMessage = {
+      role: "tool",
+      content: toolOutput,
+      toolCallId: "call_externalized_tool_name",
+      toolName: "exec",
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      ...firstMessage,
+      toolName: "shell",
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("keeps large string tool-call replay rows when the stored sidecar is unreadable", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-missing-sidecar-replay-session";
+    const toolOutput = `${"missing sidecar tool output\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "tool",
+      content: toolOutput,
+      toolCallId: "call_missing_sidecar_replay",
+      toolName: "exec",
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const [largeFile] = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFile).toBeDefined();
+    rmSync(largeFile!.storageUri);
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("deduplicates multi-part large tool-result replay rows after content rewrite", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-multi-large-tool-replay-session";
+    const firstOutput = `${"first large tool output\n".repeat(160)}done`;
+    const secondOutput = `${"second large tool output\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_multi_large_a",
+          name: "exec",
+          content: [{ type: "text", text: firstOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_multi_large_b",
+          name: "exec",
+          content: [{ type: "text", text: secondOutput }],
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    expect(
+      (await engine.getSummaryStore().getLargeFilesByConversation(conversation!.conversationId)),
+    ).toHaveLength(2);
+  });
+
+  it("keeps externalized tool rows when call ids swap between parts", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-swapped-externalized-ids-session";
+    const firstOutput = `${"swapped first output\n".repeat(160)}done`;
+    const secondOutput = `${"swapped second output\n".repeat(160)}done`;
+    const firstMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_swap_a",
+          name: "exec",
+          content: [{ type: "text", text: firstOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_swap_b",
+          name: "exec",
+          content: [{ type: "text", text: secondOutput }],
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const swappedMessage = {
+      ...firstMessage,
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_swap_b",
+          name: "exec",
+          content: [{ type: "text", text: firstOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_swap_a",
+          name: "exec",
+          content: [{ type: "text", text: secondOutput }],
+        },
+      ],
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const swapped = await engine.ingestBatch({
+      sessionId,
+      messages: [swappedMessage],
+    });
+    expect(swapped.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("deduplicates mixed inline and externalized tool-result replay rows", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-mixed-large-inline-tool-replay-session";
+    const largeOutput = `${"mixed large tool output\n".repeat(160)}done`;
+    const replayedMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_mixed_large",
+          name: "exec",
+          content: [{ type: "text", text: largeOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_mixed_inline",
+          name: "exec",
+          output: "small inline output",
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replay = await engine.ingestBatch({
+      sessionId,
+      messages: [replayedMessage],
+    });
+    expect(replay.ingestedCount).toBe(0);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    expect(
+      (await engine.getSummaryStore().getLargeFilesByConversation(conversation!.conversationId)),
+    ).toHaveLength(1);
+  });
+
+  it("keeps mixed externalized tool rows when an untagged part changes", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-externalized-untagged-change-session";
+    const largeOutput = `${"externalized with note output\n".repeat(160)}done`;
+    const firstMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_externalized_note",
+          name: "exec",
+          content: [{ type: "text", text: largeOutput }],
+        },
+        { type: "text", text: "old note" },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      ...firstMessage,
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_externalized_note",
+          name: "exec",
+          content: [{ type: "text", text: largeOutput }],
+        },
+        { type: "text", text: "new note" },
+      ],
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("keeps duplicate-id externalized tool rows when one occurrence changes", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "batch-ingest-duplicate-id-externalized-session";
+    const firstOutput = `${"duplicate id first output\n".repeat(160)}done`;
+    const secondOutput = `${"duplicate id second output\n".repeat(160)}done`;
+    const changedFirstOutput = `${"changed duplicate id first output\n".repeat(160)}done`;
+    const firstMessage = {
+      role: "toolResult",
+      toolName: "exec",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_duplicate_large",
+          name: "exec",
+          content: [{ type: "text", text: firstOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_duplicate_large",
+          name: "exec",
+          content: [{ type: "text", text: secondOutput }],
+        },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      ...firstMessage,
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_duplicate_large",
+          name: "exec",
+          content: [{ type: "text", text: changedFirstOutput }],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "call_duplicate_large",
+          name: "exec",
+          content: [{ type: "text", text: secondOutput }],
+        },
+      ],
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [firstMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("keeps multi-part replay batches with only partial raw-id overlap", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-partial-raw-overlap-session";
+    const existingMessage = makeMessage({
+      role: "tool",
+      content: [{ type: "tool_result", tool_use_id: "raw-part-existing", output: "old output" }],
+    });
+    const partiallyOverlappingMessage = makeMessage({
+      role: "tool",
+      content: [
+        { type: "tool_result", tool_use_id: "raw-part-existing", output: "old output" },
+        { type: "tool_result", tool_use_id: "raw-part-new", output: "new output" },
+      ],
+    });
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [existingMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replayWithNewPart = await engine.ingestBatch({
+      sessionId,
+      messages: [partiallyOverlappingMessage],
+    });
+    expect(replayWithNewPart.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    const newParts = await engine.getConversationStore().getMessageParts(stored[1]!.messageId);
+    expect(newParts.map((part) => part.toolCallId)).toEqual([
+      "raw-part-existing",
+      "raw-part-new",
+    ]);
+  });
+
+  it("keeps partial raw-id overlap when one stored id matches multiple parts", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-duplicate-row-coverage-session";
+    const existingMessage = {
+      role: "assistant",
+      toolCallId: "raw-repeated-top-level",
+      content: [
+        { type: "text", text: "existing part one" },
+        { type: "text", text: "existing part two" },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const partiallyOverlappingMessage = {
+      role: "assistant",
+      toolCallId: "raw-repeated-top-level",
+      content: [
+        { type: "text", text: "new part one" },
+        { type: "text", id: "raw-distinct-new-part", text: "new part two" },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [existingMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const replayWithNewPart = await engine.ingestBatch({
+      sessionId,
+      messages: [partiallyOverlappingMessage],
+    });
+    expect(replayWithNewPart.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    const newParts = await engine.getConversationStore().getMessageParts(stored[1]!.messageId);
+    expect(newParts.map((part) => part.textContent)).toEqual([
+      "new part one",
+      "new part two",
+    ]);
+  });
+
+  it("keeps changed untagged parts that share a top-level replay id", async () => {
+    const engine = createEngine();
+    const sessionId = "batch-ingest-top-level-id-changed-content-session";
+    const existingMessage = {
+      role: "assistant",
+      toolCallId: "raw-untagged-top-level",
+      content: [
+        { type: "text", text: "old part one" },
+        { type: "text", text: "old part two" },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const changedMessage = {
+      role: "assistant",
+      toolCallId: "raw-untagged-top-level",
+      content: [
+        { type: "text", text: "old part one" },
+        { type: "text", text: "new untagged part" },
+      ],
+      timestamp: Date.now(),
+    } as AgentMessage;
+
+    const first = await engine.ingestBatch({
+      sessionId,
+      messages: [existingMessage],
+    });
+    expect(first.ingestedCount).toBe(1);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const changed = await engine.ingestBatch({
+      sessionId,
+      messages: [changedMessage],
+    });
+    expect(changed.ingestedCount).toBe(1);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old part one\nold part two",
+      "old part one\nnew untagged part",
+    ]);
+  });
+
   it("deduplicates raw-id replay prefix while keeping new ingestBatch tail", async () => {
     const engine = createEngine();
     const sessionId = "batch-ingest-replay-tail-session";


### PR DESCRIPTION
## Summary

- add a raw transcript-id replay filter at the `ingestBatch` boundary
- drop only messages whose raw event/tool id and stored identity already exist in the same conversation
- preserve content-only repeated rows, auto-compaction summaries, and mixed replay+new batches
- add regressions for all-duplicate replay, single-message raw-id replay, mixed replay prefix plus new tail, legitimate repeated text, and afterTurn summary persistence

## Issue linkage

Addresses #561. I am intentionally not marking this as `Closes #561` yet because the issue should stay open until this PR is merged and the reporter/maintainer has a chance to confirm the exact checkpoint-loss production trace no longer reproduces.

## Validation

From `/Volumes/LEXAR/repos/lossless-claw-issue-561-dedup`:

```bash
npx vitest run test/engine.test.ts -t "deduplicates persisted replay rows in ingestBatch|keeps content-only repeated rows in ingestBatch|deduplicates single raw-id replay rows in ingestBatch|deduplicates raw-id replay prefix while keeping new ingestBatch tail|afterTurn keeps auto-compaction summary that matches stored text"
npx vitest run test/engine.test.ts -t "ingestBatch|afterTurn dedup guard"
npm run typecheck
npm run build
git diff --check
```

All passed locally. Full-suite validation intentionally left to GitHub CI per local-resource policy.
