### PR TITLE
fix(engine): normalize sensitive field names in dedup identity comparison

### DIFF
--- a/.changeset/stable-dedup-sensitive-content.md
+++ b/.changeset/stable-dedup-sensitive-content.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent duplicate tool-call replay ingestion when OpenClaw stores a host-redacted form of sensitive message content.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -6,6 +6,7 @@
  *
  * Extracted from engine.ts (Phase 2 of the engine decomposition).
  */
+import { createRequire } from "node:module";
 import {
   formatFileReference,
   formatRawPayloadReference,
@@ -27,7 +28,60 @@ import { openClawInboundBodiesMatch } from "./openclaw-inbound-metadata.js";
 import type { ConversationStore, MessageRecord } from "./store/conversation-store.js";
 import { buildMessageIdentityHash } from "./store/message-identity.js";
 import type { LargeFileRecord, SummaryStore } from "./store/summary-store.js";
+import {
+  extractAssistantToolCallIdsForPairing,
+  extractToolPairingIdFromRecord,
+  extractToolResultIdForPairing,
+} from "./tool-pairing.js";
 import type { LcmDependencies } from "./types.js";
+
+type RedactSensitiveText = (content: string) => string;
+type StoredIncomingMatch =
+  | "exact"
+  | "externalized"
+  | "unproven-externalized"
+  | "redacted";
+type CoveredStoredIncomingMatch = StoredIncomingMatch | "decorated";
+type AlignmentMatch = CoveredStoredIncomingMatch | "unanchored-inbound";
+
+function isStrongReplayAnchor(match: AlignmentMatch | undefined): boolean {
+  return match === "exact" || match === "decorated";
+}
+
+function redactedMatchesHaveAdjacentAnchor(matches: readonly AlignmentMatch[]): boolean {
+  return matches.every(
+    (match, index) =>
+      match !== "redacted" ||
+      isStrongReplayAnchor(matches[index - 1]) ||
+      isStrongReplayAnchor(matches[index + 1]),
+  );
+}
+
+/** Load the host redactor without making the optional OpenClaw peer mandatory. */
+function loadOpenClawRedactor(): RedactSensitiveText | undefined {
+  try {
+    const require = createRequire(import.meta.url);
+    const loggingCore = require("openclaw/plugin-sdk/logging-core") as {
+      redactSensitiveText?: unknown;
+    };
+    return typeof loggingCore.redactSensitiveText === "function"
+      ? (loggingCore.redactSensitiveText as RedactSensitiveText)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function incomingToolCallIds(message: AgentMessage): Set<string> {
+  const ids = extractAssistantToolCallIdsForPairing(message);
+  const toolResultId = extractToolResultIdForPairing(message);
+  if (toolResultId) ids.push(toolResultId);
+  return new Set(ids);
+}
+
+function sameNonEmptyIds(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size > 0 && left.size === right.size && [...left].every((id) => right.has(id));
+}
 
 /**
  * Collapse only the whitespace OpenClaw core actually rewrites on the runtime
@@ -49,7 +103,48 @@ export class BatchDeduplicator {
     private readonly summaryStore: SummaryStore,
     private readonly largeFilesDir: string,
     private readonly deps: Pick<LcmDependencies, "log">,
+    private readonly redactSensitiveText: RedactSensitiveText | undefined = loadOpenClawRedactor(),
   ) {}
+
+  /**
+   * Accept host redaction only when both faces carry the same complete set of
+   * tool-call ids and applying redaction to one complete message produces the
+   * other. The provenance gate keeps different secret-bearing tool calls from
+   * collapsing; redactor failure degrades to exact-only dedup.
+   */
+  private async messagesDifferOnlyByHostRedaction(
+    persisted: MessageRecord,
+    incoming: StoredMessage,
+    incomingMessage: AgentMessage,
+  ): Promise<boolean> {
+    if (persisted.role !== incoming.role || !this.redactSensitiveText) return false;
+    const incomingIds = incomingToolCallIds(incomingMessage);
+    if (incomingIds.size === 0) return false;
+    const storedIds = await this.storedToolCallIds(persisted.messageId);
+    if (!sameNonEmptyIds(storedIds, incomingIds)) return false;
+    try {
+      const redactedPersisted = this.redactSensitiveText(persisted.content);
+      if (redactedPersisted !== persisted.content && redactedPersisted === incoming.content) {
+        return true;
+      }
+      const redactedIncoming = this.redactSensitiveText(incoming.content);
+      return redactedIncoming !== incoming.content && redactedIncoming === persisted.content;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Read stable tool-call provenance from the stored message parts. */
+  private async storedToolCallIds(messageId: number): Promise<Set<string>> {
+    const ids = new Set<string>();
+    for (const part of await this.conversationStore.getMessageParts(messageId)) {
+      if (part.toolCallId) ids.add(part.toolCallId);
+      const metadata = parsePartMetadata(part.metadata);
+      const metadataId = metadata ? extractToolPairingIdFromRecord(metadata) : undefined;
+      if (metadataId) ids.add(metadataId);
+    }
+    return ids;
+  }
 
   /**
    * Remove messages from the batch that already exist in the DB for this session.
@@ -170,11 +265,12 @@ export class BatchDeduplicator {
       const tailMessages = tail.slice(tail.length - k);
       const tailSlice = tailHashes.slice(tailHashes.length - k);
       let aligned = true;
-      let exactAnchor = false;
+      const matches: AlignmentMatch[] = [];
       for (let i = 0; i < k; i += 1) {
         const match = await this.matchStoredMessageToIncoming(
           tailMessages[i]!,
           storedBatch[i]!,
+          batch[i]!,
           batchHashes[i]!,
           tailSlice[i]!,
           rawPayloadContents[i],
@@ -199,7 +295,7 @@ export class BatchDeduplicator {
               { allowCollapsedSpaceRunMatch: true },
             )
           ) {
-            exactAnchor = true;
+            matches.push("decorated");
             continue;
           }
           if (
@@ -211,17 +307,22 @@ export class BatchDeduplicator {
               { allowUntimestampedInboundBodyMatch: true },
             )
           ) {
+            matches.push("unanchored-inbound");
             continue;
           }
           aligned = false;
           break;
         }
-        exactAnchor ||= match === "exact";
+        matches.push(match);
       }
       // Externalized-only matches are ambiguous in the same way as suffix
       // fallback anchors: they may be a replay or a legitimate repeated upload.
       // Trim only when at least one matched message still has exact identity.
-      if (aligned && exactAnchor) {
+      if (
+        aligned &&
+        matches.some(isStrongReplayAnchor) &&
+        redactedMatchesHaveAdjacentAnchor(matches)
+      ) {
         return batch.slice(k);
       }
     }
@@ -302,14 +403,20 @@ export class BatchDeduplicator {
     if (batchAtBoundaryHash !== lastDbIdentityHash) {
       const lastDbMessage = await this.conversationStore.getLastMessage(conversationId);
       const batchAtBoundary = storedBatch[storedMessageCount - 1]!;
+      const batchAtBoundaryMessage = batch[storedMessageCount - 1]!;
       if (
         !lastDbMessage ||
-        !this.runtimeRowCoversPersistedFrontierRow(
+        (!this.runtimeRowCoversPersistedFrontierRow(
           lastDbMessage.role,
           lastDbMessage.content,
           batchAtBoundary.role,
           batchAtBoundary.content,
-        )
+        ) &&
+          !(await this.messagesDifferOnlyByHostRedaction(
+            lastDbMessage,
+            batchAtBoundary,
+            batchAtBoundaryMessage,
+          )))
       ) {
         // Prefix mismatch — attempt suffix fallback before giving up.
         return this.deduplicateSuffixFallback(
@@ -340,10 +447,12 @@ export class BatchDeduplicator {
     if (storedMessages.length !== storedMessageCount) {
       return batch;
     }
+    const matches: CoveredStoredIncomingMatch[] = [];
     for (let i = 0; i < storedMessageCount; i += 1) {
       const match = await this.matchStoredMessageToIncoming(
         storedMessages[i]!,
         storedBatch[i]!,
+        batch[i]!,
         batchHashes[i]!,
         recentDbHashes[i]!,
         rawPayloadContents[i],
@@ -367,8 +476,15 @@ export class BatchDeduplicator {
         ) {
           return batch;
         }
+        matches.push("decorated");
+      } else {
+        matches.push(match);
       }
     }
+
+    // A redacted value is intentionally lossy. Require an adjacent unchanged
+    // or structurally decorated row before treating it as replay evidence.
+    if (!redactedMatchesHaveAdjacentAnchor(matches)) return batch;
 
     return batch.slice(storedMessageCount);
   }
@@ -400,10 +516,12 @@ export class BatchDeduplicator {
       );
       if (tailMessages.length === batch.length && tailHashes.length === batch.length) {
         let tailMatch = true;
+        const matches: CoveredStoredIncomingMatch[] = [];
         for (let i = 0; i < batch.length; i++) {
           const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
             tailMessages[i]!,
             storedBatch[i]!,
+            batch[i]!,
             batchHashes[i]!,
             tailHashes[i]!,
             rawPayloadContents[i],
@@ -412,8 +530,9 @@ export class BatchDeduplicator {
             tailMatch = false;
             break;
           }
+          matches.push(match);
         }
-        if (tailMatch) {
+        if (tailMatch && redactedMatchesHaveAdjacentAnchor(matches)) {
           this.deps.log.debug(
             `[lcm] dedup: tail-match detected, batch already fully stored ` +
               `(storedCount=${storedMessageCount} batchLen=${batch.length}), skipping entire batch`,
@@ -466,18 +585,19 @@ export class BatchDeduplicator {
 
     const lastStoredHash = allRecentHashes[allRecentHashes.length - 1]!;
     const lastStoredMessage = allStored[allStored.length - 1]!;
-    let ambiguousExternalizedOverlap = false;
+    let ambiguousWeakOverlap = false;
 
     for (let k = batch.length - 1; k >= 0; k--) {
       const lastMatch = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
         lastStoredMessage,
         storedBatch[k]!,
+        batch[k]!,
         batchHashes[k]!,
         lastStoredHash,
         rawPayloadContents[k],
       );
       if (lastMatch === "unproven-externalized") {
-        ambiguousExternalizedOverlap = true;
+        ambiguousWeakOverlap = true;
         continue;
       }
       if (!lastMatch) continue;
@@ -485,17 +605,18 @@ export class BatchDeduplicator {
       const matchLen = Math.min(k + 1, allRecentHashes.length);
       const startDb = allRecentHashes.length - matchLen;
       let suffixMatch = true;
-      let exactAnchor = lastMatch === "exact" || lastMatch === "decorated";
+      const matches: CoveredStoredIncomingMatch[] = [];
       for (let j = 0; j < matchLen; j++) {
         const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
           allStored[startDb + j]!,
           storedBatch[k - matchLen + 1 + j]!,
+          batch[k - matchLen + 1 + j]!,
           batchHashes[k - matchLen + 1 + j]!,
           allRecentHashes[startDb + j]!,
           rawPayloadContents[k - matchLen + 1 + j],
         );
         if (match === "unproven-externalized") {
-          ambiguousExternalizedOverlap = true;
+          ambiguousWeakOverlap = true;
           suffixMatch = false;
           break;
         }
@@ -503,8 +624,10 @@ export class BatchDeduplicator {
           suffixMatch = false;
           break;
         }
-        exactAnchor ||= match === "exact" || match === "decorated";
+        matches.push(match);
       }
+      const exactAnchor = matches.some(isStrongReplayAnchor);
+      const redactionAnchored = redactedMatchesHaveAdjacentAnchor(matches);
       const newSlice = batch.slice(k + 1);
       // Outside the transcript-covered path, an externalized-only anchor is
       // ambiguous: it may be a replay prefix or a new turn that repeats the
@@ -512,6 +635,7 @@ export class BatchDeduplicator {
       if (
         suffixMatch &&
         exactAnchor &&
+        redactionAnchored &&
         (newSlice.length > 0 || matchLen > 1 || lastMatch === "decorated")
       ) {
         this.deps.log.debug(
@@ -521,15 +645,15 @@ export class BatchDeduplicator {
         );
         return newSlice;
       }
-      if (suffixMatch && !exactAnchor) {
-        ambiguousExternalizedOverlap = true;
+      if (suffixMatch && (!exactAnchor || !redactionAnchored)) {
+        ambiguousWeakOverlap = true;
       }
     }
 
-    if (ambiguousExternalizedOverlap) {
+    if (ambiguousWeakOverlap) {
       this.deps.log.warn(
         `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
-          `externalized-only overlap is ambiguous — ingesting full batch`,
+          `externalized/redacted-only overlap is ambiguous — ingesting full batch`,
       );
       return batch;
     }
@@ -553,13 +677,15 @@ export class BatchDeduplicator {
   private async matchStoredMessageToIncomingOrDecoratedCoverage(
     storedMessage: MessageRecord,
     incoming: StoredMessage,
+    incomingMessage: AgentMessage,
     incomingHash: string,
     storedHash: string,
     incomingRawPayloadContent?: string | null,
-  ): Promise<"exact" | "externalized" | "unproven-externalized" | "decorated" | null> {
+  ): Promise<CoveredStoredIncomingMatch | null> {
     const match = await this.matchStoredMessageToIncoming(
       storedMessage,
       incoming,
+      incomingMessage,
       incomingHash,
       storedHash,
       incomingRawPayloadContent,
@@ -580,10 +706,11 @@ export class BatchDeduplicator {
   private async matchStoredMessageToIncoming(
     storedMessage: MessageRecord,
     incoming: StoredMessage,
+    incomingMessage: AgentMessage,
     incomingHash: string,
     storedHash: string,
     incomingRawPayloadContent?: string | null,
-  ): Promise<"exact" | "externalized" | "unproven-externalized" | null> {
+  ): Promise<StoredIncomingMatch | null> {
     if (
       storedHash === incomingHash &&
       storedMessage.role === incoming.role &&
@@ -591,11 +718,19 @@ export class BatchDeduplicator {
     ) {
       return "exact";
     }
-    return this.messagesAreExternalizedEquivalent(
+    const externalizedMatch = await this.messagesAreExternalizedEquivalent(
       storedMessage,
       incoming,
       incomingRawPayloadContent,
     );
+    if (externalizedMatch) return externalizedMatch;
+    return (await this.messagesDifferOnlyByHostRedaction(
+      storedMessage,
+      incoming,
+      incomingMessage,
+    ))
+      ? "redacted"
+      : null;
   }
 
   private async countPersistedIdentityOverlaps(

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { BatchDeduplicator } from "../src/batch-dedup.js";
-import type { ConversationStore, MessageRecord } from "../src/store/conversation-store.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type {
+  ConversationStore,
+  MessagePartRecord,
+  MessageRecord,
+} from "../src/store/conversation-store.js";
 import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 import type { SummaryStore } from "../src/store/summary-store.js";
 import { makeMessage } from "./helpers.js";
@@ -12,6 +17,7 @@ function makeLog() {
 type FakeConversationStore = {
   conversationId: number;
   messages: MessageRecord[];
+  toolCallIdsByMessageId?: Record<number, string[]>;
 };
 
 function makeConversationStore(initial: FakeConversationStore): ConversationStore {
@@ -60,21 +66,45 @@ function makeConversationStore(initial: FakeConversationStore): ConversationStor
           (m) => buildMessageIdentityHash(m.role, m.content) === identityHash && m.role === role,
         ).length,
     ),
+    getMessageParts: vi.fn(async (messageId: number) =>
+      (initial.toolCallIdsByMessageId?.[messageId] ?? []).map(
+        (toolCallId, ordinal): MessagePartRecord => ({
+          partId: `${messageId}:${ordinal}`,
+          messageId,
+          sessionId: "s1",
+          partType: "tool",
+          ordinal,
+          textContent: null,
+          toolCallId,
+          toolName: null,
+          toolInput: null,
+          toolOutput: null,
+          metadata: null,
+        }),
+      ),
+    ),
   } as unknown as ConversationStore;
 }
 
-function makeDedup(store: FakeConversationStore) {
+type RedactSensitiveText = (content: string) => string;
+
+function makeDedup(store: FakeConversationStore, redactSensitiveText?: RedactSensitiveText) {
   return new BatchDeduplicator(
     makeConversationStore(store),
     {} as unknown as SummaryStore,
     "/tmp/lcm-batch-dedup-test",
     { log: makeLog() },
+    redactSensitiveText,
   );
 }
 
-function storedMessage(role: string, content: string): MessageRecord {
+function redactTenantSecret(content: string): string {
+  return content.replace(/tenant-secret-[a-z]+/g, "***");
+}
+
+function storedMessage(role: string, content: string, messageId = 0): MessageRecord {
   return {
-    messageId: 0,
+    messageId,
     conversationId: 1,
     seq: 0,
     role: role as MessageRecord["role"],
@@ -83,6 +113,14 @@ function storedMessage(role: string, content: string): MessageRecord {
     createdAt: new Date(),
     largeContent: null,
   };
+}
+
+function toolResultMessage(content: string, toolCallId: string): AgentMessage {
+  return {
+    ...makeMessage({ role: "toolResult", content }),
+    toolCallId,
+    toolName: "read",
+  } as AgentMessage;
 }
 
 describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
@@ -155,6 +193,167 @@ describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
     ];
     const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
     expect(result).toEqual([batch[1]]);
+  });
+
+  it("trims a replay when one row is exactly the host-redacted form of the stored row", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("tool", "tool output tenant-secret-alpha", 1),
+          storedMessage("assistant", "exact replay anchor"),
+        ],
+        toolCallIdsByMessageId: { 1: ["call-secret"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("tool output ***", "call-secret"),
+      makeMessage({ role: "assistant", content: "exact replay anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual([batch[2]]);
+  });
+
+  it("uses an exact neighbor to anchor a redaction-divergent oversized suffix replay", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("user", "older turn"),
+          storedMessage("assistant", "older reply"),
+          storedMessage("tool", "tool output tenant-secret-alpha", 1),
+          storedMessage("assistant", "exact replay anchor"),
+        ],
+        toolCallIdsByMessageId: { 1: ["call-secret"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("tool output ***", "call-secret"),
+      makeMessage({ role: "assistant", content: "exact replay anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual([batch[2]]);
+  });
+
+  it("does not collapse different raw values that redact to the same text", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("tool", "tool output tenant-secret-alpha", 1),
+          storedMessage("assistant", "exact replay anchor"),
+        ],
+        toolCallIdsByMessageId: { 1: ["call-secret"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("tool output tenant-secret-beta", "call-secret"),
+      makeMessage({ role: "assistant", content: "exact replay anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual(batch);
+  });
+
+  it("does not collapse a raw value against an unproven persisted redaction", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("tool", "tool output ***", 1),
+          storedMessage("assistant", "exact replay anchor"),
+        ],
+        toolCallIdsByMessageId: { 1: ["call-alpha"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("tool output tenant-secret-beta", "call-beta"),
+      makeMessage({ role: "assistant", content: "exact replay anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual(batch);
+  });
+
+  it("trims a persisted host-redacted tool replay when the tool call id is unchanged", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("tool", "tool output ***", 1),
+          storedMessage("assistant", "exact replay anchor"),
+        ],
+        toolCallIdsByMessageId: { 1: ["call-secret"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("tool output tenant-secret-alpha", "call-secret"),
+      makeMessage({ role: "assistant", content: "exact replay anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual([batch[2]]);
+  });
+
+  it("does not let a distant exact row anchor consecutive redaction-only matches", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [
+          storedMessage("tool", "first output ***", 1),
+          storedMessage("tool", "second output ***", 2),
+          storedMessage("assistant", "distant exact anchor"),
+        ],
+        toolCallIdsByMessageId: {
+          1: ["call-first"],
+          2: ["call-second"],
+        },
+      },
+      redactTenantSecret,
+    );
+    const batch = [
+      toolResultMessage("first output tenant-secret-alpha", "call-first"),
+      toolResultMessage("second output tenant-secret-beta", "call-second"),
+      makeMessage({ role: "assistant", content: "distant exact anchor" }),
+      makeMessage({ role: "user", content: "new turn" }),
+    ];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual(batch);
+  });
+
+  it("does not treat a lone redaction-only match as enough evidence to trim", async () => {
+    const dedup = makeDedup(
+      {
+        conversationId: 1,
+        messages: [storedMessage("tool", "tool output tenant-secret-alpha", 1)],
+        toolCallIdsByMessageId: { 1: ["call-secret"] },
+      },
+      redactTenantSecret,
+    );
+    const batch = [toolResultMessage("tool output ***", "call-secret")];
+
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+
+    expect(result).toEqual(batch);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix duplicate tool-call replay ingestion when OpenClaw stores a host-redacted form of sensitive message content.
- Port the fix to the current dedup owner in `src/batch-dedup.ts`.
- Keep OpenClaw optional by loading `openclaw/plugin-sdk/logging-core` dynamically when available.
- Require exact, non-empty tool-call ID agreement plus an adjacent exact/decorated anchor before accepting redaction equivalence.
- Add focused regression coverage and a patch changeset.

## Why

OpenClaw host hooks can redact sensitive field names before a message is stored. Lossless Claw previously compared the raw stored text during after-turn batch deduplication, so a redacted replay could appear new and be ingested again. The duplicate tool-call rows could later produce synthetic `[lossless-claw] missing tool result` repairs.

## Compatibility

No OpenClaw compatibility floor changes. If the optional SDK redactor cannot be resolved or throws, deduplication falls back to exact matching.

## Testing

- `npm test -- test/batch-dedup.test.ts test/f1-degraded-double-write.test.ts test/whitespace-divergence-double-write.test.ts`
- `npm run typecheck`
- Hosted CI: test, plugin-inspector, smoke-latest-openclaw