### PR TITLE
feat(config): add enableSummaryThinking to control reasoning during summarization [AI]

### DIFF
--- a/.changeset/enable-summary-thinking.md
+++ b/.changeset/enable-summary-thinking.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add `enableSummaryThinking` config option to control whether summarization calls request a low reasoning budget from the model. Defaults to `true` (preserves current behavior). Set to `false` to disable reasoning and keep summarization output concise when reasoning is not needed for faithful summaries.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "timezone": "America/Los_Angeles",
   "pruneHeartbeatOk": false,
   "transcriptGcEnabled": false,
+  "enableSummaryThinking": true,
   "maxAssemblyTokenBudget": 30000,
   "summaryMaxOverageFactor": 3,
   "customInstructions": "",
@@ -150,6 +151,7 @@ openclaw plugins install --link /path/to/lossless-claw
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |
 | `transcriptGcEnabled` | `boolean` | `false` | `LCM_TRANSCRIPT_GC_ENABLED` | Enables transcript rewrite GC during `maintain()`; disabled by default so transcript rewrites stay opt-in. |
+| `enableSummaryThinking` | `boolean` | `true` | `LCM_ENABLE_SUMMARY_THINKING` | When true, requests low reasoning budget from the model during summarization calls. Set to false to disable reasoning and keep summarization output concise. |
 | `proactiveThresholdCompactionMode` | `"deferred" \| "inline"` | `"deferred"` | `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | Controls whether proactive threshold compaction is deferred into maintenance debt by default or run inline for legacy behavior. |
 | `autoRotateSessionFiles.enabled` | `boolean` | `true` | `LCM_AUTO_ROTATE_SESSION_FILES_ENABLED` | Enables automatic rotation for oversized LCM-managed session JSONL files. |
 | `autoRotateSessionFiles.createBackups` | `boolean` | `false` | `LCM_AUTO_ROTATE_SESSION_FILES_CREATE_BACKUPS` | Creates or replaces the rolling `rotate-latest` SQLite backup before automatic session-file rotation. Manual `/lcm rotate` backups are always created. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -257,6 +257,10 @@
       "label": "Transcript GC",
       "help": "Enable transcript rewrite GC during maintain(); disabled by default"
     },
+    "enableSummaryThinking": {
+      "label": "Enable Summary Thinking",
+      "help": "Request low reasoning budget from the model during summarization calls"
+    },
     "proactiveThresholdCompactionMode": {
       "label": "Proactive Threshold Compaction Mode",
       "help": "Choose deferred compaction debt by default or keep legacy inline proactive compaction"
@@ -525,6 +529,9 @@
         "type": "boolean"
       },
       "transcriptGcEnabled": {
+        "type": "boolean"
+      },
+      "enableSummaryThinking": {
         "type": "boolean"
       },
       "proactiveThresholdCompactionMode": {

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -286,6 +286,20 @@ Why it matters:
 - keep this off unless you want transcript GC to mutate the live session file during maintenance
 - the default is `false`
 
+### `enableSummaryThinking`
+
+Controls whether the summarization model receives a low reasoning budget.
+
+Why it matters:
+
+- when `true` (default), summarization calls request `reasoningIfSupported: "low"`, allowing the model to think before producing summaries — this is the current default behavior
+- when `false`, no explicit reasoning budget is requested, which can reduce cost and keep summarization output more concise when reasoning is not needed for faithful summaries
+- set to `false` when you want to minimize token spend on reasoning during compaction, especially with reasoning-capable models
+
+Env override:
+
+- `LCM_ENABLE_SUMMARY_THINKING`
+
 ### `proactiveThresholdCompactionMode`
 
 Controls whether proactive threshold compaction is deferred into maintenance debt or kept inline for legacy behavior.

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -141,6 +141,8 @@ export type LcmConfig = {
   pruneHeartbeatOk: boolean;
   /** When true, maintain() may rewrite transcript entries for transcript GC. */
   transcriptGcEnabled: boolean;
+  /** When true, requests low reasoning from the model for summarization calls. */
+  enableSummaryThinking: boolean;
   /** Controls whether proactive threshold compaction runs inline or is deferred. */
   proactiveThresholdCompactionMode: ProactiveThresholdCompactionMode;
   /** Automatically rotate LCM-managed session JSONL files that exceed a size ceiling. */
@@ -624,6 +626,10 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
           ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"
           : toBool(pc.transcriptGcEnabled) ?? false,
+      enableSummaryThinking:
+        env.LCM_ENABLE_SUMMARY_THINKING !== undefined
+          ? env.LCM_ENABLE_SUMMARY_THINKING === "true"
+          : toBool(pc.enableSummaryThinking) ?? true,
       proactiveThresholdCompactionMode,
       autoRotateSessionFiles: {
         enabled:

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1474,7 +1474,9 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             },
           ],
           maxTokens: targetTokens,
-          reasoningIfSupported: "low",
+          ...(params.deps.config.enableSummaryThinking !== false
+            ? ({ reasoningIfSupported: "low" } as const)
+            : {}),
           ...(reasoning ? { reasoning } : {}),
         }), summarizerTimeoutMs, label);
 

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1644,11 +1644,12 @@ export async function createLcmSummarizeFromLegacyParams(params: {
         }
         params.deps.log.warn(`${diagParts.join("; ")}; retrying with conservative settings`);
 
-        // Single retry with conservative parameters: low temperature and low
-        // reasoning budget to coax a textual response from providers that
-        // sometimes return reasoning-only or empty blocks on the first pass.
+        // Single retry with conservative parameters to coax a textual response
+        // from providers that sometimes return reasoning-only or empty blocks.
         try {
-          const retryResult = await attemptSummarizerCall("retry", "low");
+          const retryReasoning =
+            params.deps.config.enableSummaryThinking !== false ? "low" : undefined;
+          const retryResult = await attemptSummarizerCall("retry", retryReasoning);
           const retryNormalized = normalizeCompletionSummary(retryResult.content);
           const retryEnvelopeNormalized = retryNormalized.summary
             ? retryNormalized

--- a/test/anti-replay-burst-regression.test.ts
+++ b/test/anti-replay-burst-regression.test.ts
@@ -88,6 +88,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",
     autoRotateSessionFiles: {
       enabled: true,

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -53,6 +53,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",
     autoRotateSessionFiles: {
       enabled: true,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -83,6 +83,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",
     autoRotateSessionFiles: {
       enabled: true,

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -37,6 +37,7 @@ const BASE_CONFIG: LcmConfig = {
   timezone: "UTC",
   pruneHeartbeatOk: false,
   transcriptGcEnabled: false,
+  enableSummaryThinking: true,
   proactiveThresholdCompactionMode: "deferred",
   autoRotateSessionFiles: {
     enabled: true,

--- a/test/lcm-summarizer-reasoning.test.ts
+++ b/test/lcm-summarizer-reasoning.test.ts
@@ -94,4 +94,40 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(calls[1]?.reasoning).toBe("low");
     expect(calls[1]?.reasoningIfSupported).toBe("low");
   });
+
+  it("does not request reasoning on retry when summary thinking is disabled", async () => {
+    const { deps, calls } = createDeps({
+      config: {
+        leafTargetTokens: 128,
+        condensedTargetTokens: 128,
+        enableSummaryThinking: false,
+      },
+      complete: async (params: Record<string, unknown>) => {
+        calls.push(params);
+        if (calls.length === 1) {
+          return { content: [] };
+        }
+        return { content: [{ type: "text", text: "Recovered summary" }] };
+      },
+    });
+
+    const summarizer = await createLcmSummarizeFromLegacyParams({
+      deps: deps as never,
+      legacyParams: {
+        provider: "openrouter",
+        model: "minimax/minimax-m2.7",
+        config: {},
+      },
+    });
+
+    expect(summarizer).toBeDefined();
+    const summary = await summarizer!.fn("Summarize this conversation.");
+
+    expect(summary).toBe("Recovered summary");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.reasoning).toBeUndefined();
+    expect(calls[0]?.reasoningIfSupported).toBeUndefined();
+    expect(calls[1]?.reasoning).toBeUndefined();
+    expect(calls[1]?.reasoningIfSupported).toBeUndefined();
+  });
 });

--- a/test/session-operation-queues.test.ts
+++ b/test/session-operation-queues.test.ts
@@ -57,6 +57,7 @@ function createTestConfig(databasePath: string): LcmConfig {
     timezone: "UTC",
     pruneHeartbeatOk: false,
     transcriptGcEnabled: false,
+    enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",
     autoRotateSessionFiles: {
       enabled: true,


### PR DESCRIPTION
## Summary

- **Problem**: Summarization calls always request `reasoningIfSupported: "low"`, which adds reasoning overhead to every compaction call. Users who want concise summarization output without reasoning cost had no way to disable it.
- **What changed**: Added `enableSummaryThinking` config option (env: `LCM_ENABLE_SUMMARY_THINKING`) that gates whether `reasoningIfSupported: "low"` is sent with summarization calls.
- **Default**: `true` — preserves existing behavior. Set to `false` to opt out of reasoning.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Human Verification

- Verified scenarios: pnpm build + typecheck + 1083 tests pass, config parsing with env var and plugin config, config schema accepts the new field
- Edge cases checked: undefined in test deps (defaults to behavior via !== false guard), explicit false disables reasoning, explicit true enables it
- What I did NOT verify: running against a live OpenClaw instance, end-to-end reasoning behavior with a real model

## Compatibility / Migration

- **Backward compatible**: Yes
- **Config/env changes needed**: No (default true preserves current behavior)
- **Migration needed**: No

## Failure Recovery

- **Revert**: set `enableSummaryThinking: true` or remove the config key
- **Known bad symptom**: summaries appear more verbose with reasoning when enabled; set to false to disable