### PR TITLE
docs: add changeset for replay dedupe

### DIFF
--- a/.changeset/deduplicate-replayed-tool-results.md
+++ b/.changeset/deduplicate-replayed-tool-results.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Deduplicate replayed checkpoint tool-result batches without dropping changed payloads or metadata.


### PR DESCRIPTION
## What
Adds the missing Changesets release note for PR #826.

## Why
PR #826 changed package-visible replay deduplication behavior and needs a patch release note per repository policy.

## Changes
- Add patch changeset

## Testing
- git diff --check
- Not run: docs-only changeset follow-up