### PR TITLE
fix(engine): recover checkpoint-missing afterTurn frontier instead of looping forever (#837)

### DIFF
--- a/.changeset/afterturn-checkpoint-missing-no-anchor.md
+++ b/.changeset/afterturn-checkpoint-missing-no-anchor.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix an `afterTurn` deadlock where a conversation with `bootstrapped_at` set but no `conversation_bootstrap_state` row (`reason="checkpoint-missing"`) and a non-anchoring DB frontier (e.g. a single injected `Conversation info (untrusted metadata)` preamble) imported 0 messages and never persisted a checkpoint. Such conversations emitted the `found no anchor and imported 0 messages` / `did not cover the transcript frontier` warning pair on every turn forever, with compaction permanently disabled until the row was archived by hand.
+
+The recovery path (`allowNoAnchorImportOnCheckpointMissing`) previously ran only on the rotate lane. The `afterTurn` lane now also recovers a `checkpoint-missing` no-anchor frontier, but only for already-bootstrapped conversations (`bootstrapped_at` set) — a never-bootstrapped conversation with a divergent rewritten transcript still freezes per #649's no-proof-no-advance guard. The downstream no-anchor import remains guarded by replay-overlap detection, the import cap, and the delivery-only block.
+
+Fixes #837.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7379,6 +7379,24 @@ export class LcmContextEngine implements ContextEngine {
             hasOverlap: sessionFileState.size === 0,
           };
         }
+        // #837: a conversation with bootstrapped_at SET but no bootstrap_state
+        // row reaches reason="checkpoint-missing" with a non-anchoring frontier
+        // (e.g. a single injected metadata preamble). Without a no-anchor import
+        // it imports 0 messages and never persists a checkpoint, so afterTurn
+        // loops the "did not cover the transcript frontier" warning forever and
+        // compaction never runs. The rotate lane already recovers via
+        // allowNoAnchorImportOnCheckpointMissing; mirror that on the afterTurn
+        // lane, but ONLY for already-bootstrapped conversations. A never
+        // -bootstrapped conversation (bootstrapped_at NULL) with a divergent
+        // rewritten transcript must still freeze per #649's no-proof-no-advance
+        // guard, so we gate on conversation.bootstrappedAt to avoid grafting a
+        // foreign transcript onto genuine history. The downstream no-anchor
+        // import path is itself guarded (replay-overlap detection, import cap,
+        // delivery-only block).
+        const recoverCheckpointMissingNoAnchor =
+          reason === "checkpoint-missing" &&
+          (params.allowNoAnchorImportOnCheckpointMissing === true ||
+            conversation.bootstrappedAt !== null);
         const reconcile = await this.reconcileSessionTail({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
@@ -7388,11 +7406,12 @@ export class LcmContextEngine implements ContextEngine {
           allowNoAnchorImport:
             reason === "path-mismatch" ||
             reason === "same-path-shrink" ||
-            (reason === "checkpoint-missing" && params.allowNoAnchorImportOnCheckpointMissing === true),
-          noAnchorImportReason:
-            reason === "checkpoint-missing" && params.allowNoAnchorImportOnCheckpointMissing === true
+            recoverCheckpointMissingNoAnchor,
+          noAnchorImportReason: recoverCheckpointMissingNoAnchor
+            ? params.allowNoAnchorImportOnCheckpointMissing === true
               ? "rotate-checkpoint-missing"
-              : reason,
+              : "checkpoint-missing-recovery"
+            : reason,
         });
         if (reconcile.blockedByImportCap) {
           return { importedMessages: 0, blockedByImportCap: true, hasOverlap: reconcile.hasOverlap };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6333,7 +6333,8 @@ export class LcmContextEngine implements ContextEngine {
       if (anchorIndex < 0) {
         if (params.allowNoAnchorImport) {
           if (
-            params.noAnchorImportReason === "path-mismatch" &&
+            (params.noAnchorImportReason === "path-mismatch" ||
+              params.noAnchorImportReason === "checkpoint-missing-recovery") &&
             isLikelyInjectedDeliveryOnlyTranscript(historicalMessages)
           ) {
             this.deps.log.warn(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1505,6 +1505,7 @@ const PROMPT_RECALL_SEARCH_LIMIT = PROMPT_RECALL_MAX_MESSAGES * 2;
 const PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT = PROMPT_RECALL_SEARCH_LIMIT * 4;
 const DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES = 4;
 const INJECTED_DELIVERY_TRANSCRIPT_PATTERN = /\b(?:delivery[-_\s]?mirror|config[-_\s]?audit)\b/i;
+const INJECTED_METADATA_PREAMBLE_PREFIX = "Conversation info (untrusted metadata)";
 const OPENCLAW_RUNTIME_CONTEXT_SENTINEL =
   "OpenClaw runtime context for the immediately preceding user message. This context is runtime-generated, not user-author.";
 const PROMPT_RECALL_SENSITIVE_IDENTIFIER_PATTERN =
@@ -1567,6 +1568,16 @@ function isLikelyInjectedDeliveryOnlyTranscript(messages: AgentMessage[]): boole
     messages.length > 0 &&
     messages.length <= DELIVERY_ONLY_TRANSCRIPT_MAX_MESSAGES &&
     messages.every(isLikelyInjectedDeliveryMessage)
+  );
+}
+
+function isLikelyInjectedMetadataPreambleRecord(message: {
+  role: string;
+  content: string;
+}): boolean {
+  return (
+    message.role === "user" &&
+    message.content.trimStart().startsWith(INJECTED_METADATA_PREAMBLE_PREFIX)
   );
 }
 
@@ -7387,18 +7398,31 @@ export class LcmContextEngine implements ContextEngine {
         // loops the "did not cover the transcript frontier" warning forever and
         // compaction never runs. The rotate lane already recovers via
         // allowNoAnchorImportOnCheckpointMissing; mirror that on the afterTurn
-        // lane, but ONLY for already-bootstrapped conversations. A never
-        // -bootstrapped conversation (bootstrapped_at NULL) with a divergent
-        // rewritten transcript must still freeze per #649's no-proof-no-advance
-        // guard, so we gate on conversation.bootstrappedAt to avoid grafting a
-        // foreign transcript onto genuine history. The downstream no-anchor
+        // lane, but ONLY for the observed injected-metadata frontier. A real
+        // historical DB tail with a divergent rewritten transcript must still
+        // freeze per #649's no-proof-no-advance guard, so do not treat
+        // bootstrapped_at alone as lineage proof. The downstream no-anchor
         // import path is itself guarded (replay-overlap detection, import cap,
         // delivery-only block).
-        const recoverCheckpointMissingNoAnchor =
+        let checkpointMissingMetadataFrontier = false;
+        if (
           reason === "checkpoint-missing" &&
           conversation.sessionId === params.sessionId &&
+          conversation.bootstrappedAt !== null
+        ) {
+          const [existingMessageCount, latestPersistedMessage] = await Promise.all([
+            this.conversationStore.getMessageCount(conversation.conversationId),
+            this.conversationStore.getLastMessage(conversation.conversationId),
+          ]);
+          checkpointMissingMetadataFrontier =
+            existingMessageCount === 1 &&
+            latestPersistedMessage !== null &&
+            isLikelyInjectedMetadataPreambleRecord(latestPersistedMessage);
+        }
+        const recoverCheckpointMissingNoAnchor =
+          reason === "checkpoint-missing" &&
           (params.allowNoAnchorImportOnCheckpointMissing === true ||
-            conversation.bootstrappedAt !== null);
+            checkpointMissingMetadataFrontier);
         const reconcile = await this.reconcileSessionTail({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7396,6 +7396,7 @@ export class LcmContextEngine implements ContextEngine {
         // delivery-only block).
         const recoverCheckpointMissingNoAnchor =
           reason === "checkpoint-missing" &&
+          conversation.sessionId === params.sessionId &&
           (params.allowNoAnchorImportOnCheckpointMissing === true ||
             conversation.bootstrappedAt !== null);
         const reconcile = await this.reconcileSessionTail({

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12328,6 +12328,84 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).toBeNull();
   });
 
+  it("afterTurn does not recover checkpoint-missing transcript traffic from another runtime session", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const firstSessionId = "after-turn-checkpoint-missing-rollover-old-runtime";
+    const secondSessionId = "after-turn-checkpoint-missing-rollover-new-runtime";
+    const sessionKey = "agent:main:test:checkpoint-missing-runtime-rollover";
+
+    const oldSessionFile = createSessionFilePath("after-turn-checkpoint-missing-rollover-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old checkpoint-missing rollover question" },
+      { role: "assistant", content: "old checkpoint-missing rollover answer" },
+    ]);
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: firstSessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    expect(conversation?.bootstrappedAt).toBeTruthy();
+
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
+    try {
+      rawDb
+        .prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`)
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const newSessionFile = createSessionFilePath("after-turn-checkpoint-missing-rollover-new");
+    writeLeafTranscript(newSessionFile, [
+      { role: "user", content: "new unrelated checkpoint-missing runtime question" },
+      { role: "assistant", content: "new unrelated checkpoint-missing runtime answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+      messages: [
+        makeMessage({
+          role: "assistant",
+          content: "new unrelated checkpoint-missing runtime answer",
+        }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("did not cover the transcript frontier")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old checkpoint-missing rollover question",
+      "old checkpoint-missing rollover answer",
+    ]);
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+    await expect(
+      engine.getConversationStore().getConversationBySessionId(secondSessionId),
+    ).resolves.toBeNull();
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12406,6 +12406,79 @@ describe("LcmContextEngine fidelity and token budget", () => {
     ).resolves.toBeNull();
   });
 
+  it("afterTurn does not recover checkpoint-missing divergent transcript over real history", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-checkpoint-missing-real-history";
+    const sessionKey = "agent:main:test:checkpoint-missing-real-history";
+
+    const oldSessionFile = createSessionFilePath("after-turn-checkpoint-missing-real-history-old");
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "old checkpoint-missing real-history question" },
+      { role: "assistant", content: "old checkpoint-missing real-history answer" },
+    ]);
+    await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    expect(conversation?.bootstrappedAt).toBeTruthy();
+
+    const rawDb = createLcmDatabaseConnection(getEngineConfig(engine).databasePath);
+    try {
+      rawDb
+        .prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`)
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    writeLeafTranscript(oldSessionFile, [
+      { role: "user", content: "rewritten unrelated checkpoint-missing question" },
+      { role: "assistant", content: "rewritten unrelated checkpoint-missing answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: oldSessionFile,
+      messages: [
+        makeMessage({
+          role: "assistant",
+          content: "rewritten unrelated checkpoint-missing answer",
+        }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("did not cover the transcript frontier")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old checkpoint-missing real-history question",
+      "old checkpoint-missing real-history answer",
+    ]);
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12133,6 +12133,138 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
   });
 
+  it("afterTurn recovers a checkpoint-missing conversation with a non-anchoring frontier instead of looping forever (#837)", async () => {
+    // #837: a conversation with bootstrapped_at set but NO
+    // conversation_bootstrap_state row classifies as reason="checkpoint-missing"
+    // on the afterTurn slow path. Unlike the rotate lane, afterTurn used to call
+    // reconcileSessionTail WITHOUT allowNoAnchorImportOnCheckpointMissing, so a
+    // DB frontier of only non-anchoring rows (e.g. an injected metadata
+    // preamble) imported 0 messages and never persisted a checkpoint. Net
+    // effect: every turn emitted "found no anchor and imported 0 messages" +
+    // "did not cover the transcript frontier" forever, compaction never ran, and
+    // the conversation was a permanent LCM no-op until manually archived.
+    //
+    // This is the sibling of the #649 follow-up above: there the transcript
+    // could not be stat/read (ENOENT) and the placeholder-seed escape hatch
+    // fired; here the transcript EXISTS with real content, so stat/read succeeds
+    // and the only escape is to let afterTurn import the no-anchor epoch the same
+    // way the rotate lane already does.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-checkpoint-missing-no-anchor-recovery";
+    const sessionKey = "agent:main:test:checkpoint-missing-no-anchor-recovery";
+
+    // Build the exact production shape: a single non-anchoring DB frontier row
+    // (the injected metadata preamble), bootstrapped_at set, and NO
+    // bootstrap_state row.
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(conversation!.conversationId);
+
+    const refreshed = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(refreshed?.bootstrappedAt).toBeTruthy();
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+
+    // A real, growing transcript whose messages do NOT anchor to the lone
+    // injected preamble row in the DB.
+    const sessionFile = createSessionFilePath("after-turn-checkpoint-missing-no-anchor");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "CRABPOT_837_FACT is amber-beacon-7." },
+      { role: "assistant", content: "noted the fact" },
+      { role: "user", content: "follow-up question" },
+      { role: "assistant", content: "follow-up answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "follow-up question" }),
+        makeMessage({ role: "assistant", content: "follow-up answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // Recovery, not deadlock: the transcript history is imported and a
+    // bootstrap_state checkpoint is persisted so future turns advance.
+    const recoveredState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(recoveredState).not.toBeNull();
+    expect(recoveredState?.sessionFilePath).toBe(sessionFile);
+    expect(recoveredState?.lastProcessedOffset).toBeGreaterThan(0);
+
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("CRABPOT_837_FACT is amber-beacon-7.");
+    expect(contents).toContain("follow-up answer");
+
+    // The forever-loop warning pair must NOT have fired.
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(
+      warns.some((m) => m.includes("did not cover the transcript frontier")),
+    ).toBe(false);
+    expect(
+      warns.some((m) =>
+        m.includes("found no anchor and imported 0 messages; skipping checkpoint refresh"),
+      ),
+    ).toBe(false);
+
+    // A second ordinary turn must keep advancing on the fast path (no relapse
+    // into the checkpoint-missing slow-path loop).
+    warnLog.mockClear();
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "CRABPOT_837_FACT is amber-beacon-7." },
+      { role: "assistant", content: "noted the fact" },
+      { role: "user", content: "follow-up question" },
+      { role: "assistant", content: "follow-up answer" },
+      { role: "user", content: "third turn user" },
+      { role: "assistant", content: "third turn assistant" },
+    ]);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "third turn assistant" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const secondWarns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(
+      secondWarns.some((m) => m.includes("did not cover the transcript frontier")),
+    ).toBe(false);
+    const finalContents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(finalContents).toContain("third turn assistant");
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12265,6 +12265,69 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(finalContents).toContain("third turn assistant");
   });
 
+  it("afterTurn does not recover checkpoint-missing delivery-only transcript traffic", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-checkpoint-missing-delivery-only";
+    const sessionKey = "agent:main:signal:checkpoint-missing-delivery-only";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(conversation!.conversationId);
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+
+    const sessionFile = createSessionFilePath("after-turn-checkpoint-missing-delivery-only");
+    writeLeafTranscript(sessionFile, [
+      { role: "system", content: "delivery-mirror config-audit: refreshed host policy" },
+      { role: "system", content: "config-audit delivery-mirror: no user turn" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "assistant", content: "assistant delta without foreground user" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("delivery-only path-mismatched transcript")),
+    ).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): injected preamble",
+    ]);
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";


### PR DESCRIPTION
## Summary

Fixes #837 — an `afterTurn` deadlock that emits this warning pair **every single turn, forever** on affected sessions:

```
[lcm] afterTurn: transcript reconcile found no anchor and imported 0 messages; skipping checkpoint refresh ... reason=checkpoint-missing
[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence ...
```

For such a conversation, compaction never runs and LCM is a permanent no-op until the row is archived by hand.

## Root cause

A conversation with `bootstrapped_at` **set** but **no** `conversation_bootstrap_state` row classifies as `reason="checkpoint-missing"` on the `afterTurn` slow path. When the DB frontier holds only **non-anchoring** rows (e.g. a single injected `Conversation info (untrusted metadata)` preamble), `reconcileSessionTail` imports **0 messages and never persists a checkpoint**.

The recovery flag `allowNoAnchorImportOnCheckpointMissing` exists, but was only ever passed on the **rotate** lane (`reconcileRawTranscriptForRotate`), never on the `afterTurn` lane. So a `checkpoint-missing` conversation could only recover if a rotate happened to run; on the ordinary turn lane it looped indefinitely.

## Fix

`afterTurn` now also recovers a `checkpoint-missing` no-anchor frontier — but **gated on `conversation.bootstrappedAt`**:

- **bootstrapped_at set** (the #837 shape) → import the no-anchor epoch and persist a checkpoint, mirroring the rotate lane.
- **bootstrapped_at NULL** (a never-bootstrapped conversation whose transcript was rewritten to divergent content) → still freezes, preserving **#649**'s no-proof-no-advance guard.

The discriminator was verified empirically: the existing #649 divergent-transcript test runs with `bootstrappedAt = null`, while the #837 production shape has it set. The downstream no-anchor import stays guarded by replay-overlap detection, the import cap, and the delivery-only block — so this recovers instead of grafting a foreign transcript or flooding.

This is **Option 1** from the issue (smallest change, symmetric with the rotate lane), refined with the `bootstrappedAt` gate so it does not regress #649.

## Tests

- New regression test reproduces the exact production shape (bootstrapped, no state row, single injected metadata-preamble frontier) and asserts:
  - the transcript history is imported and a `bootstrap_state` checkpoint is persisted (`lastProcessedOffset > 0`),
  - the forever-loop warning pair does **not** fire,
  - a second ordinary turn keeps advancing on the fast path.
- Verified the test **fails without the fix** (checkpoint stays `null`) and **passes with it**.
- Full suite green: **1132/1132** tests pass. The previously-passing #649 test (`afterTurn skips persistence when full reread finds no anchor and imports nothing`) still passes unchanged.

## Production evidence

Reproduced on a live host: **49** active conversations in the `bootstrapped_at`-set / `bootstrap_state`-missing state on a single database — exactly the count reported in #837. The affected channel session produced the warning pair on every turn until the row was archived by hand.

## Notes

- `@martian-engineering/lossless-claw` **0.12.0**, branched off current `upstream/main`.
- Includes a `patch` changeset.
- `dist/` is not committed (built on release).
