### PR TITLE
fix(lcm-tools): support session keys for resumed thread recall

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -41,7 +41,8 @@ Use `mode: "full_text"` for keyword or topical recall. Full-text queries are not
 | `pattern` | string | ✅ | — | Search pattern |
 | `mode` | string | | `"regex"` | `"regex"` or `"full_text"` |
 | `scope` | string | | `"both"` | `"messages"`, `"summaries"`, or `"both"` |
-| `conversationId` | number | | current session family | Specific physical conversation to search |
+| `conversationId` | number/string | | current session family | LCM database conversation_id. Do not pass a Discord snowflake. |
+| `sessionKey` | string | | current session family | Stable LCM session key for resumed Discord/thread sessions |
 | `allConversations` | boolean | | `false` | Search all conversations |
 | `since` | string | | — | ISO timestamp lower bound |
 | `before` | string | | — | ISO timestamp upper bound |
@@ -81,7 +82,8 @@ Look up metadata and content for a specific summary or stored file.
 | Param | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `id` | string | ✅ | — | `sum_xxx` for summaries, `file_xxx` for files |
-| `conversationId` | number | | current session family | Scope to a specific physical conversation |
+| `conversationId` | number/string | | current session family | LCM database conversation_id. Do not pass a Discord snowflake. |
+| `sessionKey` | string | | current session family | Stable LCM session key for resumed Discord/thread sessions |
 | `allConversations` | boolean | | `false` | Allow cross-conversation lookups |
 
 **Returns for summaries:**
@@ -125,7 +127,8 @@ When `allConversations: true` is set, `lcm_expand_query` can now synthesize one 
 | `summaryIds` | string[] | ✅* | — | Specific summary IDs to expand (if no `query`) |
 | `maxTokens` | number | | 2000 | Answer length cap |
 | `timeoutMs` | number | ✅ | `delegationTimeoutMs + 30000` | Total OpenClaw dynamic tool RPC timeout; use the schema default so delegated recall can finish before the host watchdog fires |
-| `conversationId` | number | | current session family | Scope to a specific physical conversation |
+| `conversationId` | number/string | | current session family | LCM database conversation_id. Do not pass a Discord snowflake. |
+| `sessionKey` | string | | current session family | Stable LCM session key for resumed Discord/thread sessions |
 | `allConversations` | boolean | | `false` | Search across all conversations |
 
 *One of `query` or `summaryIds` is required.
@@ -191,7 +194,7 @@ listing something you need, use `lcm_expand_query` to get the full detail.
 
 ### Conversation scoping
 
-By default, tools operate on the current session family: the active conversation plus archived segments that share the same stable session identity. This keeps recall continuous across session rotation and `/reset` replacement rows without widening the search to unrelated sessions. Use `lcm_grep(..., allConversations: true)` when you need broad global discovery. Use `lcm_expand_query(..., allConversations: true)` when you want bounded synthesis across sessions. Use `conversationId` when you already know the exact physical conversation to inspect or expand.
+By default, tools operate on the current session family: the active conversation plus archived segments that share the same stable session identity. This keeps recall continuous across session rotation and `/reset` replacement rows without widening the search to unrelated sessions. Use `sessionKey` when you need to recover a resumed Discord/thread session family by stable runtime key. Use `lcm_grep(..., allConversations: true)` when you need broad global discovery. Use `lcm_expand_query(..., allConversations: true)` when you want bounded synthesis across sessions. Use `conversationId` only when you already know the exact LCM database `conversation_id` to inspect or expand; a Discord snowflake is not a valid `conversationId`.
 
 ### Performance considerations
 

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -65,6 +65,59 @@ function isIsolatedCronSessionKey(sessionKey?: string): boolean {
   return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
 }
 
+const CONVERSATION_ID_SCOPE_ERROR =
+  "conversationId is an LCM database conversation_id, not a Discord snowflake. Use sessionKey or allConversations.";
+
+function normalizeSessionKeyParam(value: unknown): { sessionKey?: string; error?: string } {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "string") {
+    return { error: "sessionKey must be a string when provided." };
+  }
+  const sessionKey = value.trim();
+  if (!sessionKey) {
+    return { error: "sessionKey must be a non-empty string when provided." };
+  }
+  return { sessionKey };
+}
+
+function normalizeConversationIdParam(value: unknown): { conversationId?: number; error?: string } {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
+      return { error: "conversationId must be a positive integer." };
+    }
+    if (!Number.isSafeInteger(value)) {
+      return { error: CONVERSATION_ID_SCOPE_ERROR };
+    }
+    return { conversationId: value };
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { error: "conversationId must be a positive integer when provided." };
+    }
+    if (!/^\d+$/.test(trimmed)) {
+      return { error: "conversationId must be a positive integer string when provided." };
+    }
+    const parsed = BigInt(trimmed);
+    if (parsed < 1n) {
+      return { error: "conversationId must be a positive integer." };
+    }
+    if (parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+      return { error: CONVERSATION_ID_SCOPE_ERROR };
+    }
+    return { conversationId: Number(parsed) };
+  }
+
+  return { error: "conversationId must be a positive integer or integer string when provided." };
+}
+
 /**
  * Parse an ISO-8601 timestamp tool parameter into a Date.
  *
@@ -105,7 +158,15 @@ export async function resolveLcmConversationScope(input: {
   deps?: Pick<LcmDependencies, "isSubagentSessionKey" | "resolveSessionIdFromSessionKey">;
 }): Promise<LcmConversationScope> {
   const { lcm, params } = input;
-  const explicitSessionKey = input.sessionKey?.trim();
+  const requestedSessionKey = normalizeSessionKeyParam(params.sessionKey);
+  if (requestedSessionKey.error) {
+    return {
+      allConversations: false,
+      delegated: false,
+      error: requestedSessionKey.error,
+    };
+  }
+  const explicitSessionKey = requestedSessionKey.sessionKey ?? input.sessionKey?.trim();
   const normalizedInputSessionId = input.sessionId?.trim();
   const sessionIdAsSessionKey =
     !explicitSessionKey
@@ -119,10 +180,15 @@ export async function resolveLcmConversationScope(input: {
   const isolateCurrentSessionFamily = isIsolatedCronSessionKey(normalizedSessionKey);
   let allowedConversationIds: number[] = [];
 
-  const explicitConversationId =
-    typeof params.conversationId === "number" && Number.isFinite(params.conversationId)
-      ? Math.trunc(params.conversationId)
-      : undefined;
+  const requestedConversationId = normalizeConversationIdParam(params.conversationId);
+  if (requestedConversationId.error) {
+    return {
+      allConversations: false,
+      delegated: isDelegatedSession,
+      error: requestedConversationId.error,
+    };
+  }
+  const explicitConversationId = requestedConversationId.conversationId;
 
   if (isDelegatedSession) {
     const delegatedGrantId = resolveDelegatedExpansionGrantId(normalizedSessionKey!);
@@ -248,7 +314,7 @@ export async function resolveLcmConversationScope(input: {
   if (!normalizedSessionId && normalizedSessionKey && input.deps) {
     normalizedSessionId = await input.deps.resolveSessionIdFromSessionKey(normalizedSessionKey);
   }
-  if (!normalizedSessionId && !input.sessionKey?.trim()) {
+  if (!normalizedSessionId && !normalizedSessionKey) {
     return {
       conversationId:
         isDelegatedSession && allowedConversationIds.length === 1
@@ -263,7 +329,7 @@ export async function resolveLcmConversationScope(input: {
   const conversation = await lookupConversationForSession({
     lcm,
     sessionId: normalizedSessionId,
-    sessionKey: input.sessionKey,
+    sessionKey: normalizedSessionKey,
   });
   if (!conversation) {
     return {
@@ -284,7 +350,7 @@ export async function resolveLcmConversationScope(input: {
       ? await store.getConversationFamilyIds({
           conversationId: conversation.conversationId,
           sessionId: normalizedSessionId,
-          sessionKey: input.sessionKey,
+          sessionKey: normalizedSessionKey,
         })
       : [conversation.conversationId];
 

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -30,9 +30,15 @@ const LcmDescribeSchema = Type.Object({
     description: "The LCM ID to look up. Use sum_xxx for summaries, file_xxx for files.",
   }),
   conversationId: Type.Optional(
-    Type.Number({
+    Type.Union([Type.Number(), Type.String()], {
       description:
-        "Physical conversation ID to scope describe lookups to. If omitted, uses the current session family.",
+        "LCM database conversation_id to scope describe lookups to. Accepts a small integer number or integer string. Do not pass a Discord snowflake; use sessionKey or allConversations instead. If omitted, uses the current session family.",
+    }),
+  ),
+  sessionKey: Type.Optional(
+    Type.String({
+      description:
+        "Stable LCM session key to scope describe lookups to. Use this for resumed Discord/thread sessions instead of passing a Discord snowflake as conversationId.",
     }),
   ),
   allConversations: Type.Optional(

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -73,9 +73,15 @@ function createLcmExpandQuerySchema(dynamicToolTimeoutMs: number) {
         "Natural-language question or task to answer using expanded context. Put the answer request here, not in query.",
     }),
     conversationId: Type.Optional(
-      Type.Number({
+      Type.Union([Type.Number(), Type.String()], {
         description:
-          "Physical conversation ID to scope expansion to. If omitted, uses the current session family.",
+          "LCM database conversation_id to scope expansion to. Accepts a small integer number or integer string. Do not pass a Discord snowflake; use sessionKey or allConversations instead. If omitted, uses the current session family.",
+      }),
+    ),
+    sessionKey: Type.Optional(
+      Type.String({
+        description:
+          "Stable LCM session key to scope expansion to. Use this for resumed Discord/thread sessions instead of passing a Discord snowflake as conversationId.",
       }),
     ),
     allConversations: Type.Optional(

--- a/src/tools/lcm-expand-tool.ts
+++ b/src/tools/lcm-expand-tool.ts
@@ -52,9 +52,15 @@ const LcmExpandSchema = Type.Object({
     }),
   ),
   conversationId: Type.Optional(
-    Type.Number({
+    Type.Union([Type.Number(), Type.String()], {
       description:
-        "Conversation ID to scope the expansion to. If omitted, uses the current session's conversation.",
+        "LCM database conversation_id to scope the expansion to. Accepts a small integer number or integer string. Do not pass a Discord snowflake; use sessionKey or allConversations instead. If omitted, uses the current session family.",
+    }),
+  ),
+  sessionKey: Type.Optional(
+    Type.String({
+      description:
+        "Stable LCM session key to scope expansion to. Use this for resumed Discord/thread sessions instead of passing a Discord snowflake as conversationId.",
     }),
   ),
   allConversations: Type.Optional(

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -42,9 +42,15 @@ const LcmGrepSchema = Type.Object({
     }),
   ),
   conversationId: Type.Optional(
-    Type.Number({
+    Type.Union([Type.Number(), Type.String()], {
       description:
-        "Physical conversation ID to search within. If omitted, defaults to the current session family.",
+        "LCM database conversation_id to search within. Accepts a small integer number or integer string. Do not pass a Discord snowflake; use sessionKey or allConversations instead. If omitted, defaults to the current session family.",
+    }),
+  ),
+  sessionKey: Type.Optional(
+    Type.String({
+      description:
+        "Stable LCM session key to search within. Use this for resumed Discord/thread sessions instead of passing a Discord snowflake as conversationId.",
     }),
   ),
   allConversations: Type.Optional(

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -549,6 +549,83 @@ describe("LCM tools session scoping", () => {
     expect(text).not.toContain("session family rooted at 42");
   });
 
+  it("lcm_grep scopes by explicit sessionKey parameter for resumed thread families", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps({
+        resolveSessionIdFromSessionKey: vi.fn(async () => "uuid-after-reset"),
+      }),
+      lcm: buildLcmEngine({
+        retrieval,
+        conversationIdBySessionKey: 3556,
+        conversationFamilyIds: [3556, 3549],
+      }) as never,
+      sessionKey: "agent:main:current-channel-session",
+    });
+    const result = await tool.execute("call-explicit-session-key", {
+      pattern: "Dade",
+      sessionKey: "agent:main:discord:thread:1480000000000000000",
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 3556,
+        conversationIds: [3556, 3549],
+      }),
+    );
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("session family rooted at 3556");
+  });
+
+  it("lcm_grep rejects Discord snowflakes passed as conversationId before searching", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-discord-snowflake", {
+      pattern: "Dade",
+      conversationId: "1482752645847453710",
+    });
+
+    expect(retrieval.grep).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain(
+      "conversationId is an LCM database conversation_id, not a Discord snowflake",
+    );
+  });
+
+  it("lcm_grep schema advertises sessionKey and safe conversationId usage", () => {
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+    });
+    const parameters = tool.parameters as {
+      properties: Record<string, { description?: string }>;
+    };
+
+    expect(parameters.properties.sessionKey?.description).toContain("Stable LCM session key");
+    expect(parameters.properties.conversationId?.description).toContain("LCM database conversation_id");
+    expect(parameters.properties.conversationId?.description).toContain("Do not pass a Discord snowflake");
+  });
+
   it("lcm_grep rejects allConversations from a sub-agent without a delegated grant", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({


### PR DESCRIPTION
## Summary
- Adds explicit `sessionKey` support to agent-facing LCM tools: `lcm_grep`, `lcm_describe`, `lcm_expand`, and `lcm_expand_query`.
- Keeps `conversationId` for real LCM database IDs, but validates finite positive safe integers and integer strings only.
- Rejects likely Discord snowflake IDs with an actionable error telling agents to use `sessionKey` for Discord/thread recall.
- Documents the tool contract and adds regression coverage.

## Why
Discord thread/session recall can resume under a stable session key while the tool contract currently exposes only numeric `conversationId`. Agents then have two bad failure modes: they miss resumed-thread context, or they pass Discord snowflakes as `conversationId`, which is not the LCM physical `conversation_id` and is unsafe to parse as a JS number.

This change makes resumed-thread recall explicit and fails closed on snowflake-like IDs.

## Verification
- `pnpm vitest run test/lcm-tools.test.ts --reporter=basic`
  - 19 tests passed
- `pnpm run typecheck`
  - passed
- `pnpm run build`
  - passed
- `pnpm test`
  - 50 test files passed, 1137 tests passed
- `pnpm run release:verify`
  - typecheck passed
  - build passed
  - test suite passed: 50 files, 1137 tests
  - `npm pack --dry-run` completed

## Live validation from downstream install
A local OpenClaw install using this patch was rebuilt and verified separately. The installed bundle contained the expected `sessionKey`, Discord-snowflake, and LCM database `conversation_id` diagnostics, and `lossless-claw` remained loaded/enabled/activated as the selected context engine.
