### PR TITLE
fix: skip heartbeat transcript reconcile imports

### DIFF
--- a/.changeset/quiet-heartbeats-reconcile.md
+++ b/.changeset/quiet-heartbeats-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip append-only transcript reconciliation imports for heartbeat afterTurn calls and advance the checkpoint over the heartbeat delta.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7161,6 +7161,18 @@ export class LcmContextEngine implements ContextEngine {
               checkpoint.lastSeenMtimeMs === 0 &&
               checkpoint.lastProcessedOffset === 0 &&
               checkpoint.lastProcessedEntryHash === null;
+            if (params.isHeartbeat) {
+              if (!placeholderCheckpoint) {
+                await this.refreshBootstrapState({
+                  conversationId: conversation.conversationId,
+                  sessionFile: params.sessionFile,
+                });
+                this.deps.log.debug(
+                  `[lcm] afterTurn: skipped heartbeat transcript append-only delta and refreshed checkpoint conversation=${conversation.conversationId} sessionFile=${params.sessionFile} appendedMessages=${appended.messages.length}`,
+                );
+              }
+              return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+            }
             if (placeholderCheckpoint && appended.messages.length > 0) {
               const reconcile = await this.reconcileSessionTail({
                 sessionId: params.sessionId,

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -16055,6 +16055,76 @@ describe("LcmContextEngine fidelity and token budget", () => {
     });
     expect(conversation).toBeNull();
   });
+
+  it("afterTurn heartbeat flag skips append-only transcript deltas and advances the checkpoint", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-flag-append-only-skip";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-flag-append-only-skip";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-flag-append-only-skip");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const heartbeatMessages = [
+      makeMessage({
+        role: "user",
+        content:
+          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+      }),
+      makeMessage({
+        role: "tool",
+        content: "# HEARTBEAT.md\n\nIf nothing needs attention, stay quiet.",
+      }),
+      makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+    ];
+    for (const message of heartbeatMessages) {
+      appendSessionMessage(sm, message);
+    }
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    let stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "real assistant" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real user",
+      "real assistant",
+    ]);
+  });
 });
 
 // ── afterTurn dedup guard ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- skip append-only transcript reconciliation imports when OpenClaw marks afterTurn as a heartbeat
- refresh the bootstrap checkpoint over the heartbeat transcript delta so the next normal turn does not import stale heartbeat messages
- add a regression that seeds a normal transcript, appends a heartbeat-only delta, then verifies the next normal turn imports only real messages

## Verification

- `npm run build`
- `env -u OPENCLAW_STATE_DIR npm test -- test/engine.test.ts -t "heartbeat flag"`
- `env -u OPENCLAW_STATE_DIR npm test`

Related to openclaw/openclaw#90632 / openclaw/openclaw#89302.