### PR TITLE
fix: skip startup maintenance during runtime inspection

### DIFF
--- a/.changeset/runtime-inspection-maintenance.md
+++ b/.changeset/runtime-inspection-maintenance.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip startup maintenance during OpenClaw runtime inspection and read-only plugin discovery.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10958,7 +10958,9 @@ export class LcmContextEngine implements ContextEngine {
   }
 
   /** Scan OpenClaw-indexed startup transcripts and rotate oversized active LCM sessions. */
-  async autoRotateManagedSessionFilesAtStartup(): Promise<void> {
+  async autoRotateManagedSessionFilesAtStartup(params?: {
+    listStartupSessionFileCandidates?: () => Promise<StartupSessionFileCandidate[]>;
+  }): Promise<void> {
     const startedAt = Date.now();
     const thresholdBytes = this.config.autoRotateSessionFiles.sizeBytes;
     const mode = this.getAutoRotateSessionFileMode("startup");
@@ -10988,7 +10990,9 @@ export class LcmContextEngine implements ContextEngine {
       logSummary("engine-unhealthy");
       return;
     }
-    if (!this.deps.listStartupSessionFileCandidates) {
+    const listStartupSessionFileCandidates =
+      params?.listStartupSessionFileCandidates ?? this.deps.listStartupSessionFileCandidates;
+    if (!listStartupSessionFileCandidates) {
       logSummary("no-indexed-session-provider");
       return;
     }
@@ -10996,7 +11000,7 @@ export class LcmContextEngine implements ContextEngine {
     this.ensureMigrated();
     let indexedCandidates: StartupSessionFileCandidate[];
     try {
-      indexedCandidates = await this.deps.listStartupSessionFileCandidates();
+      indexedCandidates = await listStartupSessionFileCandidates();
     } catch (error) {
       summary.warned += 1;
       this.logAutoRotateSessionFileDecision({

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -525,7 +525,59 @@ function assertContextEngineRegistrationAvailable(
 
 /** Return true for OpenClaw's descriptor-only CLI registration pass. */
 function isCliMetadataRegistration(api: OpenClawPluginApi): boolean {
-  return (api as { registrationMode?: unknown }).registrationMode === "cli-metadata";
+  const topLevelMode = (api as { registrationMode?: unknown }).registrationMode;
+  if (topLevelMode === "cli-metadata") {
+    return true;
+  }
+  return (api.runtime as { registrationMode?: unknown } | undefined)?.registrationMode === "cli-metadata";
+}
+
+/** Return the public plugin registration mode exposed by newer OpenClaw hosts. */
+function readPluginRegistrationMode(api: OpenClawPluginApi): string | undefined {
+  const topLevelMode = (api as { registrationMode?: unknown }).registrationMode;
+  if (typeof topLevelMode === "string" && topLevelMode.trim()) {
+    return topLevelMode.trim();
+  }
+  const runtimeMode = (api.runtime as { registrationMode?: unknown } | undefined)?.registrationMode;
+  return typeof runtimeMode === "string" && runtimeMode.trim() ? runtimeMode.trim() : undefined;
+}
+
+/** Return true when the registration context is for diagnostics rather than live operation. */
+function isReadOnlyRegistrationMode(mode: string | undefined): boolean {
+  return mode === "cli-metadata" || mode === "discovery" || mode === "tool-discovery";
+}
+
+/** Detect the current OpenClaw CLI runtime inspection path before a host flag exists. */
+function isRuntimeInspectCliInvocation(argv: readonly string[] = process.argv): boolean {
+  const args = argv.slice(2);
+  const pluginsIndex = args.findIndex((arg) => arg === "plugins" || arg === "plugin");
+  if (pluginsIndex < 0) {
+    return false;
+  }
+  const subcommand = args[pluginsIndex + 1];
+  if (subcommand !== "inspect" && subcommand !== "info") {
+    return false;
+  }
+  return args.some((arg) => arg === "--runtime" || arg.startsWith("--runtime="));
+}
+
+/** Return true when the host explicitly marks this runtime load as read-only. */
+function hasReadOnlyRuntimeInspectionSignal(api: OpenClawPluginApi): boolean {
+  const runtime = isRecord(api.runtime) ? api.runtime : undefined;
+  const inspection = isRecord(runtime?.inspection) ? runtime.inspection : undefined;
+  const diagnostics = isRecord(runtime?.diagnostics) ? runtime.diagnostics : undefined;
+  return inspection?.readOnly === true || diagnostics?.readOnly === true;
+}
+
+/** Startup maintenance may write transcripts, summaries, checkpoints, or session stores. */
+function canRunStartupMaintenance(api: OpenClawPluginApi): boolean {
+  if (isReadOnlyRegistrationMode(readPluginRegistrationMode(api))) {
+    return false;
+  }
+  if (hasReadOnlyRuntimeInspectionSignal(api)) {
+    return false;
+  }
+  return !isRuntimeInspectCliInvocation();
 }
 
 /** Resolve plugin config from direct runtime injection or the root OpenClaw config fallback. */
@@ -1648,35 +1700,13 @@ const lcmPlugin = {
     const deps = createLcmDependencies(api, registrationConfig);
     const dbPath = deps.config.databasePath;
     const normalizedDbPath = normalizePath(dbPath);
-
-    // ── Singleton check ─────────────────────────────────────────────
-    // OpenClaw v2026.4.5+ calls register() per-agent-context (main,
-    // subagents, cron lanes). Reuse the existing connection and engine
-    // when the same DB path is already initialized.
-    const existingInit = getSharedInit(normalizedDbPath);
-    if (existingInit && !existingInit.stopped) {
-      deps.log.debug(`[lcm] Reusing shared engine init for db=${normalizedDbPath}`);
-      wirePluginHandlers(api, deps, existingInit);
-      return;
-    }
-
-    // ── Eager-first DB init with deferred fallback on lock ──────────
-    let database: DatabaseSync | null = null;
-    let lcm: LcmContextEngine | null = null;
-    let initPromise: Promise<LcmContextEngine> | null = null;
-    let initError: Error | null = null;
-    let resolveDeferredInit: ((engine: LcmContextEngine) => void) | null = null;
-    let rejectDeferredInit: ((error: Error) => void) | null = null;
-    let stopped = false;
-
-    /** Normalize unknown failures into stable Error instances. */
-    function toInitError(error: unknown): Error {
-      return error instanceof Error ? error : new Error(String(error));
-    }
+    const allowStartupMaintenance = canRunStartupMaintenance(api);
 
     /** Start the non-blocking startup scan for oversized LCM-managed transcripts. */
     function scheduleStartupAutoRotate(nextEngine: LcmContextEngine): void {
-      void nextEngine.autoRotateManagedSessionFilesAtStartup().catch((error) => {
+      void nextEngine.autoRotateManagedSessionFilesAtStartup({
+        listStartupSessionFileCandidates: deps.listStartupSessionFileCandidates,
+      }).catch((error) => {
         deps.log.warn(
           `[lcm] auto-rotate: phase=startup action=warn durationMs=0 reason=startup-scan-failed error=${describeLogError(error).replace(/\s+/g, "_")}`,
         );
@@ -1823,6 +1853,75 @@ const lcmPlugin = {
       });
     }
 
+    /** Schedule all startup maintenance with this registration's runtime surfaces. */
+    function scheduleStartupMaintenance(nextEngine: LcmContextEngine): void {
+      scheduleStartupAutoRotate(nextEngine);
+      scheduleStartupSessionTotalTokensRecovery(nextEngine);
+    }
+
+    function logStartupMaintenanceSchedulingError(error: unknown): void {
+      deps.log.warn(
+        `[lcm] startup maintenance scheduling failed: ${describeLogError(error)}`,
+      );
+    }
+
+    // ── Singleton check ─────────────────────────────────────────────
+    // OpenClaw v2026.4.5+ calls register() per-agent-context (main,
+    // subagents, cron lanes). Reuse the existing connection and engine
+    // when the same DB path is already initialized.
+    const existingInit = getSharedInit(normalizedDbPath);
+    if (existingInit && !existingInit.stopped) {
+      deps.log.debug(`[lcm] Reusing shared engine init for db=${normalizedDbPath}`);
+      if (allowStartupMaintenance) {
+        existingInit.runStartupMaintenanceOnce(
+          scheduleStartupMaintenance,
+          logStartupMaintenanceSchedulingError,
+        );
+      }
+      wirePluginHandlers(api, deps, existingInit);
+      return;
+    }
+
+    // ── Eager-first DB init with deferred fallback on lock ──────────
+    let database: DatabaseSync | null = null;
+    let lcm: LcmContextEngine | null = null;
+    let initPromise: Promise<LcmContextEngine> | null = null;
+    let initError: Error | null = null;
+    let resolveDeferredInit: ((engine: LcmContextEngine) => void) | null = null;
+    let rejectDeferredInit: ((error: Error) => void) | null = null;
+    let stopped = false;
+    let startupMaintenanceStarted = false;
+    let shared: SharedLcmInit | null = null;
+
+    /** Normalize unknown failures into stable Error instances. */
+    function toInitError(error: unknown): Error {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+
+    /** Schedule prompt-mutating startup maintenance once for live runtime registrations. */
+    function runStartupMaintenanceOnce(
+      scheduleStartupMaintenanceForEngine: (engine: LcmContextEngine) => void,
+      logScheduleError: (error: unknown) => void,
+    ): void {
+      if (startupMaintenanceStarted) {
+        return;
+      }
+      startupMaintenanceStarted = true;
+      if (shared) {
+        shared.startupMaintenanceStarted = true;
+      }
+
+      const cachedEngine = lcm;
+      if (cachedEngine) {
+        scheduleStartupMaintenanceForEngine(cachedEngine);
+        return;
+      }
+
+      void waitForEngine()
+        .then((nextEngine) => scheduleStartupMaintenanceForEngine(nextEngine))
+        .catch((error) => logScheduleError(error));
+    }
+
     /** Build a live DB+engine pair and roll back the DB handle if engine init fails. */
     function initializeEngine(): LcmContextEngine {
       const startedAt = Date.now();
@@ -1835,8 +1934,12 @@ const lcmPlugin = {
         (deps.log.hostInfo ?? deps.log.info)(
           `[lcm] Engine initialized for db=${normalizedDbPath} duration=${Date.now() - startedAt}ms`,
         );
-        scheduleStartupAutoRotate(nextEngine);
-        scheduleStartupSessionTotalTokensRecovery(nextEngine);
+        if (allowStartupMaintenance) {
+          runStartupMaintenanceOnce(
+            scheduleStartupMaintenance,
+            logStartupMaintenanceSchedulingError,
+          );
+        }
         return nextEngine;
       } catch (error) {
         closeLcmConnection(nextDatabase);
@@ -1880,6 +1983,9 @@ const lcmPlugin = {
 
     /** Return the initialized engine, waiting for deferred startup when the DB is lock-contended. */
     async function waitForEngine(): Promise<LcmContextEngine> {
+      if (!allowStartupMaintenance) {
+        throw new Error("[lcm] Engine initialization is disabled during read-only plugin registration");
+      }
       if (stopped) {
         throw new Error("[lcm] Database connection closed after gateway_stop");
       }
@@ -1918,45 +2024,52 @@ const lcmPlugin = {
       return database;
     }
 
-    try {
-      const nextEngine = initializeEngine();
-      initPromise = Promise.resolve(nextEngine);
-    } catch (error) {
-      const normalized = toInitError(error);
-      if (!/database is locked/i.test(normalized.message)) {
-        initError = normalized;
-        throw normalized;
-      }
+    if (allowStartupMaintenance) {
+      try {
+        const nextEngine = initializeEngine();
+        initPromise = Promise.resolve(nextEngine);
+      } catch (error) {
+        const normalized = toInitError(error);
+        if (!/database is locked/i.test(normalized.message)) {
+          initError = normalized;
+          throw normalized;
+        }
 
-      deps.log.warn("[lcm] DB locked during eager init, deferring to gateway_start");
-      ensureDeferredInitPromise();
-      api.on("gateway_start", async () => {
-        if (stopped || lcm || initError) {
-          return;
-        }
-        try {
-          const nextEngine = initializeEngine();
-          initPromise = Promise.resolve(nextEngine);
-          resolveDeferredEngine(nextEngine);
-        } catch (retryError) {
-          const normalizedRetryError = toInitError(retryError);
-          rejectDeferredEngine(normalizedRetryError);
-          deps.log.error(`[lcm] Deferred DB init failed: ${normalizedRetryError.message}`);
-        }
-      });
+        deps.log.warn("[lcm] DB locked during eager init, deferring to gateway_start");
+        ensureDeferredInitPromise();
+        api.on("gateway_start", async () => {
+          if (stopped || lcm || initError) {
+            return;
+          }
+          try {
+            const nextEngine = initializeEngine();
+            initPromise = Promise.resolve(nextEngine);
+            resolveDeferredEngine(nextEngine);
+          } catch (retryError) {
+            const normalizedRetryError = toInitError(retryError);
+            rejectDeferredEngine(normalizedRetryError);
+            deps.log.error(`[lcm] Deferred DB init failed: ${normalizedRetryError.message}`);
+          }
+        });
+      }
     }
 
-    const shared: SharedLcmInit = {
+    const nextShared: SharedLcmInit = {
       stopped: false,
+      startupMaintenanceStarted,
       getCachedEngine: () => lcm,
       waitForEngine,
       waitForDatabase,
+      runStartupMaintenanceOnce,
     };
-    setSharedInit(normalizedDbPath, shared);
+    shared = nextShared;
+    if (allowStartupMaintenance) {
+      setSharedInit(normalizedDbPath, nextShared);
+    }
 
     api.on("gateway_stop", async () => {
       stopped = true;
-      shared.stopped = true;
+      nextShared.stopped = true;
       if (!lcm && !database) {
         rejectDeferredEngine(new Error("[lcm] Database connection closed after gateway_stop"));
       }
@@ -1968,7 +2081,7 @@ const lcmPlugin = {
       removeSharedInit(normalizedDbPath);
     });
 
-    wirePluginHandlers(api, deps, shared);
+    wirePluginHandlers(api, deps, nextShared);
 
     logStartupBannerOnce({
       key: "plugin-loaded",

--- a/src/plugin/shared-init.ts
+++ b/src/plugin/shared-init.ts
@@ -19,12 +19,19 @@ import type { LcmContextEngine } from "../engine.js";
 export type SharedLcmInit = {
   /** Whether gateway_stop has been called. */
   stopped: boolean;
+  /** Whether startup maintenance has already been scheduled for this init. */
+  startupMaintenanceStarted: boolean;
   /** Sync accessor — returns the engine if already initialized, null otherwise. */
   getCachedEngine: () => LcmContextEngine | null;
   /** Async accessor for the initialized engine (waits for deferred init). */
   waitForEngine: () => Promise<LcmContextEngine>;
   /** Async accessor for the initialized DB handle (waits for deferred init). */
   waitForDatabase: () => Promise<DatabaseSync>;
+  /** Schedule startup maintenance once against the shared engine. */
+  runStartupMaintenanceOnce: (
+    scheduleStartupMaintenance: (engine: LcmContextEngine) => void,
+    logScheduleError: (error: unknown) => void,
+  ) => void;
 };
 
 const SHARED_KEY = Symbol.for(

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import * as connectionModule from "../src/db/connection.js";
 import { closeLcmConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
 import { clearAllSharedInit } from "../src/plugin/shared-init.js";
 import { resetStartupBannerLogsForTests } from "../src/startup-banner-log.js";
 
@@ -281,6 +282,174 @@ describe("lcm plugin registration", () => {
     expect(warnLog).not.toHaveBeenCalledWith(
       expect.stringContaining("runtime.llm.complete is unavailable"),
     );
+  });
+
+  it("does not initialize runtime surfaces during runtime-scoped CLI metadata registration", () => {
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, getRegisteredContextEngines, infoLog, warnLog } = buildApi(
+      { enabled: true },
+      {
+        includeRuntimeLlm: false,
+      },
+    );
+    (api.runtime as { registrationMode?: string }).registrationMode = "cli-metadata";
+
+    lcmPlugin.register(api);
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(getRegisteredContextEngines()).toEqual([]);
+    expect(api.registerCommand).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(api.on).not.toHaveBeenCalled();
+    expect(infoLog).not.toHaveBeenCalled();
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("runtime.llm.complete is unavailable"),
+    );
+  });
+
+  it.each(["discovery", "tool-discovery"])(
+    "does not eagerly initialize the engine during %s registration",
+    (registrationMode) => {
+      const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+      dbPaths.add(dbPath);
+      const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+      const { api, getFactory } = buildApi(
+        { enabled: true, dbPath },
+        { registrationMode },
+      );
+
+      lcmPlugin.register(api);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(getFactory()).toBeTypeOf("function");
+    },
+  );
+
+  it.each(["discovery", "tool-discovery"])(
+    "does not schedule startup maintenance during %s registration",
+    async (registrationMode) => {
+      const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+      dbPaths.add(dbPath);
+      const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+      const autoRotateSpy = vi
+        .spyOn(LcmContextEngine.prototype, "autoRotateManagedSessionFilesAtStartup")
+        .mockResolvedValue();
+      const { api, getFactory } = buildApi(
+        { enabled: true, dbPath },
+        { registrationMode },
+      );
+
+      lcmPlugin.register(api);
+
+      const factory = getFactory();
+      expect(factory).toBeTypeOf("function");
+      await expect(Promise.resolve(factory!())).rejects.toThrow(
+        "Engine initialization is disabled during read-only plugin registration",
+      );
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(autoRotateSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("schedules startup maintenance when live registration follows read-only registration", () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const autoRotateSpy = vi
+      .spyOn(LcmContextEngine.prototype, "autoRotateManagedSessionFilesAtStartup")
+      .mockResolvedValue();
+    const first = buildApi(
+      { enabled: true, dbPath },
+      { registrationMode: "discovery" },
+    );
+
+    lcmPlugin.register(first.api);
+    expect(autoRotateSpy).not.toHaveBeenCalled();
+
+    const second = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(second.api);
+
+    expect(autoRotateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses live runtime startup APIs after read-only registration", () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const sessionStorePath = join(
+      tmpdir(),
+      `lossless-claw-session-store-${Date.now()}-${Math.random().toString(16)}.json`,
+    );
+    const autoRotateSpy = vi
+      .spyOn(LcmContextEngine.prototype, "autoRotateManagedSessionFilesAtStartup")
+      .mockResolvedValue();
+    writeFileSync(sessionStorePath, "{}\n", "utf8");
+
+    const first = buildApi(
+      { enabled: true, dbPath },
+      { registrationMode: "discovery" },
+    );
+    lcmPlugin.register(first.api);
+    expect(autoRotateSpy).not.toHaveBeenCalled();
+
+    const second = buildApi(
+      { enabled: true, dbPath },
+      {
+        runtimeConfig: {
+          session: {
+            store: sessionStorePath,
+          },
+        },
+      },
+    );
+    attachSessionStoreApi(second.api, sessionStorePath);
+    lcmPlugin.register(second.api);
+
+    expect(autoRotateSpy).toHaveBeenCalledTimes(1);
+    expect(autoRotateSpy).toHaveBeenCalledWith({
+      listStartupSessionFileCandidates: expect.any(Function),
+    });
+    rmSync(sessionStorePath, { force: true });
+  });
+
+  it("does not schedule startup maintenance during CLI runtime inspection", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    const originalArgv = process.argv;
+    dbPaths.add(dbPath);
+    const autoRotateSpy = vi
+      .spyOn(LcmContextEngine.prototype, "autoRotateManagedSessionFilesAtStartup")
+      .mockResolvedValue();
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+
+    process.argv = ["node", "openclaw", "plugins", "inspect", "lossless-claw", "--runtime"];
+    try {
+      lcmPlugin.register(api);
+
+      const factory = getFactory();
+      expect(factory).toBeTypeOf("function");
+      await expect(Promise.resolve(factory!())).rejects.toThrow(
+        "Engine initialization is disabled during read-only plugin registration",
+      );
+      expect(autoRotateSpy).not.toHaveBeenCalled();
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("does not eagerly initialize the engine during CLI runtime inspection", () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    const originalArgv = process.argv;
+    dbPaths.add(dbPath);
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+
+    process.argv = ["node", "openclaw", "plugins", "inspect", "lossless-claw", "--runtime"];
+    try {
+      lcmPlugin.register(api);
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(getFactory()).toBeTypeOf("function");
+    } finally {
+      process.argv = originalArgv;
+    }
   });
 
   it("fails fast with a compatibility diagnostic when context-engine registration is unavailable", () => {


### PR DESCRIPTION
## What

Prevent Lossless startup maintenance from running during OpenClaw runtime inspection and read-only plugin discovery while preserving normal live startup maintenance.

Fixes #841.

## Why

Runtime inspection can load the plugin outside a live gateway startup context. Startup auto-rotation and session-store recovery are stateful and should not mutate transcripts, summaries, checkpoints, or session metadata during inspection.

## Changes

- Detect read-only registration contexts
- Skip startup maintenance during inspection
- Preserve later live maintenance scheduling
- Add regression coverage for reuse paths
- Add patch changeset

## Testing

- `npm test -- plugin-config-registration.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "npm test -- plugin-config-registration.test.ts"`

Autoreview result: clean, no accepted/actionable findings reported.
