### PR TITLE
fix: skip synthetic heartbeats during bootstrap reconcile

### DIFF
--- a/.changeset/fuzzy-heartbeats-reconcile.md
+++ b/.changeset/fuzzy-heartbeats-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip synthetic OpenClaw heartbeat transcript rows during bootstrap/reconcile imports so heartbeat-only tails cannot trip replay-flood quarantine.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6392,7 +6392,11 @@ export class LcmContextEngine implements ContextEngine {
             messages: historicalMessages,
           });
           const persistedIdentityOverlaps = replayAnalysis.overlaps;
-          let noAnchorImportMessages = historicalMessages;
+          let noAnchorImportMessages = this.filterSyntheticHeartbeatTranscriptMessages({
+            messages: historicalMessages,
+            sessionContext,
+            source: "reconcileSessionTail no-anchor",
+          });
           const replayThreshold = Math.max(3, Math.ceil(historicalMessages.length * 0.5));
           if (persistedIdentityOverlaps >= replayThreshold) {
             if (replayAnalysis.firstNonOverlappingIndex < 0) {
@@ -6411,7 +6415,11 @@ export class LcmContextEngine implements ContextEngine {
             }
 
             if (replayAnalysis.firstNonOverlappingIndex > 0) {
-              noAnchorImportMessages = historicalMessages.slice(replayAnalysis.firstNonOverlappingIndex);
+              noAnchorImportMessages = this.filterSyntheticHeartbeatTranscriptMessages({
+                messages: historicalMessages.slice(replayAnalysis.firstNonOverlappingIndex),
+                sessionContext,
+                source: "reconcileSessionTail no-anchor replay-prefix",
+              });
               this.deps.log.warn(
                 `[lcm] reconcileSessionTail: duplicate transcript replay guard dropped ${replayAnalysis.firstNonOverlappingIndex}/${historicalMessages.length} already-persisted prefix messages for ${sessionContext} before no-anchor import (reason: ${params.noAnchorImportReason ?? "unspecified"})`,
               );
@@ -6492,7 +6500,11 @@ export class LcmContextEngine implements ContextEngine {
       source: "reconcileSessionTail",
       priorMessages: historicalMessages.slice(0, anchorIndex + 1),
     });
-    const missingTail = missingTailFiltered.messages;
+    const missingTail = this.filterSyntheticHeartbeatTranscriptMessages({
+      messages: missingTailFiltered.messages,
+      sessionContext,
+      source: "reconcileSessionTail",
+    });
 
     if (existingDbCount > 0 && missingTail.length > Math.max(existingDbCount * 0.2, 50)) {
       this.deps.log.warn(
@@ -7515,6 +7527,20 @@ export class LcmContextEngine implements ContextEngine {
         };
   }
 
+  private filterSyntheticHeartbeatTranscriptMessages(params: {
+    messages: AgentMessage[];
+    sessionContext: string;
+    source: string;
+  }): AgentMessage[] {
+    const filtered = filterSyntheticHeartbeatMessages(params.messages);
+    if (filtered.skipped > 0) {
+      this.deps.log.debug(
+        `[lcm] ${params.source}: skipped ${filtered.skipped}/${params.messages.length} synthetic heartbeat transcript messages for ${params.sessionContext}`,
+      );
+    }
+    return filtered.messages;
+  }
+
   private async reconcileTranscriptTailForAfterTurn(params: {
     sessionId: string;
     sessionKey?: string;
@@ -8037,7 +8063,11 @@ export class LcmContextEngine implements ContextEngine {
                   source: "bootstrap append-only",
                   sessionFile: params.sessionFile,
                 });
-                const replayFilteredMessages = replayFiltered.messages;
+                const replayFilteredMessages = this.filterSyntheticHeartbeatTranscriptMessages({
+                  messages: replayFiltered.messages,
+                  sessionContext: appendOnlySessionContext,
+                  source: "bootstrap append-only",
+                });
                 const appendOnlyOverlapsPersisted = await this.appendOnlyMessagesOverlapPersistedTranscript({
                   conversationId,
                   messages: replayFilteredMessages,
@@ -11788,6 +11818,7 @@ export class LcmContextEngine implements ContextEngine {
 
 const HEARTBEAT_OK_TOKEN = "heartbeat_ok";
 const HEARTBEAT_TURN_MARKER = "heartbeat.md";
+const OPENCLAW_HEARTBEAT_POLL = "[openclaw heartbeat poll]";
 
 /**
  * Detect whether an assistant message is a heartbeat ack.
@@ -11817,6 +11848,64 @@ function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {
   }
 
   return false;
+}
+
+function filterSyntheticHeartbeatMessages(
+  messages: AgentMessage[],
+): { messages: AgentMessage[]; skipped: number } {
+  if (messages.length === 0) {
+    return { messages, skipped: 0 };
+  }
+
+  const skipIndexes = new Set<number>();
+  for (let index = 0; index < messages.length; index += 1) {
+    const stored = toStoredMessage(messages[index]!);
+    if (
+      stored.role === "user" &&
+      stored.content.trim().toLowerCase() === OPENCLAW_HEARTBEAT_POLL
+    ) {
+      skipIndexes.add(index);
+    }
+  }
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const stored = toStoredMessage(messages[index]!);
+    if (stored.role !== "assistant" || !isHeartbeatOkContent(stored.content)) {
+      continue;
+    }
+
+    let turnStart = -1;
+    for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+      const previous = toStoredMessage(messages[cursor]!);
+      if (previous.role === "user") {
+        turnStart = cursor;
+        break;
+      }
+    }
+    if (turnStart < 0) {
+      continue;
+    }
+
+    const turnMessages = messages
+      .slice(turnStart, index + 1)
+      .map((message) => toStoredMessage(message));
+    if (!turnLooksLikeHeartbeatTurn(turnMessages)) {
+      continue;
+    }
+
+    for (let cursor = turnStart; cursor <= index; cursor += 1) {
+      skipIndexes.add(cursor);
+    }
+  }
+
+  if (skipIndexes.size === 0) {
+    return { messages, skipped: 0 };
+  }
+
+  return {
+    messages: messages.filter((_, index) => !skipIndexes.has(index)),
+    skipped: skipIndexes.size,
+  };
 }
 
 function turnLooksLikeHeartbeatTurn(turnMessages: Array<{ content: string }>): boolean {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -5554,6 +5554,100 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(bootstrapState?.lastProcessedEntryHash).not.toBe(firstBootstrapState!.lastProcessedEntryHash);
   });
 
+  it("skips synthetic heartbeat polls during bootstrap full-reconcile", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-reconcile-heartbeat-polls");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-reconcile-heartbeat-polls";
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine
+      .getSummaryStore()
+      .upsertConversationBootstrapState({
+        conversationId: conversation!.conversationId,
+        sessionFilePath: sessionFile,
+        lastSeenSize: 1,
+        lastSeenMtimeMs: 0,
+        lastProcessedOffset: 1,
+        lastProcessedEntryHash: "mismatch",
+      });
+
+    for (let index = 0; index < 4; index += 1) {
+      appendSessionMessage(sm, makeMessage({ role: "user", content: "[OpenClaw heartbeat poll]" }));
+    }
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: "already bootstrapped",
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["seed user", "seed assistant"]);
+  });
+
+  it("skips heartbeat ACK turns while reconciling real bootstrap tail messages", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-reconcile-heartbeat-turn-tail");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-reconcile-heartbeat-turn-tail";
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    await engine
+      .getSummaryStore()
+      .upsertConversationBootstrapState({
+        conversationId: conversation!.conversationId,
+        sessionFilePath: sessionFile,
+        lastSeenSize: 1,
+        lastSeenMtimeMs: 0,
+        lastProcessedOffset: 1,
+        lastProcessedEntryHash: "mismatch",
+      });
+
+    appendSessionMessage(
+      sm,
+      makeMessage({
+        role: "user",
+        content: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+      }),
+    );
+    appendSessionMessage(
+      sm,
+      makeMessage({ role: "tool", content: "# HEARTBEAT.md\n\nIf nothing needs attention, stay quiet." }),
+    );
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real recovered user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real recovered assistant" }));
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 2,
+      reason: "reconciled missing session messages",
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real recovered user",
+      "real recovered assistant",
+    ]);
+  });
+
   it("imports appended tail messages without replaying full reconciliation", async () => {
     const sessionFile = createSessionFilePath("append-only-tail");
     const sm = SessionManager.open(sessionFile);


### PR DESCRIPTION
## Summary

- filter synthetic `[OpenClaw heartbeat poll]` transcript rows out of bootstrap/reconcile import candidates
- filter full HEARTBEAT_OK transcript turns during reconcile while preserving adjacent real tail messages
- keep the generic user anti-replay guard intact; this only removes known synthetic host traffic before import/replay evaluation

## Why

PR #840 fixed heartbeat-marked afterTurn append-only deltas, but an existing transcript can still contain synthetic heartbeat rows before bootstrap/full-reconcile runs. Those rows can collapse into one SQLite second during reconcile import and trip the role=user replay flood guard, causing host quarantine/fallback.

## Verification

- `env -u OPENCLAW_STATE_DIR npx vitest run test/engine.test.ts --testNamePattern "skips synthetic heartbeat polls|skips heartbeat ACK turns|heartbeat flag skips append-only transcript deltas"`
- `npm run build`
- `env -u OPENCLAW_STATE_DIR npm test`