### PR TITLE
Add configurable context threshold overrides

### DIFF
--- a/.changeset/context-threshold-overrides.md
+++ b/.changeset/context-threshold-overrides.md
@@ -1,0 +1,6 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add scoped context threshold overrides for matching model ids, model context-window
+ranges, and session patterns.

--- a/.changeset/context-threshold-overrides.md
+++ b/.changeset/context-threshold-overrides.md
@@ -1,0 +1,6 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add scoped context threshold overrides for matching model ids, model context-window
+ranges, and session patterns.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
           "leafChunkTokens": 80000,
           "newSessionRetainDepth": 2,
           "contextThreshold": 0.75,
+          "contextThresholdOverrides": [
+            {
+              "name": "large-context-models",
+              "match": { "modelContextWindowMin": 900000 },
+              "contextThreshold": 0.15
+            },
+            {
+              "name": "telegram-sessions",
+              "match": { "sessionPattern": "agent:*:telegram:**" },
+              "contextThreshold": 0.3
+            }
+          ],
           "incrementalMaxDepth": 1,
           "cacheAwareCompaction": {
             "enabled": true,
@@ -285,6 +297,7 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 - **leafChunkTokens=20000** limits how large each leaf compaction chunk can grow before LCM summarizes it. Increase this when your summary provider is quota-limited and frequent leaf compactions are exhausting that quota.
 - **incrementalMaxDepth=1** runs one condensed pass after each leaf compaction by default. Set to `0` for leaf-only behavior, a larger positive integer for a deeper cap, or `-1` for unlimited cascading.
 - **contextThreshold=0.75** triggers compaction when context reaches 75% of the model's window, leaving headroom for the model's response.
+- **contextThresholdOverrides** optionally picks a different threshold for matching model ids, model context-window ranges, or session patterns. If no rule matches, LCM falls back to `contextThreshold`.
 
 ### Session exclusion patterns
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,23 @@ Most installations only need to override a handful of keys. If you want a comple
   "statelessSessionPatterns": [],
   "skipStatelessSessions": true,
   "contextThreshold": 0.75,
+  "contextThresholdOverrides": [
+    {
+      "name": "large-context-models",
+      "match": { "modelContextWindowMin": 900000 },
+      "contextThreshold": 0.15
+    },
+    {
+      "name": "small-context-models",
+      "match": { "modelContextWindowMax": 250000 },
+      "contextThreshold": 0.2
+    },
+    {
+      "name": "telegram-sessions",
+      "match": { "sessionPattern": "agent:*:telegram:**" },
+      "contextThreshold": 0.3
+    }
+  ],
   "freshTailCount": 64,
   "freshTailMaxTokens": 24000,
   "promptAwareEviction": false,
@@ -180,6 +197,7 @@ Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rot
 | Key | Type | Default | Env override | Purpose |
 | --- | --- | --- | --- | --- |
 | `contextThreshold` | `number` | `0.75` | `LCM_CONTEXT_THRESHOLD` | Fraction of the active model context window that triggers compaction. |
+| `contextThresholdOverrides` | `Array<{ name?: string; match: object; contextThreshold: number }>` | `[]` | none | Optional ordered rules that override `contextThreshold` by model id, model context-window range, or session glob pattern. |
 | `freshTailCount` | `integer` | `64` | `LCM_FRESH_TAIL_COUNT` | Number of newest messages always kept raw. |
 | `freshTailMaxTokens` | `integer` | unset | `LCM_FRESH_TAIL_MAX_TOKENS` | Optional token cap for the protected fresh tail. The newest message is always preserved even if it exceeds the cap. |
 | `promptAwareEviction` | `boolean` | `false` | `LCM_PROMPT_AWARE_EVICTION_ENABLED` | When enabled, budget-constrained assembly keeps older evictable items by prompt relevance instead of pure chronology. This improves retrieval under tight budgets, but it can reduce prompt-cache hit rates because the preserved prefix changes as prompts change. |
@@ -265,13 +283,15 @@ Summary calls are executed through OpenClaw's `api.runtime.llm.complete` capabil
 
 Automatic compaction is threshold-only:
 
-- `afterTurn()` evaluates `contextThreshold` against the active token budget
+- `afterTurn()` evaluates the resolved context threshold against the active token budget
 - below threshold, no automatic compaction runs and no leaf debt is recorded
 - at or above threshold, inline mode runs a threshold full sweep immediately
 - deferred mode records one coalesced `"threshold"` maintenance row and normally drains it in the background or host-approved `maintain()`
 - pre-assembly drain is reserved as an emergency safeguard when the live prompt is already over the active token budget
 
 Lossless still records prompt-cache telemetry for status and diagnostics, but cache hotness no longer delays threshold debt. Legacy `cacheAwareCompaction.*` and `dynamicLeafChunkTokens.*` settings remain accepted so existing OpenClaw config continues to load, but they do not change automatic compaction behavior.
+
+`contextThresholdOverrides` are optional and never replace the global fallback. Each rule's `match` object can include `model`, `modelContextWindowMin`, `modelContextWindowMax`, and `sessionPattern`; all fields in a rule must match. If several rules match, Lossless picks the highest-specificity rule, then the earliest rule in the array for ties. Exact `model` matches have higher specificity than `sessionPattern` matches, and session-pattern matches have higher specificity than context-window range matches. Threshold selection logs include the chosen threshold, source, rule index/name, token budget, threshold tokens, model, context-window value, and match reason.
 
 Full sweeps first run leaf passes until there are no more eligible raw-message chunks outside the fresh tail. Condensation is then driven by summarized-prefix pressure: the routine condensation phase obeys `sweepMaxDepth`, and if the summarized prefix still exceeds `summaryPrefixTargetTokens`, a pressure phase may use `condensedMinFanoutHard` and condense deeper. Total context pressure starts the sweep, but does not by itself force deeper condensation once the raw prefix has been summarized.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -25,6 +25,10 @@
       "label": "Context Threshold",
       "help": "Fraction of context window that triggers compaction (0.0–1.0)"
     },
+    "contextThresholdOverrides": {
+      "label": "Context Threshold Overrides",
+      "help": "Optional ordered rules that override contextThreshold by model, model context-window range, or session glob pattern"
+    },
     "sweepMaxDepth": {
       "label": "Sweep Max Depth",
       "help": "Preferred maximum condensation source depth during routine full sweeps (0 = leaf only, -1 = unlimited). Pressure sweeps may go deeper when summarized context remains above target."
@@ -317,6 +321,50 @@
         "type": "number",
         "minimum": 0,
         "maximum": 1
+      },
+      "contextThresholdOverrides": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "match",
+            "contextThreshold"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "match": {
+              "type": "object",
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "model": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "modelContextWindowMin": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "modelContextWindowMax": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "sessionPattern": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "contextThreshold": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        }
       },
       "sweepMaxDepth": {
         "type": "integer",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -30,6 +30,44 @@ Good default:
 
 - `0.75`
 
+### `contextThresholdOverrides`
+
+Optional ordered rules that choose a different compaction threshold for matching runtime contexts.
+
+Supported match fields:
+
+- `model`: exact runtime model id, such as `openai/gpt-5.5`
+- `modelContextWindowMin`: match models/windows at or above this token count
+- `modelContextWindowMax`: match models/windows at or below this token count
+- `sessionPattern`: session-key glob, using the same `*` and `**` semantics as ignored/stateless sessions
+
+Rules are AND-matched: if a rule includes both `model` and `sessionPattern`, both must match. If multiple rules match, Lossless picks the highest-specificity rule, then the earliest rule in the array for ties. If no rule matches, it falls back to global `contextThreshold`.
+
+Example:
+
+```json
+{
+  "contextThreshold": 0.75,
+  "contextThresholdOverrides": [
+    {
+      "name": "large-context-models",
+      "match": { "modelContextWindowMin": 900000 },
+      "contextThreshold": 0.15
+    },
+    {
+      "name": "telegram-sessions",
+      "match": { "sessionPattern": "agent:*:telegram:**" },
+      "contextThreshold": 0.3
+    }
+  ]
+}
+```
+
+Debugging:
+
+- threshold-selection logs include the selected threshold, source, rule index/name, token budget, threshold tokens, model, context-window value, and match reason
+- there is no env-var override for `contextThresholdOverrides`; use plugin config for structured rules
+
 ### `freshTailCount`
 
 Keeps the newest messages raw instead of compacting them.

--- a/src/compaction-telemetry.ts
+++ b/src/compaction-telemetry.ts
@@ -5,6 +5,8 @@
  *
  * Extracted from engine.ts (Phase 3 of the engine decomposition).
  */
+import type { ResolvedContextThreshold } from "./context-threshold.js";
+import { readRuntimeModelContext } from "./runtime-model.js";
 import type { CompactionMaintenanceStore } from "./store/compaction-maintenance-store.js";
 import {
   type CacheState,
@@ -36,10 +38,7 @@ export class CompactionTelemetryRecorder {
   /** Extract the current prompt-cache snapshot from runtime context, if present. */
   private readPromptCacheSnapshot(runtimeContext?: Record<string, unknown>): PromptCacheSnapshot | null {
     const promptCache = asRecord(runtimeContext?.promptCache);
-    const provider = safeString(runtimeContext?.provider)?.trim()
-      ?? safeString(runtimeContext?.providerId)?.trim();
-    const model = safeString(runtimeContext?.model)?.trim()
-      ?? safeString(runtimeContext?.modelId)?.trim();
+    const { provider, model } = readRuntimeModelContext(runtimeContext);
     if (!promptCache && !provider && !model) {
       return null;
     }
@@ -205,6 +204,8 @@ export class CompactionTelemetryRecorder {
     currentTokenCount?: number;
     projectedTokenCount?: number;
     rawTokensOutsideTail?: number;
+    /** Threshold that triggered the debt, reused verbatim by the drain. */
+    contextThreshold?: ResolvedContextThreshold;
   }): Promise<void> {
     await this.compactionMaintenanceStore.requestProactiveCompactionDebt({
       conversationId: params.conversationId,
@@ -213,9 +214,11 @@ export class CompactionTelemetryRecorder {
       currentTokenCount: params.currentTokenCount ?? null,
       projectedTokenCount: params.projectedTokenCount ?? null,
       rawTokensOutsideTail: params.rawTokensOutsideTail ?? null,
+      contextThreshold: params.contextThreshold?.contextThreshold ?? null,
+      contextThresholdSource: params.contextThreshold?.source ?? null,
     });
     this.deps.log.debug(
-      `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"} projectedTokenCount=${params.projectedTokenCount ?? "null"} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"}`,
+      `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"} projectedTokenCount=${params.projectedTokenCount ?? "null"} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"} contextThreshold=${params.contextThreshold?.contextThreshold ?? "null"} contextThresholdSource=${params.contextThreshold?.source ?? "null"}`,
     );
   }
 }

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -149,6 +149,13 @@ type CondensedPhaseCandidate = {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+function resolveContextThreshold(config: CompactionConfig, override?: number): number {
+  if (typeof override === "number" && Number.isFinite(override) && override >= 0 && override <= 1) {
+    return override;
+  }
+  return config.contextThreshold;
+}
+
 
 /** Deterministically cap summary text so the persisted output stays within maxTokens. */
 function capSummaryText(
@@ -690,6 +697,7 @@ export class CompactionEngine {
     conversationId: number,
     tokenBudget: number,
     observedTokenCount?: number,
+    options?: { contextThreshold?: number },
   ): Promise<CompactionDecision> {
     const storedTokens = await this.summaryStore.getContextTokenCount(conversationId);
     const liveTokens =
@@ -703,7 +711,9 @@ export class CompactionEngine {
     const projectedTokens =
       liveTokens > 0 ? liveTokens + (rawTokensOutsideTail ?? 0) : undefined;
     const currentTokens = Math.max(storedTokens, projectedTokens ?? liveTokens);
-    const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    const threshold = Math.floor(
+      resolveContextThreshold(this.config, options?.contextThreshold) * tokenBudget,
+    );
 
     if (currentTokens > threshold) {
       return {
@@ -757,6 +767,7 @@ export class CompactionEngine {
   async compact(input: {
     conversationId: number;
     tokenBudget: number;
+    contextThreshold?: number;
     /** LLM call function for summarization */
     summarize: CompactionSummarizeFn;
     force?: boolean;
@@ -792,6 +803,7 @@ export class CompactionEngine {
   private async _compactLeafImpl(input: {
     conversationId: number;
     tokenBudget: number;
+    contextThreshold?: number;
     summarize: CompactionSummarizeFn;
     leafChunkTokens?: number;
     force?: boolean;
@@ -802,7 +814,9 @@ export class CompactionEngine {
     const { conversationId, tokenBudget, summarize, force } = input;
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
-    const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    const threshold = Math.floor(
+      resolveContextThreshold(this.config, input.contextThreshold) * tokenBudget,
+    );
     const leafTrigger = await this.evaluateLeafTrigger(conversationId, input.leafChunkTokens);
 
     if (!force && tokensBefore <= threshold && !leafTrigger.shouldCompact) {
@@ -925,6 +939,7 @@ export class CompactionEngine {
   async compactFullSweep(input: {
     conversationId: number;
     tokenBudget: number;
+    contextThreshold?: number;
     summarize: CompactionSummarizeFn;
     force?: boolean;
     hardTrigger?: boolean;
@@ -943,7 +958,8 @@ export class CompactionEngine {
     const { conversationId, tokenBudget, summarize, force, hardTrigger } = input;
 
     const tokensBefore = await this.summaryStore.getContextTokenCount(conversationId);
-    const threshold = Math.floor(this.config.contextThreshold * tokenBudget);
+    const contextThreshold = resolveContextThreshold(this.config, input.contextThreshold);
+    const threshold = Math.floor(contextThreshold * tokenBudget);
     const stopAtTokens =
       typeof input.stopAtTokens === "number" &&
       Number.isFinite(input.stopAtTokens) &&
@@ -1092,7 +1108,10 @@ export class CompactionEngine {
 
     // Phase 2: depth-aware condensed passes, always processing shallowest depth first.
     const preferredMaxSourceDepth = this.resolveSweepMaxDepth();
-    const summaryPrefixTargetTokens = this.resolveSummaryPrefixTargetTokens(tokenBudget);
+    const summaryPrefixTargetTokens = this.resolveSummaryPrefixTargetTokens(
+      tokenBudget,
+      contextThreshold,
+    );
     const hasSummaryPrefixPressure = async (): Promise<boolean> =>
       (await this.countSummaryTokensOutsideFreshTail(conversationId)) > summaryPrefixTargetTokens;
     const hasStopTargetPressure = (): boolean =>
@@ -1228,6 +1247,7 @@ export class CompactionEngine {
   async compactUntilUnder(input: {
     conversationId: number;
     tokenBudget: number;
+    contextThreshold?: number;
     targetTokens?: number;
     currentTokens?: number;
     summarize: CompactionSummarizeFn;
@@ -1239,6 +1259,7 @@ export class CompactionEngine {
   private async _compactUntilUnderImpl(input: {
     conversationId: number;
     tokenBudget: number;
+    contextThreshold?: number;
     targetTokens?: number;
     currentTokens?: number;
     summarize: CompactionSummarizeFn;
@@ -1298,6 +1319,7 @@ export class CompactionEngine {
       const result = await this.compact({
         conversationId,
         tokenBudget,
+        contextThreshold: input.contextThreshold,
         summarize,
         force: true,
         summaryModel: input.summaryModel,
@@ -1711,7 +1733,7 @@ export class CompactionEngine {
   }
 
   /** Resolve the summarized-prefix pressure target for this token budget. */
-  private resolveSummaryPrefixTargetTokens(tokenBudget: number): number {
+  private resolveSummaryPrefixTargetTokens(tokenBudget: number, contextThresholdOverride?: number): number {
     if (
       typeof this.config.summaryPrefixTargetTokens === "number" &&
       Number.isFinite(this.config.summaryPrefixTargetTokens) &&
@@ -1719,7 +1741,10 @@ export class CompactionEngine {
     ) {
       return Math.floor(this.config.summaryPrefixTargetTokens);
     }
-    const threshold = Math.max(1, Math.floor(this.config.contextThreshold * tokenBudget));
+    const threshold = Math.max(
+      1,
+      Math.floor(resolveContextThreshold(this.config, contextThresholdOverride) * tokenBudget),
+    );
     const derivedTarget = Math.floor(threshold * 0.5);
     return Math.max(
       this.config.condensedTargetTokens,

--- a/src/context-threshold.ts
+++ b/src/context-threshold.ts
@@ -1,0 +1,229 @@
+/**
+ * Scoped context-threshold override resolution.
+ *
+ * Operators can configure `contextThresholdOverrides` rules that pick a
+ * different compaction threshold per runtime context: exact model id,
+ * model context-window range, and session-key glob. This module owns rule
+ * matching, specificity ranking, and the resolved-threshold descriptor the
+ * engine threads through compaction calls and deferred maintenance debt.
+ */
+import type { ContextThresholdOverride } from "./db/config.js";
+import type { RuntimeModelContext } from "./runtime-model.js";
+import { compileSessionPattern } from "./session-patterns.js";
+
+export type ResolvedContextThreshold = {
+  contextThreshold: number;
+  source: "global" | "override";
+  /** Human-readable match summary for threshold-selection log lines. */
+  reason: string;
+  ruleIndex?: number;
+  ruleName?: string;
+  specificity: number;
+  modelRef?: string;
+  modelContextWindow?: number;
+};
+
+type CompiledOverrideRule = {
+  rule: ContextThresholdOverride;
+  index: number;
+  specificity: number;
+  /** Precompiled session glob, present iff the rule has a sessionPattern. */
+  sessionPattern?: RegExp;
+};
+
+// Specificity ranks competing matches: an exact model id beats a session
+// pattern, which beats context-window range bounds. Ties resolve to the
+// earliest rule in config order.
+function ruleSpecificity(rule: ContextThresholdOverride): number {
+  let score = 0;
+  if (rule.match.model) {
+    score += 100;
+  }
+  if (rule.match.sessionPattern) {
+    score += 50;
+  }
+  if (rule.match.modelContextWindowMin !== undefined) {
+    score += 20;
+  }
+  if (rule.match.modelContextWindowMax !== undefined) {
+    score += 20;
+  }
+  return score;
+}
+
+// All matchers within a rule AND together; a rule with no satisfied
+// requirement fails. Window-range matchers require explicit runtime window
+// metadata — the token budget is never used as a proxy.
+function ruleMatches(params: {
+  compiled: CompiledOverrideRule;
+  sessionKey?: string;
+  runtime: RuntimeModelContext;
+}): boolean {
+  const { rule, sessionPattern } = params.compiled;
+  const runtime = params.runtime;
+
+  if (rule.match.model) {
+    const normalizedRuleModel = rule.match.model.trim();
+    const candidates = [runtime.modelRef, runtime.model].filter(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+    );
+    if (!candidates.includes(normalizedRuleModel)) {
+      return false;
+    }
+  }
+
+  if (sessionPattern) {
+    const sessionKey = params.sessionKey?.trim();
+    if (!sessionKey || !sessionPattern.test(sessionKey)) {
+      return false;
+    }
+  }
+
+  if (
+    rule.match.modelContextWindowMin !== undefined ||
+    rule.match.modelContextWindowMax !== undefined
+  ) {
+    if (runtime.modelContextWindow === undefined) {
+      return false;
+    }
+    if (
+      rule.match.modelContextWindowMin !== undefined &&
+      runtime.modelContextWindow < rule.match.modelContextWindowMin
+    ) {
+      return false;
+    }
+    if (
+      rule.match.modelContextWindowMax !== undefined &&
+      runtime.modelContextWindow > rule.match.modelContextWindowMax
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Summarize which matchers selected the winning rule for log lines.
+function describeRuleMatch(
+  rule: ContextThresholdOverride,
+  runtime: RuntimeModelContext,
+): string {
+  const parts: string[] = [];
+  if (rule.match.model) {
+    parts.push(`model=${rule.match.model}`);
+  }
+  if (rule.match.modelContextWindowMin !== undefined) {
+    parts.push(`modelContextWindow>=${rule.match.modelContextWindowMin}`);
+  }
+  if (rule.match.modelContextWindowMax !== undefined) {
+    parts.push(`modelContextWindow<=${rule.match.modelContextWindowMax}`);
+  }
+  if (rule.match.sessionPattern) {
+    parts.push(`sessionPattern=${rule.match.sessionPattern}`);
+  }
+  if (runtime.modelContextWindow !== undefined) {
+    parts.push(`resolvedModelContextWindow=${runtime.modelContextWindow}`);
+  }
+  return parts.join(",");
+}
+
+/**
+ * Rehydrate a resolved threshold persisted on a deferred maintenance debt
+ * row, so a background drain reuses the threshold that triggered the debt
+ * instead of re-resolving against possibly absent runtime metadata.
+ */
+export function persistedContextThresholdOverride(maintenance: {
+  contextThreshold: number | null;
+  contextThresholdSource: "global" | "override" | null;
+}): ResolvedContextThreshold | undefined {
+  if (
+    typeof maintenance.contextThreshold !== "number" ||
+    !Number.isFinite(maintenance.contextThreshold)
+  ) {
+    return undefined;
+  }
+  return {
+    contextThreshold: maintenance.contextThreshold,
+    source: maintenance.contextThresholdSource === "override" ? "override" : "global",
+    specificity: 0,
+    reason: "persisted deferred threshold debt",
+  };
+}
+
+/** Format the resolved-threshold fields shared by all selection log lines. */
+export function describeResolvedContextThreshold(resolved: ResolvedContextThreshold): string {
+  return (
+    `threshold=${resolved.contextThreshold} source=${resolved.source}` +
+    ` ruleIndex=${resolved.ruleIndex ?? "none"} ruleName=${resolved.ruleName ?? "none"}` +
+    ` specificity=${resolved.specificity} model=${resolved.modelRef ?? "none"}` +
+    ` modelContextWindow=${resolved.modelContextWindow ?? "none"}` +
+    ` reason=${resolved.reason.replaceAll(" ", "_")}`
+  );
+}
+
+/**
+ * Resolves the effective compaction threshold for a runtime context from the
+ * configured override rules, falling back to the global `contextThreshold`.
+ * Rules are validated by config parsing and compiled once at construction.
+ */
+export class ContextThresholdResolver {
+  private readonly rules: CompiledOverrideRule[];
+
+  constructor(
+    private readonly globalThreshold: number,
+    overrides: ContextThresholdOverride[] = [],
+  ) {
+    this.rules = overrides.map((rule, index) => ({
+      rule,
+      index,
+      specificity: ruleSpecificity(rule),
+      ...(rule.match.sessionPattern
+        ? { sessionPattern: compileSessionPattern(rule.match.sessionPattern) }
+        : {}),
+    }));
+  }
+
+  /** Pick the highest-specificity matching rule (earliest wins ties). */
+  resolve(params: {
+    sessionKey?: string;
+    runtime: RuntimeModelContext;
+  }): ResolvedContextThreshold {
+    const runtime = params.runtime;
+    let best: CompiledOverrideRule | undefined;
+    for (const compiled of this.rules) {
+      if (!ruleMatches({ compiled, sessionKey: params.sessionKey, runtime })) {
+        continue;
+      }
+      if (!best || compiled.specificity > best.specificity) {
+        best = compiled;
+      }
+    }
+
+    const runtimeFields = {
+      ...(runtime.modelRef ? { modelRef: runtime.modelRef } : {}),
+      ...(runtime.modelContextWindow !== undefined
+        ? { modelContextWindow: runtime.modelContextWindow }
+        : {}),
+    };
+
+    if (!best) {
+      return {
+        contextThreshold: this.globalThreshold,
+        source: "global",
+        reason: "no_override_matched",
+        specificity: 0,
+        ...runtimeFields,
+      };
+    }
+
+    return {
+      contextThreshold: best.rule.contextThreshold,
+      source: "override",
+      ruleIndex: best.index,
+      ...(best.rule.name ? { ruleName: best.rule.name } : {}),
+      reason: describeRuleMatch(best.rule, runtime),
+      specificity: best.specificity,
+      ...runtimeFields,
+    };
+  }
+}

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -61,6 +61,19 @@ export type IndependentLogFileConfig = {
   maxFileBytes: number;
 };
 
+export type ContextThresholdOverrideMatch = {
+  model?: string;
+  modelContextWindowMin?: number;
+  modelContextWindowMax?: number;
+  sessionPattern?: string;
+};
+
+export type ContextThresholdOverride = {
+  name?: string;
+  match: ContextThresholdOverrideMatch;
+  contextThreshold: number;
+};
+
 export type LcmConfigSource = "env" | "plugin-config" | "default";
 
 export type LcmConfigDiagnostics = {
@@ -82,6 +95,8 @@ export type LcmConfig = {
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
   contextThreshold: number;
+  /** Optional ordered rules that override contextThreshold for matching runtime contexts. */
+  contextThresholdOverrides?: ContextThresholdOverride[];
   freshTailCount: number;
   /** Optional token cap for the protected fresh tail; newest message is always preserved. */
   freshTailMaxTokens?: number;
@@ -360,6 +375,108 @@ function toRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function parseContextThresholdOverrideThreshold(value: unknown, path: string): number {
+  const threshold = toNumber(value);
+  if (
+    threshold === undefined ||
+    !Number.isFinite(threshold) ||
+    threshold < 0 ||
+    threshold > 1
+  ) {
+    throw new Error(`${path}.contextThreshold must be a finite number between 0 and 1`);
+  }
+  return threshold;
+}
+
+function parsePositiveIntegerMatcher(value: unknown, path: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = toNumber(value);
+  if (
+    parsed === undefined ||
+    !Number.isFinite(parsed) ||
+    !Number.isInteger(parsed) ||
+    parsed < 1
+  ) {
+    throw new Error(`${path} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonEmptyStringMatcher(value: unknown, path: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = toStr(value);
+  if (parsed === undefined) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+  return parsed;
+}
+
+function toContextThresholdOverrides(value: unknown): ContextThresholdOverride[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("contextThresholdOverrides must be an array");
+  }
+
+  return value.map((entry, index) => {
+    const path = `contextThresholdOverrides[${index}]`;
+    const record = toRecord(entry);
+    if (!record) {
+      throw new Error(`${path} must be an object`);
+    }
+    const matchRecord = toRecord(record.match);
+    if (!matchRecord) {
+      throw new Error(`${path}.match must be an object`);
+    }
+
+    const model = parseNonEmptyStringMatcher(matchRecord.model, `${path}.match.model`);
+    const sessionPattern = parseNonEmptyStringMatcher(
+      matchRecord.sessionPattern,
+      `${path}.match.sessionPattern`,
+    );
+    const modelContextWindowMin = parsePositiveIntegerMatcher(
+      matchRecord.modelContextWindowMin,
+      `${path}.match.modelContextWindowMin`,
+    );
+    const modelContextWindowMax = parsePositiveIntegerMatcher(
+      matchRecord.modelContextWindowMax,
+      `${path}.match.modelContextWindowMax`,
+    );
+
+    if (
+      model === undefined &&
+      sessionPattern === undefined &&
+      modelContextWindowMin === undefined &&
+      modelContextWindowMax === undefined
+    ) {
+      throw new Error(`${path}.match must include at least one matcher`);
+    }
+    if (
+      modelContextWindowMin !== undefined &&
+      modelContextWindowMax !== undefined &&
+      modelContextWindowMin > modelContextWindowMax
+    ) {
+      throw new Error(`${path}.match.modelContextWindowMin must be <= modelContextWindowMax`);
+    }
+
+    return {
+      ...(toStr(record.name) ? { name: toStr(record.name) } : {}),
+      match: {
+        ...(model ? { model } : {}),
+        ...(modelContextWindowMin !== undefined ? { modelContextWindowMin } : {}),
+        ...(modelContextWindowMax !== undefined ? { modelContextWindowMax } : {}),
+        ...(sessionPattern ? { sessionPattern } : {}),
+      },
+      contextThreshold: parseContextThresholdOverrideThreshold(record.contextThreshold, path),
+    };
+  });
+}
+
 function parseEnvStrArray(value: string | undefined): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -556,6 +673,7 @@ export function resolveLcmConfigWithDiagnostics(
       contextThreshold:
         parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
           ?? toNumber(pc.contextThreshold) ?? 0.75,
+      contextThresholdOverrides: toContextThresholdOverrides(pc.contextThresholdOverrides),
       freshTailCount:
         parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
           ?? toNumber(pc.freshTailCount) ?? 64,

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -61,6 +61,19 @@ export type IndependentLogFileConfig = {
   maxFileBytes: number;
 };
 
+export type ContextThresholdOverrideMatch = {
+  model?: string;
+  modelContextWindowMin?: number;
+  modelContextWindowMax?: number;
+  sessionPattern?: string;
+};
+
+export type ContextThresholdOverride = {
+  name?: string;
+  match: ContextThresholdOverrideMatch;
+  contextThreshold: number;
+};
+
 export type LcmConfigSource = "env" | "plugin-config" | "default";
 
 export type LcmConfigDiagnostics = {
@@ -82,6 +95,8 @@ export type LcmConfig = {
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
   contextThreshold: number;
+  /** Optional ordered rules that override contextThreshold for matching runtime contexts. */
+  contextThresholdOverrides?: ContextThresholdOverride[];
   freshTailCount: number;
   /** Optional token cap for the protected fresh tail; newest message is always preserved. */
   freshTailMaxTokens?: number;
@@ -360,6 +375,94 @@ function toRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function parseContextThresholdOverrideThreshold(value: unknown, path: string): number {
+  const threshold = toNumber(value);
+  if (
+    threshold === undefined ||
+    !Number.isFinite(threshold) ||
+    threshold < 0 ||
+    threshold > 1
+  ) {
+    throw new Error(`${path}.contextThreshold must be a finite number between 0 and 1`);
+  }
+  return threshold;
+}
+
+function parsePositiveIntegerMatcher(value: unknown, path: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = toNumber(value);
+  if (
+    parsed === undefined ||
+    !Number.isFinite(parsed) ||
+    !Number.isInteger(parsed) ||
+    parsed < 1
+  ) {
+    throw new Error(`${path} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function toContextThresholdOverrides(value: unknown): ContextThresholdOverride[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("contextThresholdOverrides must be an array");
+  }
+
+  return value.map((entry, index) => {
+    const path = `contextThresholdOverrides[${index}]`;
+    const record = toRecord(entry);
+    if (!record) {
+      throw new Error(`${path} must be an object`);
+    }
+    const matchRecord = toRecord(record.match);
+    if (!matchRecord) {
+      throw new Error(`${path}.match must be an object`);
+    }
+
+    const model = toStr(matchRecord.model);
+    const sessionPattern = toStr(matchRecord.sessionPattern);
+    const modelContextWindowMin = parsePositiveIntegerMatcher(
+      matchRecord.modelContextWindowMin,
+      `${path}.match.modelContextWindowMin`,
+    );
+    const modelContextWindowMax = parsePositiveIntegerMatcher(
+      matchRecord.modelContextWindowMax,
+      `${path}.match.modelContextWindowMax`,
+    );
+
+    if (
+      model === undefined &&
+      sessionPattern === undefined &&
+      modelContextWindowMin === undefined &&
+      modelContextWindowMax === undefined
+    ) {
+      throw new Error(`${path}.match must include at least one matcher`);
+    }
+    if (
+      modelContextWindowMin !== undefined &&
+      modelContextWindowMax !== undefined &&
+      modelContextWindowMin > modelContextWindowMax
+    ) {
+      throw new Error(`${path}.match.modelContextWindowMin must be <= modelContextWindowMax`);
+    }
+
+    return {
+      ...(toStr(record.name) ? { name: toStr(record.name) } : {}),
+      match: {
+        ...(model ? { model } : {}),
+        ...(modelContextWindowMin !== undefined ? { modelContextWindowMin } : {}),
+        ...(modelContextWindowMax !== undefined ? { modelContextWindowMax } : {}),
+        ...(sessionPattern ? { sessionPattern } : {}),
+      },
+      contextThreshold: parseContextThresholdOverrideThreshold(record.contextThreshold, path),
+    };
+  });
+}
+
 function parseEnvStrArray(value: string | undefined): string[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -556,6 +659,7 @@ export function resolveLcmConfigWithDiagnostics(
       contextThreshold:
         parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
           ?? toNumber(pc.contextThreshold) ?? 0.75,
+      contextThresholdOverrides: toContextThresholdOverrides(pc.contextThresholdOverrides),
       freshTailCount:
         parseFiniteInt(env.LCM_FRESH_TAIL_COUNT)
           ?? toNumber(pc.freshTailCount) ?? 64,

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -404,6 +404,17 @@ function parsePositiveIntegerMatcher(value: unknown, path: string): number | und
   return parsed;
 }
 
+function parseNonEmptyStringMatcher(value: unknown, path: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = toStr(value);
+  if (parsed === undefined) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+  return parsed;
+}
+
 function toContextThresholdOverrides(value: unknown): ContextThresholdOverride[] {
   if (value === undefined) {
     return [];
@@ -423,8 +434,11 @@ function toContextThresholdOverrides(value: unknown): ContextThresholdOverride[]
       throw new Error(`${path}.match must be an object`);
     }
 
-    const model = toStr(matchRecord.model);
-    const sessionPattern = toStr(matchRecord.sessionPattern);
+    const model = parseNonEmptyStringMatcher(matchRecord.model, `${path}.match.model`);
+    const sessionPattern = parseNonEmptyStringMatcher(
+      matchRecord.sessionPattern,
+      `${path}.match.sessionPattern`,
+    );
     const modelContextWindowMin = parsePositiveIntegerMatcher(
       matchRecord.modelContextWindowMin,
       `${path}.match.modelContextWindowMin`,

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -184,6 +184,12 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   const hasNextAttemptAfter = maintenanceColumns.some(
     (col) => col.name === "next_attempt_after",
   );
+  const hasContextThreshold = maintenanceColumns.some(
+    (col) => col.name === "context_threshold",
+  );
+  const hasContextThresholdSource = maintenanceColumns.some(
+    (col) => col.name === "context_threshold_source",
+  );
 
   if (!hasProjectedTokenCount) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
@@ -198,6 +204,12 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   }
   if (!hasNextAttemptAfter) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN next_attempt_after TEXT`);
+  }
+  if (!hasContextThreshold) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN context_threshold REAL`);
+  }
+  if (!hasContextThresholdSource) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN context_threshold_source TEXT`);
   }
 }
 
@@ -1133,6 +1145,8 @@ export function runLcmMigrations(
       current_token_count INTEGER,
       projected_token_count INTEGER,
       raw_tokens_outside_tail INTEGER,
+      context_threshold REAL,
+      context_threshold_source TEXT,
       retry_attempts INTEGER NOT NULL DEFAULT 0,
       next_attempt_after TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -184,6 +184,12 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   const hasNextAttemptAfter = maintenanceColumns.some(
     (col) => col.name === "next_attempt_after",
   );
+  const hasContextThreshold = maintenanceColumns.some(
+    (col) => col.name === "context_threshold",
+  );
+  const hasContextThresholdSource = maintenanceColumns.some(
+    (col) => col.name === "context_threshold_source",
+  );
 
   if (!hasProjectedTokenCount) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
@@ -198,6 +204,12 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   }
   if (!hasNextAttemptAfter) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN next_attempt_after TEXT`);
+  }
+  if (!hasContextThreshold) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN context_threshold REAL`);
+  }
+  if (!hasContextThresholdSource) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN context_threshold_source TEXT`);
   }
 }
 
@@ -1096,6 +1108,8 @@ export function runLcmMigrations(
       current_token_count INTEGER,
       projected_token_count INTEGER,
       raw_tokens_outside_tail INTEGER,
+      context_threshold REAL,
+      context_threshold_source TEXT,
       retry_attempts INTEGER NOT NULL DEFAULT 0,
       next_attempt_after TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -28,7 +28,7 @@ import {
   type AssemblyOverflowDiagnostics,
 } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
-import type { LcmConfig } from "./db/config.js";
+import type { ContextThresholdOverride, LcmConfig } from "./db/config.js";
 import { getLcmDbFeatures } from "./db/features.js";
 import { runLcmMigrations } from "./db/migration.js";
 import {
@@ -49,7 +49,7 @@ import {
 import { describeLogError } from "./lcm-log.js";
 import { describeLcmConfigSource } from "./db/config.js";
 import { RetrievalEngine } from "./retrieval.js";
-import { compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
+import { compileSessionPattern, compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
 import { logStartupBannerOnce } from "./startup-banner-log.js";
 import {
   CompactionTelemetryStore,
@@ -142,6 +142,22 @@ type PromptCacheSnapshot = {
   lastCacheTouchAt?: Date;
   provider?: string;
   model?: string;
+};
+type RuntimeThresholdContext = {
+  provider?: string;
+  model?: string;
+  modelRef?: string;
+  modelContextWindow?: number;
+};
+type ResolvedContextThreshold = {
+  contextThreshold: number;
+  source: "global" | "override";
+  reason: string;
+  ruleIndex?: number;
+  ruleName?: string;
+  specificity: number;
+  modelRef?: string;
+  modelContextWindow?: number;
 };
 type TranscriptRewriteReplacement = {
   entryId: string;
@@ -3810,6 +3826,199 @@ export class LcmContextEngine implements ContextEngine {
     return matchesSessionPattern(trimmedKey, this.statelessSessionPatterns);
   }
 
+  private normalizePositiveInteger(value: unknown): number | undefined {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+      return undefined;
+    }
+    return Math.floor(value);
+  }
+
+  private readRuntimeThresholdContext(params: {
+    tokenBudget: number;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
+  }): RuntimeThresholdContext {
+    const context = asRecord(params.runtimeContext) ?? asRecord(params.legacyParams) ?? {};
+    const provider = safeString(context.provider)?.trim() ?? safeString(context.providerId)?.trim();
+    const model = safeString(context.model)?.trim() ?? safeString(context.modelId)?.trim();
+    const modelRef =
+      model && provider && !model.includes("/")
+        ? `${provider}/${model}`
+        : model;
+    const modelContextWindow =
+      this.normalizePositiveInteger(context.modelContextWindow)
+      ?? this.normalizePositiveInteger(context.modelContextWindowTokens)
+      ?? this.normalizePositiveInteger(context.contextWindow)
+      ?? this.normalizePositiveInteger(context.contextWindowTokens)
+      ?? this.normalizePositiveInteger(context.maxContextTokens)
+      ?? this.normalizePositiveInteger(context.contextWindowMax)
+      ?? params.tokenBudget;
+
+    return {
+      ...(provider ? { provider } : {}),
+      ...(model ? { model } : {}),
+      ...(modelRef ? { modelRef } : {}),
+      modelContextWindow,
+    };
+  }
+
+  private contextThresholdOverrideSpecificity(rule: ContextThresholdOverride): number {
+    let score = 0;
+    if (rule.match.model) {
+      score += 100;
+    }
+    if (rule.match.sessionPattern) {
+      score += 50;
+    }
+    if (rule.match.modelContextWindowMin !== undefined) {
+      score += 20;
+    }
+    if (rule.match.modelContextWindowMax !== undefined) {
+      score += 20;
+    }
+    return score;
+  }
+
+  private contextThresholdOverrideMatches(params: {
+    rule: ContextThresholdOverride;
+    sessionKey?: string;
+    runtime: RuntimeThresholdContext;
+  }): boolean {
+    const { rule, runtime } = params;
+    if (rule.match.model) {
+      const normalizedRuleModel = rule.match.model.trim();
+      const candidates = [runtime.modelRef, runtime.model].filter(
+        (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+      );
+      if (!candidates.includes(normalizedRuleModel)) {
+        return false;
+      }
+    }
+
+    if (rule.match.sessionPattern) {
+      const sessionKey = params.sessionKey?.trim();
+      if (!sessionKey || !compileSessionPattern(rule.match.sessionPattern).test(sessionKey)) {
+        return false;
+      }
+    }
+
+    if (
+      rule.match.modelContextWindowMin !== undefined &&
+      runtime.modelContextWindow !== undefined &&
+      runtime.modelContextWindow < rule.match.modelContextWindowMin
+    ) {
+      return false;
+    }
+    if (
+      rule.match.modelContextWindowMax !== undefined &&
+      runtime.modelContextWindow !== undefined &&
+      runtime.modelContextWindow > rule.match.modelContextWindowMax
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private describeContextThresholdOverrideReason(params: {
+    rule: ContextThresholdOverride;
+    runtime: RuntimeThresholdContext;
+    sessionKey?: string;
+  }): string {
+    const parts: string[] = [];
+    if (params.rule.match.model) {
+      parts.push(`model=${params.rule.match.model}`);
+    }
+    if (params.rule.match.modelContextWindowMin !== undefined) {
+      parts.push(`modelContextWindow>=${params.rule.match.modelContextWindowMin}`);
+    }
+    if (params.rule.match.modelContextWindowMax !== undefined) {
+      parts.push(`modelContextWindow<=${params.rule.match.modelContextWindowMax}`);
+    }
+    if (params.rule.match.sessionPattern) {
+      parts.push(`sessionPattern=${params.rule.match.sessionPattern}`);
+    }
+    if (params.runtime.modelContextWindow !== undefined) {
+      parts.push(`resolvedModelContextWindow=${params.runtime.modelContextWindow}`);
+    }
+    return parts.join(",");
+  }
+
+  private resolveContextThreshold(params: {
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    runtimeContext?: Record<string, unknown>;
+    legacyParams?: Record<string, unknown>;
+  }): ResolvedContextThreshold {
+    const runtime = this.readRuntimeThresholdContext({
+      tokenBudget: params.tokenBudget,
+      runtimeContext: params.runtimeContext,
+      legacyParams: params.legacyParams,
+    });
+    let best:
+      | {
+          rule: ContextThresholdOverride;
+          index: number;
+          specificity: number;
+        }
+      | undefined;
+
+    (this.config.contextThresholdOverrides ?? []).forEach((rule, index) => {
+      if (!this.contextThresholdOverrideMatches({ rule, sessionKey: params.sessionKey, runtime })) {
+        return;
+      }
+      const specificity = this.contextThresholdOverrideSpecificity(rule);
+      if (!best || specificity > best.specificity) {
+        best = { rule, index, specificity };
+      }
+    });
+
+    if (!best) {
+      return {
+        contextThreshold: this.config.contextThreshold,
+        source: "global",
+        reason: "no_override_matched",
+        specificity: 0,
+        ...(runtime.modelRef ? { modelRef: runtime.modelRef } : {}),
+        ...(runtime.modelContextWindow !== undefined
+          ? { modelContextWindow: runtime.modelContextWindow }
+          : {}),
+      };
+    }
+
+    return {
+      contextThreshold: best.rule.contextThreshold,
+      source: "override",
+      ruleIndex: best.index,
+      ...(best.rule.name ? { ruleName: best.rule.name } : {}),
+      reason: this.describeContextThresholdOverrideReason({
+        rule: best.rule,
+        runtime,
+        sessionKey: params.sessionKey,
+      }),
+      specificity: best.specificity,
+      ...(runtime.modelRef ? { modelRef: runtime.modelRef } : {}),
+      ...(runtime.modelContextWindow !== undefined
+        ? { modelContextWindow: runtime.modelContextWindow }
+        : {}),
+    };
+  }
+
+  private logContextThresholdSelection(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    thresholdTokens: number;
+    resolved: ResolvedContextThreshold;
+    phase: string;
+  }): void {
+    this.deps.log.info(
+      `[lcm] threshold: selected phase=${params.phase} conversation=${params.conversationId} session=${params.sessionId} ${params.sessionKey?.trim() ? `sessionKey=${params.sessionKey.trim()} ` : ""}threshold=${params.resolved.contextThreshold} thresholdTokens=${params.thresholdTokens} tokenBudget=${params.tokenBudget} source=${params.resolved.source} ruleIndex=${params.resolved.ruleIndex ?? "none"} ruleName=${params.resolved.ruleName ?? "none"} specificity=${params.resolved.specificity} model=${params.resolved.modelRef ?? "none"} modelContextWindow=${params.resolved.modelContextWindow ?? "none"} reason=${params.resolved.reason.replaceAll(" ", "_")}`,
+    );
+  }
+
   // ── Circuit breaker helpers ──────────────────────────────────────────────
 
   private getCircuitBreakerState(key: string): CircuitBreakerState {
@@ -4514,11 +4723,30 @@ export class LcmContextEngine implements ContextEngine {
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
+        const resolvedContextThreshold = this.resolveContextThreshold({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget: resolvedTokenBudget,
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
+        });
         const thresholdDecision = await this.compaction.evaluate(
           params.conversationId,
           resolvedTokenBudget,
           resolvedCurrentTokenCount,
+          ...(resolvedContextThreshold.source === "override"
+            ? [{ contextThreshold: resolvedContextThreshold.contextThreshold }]
+            : []),
         );
+        this.logContextThresholdSelection({
+          conversationId: params.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget: resolvedTokenBudget,
+          thresholdTokens: thresholdDecision.threshold,
+          resolved: resolvedContextThreshold,
+          phase: "maintain",
+        });
         if (!thresholdDecision.shouldCompact) {
           const result: CompactResult = {
             ok: true,
@@ -4735,10 +4963,25 @@ export class LcmContextEngine implements ContextEngine {
           }
         ).currentTokenCount,
     );
+    const resolvedContextThreshold = this.resolveContextThreshold({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      tokenBudget,
+      runtimeContext: params.runtimeContext,
+      legacyParams,
+    });
     const decision =
       observedTokens !== undefined
-        ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
-        : await this.compaction.evaluate(conversationId, tokenBudget);
+        ? resolvedContextThreshold.source === "override"
+          ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens, {
+              contextThreshold: resolvedContextThreshold.contextThreshold,
+            })
+          : await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
+        : resolvedContextThreshold.source === "override"
+          ? await this.compaction.evaluate(conversationId, tokenBudget, undefined, {
+              contextThreshold: resolvedContextThreshold.contextThreshold,
+            })
+          : await this.compaction.evaluate(conversationId, tokenBudget);
     const targetTokens =
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
     // Codex can report a live prompt count that includes runtime framing,
@@ -4789,6 +5032,16 @@ export class LcmContextEngine implements ContextEngine {
     const liveContextStillExceedsTarget =
       thresholdPressureTokens !== undefined && thresholdPressureTokens >= targetTokens;
 
+    this.logContextThresholdSelection({
+      conversationId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      tokenBudget,
+      thresholdTokens: decision.threshold,
+      resolved: resolvedContextThreshold,
+      phase: "compact",
+    });
+
     this.deps.log.info(
       `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
     );
@@ -4820,6 +5073,9 @@ export class LcmContextEngine implements ContextEngine {
         sweepResult = await this.compaction.compact({
           conversationId,
           tokenBudget,
+          ...(resolvedContextThreshold.source === "override"
+            ? { contextThreshold: resolvedContextThreshold.contextThreshold }
+            : {}),
           summarize,
           force: forceThresholdSweep,
           hardTrigger: false,
@@ -4960,6 +5216,9 @@ export class LcmContextEngine implements ContextEngine {
       compactResult = await this.compaction.compactUntilUnder({
         conversationId,
         tokenBudget,
+        ...(resolvedContextThreshold.source === "override"
+          ? { contextThreshold: resolvedContextThreshold.contextThreshold }
+          : {}),
         targetTokens: convergenceTargetTokens,
         ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
         summarize,
@@ -9349,11 +9608,29 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     try {
+      const resolvedContextThreshold = this.resolveContextThreshold({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget,
+        legacyParams,
+      });
       const thresholdDecision = await this.compaction.evaluate(
         conversation.conversationId,
         tokenBudget,
         observedCurrentTokenCount,
+        ...(resolvedContextThreshold.source === "override"
+          ? [{ contextThreshold: resolvedContextThreshold.contextThreshold }]
+          : []),
       );
+      this.logContextThresholdSelection({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget,
+        thresholdTokens: thresholdDecision.threshold,
+        resolved: resolvedContextThreshold,
+        phase: "afterTurn",
+      });
       const thresholdDiagnostics = {
         projectedTokenCount: thresholdDecision.projectedTokens,
         rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -9708,6 +9708,7 @@ export class LcmContextEngine implements ContextEngine {
             tokenBudget,
             currentTokenCount: observedCurrentTokenCount,
             compactionTarget: "threshold",
+            contextThresholdOverride: resolvedContextThreshold,
             legacyParams,
           });
           if (!compactResult.ok) {
@@ -10337,6 +10338,7 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget?: number;
     currentTokenCount?: number;
     compactionTarget?: "budget" | "threshold";
+    contextThresholdOverride?: ResolvedContextThreshold;
     customInstructions?: string;
     /** OpenClaw runtime param name (preferred). */
     runtimeContext?: Record<string, unknown>;
@@ -10390,6 +10392,7 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget: params.tokenBudget,
           currentTokenCount: params.currentTokenCount,
           compactionTarget: params.compactionTarget,
+          contextThresholdOverride: params.contextThresholdOverride,
           customInstructions: params.customInstructions,
           runtimeContext: params.runtimeContext,
           legacyParams: params.legacyParams,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -9612,6 +9612,7 @@ export class LcmContextEngine implements ContextEngine {
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         tokenBudget,
+        runtimeContext: params.runtimeContext,
         legacyParams,
       });
       const thresholdDecision = await this.compaction.evaluate(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -191,6 +191,7 @@ type CompactionExecutionParams = {
   tokenBudget?: number;
   currentTokenCount?: number;
   compactionTarget?: "budget" | "threshold";
+  contextThresholdOverride?: ResolvedContextThreshold;
   customInstructions?: string;
   /** OpenClaw runtime param name (preferred). */
   runtimeContext?: Record<string, unknown>;
@@ -4740,16 +4741,16 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
         maintenance.projectedTokenCount ?? undefined,
       );
+      const resolvedContextThreshold = this.resolveContextThreshold({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget: resolvedTokenBudget,
+        runtimeContext: params.runtimeContext,
+        legacyParams: params.legacyParams,
+      });
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
-        const resolvedContextThreshold = this.resolveContextThreshold({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          tokenBudget: resolvedTokenBudget,
-          runtimeContext: params.runtimeContext,
-          legacyParams: params.legacyParams,
-        });
         const thresholdDecision = await this.compaction.evaluate(
           params.conversationId,
           resolvedTokenBudget,
@@ -4798,6 +4799,7 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget: resolvedTokenBudget,
         currentTokenCount: resolvedCurrentTokenCount,
         compactionTarget: "threshold",
+        contextThresholdOverride: resolvedContextThreshold,
         runtimeContext: params.runtimeContext,
         legacyParams: params.legacyParams,
       });
@@ -4983,13 +4985,15 @@ export class LcmContextEngine implements ContextEngine {
           }
         ).currentTokenCount,
     );
-    const resolvedContextThreshold = this.resolveContextThreshold({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      tokenBudget,
-      runtimeContext: params.runtimeContext,
-      legacyParams,
-    });
+    const resolvedContextThreshold =
+      params.contextThresholdOverride
+      ?? this.resolveContextThreshold({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget,
+        runtimeContext: params.runtimeContext,
+        legacyParams,
+      });
     const decision =
       observedTokens !== undefined
         ? resolvedContextThreshold.source === "override"

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -19,7 +19,14 @@ import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import { BatchDeduplicator } from "./batch-dedup.js";
 import { CompactionGuards } from "./compaction-guards.js";
 import { CompactionTelemetryRecorder } from "./compaction-telemetry.js";
+import {
+  ContextThresholdResolver,
+  describeResolvedContextThreshold,
+  persistedContextThresholdOverride,
+  type ResolvedContextThreshold,
+} from "./context-threshold.js";
 import { LargeFileInterceptor } from "./large-file-interceptor.js";
+import { readRuntimeModelContext } from "./runtime-model.js";
 import type { LcmConfig } from "./db/config.js";
 import { getLcmDbFeatures } from "./db/features.js";
 import { runLcmMigrations } from "./db/migration.js";
@@ -91,6 +98,8 @@ type CompactionExecutionParams = {
   tokenBudget?: number;
   currentTokenCount?: number;
   compactionTarget?: "budget" | "threshold";
+  /** Caller-resolved threshold; skips re-resolving from runtime metadata. */
+  contextThresholdOverride?: ResolvedContextThreshold;
   customInstructions?: string;
   /** OpenClaw runtime param name (preferred). */
   runtimeContext?: Record<string, unknown>;
@@ -264,6 +273,9 @@ export class LcmContextEngine implements ContextEngine {
   // ── Compaction telemetry + deferred-debt recording ───────────────────────
   private readonly telemetryRecorder: CompactionTelemetryRecorder;
 
+  // ── Scoped context-threshold override resolution ─────────────────────────
+  private readonly contextThresholdResolver: ContextThresholdResolver;
+
   // ── Managed session-file rotation ────────────────────────────────────────
   private readonly sessionRotation: SessionRotationService;
 
@@ -366,6 +378,10 @@ export class LcmContextEngine implements ContextEngine {
       this.compactionTelemetryStore,
       this.compactionMaintenanceStore,
       this.deps,
+    );
+    this.contextThresholdResolver = new ContextThresholdResolver(
+      this.config.contextThreshold,
+      this.config.contextThresholdOverrides,
     );
 
     if (!this.fts5Available) {
@@ -779,6 +795,18 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
         maintenance.projectedTokenCount ?? undefined,
       );
+      // Prefer the threshold persisted with the debt row: a background drain
+      // may lack the runtime model metadata that originally selected it, and
+      // re-resolving could silently flip the compaction decision.
+      const resolvedContextThreshold =
+        persistedContextThresholdOverride(maintenance)
+        ?? this.contextThresholdResolver.resolve({
+          sessionKey: params.sessionKey,
+          runtime: readRuntimeModelContext(
+            asRecord(params.runtimeContext),
+            asRecord(params.legacyParams),
+          ),
+        });
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
@@ -786,7 +814,17 @@ export class LcmContextEngine implements ContextEngine {
           params.conversationId,
           resolvedTokenBudget,
           resolvedCurrentTokenCount,
+          { contextThreshold: resolvedContextThreshold.contextThreshold },
         );
+        this.logContextThresholdSelection({
+          conversationId: params.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget: resolvedTokenBudget,
+          thresholdTokens: thresholdDecision.threshold,
+          resolved: resolvedContextThreshold,
+          phase: "maintain",
+        });
         if (!thresholdDecision.shouldCompact) {
           const result: CompactResult = {
             ok: true,
@@ -818,6 +856,7 @@ export class LcmContextEngine implements ContextEngine {
         tokenBudget: resolvedTokenBudget,
         currentTokenCount: resolvedCurrentTokenCount,
         compactionTarget: "threshold",
+        contextThresholdOverride: resolvedContextThreshold,
         runtimeContext: params.runtimeContext,
         legacyParams: params.legacyParams,
       });
@@ -937,6 +976,21 @@ export class LcmContextEngine implements ContextEngine {
     return drainResult;
   }
 
+  /** Log which context threshold was selected for a compaction decision. */
+  private logContextThresholdSelection(params: {
+    conversationId: number;
+    sessionId: string;
+    sessionKey?: string;
+    tokenBudget: number;
+    thresholdTokens: number;
+    resolved: ResolvedContextThreshold;
+    phase: string;
+  }): void {
+    this.deps.log.info(
+      `[lcm] threshold: selected phase=${params.phase} conversation=${params.conversationId} session=${params.sessionId} ${params.sessionKey?.trim() ? `sessionKey=${params.sessionKey.trim()} ` : ""}thresholdTokens=${params.thresholdTokens} tokenBudget=${params.tokenBudget} ${describeResolvedContextThreshold(params.resolved)}`,
+    );
+  }
+
   /** Run the actual compaction body without taking the per-session queue. */
   private async executeCompactionCore(params: CompactionExecutionParams): Promise<CompactResult> {
     const startedAt = Date.now();
@@ -1005,10 +1059,18 @@ export class LcmContextEngine implements ContextEngine {
           }
         ).currentTokenCount,
     );
-    const decision =
-      observedTokens !== undefined
-        ? await this.compaction.evaluate(conversationId, tokenBudget, observedTokens)
-        : await this.compaction.evaluate(conversationId, tokenBudget);
+    // The resolved threshold is passed unconditionally: when no override rule
+    // matches, the resolved value equals the global config.contextThreshold,
+    // so the call is behavior-identical to omitting it.
+    const resolvedContextThreshold =
+      params.contextThresholdOverride
+      ?? this.contextThresholdResolver.resolve({
+        sessionKey: params.sessionKey,
+        runtime: readRuntimeModelContext(asRecord(params.runtimeContext), asRecord(params.legacyParams)),
+      });
+    const decision = await this.compaction.evaluate(conversationId, tokenBudget, observedTokens, {
+      contextThreshold: resolvedContextThreshold.contextThreshold,
+    });
     const targetTokens =
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
     // Codex can report a live prompt count that includes runtime framing,
@@ -1058,6 +1120,16 @@ export class LcmContextEngine implements ContextEngine {
         : observedTokens;
     const liveContextStillExceedsTarget =
       thresholdPressureTokens !== undefined && thresholdPressureTokens >= targetTokens;
+
+    this.logContextThresholdSelection({
+      conversationId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      tokenBudget,
+      thresholdTokens: decision.threshold,
+      resolved: resolvedContextThreshold,
+      phase: "compact",
+    });
 
     this.deps.log.info(
       `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
@@ -1113,6 +1185,7 @@ export class LcmContextEngine implements ContextEngine {
         this.compaction.compact({
           conversationId,
           tokenBudget,
+          contextThreshold: resolvedContextThreshold.contextThreshold,
           summarize,
           force: forceThresholdSweep,
           hardTrigger: false,
@@ -1323,6 +1396,7 @@ export class LcmContextEngine implements ContextEngine {
       compactResult = await this.compaction.compactUntilUnder({
         conversationId,
         tokenBudget,
+        contextThreshold: resolvedContextThreshold.contextThreshold,
         targetTokens: convergenceTargetTokens,
         ...(effectiveCurrentTokens !== undefined ? { currentTokens: effectiveCurrentTokens } : {}),
         summarize,
@@ -2939,7 +3013,11 @@ export class LcmContextEngine implements ContextEngine {
     };
     const recordAfterTurnCompactionRetry = async (
       reason: string,
-      diagnostics?: { projectedTokenCount?: number; rawTokensOutsideTail?: number },
+      diagnostics?: {
+        projectedTokenCount?: number;
+        rawTokensOutsideTail?: number;
+        contextThreshold?: ResolvedContextThreshold;
+      },
     ): Promise<void> => {
       try {
         await this.telemetryRecorder.recordDeferredCompactionDebt({
@@ -2949,6 +3027,7 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
           projectedTokenCount: diagnostics?.projectedTokenCount,
           rawTokensOutsideTail: diagnostics?.rawTokensOutsideTail,
+          contextThreshold: diagnostics?.contextThreshold,
         });
       } catch (err) {
         this.deps.log.warn(
@@ -2980,14 +3059,32 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     try {
+      const resolvedContextThreshold = this.contextThresholdResolver.resolve({
+        sessionKey: params.sessionKey,
+        runtime: readRuntimeModelContext(
+          asRecord(params.runtimeContext),
+          asRecord(params.legacyCompactionParams),
+        ),
+      });
       const thresholdDecision = await this.compaction.evaluate(
         conversation.conversationId,
         tokenBudget,
         observedCurrentTokenCount,
+        { contextThreshold: resolvedContextThreshold.contextThreshold },
       );
+      this.logContextThresholdSelection({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget,
+        thresholdTokens: thresholdDecision.threshold,
+        resolved: resolvedContextThreshold,
+        phase: "afterTurn",
+      });
       const thresholdDiagnostics = {
         projectedTokenCount: thresholdDecision.projectedTokens,
         rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+        contextThreshold: resolvedContextThreshold,
       };
       if (this.config.proactiveThresholdCompactionMode === "inline") {
         if (thresholdDecision.shouldCompact) {
@@ -2998,6 +3095,7 @@ export class LcmContextEngine implements ContextEngine {
             tokenBudget,
             currentTokenCount: observedCurrentTokenCount,
             compactionTarget: "threshold",
+            contextThresholdOverride: resolvedContextThreshold,
             legacyParams,
           });
           if (!compactResult.ok) {
@@ -3013,6 +3111,7 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
           projectedTokenCount: thresholdDecision.projectedTokens,
           rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+          contextThreshold: resolvedContextThreshold,
         });
         deferredCompactionDrain = {
           tokenBudget,
@@ -3732,6 +3831,8 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget?: number;
     currentTokenCount?: number;
     compactionTarget?: "budget" | "threshold";
+    /** Caller-resolved threshold; skips re-resolving from runtime metadata. */
+    contextThresholdOverride?: ResolvedContextThreshold;
     customInstructions?: string;
     /** OpenClaw runtime param name (preferred). */
     runtimeContext?: Record<string, unknown>;
@@ -3785,6 +3886,7 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget: params.tokenBudget,
           currentTokenCount: params.currentTokenCount,
           compactionTarget: params.compactionTarget,
+          contextThresholdOverride: params.contextThresholdOverride,
           customInstructions: params.customInstructions,
           runtimeContext: params.runtimeContext,
           legacyParams: params.legacyParams,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -986,7 +986,7 @@ export class LcmContextEngine implements ContextEngine {
     resolved: ResolvedContextThreshold;
     phase: string;
   }): void {
-    this.deps.log.info(
+    this.deps.log.debug(
       `[lcm] threshold: selected phase=${params.phase} conversation=${params.conversationId} session=${params.sessionId} ${params.sessionKey?.trim() ? `sessionKey=${params.sessionKey.trim()} ` : ""}thresholdTokens=${params.thresholdTokens} tokenBudget=${params.tokenBudget} ${describeResolvedContextThreshold(params.resolved)}`,
     );
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3851,8 +3851,7 @@ export class LcmContextEngine implements ContextEngine {
       ?? this.normalizePositiveInteger(context.contextWindow)
       ?? this.normalizePositiveInteger(context.contextWindowTokens)
       ?? this.normalizePositiveInteger(context.maxContextTokens)
-      ?? this.normalizePositiveInteger(context.contextWindowMax)
-      ?? params.tokenBudget;
+      ?? this.normalizePositiveInteger(context.contextWindowMax);
 
     return {
       ...(provider ? { provider } : {}),
@@ -3903,18 +3902,24 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     if (
-      rule.match.modelContextWindowMin !== undefined &&
-      runtime.modelContextWindow !== undefined &&
-      runtime.modelContextWindow < rule.match.modelContextWindowMin
+      rule.match.modelContextWindowMin !== undefined ||
+      rule.match.modelContextWindowMax !== undefined
     ) {
-      return false;
-    }
-    if (
-      rule.match.modelContextWindowMax !== undefined &&
-      runtime.modelContextWindow !== undefined &&
-      runtime.modelContextWindow > rule.match.modelContextWindowMax
-    ) {
-      return false;
+      if (runtime.modelContextWindow === undefined) {
+        return false;
+      }
+      if (
+        rule.match.modelContextWindowMin !== undefined &&
+        runtime.modelContextWindow < rule.match.modelContextWindowMin
+      ) {
+        return false;
+      }
+      if (
+        rule.match.modelContextWindowMax !== undefined &&
+        runtime.modelContextWindow > rule.match.modelContextWindowMax
+      ) {
+        return false;
+      }
     }
 
     return true;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -159,6 +159,23 @@ type ResolvedContextThreshold = {
   modelRef?: string;
   modelContextWindow?: number;
 };
+
+function persistedContextThresholdOverride(
+  maintenance: ConversationCompactionMaintenanceRecord,
+): ResolvedContextThreshold | undefined {
+  if (
+    typeof maintenance.contextThreshold !== "number" ||
+    !Number.isFinite(maintenance.contextThreshold)
+  ) {
+    return undefined;
+  }
+  return {
+    contextThreshold: maintenance.contextThreshold,
+    source: maintenance.contextThresholdSource === "override" ? "override" : "global",
+    specificity: 0,
+    reason: "persisted deferred threshold debt",
+  };
+}
 type TranscriptRewriteReplacement = {
   entryId: string;
   message: AgentMessage;
@@ -4575,6 +4592,7 @@ export class LcmContextEngine implements ContextEngine {
     currentTokenCount?: number;
     projectedTokenCount?: number;
     rawTokensOutsideTail?: number;
+    contextThreshold?: ResolvedContextThreshold;
   }): Promise<void> {
     await this.compactionMaintenanceStore.requestProactiveCompactionDebt({
       conversationId: params.conversationId,
@@ -4583,6 +4601,8 @@ export class LcmContextEngine implements ContextEngine {
       currentTokenCount: params.currentTokenCount ?? null,
       projectedTokenCount: params.projectedTokenCount ?? null,
       rawTokensOutsideTail: params.rawTokensOutsideTail ?? null,
+      contextThreshold: params.contextThreshold?.contextThreshold ?? null,
+      contextThresholdSource: params.contextThreshold?.source ?? null,
     });
     this.deps.log.debug(
       `[lcm] deferred compaction debt recorded: conversation=${params.conversationId} reason=${params.reason} tokenBudget=${params.tokenBudget} currentTokenCount=${params.currentTokenCount ?? "null"} projectedTokenCount=${params.projectedTokenCount ?? "null"} rawTokensOutsideTail=${params.rawTokensOutsideTail ?? "null"}`,
@@ -4741,13 +4761,15 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
         maintenance.projectedTokenCount ?? undefined,
       );
-      const resolvedContextThreshold = this.resolveContextThreshold({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        tokenBudget: resolvedTokenBudget,
-        runtimeContext: params.runtimeContext,
-        legacyParams: params.legacyParams,
-      });
+      const resolvedContextThreshold =
+        persistedContextThresholdOverride(maintenance)
+        ?? this.resolveContextThreshold({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget: resolvedTokenBudget,
+          runtimeContext: params.runtimeContext,
+          legacyParams: params.legacyParams,
+        });
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
@@ -9597,7 +9619,11 @@ export class LcmContextEngine implements ContextEngine {
     };
     const recordAfterTurnCompactionRetry = async (
       reason: string,
-      diagnostics?: { projectedTokenCount?: number; rawTokensOutsideTail?: number },
+      diagnostics?: {
+        projectedTokenCount?: number;
+        rawTokensOutsideTail?: number;
+        contextThreshold?: ResolvedContextThreshold;
+      },
     ): Promise<void> => {
       try {
         await this.recordDeferredCompactionDebt({
@@ -9607,6 +9633,7 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
           projectedTokenCount: diagnostics?.projectedTokenCount,
           rawTokensOutsideTail: diagnostics?.rawTokensOutsideTail,
+          contextThreshold: diagnostics?.contextThreshold,
         });
       } catch (err) {
         this.deps.log.warn(
@@ -9670,6 +9697,7 @@ export class LcmContextEngine implements ContextEngine {
       const thresholdDiagnostics = {
         projectedTokenCount: thresholdDecision.projectedTokens,
         rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+        contextThreshold: resolvedContextThreshold,
       };
       if (this.config.proactiveThresholdCompactionMode === "inline") {
         if (thresholdDecision.shouldCompact) {
@@ -9695,6 +9723,7 @@ export class LcmContextEngine implements ContextEngine {
           currentTokenCount: observedCurrentTokenCount,
           projectedTokenCount: thresholdDecision.projectedTokens,
           rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+          contextThreshold: resolvedContextThreshold,
         });
         deferredCompactionDrain = {
           tokenBudget,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4751,14 +4751,19 @@ export class LcmContextEngine implements ContextEngine {
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {
-        const thresholdDecision = await this.compaction.evaluate(
-          params.conversationId,
-          resolvedTokenBudget,
-          resolvedCurrentTokenCount,
-          ...(resolvedContextThreshold.source === "override"
-            ? [{ contextThreshold: resolvedContextThreshold.contextThreshold }]
-            : []),
-        );
+        const thresholdDecision =
+          resolvedContextThreshold.source === "override"
+            ? await this.compaction.evaluate(
+                params.conversationId,
+                resolvedTokenBudget,
+                resolvedCurrentTokenCount,
+                { contextThreshold: resolvedContextThreshold.contextThreshold },
+              )
+            : await this.compaction.evaluate(
+                params.conversationId,
+                resolvedTokenBudget,
+                resolvedCurrentTokenCount,
+              );
         this.logContextThresholdSelection({
           conversationId: params.conversationId,
           sessionId: params.sessionId,
@@ -9640,14 +9645,19 @@ export class LcmContextEngine implements ContextEngine {
         runtimeContext: params.runtimeContext,
         legacyParams: legacyCompactionParams,
       });
-      const thresholdDecision = await this.compaction.evaluate(
-        conversation.conversationId,
-        tokenBudget,
-        observedCurrentTokenCount,
-        ...(resolvedContextThreshold.source === "override"
-          ? [{ contextThreshold: resolvedContextThreshold.contextThreshold }]
-          : []),
-      );
+      const thresholdDecision =
+        resolvedContextThreshold.source === "override"
+          ? await this.compaction.evaluate(
+              conversation.conversationId,
+              tokenBudget,
+              observedCurrentTokenCount,
+              { contextThreshold: resolvedContextThreshold.contextThreshold },
+            )
+          : await this.compaction.evaluate(
+              conversation.conversationId,
+              tokenBudget,
+              observedCurrentTokenCount,
+            );
       this.logContextThresholdSelection({
         conversationId: conversation.conversationId,
         sessionId: params.sessionId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3838,20 +3838,35 @@ export class LcmContextEngine implements ContextEngine {
     runtimeContext?: Record<string, unknown>;
     legacyParams?: Record<string, unknown>;
   }): RuntimeThresholdContext {
-    const context = asRecord(params.runtimeContext) ?? asRecord(params.legacyParams) ?? {};
-    const provider = safeString(context.provider)?.trim() ?? safeString(context.providerId)?.trim();
-    const model = safeString(context.model)?.trim() ?? safeString(context.modelId)?.trim();
+    const runtimeContext = asRecord(params.runtimeContext) ?? {};
+    const legacyParams = asRecord(params.legacyParams) ?? {};
+    const provider =
+      safeString(runtimeContext.provider)?.trim()
+      ?? safeString(runtimeContext.providerId)?.trim()
+      ?? safeString(legacyParams.provider)?.trim()
+      ?? safeString(legacyParams.providerId)?.trim();
+    const model =
+      safeString(runtimeContext.model)?.trim()
+      ?? safeString(runtimeContext.modelId)?.trim()
+      ?? safeString(legacyParams.model)?.trim()
+      ?? safeString(legacyParams.modelId)?.trim();
     const modelRef =
       model && provider && !model.includes("/")
         ? `${provider}/${model}`
         : model;
     const modelContextWindow =
-      this.normalizePositiveInteger(context.modelContextWindow)
-      ?? this.normalizePositiveInteger(context.modelContextWindowTokens)
-      ?? this.normalizePositiveInteger(context.contextWindow)
-      ?? this.normalizePositiveInteger(context.contextWindowTokens)
-      ?? this.normalizePositiveInteger(context.maxContextTokens)
-      ?? this.normalizePositiveInteger(context.contextWindowMax);
+      this.normalizePositiveInteger(runtimeContext.modelContextWindow)
+      ?? this.normalizePositiveInteger(runtimeContext.modelContextWindowTokens)
+      ?? this.normalizePositiveInteger(runtimeContext.contextWindow)
+      ?? this.normalizePositiveInteger(runtimeContext.contextWindowTokens)
+      ?? this.normalizePositiveInteger(runtimeContext.maxContextTokens)
+      ?? this.normalizePositiveInteger(runtimeContext.contextWindowMax)
+      ?? this.normalizePositiveInteger(legacyParams.modelContextWindow)
+      ?? this.normalizePositiveInteger(legacyParams.modelContextWindowTokens)
+      ?? this.normalizePositiveInteger(legacyParams.contextWindow)
+      ?? this.normalizePositiveInteger(legacyParams.contextWindowTokens)
+      ?? this.normalizePositiveInteger(legacyParams.maxContextTokens)
+      ?? this.normalizePositiveInteger(legacyParams.contextWindowMax);
 
     return {
       ...(provider ? { provider } : {}),
@@ -9516,7 +9531,8 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    const legacyParams = asRecord(params.runtimeContext) ?? asRecord(params.legacyCompactionParams);
+    const legacyCompactionParams = asRecord(params.legacyCompactionParams);
+    const legacyParams = asRecord(params.runtimeContext) ?? legacyCompactionParams;
     const DEFAULT_AFTER_TURN_TOKEN_BUDGET = 128_000;
     const resolvedTokenBudget = this.resolveTokenBudget({
       tokenBudget: params.tokenBudget,
@@ -9618,7 +9634,7 @@ export class LcmContextEngine implements ContextEngine {
         sessionKey: params.sessionKey,
         tokenBudget,
         runtimeContext: params.runtimeContext,
-        legacyParams,
+        legacyParams: legacyCompactionParams,
       });
       const thresholdDecision = await this.compaction.evaluate(
         conversation.conversationId,

--- a/src/runtime-model.ts
+++ b/src/runtime-model.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared extraction of runtime model metadata (provider, model id, and model
+ * context-window size) from the untyped runtime-context / legacy-param bags
+ * that hosts pass into the engine.
+ */
+import { safeString } from "./value-utils.js";
+
+export type RuntimeModelContext = {
+  provider?: string;
+  model?: string;
+  /** `provider/model` when the host reports a bare model id plus a provider. */
+  modelRef?: string;
+  modelContextWindow?: number;
+};
+
+// Hosts disagree on the key that carries the model context-window size;
+// probe the known spellings in preference order.
+const MODEL_CONTEXT_WINDOW_KEYS = [
+  "modelContextWindow",
+  "modelContextWindowTokens",
+  "contextWindow",
+  "contextWindowTokens",
+  "maxContextTokens",
+  "contextWindowMax",
+];
+
+const PROVIDER_KEYS = ["provider", "providerId"];
+const MODEL_KEYS = ["model", "modelId"];
+
+// Normalize a candidate context-window value to a positive integer.
+function toPositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+// First non-empty string among the given keys, scanning bags in order.
+function firstString(bags: Record<string, unknown>[], keys: string[]): string | undefined {
+  for (const bag of bags) {
+    for (const key of keys) {
+      const value = safeString(bag[key])?.trim();
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+// First valid context-window value among the known keys, scanning bags in order.
+function firstContextWindow(bags: Record<string, unknown>[]): number | undefined {
+  for (const bag of bags) {
+    for (const key of MODEL_CONTEXT_WINDOW_KEYS) {
+      const value = toPositiveInteger(bag[key]);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract provider/model/context-window metadata from host param bags.
+ * Earlier bags win, so callers pass the preferred bag first
+ * (e.g. runtimeContext before legacy compaction params).
+ */
+export function readRuntimeModelContext(
+  ...bags: Array<Record<string, unknown> | undefined>
+): RuntimeModelContext {
+  const present = bags.filter((bag): bag is Record<string, unknown> => bag !== undefined);
+  const provider = firstString(present, PROVIDER_KEYS);
+  const model = firstString(present, MODEL_KEYS);
+  const modelRef =
+    model && provider && !model.includes("/") ? `${provider}/${model}` : model;
+  const modelContextWindow = firstContextWindow(present);
+
+  return {
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    ...(modelRef ? { modelRef } : {}),
+    ...(modelContextWindow !== undefined ? { modelContextWindow } : {}),
+  };
+}

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -15,6 +15,8 @@ export type ConversationCompactionMaintenanceRecord = {
   currentTokenCount: number | null;
   projectedTokenCount: number | null;
   rawTokensOutsideTail: number | null;
+  contextThreshold: number | null;
+  contextThresholdSource: "global" | "override" | null;
   retryAttempts: number;
   nextAttemptAfter: Date | null;
   updatedAt: Date;
@@ -33,6 +35,8 @@ type ConversationCompactionMaintenanceRow = {
   current_token_count: number | null;
   projected_token_count: number | null;
   raw_tokens_outside_tail: number | null;
+  context_threshold: number | null;
+  context_threshold_source: string | null;
   retry_attempts: number;
   next_attempt_after: string | null;
   updated_at: string;
@@ -72,6 +76,14 @@ function toMaintenanceRecord(
     currentTokenCount: row.current_token_count,
     projectedTokenCount: row.projected_token_count,
     rawTokensOutsideTail: row.raw_tokens_outside_tail,
+    contextThreshold:
+      typeof row.context_threshold === "number" && Number.isFinite(row.context_threshold)
+        ? row.context_threshold
+        : null,
+    contextThresholdSource:
+      row.context_threshold_source === "override" || row.context_threshold_source === "global"
+        ? row.context_threshold_source
+        : null,
     retryAttempts:
       typeof row.retry_attempts === "number" && Number.isFinite(row.retry_attempts)
         ? Math.max(0, Math.floor(row.retry_attempts))
@@ -111,6 +123,14 @@ function mergeMaintenanceRecord(
       patch.rawTokensOutsideTail !== undefined
         ? patch.rawTokensOutsideTail
         : existing?.rawTokensOutsideTail ?? null,
+    contextThreshold:
+      patch.contextThreshold !== undefined
+        ? patch.contextThreshold
+        : existing?.contextThreshold ?? null,
+    contextThresholdSource:
+      patch.contextThresholdSource !== undefined
+        ? patch.contextThresholdSource
+        : existing?.contextThresholdSource ?? null,
     retryAttempts:
       patch.retryAttempts !== undefined
         ? Math.max(0, Math.floor(patch.retryAttempts))
@@ -157,6 +177,8 @@ export class CompactionMaintenanceStore {
            current_token_count,
            projected_token_count,
            raw_tokens_outside_tail,
+           context_threshold,
+           context_threshold_source,
            retry_attempts,
            next_attempt_after,
            updated_at
@@ -185,10 +207,12 @@ export class CompactionMaintenanceStore {
            current_token_count,
            projected_token_count,
            raw_tokens_outside_tail,
+           context_threshold,
+           context_threshold_source,
            retry_attempts,
            next_attempt_after,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -201,6 +225,8 @@ export class CompactionMaintenanceStore {
            current_token_count = excluded.current_token_count,
            projected_token_count = excluded.projected_token_count,
            raw_tokens_outside_tail = excluded.raw_tokens_outside_tail,
+           context_threshold = excluded.context_threshold,
+           context_threshold_source = excluded.context_threshold_source,
            retry_attempts = excluded.retry_attempts,
            next_attempt_after = excluded.next_attempt_after,
            updated_at = datetime('now')`,
@@ -218,6 +244,8 @@ export class CompactionMaintenanceStore {
         record.currentTokenCount ?? null,
         record.projectedTokenCount ?? null,
         record.rawTokensOutsideTail ?? null,
+        record.contextThreshold ?? null,
+        record.contextThresholdSource ?? null,
         record.retryAttempts,
         record.nextAttemptAfter?.toISOString() ?? null,
       );
@@ -232,6 +260,8 @@ export class CompactionMaintenanceStore {
     currentTokenCount?: number | null;
     projectedTokenCount?: number | null;
     rawTokensOutsideTail?: number | null;
+    contextThreshold?: number | null;
+    contextThresholdSource?: "global" | "override" | null;
   }): Promise<void> {
     const existing = await this.getConversationCompactionMaintenance(input.conversationId);
     await this.saveConversationCompactionMaintenance(
@@ -244,6 +274,12 @@ export class CompactionMaintenanceStore {
         currentTokenCount: input.currentTokenCount ?? existing?.currentTokenCount ?? null,
         projectedTokenCount: input.projectedTokenCount ?? existing?.projectedTokenCount ?? null,
         rawTokensOutsideTail: input.rawTokensOutsideTail ?? existing?.rawTokensOutsideTail ?? null,
+        // Unlike the token diagnostics above, the persisted threshold is NOT
+        // carried over from the previous row: a stale threshold must not
+        // outlive the debt that resolved it, so new debt without a threshold
+        // resets both columns to null.
+        contextThreshold: input.contextThreshold ?? null,
+        contextThresholdSource: input.contextThresholdSource ?? null,
       }),
     );
   }

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -292,9 +292,8 @@ export class CompactionMaintenanceStore {
         currentTokenCount: input.currentTokenCount ?? existing?.currentTokenCount ?? null,
         projectedTokenCount: input.projectedTokenCount ?? existing?.projectedTokenCount ?? null,
         rawTokensOutsideTail: input.rawTokensOutsideTail ?? existing?.rawTokensOutsideTail ?? null,
-        contextThreshold: input.contextThreshold ?? existing?.contextThreshold ?? null,
-        contextThresholdSource:
-          input.contextThresholdSource ?? existing?.contextThresholdSource ?? null,
+        contextThreshold: input.contextThreshold ?? null,
+        contextThresholdSource: input.contextThresholdSource ?? null,
       }),
     );
   }

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -15,6 +15,8 @@ export type ConversationCompactionMaintenanceRecord = {
   currentTokenCount: number | null;
   projectedTokenCount: number | null;
   rawTokensOutsideTail: number | null;
+  contextThreshold: number | null;
+  contextThresholdSource: "global" | "override" | null;
   retryAttempts: number;
   nextAttemptAfter: Date | null;
   updatedAt: Date;
@@ -33,6 +35,8 @@ type ConversationCompactionMaintenanceRow = {
   current_token_count: number | null;
   projected_token_count: number | null;
   raw_tokens_outside_tail: number | null;
+  context_threshold: number | null;
+  context_threshold_source: string | null;
   retry_attempts: number;
   next_attempt_after: string | null;
   updated_at: string;
@@ -72,6 +76,14 @@ function toMaintenanceRecord(
     currentTokenCount: row.current_token_count,
     projectedTokenCount: row.projected_token_count,
     rawTokensOutsideTail: row.raw_tokens_outside_tail,
+    contextThreshold:
+      typeof row.context_threshold === "number" && Number.isFinite(row.context_threshold)
+        ? row.context_threshold
+        : null,
+    contextThresholdSource:
+      row.context_threshold_source === "override" || row.context_threshold_source === "global"
+        ? row.context_threshold_source
+        : null,
     retryAttempts:
       typeof row.retry_attempts === "number" && Number.isFinite(row.retry_attempts)
         ? Math.max(0, Math.floor(row.retry_attempts))
@@ -111,6 +123,14 @@ function mergeMaintenanceRecord(
       patch.rawTokensOutsideTail !== undefined
         ? patch.rawTokensOutsideTail
         : existing?.rawTokensOutsideTail ?? null,
+    contextThreshold:
+      patch.contextThreshold !== undefined
+        ? patch.contextThreshold
+        : existing?.contextThreshold ?? null,
+    contextThresholdSource:
+      patch.contextThresholdSource !== undefined
+        ? patch.contextThresholdSource
+        : existing?.contextThresholdSource ?? null,
     retryAttempts:
       patch.retryAttempts !== undefined
         ? Math.max(0, Math.floor(patch.retryAttempts))
@@ -157,6 +177,8 @@ export class CompactionMaintenanceStore {
            current_token_count,
            projected_token_count,
            raw_tokens_outside_tail,
+           context_threshold,
+           context_threshold_source,
            retry_attempts,
            next_attempt_after,
            updated_at
@@ -185,10 +207,12 @@ export class CompactionMaintenanceStore {
            current_token_count,
            projected_token_count,
            raw_tokens_outside_tail,
+           context_threshold,
+           context_threshold_source,
            retry_attempts,
            next_attempt_after,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -201,6 +225,8 @@ export class CompactionMaintenanceStore {
            current_token_count = excluded.current_token_count,
            projected_token_count = excluded.projected_token_count,
            raw_tokens_outside_tail = excluded.raw_tokens_outside_tail,
+           context_threshold = excluded.context_threshold,
+           context_threshold_source = excluded.context_threshold_source,
            retry_attempts = excluded.retry_attempts,
            next_attempt_after = excluded.next_attempt_after,
            updated_at = datetime('now')`,
@@ -218,6 +244,8 @@ export class CompactionMaintenanceStore {
         record.currentTokenCount ?? null,
         record.projectedTokenCount ?? null,
         record.rawTokensOutsideTail ?? null,
+        record.contextThreshold ?? null,
+        record.contextThresholdSource ?? null,
         record.retryAttempts,
         record.nextAttemptAfter?.toISOString() ?? null,
       );
@@ -232,6 +260,8 @@ export class CompactionMaintenanceStore {
     currentTokenCount?: number | null;
     projectedTokenCount?: number | null;
     rawTokensOutsideTail?: number | null;
+    contextThreshold?: number | null;
+    contextThresholdSource?: "global" | "override" | null;
   }): Promise<void> {
     const existing = await this.getConversationCompactionMaintenance(input.conversationId);
     await this.saveConversationCompactionMaintenance(
@@ -244,6 +274,9 @@ export class CompactionMaintenanceStore {
         currentTokenCount: input.currentTokenCount ?? existing?.currentTokenCount ?? null,
         projectedTokenCount: input.projectedTokenCount ?? existing?.projectedTokenCount ?? null,
         rawTokensOutsideTail: input.rawTokensOutsideTail ?? existing?.rawTokensOutsideTail ?? null,
+        contextThreshold: input.contextThreshold ?? existing?.contextThreshold ?? null,
+        contextThresholdSource:
+          input.contextThresholdSource ?? existing?.contextThresholdSource ?? null,
       }),
     );
   }

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -210,10 +210,8 @@ export class CompactionMaintenanceStore {
            context_threshold,
            context_threshold_source,
            retry_attempts,
-           next_attempt_after,
-           updated_at
+           next_attempt_after
          ) VALUES (
-           ?,
            ?,
            ?,
            ?,
@@ -247,7 +245,7 @@ export class CompactionMaintenanceStore {
            context_threshold_source = excluded.context_threshold_source,
            retry_attempts = excluded.retry_attempts,
            next_attempt_after = excluded.next_attempt_after,
-           updated_at = excluded.updated_at`,
+           updated_at = datetime('now')`,
       )
       .run(
         record.conversationId,
@@ -266,7 +264,6 @@ export class CompactionMaintenanceStore {
         record.contextThresholdSource ?? null,
         record.retryAttempts,
         record.nextAttemptAfter?.toISOString() ?? null,
-        record.updatedAt.toISOString(),
       );
   }
 

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -44,6 +44,30 @@ type ConversationCompactionMaintenanceRow = {
 
 const DEFERRED_COMPACTION_RETRY_BASE_MS = 5 * 60 * 1000;
 const DEFERRED_COMPACTION_RETRY_MAX_MS = 30 * 60 * 1000;
+const MAINTENANCE_INSERT_COLUMNS = [
+  "conversation_id",
+  "pending",
+  "requested_at",
+  "reason",
+  "running",
+  "last_started_at",
+  "last_finished_at",
+  "last_failure_summary",
+  "token_budget",
+  "current_token_count",
+  "projected_token_count",
+  "raw_tokens_outside_tail",
+  "context_threshold",
+  "context_threshold_source",
+  "retry_attempts",
+  "next_attempt_after",
+] as const;
+const MAINTENANCE_INSERT_PLACEHOLDERS = MAINTENANCE_INSERT_COLUMNS.map(() => "?").join(", ");
+const MAINTENANCE_UPDATE_ASSIGNMENTS = MAINTENANCE_INSERT_COLUMNS.filter(
+  (column) => column !== "conversation_id",
+)
+  .map((column) => `${column} = excluded.${column}`)
+  .join(",\n           ");
 
 function computeDeferredCompactionRetryDelayMs(attempts: number): number {
   const safeAttempts = Number.isFinite(attempts) ? Math.max(1, Math.floor(attempts)) : 1;
@@ -192,79 +216,36 @@ export class CompactionMaintenanceStore {
   private async saveConversationCompactionMaintenance(
     record: ConversationCompactionMaintenanceRecord,
   ): Promise<void> {
+    const values = [
+      record.conversationId,
+      record.pending ? 1 : 0,
+      record.requestedAt?.toISOString() ?? null,
+      record.reason ?? null,
+      record.running ? 1 : 0,
+      record.lastStartedAt?.toISOString() ?? null,
+      record.lastFinishedAt?.toISOString() ?? null,
+      record.lastFailureSummary ?? null,
+      record.tokenBudget ?? null,
+      record.currentTokenCount ?? null,
+      record.projectedTokenCount ?? null,
+      record.rawTokensOutsideTail ?? null,
+      record.contextThreshold ?? null,
+      record.contextThresholdSource ?? null,
+      record.retryAttempts,
+      record.nextAttemptAfter?.toISOString() ?? null,
+    ];
     this.db
       .prepare(
         `INSERT INTO conversation_compaction_maintenance (
-           conversation_id,
-           pending,
-           requested_at,
-           reason,
-           running,
-           last_started_at,
-           last_finished_at,
-           last_failure_summary,
-           token_budget,
-           current_token_count,
-           projected_token_count,
-           raw_tokens_outside_tail,
-           context_threshold,
-           context_threshold_source,
-           retry_attempts,
-           next_attempt_after
+           ${MAINTENANCE_INSERT_COLUMNS.join(",\n           ")}
          ) VALUES (
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?,
-           ?
+           ${MAINTENANCE_INSERT_PLACEHOLDERS}
          )
          ON CONFLICT(conversation_id) DO UPDATE SET
-           pending = excluded.pending,
-           requested_at = excluded.requested_at,
-           reason = excluded.reason,
-           running = excluded.running,
-           last_started_at = excluded.last_started_at,
-           last_finished_at = excluded.last_finished_at,
-           last_failure_summary = excluded.last_failure_summary,
-           token_budget = excluded.token_budget,
-           current_token_count = excluded.current_token_count,
-           projected_token_count = excluded.projected_token_count,
-           raw_tokens_outside_tail = excluded.raw_tokens_outside_tail,
-           context_threshold = excluded.context_threshold,
-           context_threshold_source = excluded.context_threshold_source,
-           retry_attempts = excluded.retry_attempts,
-           next_attempt_after = excluded.next_attempt_after,
+           ${MAINTENANCE_UPDATE_ASSIGNMENTS},
            updated_at = datetime('now')`,
       )
-      .run(
-        record.conversationId,
-        record.pending ? 1 : 0,
-        record.requestedAt?.toISOString() ?? null,
-        record.reason ?? null,
-        record.running ? 1 : 0,
-        record.lastStartedAt?.toISOString() ?? null,
-        record.lastFinishedAt?.toISOString() ?? null,
-        record.lastFailureSummary ?? null,
-        record.tokenBudget ?? null,
-        record.currentTokenCount ?? null,
-        record.projectedTokenCount ?? null,
-        record.rawTokensOutsideTail ?? null,
-        record.contextThreshold ?? null,
-        record.contextThresholdSource ?? null,
-        record.retryAttempts,
-        record.nextAttemptAfter?.toISOString() ?? null,
-      );
+      .run(...values);
   }
 
   /** Record or refresh deferred proactive-compaction debt for a conversation. */

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -229,7 +229,7 @@ export class CompactionMaintenanceStore {
            ?,
            ?,
            ?,
-           datetime('now')
+           ?
          )
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
@@ -247,7 +247,7 @@ export class CompactionMaintenanceStore {
            context_threshold_source = excluded.context_threshold_source,
            retry_attempts = excluded.retry_attempts,
            next_attempt_after = excluded.next_attempt_after,
-           updated_at = datetime('now')`,
+           updated_at = excluded.updated_at`,
       )
       .run(
         record.conversationId,
@@ -266,6 +266,7 @@ export class CompactionMaintenanceStore {
         record.contextThresholdSource ?? null,
         record.retryAttempts,
         record.nextAttemptAfter?.toISOString() ?? null,
+        record.updatedAt.toISOString(),
       );
   }
 

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -212,7 +212,25 @@ export class CompactionMaintenanceStore {
            retry_attempts,
            next_attempt_after,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           ?,
+           datetime('now')
+         )
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -80,6 +80,8 @@ describe("CompactionMaintenanceStore", () => {
       currentTokenCount: 300,
       projectedTokenCount: 620,
       rawTokensOutsideTail: 320,
+      contextThreshold: 0.15,
+      contextThresholdSource: "override",
     });
 
     const record = await store.getConversationCompactionMaintenance(conversation.conversationId);
@@ -90,6 +92,25 @@ describe("CompactionMaintenanceStore", () => {
       currentTokenCount: 300,
       projectedTokenCount: 620,
       rawTokensOutsideTail: 320,
+      contextThreshold: 0.15,
+      contextThresholdSource: "override",
+    });
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 700,
+      currentTokenCount: 400,
+    });
+
+    const refreshed = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(refreshed).toMatchObject({
+      pending: true,
+      reason: "leaf-trigger",
+      tokenBudget: 700,
+      currentTokenCount: 400,
+      contextThreshold: null,
+      contextThresholdSource: null,
     });
   });
 

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -80,6 +80,8 @@ describe("CompactionMaintenanceStore", () => {
       currentTokenCount: 300,
       projectedTokenCount: 620,
       rawTokensOutsideTail: 320,
+      contextThreshold: 0.15,
+      contextThresholdSource: "override",
     });
 
     const record = await store.getConversationCompactionMaintenance(conversation.conversationId);
@@ -90,6 +92,8 @@ describe("CompactionMaintenanceStore", () => {
       currentTokenCount: 300,
       projectedTokenCount: 620,
       rawTokensOutsideTail: 320,
+      contextThreshold: 0.15,
+      contextThresholdSource: "override",
     });
   });
 

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -95,6 +95,23 @@ describe("CompactionMaintenanceStore", () => {
       contextThreshold: 0.15,
       contextThresholdSource: "override",
     });
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "leaf-trigger",
+      tokenBudget: 700,
+      currentTokenCount: 400,
+    });
+
+    const refreshed = await store.getConversationCompactionMaintenance(conversation.conversationId);
+    expect(refreshed).toMatchObject({
+      pending: true,
+      reason: "leaf-trigger",
+      tokenBudget: 700,
+      currentTokenCount: 400,
+      contextThreshold: null,
+      contextThresholdSource: null,
+    });
   });
 
   it("records retry backoff after failures and clears it after success", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,6 +31,7 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
     expect(config.contextThreshold).toBe(0.75);
+    expect(config.contextThresholdOverrides).toEqual([]);
     expect(config.freshTailCount).toBe(64);
     expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.promptAwareEviction).toBe(false);
@@ -79,6 +80,17 @@ describe("resolveLcmConfig", () => {
   it("reads values from plugin config", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: 0.5,
+      contextThresholdOverrides: [
+        {
+          name: "large-context",
+          match: { modelContextWindowMin: 900000 },
+          contextThreshold: 0.15,
+        },
+        {
+          match: { model: "openai/gpt-5.5", sessionPattern: "agent:*:telegram:**" },
+          contextThreshold: 0.35,
+        },
+      ],
       freshTailCount: 16,
       freshTailMaxTokens: 12000,
       promptAwareEviction: false,
@@ -130,6 +142,17 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual(["agent:*:ephemeral:**"]);
     expect(config.skipStatelessSessions).toBe(false);
     expect(config.contextThreshold).toBe(0.5);
+    expect(config.contextThresholdOverrides).toEqual([
+      {
+        name: "large-context",
+        match: { modelContextWindowMin: 900000 },
+        contextThreshold: 0.15,
+      },
+      {
+        match: { model: "openai/gpt-5.5", sessionPattern: "agent:*:telegram:**" },
+        contextThreshold: 0.35,
+      },
+    ]);
     expect(config.freshTailCount).toBe(16);
     expect(config.freshTailMaxTokens).toBe(12000);
     expect(config.promptAwareEviction).toBe(false);
@@ -706,6 +729,68 @@ describe("resolveLcmConfig", () => {
     expect(manifest.configSchema.properties.promptAwareEviction).toEqual({
       type: "boolean",
     });
+  });
+
+  it("ships a manifest with contextThresholdOverrides in schema", () => {
+    expect(manifest.configSchema.properties.contextThresholdOverrides).toMatchObject({
+      type: "array",
+      items: {
+        type: "object",
+        required: ["match", "contextThreshold"],
+        properties: {
+          match: {
+            type: "object",
+            minProperties: 1,
+          },
+          contextThreshold: {
+            type: "number",
+            minimum: 0,
+            maximum: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects invalid contextThresholdOverrides", () => {
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { model: "openai/gpt-5.5" }, contextThreshold: 1.5 },
+        ],
+      })
+    ).toThrow(/contextThreshold/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: {}, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/at least one matcher/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          {
+            match: { modelContextWindowMin: 900000, modelContextWindowMax: 250000 },
+            contextThreshold: 0.5,
+          },
+        ],
+      })
+    ).toThrow(/modelContextWindowMin/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { model: "   " }, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/model/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { sessionPattern: "" }, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/sessionPattern/);
   });
 
   it("ships a manifest with dynamicLeafChunkTokens in schema", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -777,6 +777,20 @@ describe("resolveLcmConfig", () => {
         ],
       })
     ).toThrow(/modelContextWindowMin/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { model: "   " }, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/model/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { sessionPattern: "" }, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/sessionPattern/);
   });
 
   it("ships a manifest with dynamicLeafChunkTokens in schema", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,6 +31,7 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
     expect(config.contextThreshold).toBe(0.75);
+    expect(config.contextThresholdOverrides).toEqual([]);
     expect(config.freshTailCount).toBe(64);
     expect(config.freshTailMaxTokens).toBeUndefined();
     expect(config.promptAwareEviction).toBe(false);
@@ -79,6 +80,17 @@ describe("resolveLcmConfig", () => {
   it("reads values from plugin config", () => {
     const config = resolveLcmConfig({}, {
       contextThreshold: 0.5,
+      contextThresholdOverrides: [
+        {
+          name: "large-context",
+          match: { modelContextWindowMin: 900000 },
+          contextThreshold: 0.15,
+        },
+        {
+          match: { model: "openai/gpt-5.5", sessionPattern: "agent:*:telegram:**" },
+          contextThreshold: 0.35,
+        },
+      ],
       freshTailCount: 16,
       freshTailMaxTokens: 12000,
       promptAwareEviction: false,
@@ -130,6 +142,17 @@ describe("resolveLcmConfig", () => {
     expect(config.statelessSessionPatterns).toEqual(["agent:*:ephemeral:**"]);
     expect(config.skipStatelessSessions).toBe(false);
     expect(config.contextThreshold).toBe(0.5);
+    expect(config.contextThresholdOverrides).toEqual([
+      {
+        name: "large-context",
+        match: { modelContextWindowMin: 900000 },
+        contextThreshold: 0.15,
+      },
+      {
+        match: { model: "openai/gpt-5.5", sessionPattern: "agent:*:telegram:**" },
+        contextThreshold: 0.35,
+      },
+    ]);
     expect(config.freshTailCount).toBe(16);
     expect(config.freshTailMaxTokens).toBe(12000);
     expect(config.promptAwareEviction).toBe(false);
@@ -706,6 +729,54 @@ describe("resolveLcmConfig", () => {
     expect(manifest.configSchema.properties.promptAwareEviction).toEqual({
       type: "boolean",
     });
+  });
+
+  it("ships a manifest with contextThresholdOverrides in schema", () => {
+    expect(manifest.configSchema.properties.contextThresholdOverrides).toMatchObject({
+      type: "array",
+      items: {
+        type: "object",
+        required: ["match", "contextThreshold"],
+        properties: {
+          match: {
+            type: "object",
+            minProperties: 1,
+          },
+          contextThreshold: {
+            type: "number",
+            minimum: 0,
+            maximum: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects invalid contextThresholdOverrides", () => {
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: { model: "openai/gpt-5.5" }, contextThreshold: 1.5 },
+        ],
+      })
+    ).toThrow(/contextThreshold/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          { match: {}, contextThreshold: 0.5 },
+        ],
+      })
+    ).toThrow(/at least one matcher/);
+    expect(() =>
+      resolveLcmConfig({}, {
+        contextThresholdOverrides: [
+          {
+            match: { modelContextWindowMin: 900000, modelContextWindowMax: 250000 },
+            contextThreshold: 0.5,
+          },
+        ],
+      })
+    ).toThrow(/modelContextWindowMin/);
   });
 
   it("ships a manifest with dynamicLeafChunkTokens in schema", () => {

--- a/test/context-threshold.test.ts
+++ b/test/context-threshold.test.ts
@@ -1,0 +1,207 @@
+// Unit tests for the extracted context-threshold override resolver and the
+// shared runtime model-metadata extraction it consumes.
+import { describe, expect, it } from "vitest";
+import {
+  ContextThresholdResolver,
+  persistedContextThresholdOverride,
+} from "../src/context-threshold.js";
+import { readRuntimeModelContext } from "../src/runtime-model.js";
+
+describe("readRuntimeModelContext", () => {
+  it("extracts provider, model, and modelRef from a runtime bag", () => {
+    expect(readRuntimeModelContext({ provider: "openai", model: "gpt-5.5" })).toEqual({
+      provider: "openai",
+      model: "gpt-5.5",
+      modelRef: "openai/gpt-5.5",
+    });
+  });
+
+  it("keeps an already-qualified model id as the modelRef", () => {
+    expect(readRuntimeModelContext({ provider: "openai", model: "openai/gpt-5.5" })).toEqual({
+      provider: "openai",
+      model: "openai/gpt-5.5",
+      modelRef: "openai/gpt-5.5",
+    });
+  });
+
+  it("supports alternate provider/model key spellings", () => {
+    expect(readRuntimeModelContext({ providerId: "anthropic", modelId: "claude-fable-5" })).toEqual({
+      provider: "anthropic",
+      model: "claude-fable-5",
+      modelRef: "anthropic/claude-fable-5",
+    });
+  });
+
+  it("probes the known context-window key spellings", () => {
+    for (const key of [
+      "modelContextWindow",
+      "modelContextWindowTokens",
+      "contextWindow",
+      "contextWindowTokens",
+      "maxContextTokens",
+      "contextWindowMax",
+    ]) {
+      expect(readRuntimeModelContext({ [key]: 200_000 })).toEqual({
+        modelContextWindow: 200_000,
+      });
+    }
+  });
+
+  it("prefers earlier bags over later ones", () => {
+    expect(
+      readRuntimeModelContext(
+        { model: "gpt-5.5", contextWindow: 400_000 },
+        { provider: "legacy", model: "old-model", modelContextWindow: 200_000 },
+      ),
+    ).toEqual({
+      provider: "legacy",
+      model: "gpt-5.5",
+      modelRef: "legacy/gpt-5.5",
+      modelContextWindow: 400_000,
+    });
+  });
+
+  it("ignores invalid context-window values and missing bags", () => {
+    expect(readRuntimeModelContext(undefined, { modelContextWindow: -1 })).toEqual({});
+    expect(readRuntimeModelContext({ modelContextWindow: Number.NaN })).toEqual({});
+    expect(readRuntimeModelContext()).toEqual({});
+  });
+});
+
+describe("ContextThresholdResolver", () => {
+  it("falls back to the global threshold when no rules are configured", () => {
+    const resolver = new ContextThresholdResolver(0.75);
+    expect(resolver.resolve({ runtime: {} })).toMatchObject({
+      contextThreshold: 0.75,
+      source: "global",
+      reason: "no_override_matched",
+      specificity: 0,
+    });
+  });
+
+  it("matches an exact model id against modelRef or bare model", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { model: "openai/gpt-5.5" }, contextThreshold: 0.3 },
+    ]);
+    expect(
+      resolver.resolve({ runtime: readRuntimeModelContext({ provider: "openai", model: "gpt-5.5" }) }),
+    ).toMatchObject({ contextThreshold: 0.3, source: "override", ruleIndex: 0 });
+    expect(
+      resolver.resolve({ runtime: readRuntimeModelContext({ model: "openai/gpt-5.5" }) }),
+    ).toMatchObject({ contextThreshold: 0.3, source: "override" });
+    expect(
+      resolver.resolve({ runtime: readRuntimeModelContext({ model: "gpt-5.5" }) }),
+    ).toMatchObject({ contextThreshold: 0.75, source: "global" });
+  });
+
+  it("matches session-key globs with precompiled patterns", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { name: "telegram", match: { sessionPattern: "agent:*:telegram:**" }, contextThreshold: 0.3 },
+    ]);
+    expect(
+      resolver.resolve({ sessionKey: "agent:main:telegram:group:123", runtime: {} }),
+    ).toMatchObject({ contextThreshold: 0.3, source: "override", ruleName: "telegram" });
+    expect(
+      resolver.resolve({ sessionKey: "agent:main:discord:group:123", runtime: {} }),
+    ).toMatchObject({ contextThreshold: 0.75, source: "global" });
+    expect(resolver.resolve({ runtime: {} })).toMatchObject({ source: "global" });
+  });
+
+  it("requires explicit window metadata for window-range rules", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { modelContextWindowMax: 250_000 }, contextThreshold: 0.1 },
+    ]);
+    // No runtime window: the rule must not match, even if a token budget exists.
+    expect(resolver.resolve({ runtime: {} })).toMatchObject({ source: "global" });
+    expect(
+      resolver.resolve({ runtime: { modelContextWindow: 200_000 } }),
+    ).toMatchObject({ contextThreshold: 0.1, source: "override" });
+    expect(
+      resolver.resolve({ runtime: { modelContextWindow: 400_000 } }),
+    ).toMatchObject({ source: "global" });
+  });
+
+  it("ANDs all matchers within a rule", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      {
+        match: { model: "openai/gpt-5.5", sessionPattern: "agent:*:telegram:**" },
+        contextThreshold: 0.2,
+      },
+    ]);
+    const runtime = readRuntimeModelContext({ provider: "openai", model: "gpt-5.5" });
+    expect(
+      resolver.resolve({ sessionKey: "agent:main:telegram:group:1", runtime }),
+    ).toMatchObject({ contextThreshold: 0.2, source: "override" });
+    expect(
+      resolver.resolve({ sessionKey: "agent:main:discord:group:1", runtime }),
+    ).toMatchObject({ source: "global" });
+    expect(
+      resolver.resolve({ sessionKey: "agent:main:telegram:group:1", runtime: {} }),
+    ).toMatchObject({ source: "global" });
+  });
+
+  it("picks the highest-specificity match, breaking ties by config order", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { name: "window", match: { modelContextWindowMin: 100_000 }, contextThreshold: 0.5 },
+      { name: "model", match: { model: "openai/gpt-5.5" }, contextThreshold: 0.2 },
+      { name: "window-dup", match: { modelContextWindowMin: 100_000 }, contextThreshold: 0.4 },
+    ]);
+    const runtime = readRuntimeModelContext({
+      provider: "openai",
+      model: "gpt-5.5",
+      modelContextWindow: 400_000,
+    });
+    // Exact model (100) outranks window bounds (20).
+    expect(resolver.resolve({ runtime })).toMatchObject({
+      contextThreshold: 0.2,
+      ruleName: "model",
+      specificity: 100,
+    });
+    // Without the model rule matching, the earliest equal-specificity rule wins.
+    expect(
+      resolver.resolve({ runtime: { modelContextWindow: 400_000 } }),
+    ).toMatchObject({ contextThreshold: 0.5, ruleName: "window", ruleIndex: 0 });
+  });
+
+  it("reports the winning rule's matchers in the reason", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      {
+        name: "small-windows",
+        match: { modelContextWindowMax: 250_000 },
+        contextThreshold: 0.1,
+      },
+    ]);
+    const resolved = resolver.resolve({ runtime: { modelContextWindow: 200_000 } });
+    expect(resolved.reason).toBe(
+      "modelContextWindow<=250000,resolvedModelContextWindow=200000",
+    );
+    expect(resolved.modelContextWindow).toBe(200_000);
+  });
+});
+
+describe("persistedContextThresholdOverride", () => {
+  it("rehydrates a threshold persisted on a maintenance debt row", () => {
+    expect(
+      persistedContextThresholdOverride({
+        contextThreshold: 0.1,
+        contextThresholdSource: "override",
+      }),
+    ).toMatchObject({
+      contextThreshold: 0.1,
+      source: "override",
+      reason: "persisted deferred threshold debt",
+    });
+    expect(
+      persistedContextThresholdOverride({
+        contextThreshold: 0.5,
+        contextThresholdSource: "global",
+      }),
+    ).toMatchObject({ contextThreshold: 0.5, source: "global" });
+  });
+
+  it("returns undefined when no threshold was persisted", () => {
+    expect(
+      persistedContextThresholdOverride({ contextThreshold: null, contextThresholdSource: null }),
+    ).toBeUndefined();
+  });
+});

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -843,7 +843,9 @@ describe("LcmContextEngine afterTurn", () => {
       },
     });
 
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 4_096, 500);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 4_096, 500, {
+      contextThreshold: 0.75,
+    });
   });
 
   it("afterTurn falls back to local message token estimates when runtimeContext.currentTokenCount is absent", async () => {
@@ -884,6 +886,7 @@ describe("LcmContextEngine afterTurn", () => {
       expect.any(Number),
       4_096,
       estimateSerializedMessageTokens(turnMessage),
+      { contextThreshold: 0.75 },
     );
   });
 
@@ -1041,6 +1044,167 @@ describe("LcmContextEngine afterTurn", () => {
       .getConversationCompactionMaintenance(conversation!.conversationId);
     expect(maintenance?.pending ?? false).toBe(false);
     expect(compactSpy).not.toHaveBeenCalled();
+  });
+
+  it("afterTurn does not use tokenBudget as a model context-window override fallback", async () => {
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-window-override-requires-explicit-window";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 50_000,
+      threshold: 150_000,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-window-override-requires-explicit-window"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 200_000,
+      runtimeContext: {
+        currentTokenCount: 50_000,
+        provider: "openai",
+        model: "gpt-5.5",
+      },
+    });
+
+    // No explicit window metadata: the window rule must not match, so the
+    // resolved threshold falls back to the global 0.75 default.
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 50_000, {
+      contextThreshold: 0.75,
+    });
+  });
+
+  it("afterTurn falls back to legacy model context-window metadata for threshold overrides", async () => {
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-window-override-legacy-metadata";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 80_000,
+      threshold: 50_000,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-window-override-legacy-metadata"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 500_000,
+      runtimeContext: {
+        currentTokenCount: 80_000,
+      },
+      legacyCompactionParams: {
+        modelContextWindow: 200_000,
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 500_000, 80_000, {
+      contextThreshold: 0.1,
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).toMatchObject({
+      pending: true,
+      contextThreshold: 0.1,
+      contextThresholdSource: "override",
+    });
+  });
+
+  it("afterTurn forwards legacy-only resolved threshold overrides into inline compaction", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-inline-threshold-override-legacy-metadata";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 80_000,
+      threshold: 50_000,
+    });
+    const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-inline-threshold-override-legacy-metadata"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 500_000,
+      runtimeContext: {
+        currentTokenCount: 80_000,
+      },
+      legacyCompactionParams: {
+        modelContextWindow: 200_000,
+      },
+    });
+
+    expect(compactSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        compactionTarget: "threshold",
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.1,
+          source: "override",
+        }),
+      }),
+    );
   });
 
   it("afterTurn schedules a deferred threshold drain even when compactionTelemetry has no provider/model", async () => {
@@ -3046,7 +3210,9 @@ describe("LcmContextEngine afterTurn", () => {
       },
     });
 
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), 204_800);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), 204_800, {
+      contextThreshold: 0.75,
+    });
     expect(debugLog).toHaveBeenCalledWith(
       expect.stringContaining("using runtime prompt token count currentTokenCount=204800"),
     );

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -2156,7 +2156,7 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 5000);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 5000, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -1146,7 +1146,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400, 500);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400, 500, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
@@ -1201,7 +1201,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
     expect(result.reason).toBe("compacted");
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
@@ -1244,7 +1244,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(false);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 123);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 123, undefined, { contextThreshold: 0.75 });
     expect(compactSpy).not.toHaveBeenCalled();
   });
 
@@ -1313,7 +1313,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
     expect(result.reason).toBe("compacted");
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
@@ -1366,7 +1366,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
@@ -1423,7 +1423,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400, 500);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 400, 500, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
@@ -1834,7 +1834,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
         targetTokens: 200_000,
       }),
     );
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 277_403);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 277_403, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).not.toHaveBeenCalled();
     expect(compactUntilUnderSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1892,7 +1892,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.reason).toBe("compacted");
     expect(result.result?.tokensBefore).toBe(150_000);
     expect(result.result?.tokensAfter).toBe(118_000);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 120_000);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 120_000, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).not.toHaveBeenCalled();
     expect(compactUntilUnderSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -571,7 +571,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(false);
-    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 123);
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 123, undefined, { contextThreshold: 0.75 });
     expect(compactSpy).not.toHaveBeenCalled();
   });
 

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -123,7 +123,14 @@ describe("LcmContextEngine maintain and assemble budget", () => {
   });
 
   it("maintain() consumes deferred threshold debt when the host opts in", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
     const sessionId = "maintain-deferred-compaction-enabled";
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
@@ -131,8 +138,10 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
-      tokenBudget: 4_096,
-      currentTokenCount: 3_500,
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
+      contextThreshold: 0.1,
+      contextThresholdSource: "override",
     });
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
@@ -151,8 +160,8 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       sessionFile: createSessionFilePath("maintain-deferred-compaction-enabled-maintain"),
       runtimeContext: {
         allowDeferredCompactionExecution: true,
-        tokenBudget: 4_096,
-        currentTokenCount: 3_500,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
       },
     });
 
@@ -163,9 +172,13 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       expect.objectContaining({
         conversationId: conversation.conversationId,
         sessionId,
-        tokenBudget: 4_096,
-        currentTokenCount: 3_500,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
         compactionTarget: "threshold",
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.1,
+          source: "override",
+        }),
       }),
     );
     expect(maintenance?.pending).toBe(false);
@@ -212,7 +225,9 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const maintenance = await engine
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation.conversationId);
-    expect(evaluateSpy).toHaveBeenCalledWith(conversation.conversationId, 4_096, 1_024);
+    expect(evaluateSpy).toHaveBeenCalledWith(conversation.conversationId, 4_096, 1_024, {
+      contextThreshold: 0.75,
+    });
     expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
     expect(maintenance?.pending).toBe(false);
     expect(maintenance?.running).toBe(false);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11948,6 +11948,64 @@ describe("LcmContextEngine fidelity and token budget", () => {
     });
   });
 
+  it("afterTurn forwards legacy-only resolved threshold overrides into inline compaction", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-inline-threshold-override-legacy-metadata";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 80_000,
+      threshold: 50_000,
+    });
+    const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-inline-threshold-override-legacy-metadata"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 500_000,
+      runtimeContext: {
+        currentTokenCount: 80_000,
+      },
+      legacyCompactionParams: {
+        modelContextWindow: 200_000,
+      },
+    });
+
+    expect(compactSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        compactionTarget: "threshold",
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.1,
+          source: "override",
+        }),
+      }),
+    );
+  });
+
   it("afterTurn schedules a deferred threshold drain even when compactionTelemetry has no provider/model", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-no-cache-context-threshold";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11849,6 +11849,49 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(compactSpy).not.toHaveBeenCalled();
   });
 
+  it("afterTurn does not use tokenBudget as a model context-window override fallback", async () => {
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-window-override-requires-explicit-window";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below threshold",
+      currentTokens: 50_000,
+      threshold: 150_000,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-window-override-requires-explicit-window"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 200_000,
+      runtimeContext: {
+        currentTokenCount: 50_000,
+        provider: "openai",
+        model: "gpt-5.5",
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 50_000);
+  });
+
   it("afterTurn schedules a deferred threshold drain even when compactionTelemetry has no provider/model", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-no-cache-context-threshold";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11892,6 +11892,52 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 50_000);
   });
 
+  it("afterTurn falls back to legacy model context-window metadata for threshold overrides", async () => {
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
+    const sessionId = "after-turn-window-override-legacy-metadata";
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+          options?: { contextThreshold?: number },
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 80_000,
+      threshold: 50_000,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-window-override-legacy-metadata"),
+      messages: [makeMessage({ role: "assistant", content: "fresh turn content" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 500_000,
+      runtimeContext: {
+        currentTokenCount: 80_000,
+      },
+      legacyCompactionParams: {
+        modelContextWindow: 200_000,
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 500_000, 80_000, {
+      contextThreshold: 0.1,
+    });
+  });
+
   it("afterTurn schedules a deferred threshold drain even when compactionTelemetry has no provider/model", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-no-cache-context-threshold";

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -14454,7 +14454,14 @@ describe("LcmContextEngine fidelity and token budget", () => {
   });
 
   it("maintain() consumes deferred threshold debt when the host opts in", async () => {
-    const engine = createEngine();
+    const engine = createEngineWithConfig({
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.1,
+        },
+      ],
+    });
     const sessionId = "maintain-deferred-compaction-enabled";
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
@@ -14462,8 +14469,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
-      tokenBudget: 4_096,
-      currentTokenCount: 3_500,
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
     });
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
@@ -14482,8 +14489,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
       sessionFile: createSessionFilePath("maintain-deferred-compaction-enabled-maintain"),
       runtimeContext: {
         allowDeferredCompactionExecution: true,
-        tokenBudget: 4_096,
-        currentTokenCount: 3_500,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
+        modelContextWindow: 200_000,
       },
     });
 
@@ -14494,9 +14502,13 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect.objectContaining({
         conversationId: conversation.conversationId,
         sessionId,
-        tokenBudget: 4_096,
-        currentTokenCount: 3_500,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
         compactionTarget: "threshold",
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.1,
+          source: "override",
+        }),
       }),
     );
     expect(maintenance?.pending).toBe(false);

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -11936,6 +11936,16 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 500_000, 80_000, {
       contextThreshold: 0.1,
     });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).toMatchObject({
+      pending: true,
+      contextThreshold: 0.1,
+      contextThresholdSource: "override",
+    });
   });
 
   it("afterTurn schedules a deferred threshold drain even when compactionTelemetry has no provider/model", async () => {
@@ -14471,6 +14481,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
       reason: "threshold",
       tokenBudget: 500_000,
       currentTokenCount: 80_000,
+      contextThreshold: 0.1,
+      contextThresholdSource: "override",
     });
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
@@ -14491,7 +14503,6 @@ describe("LcmContextEngine fidelity and token budget", () => {
         allowDeferredCompactionExecution: true,
         tokenBudget: 500_000,
         currentTokenCount: 80_000,
-        modelContextWindow: 200_000,
       },
     });
 

--- a/test/lcm-integration-compaction.test.ts
+++ b/test/lcm-integration-compaction.test.ts
@@ -2009,6 +2009,29 @@ describe("LCM integration: compaction", () => {
     expect(decision.threshold).toBe(450);
   });
 
+  it("evaluate accepts a per-call contextThreshold override", async () => {
+    await ingestMessages(convStore, sumStore, 4, {
+      contentFn: (i) => `Override ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const defaultDecision = await compactionEngine.evaluate(CONV_ID, 600);
+    expect(defaultDecision).toMatchObject({
+      shouldCompact: false,
+      threshold: 450,
+      currentTokens: 400,
+    });
+
+    const overrideDecision = await compactionEngine.evaluate(CONV_ID, 600, undefined, {
+      contextThreshold: 0.5,
+    });
+    expect(overrideDecision).toMatchObject({
+      shouldCompact: true,
+      threshold: 300,
+      currentTokens: 400,
+    });
+  });
+
   it("evaluate compacts when observed tokens plus raw backlog exceed the threshold", async () => {
     const backlogEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
@@ -2076,6 +2099,40 @@ describe("LCM integration: compaction", () => {
       currentTokens: 300,
       threshold: 450,
     });
+  });
+
+  it("compactFullSweep accepts a per-call contextThreshold override", async () => {
+    const thresholdAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      contextThreshold: 0.75,
+      leafChunkTokens: 20_000,
+      condensedTargetTokens: 100,
+      summaryPrefixTargetTokens: undefined,
+      freshTailCount: 1,
+    });
+    await ingestMessages(convStore, sumStore, 3, {
+      contentFn: (i) => `Threshold target ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const defaultResult = await thresholdAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      summarize: async () => "leaf summary",
+    });
+    expect(defaultResult.actionTaken).toBe(false);
+    expect(defaultResult.tokensBefore).toBe(300);
+
+    const overrideResult = await thresholdAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      contextThreshold: 0.2,
+      summarize: async () => "leaf summary",
+    });
+
+    expect(overrideResult.actionTaken).toBe(true);
+    expect(overrideResult.tokensBefore).toBe(300);
+    expect(overrideResult.tokensAfter).toBeLessThan(300);
   });
 
   it("compactUntilUnder uses currentTokens when stored tokens are stale", async () => {

--- a/test/lcm-integration.test.ts
+++ b/test/lcm-integration.test.ts
@@ -3354,6 +3354,29 @@ describe("LCM integration: compaction", () => {
     expect(decision.threshold).toBe(450);
   });
 
+  it("evaluate accepts a per-call contextThreshold override", async () => {
+    await ingestMessages(convStore, sumStore, 4, {
+      contentFn: (i) => `Override ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const defaultDecision = await compactionEngine.evaluate(CONV_ID, 600);
+    expect(defaultDecision).toMatchObject({
+      shouldCompact: false,
+      threshold: 450,
+      currentTokens: 400,
+    });
+
+    const overrideDecision = await compactionEngine.evaluate(CONV_ID, 600, undefined, {
+      contextThreshold: 0.5,
+    });
+    expect(overrideDecision).toMatchObject({
+      shouldCompact: true,
+      threshold: 300,
+      currentTokens: 400,
+    });
+  });
+
   it("evaluate compacts when observed tokens plus raw backlog exceed the threshold", async () => {
     const backlogEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
@@ -3421,6 +3444,40 @@ describe("LCM integration: compaction", () => {
       currentTokens: 300,
       threshold: 450,
     });
+  });
+
+  it("compactFullSweep accepts a per-call contextThreshold override", async () => {
+    const thresholdAwareEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      contextThreshold: 0.75,
+      leafChunkTokens: 20_000,
+      condensedTargetTokens: 100,
+      summaryPrefixTargetTokens: undefined,
+      freshTailCount: 1,
+    });
+    await ingestMessages(convStore, sumStore, 3, {
+      contentFn: (i) => `Threshold target ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    const defaultResult = await thresholdAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      summarize: async () => "leaf summary",
+    });
+    expect(defaultResult.actionTaken).toBe(false);
+    expect(defaultResult.tokensBefore).toBe(300);
+
+    const overrideResult = await thresholdAwareEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      contextThreshold: 0.2,
+      summarize: async () => "leaf summary",
+    });
+
+    expect(overrideResult.actionTaken).toBe(true);
+    expect(overrideResult.tokensBefore).toBe(300);
+    expect(overrideResult.tokensAfter).toBeLessThan(300);
   });
 
   it("compactUntilUnder uses currentTokens when stored tokens are stale", async () => {

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -164,10 +164,12 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(columns.some((column) => column.name === "raw_tokens_outside_tail")).toBe(true);
     expect(columns.some((column) => column.name === "retry_attempts")).toBe(true);
     expect(columns.some((column) => column.name === "next_attempt_after")).toBe(true);
+    expect(columns.some((column) => column.name === "context_threshold")).toBe(true);
+    expect(columns.some((column) => column.name === "context_threshold_source")).toBe(true);
 
     const row = db
       .prepare(
-        `SELECT pending, reason, token_budget, current_token_count, retry_attempts, next_attempt_after
+        `SELECT pending, reason, token_budget, current_token_count, retry_attempts, next_attempt_after, context_threshold, context_threshold_source
          FROM conversation_compaction_maintenance
          WHERE conversation_id = 1`,
       )
@@ -178,6 +180,8 @@ describe("runLcmMigrations summary depth backfill", () => {
       current_token_count: number;
       retry_attempts: number;
       next_attempt_after: string | null;
+      context_threshold: number | null;
+      context_threshold_source: string | null;
     };
     expect(row).toEqual({
       pending: 1,
@@ -186,6 +190,8 @@ describe("runLcmMigrations summary depth backfill", () => {
       current_token_count: 3500,
       retry_attempts: 0,
       next_attempt_after: null,
+      context_threshold: null,
+      context_threshold_source: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- add optional `contextThresholdOverrides` config rules for model, effective context window, and session pattern matching
- keep the existing global `contextThreshold` fallback unchanged
- thread the resolved threshold through compaction evaluation, manual compaction, sweeps, and derived summary-prefix target sizing
- document the new config and add validation/matching coverage

## Behaviour
- Overrides are optional and backward compatible.
- If no override matches, Lossless uses the existing global `contextThreshold`.
- If multiple rules match, the resolver picks the highest specificity, then the earliest rule in config order.
- Override values use the same numeric range as global `contextThreshold`.

## Motivation
A single global threshold behaves differently across models with very different context windows. Operators may want earlier compaction for smaller/effective budgets and different operational targets for larger-context models or specific session classes.

## Tests
- `npm run typecheck`
- `npm test` (53 files, 1209 tests)
