### PR TITLE
fix: preserve context engine wrapper hooks

### DIFF
--- a/.changeset/preserve-context-engine-hooks.md
+++ b/.changeset/preserve-context-engine-hooks.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve context-engine lifecycle hooks when adding host memory supplements to assembled prompts.

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -63,6 +63,20 @@ export type CompactResult = {
   exhausted?: boolean;
 };
 
+export type ContextEngineMaintenanceResult = {
+  changed: boolean;
+  bytesFreed: number;
+  rewrittenEntries: number;
+  reason?: string;
+};
+
+export type ContextEngineMaintenanceRuntimeContext = Record<string, unknown> & {
+  allowDeferredCompactionExecution?: boolean;
+  rewriteTranscriptEntries?: (
+    request: Record<string, unknown>,
+  ) => Promise<ContextEngineMaintenanceResult>;
+};
+
 export type IngestResult = {
   ingested: boolean;
 };
@@ -167,6 +181,19 @@ export type ContextEngine = {
     messages: AgentMessage[];
     isHeartbeat?: boolean;
   }): Promise<IngestBatchResult>;
+  afterTurn?(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    messages: AgentMessage[];
+    prePromptMessageCount: number;
+    autoCompactionSummary?: string;
+    isHeartbeat?: boolean;
+    tokenBudget?: number;
+    currentTokenCount?: number;
+    runtimeContext?: Record<string, unknown>;
+    legacyCompactionParams?: Record<string, unknown>;
+  }): Promise<void>;
   assemble(params: {
     sessionId: string;
     sessionKey?: string;
@@ -200,4 +227,11 @@ export type ContextEngine = {
     childSessionKey: string;
     reason?: SubagentEndReason;
   }): Promise<void>;
+  maintain?(params: {
+    sessionId: string;
+    sessionFile: string;
+    sessionKey?: string;
+    runtimeContext?: ContextEngineMaintenanceRuntimeContext;
+  }): Promise<ContextEngineMaintenanceResult>;
+  dispose?(): Promise<void>;
 };

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -143,19 +143,28 @@ async function loadBuildMemorySystemPromptAdditionModule(): Promise<BuildMemoryS
 class MemorySupplementContextEngine implements ContextEngine {
   readonly info: ContextEngine["info"];
   readonly ingestBatch: ContextEngine["ingestBatch"];
+  readonly afterTurn: ContextEngine["afterTurn"];
   readonly prepareSubagentSpawn: ContextEngine["prepareSubagentSpawn"];
   readonly onSubagentEnded: ContextEngine["onSubagentEnded"];
+  readonly maintain: ContextEngine["maintain"];
+  readonly dispose: ContextEngine["dispose"];
 
   constructor(private readonly inner: ContextEngine) {
     const ingestBatch = inner.ingestBatch?.bind(inner);
+    const afterTurn = inner.afterTurn?.bind(inner);
     const prepareSubagentSpawn = inner.prepareSubagentSpawn?.bind(inner);
     const onSubagentEnded = inner.onSubagentEnded?.bind(inner);
+    const maintain = inner.maintain?.bind(inner);
+    const dispose = inner.dispose?.bind(inner);
     this.info = inner.info;
     this.ingestBatch = ingestBatch ? (params) => ingestBatch(params) : undefined;
+    this.afterTurn = afterTurn ? (params) => afterTurn(params) : undefined;
     this.prepareSubagentSpawn = prepareSubagentSpawn
       ? (params) => prepareSubagentSpawn(params)
       : undefined;
     this.onSubagentEnded = onSubagentEnded ? (params) => onSubagentEnded(params) : undefined;
+    this.maintain = maintain ? (params) => maintain(params) : undefined;
+    this.dispose = dispose ? () => dispose() : undefined;
   }
 
   get config(): unknown {

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -487,6 +487,9 @@ describe("lcm plugin registration", () => {
     expect(factory).toBeTypeOf("function");
 
     const engine = factory!() as {
+      afterTurn?: unknown;
+      maintain?: unknown;
+      dispose?: unknown;
       assemble: (params: {
         sessionId: string;
         messages: unknown[];
@@ -494,6 +497,9 @@ describe("lcm plugin registration", () => {
         citationsMode?: string;
       }) => Promise<{ systemPromptAddition?: string }>;
     };
+    expect(engine.afterTurn).toBeTypeOf("function");
+    expect(engine.maintain).toBeTypeOf("function");
+    expect(engine.dispose).toBeTypeOf("function");
     const result = await engine.assemble({
       sessionId: "missing-session",
       messages: [],


### PR DESCRIPTION
## What

Preserves Lossless context-engine lifecycle hooks when wrapping the engine to inject OpenClaw host memory supplements into assembled prompts.

## Why

PR #742 fixed missing `systemPromptAddition` content by wrapping `assemble()`, but the wrapper only forwarded selected methods. That hid `afterTurn` from OpenClaws embedded runner, causing recent transcript turns to miss Lossless transcript-frontier reconciliation path.

## Changes

- Forward lifecycle hooks from wrapper
- Add hook methods to bridge type
- Assert wrapped engine exposes hooks
- Add patch changeset

## Testing

- `git diff --check`
- `npm run typecheck`
- `env -u OPENCLAW_STATE_DIR npm test -- test/plugin-config-registration.test.ts`
