### PR TITLE
Rebuild transcript reconciliation around stable entry ids

### DIFF
--- a/.changeset/entry-id-reconciliation.md
+++ b/.changeset/entry-id-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Rebuild transcript reconciliation around the stable JSONL envelope ids that OpenClaw already writes. Transcript imports are now idempotent by construction (`messages.transcript_entry_id` with a partial unique index), the afterTurn runtime batch is reconciled by exact alignment against the covered transcript frontier instead of heuristic dedup, rewritten/rotated transcripts are recognized as declared epoch rollovers via the session header id instead of path/size heuristics, and flush-lagged runtime rows are healed in place by adopting the catch-up entry's id rather than duplicated. Entry-id anchoring also survives post-ingest content rewriting (externalized tool results), which previously could freeze conversations. The content-identity machinery remains as the fallback for transcripts without envelope ids. Design: specs/transcript-reconciliation-by-entry-id.md.

--- a/.changeset/leaf-path-stale-id-adoption.md
+++ b/.changeset/leaf-path-stale-id-adoption.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Follow the transcript's parentId leaf path during reconciliation and adopt re-issued entry ids onto rows stranded by host copy-on-write rewrites (rewriteTranscriptEntries, host tool-result truncation, gateway chat edits), so rewritten suffixes re-stamp in place instead of importing as content duplicates.

--- a/.changeset/remove-pi-runtime-dependency.md
+++ b/.changeset/remove-pi-runtime-dependency.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove the runtime dependency on @earendil-works/pi-coding-agent: rotate and transcript-GC entry-id mapping now use the plugin's own read-only leaf-path parser instead of SessionManager.open, which migrated and rewrote v1/v2 or empty session files as a side effect and no longer tracks OpenClaw's in-tree transcript format. The pi packages remain as devDependencies for test fixtures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,9 +2221,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2239,9 +2236,6 @@
       "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2259,9 +2253,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2278,9 +2269,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2296,9 +2284,6 @@
       "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": ">=0.74 <1",
-        "@earendil-works/pi-ai": ">=0.74 <1",
-        "@earendil-works/pi-coding-agent": ">=0.74 <1",
         "@sinclair/typebox": "0.34.48"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
+        "@earendil-works/pi-agent-core": ">=0.74 <1",
+        "@earendil-works/pi-ai": ">=0.74 <1",
+        "@earendil-works/pi-coding-agent": ">=0.74 <1",
         "esbuild": "^0.28.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -34,6 +34,7 @@
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
       "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -54,6 +55,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -68,6 +70,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -83,6 +86,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -95,6 +99,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -108,6 +113,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -121,6 +127,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -135,6 +142,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -144,6 +152,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -155,6 +164,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -167,6 +177,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -180,6 +191,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -193,6 +205,7 @@
       "version": "3.1046.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1046.0.tgz",
       "integrity": "sha512-MT+nf7bna9gEohYFqUbPivR/XFPq7K8PmvgZY0h+kC/4k9SYDjQjsuA+sGH2AaZwJmMGXhmL4FpWRsYMc5gOQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -226,6 +239,7 @@
       "version": "3.997.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
       "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -255,6 +269,7 @@
       "version": "3.1046.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1046.0.tgz",
       "integrity": "sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -272,6 +287,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -287,6 +303,7 @@
       "version": "3.974.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.9.tgz",
       "integrity": "sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -304,6 +321,7 @@
       "version": "3.972.35",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.35.tgz",
       "integrity": "sha512-WkFQ8BedszVomhh/Zzs8WwnE/XBmTqZjoQVB8u/4zH6kZCjouXZpPpb93gD8m0EZmzAl7dxHE/y+yDpuKzNCMw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -320,6 +338,7 @@
       "version": "3.972.37",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.37.tgz",
       "integrity": "sha512-ylx0ZJTU+2eNcvXQ69VNR3TVSYa/ibpvdK717/NxqR9aXRMn2QRWZaiI8aa5yY/fOWZ5mknSmxGaVxxtdwv3EA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -338,6 +357,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.39.tgz",
       "integrity": "sha512-QhRSrdkk+Gq0AFIylpiI0N6lcJqFYV9Jtr4Luz5FpYOYbjJSfyTG6iLhnK/UPIgN1Jnon8WAmSC//16XYGvwkA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -362,6 +382,7 @@
       "version": "3.997.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
       "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -391,6 +412,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -406,6 +428,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.39.tgz",
       "integrity": "sha512-1hU0NtC04QbFIuoBuF4aQ2A97GsSE5/A0ZJpDijwexsBREIQ4KPRYl3v/FfKCPBYsaTeGjkOFx5nLhWHY24LOw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -423,6 +446,7 @@
       "version": "3.997.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
       "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -452,6 +476,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -467,6 +492,7 @@
       "version": "3.972.40",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.40.tgz",
       "integrity": "sha512-ZgrQaGkpyTlVSCCsffzijVg+KgftTAWYvI5Otc36J/4jNiHb+7MmBiJIR0a5AHLvifC92PiYHt5pijP0dswd1w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.35",
@@ -489,6 +515,7 @@
       "version": "3.972.35",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.35.tgz",
       "integrity": "sha512-hNj1rAwZWT1vfz54BwH8FUWxZuqStrM25Q5LEIwn2erHPMRVAjLlpZqEbCEEqS99eEEOhdeetnS0WeNa3iYeEQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -505,6 +532,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.39.tgz",
       "integrity": "sha512-mwIPNPldyCZkvHozb6E0X/vuQLN1UCjcA6MwUf1gaO7EwghCmuNZXatq0L3zptKFvPC4Nds7+WFUkifI1XmbSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -523,6 +551,7 @@
       "version": "3.997.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
       "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -552,6 +581,7 @@
       "version": "3.1046.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1046.0.tgz",
       "integrity": "sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -569,6 +599,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -584,6 +615,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.39.tgz",
       "integrity": "sha512-b9HT8CnpyPVn1hU14Q7ihjwSPlRzToYmRYJxRd5jNHEZ43lrIhoLaTT8JmfQQt5j5M8rTX1iN1X8mvu0SM1dXA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -601,6 +633,7 @@
       "version": "3.997.7",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
       "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -630,6 +663,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -645,6 +679,7 @@
       "version": "3.972.15",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.15.tgz",
       "integrity": "sha512-Al7z1qKPUIRILnB3Ggd1Tz88wjSkQjDErajR7YY33mquTbeN0gTDtJtclNtyhQMWr7ZRpQk0v5/xop4fjT0sug==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -660,6 +695,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.11.tgz",
       "integrity": "sha512-A0Z45YInBwsAabF8jf9hEQjXDuq4gFHNNqxCYuk8iREFZ7hw0NZ6+7FFlYa11gJ+i6y79C4J6giQ7fa1EDRYxw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -675,6 +711,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz",
       "integrity": "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -690,6 +727,7 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
       "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -704,6 +742,7 @@
       "version": "3.972.12",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz",
       "integrity": "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -720,6 +759,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.39.tgz",
       "integrity": "sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -737,6 +777,7 @@
       "version": "3.996.9",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
       "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -752,6 +793,7 @@
       "version": "3.972.17",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.17.tgz",
       "integrity": "sha512-0PRAeIunuJRAweM/YWATe0jCHx4BMzSuwry461/TgcwMc8mNShwTdXiG6eEQBD7u+nNPC8Inp9KXjSB6D7uNYg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.9",
@@ -770,6 +812,7 @@
       "version": "3.972.14",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz",
       "integrity": "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -785,6 +828,7 @@
       "version": "3.996.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
       "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -801,6 +845,7 @@
       "version": "3.973.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
       "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -814,6 +859,7 @@
       "version": "3.965.4",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
       "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -826,6 +872,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz",
       "integrity": "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -838,6 +885,7 @@
       "version": "3.973.25",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.25.tgz",
       "integrity": "sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.39",
@@ -862,6 +910,7 @@
       "version": "3.972.23",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.23.tgz",
       "integrity": "sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
@@ -877,6 +926,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
       "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -886,6 +936,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1401,6 +1452,7 @@
       "version": "0.75.3",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.3.tgz",
       "integrity": "sha512-azg09GSrckQa3ffbH09YEZC7DyHgmNSX+vmWEoEhQvp4icbzqbqLfIeMayMNEK/aGusm1SghZC4bPlDdagDALg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.75.3",
@@ -1416,6 +1468,7 @@
       "version": "0.75.3",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.3.tgz",
       "integrity": "sha512-UKccS+ADlkSVJ49a00346jUfXmUi6zzzB+pPWotsyA6SxhKr2ejjkGQksGyR1DyNVrsEP/WWlsOSTUUwVlzNaA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
@@ -1439,6 +1492,7 @@
       "version": "0.75.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.1.tgz",
       "integrity": "sha512-QMbmv8lFQ8P98kpuMc/z1ATTq7t0lQ+Bo3GLiOKQ/HonO34n4E1+395FCqlmG8zJEhiMp4yqVTzlj7BALQMlqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.75.1",
@@ -1472,6 +1526,7 @@
       "version": "0.75.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.1.tgz",
       "integrity": "sha512-IFDSvCXcXMoIxFKxdhqc7ybX8p86KpdxoTUTYEq3FHilMFkBqlXqZD0jZBitqxStBjjMkAlhjS1bKS0IOXSpsg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.0",
@@ -1930,6 +1985,7 @@
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.41.0.tgz",
       "integrity": "sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -1975,6 +2031,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1992,12 +2049,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -2015,6 +2074,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -2151,6 +2211,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
       "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2176,6 +2237,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2189,6 +2251,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
       "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,6 +2268,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2221,6 +2285,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,6 +2302,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2253,6 +2319,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2269,6 +2336,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,6 +2353,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2301,6 +2370,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2317,6 +2387,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2330,6 +2401,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
       "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
@@ -2341,6 +2413,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2391,6 +2464,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2401,30 +2475,35 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -2434,30 +2513,35 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
       "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2814,6 +2898,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
@@ -2826,6 +2911,7 @@
       "version": "3.24.2",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
       "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -2840,6 +2926,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.2.tgz",
       "integrity": "sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.2",
@@ -2854,6 +2941,7 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.2.tgz",
       "integrity": "sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.2",
@@ -2868,6 +2956,7 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.2.tgz",
       "integrity": "sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.2",
@@ -2882,6 +2971,7 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.2.tgz",
       "integrity": "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.2",
@@ -2896,6 +2986,7 @@
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
       "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2933,6 +3024,7 @@
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3057,6 +3149,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3076,6 +3169,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3088,6 +3182,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3127,6 +3222,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3136,6 +3232,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3169,6 +3266,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3178,12 +3276,14 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3209,6 +3309,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/cac": {
@@ -3242,6 +3343,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -3271,6 +3373,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3283,12 +3386,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3303,12 +3408,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3324,6 +3431,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3340,6 +3448,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3377,6 +3486,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
       "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3399,12 +3509,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -3414,6 +3526,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enquirer": {
@@ -3540,6 +3653,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/extendable-error": {
@@ -3570,6 +3684,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3586,6 +3701,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
       "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3635,6 +3751,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3685,6 +3802,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -3701,6 +3819,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3713,6 +3832,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -3740,6 +3860,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -3755,6 +3876,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -3769,6 +3891,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3781,6 +3904,7 @@
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.5.tgz",
       "integrity": "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.1",
@@ -3842,6 +3966,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
       "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -3860,6 +3985,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -3869,12 +3995,14 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/gtoken": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -3888,6 +4016,7 @@
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -3897,6 +4026,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
       "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -3909,6 +4039,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -3922,6 +4053,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -3962,6 +4094,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3994,6 +4127,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
       "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -4039,6 +4173,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4054,6 +4189,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -4083,6 +4219,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -4092,6 +4229,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -4105,6 +4243,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -4116,6 +4255,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -4126,6 +4266,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
       "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4157,6 +4298,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/loupe": {
@@ -4170,6 +4312,7 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4189,6 +4332,7 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -4238,6 +4382,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4253,6 +4398,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4272,6 +4418,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-domexception": {
@@ -4279,6 +4426,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4298,6 +4446,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -4316,6 +4465,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
       "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -4396,6 +4546,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
       "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-network-error": "^1.1.0"
@@ -4421,6 +4572,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
@@ -4437,6 +4589,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -4453,6 +4606,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4468,6 +4622,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4477,6 +4632,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -4614,6 +4770,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4625,6 +4782,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4634,6 +4792,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
       "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4757,6 +4916,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -4772,12 +4932,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
       "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4788,6 +4950,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4808,12 +4971,14 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -4829,6 +4994,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -4914,6 +5080,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4954,6 +5121,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4966,6 +5134,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4982,6 +5151,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/slash": {
@@ -5053,6 +5223,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5068,6 +5239,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5082,6 +5254,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5091,6 +5264,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5100,6 +5274,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5112,6 +5287,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5121,6 +5297,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5130,6 +5307,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5142,6 +5320,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5158,6 +5337,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5170,6 +5350,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5202,6 +5383,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5308,18 +5490,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typebox": {
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -5340,6 +5525,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
       "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -5349,6 +5535,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -6010,6 +6197,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6055,6 +6243,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6072,6 +6261,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6081,6 +6271,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6096,6 +6287,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6108,6 +6300,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6129,6 +6322,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6144,6 +6338,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -6159,6 +6354,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6168,6 +6364,7 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@martian-engineering/lossless-claw",
   "version": "0.12.0",
-  "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
+  "description": "Lossless Context Management plugin for OpenClaw \u2014 DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",
   "license": "MIT",
@@ -35,14 +35,14 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@earendil-works/pi-agent-core": ">=0.74 <1",
-    "@earendil-works/pi-ai": ">=0.74 <1",
-    "@earendil-works/pi-coding-agent": ">=0.74 <1",
     "@sinclair/typebox": "0.34.48"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
+    "@earendil-works/pi-agent-core": ">=0.74 <1",
+    "@earendil-works/pi-ai": ">=0.74 <1",
+    "@earendil-works/pi-coding-agent": ">=0.74 <1",
     "esbuild": "^0.28.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -188,13 +188,20 @@ the next turn's idempotent transcript read.
   order. Missing entries first attempt **adoption**: an identity-matched row
   with a NULL entry id (runtime flush-lag rows, pre-migration data) is
   stamped with the entry id instead of imported, healing legacy rows in
-  place. Entry-id anchoring is immune to post-ingest content rewriting
-  (tool-result externalization), which defeats content-identity anchors.
+  place. Entry-id anchoring also survives post-ingest content rewriting
+  (tool-result externalization) — *but not the way the original draft of
+  this spec claimed*: the host implements content rewriting as copy-on-write
+  re-append under **new** entry ids (see Phase 5), so the surviving anchor
+  is the unchanged prefix, and the rewritten suffix heals via stale-id
+  adoption rather than id equality.
 - *(Adjusted during implementation.)* Repeated content arriving under fresh
-  entry ids is now imported as genuine traffic instead of tripping the
+  entry ids is imported as genuine traffic instead of tripping the
   user-role replay-flood guard — the host's SessionManager declared them new
   entries, and true replays (same ids) are skipped exactly. The import cap
-  still bounds id-bearing imports as a sanity limit.
+  still bounds id-bearing imports as a sanity limit. *(Refined in Phase 5:
+  when the identity-matched original's entry id has left the leaf path, the
+  fresh id is a host re-issue for the same message and is adopted, not
+  imported; only repeats whose originals are still live import as new.)*
 
 **Effect:** rewritten/rotated transcripts are recognized exactly instead of
 inferred; the anchor scan, occurrence counting, and the per-process file-stat
@@ -220,6 +227,45 @@ memo cache become legacy-only paths.
   machinery.
 - Transcript reading/parsing fully lives in `src/transcript.ts` (done in
   Phase 1); `engine.ts` shrank accordingly.
+
+### Phase 5 — Leaf-path reconciliation and stale-id adoption
+
+Added after auditing the *actual* host source (see the corrected addendum
+below): entry ids identify tree **nodes**, not logical messages. The host
+implements every history edit — the `rewriteTranscriptEntries` hook this
+plugin's transcript GC calls, the host's own oversized-tool-result
+truncation, and gateway chat edits — as copy-on-write: it branches at the
+first replaced entry's parent and re-appends the whole active suffix as new
+entries with freshly generated ids. The replaced entries stay in the file
+as an abandoned branch, and the internal old→new id map is not returned to
+the caller. Without countermeasures, the re-issued ids read as "genuine new
+traffic" and the suffix re-imports as content duplicates — with the flood
+guard intentionally disabled for id-bearing imports.
+
+- **Leaf-path reading.** `readLeafPathMessages` now walks the `parentId`
+  chain from the file's last entry (the host's leaf) when every line
+  carries an envelope id, so abandoned branches are invisible to
+  reconciliation. A mid-file `parentId: null` reached from the leaf is a
+  genuine root (host `resetLeaf`). Id-less cohorts, dangling parents,
+  cycles, and JSON-array files keep the legacy flatten behavior.
+- **Stale-id adoption.** A missing leaf-path entry that fails NULL-id
+  adoption next looks for an identity-matched row whose stored entry id has
+  left the leaf path — a row stranded by a host rewrite — and re-stamps it
+  with the re-issued id instead of importing a duplicate
+  (`adoptStaleTranscriptEntryId`). Runs in both the entry-id reconcile loop
+  and the no-anchor new-epoch import (declared rollovers, path-mismatch
+  rotations, compaction successors).
+- **No-anchor replay block scoped to id-less traffic.** A fully id-bearing
+  no-anchor batch resolves identity overlaps exactly via adoption, so the
+  content replay-overlap block (which would freeze a rewritten epoch with
+  ≥ 3 identical kept messages) applies only to id-less batches. Adoption
+  reports `hasOverlap` so the checkpoint refreshes instead of re-entering
+  the slow path every turn.
+- **Known gap (accepted).** An entry whose *content* was replaced (the
+  externalized stub itself) matches no identity and imports as a new row —
+  one row per actually-replaced entry, bounded by the import cap. Closing
+  it exactly requires the host to return its old→new id map from
+  `rewriteTranscriptEntries` (it already builds one); deferred by decision.
 
 ## What stays
 
@@ -261,6 +307,8 @@ memo cache become legacy-only paths.
   import with adoption
 - [x] Phase 4 — pure planner functions in `src/reconcile-plan.ts` +
   `src/transcript.ts` extraction
+- [x] Phase 5 — leaf-path reading + stale-id adoption for host
+  copy-on-write rewrites
 
 ## Addendum: what the host source settles (post-implementation)
 
@@ -268,18 +316,43 @@ The four phases above are deliberately additive — a strangler-fig pattern
 that routes id-bearing traffic onto exact paths while keeping every legacy
 path bit-for-bit intact (`src/` ended at +992/−286). The open question was
 how much of the legacy machinery is genuinely required by the host versus
-retained out of caution. The transcript writer is `SessionManager` from
-`@earendil-works/pi-coding-agent` (this plugin imports the same class for
-its rotate path), and reading its source answers that question in both
-directions.
+retained out of caution.
+
+> **Correction (2026-06-10).** The first draft of this addendum audited
+> `SessionManager` from `@earendil-works/pi-coding-agent`. OpenClaw no
+> longer uses that package — the transcript writer is the in-tree embedded
+> harness (`openclaw/src/agents/sessions/session-manager.ts` and
+> `src/agents/embedded-agent-runner/`), forked from pi and format-identical
+> (v3, same entry types) *today*, but evolving independently. A sweep of
+> 920 live session files confirmed: all v3, every message line id-bearing,
+> zero JSON-array files. The behavioral claims below were re-verified
+> against the embedded source; the one the original audit got wrong —
+> id stability under content rewrites — is what Phase 5 fixes. Note this
+> plugin still imports the pi `SessionManager` for its rotate and GC
+> entry-id mapping paths; that pairing works while the formats match and
+> should be replaced with the plugin's own parser (tracked separately).
 
 ### Confirmed: entry ids are unconditional in the current format
 
 `appendMessage` always writes `{type:"message", id, parentId, timestamp,
-message}` with a collision-checked 8-hex id, and the session header always
-carries an id (v3 format). No code path writes an id-less message line. For
-any transcript the current host writes, the entry-id path covers 100% of
+message}` with a generated id (8-hex with full-UUID fallback in the
+embedded `SessionManager`; other host writer paths use full UUIDs — ids
+are opaque strings either way), and the session header always carries an
+id (v3 format). No code path writes an id-less message line. For any
+transcript the current host writes, the entry-id path covers 100% of
 traffic.
+
+### Corrected: entry ids are node ids, not message ids
+
+The original audit concluded entry ids were stable identities. They are —
+for *appends*. Every history edit is copy-on-write: the host re-appends
+the active suffix under new ids (`transcript-rewrite.ts`), used by this
+plugin's own transcript GC, by the host's oversized-tool-result
+truncation, and by gateway chat edits. `v1→v2` migration likewise
+regenerates every id. Compaction-successor rotation, corruption recovery,
+and `v2→v3` migration preserve entry ids (corruption recovery and
+rotation re-issue the *header* id only). Phase 5 exists because of this
+distinction.
 
 ### Confirmed: two "legacy" paths are load-bearing host behavior
 
@@ -312,12 +385,13 @@ and is a deletion candidate pending a maintainer decision.
 ### Discovery: sessions are trees, not logs
 
 Entries carry `parentId`; `branch()` / `resetLeaf()` create alternate paths
-within the same append-only file. `readLeafPathMessages`, despite its name,
-flattens *all* branches in file order, so LCM imports messages from
-abandoned branches today. That is a plausible source of "duplicate-ish
-content" incidents independent of replay. The `parentId` metadata captured
-in Phase 1 is sufficient to follow the actual leaf path; leaf-path-aware
-reconciliation is the highest-value follow-up this audit surfaced.
+within the same append-only file. `readLeafPathMessages` historically
+flattened *all* branches in file order, so LCM imported messages from
+abandoned branches — a plausible source of "duplicate-ish content"
+incidents independent of replay, and the amplifier that turned host
+copy-on-write rewrites into duplicate imports. Phase 5 made the function
+live up to its name: it follows the actual leaf path whenever the file has
+full id coverage.
 
 ### Revised deletion picture
 
@@ -329,6 +403,8 @@ reconciliation is the highest-value follow-up this audit surfaced.
 | JSON-array parsing | Deletable — nothing writes it today (needs maintainer decision) |
 | Timestamp-flood guards | Demote — only protect file-less-window runtime ingests now |
 | `deduplicateAfterTurnBatch` oversized/suffix heuristics | Likely collapsible into the alignment helper; scoped to the file-less window |
+| No-anchor replay-overlap block + prefix drop | Id-less traffic only as of Phase 5 — id-bearing batches resolve overlaps exactly via adoption |
+| Flatten-in-file-order transcript reading | Fallback only as of Phase 5 — leaf-path walk covers all full-id-coverage files |
 
 Net: the "require entry ids and delete the legacy stack" option is smaller
 than the pre-audit estimate, because the host's deferred-flush design makes

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -126,7 +126,7 @@ independently with tests green.
 any host that writes entry IDs. Flood guards stop being the only line of
 defense.
 
-### Phase 2 — Transcript as the single persistence source in `afterTurn`
+### Phase 2 — Exact runtime-batch alignment against the covered frontier
 
 - `TranscriptReconcileResult` gains `transcriptCovered: boolean` — true only
   when the reconcile path actually read the transcript to EOF (append-only
@@ -134,17 +134,32 @@ defense.
   overlap / imported). The missing-file and unreadable-file fallbacks that
   return `hasOverlap: true` to "allow live afterTurn persistence" set it
   false.
-- In `afterTurn`: when `transcriptCovered` is true, the runtime messages
-  array is **not** persisted (the transcript reconcile already imported the
-  turn; if the host flushed the transcript late, the next turn's append-only
-  read imports the remainder idempotently). When false, the existing
-  runtime-array path runs unchanged.
+- *(Adjusted during implementation.)* The original plan — skip runtime-array
+  persistence entirely when covered — is unsafe: the host can fire
+  `afterTurn` before flushing the turn's tail to the transcript, and the
+  regression suite encodes that case. Reading the file to EOF proves the DB
+  matches the file, not that the file contains the turn.
+- Instead, when covered, the runtime batch is reconciled by **exact tail
+  alignment** (`alignRuntimeBatchAgainstCoveredFrontier`): because the DB
+  tail now provably equals the transcript frontier, either (a) the batch
+  aligns fully with the tail — nothing to ingest, (b) a prefix aligns —
+  ingest only the flush-lagged remainder, or (c) nothing aligns — ingest all
+  if the batch has zero persisted-identity overlap (genuinely unflushed
+  turn), otherwise fail closed (stale replay snapshot; the next covered
+  transcript read delivers anything real, idempotently).
+- Flush-lagged messages persisted from the runtime array carry no entry id;
+  when the transcript catches up, the existing identity-overlap guards
+  (append-only overlap check + anchor scan) dedupe the catch-up entries.
+  This cross-pipeline overlap is why Phase 3's entry-id set-difference
+  import must *adopt* identity-matched NULL-entry-id tail rows (stamp the
+  entry id onto the matched row) rather than blindly importing every
+  missing id.
 - `deduplicateAfterTurnBatch` and its oversized/suffix fallbacks remain for
-  the not-covered fallback path only, and are no longer load-bearing on the
-  common path.
+  the not-covered fallback path only.
 
-**Effect:** on the common path there is exactly one writer. The
-dual-pipeline dedup heuristics stop running every turn.
+**Effect:** on the common path the heuristic dedup stack is replaced by one
+exact, explainable rule, and every fail-closed outcome is self-healing via
+the next turn's idempotent transcript read.
 
 ### Phase 3 — Declared epochs and exact checkpoints
 
@@ -232,8 +247,8 @@ memo cache become legacy-only paths.
 
 - [x] Phase 1 — envelope-preserving parser, `transcript_entry_id` column +
   partial unique index, entry-ID idempotent ingest
-- [ ] Phase 2 — `transcriptCovered` gating; runtime array persists only as
-  fallback
+- [x] Phase 2 — `transcriptCovered` + exact covered-frontier alignment;
+  heuristic dedup retained only for uncovered paths
 - [ ] Phase 3 — session-header epochs, entry-ID checkpoints, set-difference
   import
 - [ ] Phase 4 — pure `planTranscriptImport` planner + `src/transcript.ts`

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -202,27 +202,24 @@ memo cache become legacy-only paths.
 
 ### Phase 4 — Pure reconciliation planner
 
-- New `src/reconcile-plan.ts` exposes a pure function:
-
-  ```ts
-  planTranscriptImport(params: {
-    entries: TranscriptEntry[];
-    existingEntryIds: ReadonlySet<string>;
-    checkpoint: { sessionHeaderId: string | null; lastProcessedEntryId: string | null } | null;
-    transcriptHeaderId: string | null;
-  }): {
-    decision: "append" | "epoch-rollover" | "legacy-heuristics" | "noop";
-    toImport: TranscriptEntry[];
-    reason: string;
-  }
-  ```
-
-  No IO, no logging, no store access — unit-testable without the engine.
-- `reconcileSessionTail` consults the planner first; only the
-  `legacy-heuristics` decision falls through to the existing content-identity
+- New `src/reconcile-plan.ts` — no IO, no logging, no store access;
+  unit-testable without the engine. *(Adjusted during implementation:
+  instead of one monolithic `planTranscriptImport`, the planner is three
+  composable pure functions, because the synthetic-heartbeat filter must run
+  between candidate selection and the cap check and operates on message
+  content the planner does not see.)*
+  - `selectEntryIdTail({entryIds, existingEntryIds, lastProcessedEntryId})`
+    → `no-id-lineage` | `at-tip` | `tail{anchorIndex, missingIndexes}` —
+    the anchor/set-difference core of `reconcileSessionTailByEntryIds`.
+  - `resolveEpochRoute({checkpointHeaderId, transcriptHeaderId})` →
+    `same-epoch` | `declared-rollover` | `undeclared`.
+  - `transcriptImportCap(existingDbCount)` — the single definition of the
+    max(20%, 50) sanity bound, replacing three inline copies.
+- `reconcileSessionTail` consults the entry-id planner first; only the
+  `no-id-lineage` outcome falls through to the existing content-identity
   machinery.
-- Transcript reading/parsing fully lives in `src/transcript.ts`;
-  `engine.ts` shrinks accordingly.
+- Transcript reading/parsing fully lives in `src/transcript.ts` (done in
+  Phase 1); `engine.ts` shrank accordingly.
 
 ## What stays
 
@@ -262,5 +259,5 @@ memo cache become legacy-only paths.
   heuristic dedup retained only for uncovered paths
 - [x] Phase 3 — session-header epochs, entry-ID checkpoints, set-difference
   import with adoption
-- [ ] Phase 4 — pure `planTranscriptImport` planner + `src/transcript.ts`
-  extraction
+- [x] Phase 4 — pure planner functions in `src/reconcile-plan.ts` +
+  `src/transcript.ts` extraction

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -180,10 +180,21 @@ the next turn's idempotent transcript read.
      sanity bounds only.
   3. Header ID absent (legacy/array-mode transcripts) → existing heuristic
      reason taxonomy unchanged.
-- Entry-ID set-difference import: for transcripts where (nearly) all entries
-  carry IDs, `reconcileSessionTail` skips the backward anchor scan and
-  occurrence counting entirely — one batched query for which IDs already
-  exist, then import the missing ones in order.
+- Entry-ID set-difference import: for transcripts where all entries carry
+  IDs, `reconcileSessionTail` skips the backward anchor scan and occurrence
+  counting entirely (`reconcileSessionTailByEntryIds`) — anchor on the
+  checkpoint's `last_processed_entry_id` (or the newest persisted ID), one
+  batched existence query for the tail, then import the missing entries in
+  order. Missing entries first attempt **adoption**: an identity-matched row
+  with a NULL entry id (runtime flush-lag rows, pre-migration data) is
+  stamped with the entry id instead of imported, healing legacy rows in
+  place. Entry-id anchoring is immune to post-ingest content rewriting
+  (tool-result externalization), which defeats content-identity anchors.
+- *(Adjusted during implementation.)* Repeated content arriving under fresh
+  entry ids is now imported as genuine traffic instead of tripping the
+  user-role replay-flood guard — the host's SessionManager declared them new
+  entries, and true replays (same ids) are skipped exactly. The import cap
+  still bounds id-bearing imports as a sanity limit.
 
 **Effect:** rewritten/rotated transcripts are recognized exactly instead of
 inferred; the anchor scan, occurrence counting, and the per-process file-stat
@@ -249,7 +260,7 @@ memo cache become legacy-only paths.
   partial unique index, entry-ID idempotent ingest
 - [x] Phase 2 — `transcriptCovered` + exact covered-frontier alignment;
   heuristic dedup retained only for uncovered paths
-- [ ] Phase 3 — session-header epochs, entry-ID checkpoints, set-difference
-  import
+- [x] Phase 3 — session-header epochs, entry-ID checkpoints, set-difference
+  import with adoption
 - [ ] Phase 4 — pure `planTranscriptImport` planner + `src/transcript.ts`
   extraction

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -327,10 +327,14 @@ retained out of caution.
 > 920 live session files confirmed: all v3, every message line id-bearing,
 > zero JSON-array files. The behavioral claims below were re-verified
 > against the embedded source; the one the original audit got wrong —
-> id stability under content rewrites — is what Phase 5 fixes. Note this
-> plugin still imports the pi `SessionManager` for its rotate and GC
-> entry-id mapping paths; that pairing works while the formats match and
-> should be replaced with the plugin's own parser (tracked separately).
+> id stability under content rewrites — is what Phase 5 fixes. The plugin's
+> last two runtime uses of the pi `SessionManager` (rotate, GC entry-id
+> mapping) were replaced with the plugin's own read-only parser
+> (`readLeafPathRawEntries`), and `@earendil-works/*` moved to
+> devDependencies — pi's `SessionManager.open` migrates and rewrites v1/v2
+> or empty files as a side effect, and the pi package no longer tracks the
+> host's in-tree format. Tests still write fixtures through it while the
+> formats remain identical.
 
 ### Confirmed: entry ids are unconditional in the current format
 

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -261,3 +261,77 @@ memo cache become legacy-only paths.
   import with adoption
 - [x] Phase 4 — pure planner functions in `src/reconcile-plan.ts` +
   `src/transcript.ts` extraction
+
+## Addendum: what the host source settles (post-implementation)
+
+The four phases above are deliberately additive — a strangler-fig pattern
+that routes id-bearing traffic onto exact paths while keeping every legacy
+path bit-for-bit intact (`src/` ended at +992/−286). The open question was
+how much of the legacy machinery is genuinely required by the host versus
+retained out of caution. The transcript writer is `SessionManager` from
+`@earendil-works/pi-coding-agent` (this plugin imports the same class for
+its rotate path), and reading its source answers that question in both
+directions.
+
+### Confirmed: entry ids are unconditional in the current format
+
+`appendMessage` always writes `{type:"message", id, parentId, timestamp,
+message}` with a collision-checked 8-hex id, and the session header always
+carries an id (v3 format). No code path writes an id-less message line. For
+any transcript the current host writes, the entry-id path covers 100% of
+traffic.
+
+### Confirmed: two "legacy" paths are load-bearing host behavior
+
+1. **Deferred flush is by design.** `SessionManager._persist` buffers every
+   entry in memory until the first *assistant* message exists, then writes
+   the whole file at once. Every new session therefore passes through a
+   window where the transcript file does not exist on disk. The
+   missing-file → runtime-array persistence fallback (and Phase 2's
+   covered-frontier alignment) is **permanent architecture**, not a
+   transitional compatibility shim. This also retroactively explains the
+   flush-lag regression fixture that forced the Phase 2 adjustment, and is
+   a plausible contributor to several historical dual-source bugs.
+2. **Same-path rewrites are real host events.** `setSessionFile` rewrites
+   the file in place on version migration, recreates corrupted/empty files
+   with a *new* header id, and `_rewriteFile` serves branch/compaction
+   operations. Phase 3's header-id rollover detection maps to actual host
+   behavior; the rewrite/shrink handling cannot be deleted, only kept in
+   its declared form.
+
+### Confirmed: the id-less cohort is real but aging
+
+v1 session files had no entry ids; `migrateV1ToV2` adds them when the host
+next loads the file (and `_rewriteFile`s it). LCM can read not-yet-migrated
+v1 files directly (startup scans, resumed archives), so the content-anchor
+machinery is needed for exactly that cohort until it ages out. The
+JSON-array transcript format, by contrast, is written by nothing in the
+current host — its origin predates this repo's squashed import history —
+and is a deletion candidate pending a maintainer decision.
+
+### Discovery: sessions are trees, not logs
+
+Entries carry `parentId`; `branch()` / `resetLeaf()` create alternate paths
+within the same append-only file. `readLeafPathMessages`, despite its name,
+flattens *all* branches in file order, so LCM imports messages from
+abandoned branches today. That is a plausible source of "duplicate-ish
+content" incidents independent of replay. The `parentId` metadata captured
+in Phase 1 is sufficient to follow the actual leaf path; leaf-path-aware
+reconciliation is the highest-value follow-up this audit surfaced.
+
+### Revised deletion picture
+
+| Component | Verdict from host source |
+|---|---|
+| Runtime-array fallback + covered alignment | Keep permanently — deferred flush guarantees file-less turns |
+| Header-id rollover, entry-id checkpoints | Keep — maps to real `_rewriteFile`/migration events |
+| Content anchor scan + occurrence counting | Keep until v1 files age out, then delete |
+| JSON-array parsing | Deletable — nothing writes it today (needs maintainer decision) |
+| Timestamp-flood guards | Demote — only protect file-less-window runtime ingests now |
+| `deduplicateAfterTurnBatch` oversized/suffix heuristics | Likely collapsible into the alignment helper; scoped to the file-less window |
+
+Net: the "require entry ids and delete the legacy stack" option is smaller
+than the pre-audit estimate, because the host's deferred-flush design makes
+the dual-source problem permanent. The code that remains, remains because
+the host architecture demands it — not because behavior preservation was
+assumed.

--- a/specs/transcript-reconciliation-by-entry-id.md
+++ b/specs/transcript-reconciliation-by-entry-id.md
@@ -1,0 +1,240 @@
+# Transcript Reconciliation by Entry ID
+
+**Status:** In progress
+**Date:** 2026-06-10
+**Scope:** `lossless-claw` plugin (no OpenClaw runtime changes required)
+**Priority:** High
+
+## Problem
+
+Transcript reconciliation — the logic that keeps the LCM SQLite store in sync
+with the OpenClaw session JSONL file — is the source of most recent
+regressions (#591, #640, #649, #659, #685, #706, #835, #837, #840, #846, the
+replay-flood guards, role-aware thresholds, ambiguous-rollover handling). Of
+the last 30 commits touching `engine.ts`, at least 12 are reconciliation
+fixes, and several of those patch problems created by earlier fixes (#837
+fixes a freeze introduced by #649's fail-closed guard, which itself patched a
+hole left by #591's flood guard).
+
+The complexity is not accidental sprawl; it is forced by two foundational
+decisions:
+
+### 1. Lossy message identity
+
+Reconciliation identifies messages by content: `role + "\0" + content`
+(`messageIdentity`), with a non-unique `identity_hash` index, and the
+checkpoint anchor (`createBootstrapEntryHash`) is likewise a SHA-256 of
+`{role, content}`. Content identity cannot distinguish "this transcript line
+was replayed" from "a new message that happens to be identical" — which is
+common traffic (empty tool results, heartbeat acks, repeated outputs within
+the same second, since `datetime('now')` has 1-second granularity).
+
+Meanwhile, every transcript JSONL entry carries a stable envelope:
+
+```json
+{ "type": "message", "id": "…", "parentId": "…", "timestamp": "…", "message": { "role": "…", "content": […] } }
+```
+
+`extractCanonicalBootstrapMessage` strips that envelope at parse time and
+keeps only `entry.message`. The exact information the guard stack tries to
+reconstruct heuristically is discarded before reconciliation begins.
+
+Because identity is ambiguous and writes are not idempotent (no uniqueness
+constraint on messages), every code path must *prove* non-duplication before
+inserting. Failure in one direction is silent duplication (replay floods);
+failure in the other is a frozen conversation that never compacts. The result
+is a stack of at least eight independent, incident-calibrated thresholds:
+
+| Guard | Threshold |
+|---|---|
+| Replay-overlap block (no-anchor import) | ≥ max(3, 50% of batch) |
+| No-anchor import cap | max(20% of DB, 50) messages |
+| Timestamp-flood, user role | 3 per (conversation, second) |
+| Timestamp-flood, internal roles | 32 per (conversation, identity, second) |
+| Bootstrap replay prefix minimum | 3 messages |
+| Tail-anchor continuity proof | 3-message contiguous suffix match |
+| Delivery-only transcript detection | ≤ 4 messages matching `delivery-mirror\|config-audit` |
+| Heartbeat detection | literal `"heartbeat_ok"` / `"heartbeat.md"` markers |
+
+None of these are derived from anything; each is a calibration against a past
+incident, so each new traffic shape becomes a new regression.
+
+Notably, the codebase already half-trusts stable IDs:
+`filterPersistedRawIdReplayBatch` and `countActiveCrossConversationRawIdMatches`
+extract raw event IDs from `message_parts.metadata` and make drop decisions on
+exact ID matches. They are used as yet another heuristic layer rather than as
+the primary identity.
+
+### 2. Two competing ingestion sources
+
+Both the transcript file (via `reconcileTranscriptTailForAfterTurn`) and the
+runtime `afterTurn` messages array (via `deduplicateAfterTurnBatch` →
+`ingestBatch`) persist messages, and each carries its own dedup stack that
+must reason about the other's output. The code itself states the transcript
+is authoritative by `afterTurn` time ("The transcript has the complete turn by
+this point"). The runtime-array pipeline exists for the cases where the
+transcript is missing or unreadable, but it runs unconditionally, so the
+aligned-tail/oversized/suffix-fallback heuristics in
+`deduplicateAfterTurnBatch` are load-bearing on every turn.
+
+### 3. Epochs are inferred, not declared
+
+Path-mismatch, same-path-shrink, no-anchor, and ambiguous-rollover detection
+are heuristic proxies for "the transcript was rewritten, rotated, or forked."
+The transcript's session header line (`{"type":"session","id":…,
+"parentSession":…}`) declares this directly and is currently only consulted
+for `parentSession`.
+
+### 4. Mechanism, policy, and logging are interleaved
+
+`reconcileSessionTail` computes the transcript/DB diff *and* applies caps,
+blocks, and filters *and* logs, across ~10 return sites that must each set
+`hasOverlap` / `blockedByImportCap` / `blockedReason` correctly; the caller
+re-derives "unsafe to advance" from flag combinations. The decision logic
+cannot be tested without the full engine harness.
+
+## Design
+
+Promote the transcript entry ID from "heuristic #9" to the primary message
+identity, make storage idempotent on it, and let the guard stack demote from
+correctness-critical to telemetry. Work proceeds in four phases, each landing
+independently with tests green.
+
+### Phase 1 — Idempotent writes keyed on transcript entry ID
+
+- Parsing keeps the JSONL envelope. A new `src/transcript.ts` module owns
+  transcript reading/parsing (moved out of `engine.ts`) and attaches envelope
+  metadata (`id`, `parentId`, `timestamp`) to each parsed message via a
+  symbol-keyed property (survives object spread; invisible to
+  `JSON.stringify`). Helpers: `attachTranscriptEntryMeta`,
+  `getTranscriptEntryMeta`, `getTranscriptEntryId`.
+- Schema: `messages.transcript_entry_id TEXT` (additive `ALTER`, idempotent)
+  plus a **partial unique index**
+  `messages_conv_entry_unique_idx ON messages(conversation_id,
+  transcript_entry_id) WHERE transcript_entry_id IS NOT NULL`. Legacy rows
+  stay NULL and are unaffected.
+- `ingestSingle` extracts the entry ID from the message's transcript metadata.
+  If a row with the same `(conversation_id, transcript_entry_id)` exists, the
+  ingest is skipped *before* any side effects (parts, context items, FTS,
+  large-file interception). The unique index backstops races.
+- Behavior of all existing guards is unchanged in this phase; the entry-ID
+  check simply runs first. Messages without entry IDs (runtime-array ingest,
+  array-mode session files, host formats without envelopes) behave exactly as
+  before.
+
+**Effect:** replaying a transcript region becomes a no-op by construction for
+any host that writes entry IDs. Flood guards stop being the only line of
+defense.
+
+### Phase 2 — Transcript as the single persistence source in `afterTurn`
+
+- `TranscriptReconcileResult` gains `transcriptCovered: boolean` — true only
+  when the reconcile path actually read the transcript to EOF (append-only
+  fast path with successful parse, or slow-path full re-read that found
+  overlap / imported). The missing-file and unreadable-file fallbacks that
+  return `hasOverlap: true` to "allow live afterTurn persistence" set it
+  false.
+- In `afterTurn`: when `transcriptCovered` is true, the runtime messages
+  array is **not** persisted (the transcript reconcile already imported the
+  turn; if the host flushed the transcript late, the next turn's append-only
+  read imports the remainder idempotently). When false, the existing
+  runtime-array path runs unchanged.
+- `deduplicateAfterTurnBatch` and its oversized/suffix fallbacks remain for
+  the not-covered fallback path only, and are no longer load-bearing on the
+  common path.
+
+**Effect:** on the common path there is exactly one writer. The
+dual-pipeline dedup heuristics stop running every turn.
+
+### Phase 3 — Declared epochs and exact checkpoints
+
+- `src/transcript.ts` parses the session header line and exposes
+  `readTranscriptHeader(sessionFile)` → `{ sessionHeaderId, parentSession }`.
+- `conversation_bootstrap_state` gains `session_header_id TEXT` and
+  `last_processed_entry_id TEXT` (additive ALTERs).
+- `refreshBootstrapState` records the header ID and the entry ID of the last
+  processed entry alongside the existing size/mtime/offset/content-hash.
+- Reconcile decision order becomes:
+  1. Header ID present on both sides and **equal** → same epoch. Append-only
+     by offset is valid when the file grew; the entry-ID at the checkpoint
+     boundary is the exact anchor (content-hash anchor retained as legacy
+     fallback).
+  2. Header IDs **differ** → declared epoch change (rewrite/rotation), no
+     heuristics: full re-read, import by entry-ID set difference
+     (idempotent via Phase 1), refresh checkpoint. Import caps remain as
+     sanity bounds only.
+  3. Header ID absent (legacy/array-mode transcripts) → existing heuristic
+     reason taxonomy unchanged.
+- Entry-ID set-difference import: for transcripts where (nearly) all entries
+  carry IDs, `reconcileSessionTail` skips the backward anchor scan and
+  occurrence counting entirely — one batched query for which IDs already
+  exist, then import the missing ones in order.
+
+**Effect:** rewritten/rotated transcripts are recognized exactly instead of
+inferred; the anchor scan, occurrence counting, and the per-process file-stat
+memo cache become legacy-only paths.
+
+### Phase 4 — Pure reconciliation planner
+
+- New `src/reconcile-plan.ts` exposes a pure function:
+
+  ```ts
+  planTranscriptImport(params: {
+    entries: TranscriptEntry[];
+    existingEntryIds: ReadonlySet<string>;
+    checkpoint: { sessionHeaderId: string | null; lastProcessedEntryId: string | null } | null;
+    transcriptHeaderId: string | null;
+  }): {
+    decision: "append" | "epoch-rollover" | "legacy-heuristics" | "noop";
+    toImport: TranscriptEntry[];
+    reason: string;
+  }
+  ```
+
+  No IO, no logging, no store access — unit-testable without the engine.
+- `reconcileSessionTail` consults the planner first; only the
+  `legacy-heuristics` decision falls through to the existing content-identity
+  machinery.
+- Transcript reading/parsing fully lives in `src/transcript.ts`;
+  `engine.ts` shrinks accordingly.
+
+## What stays
+
+- Bootstrap token budget and fork bounding (`trimBootstrapMessagesToBudget`,
+  `fork_bounded`).
+- Rotate-coverage ordering (reconcile before rotate compaction).
+- Heartbeat filtering — but as *storage policy* ("do we want these rows?")
+  rather than a correctness guard.
+- The timestamp-flood guard and import caps — demoted to sanity
+  bounds/telemetry for entry-ID traffic, still primary for ID-less traffic.
+
+## Risks and mitigations
+
+- **ID-less transcripts.** Array-mode session files and bare
+  `{role, content}` JSONL lines have no envelope. Every phase treats entry
+  IDs as optional; the content-identity path remains as the explicit
+  fallback.
+- **Legacy rows.** Existing DB rows have `transcript_entry_id = NULL`. No
+  backfill is attempted; the partial unique index only protects new writes,
+  which is sufficient — duplicates of legacy rows are still caught by the
+  (unchanged) content-identity guards until those regions age out via
+  compaction/rotation.
+- **Transcript flush lag (Phase 2).** If a host fires `afterTurn` before
+  flushing the final assistant message, that message is imported on the next
+  turn's append-only read instead. Ordering by `seq` is preserved;
+  compaction-threshold evaluation may lag one turn. If a host is found that
+  never flushes, `transcriptCovered` is false there and the runtime path
+  still applies.
+- **Duplicate entry IDs within one file.** The unique index makes the second
+  occurrence a skip; this matches the semantics of a replayed line.
+
+## Phase status
+
+- [x] Phase 1 — envelope-preserving parser, `transcript_entry_id` column +
+  partial unique index, entry-ID idempotent ingest
+- [ ] Phase 2 — `transcriptCovered` gating; runtime array persists only as
+  fallback
+- [ ] Phase 3 — session-header epochs, entry-ID checkpoints, set-difference
+  import
+- [ ] Phase 4 — pure `planTranscriptImport` planner + `src/transcript.ts`
+  extraction

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -374,6 +374,24 @@ function ensureConversationBootstrapStateForkColumns(db: DatabaseSync): void {
   }
 }
 
+/**
+ * Declared-epoch reconciliation state: the transcript's session header id
+ * (rewrites/rotations change it) and the envelope id of the last processed
+ * transcript entry (exact resume anchor, immune to content rewriting).
+ * See specs/transcript-reconciliation-by-entry-id.md.
+ */
+function ensureConversationBootstrapStateEpochColumns(db: DatabaseSync): void {
+  const columns = db
+    .prepare(`PRAGMA table_info(conversation_bootstrap_state)`)
+    .all() as SummaryColumnInfo[];
+  if (!columns.some((col) => col.name === "session_header_id")) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN session_header_id TEXT`);
+  }
+  if (!columns.some((col) => col.name === "last_processed_entry_id")) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN last_processed_entry_id TEXT`);
+  }
+}
+
 function backfillMessageIdentityHashes(
   db: DatabaseSync,
   options?: { managesOwnTransaction?: boolean },
@@ -1072,6 +1090,8 @@ export function runLcmMigrations(
       last_seen_mtime_ms INTEGER NOT NULL,
       last_processed_offset INTEGER NOT NULL,
       last_processed_entry_hash TEXT,
+      session_header_id TEXT,
+      last_processed_entry_id TEXT,
       fork_bounded INTEGER NOT NULL DEFAULT 0,
       fork_source_message_count INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -1231,6 +1251,9 @@ export function runLcmMigrations(
     );
     runMigrationStep("ensureConversationBootstrapStateForkColumns", log, () =>
       ensureConversationBootstrapStateForkColumns(db),
+    );
+    runMigrationStep("ensureConversationBootstrapStateEpochColumns", log, () =>
+      ensureConversationBootstrapStateEpochColumns(db),
     );
     // Belt-and-suspenders: ensure message_parts exists even if the bulk
     // CREATE TABLE block above was interrupted before reaching it.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -339,6 +339,22 @@ function ensureMessageLargeContentColumn(db: DatabaseSync): void {
   }
 }
 
+/**
+ * Transcript-entry-id reconciliation: the stable JSONL envelope id of the
+ * transcript entry a message was imported from. NULL for runtime-array
+ * ingests, legacy rows, and transcripts without envelopes. The partial
+ * unique index makes transcript imports idempotent — replaying a transcript
+ * region can never duplicate rows. See
+ * specs/transcript-reconciliation-by-entry-id.md.
+ */
+function ensureMessageTranscriptEntryIdColumn(db: DatabaseSync): void {
+  const messageColumns = db.prepare(`PRAGMA table_info(messages)`).all() as SummaryColumnInfo[];
+  const hasTranscriptEntryId = messageColumns.some((col) => col.name === "transcript_entry_id");
+  if (!hasTranscriptEntryId) {
+    db.exec(`ALTER TABLE messages ADD COLUMN transcript_entry_id TEXT`);
+  }
+}
+
 function ensureConversationBootstrapStateForkColumns(db: DatabaseSync): void {
   const columns = db
     .prepare(`PRAGMA table_info(conversation_bootstrap_state)`)
@@ -951,6 +967,7 @@ export function runLcmMigrations(
       content TEXT NOT NULL,
       token_count INTEGER NOT NULL,
       identity_hash TEXT,
+      transcript_entry_id TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       UNIQUE (conversation_id, seq)
     );
@@ -1224,6 +1241,18 @@ export function runLcmMigrations(
     runMigrationStep("createMessagesIdentityHashIndex", log, () =>
       db.exec(
         `CREATE INDEX IF NOT EXISTS messages_conv_identity_hash_idx ON messages (conversation_id, identity_hash)`,
+      ),
+    );
+    runMigrationStep("ensureMessageTranscriptEntryIdColumn", log, () =>
+      ensureMessageTranscriptEntryIdColumn(db),
+    );
+    // Partial unique index: NULL entry ids (legacy rows, runtime ingests) are
+    // exempt, so this only enforces idempotency for transcript-imported rows.
+    runMigrationStep("createMessagesTranscriptEntryIdIndex", log, () =>
+      db.exec(
+        `CREATE UNIQUE INDEX IF NOT EXISTS messages_conv_entry_unique_idx
+         ON messages (conversation_id, transcript_entry_id)
+         WHERE transcript_entry_id IS NOT NULL`,
       ),
     );
     runMigrationStep("ensureCompactionTelemetryColumns", log, () =>

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6073,8 +6073,14 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
 
+    // Ids on the current leaf path. A persisted row whose entry id is NOT in
+    // this set was stranded by a host history rewrite (the suffix was
+    // re-appended under new ids) and is eligible for stale-id re-stamping.
+    const leafEntryIds = new Set(entryIds);
+
     let importedMessages = 0;
     let adoptedMessages = 0;
+    let restampedMessages = 0;
     for (const message of missingTail) {
       const entryId = getTranscriptEntryId(message)!;
       const stored = toStoredMessage(message);
@@ -6086,6 +6092,17 @@ export class LcmContextEngine implements ContextEngine {
       );
       if (adopted) {
         adoptedMessages += 1;
+        continue;
+      }
+      const restamped = await this.adoptStaleTranscriptEntryId({
+        conversationId,
+        leafEntryIds,
+        role: stored.role,
+        content: stored.content,
+        entryId,
+      });
+      if (restamped) {
+        restampedMessages += 1;
         continue;
       }
       // Entry-id-verified imports are exact (the id is proven absent), so the
@@ -6102,9 +6119,45 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     this.deps.log.debug(
-      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages}`,
+      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages}`,
     );
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+  }
+
+  /**
+   * Re-stamp an identity-matched row whose stored entry id has left the
+   * transcript's leaf path. Host history rewrites (rewriteTranscriptEntries,
+   * the host's own tool-result truncation, gateway chat edits) re-append the
+   * active suffix under freshly generated ids; the stranded rows are the
+   * same messages, so they adopt the re-issued id instead of importing a
+   * duplicate. Rows whose ids are still on the leaf path are live entries
+   * and never touched. Returns true when a row was re-stamped.
+   */
+  private async adoptStaleTranscriptEntryId(params: {
+    conversationId: number;
+    leafEntryIds: ReadonlySet<string>;
+    role: StoredMessage["role"];
+    content: string;
+    entryId: string;
+  }): Promise<boolean> {
+    const candidates = await this.conversationStore.listTranscriptEntryIdsByIdentity(
+      params.conversationId,
+      params.role,
+      params.content,
+    );
+    for (const candidate of candidates) {
+      if (params.leafEntryIds.has(candidate.transcriptEntryId)) {
+        continue;
+      }
+      const restamped = await this.conversationStore.restampTranscriptEntryId(
+        candidate.messageId,
+        params.entryId,
+      );
+      if (restamped) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async reconcileSessionTail(params: {
@@ -6277,8 +6330,18 @@ export class LcmContextEngine implements ContextEngine {
             sessionContext,
             source: "reconcileSessionTail no-anchor",
           });
+          // A fully id-bearing batch resolves identity overlaps exactly:
+          // identity matches adopt the re-issued entry id (host rewrites and
+          // rotations re-append the surviving suffix under new ids) and only
+          // genuinely-new entries import. The replay-overlap block below
+          // exists for id-less ambiguity, where overlap could equally mean a
+          // replayed file; applying it here would freeze rewritten-epoch
+          // transcripts instead of healing them.
+          const allEntryIdBearing =
+            noAnchorImportMessages.length > 0 &&
+            noAnchorImportMessages.every((message) => getTranscriptEntryId(message) !== null);
           const replayThreshold = Math.max(3, Math.ceil(historicalMessages.length * 0.5));
-          if (persistedIdentityOverlaps >= replayThreshold) {
+          if (!allEntryIdBearing && persistedIdentityOverlaps >= replayThreshold) {
             if (replayAnalysis.firstNonOverlappingIndex < 0) {
               this.deps.log.warn(
                 `[lcm] reconcileSessionTail: duplicate transcript replay blocked for ${sessionContext} - ${persistedIdentityOverlaps}/${historicalMessages.length} candidate messages already exist (reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent replay flood.`,
@@ -6344,8 +6407,45 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
 
+          // Ids on the current leaf path, for stale-id re-stamping of rows
+          // stranded by the rewrite/rotation that produced this new epoch.
+          const noAnchorLeafEntryIds = new Set(
+            historicalMessages
+              .map((message) => getTranscriptEntryId(message))
+              .filter((id): id is string => id !== null),
+          );
           let importedMessages = 0;
+          let adoptedMessages = 0;
           for (const message of noAnchorImportMessages) {
+            const entryId = getTranscriptEntryId(message);
+            if (entryId) {
+              const alreadyPersisted = await this.conversationStore.hasMessageByTranscriptEntryId(
+                conversationId,
+                entryId,
+              );
+              if (alreadyPersisted) {
+                continue;
+              }
+              const stored = toStoredMessage(message);
+              const adopted =
+                (await this.conversationStore.adoptTranscriptEntryId(
+                  conversationId,
+                  stored.role,
+                  stored.content,
+                  entryId,
+                )) ||
+                (await this.adoptStaleTranscriptEntryId({
+                  conversationId,
+                  leafEntryIds: noAnchorLeafEntryIds,
+                  role: stored.role,
+                  content: stored.content,
+                  entryId,
+                }));
+              if (adopted) {
+                adoptedMessages += 1;
+                continue;
+              }
+            }
             const result = await this.ingestSingle({
               sessionId,
               sessionKey: params.sessionKey,
@@ -6357,9 +6457,13 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
           this.deps.log.warn(
-            `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} overlap=false`,
+            `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} overlap=${adoptedMessages > 0}`,
           );
-          return { blockedByImportCap: false, importedMessages, hasOverlap: false };
+          // Adoption proves the "new epoch" overlaps persisted history (the
+          // host re-issued ids for messages we already hold), so report the
+          // overlap — the caller then refreshes the checkpoint instead of
+          // re-entering this path every turn.
+          return { blockedByImportCap: false, importedMessages, hasOverlap: adoptedMessages > 0 };
         }
         this.deps.log.debug(
           `[lcm] reconcileSessionTail: no anchor for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=false`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5,7 +5,6 @@ import type { FileHandle } from "node:fs/promises";
 import { join, resolve as resolvePath } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { createInterface } from "node:readline";
-import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type {
   ContextEngine,
   ContextEngineInfo,
@@ -95,8 +94,10 @@ import {
   readAppendedLeafPathMessages,
   readLastJsonlEntryBeforeOffset,
   readLeafPathMessages,
+  readLeafPathRawEntries,
   readSessionParentSessionReference,
   readTranscriptHeader,
+  type TranscriptRawEntry,
 } from "./transcript.js";
 import { resolveEpochRoute, selectEntryIdTail, transcriptImportCap } from "./reconcile-plan.js";
 
@@ -758,17 +759,22 @@ function extractTranscriptToolCallId(message: AgentMessage): string | undefined 
   return undefined;
 }
 
-function listTranscriptToolResultEntryIdsByCallId(sessionFile: string): Map<string, string> {
-  const sessionManager = SessionManager.open(sessionFile);
-  const branch = sessionManager.getBranch();
+async function listTranscriptToolResultEntryIdsByCallId(
+  sessionFile: string,
+): Promise<Map<string, string>> {
+  const leafPathMessages = await readLeafPathMessages(sessionFile);
   const entryIdsByCallId = new Map<string, string>();
   const duplicateCallIds = new Set<string>();
 
-  for (const entry of branch) {
-    if (entry.type !== "message" || entry.message.role !== "toolResult") {
+  for (const message of leafPathMessages) {
+    if (message.role !== "toolResult") {
       continue;
     }
-    const toolCallId = extractTranscriptToolCallId(entry.message as AgentMessage);
+    const entryId = getTranscriptEntryId(message);
+    if (!entryId) {
+      continue;
+    }
+    const toolCallId = extractTranscriptToolCallId(message);
     if (!toolCallId) {
       continue;
     }
@@ -776,7 +782,7 @@ function listTranscriptToolResultEntryIdsByCallId(sessionFile: string): Map<stri
       duplicateCallIds.add(toolCallId);
       continue;
     }
-    entryIdsByCallId.set(toolCallId, entry.id);
+    entryIdsByCallId.set(toolCallId, entryId);
   }
 
   for (const duplicateCallId of duplicateCallIds) {
@@ -8852,7 +8858,7 @@ export class LcmContextEngine implements ContextEngine {
           };
         }
 
-        const transcriptEntryIdsByCallId = listTranscriptToolResultEntryIdsByCallId(
+        const transcriptEntryIdsByCallId = await listTranscriptToolResultEntryIdsByCallId(
           params.sessionFile,
         );
         const replacements: TranscriptRewriteReplacement[] = [];
@@ -11267,9 +11273,13 @@ export class LcmContextEngine implements ContextEngine {
     conversationId: number;
     sessionFile: string;
   }): Promise<RotateTranscriptRewriteResult> {
-    const sessionManager = SessionManager.open(params.sessionFile);
-    const header = sessionManager.getHeader();
-    const branch = sessionManager.getBranch();
+    const { header, entries: branch } = await readLeafPathRawEntries(params.sessionFile);
+    if (!header) {
+      // SessionManager.open used to synthesize a header (and rewrite the
+      // file) here; reading is now side-effect free, so a headerless file is
+      // the host's problem to recover, not ours to rotate.
+      throw new Error("session file has no session header; refusing to rotate");
+    }
     const originalStats = await stat(params.sessionFile);
 
     const messageIndices: number[] = [];
@@ -11288,10 +11298,15 @@ export class LcmContextEngine implements ContextEngine {
         ? (messageIndices[messageIndices.length - keepTailMessageCount] ?? branch.length)
         : branch.length;
 
-    const latestPreludeEntries = new Map<string, (typeof branch)[number]>();
+    const latestPreludeEntries = new Map<string, TranscriptRawEntry>();
     for (let index = 0; index < anchorIndex; index += 1) {
       const entry = branch[index];
-      if (entry && isRotatePreservedEntryType(entry.type) && entry.type !== "message") {
+      if (
+        entry &&
+        typeof entry.type === "string" &&
+        isRotatePreservedEntryType(entry.type) &&
+        entry.type !== "message"
+      ) {
         latestPreludeEntries.set(entry.type, entry);
       }
     }
@@ -11306,7 +11321,7 @@ export class LcmContextEngine implements ContextEngine {
 
     for (let index = anchorIndex; index < branch.length; index += 1) {
       const entry = branch[index];
-      if (entry && isRotatePreservedEntryType(entry.type)) {
+      if (entry && typeof entry.type === "string" && isRotatePreservedEntryType(entry.type)) {
         entriesToKeep.push({ ...entry });
       }
     }
@@ -11316,8 +11331,8 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     let previousEntryId: string | null = null;
-    const linearizedEntries = entriesToKeep.map((entry): (typeof branch)[number] => {
-      const nextEntry = {
+    const linearizedEntries = entriesToKeep.map((entry): TranscriptRawEntry => {
+      const nextEntry: TranscriptRawEntry = {
         ...entry,
         parentId: previousEntryId,
       };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -96,6 +96,7 @@ import {
   readLastJsonlEntryBeforeOffset,
   readLeafPathMessages,
   readSessionParentSessionReference,
+  readTranscriptHeader,
 } from "./transcript.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
@@ -5996,12 +5997,132 @@ export class LcmContextEngine implements ContextEngine {
    * Reconcile session-file history with persisted messages and append only the
    * tail that is present in JSONL but missing from LCM.
    */
+  /**
+   * Exact reconciliation for transcripts whose entries all carry stable
+   * envelope ids: anchor on the checkpoint's last processed entry id (or the
+   * newest id already persisted), then import only the tail entries whose
+   * ids are missing — adopting identity-matched rows that were persisted
+   * without an id (runtime flush lag, pre-migration data) instead of
+   * importing duplicates. Entry-id matching is immune to content rewriting
+   * (externalized tool results), which defeats content-identity anchors.
+   *
+   * Returns null when no id lineage links the transcript to this
+   * conversation; the caller's content-identity machinery and no-anchor
+   * guards then decide.
+   */
+  private async reconcileSessionTailByEntryIds(params: {
+    sessionId: string;
+    sessionKey?: string;
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+    entryIds: string[];
+    lastProcessedEntryId?: string | null;
+    existingDbCount: number;
+    sessionContext: string;
+    startedAt: number;
+  }): Promise<TranscriptReconcileResult | null> {
+    const { conversationId, historicalMessages, entryIds, sessionContext, startedAt } = params;
+
+    let anchorIndex = params.lastProcessedEntryId
+      ? entryIds.lastIndexOf(params.lastProcessedEntryId)
+      : -1;
+    let knownExisting: Set<string>;
+    if (anchorIndex >= 0) {
+      knownExisting = await this.conversationStore.filterExistingTranscriptEntryIds(
+        conversationId,
+        entryIds.slice(anchorIndex + 1),
+      );
+    } else {
+      knownExisting = await this.conversationStore.filterExistingTranscriptEntryIds(
+        conversationId,
+        entryIds,
+      );
+      if (knownExisting.size === 0) {
+        return null;
+      }
+      for (let index = entryIds.length - 1; index >= 0; index -= 1) {
+        if (knownExisting.has(entryIds[index]!)) {
+          anchorIndex = index;
+          break;
+        }
+      }
+    }
+
+    if (anchorIndex >= historicalMessages.length - 1) {
+      this.deps.log.debug(
+        `[lcm] reconcileSessionTail: entry-id anchor at tip for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=true`,
+      );
+      return { blockedByImportCap: false, importedMessages: 0, hasOverlap: true };
+    }
+
+    const candidates: AgentMessage[] = [];
+    for (let index = anchorIndex + 1; index < historicalMessages.length; index += 1) {
+      if (!knownExisting.has(entryIds[index]!)) {
+        candidates.push(historicalMessages[index]!);
+      }
+    }
+    const missingTail = this.filterSyntheticHeartbeatTranscriptMessages({
+      messages: candidates,
+      sessionContext,
+      source: "reconcileSessionTail entry-id",
+    });
+
+    if (
+      params.existingDbCount > 0 &&
+      missingTail.length > Math.max(params.existingDbCount * 0.2, 50)
+    ) {
+      this.deps.log.warn(
+        `[lcm] reconcileSessionTail: entry-id import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${params.existingDbCount}). Aborting to prevent flood.`,
+      );
+      return {
+        blockedByImportCap: true,
+        blockedReason: "import-cap",
+        importedMessages: 0,
+        hasOverlap: true,
+      };
+    }
+
+    let importedMessages = 0;
+    let adoptedMessages = 0;
+    for (const message of missingTail) {
+      const entryId = getTranscriptEntryId(message)!;
+      const stored = toStoredMessage(message);
+      const adopted = await this.conversationStore.adoptTranscriptEntryId(
+        conversationId,
+        stored.role,
+        stored.content,
+        entryId,
+      );
+      if (adopted) {
+        adoptedMessages += 1;
+        continue;
+      }
+      // Entry-id-verified imports are exact (the id is proven absent), so the
+      // same-second replay flood heuristic does not apply.
+      const result = await this.ingestSingle({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        message,
+        skipReplayTimestampFloodGuard: true,
+      });
+      if (result.ingested) {
+        importedMessages += 1;
+      }
+    }
+
+    this.deps.log.debug(
+      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages}`,
+    );
+    return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+  }
+
   private async reconcileSessionTail(params: {
     sessionId: string;
     sessionKey?: string;
     conversationId: number;
     historicalMessages: AgentMessage[];
     checkpointEntryHash?: string | null;
+    lastProcessedEntryId?: string | null;
     skipContentAnchorScan?: boolean;
     allowNoAnchorImport?: boolean;
     noAnchorImportReason?: string;
@@ -6028,6 +6149,26 @@ export class LcmContextEngine implements ContextEngine {
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: false };
     }
     const existingDbCount = await this.conversationStore.getMessageCount(conversationId);
+
+    // Exact path: when every transcript entry carries a stable envelope id,
+    // anchor and diff by id instead of content identity.
+    const candidateEntryIds = historicalMessages.map((message) => getTranscriptEntryId(message));
+    if (candidateEntryIds.every((entryId): entryId is string => entryId !== null)) {
+      const entryIdResult = await this.reconcileSessionTailByEntryIds({
+        sessionId,
+        sessionKey: params.sessionKey,
+        conversationId,
+        historicalMessages,
+        entryIds: candidateEntryIds,
+        lastProcessedEntryId: params.lastProcessedEntryId,
+        existingDbCount,
+        sessionContext,
+        startedAt,
+      });
+      if (entryIdResult) {
+        return entryIdResult;
+      }
+    }
 
     const storedHistoricalMessages = historicalMessages.map((message) => toStoredMessage(message));
 
@@ -7252,21 +7393,42 @@ export class LcmContextEngine implements ContextEngine {
           reason === "checkpoint-missing" &&
           (params.allowNoAnchorImportOnCheckpointMissing === true ||
             checkpointMissingMetadataFrontier);
+        // A transcript whose session header id differs from the checkpoint's
+        // is a *declared* epoch change (rewrite/rotation) — no heuristics
+        // needed, so a same-path full rewrite may import as a new epoch
+        // instead of freezing on "no anchor". The no-anchor path's replay
+        // guards and import caps still apply as sanity bounds.
+        const transcriptHeader = await readTranscriptHeader(params.sessionFile);
+        const declaredEpochRollover =
+          checkpoint?.sessionHeaderId != null &&
+          transcriptHeader.sessionHeaderId != null &&
+          checkpoint.sessionHeaderId !== transcriptHeader.sessionHeaderId;
+        if (declaredEpochRollover) {
+          this.deps.log.warn(
+            `[lcm] afterTurn: transcript session header changed (${checkpoint?.sessionHeaderId} -> ${transcriptHeader.sessionHeaderId}); treating as declared epoch rollover conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+          );
+        }
         const reconcile = await this.reconcileSessionTail({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           conversationId: conversation.conversationId,
           historicalMessages,
+          lastProcessedEntryId: declaredEpochRollover
+            ? null
+            : checkpoint?.lastProcessedEntryId ?? null,
           skipContentAnchorScan: reason === "same-path-shrink",
           allowNoAnchorImport:
             reason === "path-mismatch" ||
             reason === "same-path-shrink" ||
+            declaredEpochRollover ||
             recoverCheckpointMissingNoAnchor,
           noAnchorImportReason: recoverCheckpointMissingNoAnchor
             ? params.allowNoAnchorImportOnCheckpointMissing === true
               ? "rotate-checkpoint-missing"
               : "checkpoint-missing-recovery"
-            : reason,
+            : declaredEpochRollover && reason === "append-only-ineligible"
+              ? "declared-epoch-rollover"
+              : reason,
         });
         if (reconcile.blockedByImportCap) {
           return { importedMessages: 0, blockedByImportCap: true, hasOverlap: reconcile.hasOverlap };
@@ -7355,6 +7517,24 @@ export class LcmContextEngine implements ContextEngine {
   }): Promise<void> {
     const latestDbMessage = await this.conversationStore.getLastMessage(params.conversationId);
     const fileStats = params.fileStats ?? (await stat(params.sessionFile));
+    // The checkpoint marks the whole file processed (offset = size), so the
+    // exact resume anchor is the envelope id of the file's last message entry.
+    let lastProcessedEntryId: string | null = null;
+    const lastEntryLine = await readLastJsonlEntryBeforeOffset(
+      params.sessionFile,
+      fileStats.size,
+      true,
+    );
+    if (lastEntryLine) {
+      try {
+        const parsed = JSON.parse(lastEntryLine) as { id?: unknown; uuid?: unknown };
+        const rawId = typeof parsed.id === "string" ? parsed.id : typeof parsed.uuid === "string" ? parsed.uuid : "";
+        lastProcessedEntryId = rawId.trim() || null;
+      } catch {
+        // Bare-message lines have no envelope id.
+      }
+    }
+    const header = await readTranscriptHeader(params.sessionFile);
     await this.summaryStore.upsertConversationBootstrapState({
       conversationId: params.conversationId,
       sessionFilePath: params.sessionFile,
@@ -7371,6 +7551,8 @@ export class LcmContextEngine implements ContextEngine {
                 tokenCount: latestDbMessage.tokenCount,
               })
             : null,
+      sessionHeaderId: header.sessionHeaderId,
+      lastProcessedEntryId,
       forkBounded: params.forkBounded,
       forkSourceMessageCount: params.forkSourceMessageCount,
     });
@@ -7999,6 +8181,10 @@ export class LcmContextEngine implements ContextEngine {
               transcriptEpochReason === "same-path-shrink"
                 ? undefined
                 : bootstrapState?.lastProcessedEntryHash,
+            lastProcessedEntryId:
+              transcriptEpochReason === "same-path-shrink"
+                ? undefined
+                : bootstrapState?.lastProcessedEntryId,
             skipContentAnchorScan: transcriptEpochReason === "same-path-shrink",
             allowNoAnchorImport: transcriptEpochRotated,
             noAnchorImportReason: transcriptEpochReason,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -87,6 +87,16 @@ import {
   withExclusiveDatabaseLock,
 } from "./transaction-mutex.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
+import {
+  extractBootstrapMessageCandidate,
+  getTranscriptEntryId,
+  isBootstrapMessage,
+  parseBootstrapJsonl,
+  readAppendedLeafPathMessages,
+  readLastJsonlEntryBeforeOffset,
+  readLeafPathMessages,
+  readSessionParentSessionReference,
+} from "./transcript.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type RepairLogger = { warn: (message: string) => void };
@@ -1878,158 +1888,6 @@ function extractRuntimePromptTokenCount(runtimeContext?: Record<string, unknown>
   return undefined;
 }
 
-function isBootstrapMessage(value: unknown): value is AgentMessage {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const msg = value as { role?: unknown; content?: unknown; command?: unknown; output?: unknown };
-  if (typeof msg.role !== "string") {
-    return false;
-  }
-  return "content" in msg || ("command" in msg && "output" in msg);
-}
-
-function extractCanonicalBootstrapMessage(value: unknown): AgentMessage | null {
-  if (isBootstrapMessage(value)) {
-    return value;
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const entry = value as { type?: unknown; message?: unknown };
-  if ("message" in entry) {
-    if (entry.type !== undefined && entry.type !== "message") {
-      return null;
-    }
-    return isBootstrapMessage(entry.message) ? entry.message : null;
-  }
-  return null;
-}
-
-function extractBootstrapMessageCandidate(value: unknown): AgentMessage | null {
-  return extractCanonicalBootstrapMessage(value);
-}
-
-function parseBootstrapJsonl(raw: string, options?: {
-  strict?: boolean;
-}): { messages: AgentMessage[]; sawNonWhitespace: boolean; hadMalformedLine: boolean } {
-  const messages: AgentMessage[] = [];
-  const lines = raw.split(/\r?\n/);
-  let sawNonWhitespace = false;
-  let hadMalformedLine = false;
-  for (const line of lines) {
-    const item = line.trim();
-    if (!item) {
-      continue;
-    }
-    sawNonWhitespace = true;
-    try {
-      const parsed = JSON.parse(item);
-      const candidate = extractBootstrapMessageCandidate(parsed);
-      if (candidate) {
-        messages.push(candidate);
-        continue;
-      }
-    } catch {
-      if (options?.strict) {
-        hadMalformedLine = true;
-      }
-    }
-  }
-  return { messages, sawNonWhitespace, hadMalformedLine };
-}
-
-/** Load recoverable messages from a JSON/JSONL session file without full-file reads for JSONL. */
-async function readLeafPathMessages(sessionFile: string): Promise<AgentMessage[]> {
-  try {
-    let sawNonWhitespace = false;
-    let jsonArrayMode = false;
-    let jsonArrayBuffer = "";
-    const messages: AgentMessage[] = [];
-    const stream = createReadStream(sessionFile, { encoding: "utf8" });
-    const lines = createInterface({
-      input: stream,
-      crlfDelay: Infinity,
-    });
-
-    for await (const line of lines) {
-      if (!sawNonWhitespace) {
-        const trimmed = line.trim();
-        if (trimmed) {
-          sawNonWhitespace = true;
-          if (trimmed.startsWith("[")) {
-            jsonArrayMode = true;
-          }
-        }
-      }
-
-      if (jsonArrayMode) {
-        jsonArrayBuffer += `${line}\n`;
-        continue;
-      }
-
-      const parsed = parseBootstrapJsonl(line);
-      if (parsed.messages.length > 0) {
-        messages.push(...parsed.messages);
-      }
-    }
-
-    if (jsonArrayMode) {
-      const trimmed = jsonArrayBuffer.trim();
-      if (!trimmed) {
-        return [];
-      }
-      try {
-        const parsed = JSON.parse(trimmed);
-        if (!Array.isArray(parsed)) {
-          return [];
-        }
-        return parsed.filter(isBootstrapMessage);
-      } catch {
-        return [];
-      }
-    }
-
-    return messages;
-  } catch {
-    return [];
-  }
-}
-
-async function readSessionParentSessionReference(sessionFile: string): Promise<string | null> {
-  try {
-    const stream = createReadStream(sessionFile, { encoding: "utf8" });
-    const lines = createInterface({
-      input: stream,
-      crlfDelay: Infinity,
-    });
-    try {
-      for await (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) {
-          continue;
-        }
-        try {
-          const parsed = JSON.parse(trimmed) as { type?: unknown; parentSession?: unknown };
-          if (parsed.type !== "session" || typeof parsed.parentSession !== "string") {
-            return null;
-          }
-          const parentSession = parsed.parentSession.trim();
-          return parentSession.length > 0 ? parentSession : null;
-        } catch {
-          return null;
-        }
-      }
-    } finally {
-      lines.close();
-      stream.destroy();
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
 /**
  * Resolve the first-time bootstrap token budget.
  *
@@ -2092,126 +1950,6 @@ function trimBootstrapMessagesToBudget(messages: AgentMessage[], maxTokens: numb
 
   kept.reverse();
   return kept;
-}
-
-async function readFileSegment(sessionFile: string, offset: number): Promise<string | null> {
-  let fh: FileHandle | null = null;
-  try {
-    fh = await open(sessionFile, "r");
-    const stats = await fh.stat();
-    const safeOffset = Math.max(0, Math.min(Math.floor(offset), stats.size));
-    const length = stats.size - safeOffset;
-    if (length <= 0) {
-      return "";
-    }
-    const buffer = Buffer.alloc(length);
-    await fh.read(buffer, 0, length, safeOffset);
-    return buffer.toString("utf8");
-  } catch {
-    return null;
-  } finally {
-    await fh?.close();
-  }
-}
-
-async function readLastJsonlEntryBeforeOffset(
-  sessionFile: string,
-  offset: number,
-  messageOnly = false,
-  matcher?: (message: AgentMessage) => boolean,
-): Promise<string | null> {
-  const chunkSize = 16_384;
-  const safeOffset = Math.max(0, Math.floor(offset));
-  if (safeOffset <= 0) {
-    return null;
-  }
-
-  let fh: FileHandle | null = null;
-  try {
-    fh = await open(sessionFile, "r");
-    let cursor = safeOffset;
-    let carry = "";
-    while (true) {
-      const trimmedEnd = carry.replace(/\s+$/u, "");
-      if (trimmedEnd) {
-        const newlineIndex = Math.max(trimmedEnd.lastIndexOf("\n"), trimmedEnd.lastIndexOf("\r"));
-        if (newlineIndex >= 0) {
-          const candidate = trimmedEnd.slice(newlineIndex + 1).trim();
-          if (candidate) {
-            if (messageOnly) {
-              let matchedMessage: AgentMessage | null = null;
-              try {
-                matchedMessage = extractBootstrapMessageCandidate(JSON.parse(candidate));
-              } catch { /* not valid JSON, skip */ }
-              if (!matchedMessage || (matcher && !matcher(matchedMessage))) {
-                carry = trimmedEnd.slice(0, newlineIndex);
-                continue;
-              }
-            }
-            return candidate;
-          }
-          carry = trimmedEnd.slice(0, newlineIndex);
-          continue;
-        }
-      }
-
-      // No more newlines in current carry — need more data from earlier in the file.
-      if (cursor <= 0) {
-        // Reached start-of-file: whatever is left is the first line.
-        const firstLine = trimmedEnd.trim() || null;
-        if (!firstLine) return null;
-        if (messageOnly) {
-          let matchedMessage: AgentMessage | null = null;
-          try {
-            matchedMessage = extractBootstrapMessageCandidate(JSON.parse(firstLine));
-          } catch { /* not valid JSON */ }
-          if (!matchedMessage || (matcher && !matcher(matchedMessage))) return null;
-        }
-        return firstLine;
-      }
-
-      const start = Math.max(0, cursor - chunkSize);
-      const length = cursor - start;
-      const buffer = Buffer.alloc(length);
-      await fh.read(buffer, 0, length, start);
-      carry = buffer.toString("utf8") + carry;
-      cursor = start;
-    }
-  } catch {
-    return null;
-  } finally {
-    await fh?.close();
-  }
-}
-
-async function readAppendedLeafPathMessages(params: {
-  sessionFile: string;
-  offset: number;
-}): Promise<{ messages: AgentMessage[]; canUseAppendOnly: boolean; sawNonWhitespace: boolean }> {
-  const raw = await readFileSegment(params.sessionFile, params.offset);
-  if (raw == null) {
-    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: false };
-  }
-
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return { messages: [], canUseAppendOnly: true, sawNonWhitespace: false };
-  }
-
-  if (trimmed.startsWith("[")) {
-    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: true };
-  }
-
-  const parsed = parseBootstrapJsonl(raw, { strict: true });
-  if (parsed.hadMalformedLine) {
-    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: parsed.sawNonWhitespace };
-  }
-
-  return {
-    messages: parsed.messages,
-    canUseAppendOnly: true,
-    sawNonWhitespace: parsed.sawNonWhitespace,
-  };
 }
 
 export type RotateSessionStorageResult =
@@ -8860,6 +8598,20 @@ export class LcmContextEngine implements ContextEngine {
     });
     const conversationId = conversation.conversationId;
 
+    // Exact idempotency: a message imported from a transcript entry whose id
+    // is already persisted is a replay by definition. Skip before any side
+    // effects (large-file interception, parts, context items).
+    const transcriptEntryId = getTranscriptEntryId(message);
+    if (
+      transcriptEntryId &&
+      (await this.conversationStore.hasMessageByTranscriptEntryId(
+        conversationId,
+        transcriptEntryId,
+      ))
+    ) {
+      return { ingested: false };
+    }
+
     let messageForParts = message;
 
     const nativeImageIntercepted = await this.interceptNativeImageBlocks({
@@ -8947,6 +8699,7 @@ export class LcmContextEngine implements ContextEngine {
       role: stored.role,
       content: stored.content,
       tokenCount: stored.tokenCount,
+      transcriptEntryId,
       skipReplayTimestampFloodGuard,
     });
     await this.conversationStore.createMessageParts(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -98,6 +98,7 @@ import {
   readSessionParentSessionReference,
   readTranscriptHeader,
 } from "./transcript.js";
+import { resolveEpochRoute, selectEntryIdTail, transcriptImportCap } from "./reconcile-plan.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 type RepairLogger = { warn: (message: string) => void };
@@ -6023,44 +6024,34 @@ export class LcmContextEngine implements ContextEngine {
   }): Promise<TranscriptReconcileResult | null> {
     const { conversationId, historicalMessages, entryIds, sessionContext, startedAt } = params;
 
-    let anchorIndex = params.lastProcessedEntryId
+    // Query existence only for the tail when the checkpoint anchor is still
+    // in the transcript; otherwise probe every id to find the newest
+    // persisted one.
+    const checkpointAnchorIndex = params.lastProcessedEntryId
       ? entryIds.lastIndexOf(params.lastProcessedEntryId)
       : -1;
-    let knownExisting: Set<string>;
-    if (anchorIndex >= 0) {
-      knownExisting = await this.conversationStore.filterExistingTranscriptEntryIds(
-        conversationId,
-        entryIds.slice(anchorIndex + 1),
-      );
-    } else {
-      knownExisting = await this.conversationStore.filterExistingTranscriptEntryIds(
-        conversationId,
-        entryIds,
-      );
-      if (knownExisting.size === 0) {
-        return null;
-      }
-      for (let index = entryIds.length - 1; index >= 0; index -= 1) {
-        if (knownExisting.has(entryIds[index]!)) {
-          anchorIndex = index;
-          break;
-        }
-      }
-    }
+    const knownExisting = await this.conversationStore.filterExistingTranscriptEntryIds(
+      conversationId,
+      checkpointAnchorIndex >= 0 ? entryIds.slice(checkpointAnchorIndex + 1) : entryIds,
+    );
+    const selection = selectEntryIdTail({
+      entryIds,
+      existingEntryIds: knownExisting,
+      lastProcessedEntryId: params.lastProcessedEntryId,
+    });
 
-    if (anchorIndex >= historicalMessages.length - 1) {
+    if (selection.kind === "no-id-lineage") {
+      return null;
+    }
+    if (selection.kind === "at-tip") {
       this.deps.log.debug(
         `[lcm] reconcileSessionTail: entry-id anchor at tip for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} importedMessages=0 overlap=true`,
       );
       return { blockedByImportCap: false, importedMessages: 0, hasOverlap: true };
     }
 
-    const candidates: AgentMessage[] = [];
-    for (let index = anchorIndex + 1; index < historicalMessages.length; index += 1) {
-      if (!knownExisting.has(entryIds[index]!)) {
-        candidates.push(historicalMessages[index]!);
-      }
-    }
+    const anchorIndex = selection.anchorIndex;
+    const candidates = selection.missingIndexes.map((index) => historicalMessages[index]!);
     const missingTail = this.filterSyntheticHeartbeatTranscriptMessages({
       messages: candidates,
       sessionContext,
@@ -6069,7 +6060,7 @@ export class LcmContextEngine implements ContextEngine {
 
     if (
       params.existingDbCount > 0 &&
-      missingTail.length > Math.max(params.existingDbCount * 0.2, 50)
+      missingTail.length > transcriptImportCap(params.existingDbCount)
     ) {
       this.deps.log.warn(
         `[lcm] reconcileSessionTail: entry-id import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${params.existingDbCount}). Aborting to prevent flood.`,
@@ -6315,7 +6306,7 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
 
-          const importCap = Math.max(Math.floor(existingDbCount * 0.2), 50);
+          const importCap = transcriptImportCap(existingDbCount);
           if (noAnchorImportMessages.length > importCap) {
             this.deps.log.warn(
               `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,
@@ -6395,7 +6386,7 @@ export class LcmContextEngine implements ContextEngine {
       source: "reconcileSessionTail",
     });
 
-    if (existingDbCount > 0 && missingTail.length > Math.max(existingDbCount * 0.2, 50)) {
+    if (existingDbCount > 0 && missingTail.length > transcriptImportCap(existingDbCount)) {
       this.deps.log.warn(
         `[lcm] reconcileSessionTail: import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${existingDbCount}). Aborting to prevent flood.`,
       );
@@ -7400,9 +7391,10 @@ export class LcmContextEngine implements ContextEngine {
         // guards and import caps still apply as sanity bounds.
         const transcriptHeader = await readTranscriptHeader(params.sessionFile);
         const declaredEpochRollover =
-          checkpoint?.sessionHeaderId != null &&
-          transcriptHeader.sessionHeaderId != null &&
-          checkpoint.sessionHeaderId !== transcriptHeader.sessionHeaderId;
+          resolveEpochRoute({
+            checkpointHeaderId: checkpoint?.sessionHeaderId,
+            transcriptHeaderId: transcriptHeader.sessionHeaderId,
+          }) === "declared-rollover";
         if (declaredEpochRollover) {
           this.deps.log.warn(
             `[lcm] afterTurn: transcript session header changed (${checkpoint?.sessionHeaderId} -> ${transcriptHeader.sessionHeaderId}); treating as declared epoch rollover conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3284,6 +3284,16 @@ type TranscriptReconcileResult = {
     | "ambiguous-session-key-runtime-rollover";
   importedMessages: number;
   hasOverlap: boolean;
+  /**
+   * True only when the transcript file was actually read to its frontier and
+   * reconciled into the DB this call (or proven already reconciled). When
+   * true, the transcript is the single persistence source for the turn and
+   * afterTurn must NOT also persist the runtime messages array; flush-lagged
+   * tail messages arrive on the next turn's append-only read, idempotently.
+   * False on every path that allows live runtime persistence because the
+   * transcript was missing, unreadable, or skipped.
+   */
+  transcriptCovered?: boolean;
 };
 
 type AmbiguousSessionKeyRuntimeRollover = {
@@ -6824,6 +6834,8 @@ export class LcmContextEngine implements ContextEngine {
             return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
           }
           if (batchLooksLikeHeartbeatAckTurn(historicalMessages)) {
+            // Not covered: the runtime batch path owns conversation creation
+            // and heartbeat-ack pruning for brand-new sessions.
             return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
           }
           const bootstrapMessages = trimBootstrapMessagesToBudget(
@@ -6869,6 +6881,7 @@ export class LcmContextEngine implements ContextEngine {
             importedMessages,
             blockedByImportCap: bootstrapMessages.length < historicalMessages.length,
             hasOverlap: true,
+            transcriptCovered: true,
           };
         }
 
@@ -6921,7 +6934,14 @@ export class LcmContextEngine implements ContextEngine {
                   `[lcm] afterTurn: skipped heartbeat transcript append-only delta and refreshed checkpoint conversation=${conversation.conversationId} sessionFile=${params.sessionFile} appendedMessages=${appended.messages.length}`,
                 );
               }
-              return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+              // Heartbeat turns are never persisted; the append-only delta is
+              // intentionally skipped, so the transcript counts as covered.
+              return {
+                importedMessages: 0,
+                blockedByImportCap: false,
+                hasOverlap: true,
+                transcriptCovered: true,
+              };
             }
             if (placeholderCheckpoint && appended.messages.length > 0) {
               const reconcile = await this.reconcileSessionTail({
@@ -6942,7 +6962,10 @@ export class LcmContextEngine implements ContextEngine {
                   sessionFile: params.sessionFile,
                 });
               }
-              return reconcile;
+              return {
+                ...reconcile,
+                transcriptCovered: reconcile.hasOverlap || reconcile.importedMessages > 0,
+              };
             }
 
             const appendOnlySessionContext = this.formatSessionLogContext({
@@ -6988,7 +7011,12 @@ export class LcmContextEngine implements ContextEngine {
                   sessionFile: params.sessionFile,
                 });
               }
-              return { importedMessages, blockedByImportCap: false, hasOverlap: true };
+              return {
+                importedMessages,
+                blockedByImportCap: false,
+                hasOverlap: true,
+                transcriptCovered: true,
+              };
             }
           }
         }
@@ -7019,7 +7047,14 @@ export class LcmContextEngine implements ContextEngine {
           this.deps.log.debug(
             `[lcm] afterTurn: transcript reconcile slow path skipped (file state already read this process) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
           );
-          return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+          // The memo is only populated after a successful covered full read,
+          // and the file has not changed since — still covered.
+          return {
+            importedMessages: 0,
+            blockedByImportCap: false,
+            hasOverlap: true,
+            transcriptCovered: true,
+          };
         }
 
         const rememberSlowReadState = (): void => {
@@ -7177,6 +7212,8 @@ export class LcmContextEngine implements ContextEngine {
               `[lcm] afterTurn: transcript reconcile slow path read empty messages from non-empty file (${sessionFileState?.size ?? "?"} bytes) — skipping checkpoint refresh to avoid dropping messages on parser failure conversation=${conversation.conversationId} sessionFile=${params.sessionFile}`,
             );
           }
+          // An empty transcript cannot carry the turn — let the runtime
+          // batch persist it (transcriptCovered stays false).
           return {
             importedMessages: 0,
             blockedByImportCap: false,
@@ -7262,6 +7299,7 @@ export class LcmContextEngine implements ContextEngine {
           importedMessages: reconcile.importedMessages,
           blockedByImportCap: false,
           hasOverlap: reconcile.hasOverlap,
+          transcriptCovered: true,
         };
   }
 
@@ -8075,6 +8113,67 @@ export class LcmContextEngine implements ContextEngine {
    *    is prepended — synthetic summaries can no longer interfere with
    *    replay detection
    */
+  /**
+   * After a covered transcript reconcile the DB tail IS the transcript
+   * frontier, so the runtime turn delta needs exact alignment, not heuristic
+   * dedup. Three cases:
+   *  - the transcript flushed the whole turn: the batch aligns fully with the
+   *    DB tail — nothing to ingest;
+   *  - the transcript flush lagged mid-turn: a prefix of the batch aligns
+   *    with the DB tail — ingest only the remainder;
+   *  - no tail alignment: a batch with zero persisted-identity overlap is a
+   *    genuinely unflushed new turn (ingest all); any overlap means a stale
+   *    replay snapshot — fail closed, because a covered transcript read will
+   *    deliver anything real on the next turn idempotently.
+   */
+  private async alignRuntimeBatchAgainstCoveredFrontier(
+    sessionId: string,
+    sessionKey: string | undefined,
+    batch: AgentMessage[],
+  ): Promise<AgentMessage[]> {
+    if (batch.length === 0) return batch;
+
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    if (!conversation) return batch;
+    const conversationId = conversation.conversationId;
+
+    const storedBatch = batch.map((message) => toStoredMessage(message));
+    const tail = await this.conversationStore.getLastMessages(conversationId, batch.length);
+    for (let k = Math.min(tail.length, batch.length); k > 0; k -= 1) {
+      const tailSlice = tail.slice(tail.length - k);
+      let aligned = true;
+      for (let i = 0; i < k; i += 1) {
+        if (
+          messageIdentity(tailSlice[i]!.role, tailSlice[i]!.content) !==
+          messageIdentity(storedBatch[i]!.role, storedBatch[i]!.content)
+        ) {
+          aligned = false;
+          break;
+        }
+      }
+      if (aligned) {
+        return batch.slice(k);
+      }
+    }
+
+    let persistedIdentityOverlaps = 0;
+    for (const stored of storedBatch) {
+      if (await this.conversationStore.hasMessage(conversationId, stored.role, stored.content)) {
+        persistedIdentityOverlaps += 1;
+      }
+    }
+    if (persistedIdentityOverlaps > 0) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: runtime batch does not align with the covered transcript frontier and overlaps persisted history (${persistedIdentityOverlaps}/${batch.length}); failing closed — the transcript reconcile delivers real messages next turn conversation=${conversationId}`,
+      );
+      return [];
+    }
+    return batch;
+  }
+
   private async deduplicateAfterTurnBatch(
     sessionId: string,
     sessionKey: string | undefined,
@@ -8883,6 +8982,21 @@ export class LcmContextEngine implements ContextEngine {
       if (transcriptReconcileBlockedByAmbiguousRollover) {
         await runRuntimeAutoRotate();
         return;
+      }
+    } else if (transcriptReconcileResult.transcriptCovered) {
+      // The transcript reconcile read the file to its frontier, so the DB
+      // tail is exact — use precise alignment instead of the heuristic
+      // dedup stack, and persist only what the transcript flush has not
+      // delivered yet.
+      dedupedNewMessages = await this.alignRuntimeBatchAgainstCoveredFrontier(
+        params.sessionId,
+        params.sessionKey,
+        newMessages,
+      );
+      if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
+        this.deps.log.debug(
+          `[lcm] afterTurn: transcript covered the frontier; runtime batch aligned to ${dedupedNewMessages.length}/${newMessages.length} unflushed messages ${sessionLabel}`,
+        );
       }
     } else {
       dedupedNewMessages = await this.deduplicateAfterTurnBatch(

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure planning for transcript reconciliation. No IO, no store access, no
+ * logging — every decision here is unit-testable in isolation, and the
+ * engine is responsible only for gathering inputs and executing plans.
+ * See specs/transcript-reconciliation-by-entry-id.md (Phase 4).
+ */
+
+/**
+ * Sanity bound on a single reconciliation import relative to the already
+ * persisted conversation size. Guards remain even for entry-id-verified
+ * imports: a declared-but-bogus epoch should not be able to flood the store.
+ */
+export function transcriptImportCap(existingDbCount: number): number {
+  return Math.max(Math.floor(existingDbCount * 0.2), 50);
+}
+
+export type EpochRoute =
+  /** Header ids match: the file is the same declared session epoch. */
+  | "same-epoch"
+  /** Both header ids known and different: the transcript was rewritten or
+   *  rotated — a declared epoch rollover, no heuristics required. */
+  | "declared-rollover"
+  /** One or both header ids unknown (legacy/array-mode transcripts):
+   *  heuristic reason taxonomy applies. */
+  | "undeclared";
+
+export function resolveEpochRoute(params: {
+  checkpointHeaderId: string | null | undefined;
+  transcriptHeaderId: string | null | undefined;
+}): EpochRoute {
+  const checkpointHeaderId = params.checkpointHeaderId ?? null;
+  const transcriptHeaderId = params.transcriptHeaderId ?? null;
+  if (!checkpointHeaderId || !transcriptHeaderId) {
+    return "undeclared";
+  }
+  return checkpointHeaderId === transcriptHeaderId ? "same-epoch" : "declared-rollover";
+}
+
+export type EntryIdTailSelection =
+  /** No persisted entry id links this transcript to the conversation; the
+   *  caller's content-identity machinery and no-anchor guards decide. */
+  | { kind: "no-id-lineage" }
+  /** The anchor is the newest transcript entry — nothing to import. */
+  | { kind: "at-tip"; anchorIndex: number }
+  /** Import the listed indexes (transcript order), all after the anchor and
+   *  not yet persisted. */
+  | { kind: "tail"; anchorIndex: number; missingIndexes: number[] };
+
+/**
+ * Choose the resume anchor and the missing tail for an all-id transcript.
+ *
+ * The anchor is the checkpoint's last processed entry id when the transcript
+ * still contains it, otherwise the newest entry whose id is already
+ * persisted. Entries before the anchor are never imported (mid-history
+ * gap-filling would append out of order); entries after it are imported
+ * exactly when their id is absent.
+ */
+export function selectEntryIdTail(params: {
+  entryIds: readonly string[];
+  /** Ids already persisted; must cover at least the entries after the
+   *  checkpoint anchor, or all entries when no checkpoint anchor matches. */
+  existingEntryIds: ReadonlySet<string>;
+  lastProcessedEntryId?: string | null;
+}): EntryIdTailSelection {
+  const { entryIds, existingEntryIds } = params;
+
+  let anchorIndex = params.lastProcessedEntryId
+    ? entryIds.lastIndexOf(params.lastProcessedEntryId)
+    : -1;
+  if (anchorIndex < 0) {
+    for (let index = entryIds.length - 1; index >= 0; index -= 1) {
+      if (existingEntryIds.has(entryIds[index]!)) {
+        anchorIndex = index;
+        break;
+      }
+    }
+    if (anchorIndex < 0) {
+      return { kind: "no-id-lineage" };
+    }
+  }
+
+  if (anchorIndex >= entryIds.length - 1) {
+    return { kind: "at-tip", anchorIndex };
+  }
+
+  const missingIndexes: number[] = [];
+  for (let index = anchorIndex + 1; index < entryIds.length; index += 1) {
+    if (!existingEntryIds.has(entryIds[index]!)) {
+      missingIndexes.push(index);
+    }
+  }
+  if (missingIndexes.length === 0) {
+    return { kind: "at-tip", anchorIndex };
+  }
+  return { kind: "tail", anchorIndex, missingIndexes };
+}

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -771,6 +771,40 @@ export class ConversationStore {
     return row?.count === 1;
   }
 
+  /**
+   * Stamp a transcript entry id onto the earliest identity-matching row that
+   * has none. Heals rows persisted from the runtime array (flush lag) or
+   * before the entry-id migration when the transcript later delivers the
+   * same message with its envelope id, instead of importing a duplicate.
+   * Returns true when a row was adopted.
+   */
+  async adoptTranscriptEntryId(
+    conversationId: ConversationId,
+    role: MessageRole,
+    content: string,
+    transcriptEntryId: string,
+  ): Promise<boolean> {
+    const identityHash = buildMessageIdentityHash(role, content);
+    const result = this.db
+      .prepare(
+        `UPDATE messages
+       SET transcript_entry_id = ?
+       WHERE message_id = (
+         SELECT message_id
+         FROM messages
+         WHERE conversation_id = ?
+           AND transcript_entry_id IS NULL
+           AND identity_hash = ?
+           AND role = ?
+           AND content = ?
+         ORDER BY seq
+         LIMIT 1
+       )`,
+      )
+      .run(transcriptEntryId, conversationId, identityHash, role, content);
+    return result.changes > 0;
+  }
+
   /** Return the subset of `entryIds` that already exist for the conversation. */
   async filterExistingTranscriptEntryIds(
     conversationId: ConversationId,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -706,6 +706,23 @@ export class ConversationStore {
     return rows.map(toMessageRecord);
   }
 
+  /** Last `count` messages in seq order (oldest of the tail first). */
+  async getLastMessages(conversationId: ConversationId, count: number): Promise<MessageRecord[]> {
+    if (count <= 0) {
+      return [];
+    }
+    const rows = this.db
+      .prepare(
+        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content
+       FROM messages
+       WHERE conversation_id = ?
+       ORDER BY seq DESC
+       LIMIT ?`,
+      )
+      .all(conversationId, Math.floor(count)) as unknown as MessageRow[];
+    return rows.reverse().map(toMessageRecord);
+  }
+
   async getLastMessage(conversationId: ConversationId): Promise<MessageRecord | null> {
     const row = this.db
       .prepare(

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -33,6 +33,13 @@ export type CreateMessageInput = {
   content: string;
   tokenCount: number;
   identityHash?: string;
+  /**
+   * Stable JSONL envelope id of the transcript entry this message was
+   * imported from. Enforced unique per conversation (partial index), so
+   * transcript replays cannot duplicate rows. Null/undefined for runtime
+   * ingests and envelope-less transcripts.
+   */
+  transcriptEntryId?: string | null;
   // Use only when the caller is intentionally importing a fresh transcript epoch.
   skipReplayTimestampFloodGuard?: boolean;
 };
@@ -599,8 +606,8 @@ export class ConversationStore {
 
     const result = this.db
       .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, transcript_entry_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         prepared.conversationId,
@@ -609,6 +616,7 @@ export class ConversationStore {
         prepared.content,
         prepared.tokenCount,
         prepared.identityHash,
+        prepared.transcriptEntryId ?? null,
         prepared.createdAt,
       );
 
@@ -637,8 +645,8 @@ export class ConversationStore {
     );
 
     const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, transcript_entry_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     const selectStmt = this.db.prepare(
       `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content
@@ -654,6 +662,7 @@ export class ConversationStore {
         input.content,
         input.tokenCount,
         input.identityHash,
+        input.transcriptEntryId ?? null,
         input.createdAt,
       );
 
@@ -727,6 +736,46 @@ export class ConversationStore {
       .get(conversationId, identityHash, role, content) as unknown as CountRow | undefined;
 
     return row?.count === 1;
+  }
+
+  async hasMessageByTranscriptEntryId(
+    conversationId: ConversationId,
+    transcriptEntryId: string,
+  ): Promise<boolean> {
+    const row = this.db
+      .prepare(
+        `SELECT 1 AS count
+       FROM messages
+       WHERE conversation_id = ? AND transcript_entry_id = ?
+       LIMIT 1`,
+      )
+      .get(conversationId, transcriptEntryId) as unknown as CountRow | undefined;
+
+    return row?.count === 1;
+  }
+
+  /** Return the subset of `entryIds` that already exist for the conversation. */
+  async filterExistingTranscriptEntryIds(
+    conversationId: ConversationId,
+    entryIds: readonly string[],
+  ): Promise<Set<string>> {
+    const existing = new Set<string>();
+    const chunkSize = 400;
+    for (let start = 0; start < entryIds.length; start += chunkSize) {
+      const chunk = entryIds.slice(start, start + chunkSize);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const rows = this.db
+        .prepare(
+          `SELECT transcript_entry_id
+         FROM messages
+         WHERE conversation_id = ? AND transcript_entry_id IN (${placeholders})`,
+        )
+        .all(conversationId, ...chunk) as unknown as Array<{ transcript_entry_id: string }>;
+      for (const row of rows) {
+        existing.add(row.transcript_entry_id);
+      }
+    }
+    return existing;
   }
 
   async countMessagesByIdentity(

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -805,6 +805,61 @@ export class ConversationStore {
     return result.changes > 0;
   }
 
+  /**
+   * List identity-matching rows that already carry a transcript entry id,
+   * oldest first. The engine compares these ids against the transcript's
+   * current leaf path to find rows stranded by a host history rewrite
+   * (rewriteTranscriptEntries re-appends the suffix under new ids).
+   */
+  async listTranscriptEntryIdsByIdentity(
+    conversationId: ConversationId,
+    role: MessageRole,
+    content: string,
+  ): Promise<Array<{ messageId: number; transcriptEntryId: string }>> {
+    const identityHash = buildMessageIdentityHash(role, content);
+    const rows = this.db
+      .prepare(
+        `SELECT message_id, transcript_entry_id
+       FROM messages
+       WHERE conversation_id = ?
+         AND transcript_entry_id IS NOT NULL
+         AND identity_hash = ?
+         AND role = ?
+         AND content = ?
+       ORDER BY seq`,
+      )
+      .all(conversationId, identityHash, role, content) as unknown as Array<{
+      message_id: number;
+      transcript_entry_id: string;
+    }>;
+    return rows.map((row) => ({
+      messageId: row.message_id,
+      transcriptEntryId: row.transcript_entry_id,
+    }));
+  }
+
+  /**
+   * Replace a row's stale transcript entry id with the id the host re-issued
+   * for the same message. Returns false when the new id already exists for
+   * the conversation (unique-index race: another path imported it first).
+   */
+  async restampTranscriptEntryId(
+    messageId: number,
+    transcriptEntryId: string,
+  ): Promise<boolean> {
+    try {
+      const result = this.db
+        .prepare(`UPDATE messages SET transcript_entry_id = ? WHERE message_id = ?`)
+        .run(transcriptEntryId, messageId);
+      return result.changes > 0;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("UNIQUE constraint failed")) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   /** Return the subset of `entryIds` that already exist for the conversation. */
   async filterExistingTranscriptEntryIds(
     conversationId: ConversationId,

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -118,6 +118,10 @@ export type UpsertConversationBootstrapStateInput = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash?: string | null;
+  /** Transcript session-header id; a non-null value overwrites, null preserves. */
+  sessionHeaderId?: string | null;
+  /** Envelope id of the last processed transcript entry (exact resume anchor). */
+  lastProcessedEntryId?: string | null;
   forkBounded?: boolean;
   forkSourceMessageCount?: number;
 };
@@ -129,6 +133,8 @@ export type ConversationBootstrapStateRecord = {
   lastSeenMtimeMs: number;
   lastProcessedOffset: number;
   lastProcessedEntryHash: string | null;
+  sessionHeaderId: string | null;
+  lastProcessedEntryId: string | null;
   forkBounded: boolean;
   forkSourceMessageCount: number;
   updatedAt: Date;
@@ -234,6 +240,8 @@ interface ConversationBootstrapStateRow {
   last_seen_mtime_ms: number;
   last_processed_offset: number;
   last_processed_entry_hash: string | null;
+  session_header_id: string | null;
+  last_processed_entry_id: string | null;
   fork_bounded: number;
   fork_source_message_count: number;
   updated_at: string;
@@ -337,6 +345,8 @@ function toConversationBootstrapStateRecord(
     lastSeenMtimeMs: row.last_seen_mtime_ms,
     lastProcessedOffset: row.last_processed_offset,
     lastProcessedEntryHash: row.last_processed_entry_hash,
+    sessionHeaderId: row.session_header_id ?? null,
+    lastProcessedEntryId: row.last_processed_entry_id ?? null,
     forkBounded: row.fork_bounded === 1,
     forkSourceMessageCount:
       typeof row.fork_source_message_count === "number" &&
@@ -1560,7 +1570,8 @@ export class SummaryStore {
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, fork_bounded,
+                last_processed_offset, last_processed_entry_hash, session_header_id,
+                last_processed_entry_id, fork_bounded,
                 fork_source_message_count, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
@@ -1581,16 +1592,23 @@ export class SummaryStore {
            last_seen_mtime_ms,
            last_processed_offset,
            last_processed_entry_hash,
+           session_header_id,
+           last_processed_entry_id,
            fork_bounded,
            fork_source_message_count
          )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (conversation_id) DO UPDATE SET
            session_file_path = excluded.session_file_path,
            last_seen_size = excluded.last_seen_size,
            last_seen_mtime_ms = excluded.last_seen_mtime_ms,
            last_processed_offset = excluded.last_processed_offset,
            last_processed_entry_hash = excluded.last_processed_entry_hash,
+           session_header_id = COALESCE(
+             excluded.session_header_id,
+             conversation_bootstrap_state.session_header_id
+           ),
+           last_processed_entry_id = excluded.last_processed_entry_id,
            fork_bounded = CASE
              WHEN excluded.fork_bounded = 1 THEN 1
              WHEN conversation_bootstrap_state.session_file_path != excluded.session_file_path THEN 0
@@ -1610,6 +1628,8 @@ export class SummaryStore {
         Math.max(0, Math.floor(input.lastSeenMtimeMs)),
         Math.max(0, Math.floor(input.lastProcessedOffset)),
         input.lastProcessedEntryHash ?? null,
+        input.sessionHeaderId ?? null,
+        input.lastProcessedEntryId ?? null,
         input.forkBounded === true ? 1 : 0,
         Math.max(0, Math.floor(input.forkSourceMessageCount ?? 0)),
       );
@@ -1617,7 +1637,8 @@ export class SummaryStore {
     const row = this.db
       .prepare(
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
-                last_processed_offset, last_processed_entry_hash, fork_bounded,
+                last_processed_offset, last_processed_entry_hash, session_header_id,
+                last_processed_entry_id, fork_bounded,
                 fork_source_message_count, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1,0 +1,339 @@
+import { createReadStream } from "node:fs";
+import { open } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import type { ContextEngine } from "./openclaw-bridge.js";
+
+type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
+
+/**
+ * Envelope metadata for one transcript JSONL entry. OpenClaw writes each
+ * message line as `{type:"message", id, parentId, timestamp, message}`; the
+ * `id` is the stable per-entry identity that makes transcript imports
+ * idempotent. All fields are null for transcripts that lack envelopes
+ * (JSON-array session files, bare `{role, content}` lines).
+ */
+export type TranscriptEntryMeta = {
+  entryId: string | null;
+  parentId: string | null;
+  timestamp: string | null;
+};
+
+/**
+ * Symbol-keyed so the metadata survives object spread but stays invisible to
+ * JSON serialization and message-content identity hashing.
+ */
+const TRANSCRIPT_ENTRY_META = Symbol.for("lossless-claw.transcriptEntryMeta");
+
+export function attachTranscriptEntryMeta(
+  message: AgentMessage,
+  meta: TranscriptEntryMeta,
+): AgentMessage {
+  (message as unknown as Record<symbol, TranscriptEntryMeta>)[TRANSCRIPT_ENTRY_META] = meta;
+  return message;
+}
+
+export function getTranscriptEntryMeta(message: AgentMessage): TranscriptEntryMeta | null {
+  const meta = (message as unknown as Record<symbol, TranscriptEntryMeta | undefined>)[
+    TRANSCRIPT_ENTRY_META
+  ];
+  return meta ?? null;
+}
+
+export function getTranscriptEntryId(message: AgentMessage): string | null {
+  return getTranscriptEntryMeta(message)?.entryId ?? null;
+}
+
+function normalizeEnvelopeString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function extractEnvelopeMeta(entry: Record<string, unknown>): TranscriptEntryMeta {
+  return {
+    entryId: normalizeEnvelopeString(entry.id) ?? normalizeEnvelopeString(entry.uuid),
+    parentId: normalizeEnvelopeString(entry.parentId) ?? normalizeEnvelopeString(entry.parentUuid),
+    timestamp: normalizeEnvelopeString(entry.timestamp),
+  };
+}
+
+export function isBootstrapMessage(value: unknown): value is AgentMessage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const msg = value as { role?: unknown; content?: unknown; command?: unknown; output?: unknown };
+  if (typeof msg.role !== "string") {
+    return false;
+  }
+  return "content" in msg || ("command" in msg && "output" in msg);
+}
+
+function extractCanonicalBootstrapMessage(value: unknown): AgentMessage | null {
+  if (isBootstrapMessage(value)) {
+    return value;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const entry = value as { type?: unknown; message?: unknown };
+  if ("message" in entry) {
+    if (entry.type !== undefined && entry.type !== "message") {
+      return null;
+    }
+    if (!isBootstrapMessage(entry.message)) {
+      return null;
+    }
+    return attachTranscriptEntryMeta(
+      entry.message,
+      extractEnvelopeMeta(entry as Record<string, unknown>),
+    );
+  }
+  return null;
+}
+
+export function extractBootstrapMessageCandidate(value: unknown): AgentMessage | null {
+  return extractCanonicalBootstrapMessage(value);
+}
+
+export function parseBootstrapJsonl(raw: string, options?: {
+  strict?: boolean;
+}): { messages: AgentMessage[]; sawNonWhitespace: boolean; hadMalformedLine: boolean } {
+  const messages: AgentMessage[] = [];
+  const lines = raw.split(/\r?\n/);
+  let sawNonWhitespace = false;
+  let hadMalformedLine = false;
+  for (const line of lines) {
+    const item = line.trim();
+    if (!item) {
+      continue;
+    }
+    sawNonWhitespace = true;
+    try {
+      const parsed = JSON.parse(item);
+      const candidate = extractBootstrapMessageCandidate(parsed);
+      if (candidate) {
+        messages.push(candidate);
+        continue;
+      }
+    } catch {
+      if (options?.strict) {
+        hadMalformedLine = true;
+      }
+    }
+  }
+  return { messages, sawNonWhitespace, hadMalformedLine };
+}
+
+/** Load recoverable messages from a JSON/JSONL session file without full-file reads for JSONL. */
+export async function readLeafPathMessages(sessionFile: string): Promise<AgentMessage[]> {
+  try {
+    let sawNonWhitespace = false;
+    let jsonArrayMode = false;
+    let jsonArrayBuffer = "";
+    const messages: AgentMessage[] = [];
+    const stream = createReadStream(sessionFile, { encoding: "utf8" });
+    const lines = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of lines) {
+      if (!sawNonWhitespace) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          sawNonWhitespace = true;
+          if (trimmed.startsWith("[")) {
+            jsonArrayMode = true;
+          }
+        }
+      }
+
+      if (jsonArrayMode) {
+        jsonArrayBuffer += `${line}\n`;
+        continue;
+      }
+
+      const parsed = parseBootstrapJsonl(line);
+      if (parsed.messages.length > 0) {
+        messages.push(...parsed.messages);
+      }
+    }
+
+    if (jsonArrayMode) {
+      const trimmed = jsonArrayBuffer.trim();
+      if (!trimmed) {
+        return [];
+      }
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (!Array.isArray(parsed)) {
+          return [];
+        }
+        return parsed.filter(isBootstrapMessage);
+      } catch {
+        return [];
+      }
+    }
+
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+export async function readSessionParentSessionReference(sessionFile: string): Promise<string | null> {
+  try {
+    const stream = createReadStream(sessionFile, { encoding: "utf8" });
+    const lines = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    try {
+      for await (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        try {
+          const parsed = JSON.parse(trimmed) as { type?: unknown; parentSession?: unknown };
+          if (parsed.type !== "session" || typeof parsed.parentSession !== "string") {
+            return null;
+          }
+          const parentSession = parsed.parentSession.trim();
+          return parentSession.length > 0 ? parentSession : null;
+        } catch {
+          return null;
+        }
+      }
+    } finally {
+      lines.close();
+      stream.destroy();
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export async function readFileSegment(sessionFile: string, offset: number): Promise<string | null> {
+  let fh: FileHandle | null = null;
+  try {
+    fh = await open(sessionFile, "r");
+    const stats = await fh.stat();
+    const safeOffset = Math.max(0, Math.min(Math.floor(offset), stats.size));
+    const length = stats.size - safeOffset;
+    if (length <= 0) {
+      return "";
+    }
+    const buffer = Buffer.alloc(length);
+    await fh.read(buffer, 0, length, safeOffset);
+    return buffer.toString("utf8");
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+export async function readLastJsonlEntryBeforeOffset(
+  sessionFile: string,
+  offset: number,
+  messageOnly = false,
+  matcher?: (message: AgentMessage) => boolean,
+): Promise<string | null> {
+  const chunkSize = 16_384;
+  const safeOffset = Math.max(0, Math.floor(offset));
+  if (safeOffset <= 0) {
+    return null;
+  }
+
+  let fh: FileHandle | null = null;
+  try {
+    fh = await open(sessionFile, "r");
+    let cursor = safeOffset;
+    let carry = "";
+    while (true) {
+      const trimmedEnd = carry.replace(/\s+$/u, "");
+      if (trimmedEnd) {
+        const newlineIndex = Math.max(trimmedEnd.lastIndexOf("\n"), trimmedEnd.lastIndexOf("\r"));
+        if (newlineIndex >= 0) {
+          const candidate = trimmedEnd.slice(newlineIndex + 1).trim();
+          if (candidate) {
+            if (messageOnly) {
+              let matchedMessage: AgentMessage | null = null;
+              try {
+                matchedMessage = extractBootstrapMessageCandidate(JSON.parse(candidate));
+              } catch { /* not valid JSON, skip */ }
+              if (!matchedMessage || (matcher && !matcher(matchedMessage))) {
+                carry = trimmedEnd.slice(0, newlineIndex);
+                continue;
+              }
+            }
+            return candidate;
+          }
+          carry = trimmedEnd.slice(0, newlineIndex);
+          continue;
+        }
+      }
+
+      // No more newlines in current carry — need more data from earlier in the file.
+      if (cursor <= 0) {
+        // Reached start-of-file: whatever is left is the first line.
+        const firstLine = trimmedEnd.trim() || null;
+        if (!firstLine) return null;
+        if (messageOnly) {
+          let matchedMessage: AgentMessage | null = null;
+          try {
+            matchedMessage = extractBootstrapMessageCandidate(JSON.parse(firstLine));
+          } catch { /* not valid JSON */ }
+          if (!matchedMessage || (matcher && !matcher(matchedMessage))) return null;
+        }
+        return firstLine;
+      }
+
+      const start = Math.max(0, cursor - chunkSize);
+      const length = cursor - start;
+      const buffer = Buffer.alloc(length);
+      await fh.read(buffer, 0, length, start);
+      carry = buffer.toString("utf8") + carry;
+      cursor = start;
+    }
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+export async function readAppendedLeafPathMessages(params: {
+  sessionFile: string;
+  offset: number;
+}): Promise<{ messages: AgentMessage[]; canUseAppendOnly: boolean; sawNonWhitespace: boolean }> {
+  const raw = await readFileSegment(params.sessionFile, params.offset);
+  if (raw == null) {
+    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: false };
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { messages: [], canUseAppendOnly: true, sawNonWhitespace: false };
+  }
+
+  if (trimmed.startsWith("[")) {
+    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: true };
+  }
+
+  const parsed = parseBootstrapJsonl(raw, { strict: true });
+  if (parsed.hadMalformedLine) {
+    return { messages: [], canUseAppendOnly: false, sawNonWhitespace: parsed.sawNonWhitespace };
+  }
+
+  return {
+    messages: parsed.messages,
+    canUseAppendOnly: true,
+    sawNonWhitespace: parsed.sawNonWhitespace,
+  };
+}

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -180,13 +180,77 @@ export function parseBootstrapJsonl(raw: string, options?: {
   return { messages, sawNonWhitespace, hadMalformedLine };
 }
 
-/** Load recoverable messages from a JSON/JSONL session file without full-file reads for JSONL. */
+/** One parsed transcript line that participates in the entry tree. */
+type TranscriptLineRecord = {
+  entryId: string | null;
+  parentId: string | null;
+  message: AgentMessage | null;
+};
+
+/**
+ * Select the active leaf path from parsed transcript lines, or null when the
+ * file is not eligible for path-following and the caller must flatten.
+ *
+ * OpenClaw transcripts are trees: every entry carries `parentId`, and history
+ * edits (rewriteTranscriptEntries, branch, resetLeaf) re-append the active
+ * suffix as new entries, leaving the replaced ones in the file as an
+ * abandoned branch. The file's last entry is the current leaf, so walking
+ * its parent chain to a root yields exactly the entries the host considers
+ * live. Returns null (flatten fallback) when any record lacks an entry id
+ * (bare `{role, content}` lines, v1 transcripts), a parent link is dangling,
+ * or the chain cycles. A replayed line with a duplicate id resolves to its
+ * last occurrence. A mid-file `parentId: null` reached from the leaf is a
+ * genuine root (host resetLeaf); entries before it are an abandoned branch.
+ */
+function selectLeafPathRecords(records: TranscriptLineRecord[]): TranscriptLineRecord[] | null {
+  if (records.length === 0) {
+    return null;
+  }
+  const byId = new Map<string, TranscriptLineRecord>();
+  for (const record of records) {
+    if (!record.entryId) {
+      return null;
+    }
+    byId.set(record.entryId, record);
+  }
+  const path: TranscriptLineRecord[] = [];
+  const visited = new Set<string>();
+  let current: TranscriptLineRecord | undefined = records[records.length - 1];
+  while (current) {
+    const currentId = current.entryId!;
+    if (visited.has(currentId)) {
+      return null;
+    }
+    visited.add(currentId);
+    path.push(current);
+    if (current.parentId === null) {
+      break;
+    }
+    const parent = byId.get(current.parentId);
+    if (!parent) {
+      return null;
+    }
+    current = parent;
+  }
+  path.reverse();
+  return path;
+}
+
+/**
+ * Load recoverable messages from a JSON/JSONL session file.
+ *
+ * When every transcript line carries an envelope id, only the active leaf
+ * path (see selectLeafPathRecords) is returned, so abandoned branches left
+ * behind by host history edits are invisible to reconciliation. Files
+ * without full id coverage keep the legacy flatten-in-file-order behavior.
+ */
 export async function readLeafPathMessages(sessionFile: string): Promise<AgentMessage[]> {
   try {
     let sawNonWhitespace = false;
     let jsonArrayMode = false;
     let jsonArrayBuffer = "";
-    const messages: AgentMessage[] = [];
+    const records: TranscriptLineRecord[] = [];
+    const flattened: AgentMessage[] = [];
     const stream = createReadStream(sessionFile, { encoding: "utf8" });
     const lines = createInterface({
       input: stream,
@@ -209,9 +273,38 @@ export async function readLeafPathMessages(sessionFile: string): Promise<AgentMe
         continue;
       }
 
-      const parsed = parseBootstrapJsonl(line);
-      if (parsed.messages.length > 0) {
-        messages.push(...parsed.messages);
+      const item = line.trim();
+      if (!item) {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(item);
+      } catch {
+        continue;
+      }
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed) &&
+        (parsed as { type?: unknown }).type === "session"
+      ) {
+        // The session header is not part of the entry tree.
+        continue;
+      }
+      const candidate = extractBootstrapMessageCandidate(parsed);
+      if (candidate) {
+        flattened.push(candidate);
+      }
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const meta = extractEnvelopeMeta(parsed as Record<string, unknown>);
+        // Track every id-bearing entry (messages and non-message entry types
+        // alike — both link the parent chain) plus bare envelope-less
+        // messages, which force the flatten fallback. Non-entry junk lines
+        // (no id, no message) are ignored, matching the flatten behavior.
+        if (meta.entryId !== null || candidate) {
+          records.push({ entryId: meta.entryId, parentId: meta.parentId, message: candidate });
+        }
       }
     }
 
@@ -231,7 +324,13 @@ export async function readLeafPathMessages(sessionFile: string): Promise<AgentMe
       }
     }
 
-    return messages;
+    const leafPath = selectLeafPathRecords(records);
+    if (leafPath) {
+      return leafPath
+        .map((record) => record.message)
+        .filter((message): message is AgentMessage => message !== null);
+    }
+    return flattened;
   } catch {
     return [];
   }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -60,6 +60,59 @@ function extractEnvelopeMeta(entry: Record<string, unknown>): TranscriptEntryMet
   };
 }
 
+export type TranscriptHeader = {
+  /** Stable id from the leading `{type:"session", id}` line; null when absent. */
+  sessionHeaderId: string | null;
+  parentSession: string | null;
+};
+
+/**
+ * Read the session header line (first non-whitespace line) of a transcript.
+ * A rewritten or rotated transcript gets a new header id, so comparing the
+ * stored header id against the file's declares epoch changes exactly instead
+ * of inferring them from path/size heuristics.
+ */
+export async function readTranscriptHeader(sessionFile: string): Promise<TranscriptHeader> {
+  const empty: TranscriptHeader = { sessionHeaderId: null, parentSession: null };
+  try {
+    const stream = createReadStream(sessionFile, { encoding: "utf8" });
+    const lines = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    try {
+      for await (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        try {
+          const parsed = JSON.parse(trimmed) as {
+            type?: unknown;
+            id?: unknown;
+            parentSession?: unknown;
+          };
+          if (parsed.type !== "session") {
+            return empty;
+          }
+          return {
+            sessionHeaderId: normalizeEnvelopeString(parsed.id),
+            parentSession: normalizeEnvelopeString(parsed.parentSession),
+          };
+        } catch {
+          return empty;
+        }
+      }
+    } finally {
+      lines.close();
+      stream.destroy();
+    }
+  } catch {
+    return empty;
+  }
+  return empty;
+}
+
 export function isBootstrapMessage(value: unknown): value is AgentMessage {
   if (!value || typeof value !== "object") {
     return false;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -187,6 +187,12 @@ type TranscriptLineRecord = {
   message: AgentMessage | null;
 };
 
+/** Minimal linkage every leaf-path walk participant must expose. */
+type TranscriptTreeNode = {
+  entryId: string | null;
+  parentId: string | null;
+};
+
 /**
  * Select the active leaf path from parsed transcript lines, or null when the
  * file is not eligible for path-following and the caller must flatten.
@@ -202,20 +208,20 @@ type TranscriptLineRecord = {
  * last occurrence. A mid-file `parentId: null` reached from the leaf is a
  * genuine root (host resetLeaf); entries before it are an abandoned branch.
  */
-function selectLeafPathRecords(records: TranscriptLineRecord[]): TranscriptLineRecord[] | null {
+function selectLeafPathRecords<T extends TranscriptTreeNode>(records: T[]): T[] | null {
   if (records.length === 0) {
     return null;
   }
-  const byId = new Map<string, TranscriptLineRecord>();
+  const byId = new Map<string, T>();
   for (const record of records) {
     if (!record.entryId) {
       return null;
     }
     byId.set(record.entryId, record);
   }
-  const path: TranscriptLineRecord[] = [];
+  const path: T[] = [];
   const visited = new Set<string>();
-  let current: TranscriptLineRecord | undefined = records[records.length - 1];
+  let current: T | undefined = records[records.length - 1];
   while (current) {
     const currentId = current.entryId!;
     if (visited.has(currentId)) {
@@ -333,6 +339,65 @@ export async function readLeafPathMessages(sessionFile: string): Promise<AgentMe
     return flattened;
   } catch {
     return [];
+  }
+}
+
+/** Raw transcript entry line as parsed JSON, envelope fields untouched. */
+export type TranscriptRawEntry = Record<string, unknown>;
+
+export type TranscriptRawLeafPath = {
+  /** The raw `{type:"session", ...}` header line, or null when absent. */
+  header: TranscriptRawEntry | null;
+  /**
+   * Entries of every type on the active leaf path in root→leaf order, or in
+   * file order when the file lacks full id coverage (flatten fallback).
+   */
+  entries: TranscriptRawEntry[];
+};
+
+/**
+ * Read a JSONL transcript's raw entries along the active leaf path. This is
+ * the read-only replacement for opening the file with a SessionManager —
+ * unlike `SessionManager.open`, it never migrates or rewrites the file.
+ * Non-message entry types (session_info, model_change, compaction, custom,
+ * ...) are included; the session header is returned separately.
+ */
+export async function readLeafPathRawEntries(sessionFile: string): Promise<TranscriptRawLeafPath> {
+  const result: TranscriptRawLeafPath = { header: null, entries: [] };
+  try {
+    const stream = createReadStream(sessionFile, { encoding: "utf8" });
+    const lines = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    const records: Array<TranscriptTreeNode & { raw: TranscriptRawEntry }> = [];
+    for await (const line of lines) {
+      const item = line.trim();
+      if (!item) {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(item);
+      } catch {
+        continue;
+      }
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        continue;
+      }
+      const raw = parsed as TranscriptRawEntry;
+      if (raw.type === "session") {
+        result.header ??= raw;
+        continue;
+      }
+      const meta = extractEnvelopeMeta(raw);
+      records.push({ entryId: meta.entryId, parentId: meta.parentId, raw });
+    }
+    const leafPath = selectLeafPathRecords(records);
+    result.entries = (leafPath ?? records).map((record) => record.raw);
+    return result;
+  } catch {
+    return result;
   }
 }
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3184,25 +3184,21 @@ describe("LcmContextEngine.bootstrap", () => {
     const result = await engine.bootstrap({ sessionId, sessionFile });
 
     expect(result.bootstrapped).toBe(true);
-    expect(result.importedMessages).toBe(4);
+    expect(result.importedMessages).toBe(2);
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     expect(conversation).not.toBeNull();
     expect(conversation!.bootstrappedAt).not.toBeNull();
 
+    // The abandoned pre-branch turns are not on the leaf path and stay out.
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored).toHaveLength(4);
-    expect(stored.map((m) => m.content)).toEqual([
-      "root user",
-      "abandoned assistant",
-      "abandoned user",
-      "active assistant",
-    ]);
+    expect(stored).toHaveLength(2);
+    expect(stored.map((m) => m.content)).toEqual(["root user", "active assistant"]);
 
     const contextItems = await engine
       .getSummaryStore()
       .getContextItems(conversation!.conversationId);
-    expect(contextItems).toHaveLength(4);
+    expect(contextItems).toHaveLength(2);
     expect(contextItems.every((item) => item.itemType === "message")).toBe(true);
 
     const bootstrapState = await engine

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -3417,7 +3417,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(after.slice(-3).map((message) => message.content)).toEqual(["alpha", "gamma", "beta"]);
   });
 
-  it("keeps the replay flood guard active for user-leading append-only replay batches", async () => {
+  it("skips replayed transcript lines exactly while importing repeated content under fresh entry ids", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
     tempDirs.push(tempDir);
     const dbPath = join(tempDir, "lcm.db");
@@ -3456,20 +3456,38 @@ describe("LcmContextEngine.bootstrap", () => {
       closeLcmConnection(rawDb);
     }
 
+    // A true replay duplicates JSONL lines verbatim — same entry ids. The
+    // entry-id reconciliation must skip every one without tripping guards.
+    const replayedLines = readFileSync(sessionFile, "utf8")
+      .split("\n")
+      .filter((line) => line.includes('"type":"message"') && line.includes("question"));
+    expect(replayedLines.length).toBe(3);
+    appendFileSync(sessionFile, replayedLines.join("\n") + "\n", "utf8");
+
+    const engineB = createEngineAtDatabasePath(dbPath);
+    const replayResult = await engineB.bootstrap({ sessionId, sessionFile });
+    expect(replayResult.importedMessages ?? 0).toBe(0);
+    const afterReplay = await engineB.getConversationStore().getMessages(conversation!.conversationId);
+    expect(afterReplay).toHaveLength(before.length);
+    await engineB.dispose();
+
+    // Repeated content written by the host as NEW entries (fresh entry ids)
+    // is genuine conversation traffic, not a replay — it must import.
+    const smAppend = SessionManager.open(sessionFile);
     for (const question of ["question 1", "question 2", "question 3"]) {
-      appendSessionMessage(sm, {
+      appendSessionMessage(smAppend, {
         role: "user",
         content: [{ type: "text", text: question }],
       } as AgentMessage);
     }
 
-    const engineB = createEngineAtDatabasePath(dbPath);
-    await expect(engineB.bootstrap({ sessionId, sessionFile })).rejects.toThrow(
-      "[lcm] refused replay-like message batch",
-    );
+    const engineC = createEngineAtDatabasePath(dbPath);
+    const freshResult = await engineC.bootstrap({ sessionId, sessionFile });
+    expect(freshResult.bootstrapped).toBe(true);
+    expect(freshResult.importedMessages).toBe(3);
 
-    const after = await engineB.getConversationStore().getMessages(conversation!.conversationId);
-    expect(after).toHaveLength(before.length);
+    const after = await engineC.getConversationStore().getMessages(conversation!.conversationId);
+    expect(after).toHaveLength(before.length + 3);
   });
 
   it("skips reopening the transcript when checkpoint stats match", async () => {
@@ -6668,7 +6686,7 @@ describe("LcmContextEngine.bootstrap", () => {
       reason: "reconcile import capped",
     });
     expect(warnLog).toHaveBeenCalledWith(
-      `[lcm] reconcileSessionTail: import cap exceeded for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey} — would import 60 messages (existing: 2). Aborting to prevent flood.`,
+      `[lcm] reconcileSessionTail: entry-id import cap exceeded for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey} — would import 60 messages (existing: 2). Aborting to prevent flood.`,
     );
 
     const storedAfterCap = await engine.getConversationStore().getMessages(conversation!.conversationId);

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -929,6 +929,8 @@ describe("runLcmMigrations summary depth backfill", () => {
       "last_seen_mtime_ms",
       "last_processed_offset",
       "last_processed_entry_hash",
+      "session_header_id",
+      "last_processed_entry_id",
       "fork_bounded",
       "fork_source_message_count",
       "updated_at",

--- a/test/reconcile-plan.test.ts
+++ b/test/reconcile-plan.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveEpochRoute,
+  selectEntryIdTail,
+  transcriptImportCap,
+} from "../src/reconcile-plan.js";
+
+describe("transcriptImportCap", () => {
+  it("is 20% of the existing conversation with a floor of 50", () => {
+    expect(transcriptImportCap(0)).toBe(50);
+    expect(transcriptImportCap(100)).toBe(50);
+    expect(transcriptImportCap(249)).toBe(50);
+    expect(transcriptImportCap(251)).toBe(50);
+    expect(transcriptImportCap(500)).toBe(100);
+    expect(transcriptImportCap(10_000)).toBe(2_000);
+  });
+});
+
+describe("resolveEpochRoute", () => {
+  it("declares a rollover only when both header ids are known and differ", () => {
+    expect(
+      resolveEpochRoute({ checkpointHeaderId: "h1", transcriptHeaderId: "h2" }),
+    ).toBe("declared-rollover");
+    expect(
+      resolveEpochRoute({ checkpointHeaderId: "h1", transcriptHeaderId: "h1" }),
+    ).toBe("same-epoch");
+  });
+
+  it("is undeclared when either side is missing", () => {
+    expect(resolveEpochRoute({ checkpointHeaderId: null, transcriptHeaderId: "h2" })).toBe(
+      "undeclared",
+    );
+    expect(resolveEpochRoute({ checkpointHeaderId: "h1", transcriptHeaderId: null })).toBe(
+      "undeclared",
+    );
+    expect(
+      resolveEpochRoute({ checkpointHeaderId: undefined, transcriptHeaderId: undefined }),
+    ).toBe("undeclared");
+  });
+});
+
+describe("selectEntryIdTail", () => {
+  const ids = ["e1", "e2", "e3", "e4", "e5"];
+
+  it("anchors on the checkpoint entry id and imports everything missing after it", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ids,
+        existingEntryIds: new Set(["e4"]),
+        lastProcessedEntryId: "e2",
+      }),
+    ).toEqual({ kind: "tail", anchorIndex: 1, missingIndexes: [2, 4] });
+  });
+
+  it("falls back to the newest persisted id when the checkpoint id is gone", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ids,
+        existingEntryIds: new Set(["e1", "e3"]),
+        lastProcessedEntryId: "stale-id",
+      }),
+    ).toEqual({ kind: "tail", anchorIndex: 2, missingIndexes: [3, 4] });
+  });
+
+  it("reports no id lineage when nothing is persisted and no checkpoint anchor matches", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ids,
+        existingEntryIds: new Set(),
+      }),
+    ).toEqual({ kind: "no-id-lineage" });
+  });
+
+  it("reports at-tip when the anchor is the newest entry", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ids,
+        existingEntryIds: new Set(),
+        lastProcessedEntryId: "e5",
+      }),
+    ).toEqual({ kind: "at-tip", anchorIndex: 4 });
+  });
+
+  it("reports at-tip when every entry after the anchor is already persisted", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ids,
+        existingEntryIds: new Set(["e3", "e4", "e5"]),
+        lastProcessedEntryId: "e2",
+      }),
+    ).toEqual({ kind: "at-tip", anchorIndex: 1 });
+  });
+
+  it("never imports entries before the anchor (no mid-history gap filling)", () => {
+    const selection = selectEntryIdTail({
+      entryIds: ids,
+      existingEntryIds: new Set(["e4"]),
+    });
+    // Anchor is the newest persisted id (e4); e1-e3 are missing but stay
+    // untouched because appending them now would break seq ordering.
+    expect(selection).toEqual({ kind: "tail", anchorIndex: 3, missingIndexes: [4] });
+  });
+
+  it("anchors on the last occurrence of a duplicated checkpoint id", () => {
+    expect(
+      selectEntryIdTail({
+        entryIds: ["a", "b", "a", "c"],
+        existingEntryIds: new Set(),
+        lastProcessedEntryId: "a",
+      }),
+    ).toEqual({ kind: "tail", anchorIndex: 2, missingIndexes: [3] });
+  });
+});

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -1,0 +1,410 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import {
+  getTranscriptEntryId,
+  getTranscriptEntryMeta,
+  parseBootstrapJsonl,
+  readLeafPathMessages,
+} from "../src/transcript.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function createTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createTestConfig(databasePath: string): LcmConfig {
+  return {
+    enabled: true,
+    databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 8,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
+    leafChunkTokens: 20_000,
+    leafTargetTokens: 600,
+    condensedTargetTokens: 900,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25_000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    enableSummaryThinking: true,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2 * 1024 * 1024,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120_000,
+    summaryTimeoutMs: 60_000,
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1_800_000,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.90,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40_000,
+    },
+    stripInjectedContextTags: [],
+    replayFloodThresholdExternal: 3,
+    replayFloodThresholdInternal: 32,
+  };
+}
+
+function createTestDeps(config: LcmConfig): LcmDependencies {
+  return {
+    config,
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "summary output" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({ provider: "anthropic", model: "claude-opus-4-5" })),
+    parseAgentSessionKey: (key: string) => {
+      const trimmed = key.trim();
+      if (!trimmed.startsWith("agent:")) return null;
+      const parts = trimmed.split(":");
+      if (parts.length < 3) return null;
+      return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+    },
+    isSubagentSessionKey: (key: string) => key.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => process.env.HOME ?? tmpdir(),
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+
+function createEngine(): LcmContextEngine {
+  const tempDir = createTempDir("lcm-entry-id-");
+  const config = createTestConfig(join(tempDir, "lcm.db"));
+  const db = createLcmDatabaseConnection(config.databasePath);
+  return new LcmContextEngine(createTestDeps(config), db);
+}
+
+function createSessionFilePath(name: string): string {
+  return join(createTempDir("lcm-entry-id-session-"), `${name}.jsonl`);
+}
+
+function appendSessionMessage(manager: SessionManager, message: AgentMessage): string {
+  return manager.appendMessage(
+    message as unknown as Parameters<SessionManager["appendMessage"]>[0],
+  );
+}
+
+describe("transcript entry metadata parsing", () => {
+  it("attaches envelope id/parentId/timestamp to parsed messages", () => {
+    const raw = [
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        parentId: null,
+        timestamp: "2026-06-10T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-2",
+        parentId: "entry-1",
+        timestamp: "2026-06-10T00:00:01.000Z",
+        message: { role: "assistant", content: "world" },
+      }),
+    ].join("\n");
+
+    const parsed = parseBootstrapJsonl(raw);
+    expect(parsed.messages).toHaveLength(2);
+    expect(getTranscriptEntryId(parsed.messages[0]!)).toBe("entry-1");
+    expect(getTranscriptEntryMeta(parsed.messages[1]!)).toEqual({
+      entryId: "entry-2",
+      parentId: "entry-1",
+      timestamp: "2026-06-10T00:00:01.000Z",
+    });
+  });
+
+  it("supports uuid/parentUuid envelope field names", () => {
+    const raw = JSON.stringify({
+      type: "message",
+      uuid: "u-1",
+      parentUuid: "u-0",
+      message: { role: "user", content: "hi" },
+    });
+    const parsed = parseBootstrapJsonl(raw);
+    expect(parsed.messages).toHaveLength(1);
+    expect(getTranscriptEntryMeta(parsed.messages[0]!)).toEqual({
+      entryId: "u-1",
+      parentId: "u-0",
+      timestamp: null,
+    });
+  });
+
+  it("leaves bare messages and id-less envelopes without entry ids", () => {
+    const raw = [
+      JSON.stringify({ role: "user", content: "bare" }),
+      JSON.stringify({ message: { role: "assistant", content: "enveloped, no id" } }),
+    ].join("\n");
+    const parsed = parseBootstrapJsonl(raw);
+    expect(parsed.messages).toHaveLength(2);
+    expect(getTranscriptEntryId(parsed.messages[0]!)).toBeNull();
+    expect(getTranscriptEntryId(parsed.messages[1]!)).toBeNull();
+  });
+
+  it("keeps metadata invisible to JSON serialization but preserves it across spread", () => {
+    const raw = JSON.stringify({
+      type: "message",
+      id: "entry-7",
+      message: { role: "user", content: "hello" },
+    });
+    const message = parseBootstrapJsonl(raw).messages[0]!;
+    expect(JSON.stringify(message)).not.toContain("entry-7");
+    const spread = { ...message } as AgentMessage;
+    expect(getTranscriptEntryId(spread)).toBe("entry-7");
+  });
+
+  it("reads entry ids from SessionManager-written transcripts", async () => {
+    const sessionFile = createSessionFilePath("session-manager-ids");
+    const manager = SessionManager.open(sessionFile);
+    appendSessionMessage(manager, {
+      role: "user",
+      content: [{ type: "text", text: "question" }],
+    } as AgentMessage);
+    appendSessionMessage(manager, {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+    } as AgentMessage);
+
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(messages).toHaveLength(2);
+    expect(getTranscriptEntryId(messages[0]!)).toBeTruthy();
+    expect(getTranscriptEntryId(messages[1]!)).toBeTruthy();
+    expect(getTranscriptEntryId(messages[0]!)).not.toBe(getTranscriptEntryId(messages[1]!));
+  });
+});
+
+describe("messages.transcript_entry_id schema", () => {
+  it("creates the column and a partial unique index, enforced on duplicates", () => {
+    const tempDir = createTempDir("lcm-entry-id-schema-");
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const db = createLcmDatabaseConnection(config.databasePath);
+    const engine = new LcmContextEngine(createTestDeps(config), db);
+    // Force migrations.
+    void engine;
+    (engine as unknown as { ensureMigrated: () => void }).ensureMigrated();
+
+    const columns = db.prepare(`PRAGMA table_info(messages)`).all() as Array<{ name?: string }>;
+    expect(columns.some((col) => col.name === "transcript_entry_id")).toBe(true);
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, created_at, updated_at)
+       VALUES ('schema-session', datetime('now'), datetime('now'))`,
+    ).run();
+    const insert = db.prepare(
+      `INSERT INTO messages (conversation_id, seq, role, content, token_count, transcript_entry_id)
+       VALUES (1, ?, 'user', ?, 1, ?)`,
+    );
+    insert.run(1, "first", "dup-entry");
+    expect(() => insert.run(2, "second copy of same entry", "dup-entry")).toThrow(/UNIQUE|unique/);
+    // NULL entry ids stay exempt from the uniqueness constraint.
+    insert.run(3, "legacy row", null);
+    insert.run(4, "legacy row", null);
+    closeLcmConnection(db);
+  });
+});
+
+describe("entry-id idempotent ingest", () => {
+  it("skips re-ingesting a message whose transcript entry id is already persisted", async () => {
+    const engine = createEngine();
+    const sessionId = "entry-id-ingest";
+    const raw = JSON.stringify({
+      type: "message",
+      id: "stable-entry",
+      message: { role: "user", content: "only once" },
+    });
+
+    const first = await engine.ingest({
+      sessionId,
+      message: parseBootstrapJsonl(raw).messages[0]!,
+    });
+    expect(first.ingested).toBe(true);
+
+    // Re-parse to get a distinct object with the same entry id (a replayed
+    // transcript line), and confirm it cannot duplicate the row.
+    const second = await engine.ingest({
+      sessionId,
+      message: parseBootstrapJsonl(raw).messages[0]!,
+    });
+    expect(second.ingested).toBe(false);
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    expect(conversation).not.toBeNull();
+    const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("still ingests identical content when it arrives under a new entry id", async () => {
+    const engine = createEngine();
+    const sessionId = "entry-id-distinct";
+    const makeRaw = (id: string) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        message: { role: "assistant", content: "" },
+      });
+
+    const first = await engine.ingest({
+      sessionId,
+      message: parseBootstrapJsonl(makeRaw("entry-a")).messages[0]!,
+    });
+    const second = await engine.ingest({
+      sessionId,
+      message: parseBootstrapJsonl(makeRaw("entry-b")).messages[0]!,
+    });
+    expect(first.ingested).toBe(true);
+    expect(second.ingested).toBe(true);
+  });
+
+  it("stamps transcript_entry_id on rows imported from a transcript bootstrap", async () => {
+    const sessionFile = createSessionFilePath("bootstrap-stamps-ids");
+    const manager = SessionManager.open(sessionFile);
+    for (let index = 0; index < 4; index += 1) {
+      appendSessionMessage(manager, {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `turn ${index}` }],
+      } as AgentMessage);
+    }
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-stamps-ids";
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+    expect(result.importedMessages).toBe(4);
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const config = (engine as unknown as { config: LcmConfig }).config;
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      const rows = db
+        .prepare(
+          `SELECT transcript_entry_id FROM messages WHERE conversation_id = ? ORDER BY seq`,
+        )
+        .all(conversation!.conversationId) as Array<{ transcript_entry_id: string | null }>;
+      expect(rows).toHaveLength(4);
+      for (const row of rows) {
+        expect(row.transcript_entry_id).toBeTruthy();
+      }
+      expect(new Set(rows.map((row) => row.transcript_entry_id)).size).toBe(4);
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("re-running reconciliation over the same transcript imports nothing", async () => {
+    const sessionFile = createSessionFilePath("reconcile-idempotent");
+    const manager = SessionManager.open(sessionFile);
+    for (let index = 0; index < 6; index += 1) {
+      appendSessionMessage(manager, {
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: [{ type: "text", text: `turn ${index}` }],
+      } as AgentMessage);
+    }
+
+    const engine = createEngine();
+    const sessionId = "reconcile-idempotent";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    const countBefore = await engine.getConversationStore().getMessageCount(conversationId);
+
+    // Drop the bootstrap checkpoint to force the slow-path full re-read on
+    // the next afterTurn, simulating checkpoint loss / crash recovery.
+    const config = (engine as unknown as { config: LcmConfig }).config;
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(
+        conversationId,
+      );
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const countAfter = await engine.getConversationStore().getMessageCount(conversationId);
+    expect(countAfter).toBe(countBefore);
+  });
+});

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -408,3 +408,109 @@ describe("entry-id idempotent ingest", () => {
     expect(countAfter).toBe(countBefore);
   });
 });
+
+describe("afterTurn covered-frontier alignment", () => {
+  function makeMessage(role: AgentMessage["role"], text: string): AgentMessage {
+    return { role, content: [{ type: "text", text }] } as AgentMessage;
+  }
+
+  it("does not duplicate a turn that the transcript already flushed", async () => {
+    const sessionFile = createSessionFilePath("covered-full-flush");
+    const manager = SessionManager.open(sessionFile);
+    appendSessionMessage(manager, makeMessage("user", "question one"));
+    appendSessionMessage(manager, makeMessage("assistant", "answer one"));
+
+    const engine = createEngine();
+    const sessionId = "covered-full-flush";
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", "question one"), makeMessage("assistant", "answer one")],
+      prePromptMessageCount: 0,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(messages.map((message) => message.content)).toEqual(["question one", "answer one"]);
+  });
+
+  it("persists only the flush-lagged remainder, then dedupes the transcript catch-up", async () => {
+    const sessionFile = createSessionFilePath("covered-flush-lag");
+    const manager = SessionManager.open(sessionFile);
+    appendSessionMessage(manager, makeMessage("user", "question one"));
+
+    const engine = createEngine();
+    const sessionId = "covered-flush-lag";
+    // Turn 1: the transcript flushed only the user prompt; the assistant
+    // reply exists only in the runtime batch.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", "question one"), makeMessage("assistant", "answer one")],
+      prePromptMessageCount: 0,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    const afterTurnOne = await engine.getConversationStore().getMessages(conversationId);
+    expect(afterTurnOne.map((message) => message.content)).toEqual([
+      "question one",
+      "answer one",
+    ]);
+
+    // Turn 2: the transcript catches up (flushes the assistant reply) and a
+    // new prompt arrives. The caught-up reply must not import twice even
+    // though the transcript copy carries an entry id and the runtime row
+    // does not.
+    appendSessionMessage(manager, makeMessage("assistant", "answer one"));
+    appendSessionMessage(manager, makeMessage("user", "question two"));
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", "question two"), makeMessage("assistant", "answer two")],
+      prePromptMessageCount: 0,
+    });
+
+    const afterTurnTwo = await engine.getConversationStore().getMessages(conversationId);
+    expect(afterTurnTwo.map((message) => message.content)).toEqual([
+      "question one",
+      "answer one",
+      "question two",
+      "answer two",
+    ]);
+  });
+
+  it("fails closed on a stale replay batch that overlaps persisted history", async () => {
+    const sessionFile = createSessionFilePath("covered-stale-replay");
+    const manager = SessionManager.open(sessionFile);
+    const texts = ["turn one", "turn two", "turn three", "turn four"];
+    for (const [index, text] of texts.entries()) {
+      appendSessionMessage(manager, makeMessage(index % 2 === 0 ? "user" : "assistant", text));
+    }
+
+    const engine = createEngine();
+    const sessionId = "covered-stale-replay";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(4);
+
+    // Stale runtime snapshot replaying the middle of history: no tail
+    // alignment, but identity overlap with persisted rows.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("assistant", "turn two"), makeMessage("user", "turn three")],
+      prePromptMessageCount: 0,
+    });
+
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(4);
+  });
+});

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -495,15 +495,19 @@ describe("afterTurn covered-frontier alignment", () => {
       timestamp: new Date().toISOString(),
       cwd: process.cwd(),
     });
-    const entryLine = (id: string, role: AgentMessage["role"], text: string) =>
+    const entryLine = (id: string, parentId: string | null, role: AgentMessage["role"], text: string) =>
       JSON.stringify({
         type: "message",
         id,
-        parentId: null,
+        parentId,
         timestamp: new Date().toISOString(),
         message: { role, content: [{ type: "text", text }] },
       });
-    writeFileSync(sessionFile, `${header}\n${entryLine("adopt-1", "user", "question one")}\n`, "utf8");
+    writeFileSync(
+      sessionFile,
+      `${header}\n${entryLine("adopt-1", null, "user", "question one")}\n`,
+      "utf8",
+    );
 
     const engine = createEngine();
     const sessionId = "entry-id-adoption";
@@ -516,7 +520,7 @@ describe("afterTurn covered-frontier alignment", () => {
 
     writeFileSync(
       sessionFile,
-      `${header}\n${entryLine("adopt-1", "user", "question one")}\n${entryLine("adopt-2", "assistant", "answer one")}\n${entryLine("adopt-3", "user", "question two")}\n`,
+      `${header}\n${entryLine("adopt-1", null, "user", "question one")}\n${entryLine("adopt-2", "adopt-1", "assistant", "answer one")}\n${entryLine("adopt-3", "adopt-2", "user", "question two")}\n`,
       "utf8",
     );
     await engine.afterTurn({
@@ -634,11 +638,11 @@ describe("afterTurn covered-frontier alignment", () => {
         timestamp: new Date().toISOString(),
         cwd: process.cwd(),
       });
-    const entryLine = (id: string, role: AgentMessage["role"], text: string) =>
+    const entryLine = (id: string, parentId: string | null, role: AgentMessage["role"], text: string) =>
       JSON.stringify({
         type: "message",
         id,
-        parentId: null,
+        parentId,
         timestamp: new Date().toISOString(),
         message: { role, content: [{ type: "text", text }] },
       });
@@ -646,8 +650,8 @@ describe("afterTurn covered-frontier alignment", () => {
       sessionFile,
       [
         headerLine("epoch-one-header"),
-        entryLine("old-1", "user", "old epoch question"),
-        entryLine("old-2", "assistant", "old epoch answer"),
+        entryLine("old-1", null, "user", "old epoch question"),
+        entryLine("old-2", "old-1", "assistant", "old epoch answer"),
       ].join("\n") + "\n",
       "utf8",
     );
@@ -675,9 +679,9 @@ describe("afterTurn covered-frontier alignment", () => {
       sessionFile,
       [
         headerLine("epoch-two-header"),
-        entryLine("new-1", "user", `new epoch question ${padding}`),
-        entryLine("new-2", "assistant", `new epoch answer ${padding}`),
-        entryLine("new-3", "user", `new epoch follow-up ${padding}`),
+        entryLine("new-1", null, "user", `new epoch question ${padding}`),
+        entryLine("new-2", "new-1", "assistant", `new epoch answer ${padding}`),
+        entryLine("new-3", "new-2", "user", `new epoch follow-up ${padding}`),
       ].join("\n") + "\n",
       "utf8",
     );

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -738,3 +738,191 @@ describe("afterTurn covered-frontier alignment", () => {
     expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(4);
   });
 });
+
+describe("stale entry-id adoption after host history rewrites", () => {
+  const headerLine = (headerId: string) =>
+    JSON.stringify({
+      type: "session",
+      version: 3,
+      id: headerId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    });
+  const entryLine = (
+    id: string,
+    parentId: string | null,
+    role: AgentMessage["role"],
+    text: string,
+  ) =>
+    JSON.stringify({
+      type: "message",
+      id,
+      parentId,
+      timestamp: new Date().toISOString(),
+      message: { role, content: [{ type: "text", text }] },
+    });
+
+  async function readRows(
+    engine: LcmContextEngine,
+    conversationId: number,
+  ): Promise<Array<{ content: string; transcript_entry_id: string | null }>> {
+    const config = (engine as unknown as { config: LcmConfig }).config;
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      return db
+        .prepare(
+          `SELECT content, transcript_entry_id FROM messages WHERE conversation_id = ? ORDER BY seq`,
+        )
+        .all(conversationId) as Array<{ content: string; transcript_entry_id: string | null }>;
+    } finally {
+      closeLcmConnection(db);
+    }
+  }
+
+  it("re-stamps rows stranded by a host suffix rewrite instead of duplicating", async () => {
+    const sessionFile = createSessionFilePath("stale-id-suffix-rewrite");
+    const header = headerLine("stale-id-rewrite-header");
+    const prefix = [
+      entryLine("a", null, "user", "q1"),
+      entryLine("b", "a", "assistant", "a1"),
+      entryLine("c", "b", "assistant", "big payload"),
+      entryLine("d", "c", "assistant", "a2"),
+    ];
+    writeFileSync(sessionFile, [header, ...prefix].join("\n") + "\n", "utf8");
+
+    const engine = createEngine();
+    const sessionId = "stale-id-suffix-rewrite";
+    await engine.bootstrap({ sessionId, sessionFile });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(4);
+
+    // Host rewriteTranscriptEntries: branch from "b" and re-append the suffix
+    // under new ids — "c" replaced with a stub, "d" copied verbatim. The old
+    // c/d remain in the file as an abandoned branch.
+    writeFileSync(
+      sessionFile,
+      [
+        header,
+        ...prefix,
+        entryLine("c2", "b", "assistant", "[LCM Tool Output: stub]"),
+        entryLine("d2", "c2", "assistant", "a2"),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const rows = await readRows(engine, conversationId);
+    // The verbatim re-appended "a2" adopted the re-issued id d2 instead of
+    // importing a duplicate; only the replaced stub is a genuinely new row.
+    expect(rows.map((row) => row.content)).toEqual([
+      "q1",
+      "a1",
+      "big payload",
+      "a2",
+      "[LCM Tool Output: stub]",
+    ]);
+    expect(rows.map((row) => row.transcript_entry_id)).toEqual(["a", "b", "c", "d2", "c2"]);
+  });
+
+  it("re-stamps across a declared epoch rollover that kept only re-issued ids", async () => {
+    const sessionFile = createSessionFilePath("stale-id-rollover");
+    const padding = "x".repeat(200);
+    writeFileSync(
+      sessionFile,
+      [
+        headerLine("stale-id-epoch-one"),
+        entryLine("a", null, "user", "q1"),
+        entryLine("b", "a", "assistant", `kept answer ${padding}`),
+        entryLine("c", "b", "user", `kept follow-up ${padding}`),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const engine = createEngine();
+    const sessionId = "stale-id-rollover";
+    await engine.bootstrap({ sessionId, sessionFile });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(3);
+
+    // Compaction-successor style rotation after a rewrite: same path, new
+    // header id, and the surviving tail carries re-issued ids only.
+    writeFileSync(
+      sessionFile,
+      [
+        headerLine("stale-id-epoch-two"),
+        entryLine("b2", null, "assistant", `kept answer ${padding}`),
+        entryLine("c2", "b2", "user", `kept follow-up ${padding}`),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const rows = await readRows(engine, conversationId);
+    expect(rows.map((row) => row.content)).toEqual([
+      "q1",
+      `kept answer ${padding}`,
+      `kept follow-up ${padding}`,
+    ]);
+    // The surviving rows adopted the successor's re-issued ids; nothing
+    // imported twice.
+    expect(rows.map((row) => row.transcript_entry_id)).toEqual(["a", "b2", "c2"]);
+  });
+
+  it("still imports repeated content under a fresh id when the original is live", async () => {
+    const sessionFile = createSessionFilePath("stale-id-live-repeat");
+    const header = headerLine("stale-id-live-repeat-header");
+    writeFileSync(
+      sessionFile,
+      [header, entryLine("a", null, "user", "hello")].join("\n") + "\n",
+      "utf8",
+    );
+
+    const engine = createEngine();
+    const sessionId = "stale-id-live-repeat";
+    await engine.bootstrap({ sessionId, sessionFile });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+
+    // The user repeats the same prompt later in the same live path: "a" is
+    // still on the leaf path, so its row must NOT be re-stamped — the repeat
+    // is genuine new traffic.
+    writeFileSync(
+      sessionFile,
+      [
+        header,
+        entryLine("a", null, "user", "hello"),
+        entryLine("b", "a", "assistant", "hi there"),
+        entryLine("c", "b", "user", "hello"),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const rows = await readRows(engine, conversationId);
+    expect(rows.map((row) => row.content)).toEqual(["hello", "hi there", "hello"]);
+    expect(rows.map((row) => row.transcript_entry_id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -484,6 +484,226 @@ describe("afterTurn covered-frontier alignment", () => {
     ]);
   });
 
+  it("adopts the entry id onto flush-lagged runtime rows when the transcript catches up", async () => {
+    const sessionFile = createSessionFilePath("entry-id-adoption");
+    // Write the transcript envelopes directly so flush timing is
+    // deterministic (SessionManager persists asynchronously).
+    const header = JSON.stringify({
+      type: "session",
+      version: 3,
+      id: "entry-id-adoption-header",
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    });
+    const entryLine = (id: string, role: AgentMessage["role"], text: string) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: { role, content: [{ type: "text", text }] },
+      });
+    writeFileSync(sessionFile, `${header}\n${entryLine("adopt-1", "user", "question one")}\n`, "utf8");
+
+    const engine = createEngine();
+    const sessionId = "entry-id-adoption";
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", "question one"), makeMessage("assistant", "answer one")],
+      prePromptMessageCount: 0,
+    });
+
+    writeFileSync(
+      sessionFile,
+      `${header}\n${entryLine("adopt-1", "user", "question one")}\n${entryLine("adopt-2", "assistant", "answer one")}\n${entryLine("adopt-3", "user", "question two")}\n`,
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", "question two")],
+      prePromptMessageCount: 0,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const config = (engine as unknown as { config: LcmConfig }).config;
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      const rows = db
+        .prepare(
+          `SELECT content, transcript_entry_id FROM messages WHERE conversation_id = ? ORDER BY seq`,
+        )
+        .all(conversation!.conversationId) as Array<{
+        content: string;
+        transcript_entry_id: string | null;
+      }>;
+      expect(rows.map((row) => row.content)).toEqual([
+        "question one",
+        "answer one",
+        "question two",
+      ]);
+      // The runtime-persisted "answer one" row was adopted (stamped with the
+      // catch-up entry's id) instead of duplicated.
+      expect(rows.map((row) => row.transcript_entry_id)).toEqual([
+        "adopt-1",
+        "adopt-2",
+        "adopt-3",
+      ]);
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("anchors by entry id even when stored content was rewritten (externalization)", async () => {
+    const sessionFile = createSessionFilePath("entry-id-rewritten-content");
+    const header = JSON.stringify({
+      type: "session",
+      version: 3,
+      id: "rewritten-content-header",
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    });
+    const entryLine = (index: number, role: AgentMessage["role"], text: string) =>
+      JSON.stringify({
+        type: "message",
+        id: `rewrite-${index}`,
+        parentId: index === 0 ? null : `rewrite-${index - 1}`,
+        timestamp: new Date().toISOString(),
+        message: { role, content: [{ type: "text", text }] },
+      });
+    const initialLines = [0, 1, 2, 3].map((index) =>
+      entryLine(index, index % 2 === 0 ? "user" : "assistant", `turn ${index}`),
+    );
+    writeFileSync(sessionFile, [header, ...initialLines].join("\n") + "\n", "utf8");
+
+    const engine = createEngine();
+    const sessionId = "entry-id-rewritten-content";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+
+    // Simulate post-ingest content rewriting (tool-result externalization)
+    // plus checkpoint loss — the combination that defeats content-identity
+    // anchors and used to freeze conversations.
+    const config = (engine as unknown as { config: LcmConfig }).config;
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      db.prepare(`UPDATE messages SET content = 'externalized-stub-' || seq`).run();
+      db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(
+        conversationId,
+      );
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    const appendedLines = [
+      entryLine(4, "user", "turn 4"),
+      entryLine(5, "assistant", "turn 5"),
+    ];
+    writeFileSync(
+      sessionFile,
+      [header, ...initialLines, ...appendedLines].join("\n") + "\n",
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const messages = await engine.getConversationStore().getMessages(conversationId);
+    expect(messages).toHaveLength(6);
+    expect(messages.at(-2)?.content).toBe("turn 4");
+    expect(messages.at(-1)?.content).toBe("turn 5");
+  });
+
+  it("imports a same-path rewritten transcript as a declared epoch rollover", async () => {
+    const sessionFile = createSessionFilePath("declared-epoch-rollover");
+    const headerLine = (headerId: string) =>
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: headerId,
+        timestamp: new Date().toISOString(),
+        cwd: process.cwd(),
+      });
+    const entryLine = (id: string, role: AgentMessage["role"], text: string) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: { role, content: [{ type: "text", text }] },
+      });
+    writeFileSync(
+      sessionFile,
+      [
+        headerLine("epoch-one-header"),
+        entryLine("old-1", "user", "old epoch question"),
+        entryLine("old-2", "assistant", "old epoch answer"),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const warnLog = vi.fn();
+    const tempDir = createTempDir("lcm-entry-id-rollover-");
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const deps = createTestDeps(config);
+    deps.log = { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() };
+    const db = createLcmDatabaseConnection(config.databasePath);
+    const engine = new LcmContextEngine(deps, db);
+    const sessionId = "declared-epoch-rollover";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(2);
+
+    // Rewrite the same path as a brand-new session (new header id, fresh
+    // entry ids, larger than the old file so this is not a shrink).
+    const padding = "x".repeat(160);
+    writeFileSync(
+      sessionFile,
+      [
+        headerLine("epoch-two-header"),
+        entryLine("new-1", "user", `new epoch question ${padding}`),
+        entryLine("new-2", "assistant", `new epoch answer ${padding}`),
+        entryLine("new-3", "user", `new epoch follow-up ${padding}`),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    expect(
+      warnLog.mock.calls.some((call) =>
+        String(call[0]).includes("declared epoch rollover"),
+      ),
+    ).toBe(true);
+    const messages = await engine.getConversationStore().getMessages(conversationId);
+    expect(messages.map((message) => message.content)).toEqual([
+      "old epoch question",
+      "old epoch answer",
+      `new epoch question ${padding}`,
+      `new epoch answer ${padding}`,
+      `new epoch follow-up ${padding}`,
+    ]);
+  });
+
   it("fails closed on a stale replay batch that overlaps persisted history", async () => {
     const sessionFile = createSessionFilePath("covered-stale-replay");
     const manager = SessionManager.open(sessionFile);

--- a/test/transcript-leaf-path.test.ts
+++ b/test/transcript-leaf-path.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getTranscriptEntryId, readLeafPathMessages } from "../src/transcript.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+  tempDirs.length = 0;
+});
+
+function writeSessionFile(lines: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "lcm-leaf-path-"));
+  tempDirs.push(dir);
+  const sessionFile = join(dir, "session.jsonl");
+  writeFileSync(
+    sessionFile,
+    lines.map((line) => (typeof line === "string" ? line : JSON.stringify(line))).join("\n") + "\n",
+    "utf8",
+  );
+  return sessionFile;
+}
+
+const header = { type: "session", version: 3, id: "session-1", timestamp: "2026-06-10T00:00:00.000Z" };
+
+function messageEntry(id: string, parentId: string | null, role: string, content: string) {
+  return { type: "message", id, parentId, timestamp: "2026-06-10T00:00:00.000Z", message: { role, content } };
+}
+
+function contents(messages: Awaited<ReturnType<typeof readLeafPathMessages>>): unknown[] {
+  return messages.map((message) => message.content);
+}
+
+describe("readLeafPathMessages leaf-path selection", () => {
+  it("returns the full path for a linear transcript", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "one"),
+      messageEntry("b", "a", "assistant", "two"),
+      messageEntry("c", "b", "user", "three"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["one", "two", "three"]);
+    expect(messages.map((m) => getTranscriptEntryId(m))).toEqual(["a", "b", "c"]);
+  });
+
+  it("excludes abandoned branches left by a host branch()", async () => {
+    // Host branched back to "a" and continued with b2/c2; b1/c1 are abandoned.
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "root"),
+      messageEntry("b1", "a", "assistant", "abandoned reply"),
+      messageEntry("c1", "b1", "user", "abandoned follow-up"),
+      messageEntry("b2", "a", "assistant", "active reply"),
+      messageEntry("c2", "b2", "user", "active follow-up"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["root", "active reply", "active follow-up"]);
+  });
+
+  it("excludes the old suffix after a rewriteTranscriptEntries-style re-append", async () => {
+    // Host rewrite: suffix c/d re-appended as c2/d2 (c2 replaces c's content),
+    // branching from b. The old c/d remain in the file as an abandoned branch.
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "prompt"),
+      messageEntry("b", "a", "assistant", "answer"),
+      messageEntry("c", "b", "toolResult", "oversized payload"),
+      messageEntry("d", "c", "assistant", "summary"),
+      messageEntry("c2", "b", "toolResult", "[LCM Tool Output: stub]"),
+      messageEntry("d2", "c2", "assistant", "summary"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["prompt", "answer", "[LCM Tool Output: stub]", "summary"]);
+    expect(messages.map((m) => getTranscriptEntryId(m))).toEqual(["a", "b", "c2", "d2"]);
+  });
+
+  it("starts from a mid-file root after a host resetLeaf()", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "before reset"),
+      messageEntry("b", "a", "assistant", "also before reset"),
+      messageEntry("c", null, "user", "fresh root"),
+      messageEntry("d", "c", "assistant", "fresh reply"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["fresh root", "fresh reply"]);
+  });
+
+  it("walks through non-message entries that link the chain", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "question"),
+      { type: "custom", id: "x", parentId: "a", timestamp: "2026-06-10T00:00:00.000Z", customType: "marker", data: {} },
+      messageEntry("b", "x", "assistant", "reply"),
+      { type: "compaction", id: "y", parentId: "b", timestamp: "2026-06-10T00:00:00.000Z", summary: "s", firstKeptEntryId: "a", tokensBefore: 1 },
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["question", "reply"]);
+  });
+
+  it("collapses a replayed duplicate entry line to one occurrence", async () => {
+    const replayed = messageEntry("b", "a", "assistant", "reply");
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "question"),
+      replayed,
+      replayed,
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["question", "reply"]);
+  });
+
+  it("falls back to flatten when any message lacks an entry id", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "root"),
+      messageEntry("b1", "a", "assistant", "abandoned"),
+      { role: "user", content: "bare line without envelope" },
+      messageEntry("b2", "a", "assistant", "active"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual([
+      "root",
+      "abandoned",
+      "bare line without envelope",
+      "active",
+    ]);
+  });
+
+  it("falls back to flatten on a dangling parent reference", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "one"),
+      messageEntry("b", "missing-parent", "assistant", "two"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["one", "two"]);
+  });
+
+  it("falls back to flatten on a parent cycle", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", "b", "user", "one"),
+      messageEntry("b", "a", "assistant", "two"),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["one", "two"]);
+  });
+
+  it("keeps JSON-array session files unchanged", async () => {
+    const sessionFile = writeSessionFile([
+      JSON.stringify([
+        { role: "user", content: "array one" },
+        { role: "assistant", content: "array two" },
+      ]),
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["array one", "array two"]);
+  });
+
+  it("ignores trailing malformed lines and walks from the last valid entry", async () => {
+    const sessionFile = writeSessionFile([
+      header,
+      messageEntry("a", null, "user", "one"),
+      messageEntry("b", "a", "assistant", "two"),
+      '{"type":"message","id":"c","parentId":"b","message":{"role":"user","content":"tr',
+    ]);
+    const messages = await readLeafPathMessages(sessionFile);
+    expect(contents(messages)).toEqual(["one", "two"]);
+  });
+});


### PR DESCRIPTION
Transcript reconciliation has been the source of most recent regressions (#591, #640, #649, #659, #685, #706, #835, #837, #840, #846, the replay-flood guards, role-aware thresholds). Nearly all of them trace to one root cause: reconciliation identified messages by lossy `role + content` identity while discarding the stable envelope ids (`id`, `parentId`, `timestamp`) that every transcript JSONL entry already carries, forcing a stack of incident-calibrated heuristic guards.

This PR promotes the transcript entry id to the primary message identity, in four phases (one commit each), with the full design rationale in **`specs/transcript-reconciliation-by-entry-id.md`**:

## Phase 1 — Idempotent writes (`625cc1f`)
- New `src/transcript.ts` owns transcript reading/parsing (moved out of `engine.ts`) and preserves the JSONL envelope metadata on each parsed message.
- New `messages.transcript_entry_id` column with a partial unique index on `(conversation_id, transcript_entry_id)` — transcript replays cannot duplicate rows by construction. Legacy/runtime rows stay NULL and are exempt.
- `ingestSingle` skips already-persisted entry ids before any side effects.

## Phase 2 — Exact runtime-batch alignment (`adad909`)
- New `TranscriptReconcileResult.transcriptCovered` marks paths that provably read the transcript to EOF.
- When covered, the `afterTurn` runtime batch is reconciled by **exact tail alignment** against the DB frontier instead of the heuristic aligned-tail/oversized/suffix dedup stack: fully-flushed turns ingest nothing, flush-lagged turns ingest only the remainder, non-aligning overlapping batches fail closed (self-healing via the next idempotent transcript read).
- The heuristic `deduplicateAfterTurnBatch` stack now runs only when the transcript is missing/unreadable.

## Phase 3 — Declared epochs and exact checkpoints (`7beb222`)
- `conversation_bootstrap_state` gains `session_header_id` and `last_processed_entry_id`.
- A changed session-header id is a *declared* epoch rollover: same-path full rewrites import as a new epoch (still bounded by replay guards and import caps) instead of freezing on "no anchor".
- `reconcileSessionTail` gains an exact entry-id path: anchor on the checkpoint entry id, batched set-difference, and **adoption** — identity-matched rows persisted without an id (runtime flush lag, pre-migration data) are stamped with the entry id instead of duplicated. Entry-id anchoring survives post-ingest content rewriting (externalized tool results), which previously could freeze conversations.
- True replays (same entry ids) are skipped exactly; repeated content under fresh entry ids imports as genuine traffic. One regression test was repurposed accordingly.

## Phase 4 — Pure reconciliation planner (`6bfccf4`)
- `src/reconcile-plan.ts` holds the IO-free decision core (`selectEntryIdTail`, `resolveEpochRoute`, `transcriptImportCap` — the single definition of the max(20%, 50) sanity bound, replacing three inline copies), unit-tested without the engine harness.

## Host-behavior audit (design doc addendum)
The diff is deliberately additive (strangler-fig): the legacy content-identity machinery remains as the fallback for id-less inputs. An audit of the host's transcript writer (`SessionManager` in `@earendil-works/pi-coding-agent`) — written up as an addendum in the design doc — settles which legacy paths must remain:

- **Entry ids are unconditional** in the current (v3) session format.
- **Deferred flush is by design**: the host buffers all entries until the first assistant message, so the missing-file → runtime-array fallback is permanent architecture, not a compatibility shim.
- **Same-path rewrites are real host events** (version migration, branch/compaction), validating header-id rollover detection.
- The id-less cohort is **v1 session files only** (aging out); JSON-array parsing is written by nothing today and is a deletion candidate.
- **Discovery:** session files are *trees* (`parentId` branches in one file); `readLeafPathMessages` currently flattens all branches, importing messages from abandoned branches. Leaf-path-aware reconciliation using the now-captured `parentId` metadata is the highest-value follow-up.

## Verification
- 55 test files / 1231 tests passing (baseline: 53 / 1205), including new suites `test/transcript-entry-id.test.ts` (16 tests: parsing, schema/unique-index, idempotent ingest, covered-frontier alignment, adoption, content-rewrite immunity, declared rollover) and `test/reconcile-plan.test.ts` (10 planner unit tests).
- `npm run typecheck` and `npm run build` clean; changeset included (`minor`).

https://claude.ai/code/session_01JvwUgYQbTREUC2feAkm3eX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvwUgYQbTREUC2feAkm3eX)_

---

## Update: Phase 5 — leaf-path reconciliation + stale entry-id adoption

A post-implementation audit of the **actual** host source (OpenClaw's in-tree embedded harness, not `@earendil-works/pi-coding-agent`) showed that entry ids identify tree *nodes*, not logical messages: every host history edit (`rewriteTranscriptEntries` — used by this plugin's own transcript GC — plus the host's tool-result truncation and gateway chat edits) re-appends the active suffix under **new** ids, leaving the old entries as an abandoned branch. Unhandled, the re-issued ids read as genuine new traffic and the suffix re-imports as content duplicates.

- `readLeafPathMessages` now follows the `parentId` chain from the file's last entry when every line carries an envelope id; abandoned branches are invisible to reconciliation. Id-less cohorts, dangling parents, cycles, and JSON-array files keep the flatten fallback.
- Missing leaf-path entries that fail NULL-id adoption re-stamp the earliest identity-matched row whose stored id has left the leaf path, in both the entry-id reconcile loop and the no-anchor new-epoch import.
- Fully id-bearing no-anchor batches skip the content replay-overlap block — adoption resolves their overlaps exactly, where the block would freeze rewritten-epoch transcripts.
- Spec addendum corrected (wrong audit source, id-stability claim) and Phase 5 documented, including the accepted replaced-content gap and the deferred host-side id-map option.
- **Runtime pi dependency removed.** The last two runtime uses of `@earendil-works/pi-coding-agent`'s `SessionManager` (rotate, transcript-GC entry-id mapping) now go through the plugin's own read-only `readLeafPathRawEntries` parser — `SessionManager.open` migrated/rewrote v1/v2 and empty session files as a side effect, and the pi package no longer tracks the host's in-tree format. The `@earendil-works/*` packages moved to devDependencies (test fixtures still write through pi while the formats remain identical).
