### PR TITLE
fix(engine): use identity_hash for afterTurn dedup to prevent duplicate ingestion

### DIFF
--- a/.changeset/afterturn-identity-dedup.md
+++ b/.changeset/afterturn-identity-dedup.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent `afterTurn` replay batches from duplicating messages whose stored content was rewritten during ingest, such as large-file payload references.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -157,6 +157,7 @@ export class BatchDeduplicator {
     const storedBatch = batch.map((m) => toStoredMessage(m));
     const batchHashes = computeBatchIdentityHashes(storedBatch);
     const rawPayloadContents = computeBatchRawPayloadContents(batch, storedBatch);
+    const batchCreatedAtMs = batch.map(resolveMessageCreatedAtMs);
 
     // When the DB already has more messages than the incoming batch,
     // the batch may be a tail-only replay. Try tail-matching first,
@@ -168,6 +169,7 @@ export class BatchDeduplicator {
         storedBatch,
         batchHashes,
         rawPayloadContents,
+        batchCreatedAtMs,
         storedMessageCount,
         lastDbIdentityHash,
         options,
@@ -185,6 +187,7 @@ export class BatchDeduplicator {
         storedBatch,
         batchHashes,
         rawPayloadContents,
+        batchCreatedAtMs,
         storedMessageCount,
         "prefix-mismatch",
         { onNoOverlap: "ingest" },
@@ -236,6 +239,7 @@ export class BatchDeduplicator {
     storedBatch: ReturnType<typeof toStoredMessage>[],
     batchHashes: string[],
     rawPayloadContents: Array<string | null>,
+    batchCreatedAtMs: Array<number | null>,
     storedMessageCount: number,
     lastDbIdentityHash: string,
     options?: { oversizedNoOverlap?: "ingest" | "skip" },
@@ -275,20 +279,20 @@ export class BatchDeduplicator {
       }
     }
 
-    // Fall back to suffix matching. If the DB is already longer than the
-    // incoming afterTurn batch and no suffix overlap exists, fail closed:
-    // importing the whole short batch as new would duplicate/pollute LCM with
-    // stale runtime tail snapshots. The transcript reconcile path runs before
-    // this and is responsible for importing genuine missing JSONL tail turns.
+    // Fall back to suffix matching. Outside the transcript-covered path, a
+    // short runtime batch with no overlap may be a genuine live turn after a
+    // missing/unreadable transcript reconcile. Ingest on no-overlap unless the
+    // caller has a stronger proof source and explicitly asks to skip.
     return this.deduplicateSuffixFallback(
       conversationId,
       batch,
       storedBatch,
       batchHashes,
       rawPayloadContents,
+      batchCreatedAtMs,
       storedMessageCount,
       "oversized",
-      { onNoOverlap: options?.oversizedNoOverlap ?? "skip" },
+      { onNoOverlap: options?.oversizedNoOverlap ?? "ingest" },
     );
   }
 
@@ -303,6 +307,7 @@ export class BatchDeduplicator {
     storedBatch: ReturnType<typeof toStoredMessage>[],
     batchHashes: string[],
     rawPayloadContents: Array<string | null>,
+    batchCreatedAtMs: Array<number | null>,
     storedMessageCount: number,
     context: string,
     options?: { onNoOverlap?: "ingest" | "skip" },
@@ -383,11 +388,28 @@ export class BatchDeduplicator {
       return batch;
     }
 
-    const onNoOverlap = options?.onNoOverlap ?? "skip";
+    const onNoOverlap = options?.onNoOverlap ?? "ingest";
     if (onNoOverlap === "skip") {
       this.deps.log.warn(
         `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
           `no overlap found — fail-closed skipping full batch`,
+      );
+      return [];
+    }
+
+    if (
+      await this.batchMatchesPersistedTailByTimestamp(
+        allStored,
+        allRecentHashes,
+        storedBatch,
+        batchHashes,
+        rawPayloadContents,
+        batchCreatedAtMs,
+      )
+    ) {
+      this.deps.log.warn(
+        `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
+          `no suffix overlap found but batch matches timestamp-proven persisted tail — skipping full batch`,
       );
       return [];
     }
@@ -397,6 +419,54 @@ export class BatchDeduplicator {
         `no overlap found — ingesting full batch`,
     );
     return batch;
+  }
+
+  private async batchMatchesPersistedTailByTimestamp(
+    storedMessages: MessageRecord[],
+    storedHashes: string[],
+    incomingBatch: StoredMessage[],
+    incomingHashes: string[],
+    incomingRawPayloadContents: Array<string | null>,
+    incomingCreatedAtMs: Array<number | null>,
+  ): Promise<boolean> {
+    if (
+      incomingBatch.length === 0 ||
+      storedMessages.length !== storedHashes.length ||
+      storedMessages.length < incomingBatch.length
+    ) {
+      return false;
+    }
+
+    let storedIndex = storedMessages.length - 1;
+    for (let batchIndex = incomingBatch.length - 1; batchIndex >= 0; batchIndex -= 1) {
+      let matched = false;
+      while (storedIndex >= 0) {
+        const match = await this.matchStoredMessageToIncoming(
+          storedMessages[storedIndex]!,
+          incomingBatch[batchIndex]!,
+          incomingHashes[batchIndex]!,
+          storedHashes[storedIndex]!,
+          incomingRawPayloadContents[batchIndex],
+        );
+        if (
+          match &&
+          match !== "unproven-externalized" &&
+          messageTimestampMatchesPersistedRow(
+            incomingCreatedAtMs[batchIndex],
+            storedMessages[storedIndex]!,
+          )
+        ) {
+          matched = true;
+          storedIndex -= 1;
+          break;
+        }
+        storedIndex -= 1;
+      }
+      if (!matched) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private async matchStoredMessageToIncoming(
@@ -455,16 +525,13 @@ export class BatchDeduplicator {
         return null;
       }
     }
-    if (references.some((reference) => reference.reference.startsWith("[LCM Tool Output:"))) {
-      return null;
-    }
     const provenanceBacked =
       proofKeys.size > 0 &&
       references.every((reference) => proofKeys.has(referenceProofKey(reference)));
 
     if (
       references.length === 1 &&
-      references[0]!.reference.startsWith("[LCM Raw Payload:") &&
+      isWholeIncomingReference(references[0]!) &&
       (await this.referenceMatchesWholeIncoming(
         storedMessage,
         incoming,
@@ -479,7 +546,7 @@ export class BatchDeduplicator {
     if (fileBlocks.length === 0) {
       return (
         references.length === 1 &&
-        references[0]!.reference.startsWith("[LCM Raw Payload:") &&
+        isWholeIncomingReference(references[0]!) &&
         (await this.referenceMatchesWholeIncoming(
           storedMessage,
           incoming,
@@ -553,6 +620,20 @@ export class BatchDeduplicator {
           }
         }
       }
+      if (
+        metadata.toolOutputExternalized === true &&
+        metadata.externalizationReason === "large_tool_result" &&
+        typeof metadata.externalizedFileId === "string"
+      ) {
+        proofKeys.add(`tool:${metadata.externalizedFileId}`);
+      }
+      if (
+        metadata.imageExternalized === true &&
+        metadata.externalizationReason === "native_image" &&
+        typeof metadata.externalizedFileId === "string"
+      ) {
+        proofKeys.add(`image:${metadata.externalizedFileId}`);
+      }
     }
 
     return proofKeys;
@@ -570,6 +651,17 @@ export class BatchDeduplicator {
     }
     if (this.formatExternalizedReference(reference, largeFile, storedMessage) !== storedMessage.content) {
       return false;
+    }
+    if (isImageReference(reference)) {
+      if (!largeFile.mimeType?.toLowerCase().startsWith("image/")) {
+        return false;
+      }
+      const incomingImage = extractSingleNativeImageBuffer(incomingRawPayloadContent ?? incoming.content);
+      return incomingImage
+        ? this.summaryStore.largeFileBufferEquals(reference.fileId, incomingImage, {
+            largeFilesDir: this.largeFilesDir,
+          })
+        : false;
     }
     const contentToCompare =
       reference.reference.startsWith("[LCM Raw Payload:") && incomingRawPayloadContent != null
@@ -672,6 +764,10 @@ export class BatchDeduplicator {
     largeFile: LargeFileRecord,
     storedMessage: MessageRecord,
   ): string {
+    if (isImageReference(reference)) {
+      return reference.reference;
+    }
+
     if (reference.reference.startsWith("[LCM Tool Output:")) {
       return formatToolOutputReference({
         fileId: largeFile.fileId,
@@ -725,6 +821,37 @@ function computeBatchRawPayloadContents(
   });
 }
 
+function resolveMessageCreatedAtMs(message: AgentMessage): number | null {
+  const raw = message as unknown as Record<string, unknown>;
+  const value = raw.timestamp ?? raw.createdAt ?? raw.created_at;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.floor(value / 1000) * 1000 : null;
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? Math.floor(time / 1000) * 1000 : null;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const time = Date.parse(value);
+    return Number.isFinite(time) ? Math.floor(time / 1000) * 1000 : null;
+  }
+  return null;
+}
+
+function messageTimestampMatchesPersistedRow(
+  incomingCreatedAtMs: number | null | undefined,
+  storedMessage: MessageRecord,
+): boolean {
+  if (incomingCreatedAtMs == null) {
+    return false;
+  }
+  const storedCreatedAtMs = storedMessage.createdAt.getTime();
+  if (!Number.isFinite(storedCreatedAtMs)) {
+    return false;
+  }
+  return incomingCreatedAtMs <= storedCreatedAtMs;
+}
+
 type ExternalizedReference = {
   fileId: string;
   reference: string;
@@ -756,6 +883,18 @@ function extractExternalizedReferences(content: string): ExternalizedReference[]
     });
     referencePattern.lastIndex = markerIndex;
   }
+  const imageReferencePattern =
+    /\[(?:(?:User|System|Tool|Assistant) image|Image): [^\]]*?\bLCM file:\s*(file_[a-f0-9]{16})\]/gi;
+  while ((match = imageReferencePattern.exec(content)) !== null) {
+    const fileId = match[1]?.toLowerCase();
+    if (!fileId) continue;
+    references.push({
+      fileId,
+      reference: match[0],
+      formattedReference: match[0],
+      end: imageReferencePattern.lastIndex,
+    });
+  }
   return references;
 }
 
@@ -771,7 +910,79 @@ function referenceProofKey(reference: ExternalizedReference): string {
   if (reference.reference.startsWith("[LCM File:")) {
     return `file:${reference.fileId}`;
   }
+  if (reference.reference.startsWith("[LCM Tool Output:")) {
+    return `tool:${reference.fileId}`;
+  }
+  if (isImageReference(reference)) {
+    return `image:${reference.fileId}`;
+  }
   return `other:${reference.fileId}`;
+}
+
+function isWholeIncomingReference(reference: ExternalizedReference): boolean {
+  return (
+    reference.reference.startsWith("[LCM Raw Payload:") ||
+    reference.reference.startsWith("[LCM Tool Output:") ||
+    isImageReference(reference)
+  );
+}
+
+function isImageReference(reference: ExternalizedReference): boolean {
+  return /^\[(?:(?:User|System|Tool|Assistant) image|Image): /i.test(reference.reference);
+}
+
+function extractSingleNativeImageBuffer(content: string): Buffer | null {
+  const parsed = parseJsonPayload(content);
+  const imageBlocks = parsed === undefined
+    ? extractNativeImageBuffersFromValue(content)
+    : extractNativeImageBuffersFromValue(parsed);
+  return imageBlocks.length === 1 ? imageBlocks[0]! : null;
+}
+
+function extractNativeImageBuffersFromValue(value: unknown): Buffer[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractNativeImageBuffersFromValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.type === "image") {
+    const data = typeof record.data === "string" ? record.data : undefined;
+    const decoded = data ? decodeBase64ImageData(data) : null;
+    return decoded ? [decoded] : [];
+  }
+
+  return [];
+}
+
+function decodeBase64ImageData(rawData: string): Buffer | null {
+  const dataUrlMatch = rawData.match(/^data:([^;,]+);base64,(.*)$/s);
+  const base64Data = (dataUrlMatch?.[2] ?? rawData).replace(/\s+/g, "");
+  if (!base64Data || !/^[A-Za-z0-9+/]+={0,2}$/.test(base64Data)) {
+    return null;
+  }
+  try {
+    return Buffer.from(base64Data, "base64");
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonPayload(content: string): unknown {
+  const trimmed = content.trim();
+  if (
+    !((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]")))
+  ) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
 }
 
 function parsePartMetadata(metadata: string | null): Record<string, unknown> | null {

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -14,6 +14,7 @@ import {
   type FileBlock,
 } from "./large-files.js";
 import {
+  extractStructuredText,
   RAW_PAYLOAD_EXTERNALIZATION_REASON,
   serializeRawPayloadContent,
   toStoredMessage,
@@ -472,6 +473,15 @@ export class BatchDeduplicator {
 
     const fileBlocks = parseFileBlocks(incoming.content);
     if (fileBlocks.length === 0) {
+      if (
+        await this.incomingNativeImagesMatchStoredContent(
+          storedMessage.content,
+          references,
+          incomingRawPayloadContent,
+        )
+      ) {
+        return provenanceBacked ? "externalized" : "unproven-externalized";
+      }
       return (
         references.length === 1 &&
         isWholeIncomingReference(references[0]!) &&
@@ -509,6 +519,38 @@ export class BatchDeduplicator {
       return provenanceBacked ? "externalized" : "unproven-externalized";
     }
     return null;
+  }
+
+  private async incomingNativeImagesMatchStoredContent(
+    storedContent: string,
+    references: ExternalizedReference[],
+    incomingRawPayloadContent?: string | null,
+  ): Promise<boolean> {
+    if (incomingRawPayloadContent == null || !references.every(isImageReference)) {
+      return false;
+    }
+    const blocks = extractNativeImageReplayBlocks(incomingRawPayloadContent);
+    if (!blocks) {
+      return false;
+    }
+
+    let referenceIndex = 0;
+    const rewritten: string[] = [];
+    for (const block of blocks) {
+      // Mirror extractStructuredText's array join while replacing each replayed
+      // native image with the exact stored reference after byte proof.
+      if (block.kind === "text") {
+        rewritten.push(block.text);
+        continue;
+      }
+      const reference = references[referenceIndex];
+      if (!reference || !(await this.referenceMatchesNativeImage(reference, block.buffer))) {
+        return false;
+      }
+      rewritten.push(reference.reference);
+      referenceIndex += 1;
+    }
+    return referenceIndex === references.length && rewritten.join("\n") === storedContent;
   }
 
   private async getStoredExternalizedReferenceProofKeys(
@@ -581,14 +623,9 @@ export class BatchDeduplicator {
       return false;
     }
     if (isImageReference(reference)) {
-      if (!largeFile.mimeType?.toLowerCase().startsWith("image/")) {
-        return false;
-      }
       const incomingImage = extractSingleNativeImageBuffer(incomingRawPayloadContent ?? incoming.content);
       return incomingImage
-        ? this.summaryStore.largeFileBufferEquals(reference.fileId, incomingImage, {
-            largeFilesDir: this.largeFilesDir,
-          })
+        ? this.referenceMatchesNativeImage(reference, incomingImage)
         : false;
     }
     const contentToCompare =
@@ -604,24 +641,103 @@ export class BatchDeduplicator {
     }
     if (
       !reference.reference.startsWith("[LCM Raw Payload:") ||
-      incomingRawPayloadContent == null ||
-      parseFileBlocks(incomingRawPayloadContent).length === 0
+      incomingRawPayloadContent == null
     ) {
+      return false;
+    }
+    const hasFileBlocks = parseFileBlocks(incomingRawPayloadContent).length > 0;
+    const hasNativeImages = rawPayloadHasNativeImages(incomingRawPayloadContent);
+    if (!hasFileBlocks && !hasNativeImages) {
       return false;
     }
 
     const storedPayload = await this.summaryStore.getLargeFileContent(reference.fileId, {
       largeFilesDir: this.largeFilesDir,
-      maxBytes: Buffer.byteLength(incomingRawPayloadContent, "utf8"),
+      maxBytes: largeFile.byteSize ?? Buffer.byteLength(incomingRawPayloadContent, "utf8"),
     });
     if (!storedPayload) {
       return false;
     }
-    const rewrittenPayload = await this.rewriteIncomingFileBlocksFromStoredPayload(
-      incomingRawPayloadContent,
-      storedPayload,
-    );
-    return rewrittenPayload === storedPayload;
+    if (hasFileBlocks) {
+      const rewrittenPayload = await this.rewriteIncomingFileBlocksFromStoredPayload(
+        incomingRawPayloadContent,
+        storedPayload,
+      );
+      if (rewrittenPayload === storedPayload) {
+        return true;
+      }
+    }
+    return hasNativeImages
+      ? this.incomingNativeImageRawPayloadMatchesStoredPayload(
+          incomingRawPayloadContent,
+          storedPayload,
+        )
+      : false;
+  }
+
+  private async referenceMatchesNativeImage(
+    reference: ExternalizedReference,
+    incomingImage: Buffer,
+  ): Promise<boolean> {
+    const largeFile = await this.summaryStore.getLargeFile(reference.fileId);
+    if (!largeFile?.mimeType?.toLowerCase().startsWith("image/")) {
+      return false;
+    }
+    return this.summaryStore.largeFileBufferEquals(reference.fileId, incomingImage, {
+      largeFilesDir: this.largeFilesDir,
+    });
+  }
+
+  private async incomingNativeImageRawPayloadMatchesStoredPayload(
+    incomingRawPayloadContent: string,
+    storedPayload: string,
+  ): Promise<boolean> {
+    const incoming = parseJsonPayload(incomingRawPayloadContent);
+    const stored = parseJsonPayload(storedPayload);
+    if (!Array.isArray(incoming) || !Array.isArray(stored) || incoming.length !== stored.length) {
+      return false;
+    }
+
+    for (let index = 0; index < incoming.length; index += 1) {
+      const incomingEntry = incoming[index];
+      const storedEntry = stored[index];
+      const incomingImage = extractSingleNativeImageBufferFromValue(incomingEntry);
+      if (!incomingImage) {
+        // Non-image raw blocks must remain byte-for-byte JSON equivalent.
+        if (isNativeImageEntry(incomingEntry) || JSON.stringify(incomingEntry) !== JSON.stringify(storedEntry)) {
+          return false;
+        }
+        continue;
+      }
+      if (!(await this.storedRawPayloadImageEntryMatches(storedEntry, incomingImage))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private async storedRawPayloadImageEntryMatches(
+    storedEntry: unknown,
+    incomingImage: Buffer,
+  ): Promise<boolean> {
+    if (!storedEntry || typeof storedEntry !== "object" || Array.isArray(storedEntry)) {
+      return false;
+    }
+    const record = storedEntry as Record<string, unknown>;
+    if (
+      record.type !== "text" ||
+      record.imageExternalized !== true ||
+      record.externalizationReason !== "native_image" ||
+      typeof record.text !== "string" ||
+      typeof record.externalizedFileId !== "string"
+    ) {
+      return false;
+    }
+    const references = extractExternalizedReferences(record.text);
+    if (references.length !== 1 || references[0]!.fileId !== record.externalizedFileId) {
+      return false;
+    }
+    return this.referenceMatchesNativeImage(references[0]!, incomingImage);
   }
 
   private async rewriteIncomingFileBlocksFromStoredPayload(
@@ -757,6 +873,10 @@ type ExternalizedReference = {
   end: number;
 };
 
+type NativeImageReplayBlock =
+  | { kind: "text"; text: string }
+  | { kind: "image"; buffer: Buffer };
+
 function extractExternalizedReferences(content: string): ExternalizedReference[] {
   const references: ExternalizedReference[] = [];
   const summaryMarker = "\n\nExploration Summary:";
@@ -835,6 +955,52 @@ function extractSingleNativeImageBuffer(content: string): Buffer | null {
     ? extractNativeImageBuffersFromValue(content)
     : extractNativeImageBuffersFromValue(parsed);
   return imageBlocks.length === 1 ? imageBlocks[0]! : null;
+}
+
+function extractNativeImageReplayBlocks(content: string): NativeImageReplayBlock[] | null {
+  const parsed = parseJsonPayload(content);
+  if (!Array.isArray(parsed)) {
+    return null;
+  }
+
+  const blocks: NativeImageReplayBlock[] = [];
+  let sawImage = false;
+  for (const entry of parsed) {
+    const image = extractSingleNativeImageBufferFromValue(entry);
+    if (image) {
+      blocks.push({ kind: "image", buffer: image });
+      sawImage = true;
+      continue;
+    }
+    if (isNativeImageEntry(entry)) {
+      return null;
+    }
+    const text = extractStructuredText(entry);
+    if (typeof text === "string" && text.trim().length > 0) {
+      blocks.push({ kind: "text", text });
+    }
+  }
+
+  return sawImage ? blocks : null;
+}
+
+function rawPayloadHasNativeImages(content: string): boolean {
+  const parsed = parseJsonPayload(content);
+  return Array.isArray(parsed) && parsed.some((entry) => extractSingleNativeImageBufferFromValue(entry));
+}
+
+function extractSingleNativeImageBufferFromValue(value: unknown): Buffer | null {
+  const images = extractNativeImageBuffersFromValue(value);
+  return images.length === 1 ? images[0]! : null;
+}
+
+function isNativeImageEntry(value: unknown): boolean {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).type === "image"
+  );
 }
 
 function extractNativeImageBuffersFromValue(value: unknown): Buffer[] {

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -6,15 +6,30 @@
  *
  * Extracted from engine.ts (Phase 2 of the engine decomposition).
  */
-import { toStoredMessage } from "./message-content.js";
-import { messageIdentity } from "./message-signatures.js";
+import {
+  formatFileReference,
+  formatRawPayloadReference,
+  formatToolOutputReference,
+  parseFileBlocks,
+  type FileBlock,
+} from "./large-files.js";
+import {
+  RAW_PAYLOAD_EXTERNALIZATION_REASON,
+  serializeRawPayloadContent,
+  toStoredMessage,
+  type StoredMessage,
+} from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
-import type { ConversationStore } from "./store/conversation-store.js";
+import type { ConversationStore, MessageRecord } from "./store/conversation-store.js";
+import { buildMessageIdentityHash } from "./store/message-identity.js";
+import type { LargeFileRecord, SummaryStore } from "./store/summary-store.js";
 import type { LcmDependencies } from "./types.js";
 
 export class BatchDeduplicator {
   constructor(
     private readonly conversationStore: ConversationStore,
+    private readonly summaryStore: SummaryStore,
+    private readonly largeFilesDir: string,
     private readonly deps: Pick<LcmDependencies, "log">,
   ) {}
 
@@ -58,30 +73,57 @@ export class BatchDeduplicator {
     const conversationId = conversation.conversationId;
 
     const storedBatch = batch.map((message) => toStoredMessage(message));
+    const batchHashes = computeBatchIdentityHashes(storedBatch);
+    const rawPayloadContents = computeBatchRawPayloadContents(batch, storedBatch);
     const tail = await this.conversationStore.getLastMessages(conversationId, batch.length);
-    for (let k = Math.min(tail.length, batch.length); k > 0; k -= 1) {
-      const tailSlice = tail.slice(tail.length - k);
+    const tailHashes = await this.conversationStore.getRecentMessageIdentityHashes(
+      conversationId,
+      batch.length,
+    );
+    let unprovenExternalizedOverlap = false;
+    for (let k = Math.min(tail.length, tailHashes.length, batch.length); k > 0; k -= 1) {
+      const tailMessages = tail.slice(tail.length - k);
+      const tailSlice = tailHashes.slice(tailHashes.length - k);
       let aligned = true;
+      let exactAnchor = false;
       for (let i = 0; i < k; i += 1) {
-        if (
-          messageIdentity(tailSlice[i]!.role, tailSlice[i]!.content) !==
-          messageIdentity(storedBatch[i]!.role, storedBatch[i]!.content)
-        ) {
+        const match = await this.matchStoredMessageToIncoming(
+          tailMessages[i]!,
+          storedBatch[i]!,
+          batchHashes[i]!,
+          tailSlice[i]!,
+          rawPayloadContents[i],
+        );
+        if (match === "unproven-externalized") {
+          unprovenExternalizedOverlap = true;
           aligned = false;
           break;
         }
+        if (!match) {
+          aligned = false;
+          break;
+        }
+        exactAnchor ||= match === "exact";
       }
-      if (aligned) {
+      // Externalized-only matches are ambiguous in the same way as suffix
+      // fallback anchors: they may be a replay or a legitimate repeated upload.
+      // Trim only when at least one matched message still has exact identity.
+      if (aligned && exactAnchor) {
         return batch.slice(k);
       }
     }
 
-    let persistedIdentityOverlaps = 0;
-    for (const stored of storedBatch) {
-      if (await this.conversationStore.hasMessage(conversationId, stored.role, stored.content)) {
-        persistedIdentityOverlaps += 1;
-      }
+    if (unprovenExternalizedOverlap) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: runtime batch has an unproven externalized overlap with the covered transcript frontier; ingesting full batch conversation=${conversationId}`,
+      );
+      return batch;
     }
+
+    const persistedIdentityOverlaps = await this.countPersistedIdentityOverlaps(
+      conversationId,
+      storedBatch,
+    );
     if (persistedIdentityOverlaps > 0) {
       this.deps.log.warn(
         `[lcm] afterTurn: runtime batch does not align with the covered transcript frontier and overlaps persisted history (${persistedIdentityOverlaps}/${batch.length}); failing closed — the transcript reconcile delivers real messages next turn conversation=${conversationId}`,
@@ -109,10 +151,12 @@ export class BatchDeduplicator {
     const storedMessageCount = await this.conversationStore.getMessageCount(conversationId);
     if (storedMessageCount === 0) return batch;
 
-    const lastDbMessage = await this.conversationStore.getLastMessage(conversationId);
-    if (!lastDbMessage) return batch;
+    const lastDbIdentityHash = await this.conversationStore.getLastMessageIdentityHash(conversationId);
+    if (!lastDbIdentityHash) return batch;
 
     const storedBatch = batch.map((m) => toStoredMessage(m));
+    const batchHashes = computeBatchIdentityHashes(storedBatch);
+    const rawPayloadContents = computeBatchRawPayloadContents(batch, storedBatch);
 
     // When the DB already has more messages than the incoming batch,
     // the batch may be a tail-only replay. Try tail-matching first,
@@ -122,32 +166,40 @@ export class BatchDeduplicator {
         conversationId,
         batch,
         storedBatch,
+        batchHashes,
+        rawPayloadContents,
         storedMessageCount,
-        lastDbMessage,
+        lastDbIdentityHash,
         options,
       );
     }
 
-    // Aligned-tail check: DB's last message must match the message at the
-    // exact replay boundary in the incoming batch. This replaces the
-    // hasMessage() check which could false-positive on any repeated content.
-    const batchAtBoundary = storedBatch[storedMessageCount - 1]!;
-    if (
-      messageIdentity(lastDbMessage.role, lastDbMessage.content) !==
-      messageIdentity(batchAtBoundary.role, batchAtBoundary.content)
-    ) {
+    // Aligned-tail check: DB's last message identity_hash must match the
+    // message at the exact replay boundary in the incoming batch.
+    const batchAtBoundaryHash = batchHashes[storedMessageCount - 1]!;
+    if (batchAtBoundaryHash !== lastDbIdentityHash) {
       // Prefix mismatch — attempt suffix fallback before giving up.
       return this.deduplicateSuffixFallback(
         conversationId,
         batch,
         storedBatch,
+        batchHashes,
+        rawPayloadContents,
         storedMessageCount,
         "prefix-mismatch",
+        { onNoOverlap: "ingest" },
       );
     }
 
     // Full proof: incoming batch must start with the entire stored transcript
     // in exact order before we trim anything.
+    const recentDbHashes = await this.conversationStore.getRecentMessageIdentityHashes(
+      conversationId,
+      storedMessageCount,
+    );
+    if (recentDbHashes.length !== storedMessageCount) {
+      return batch;
+    }
     const storedMessages = await this.conversationStore.getMessages(conversationId, {
       limit: storedMessageCount,
     });
@@ -155,12 +207,17 @@ export class BatchDeduplicator {
       return batch;
     }
     for (let i = 0; i < storedMessageCount; i += 1) {
-      const storedConversationMessage = storedMessages[i]!;
-      const incomingMessage = storedBatch[i]!;
-      if (
-        messageIdentity(storedConversationMessage.role, storedConversationMessage.content) !==
-        messageIdentity(incomingMessage.role, incomingMessage.content)
-      ) {
+      const match = await this.matchStoredMessageToIncoming(
+        storedMessages[i]!,
+        storedBatch[i]!,
+        batchHashes[i]!,
+        recentDbHashes[i]!,
+        rawPayloadContents[i],
+      );
+      if (!match) {
+        return batch;
+      }
+      if (match === "unproven-externalized") {
         return batch;
       }
     }
@@ -177,31 +234,33 @@ export class BatchDeduplicator {
     conversationId: number,
     batch: AgentMessage[],
     storedBatch: ReturnType<typeof toStoredMessage>[],
+    batchHashes: string[],
+    rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
-    lastDbMessage: { role: string; content: string },
+    lastDbIdentityHash: string,
     options?: { oversizedNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
-    const lastBatchIdentity = messageIdentity(
-      storedBatch[storedBatch.length - 1]!.role,
-      storedBatch[storedBatch.length - 1]!.content,
-    );
-    const lastDbIdentity = messageIdentity(lastDbMessage.role, lastDbMessage.content);
+    const lastBatchHash = batchHashes[batchHashes.length - 1]!;
 
-    // Quick check: if the last DB message matches the last batch message,
-    // verify that the entire batch matches the actual DB tail. Message seq
-    // can have gaps after maintenance deletes, so do not derive seq from count.
-    if (lastDbIdentity === lastBatchIdentity) {
-      const storedMessages = await this.conversationStore.getMessages(conversationId, {
-        limit: storedMessageCount,
-      });
-      const tailMessages = storedMessages.slice(-batch.length);
-      if (tailMessages.length === batch.length) {
+    // Quick check: if the last DB identity_hash matches the last batch
+    // identity_hash, verify that the entire batch matches the actual DB tail.
+    if (lastDbIdentityHash === lastBatchHash) {
+      const tailMessages = await this.conversationStore.getLastMessages(conversationId, batch.length);
+      const tailHashes = await this.conversationStore.getRecentMessageIdentityHashes(
+        conversationId,
+        batch.length,
+      );
+      if (tailMessages.length === batch.length && tailHashes.length === batch.length) {
         let tailMatch = true;
         for (let i = 0; i < batch.length; i++) {
-          if (
-            messageIdentity(tailMessages[i]!.role, tailMessages[i]!.content) !==
-            messageIdentity(storedBatch[i]!.role, storedBatch[i]!.content)
-          ) {
+          const match = await this.matchStoredMessageToIncoming(
+            tailMessages[i]!,
+            storedBatch[i]!,
+            batchHashes[i]!,
+            tailHashes[i]!,
+            rawPayloadContents[i],
+          );
+          if (!match || match === "unproven-externalized") {
             tailMatch = false;
             break;
           }
@@ -225,6 +284,8 @@ export class BatchDeduplicator {
       conversationId,
       batch,
       storedBatch,
+      batchHashes,
+      rawPayloadContents,
       storedMessageCount,
       "oversized",
       { onNoOverlap: options?.oversizedNoOverlap ?? "skip" },
@@ -240,46 +301,68 @@ export class BatchDeduplicator {
     conversationId: number,
     batch: AgentMessage[],
     storedBatch: ReturnType<typeof toStoredMessage>[],
+    batchHashes: string[],
+    rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
     context: string,
     options?: { onNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
+    const allRecentHashes = await this.conversationStore.getRecentMessageIdentityHashes(
+      conversationId,
+      storedMessageCount,
+    );
+    if (allRecentHashes.length === 0) return batch;
     const allStored = await this.conversationStore.getMessages(conversationId, {
       limit: storedMessageCount,
     });
-    if (allStored.length === 0) return batch;
+    if (allStored.length !== allRecentHashes.length) return batch;
 
-    const lastStoredIdentity = messageIdentity(
-      allStored[allStored.length - 1]!.role,
-      allStored[allStored.length - 1]!.content,
-    );
+    const lastStoredHash = allRecentHashes[allRecentHashes.length - 1]!;
+    const lastStoredMessage = allStored[allStored.length - 1]!;
+    let ambiguousExternalizedOverlap = false;
 
     for (let k = batch.length - 1; k >= 0; k--) {
-      if (
-        messageIdentity(storedBatch[k]!.role, storedBatch[k]!.content) !== lastStoredIdentity
-      ) {
+      const lastMatch = await this.matchStoredMessageToIncoming(
+        lastStoredMessage,
+        storedBatch[k]!,
+        batchHashes[k]!,
+        lastStoredHash,
+        rawPayloadContents[k],
+      );
+      if (lastMatch === "unproven-externalized") {
+        ambiguousExternalizedOverlap = true;
         continue;
       }
-      const matchLen = Math.min(k + 1, allStored.length);
-      const startDb = allStored.length - matchLen;
+      if (!lastMatch) continue;
+
+      const matchLen = Math.min(k + 1, allRecentHashes.length);
+      const startDb = allRecentHashes.length - matchLen;
       let suffixMatch = true;
+      let exactAnchor = lastMatch === "exact";
       for (let j = 0; j < matchLen; j++) {
-        if (
-          messageIdentity(
-            allStored[startDb + j]!.role,
-            allStored[startDb + j]!.content,
-          ) !==
-          messageIdentity(
-            storedBatch[k - matchLen + 1 + j]!.role,
-            storedBatch[k - matchLen + 1 + j]!.content,
-          )
-        ) {
+        const match = await this.matchStoredMessageToIncoming(
+          allStored[startDb + j]!,
+          storedBatch[k - matchLen + 1 + j]!,
+          batchHashes[k - matchLen + 1 + j]!,
+          allRecentHashes[startDb + j]!,
+          rawPayloadContents[k - matchLen + 1 + j],
+        );
+        if (match === "unproven-externalized") {
+          ambiguousExternalizedOverlap = true;
           suffixMatch = false;
           break;
         }
+        if (!match) {
+          suffixMatch = false;
+          break;
+        }
+        exactAnchor ||= match === "exact";
       }
       const newSlice = batch.slice(k + 1);
-      if (suffixMatch && (newSlice.length > 0 || matchLen > 1)) {
+      // Outside the transcript-covered path, an externalized-only anchor is
+      // ambiguous: it may be a replay prefix or a new turn that repeats the
+      // same upload. Require an exact anchor before trimming.
+      if (suffixMatch && exactAnchor && (newSlice.length > 0 || matchLen > 1)) {
         this.deps.log.debug(
           `[lcm] dedup: ${context} suffix-match at batch[${k}], ` +
             `returning ${newSlice.length} new messages ` +
@@ -287,9 +370,21 @@ export class BatchDeduplicator {
         );
         return newSlice;
       }
+      if (suffixMatch && !exactAnchor) {
+        ambiguousExternalizedOverlap = true;
+      }
     }
 
-    if (options?.onNoOverlap === "skip") {
+    if (ambiguousExternalizedOverlap) {
+      this.deps.log.warn(
+        `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
+          `externalized-only overlap is ambiguous — ingesting full batch`,
+      );
+      return batch;
+    }
+
+    const onNoOverlap = options?.onNoOverlap ?? "skip";
+    if (onNoOverlap === "skip") {
       this.deps.log.warn(
         `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
           `no overlap found — fail-closed skipping full batch`,
@@ -302,5 +397,393 @@ export class BatchDeduplicator {
         `no overlap found — ingesting full batch`,
     );
     return batch;
+  }
+
+  private async matchStoredMessageToIncoming(
+    storedMessage: MessageRecord,
+    incoming: StoredMessage,
+    incomingHash: string,
+    storedHash: string,
+    incomingRawPayloadContent?: string | null,
+  ): Promise<"exact" | "externalized" | "unproven-externalized" | null> {
+    if (
+      storedHash === incomingHash &&
+      storedMessage.role === incoming.role &&
+      storedMessage.content === incoming.content
+    ) {
+      return "exact";
+    }
+    return this.messagesAreExternalizedEquivalent(
+      storedMessage,
+      incoming,
+      incomingRawPayloadContent,
+    );
+  }
+
+  private async countPersistedIdentityOverlaps(
+    conversationId: number,
+    incomingBatch: StoredMessage[],
+  ): Promise<number> {
+    let overlaps = 0;
+    for (const incoming of incomingBatch) {
+      if (await this.conversationStore.hasMessage(conversationId, incoming.role, incoming.content)) {
+        overlaps += 1;
+      }
+    }
+    return overlaps;
+  }
+
+  private async messagesAreExternalizedEquivalent(
+    storedMessage: MessageRecord,
+    incoming: StoredMessage,
+    incomingRawPayloadContent?: string | null,
+  ): Promise<"externalized" | "unproven-externalized" | null> {
+    if (storedMessage.role !== incoming.role) {
+      return null;
+    }
+    let references = extractExternalizedReferences(storedMessage.content);
+    if (references.length === 0) {
+      return null;
+    }
+    const proofKeys = await this.getStoredExternalizedReferenceProofKeys(
+      storedMessage,
+      references,
+    );
+    if (proofKeys.size > 0) {
+      references = references.filter((reference) => proofKeys.has(referenceProofKey(reference)));
+      if (references.length === 0) {
+        return null;
+      }
+    }
+    if (references.some((reference) => reference.reference.startsWith("[LCM Tool Output:"))) {
+      return null;
+    }
+    const provenanceBacked =
+      proofKeys.size > 0 &&
+      references.every((reference) => proofKeys.has(referenceProofKey(reference)));
+
+    if (
+      references.length === 1 &&
+      references[0]!.reference.startsWith("[LCM Raw Payload:") &&
+      (await this.referenceMatchesWholeIncoming(
+        storedMessage,
+        incoming,
+        references[0]!,
+        incomingRawPayloadContent,
+      ))
+    ) {
+      return provenanceBacked ? "externalized" : "unproven-externalized";
+    }
+
+    const fileBlocks = parseFileBlocks(incoming.content);
+    if (fileBlocks.length === 0) {
+      return (
+        references.length === 1 &&
+        references[0]!.reference.startsWith("[LCM Raw Payload:") &&
+        (await this.referenceMatchesWholeIncoming(
+          storedMessage,
+          incoming,
+          references[0]!,
+          incomingRawPayloadContent,
+        ))
+      )
+        ? provenanceBacked ? "externalized" : "unproven-externalized"
+        : null;
+    }
+
+    let rewritten = "";
+    let cursor = 0;
+    const usedReferenceIndexes = new Set<number>();
+    for (const block of fileBlocks) {
+      const referenceIndex = await this.findMatchingReferenceIndex(
+        references,
+        block,
+        usedReferenceIndexes,
+      );
+      rewritten += incoming.content.slice(cursor, block.start);
+      if (referenceIndex < 0) {
+        rewritten += incoming.content.slice(block.start, block.end);
+      } else {
+        usedReferenceIndexes.add(referenceIndex);
+        rewritten += references[referenceIndex]!.formattedReference;
+      }
+      cursor = block.end;
+    }
+    rewritten += incoming.content.slice(cursor);
+    if (usedReferenceIndexes.size === references.length && rewritten === storedMessage.content) {
+      return provenanceBacked ? "externalized" : "unproven-externalized";
+    }
+    return null;
+  }
+
+  private async getStoredExternalizedReferenceProofKeys(
+    storedMessage: MessageRecord,
+    references: ExternalizedReference[],
+  ): Promise<Set<string>> {
+    const proofKeys = new Set<string>();
+    if (storedMessage.largeContent) {
+      for (const reference of references) {
+        if (reference.fileId === storedMessage.largeContent) {
+          proofKeys.add(referenceProofKey(reference));
+        }
+      }
+    }
+
+    const parts = await this.conversationStore.getMessageParts(storedMessage.messageId);
+    for (const part of parts) {
+      const metadata = parsePartMetadata(part.metadata);
+      if (!metadata) {
+        continue;
+      }
+      if (
+        metadata.rawPayloadExternalized === true &&
+        metadata.externalizationReason === RAW_PAYLOAD_EXTERNALIZATION_REASON &&
+        typeof metadata.externalizedFileId === "string"
+      ) {
+        proofKeys.add(`raw:${metadata.externalizedFileId}`);
+      }
+      if (
+        metadata.fileBlocksExternalized === true &&
+        metadata.externalizationReason === "large_file_block" &&
+        Array.isArray(metadata.externalizedFileIds)
+      ) {
+        for (const fileId of metadata.externalizedFileIds) {
+          if (typeof fileId === "string") {
+            proofKeys.add(`file:${fileId}`);
+          }
+        }
+      }
+    }
+
+    return proofKeys;
+  }
+
+  private async referenceMatchesWholeIncoming(
+    storedMessage: MessageRecord,
+    incoming: StoredMessage,
+    reference: ExternalizedReference,
+    incomingRawPayloadContent?: string | null,
+  ): Promise<boolean> {
+    const largeFile = await this.summaryStore.getLargeFile(reference.fileId);
+    if (!largeFile) {
+      return false;
+    }
+    if (this.formatExternalizedReference(reference, largeFile, storedMessage) !== storedMessage.content) {
+      return false;
+    }
+    const contentToCompare =
+      reference.reference.startsWith("[LCM Raw Payload:") && incomingRawPayloadContent != null
+        ? incomingRawPayloadContent
+        : incoming.content;
+    if (
+      await this.summaryStore.largeFileContentEquals(reference.fileId, contentToCompare, {
+        largeFilesDir: this.largeFilesDir,
+      })
+    ) {
+      return true;
+    }
+    if (
+      !reference.reference.startsWith("[LCM Raw Payload:") ||
+      incomingRawPayloadContent == null ||
+      parseFileBlocks(incomingRawPayloadContent).length === 0
+    ) {
+      return false;
+    }
+
+    const storedPayload = await this.summaryStore.getLargeFileContent(reference.fileId, {
+      largeFilesDir: this.largeFilesDir,
+    });
+    if (!storedPayload) {
+      return false;
+    }
+    const rewrittenPayload = await this.rewriteIncomingFileBlocksFromStoredPayload(
+      incomingRawPayloadContent,
+      storedPayload,
+    );
+    return rewrittenPayload === storedPayload;
+  }
+
+  private async rewriteIncomingFileBlocksFromStoredPayload(
+    incomingContent: string,
+    storedPayload: string,
+  ): Promise<string | null> {
+    const references = extractExternalizedReferences(storedPayload);
+    const fileBlocks = parseFileBlocks(incomingContent);
+    if (references.length === 0 || fileBlocks.length === 0) {
+      return null;
+    }
+
+    let rewritten = "";
+    let cursor = 0;
+    const usedReferenceIndexes = new Set<number>();
+    for (const block of fileBlocks) {
+      const referenceIndex = await this.findMatchingReferenceIndex(
+        references,
+        block,
+        usedReferenceIndexes,
+      );
+      rewritten += incomingContent.slice(cursor, block.start);
+      if (referenceIndex < 0) {
+        rewritten += incomingContent.slice(block.start, block.end);
+      } else {
+        usedReferenceIndexes.add(referenceIndex);
+        rewritten += references[referenceIndex]!.formattedReference;
+      }
+      cursor = block.end;
+    }
+    rewritten += incomingContent.slice(cursor);
+    return usedReferenceIndexes.size === references.length ? rewritten : null;
+  }
+
+  private async findMatchingReferenceIndex(
+    references: ExternalizedReference[],
+    block: FileBlock,
+    usedReferenceIndexes: Set<number>,
+  ): Promise<number> {
+    for (let index = 0; index < references.length; index += 1) {
+      if (usedReferenceIndexes.has(index)) {
+        continue;
+      }
+      const reference = references[index]!;
+      const largeFile = await this.summaryStore.getLargeFile(reference.fileId);
+      if (!largeFile) {
+        continue;
+      }
+      if (
+        (largeFile.fileName ?? undefined) !== block.fileName ||
+        (largeFile.mimeType ?? undefined) !== block.mimeType
+      ) {
+        continue;
+      }
+      if (
+        await this.summaryStore.largeFileContentEquals(reference.fileId, block.text, {
+          largeFilesDir: this.largeFilesDir,
+        })
+      ) {
+        reference.formattedReference = this.formatFileReference(largeFile);
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  private formatExternalizedReference(
+    reference: ExternalizedReference,
+    largeFile: LargeFileRecord,
+    storedMessage: MessageRecord,
+  ): string {
+    if (reference.reference.startsWith("[LCM Tool Output:")) {
+      return formatToolOutputReference({
+        fileId: largeFile.fileId,
+        toolName: extractReferenceField(reference.reference, "tool"),
+        byteSize: largeFile.byteSize ?? 0,
+        summary: largeFile.explorationSummary ?? "",
+      });
+    }
+
+    if (reference.reference.startsWith("[LCM Raw Payload:")) {
+      return formatRawPayloadReference({
+        fileId: largeFile.fileId,
+        role: extractReferenceField(reference.reference, "role") ?? storedMessage.role,
+        reason:
+          extractReferenceField(reference.reference, "reason") ??
+          RAW_PAYLOAD_EXTERNALIZATION_REASON,
+        byteSize: largeFile.byteSize ?? 0,
+        summary: largeFile.explorationSummary ?? "",
+      });
+    }
+
+    return this.formatFileReference(largeFile);
+  }
+
+  private formatFileReference(largeFile: LargeFileRecord): string {
+    return formatFileReference({
+      fileId: largeFile.fileId,
+      fileName: largeFile.fileName ?? undefined,
+      mimeType: largeFile.mimeType ?? undefined,
+      byteSize: largeFile.byteSize ?? 0,
+      summary: largeFile.explorationSummary ?? "",
+    });
+  }
+}
+
+function storedMessageIdentityHash(stored: StoredMessage): string {
+  return buildMessageIdentityHash(stored.role, stored.content);
+}
+
+function computeBatchIdentityHashes(batch: StoredMessage[]): string[] {
+  return batch.map((m) => storedMessageIdentityHash(m));
+}
+
+function computeBatchRawPayloadContents(
+  batch: AgentMessage[],
+  storedBatch: StoredMessage[],
+): Array<string | null> {
+  return batch.map((message, index) => {
+    const rawPayload = serializeRawPayloadContent(message, storedBatch[index]?.content ?? "");
+    return rawPayload?.content ?? null;
+  });
+}
+
+type ExternalizedReference = {
+  fileId: string;
+  reference: string;
+  formattedReference: string;
+  end: number;
+};
+
+function extractExternalizedReferences(content: string): ExternalizedReference[] {
+  const references: ExternalizedReference[] = [];
+  const summaryMarker = "\n\nExploration Summary:";
+  const referencePattern = /\[LCM (?:File|Raw Payload|Tool Output):\s*(file_[a-f0-9]{16})\b/gi;
+  let match: RegExpExecArray | null;
+  while ((match = referencePattern.exec(content)) !== null) {
+    const fileId = match[1]?.toLowerCase();
+    if (!fileId) continue;
+    const markerIndex = content.indexOf(summaryMarker, referencePattern.lastIndex);
+    if (markerIndex < 0 || content[markerIndex - 1] !== "]") {
+      continue;
+    }
+    const headerRemainder = content.slice(referencePattern.lastIndex, markerIndex);
+    if (/\][\s\S]*\[LCM (?:File|Raw Payload|Tool Output):\s*file_[a-f0-9]{16}\b/i.test(headerRemainder)) {
+      continue;
+    }
+    references.push({
+      fileId,
+      reference: content.slice(match.index, markerIndex),
+      formattedReference: content.slice(match.index, markerIndex),
+      end: markerIndex,
+    });
+    referencePattern.lastIndex = markerIndex;
+  }
+  return references;
+}
+
+function extractReferenceField(reference: string, field: "tool" | "role" | "reason"): string | undefined {
+  const match = new RegExp(`\\b${field}=([^|\\]]+)`).exec(reference);
+  return match?.[1]?.trim() || undefined;
+}
+
+function referenceProofKey(reference: ExternalizedReference): string {
+  if (reference.reference.startsWith("[LCM Raw Payload:")) {
+    return `raw:${reference.fileId}`;
+  }
+  if (reference.reference.startsWith("[LCM File:")) {
+    return `file:${reference.fileId}`;
+  }
+  return `other:${reference.fileId}`;
+}
+
+function parsePartMetadata(metadata: string | null): Record<string, unknown> | null {
+  if (!metadata) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(metadata);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
   }
 }

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -157,8 +157,6 @@ export class BatchDeduplicator {
     const storedBatch = batch.map((m) => toStoredMessage(m));
     const batchHashes = computeBatchIdentityHashes(storedBatch);
     const rawPayloadContents = computeBatchRawPayloadContents(batch, storedBatch);
-    const batchCreatedAtMs = batch.map(resolveMessageCreatedAtMs);
-
     // When the DB already has more messages than the incoming batch,
     // the batch may be a tail-only replay. Try tail-matching first,
     // then fall back to suffix-matching.
@@ -169,7 +167,6 @@ export class BatchDeduplicator {
         storedBatch,
         batchHashes,
         rawPayloadContents,
-        batchCreatedAtMs,
         storedMessageCount,
         lastDbIdentityHash,
         options,
@@ -187,7 +184,6 @@ export class BatchDeduplicator {
         storedBatch,
         batchHashes,
         rawPayloadContents,
-        batchCreatedAtMs,
         storedMessageCount,
         "prefix-mismatch",
         { onNoOverlap: "ingest" },
@@ -239,7 +235,6 @@ export class BatchDeduplicator {
     storedBatch: ReturnType<typeof toStoredMessage>[],
     batchHashes: string[],
     rawPayloadContents: Array<string | null>,
-    batchCreatedAtMs: Array<number | null>,
     storedMessageCount: number,
     lastDbIdentityHash: string,
     options?: { oversizedNoOverlap?: "ingest" | "skip" },
@@ -289,7 +284,6 @@ export class BatchDeduplicator {
       storedBatch,
       batchHashes,
       rawPayloadContents,
-      batchCreatedAtMs,
       storedMessageCount,
       "oversized",
       { onNoOverlap: options?.oversizedNoOverlap ?? "ingest" },
@@ -307,7 +301,6 @@ export class BatchDeduplicator {
     storedBatch: ReturnType<typeof toStoredMessage>[],
     batchHashes: string[],
     rawPayloadContents: Array<string | null>,
-    batchCreatedAtMs: Array<number | null>,
     storedMessageCount: number,
     context: string,
     options?: { onNoOverlap?: "ingest" | "skip" },
@@ -397,76 +390,11 @@ export class BatchDeduplicator {
       return [];
     }
 
-    if (
-      await this.batchMatchesPersistedTailByTimestamp(
-        allStored,
-        allRecentHashes,
-        storedBatch,
-        batchHashes,
-        rawPayloadContents,
-        batchCreatedAtMs,
-      )
-    ) {
-      this.deps.log.warn(
-        `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
-          `no suffix overlap found but batch matches timestamp-proven persisted tail — skipping full batch`,
-      );
-      return [];
-    }
-
     this.deps.log.warn(
       `[lcm] dedup: ${context}, storedCount=${storedMessageCount} batchLen=${batch.length}, ` +
         `no overlap found — ingesting full batch`,
     );
     return batch;
-  }
-
-  private async batchMatchesPersistedTailByTimestamp(
-    storedMessages: MessageRecord[],
-    storedHashes: string[],
-    incomingBatch: StoredMessage[],
-    incomingHashes: string[],
-    incomingRawPayloadContents: Array<string | null>,
-    incomingCreatedAtMs: Array<number | null>,
-  ): Promise<boolean> {
-    if (
-      incomingBatch.length === 0 ||
-      storedMessages.length !== storedHashes.length ||
-      storedMessages.length < incomingBatch.length
-    ) {
-      return false;
-    }
-
-    let storedIndex = storedMessages.length - 1;
-    for (let batchIndex = incomingBatch.length - 1; batchIndex >= 0; batchIndex -= 1) {
-      let matched = false;
-      while (storedIndex >= 0) {
-        const match = await this.matchStoredMessageToIncoming(
-          storedMessages[storedIndex]!,
-          incomingBatch[batchIndex]!,
-          incomingHashes[batchIndex]!,
-          storedHashes[storedIndex]!,
-          incomingRawPayloadContents[batchIndex],
-        );
-        if (
-          match &&
-          match !== "unproven-externalized" &&
-          messageTimestampMatchesPersistedRow(
-            incomingCreatedAtMs[batchIndex],
-            storedMessages[storedIndex]!,
-          )
-        ) {
-          matched = true;
-          storedIndex -= 1;
-          break;
-        }
-        storedIndex -= 1;
-      }
-      if (!matched) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private async matchStoredMessageToIncoming(
@@ -684,6 +612,7 @@ export class BatchDeduplicator {
 
     const storedPayload = await this.summaryStore.getLargeFileContent(reference.fileId, {
       largeFilesDir: this.largeFilesDir,
+      maxBytes: Buffer.byteLength(incomingRawPayloadContent, "utf8"),
     });
     if (!storedPayload) {
       return false;
@@ -819,37 +748,6 @@ function computeBatchRawPayloadContents(
     const rawPayload = serializeRawPayloadContent(message, storedBatch[index]?.content ?? "");
     return rawPayload?.content ?? null;
   });
-}
-
-function resolveMessageCreatedAtMs(message: AgentMessage): number | null {
-  const raw = message as unknown as Record<string, unknown>;
-  const value = raw.timestamp ?? raw.createdAt ?? raw.created_at;
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? Math.floor(value / 1000) * 1000 : null;
-  }
-  if (value instanceof Date) {
-    const time = value.getTime();
-    return Number.isFinite(time) ? Math.floor(time / 1000) * 1000 : null;
-  }
-  if (typeof value === "string" && value.trim()) {
-    const time = Date.parse(value);
-    return Number.isFinite(time) ? Math.floor(time / 1000) * 1000 : null;
-  }
-  return null;
-}
-
-function messageTimestampMatchesPersistedRow(
-  incomingCreatedAtMs: number | null | undefined,
-  storedMessage: MessageRecord,
-): boolean {
-  if (incomingCreatedAtMs == null) {
-    return false;
-  }
-  const storedCreatedAtMs = storedMessage.createdAt.getTime();
-  if (!Number.isFinite(storedCreatedAtMs)) {
-    return false;
-  }
-  return incomingCreatedAtMs <= storedCreatedAtMs;
 }
 
 type ExternalizedReference = {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -369,7 +369,12 @@ export class LcmContextEngine implements ContextEngine {
       this.summaryStore,
       (params) => this.resolveLargeFileTextSummarizer(params),
     );
-    this.batchDeduplicator = new BatchDeduplicator(this.conversationStore, this.deps);
+    this.batchDeduplicator = new BatchDeduplicator(
+      this.conversationStore,
+      this.summaryStore,
+      this.config.largeFilesDir,
+      this.deps,
+    );
     this.sessionRolloverDetector = new SessionRolloverDetector(
       this.conversationStore,
       this.summaryStore,
@@ -2679,6 +2684,9 @@ export class LcmContextEngine implements ContextEngine {
           messageForParts = {
             ...message,
             content: stored.content,
+            fileBlocksExternalized: true,
+            externalizedFileIds: intercepted.fileIds,
+            externalizationReason: "large_file_block",
           } as AgentMessage;
         }
       }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2811,6 +2811,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionKey: params.sessionKey,
               message,
               isHeartbeat: params.isHeartbeat,
+              createdAt: resolveTranscriptMessageCreatedAt(message),
             });
             if (result.ingested) {
               ingestedCount += 1;
@@ -2941,7 +2942,7 @@ export class LcmContextEngine implements ContextEngine {
         params.sessionKey,
         newMessages,
         {
-          oversizedNoOverlap: transcriptReconcileResult.importedMessages > 0 ? "ingest" : "skip",
+          oversizedNoOverlap: "ingest",
         },
       );
     }

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -329,7 +329,14 @@ export class LargeFileInterceptor {
         label,
       });
 
-      rewrittenContent.push({ type: "text", text: externalized.reference });
+      rewrittenContent.push({
+        type: "text",
+        text: externalized.reference,
+        externalizedFileId: externalized.fileId,
+        originalByteSize: externalized.byteSize,
+        imageExternalized: true,
+        externalizationReason: "native_image",
+      });
       fileIds.push(externalized.fileId);
       changed = true;
     }

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -463,6 +463,10 @@ export function buildMessageParts(params: {
   const topLevelReasoning = extractTopLevelReasoningContent(role, topLevel);
   const rawPayloadExternalized = safeBoolean(topLevel.rawPayloadExternalized);
   const externalizedFileId = safeString(topLevel.externalizedFileId);
+  const externalizedFileIds = Array.isArray(topLevel.externalizedFileIds)
+    ? topLevel.externalizedFileIds.filter((fileId): fileId is string => typeof fileId === "string")
+    : undefined;
+  const fileBlocksExternalized = safeBoolean(topLevel.fileBlocksExternalized);
   const originalByteSize =
     typeof topLevel.originalByteSize === "number"
       ? topLevel.originalByteSize
@@ -517,6 +521,8 @@ export function buildMessageParts(params: {
           ...topLevelReasoningMetadata(topLevelReasoning),
           rawPayloadExternalized: rawPayloadExternalized || undefined,
           externalizedFileId,
+          externalizedFileIds,
+          fileBlocksExternalized: fileBlocksExternalized || undefined,
           originalByteSize,
           externalizationReason,
         }),

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -618,6 +618,7 @@ export function buildMessageParts(params: {
           typeof metadataRecord?.originalByteSize === "number"
             ? metadataRecord.originalByteSize
             : undefined,
+        imageExternalized: safeBoolean(metadataRecord?.imageExternalized),
         toolOutputExternalized: safeBoolean(metadataRecord?.toolOutputExternalized),
         externalizationReason: safeString(metadataRecord?.externalizationReason),
         rawType: rawBlockType,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -787,6 +787,38 @@ export class ConversationStore {
     return row ? toMessageRecord(row) : null;
   }
 
+  /** Return the persisted identity hash for the newest message in a conversation. */
+  async getLastMessageIdentityHash(conversationId: ConversationId): Promise<string | null> {
+    const row = this.db
+      .prepare(
+        `SELECT identity_hash FROM messages
+       WHERE conversation_id = ?
+       ORDER BY seq DESC
+       LIMIT 1`,
+      )
+      .get(conversationId) as { identity_hash: string | null } | undefined;
+    return row?.identity_hash ?? null;
+  }
+
+  /** Return the newest `limit` persisted identity hashes in ascending seq order. */
+  async getRecentMessageIdentityHashes(
+    conversationId: ConversationId,
+    limit: number,
+  ): Promise<string[]> {
+    const rows = this.db
+      .prepare(
+        `SELECT identity_hash FROM messages
+       WHERE conversation_id = ?
+       ORDER BY seq DESC
+       LIMIT ?`,
+      )
+      .all(conversationId, limit) as { identity_hash: string | null }[];
+    return rows
+      .map((r) => r.identity_hash)
+      .filter((h): h is string => h !== null)
+      .reverse();
+  }
+
   async hasMessage(
     conversationId: ConversationId,
     role: MessageRole,

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1577,7 +1577,18 @@ export class SummaryStore {
     content: string,
     options: LargeFileReadOptions,
   ): Promise<boolean> {
-    const byteSize = Buffer.byteLength(content, "utf8");
+    return this.largeFileBufferEquals(fileId, Buffer.from(content, "utf8"), options);
+  }
+
+  /**
+   * Return true when one externalized binary/text payload exactly matches bytes.
+   */
+  async largeFileBufferEquals(
+    fileId: string,
+    content: Buffer,
+    options: LargeFileReadOptions,
+  ): Promise<boolean> {
+    const byteSize = content.byteLength;
     const row = this.db
       .prepare(
         `SELECT storage_uri
@@ -1591,7 +1602,7 @@ export class SummaryStore {
       return false;
     }
 
-    return this.validatedLargeFileContentEquals(row.storage_uri, content, options);
+    return this.validatedLargeFileBufferEquals(row.storage_uri, content, options);
   }
 
   /** Read a persisted large-file payload from disk, returning null when unavailable. */
@@ -1619,7 +1630,18 @@ export class SummaryStore {
     expectedContent: string,
     options: LargeFileReadOptions,
   ): Promise<boolean> {
-    const expected = Buffer.from(expectedContent, "utf8");
+    return this.validatedLargeFileBufferEquals(
+      storageUri,
+      Buffer.from(expectedContent, "utf8"),
+      options,
+    );
+  }
+
+  private async validatedLargeFileBufferEquals(
+    storageUri: string,
+    expected: Buffer,
+    options: LargeFileReadOptions,
+  ): Promise<boolean> {
     try {
       const file = await this.openValidatedLargeFile(storageUri, options);
       if (!file) {

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -1,4 +1,6 @@
+import { open, realpath } from "node:fs/promises";
 import type { DatabaseSync } from "node:sqlite";
+import { resolve as resolvePath, sep as pathSep } from "node:path";
 import { withDatabaseTransaction } from "../transaction-mutex.js";
 import { appendConversationScopeConstraint } from "./conversation-scope.js";
 import { sanitizeFts5Query } from "./fts5-sanitize.js";
@@ -109,6 +111,11 @@ export type LargeFileRecord = {
   storageUri: string;
   explorationSummary: string | null;
   createdAt: Date;
+};
+
+export type LargeFileReadOptions = {
+  largeFilesDir: string;
+  maxBytes?: number;
 };
 
 export type UpsertConversationBootstrapStateInput = {
@@ -1560,6 +1567,124 @@ export class SummaryStore {
       )
       .all(conversationId) as unknown as LargeFileRow[];
     return rows.map(toLargeFileRecord);
+  }
+
+  /**
+   * Return true when one externalized text payload exactly matches content.
+   */
+  async largeFileContentEquals(
+    fileId: string,
+    content: string,
+    options: LargeFileReadOptions,
+  ): Promise<boolean> {
+    const byteSize = Buffer.byteLength(content, "utf8");
+    const row = this.db
+      .prepare(
+        `SELECT storage_uri
+       FROM large_files
+       WHERE file_id = ?
+         AND byte_size = ?
+       LIMIT 1`,
+      )
+      .get(fileId, byteSize) as { storage_uri: string } | undefined;
+    if (!row) {
+      return false;
+    }
+
+    return this.validatedLargeFileContentEquals(row.storage_uri, content, options);
+  }
+
+  /** Read a persisted large-file payload from disk, returning null when unavailable. */
+  async getLargeFileContent(
+    fileId: string,
+    options: LargeFileReadOptions,
+  ): Promise<string | null> {
+    const row = this.db
+      .prepare(
+        `SELECT storage_uri
+       FROM large_files
+       WHERE file_id = ?
+       LIMIT 1`,
+      )
+      .get(fileId) as { storage_uri: string } | undefined;
+    if (!row) {
+      return null;
+    }
+
+    return this.readValidatedLargeFileContent(row.storage_uri, options);
+  }
+
+  private async validatedLargeFileContentEquals(
+    storageUri: string,
+    expectedContent: string,
+    options: LargeFileReadOptions,
+  ): Promise<boolean> {
+    const expected = Buffer.from(expectedContent, "utf8");
+    try {
+      const file = await this.openValidatedLargeFile(storageUri, options);
+      if (!file) {
+        return false;
+      }
+      try {
+        const stats = await file.stat();
+        if (!stats.isFile() || stats.size !== expected.length) {
+          return false;
+        }
+        const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, expected.length)));
+        let offset = 0;
+        while (offset < expected.length) {
+          const length = Math.min(buffer.length, expected.length - offset);
+          const { bytesRead } = await file.read(buffer, 0, length, offset);
+          if (bytesRead !== length) {
+            return false;
+          }
+          if (!buffer.subarray(0, length).equals(expected.subarray(offset, offset + length))) {
+            return false;
+          }
+          offset += length;
+        }
+        return true;
+      } finally {
+        await file.close().catch(() => undefined);
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  private async readValidatedLargeFileContent(
+    storageUri: string,
+    options: LargeFileReadOptions,
+  ): Promise<string | null> {
+    try {
+      const file = await this.openValidatedLargeFile(storageUri, options);
+      if (!file) {
+        return null;
+      }
+      try {
+        const stats = await file.stat();
+        if (!stats.isFile() || (options.maxBytes != null && stats.size > options.maxBytes)) {
+          return null;
+        }
+        return await file.readFile({ encoding: "utf8" });
+      } finally {
+        await file.close().catch(() => undefined);
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  private async openValidatedLargeFile(
+    storageUri: string,
+    options: LargeFileReadOptions,
+  ): Promise<Awaited<ReturnType<typeof open>> | null> {
+    const safeRoot = await realpath(resolvePath(options.largeFilesDir));
+    const realTarget = await realpath(resolvePath(storageUri));
+    if (realTarget !== safeRoot && !realTarget.startsWith(safeRoot + pathSep)) {
+      return null;
+    }
+    return open(realTarget, "r");
   }
 
   // ── Bootstrap state ──────────────────────────────────────────────────────

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -1122,8 +1122,8 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
   it("deduplicates raw payload replays after file block rewriting", async () => {
     const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
     const sessionId = "dedup-large-file-raw-payload-file-block-replay";
-    const fileText = `${"raw payload file block replay line\n".repeat(160)}done`;
-    const surroundingText = `${"raw payload surrounding text\n".repeat(80)}done`;
+    const fileText = `${"alpha beta gamma delta ".repeat(6)}done`;
+    const surroundingText = "short";
     const rawContent = [
       surroundingText,
       `<file name="raw-file.md" mime="text/markdown">${fileText}</file>`,
@@ -1158,13 +1158,17 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const rawPayloadFileId = /\[LCM Raw Payload:\s*(file_[a-f0-9]{16})/.exec(stored[1]!.content)?.[1];
+    expect(rawPayloadFileId).toBeTruthy();
+    const rawPayloadFile = await engine.getSummaryStore().getLargeFile(rawPayloadFileId!);
+    expect(rawPayloadFile?.byteSize).toBeGreaterThan(Buffer.byteLength(rawContent, "utf8"));
     expect(stored).toHaveLength(4);
     expect(stored[1].content).toContain("[LCM Raw Payload: file_");
-    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[1].content).not.toContain("<file name=");
     expect(stored[3].content).toBe("new D");
     expect(getLargeFileContentSpy).toHaveBeenCalledWith(expect.any(String), {
       largeFilesDir: expect.any(String),
-      maxBytes: Buffer.byteLength(rawContent, "utf8"),
+      maxBytes: rawPayloadFile!.byteSize,
     });
   });
 
@@ -1280,6 +1284,99 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored).toHaveLength(4);
     expect(stored[1].content).toContain("[User image: user-image.png");
+    expect(stored[1].content).not.toContain(base64Image.slice(0, 32));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates provenance-backed mixed multi-image reference replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 1000 });
+    const sessionId = "dedup-native-image-mixed-multi-replay";
+    const firstImage = `iVBOR${"B".repeat(600)}`;
+    const secondImage = `iVBOR${"C".repeat(600)}`;
+    const mixedContent = [
+      { type: "text", text: "before image" },
+      { type: "image", data: firstImage, mimeType: "image/png" },
+      { type: "text", text: "between images" },
+      { type: "image", data: secondImage, mimeType: "image/png" },
+      { type: "text", text: "after image" },
+    ];
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-mixed-multi-replay"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-mixed-multi-replay-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("before image");
+    expect(stored[1].content).toContain("between images");
+    expect(stored[1].content).toContain("after image");
+    expect(stored[1].content.match(/\[User image: user-image\.png/g)).toHaveLength(2);
+    expect(stored[1].content).not.toContain(firstImage.slice(0, 32));
+    expect(stored[1].content).not.toContain(secondImage.slice(0, 32));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates raw payload replays after native image rewriting", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-native-image-raw-payload-replay";
+    const base64Image = `iVBOR${"D".repeat(600)}`;
+    const mixedContent = [
+      { type: "text", text: "raw payload image prefix" },
+      { type: "image", data: base64Image, mimeType: "image/png" },
+      { type: "text", text: "raw payload image suffix" },
+    ];
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-raw-payload-replay"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-raw-payload-replay-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM Raw Payload: file_");
     expect(stored[1].content).not.toContain(base64Image.slice(0, 32));
     expect(stored[3].content).toBe("new D");
   });

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -484,7 +484,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(stored.map((m) => m.content)).toEqual(["hello", "world"]);
   });
 
-  it("fails closed for oversized no-overlap afterTurn batches", async () => {
+  it("ingests oversized no-overlap afterTurn batches without transcript coverage", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
@@ -494,11 +494,11 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
         debug: vi.fn(),
       },
     });
-    const sessionId = "dedup-oversized-no-overlap-fail-closed";
+    const sessionId = "dedup-oversized-no-overlap-ingest";
 
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-fail-closed"),
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-ingest"),
       messages: [
         makeMessage({ role: "user", content: "old A" }),
         makeMessage({ role: "assistant", content: "old B" }),
@@ -508,14 +508,12 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       tokenBudget: 4096,
     });
 
-    // Simulates a short afterTurn runtime snapshot that has no overlap with
-    // the longer stored LCM conversation. Before this guard, LCM imported the
-    // whole batch as fresh rows and polluted context; the transcript reconcile
-    // path is responsible for genuine missing JSONL tail imports before this
-    // dedup check runs.
+    // Simulates a short live afterTurn runtime snapshot with no overlap after
+    // a missing/unreadable transcript reconcile. Without transcript coverage,
+    // skipping here silently loses live messages.
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-fail-closed-2"),
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-ingest-2"),
       messages: [
         makeMessage({ role: "user", content: "unanchored user" }),
         makeMessage({ role: "assistant", content: "unanchored assistant" }),
@@ -526,9 +524,134 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored.map((m) => m.content)).toEqual(["old A", "old B", "old C"]);
+    expect(stored.map((m) => m.content)).toEqual([
+      "old A",
+      "old B",
+      "old C",
+      "unanchored user",
+      "unanchored assistant",
+    ]);
     expect(warnLog).toHaveBeenCalledWith(
-      `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — fail-closed skipping full batch`,
+      `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — ingesting full batch`,
+    );
+  });
+
+  it("skips oversized no-overlap batches that match the tail around auto-compaction summaries", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "dedup-oversized-no-overlap-all-persisted";
+    const oldBTimestamp = Date.UTC(2026, 0, 1, 0, 0, 1);
+    const lastDTimestamp = Date.UTC(2026, 0, 1, 0, 0, 4);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted"),
+      messages: [
+        { role: "user", content: "old A", timestamp: Date.UTC(2026, 0, 1, 0, 0, 0) } as AgentMessage,
+        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
+        { role: "user", content: "old C", timestamp: Date.UTC(2026, 0, 1, 0, 0, 2) } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted-summary"),
+      messages: [
+        { role: "user", content: "old A", timestamp: Date.UTC(2026, 0, 1, 0, 0, 0) } as AgentMessage,
+        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
+        { role: "user", content: "old C", timestamp: Date.UTC(2026, 0, 1, 0, 0, 2) } as AgentMessage,
+        { role: "assistant", content: "last D", timestamp: lastDTimestamp } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+      autoCompactionSummary: "[summary] compacted older context",
+    });
+
+    // The marked summary row breaks suffix alignment, but the runtime rows
+    // match the persisted tail around that summary. This is a stale replay, not
+    // a live no-overlap turn.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted-2"),
+      messages: [
+        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
+        { role: "assistant", content: "last D", timestamp: lastDTimestamp } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "old A",
+      "old B",
+      "old C",
+      "[summary] compacted older context",
+      "last D",
+    ]);
+    expect(warnLog).toHaveBeenCalledWith(
+      `[lcm] dedup: oversized, storedCount=5 batchLen=2, no suffix overlap found but batch matches timestamp-proven persisted tail — skipping full batch`,
+    );
+  });
+
+  it("ingests oversized no-overlap repeated content without auto-compaction summary proof", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "dedup-oversized-no-overlap-repeated-live";
+    const firstDeployTimestamp = Date.UTC(2026, 0, 1, 0, 1, 0);
+    const repeatedDeployTimestamp = Date.UTC(2026, 0, 1, 0, 2, 0);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-repeated-live"),
+      messages: [
+        { role: "user", content: "deploy?", timestamp: firstDeployTimestamp } as AgentMessage,
+        { role: "assistant", content: "done", timestamp: firstDeployTimestamp + 1000 } as AgentMessage,
+        { role: "assistant", content: "later tail", timestamp: firstDeployTimestamp + 2000 } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-repeated-live-2"),
+      messages: [
+        { role: "user", content: "deploy?", timestamp: repeatedDeployTimestamp } as AgentMessage,
+        { role: "assistant", content: "done", timestamp: repeatedDeployTimestamp + 1000 } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "deploy?",
+      "done",
+      "later tail",
+      "deploy?",
+      "done",
+    ]);
+    expect(warnLog).toHaveBeenCalledWith(
+      `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — ingesting full batch`,
     );
   });
 
@@ -1023,7 +1146,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(getLargeFileContentSpy).not.toHaveBeenCalled();
   });
 
-  it("preserves anchored tool output reference replays without metadata proof", async () => {
+  it("deduplicates provenance-backed anchored tool output reference replays", async () => {
     const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
     const sessionId = "dedup-large-file-tool-output-replay";
     const toolOutput = `${"tool output replay line\n".repeat(160)}done`;
@@ -1055,12 +1178,54 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored).toHaveLength(7);
+    expect(stored).toHaveLength(4);
     expect(stored[1].content).toContain("[LCM Tool Output: file_");
-    expect(stored[4].content).toContain("[LCM Tool Output: file_");
     expect(stored[1].content).not.toContain(toolOutput.slice(0, 64));
-    expect(stored[4].content).not.toContain(toolOutput.slice(0, 64));
-    expect(stored[6].content).toBe("new D");
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates provenance-backed anchored native image reference replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-native-image-replay";
+    const base64Image = `iVBOR${"A".repeat(600)}`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-replay"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({
+          role: "user",
+          content: [{ type: "image", data: base64Image, mimeType: "image/png" }],
+        }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-native-image-replay-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({
+          role: "user",
+          content: [{ type: "image", data: base64Image, mimeType: "image/png" }],
+        }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[User image: user-image.png");
+    expect(stored[1].content).not.toContain(base64Image.slice(0, 32));
+    expect(stored[3].content).toBe("new D");
   });
 
   it("preserves externalized-only repeated file prefixes when a new suffix is present", async () => {

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -8,7 +8,9 @@ import { join } from "node:path";
 import { createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateTokens } from "../src/estimate-tokens.js";
+import { formatFileReference } from "../src/large-files.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 import {
   cleanupEngineTestState,
   firstCompleteCall,
@@ -190,6 +192,53 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((m) => m.content)).toEqual(["old A", "old B", "new C", "new D"]);
+  });
+
+  it("does not trim on stale identity_hash without matching content", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-stale-identity-hash";
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-stale-identity-hash"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "assistant", content: "old B" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const db = (engine as unknown as {
+      db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+    }).db;
+    db.prepare(`UPDATE messages SET identity_hash = ? WHERE conversation_id = ? AND seq = ?`).run(
+      buildMessageIdentityHash("assistant", "new B"),
+      conversation!.conversationId,
+      1,
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-stale-identity-hash-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "assistant", content: "new B" }),
+        makeMessage({ role: "assistant", content: "new C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old A",
+      "old B",
+      "old A",
+      "new B",
+      "new C",
+    ]);
   });
 
   it("deduplicates replay when runtime sessionId changes but stable sessionKey continues", async () => {
@@ -481,6 +530,1127 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(warnLog).toHaveBeenCalledWith(
       `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — fail-closed skipping full batch`,
     );
+  });
+
+  it("preserves a repeated large-file message without an exact replay anchor", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-repeated-message";
+    const fileText = `${"dedup rewritten file line\n".repeat(160)}done`;
+    const originalContent = `<file name="dedup.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-repeated-message"),
+      messages: [makeMessage({ role: "user", content: originalContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-repeated-message-2"),
+      messages: [makeMessage({ role: "user", content: originalContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    expect(stored[0].content).toContain("[LCM File: file_");
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[0].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+  });
+
+  it("deduplicates anchored afterTurn replay after large-file content rewriting", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-rewrite-anchored-replay";
+    const fileText = `${"anchored rewritten file line\n".repeat(160)}done`;
+    const originalContent = `<file name="anchored.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-rewrite-anchored-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-rewrite-anchored-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.role)).toEqual([
+      "user",
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old A",
+      expect.stringContaining("[LCM File: file_"),
+      "old C",
+      "new D",
+    ]);
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+  });
+
+  it("deduplicates mixed small and externalized file block replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 500 });
+    const sessionId = "dedup-large-file-mixed-inline-replay";
+    const smallFile = `<file name="small.txt" mime="text/plain">small inline file</file>`;
+    const largeText = `${"mixed externalized file line\n".repeat(1200)}done`;
+    const mixedContent = [
+      "before files",
+      smallFile,
+      `<file name="large.md" mime="text/markdown">${largeText}</file>`,
+      "after files",
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-mixed-inline-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-mixed-inline-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: mixedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain(smallFile);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(largeText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates inline externalized file block replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 500 });
+    const sessionId = "dedup-large-file-inline-replay";
+    const fileText = `${"inline externalized file line\n".repeat(1200)}done`;
+    const inlineContent =
+      `prefix <file name="inline.md" mime="text/markdown">${fileText}</file> suffix`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-inline-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: inlineContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-inline-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: inlineContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("prefix [LCM File: file_");
+    expect(stored[1].content).toContain(" suffix");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates anchored replays with multiple externalized file blocks in one message", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-multi-file-block-message";
+    const firstText = `${"first same-message file line\n".repeat(160)}done`;
+    const secondText = `${"second same-message file line\n".repeat(160)}done`;
+    const multiFileContent = [
+      `<file name="first.md" mime="text/markdown">${firstText}</file>`,
+      "middle text",
+      `<file name="second.md" mime="text/markdown">${secondText}</file>`,
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-multi-file-block-message"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: multiFileContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-multi-file-block-message-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: multiFileContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content.match(/\[LCM File: file_/g)).toHaveLength(2);
+    expect(stored[1].content).not.toContain(firstText.slice(0, 64));
+    expect(stored[1].content).not.toContain(secondText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates externalized file replays when the filename contains a bracket", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-bracket-filename";
+    const fileText = `${"bracket filename file line\n".repeat(160)}done`;
+    const originalContent = `<file name="report]v2.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-bracket-filename"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-bracket-filename-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("report]v2.md");
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates externalized file replays when the filename contains an LCM-looking substring", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-lcm-substring-filename";
+    const fileText = `${"lcm substring filename file line\n".repeat(160)}done`;
+    const originalContent =
+      `<file name="notes [LCM File: file_deadbeefdeadbeef.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-lcm-substring-filename"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-lcm-substring-filename-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("notes [LCM File: file_deadbeefdeadbeef.md");
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates externalized file replays with incidental LCM text before the file", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-incidental-before-real";
+    const fileText = `${"incidental before real file line\n".repeat(160)}done`;
+    const incidentalReference = "[LCM File: file_deadbeefdeadbeef | fake.md | text/markdown | 1 bytes]";
+    const originalContent = [
+      `compare ${incidentalReference} with`,
+      `<file name="real.md" mime="text/markdown">${fileText}</file>`,
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-incidental-before-real"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-incidental-before-real-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain(incidentalReference);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates anchored raw payload reference replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-raw-payload-replay";
+    const rawText = `${"raw payload replay line\n".repeat(160)}done`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawText }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawText }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM Raw Payload: file_");
+    expect(stored[1].content).not.toContain(rawText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates anchored serialized raw payload reference replays", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-serialized-raw-payload-replay";
+    const rawText = `${"serialized raw payload replay line\n".repeat(160)}done`;
+    const rawPayload = [{ type: "text", text: rawText, metadata: { source: "vendor" } }];
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-serialized-raw-payload-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawPayload }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-serialized-raw-payload-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawPayload }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM Raw Payload: file_");
+    expect(stored[1].content).not.toContain(rawText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates raw payload replays after file block rewriting", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-raw-payload-file-block-replay";
+    const fileText = `${"raw payload file block replay line\n".repeat(160)}done`;
+    const surroundingText = `${"raw payload surrounding text\n".repeat(80)}done`;
+    const rawContent = [
+      surroundingText,
+      `<file name="raw-file.md" mime="text/markdown">${fileText}</file>`,
+      surroundingText,
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-file-block-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-file-block-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM Raw Payload: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("does not read raw payload sidecars when incoming content has no file blocks", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-raw-payload-no-file-block-read";
+    const rawText = `${"raw payload no file block line\n".repeat(160)}done`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-no-file-block-read"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: rawText }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const getLargeFileContentSpy = vi.spyOn(engine.getSummaryStore(), "getLargeFileContent");
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-raw-payload-no-file-block-read-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: `${rawText}\nchanged` }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    expect(getLargeFileContentSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves anchored tool output reference replays without metadata proof", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-tool-output-replay";
+    const toolOutput = `${"tool output replay line\n".repeat(160)}done`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-tool-output-replay"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "tool", content: toolOutput }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-tool-output-replay-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: "old A" }),
+        makeMessage({ role: "tool", content: toolOutput }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(7);
+    expect(stored[1].content).toContain("[LCM Tool Output: file_");
+    expect(stored[4].content).toContain("[LCM Tool Output: file_");
+    expect(stored[1].content).not.toContain(toolOutput.slice(0, 64));
+    expect(stored[4].content).not.toContain(toolOutput.slice(0, 64));
+    expect(stored[6].content).toBe("new D");
+  });
+
+  it("preserves externalized-only repeated file prefixes when a new suffix is present", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-rewrite-prefix-replay";
+    const fileText = `${"prefix replay file line\n".repeat(160)}done`;
+    const originalContent = `<file name="prefix.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-rewrite-prefix-replay"),
+      messages: [makeMessage({ role: "user", content: originalContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-rewrite-prefix-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "new assistant suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(3);
+    expect(stored[0].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[2].content).toBe("new assistant suffix");
+  });
+
+  it("preserves multi-message externalized replay prefixes without an exact anchor", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-multi-prefix-replay";
+    const firstText = `${"first prefix replay file line\n".repeat(160)}done`;
+    const secondText = `${"second prefix replay file line\n".repeat(160)}done`;
+    const firstContent = `<file name="first-prefix.md" mime="text/markdown">${firstText}</file>`;
+    const secondContent = `<file name="second-prefix.md" mime="text/markdown">${secondText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-multi-prefix-replay"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: firstContent }),
+        makeMessage({ role: "user", content: secondContent }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-multi-prefix-replay-2"),
+      messages: [
+        makeMessage({ role: "user", content: firstContent }),
+        makeMessage({ role: "user", content: secondContent }),
+        makeMessage({ role: "assistant", content: "new assistant suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(6);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[2].content).toContain("[LCM File: file_");
+    expect(stored[3].content).toContain("[LCM File: file_");
+    expect(stored[4].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(firstText.slice(0, 64));
+    expect(stored[2].content).not.toContain(secondText.slice(0, 64));
+    expect(stored[3].content).not.toContain(firstText.slice(0, 64));
+    expect(stored[4].content).not.toContain(secondText.slice(0, 64));
+    expect(stored[5].content).toBe("new assistant suffix");
+  });
+
+  it("preserves oversized externalized-only overlaps", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-oversized-externalized-only";
+    const fileText = `${"oversized externalized-only file line\n".repeat(160)}done`;
+    const originalContent = `<file name="oversized-only.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-oversized-externalized-only"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "assistant", content: "old B" }),
+        makeMessage({ role: "user", content: originalContent }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-oversized-externalized-only-2"),
+      messages: [
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "new assistant suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(5);
+    expect(stored[2].content).toContain("[LCM File: file_");
+    expect(stored[3].content).toContain("[LCM File: file_");
+    expect(stored[4].content).toBe("new assistant suffix");
+  });
+
+  it("deduplicates exact-anchored suffixes ending at an externalized file", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-exact-anchored-externalized-boundary";
+    const fileText = `${"externalized boundary replay file line\n".repeat(160)}done`;
+    const originalContent = `<file name="boundary.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-exact-anchored-externalized-boundary"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-exact-anchored-externalized-boundary-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "new assistant suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(3);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[2].content).toBe("new assistant suffix");
+  });
+
+  it("does not trim repeated file bytes when file metadata changed", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-metadata-change";
+    const fileText = `${"metadata sensitive file line\n".repeat(160)}done`;
+    const oldContent = `<file name="old.md" mime="text/markdown">${fileText}</file>`;
+    const newContent = `<file name="new.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-metadata-change"),
+      messages: [makeMessage({ role: "user", content: oldContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-metadata-change-2"),
+      messages: [
+        makeMessage({ role: "user", content: newContent }),
+        makeMessage({ role: "assistant", content: "new metadata suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(3);
+    expect(stored[0].content).toContain("old.md");
+    expect(stored[1].content).toContain("new.md");
+    expect(stored[2].content).toBe("new metadata suffix");
+  });
+
+  it("does not match plain text against an externalized file reference", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-plain-text-not-file";
+    const fileText = `${"plain text is not file metadata line\n".repeat(160)}done`;
+    const fileContent = `<file name="plain.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-plain-text-not-file"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: fileContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-plain-text-not-file-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: fileText }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(7);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[4].content).toContain("[LCM Raw Payload: file_");
+    expect(stored[6].content).toBe("new D");
+  });
+
+  it("does not trim uploads against pasted LCM file references without provenance", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-pasted-reference";
+    const fileText = `${"pasted reference file line\n".repeat(160)}done`;
+    const fileContent = `<file name="pasted.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-pasted-reference"),
+      messages: [makeMessage({ role: "user", content: fileContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const initialMessages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const pastedReference = `prefix ${initialMessages[0]!.content} suffix`;
+    const pastedFileId = /\[LCM File:\s*(file_[a-f0-9]{16})/.exec(initialMessages[0]!.content)?.[1];
+    expect(pastedFileId).toBeDefined();
+    const anchor = "pasted reference anchor";
+    const nextSeq = (await engine.getConversationStore().getMaxSeq(conversation!.conversationId)) + 1;
+    const pastedMessages = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation!.conversationId,
+        seq: nextSeq,
+        role: "assistant",
+        content: anchor,
+        tokenCount: 1,
+        identityHash: buildMessageIdentityHash("assistant", anchor),
+        createdAt: "2030-01-01 00:00:00",
+      },
+      {
+        conversationId: conversation!.conversationId,
+        seq: nextSeq + 1,
+        role: "user",
+        content: pastedReference,
+        tokenCount: 1,
+        identityHash: buildMessageIdentityHash("user", pastedReference),
+        createdAt: "2030-01-01 00:00:00",
+      },
+    ]);
+    await engine.getConversationStore().createMessageParts(pastedMessages[1]!.messageId, [
+      {
+        sessionId,
+        partType: "text",
+        ordinal: 0,
+        textContent: pastedReference,
+        metadata: JSON.stringify({ externalizedFileId: pastedFileId }),
+      },
+    ]);
+
+    const replayedUpload = `prefix ${fileContent} suffix`;
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-pasted-reference-2"),
+      messages: [
+        makeMessage({ role: "assistant", content: anchor }),
+        makeMessage({ role: "user", content: replayedUpload }),
+        makeMessage({ role: "assistant", content: "new pasted-reference suffix" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(6);
+    expect(stored.filter((message) => message.role === "user")).toHaveLength(3);
+    expect(stored.filter((message) => message.content === anchor)).toHaveLength(2);
+    expect(stored.filter((message) => message.content === pastedReference)).toHaveLength(1);
+    expect(stored.some((message) => message.content === "new pasted-reference suffix")).toBe(true);
+  });
+
+  it("preserves legacy file-reference replays without message-part provenance", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-legacy-reference";
+    const fileText = `${"legacy reference file line\n".repeat(160)}done`;
+    const originalContent = `<file name="legacy.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-legacy-reference"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const before = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const db = (engine as unknown as {
+      db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+    }).db;
+    db.prepare(`DELETE FROM message_parts WHERE message_id = ?`).run(before[1]!.messageId);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-legacy-reference-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(7);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[4].content).toContain("[LCM File: file_");
+    expect(stored[1].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[4].content).not.toContain(fileText.slice(0, 64));
+    expect(stored[6].content).toBe("new D");
+  });
+
+  it("deduplicates file references when summaries contain incidental file ids", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-incidental-file-id-summary";
+    const incidentalId = "[LCM File: file_deadbeefdeadbeef | incidental.md | text/markdown | 1 bytes]";
+    const fileText = `${incidentalId}\n${"incidental summary file id line\n".repeat(160)}done`;
+    const originalContent = `<file name="incidental.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-incidental-file-id-summary"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-incidental-file-id-summary-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).toContain(incidentalId);
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("deduplicates file references when summaries contain incidental LCM reference blocks", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-summary-incidental-reference-block";
+    const fileText = `${"incidental reference block line\n".repeat(160)}done`;
+    const originalContent = `<file name="real.md" mime="text/markdown">${fileText}</file>`;
+    const incidentalBlock = [
+      "[LCM Tool Output: file_deadbeefdeadbeef | tool=incidental | 1 bytes]",
+      "",
+      "Exploration Summary:",
+      "incidental summary block",
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-summary-incidental-reference-block"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const storedBefore = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const realFileId = /\[LCM File:\s*(file_[a-f0-9]{16})/.exec(storedBefore[1]!.content)?.[1];
+    expect(realFileId).toBeDefined();
+    const largeFile = await engine.getSummaryStore().getLargeFile(realFileId!);
+    expect(largeFile).not.toBeNull();
+    const rewrittenContent = formatFileReference({
+      fileId: realFileId!,
+      fileName: largeFile!.fileName ?? undefined,
+      mimeType: largeFile!.mimeType ?? undefined,
+      byteSize: largeFile!.byteSize ?? 0,
+      summary: incidentalBlock,
+    });
+    const db = (engine as unknown as {
+      db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+    }).db;
+    db.prepare(`UPDATE large_files SET exploration_summary = ? WHERE file_id = ?`).run(
+      incidentalBlock,
+      realFileId,
+    );
+    db.prepare(`UPDATE messages SET content = ?, identity_hash = ? WHERE message_id = ?`).run(
+      rewrittenContent,
+      buildMessageIdentityHash("user", rewrittenContent),
+      storedBefore[1]!.messageId,
+    );
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-summary-incidental-reference-block-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(4);
+    expect(stored[1].content).toContain("[LCM File: file_");
+    expect(stored[1].content).toContain(incidentalBlock);
+    expect(stored[3].content).toBe("new D");
+  });
+
+  it("preserves transcript-covered externalized single-message batches without an exact anchor", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-covered-frontier";
+    const fileText = `${"covered frontier file line\n".repeat(160)}done`;
+    const originalContent = `<file name="covered.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-covered-frontier"),
+      messages: [makeMessage({ role: "user", content: originalContent })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const batch = [makeMessage({ role: "user", content: originalContent })];
+    const aligned = await engine.getBatchDeduplicator().alignRuntimeBatchAgainstCoveredFrontier(
+      sessionId,
+      undefined,
+      batch,
+    );
+
+    expect(aligned).toEqual(batch);
+  });
+
+  it("preserves transcript-covered externalized overlap outside the tail", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-covered-overlap-fallback";
+    const fileText = `${"covered overlap fallback file line\n".repeat(160)}done`;
+    const originalContent = `<file name="covered-overlap.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-covered-overlap-fallback"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: originalContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const batch = [makeMessage({ role: "user", content: originalContent })];
+    const aligned = await engine.getBatchDeduplicator().alignRuntimeBatchAgainstCoveredFrontier(
+      sessionId,
+      undefined,
+      batch,
+    );
+
+    expect(aligned).toEqual(batch);
+  });
+
+  it("preserves older transcript-covered externalized overlap", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-covered-old-overlap";
+    const fileText = `${"covered old overlap file line\n".repeat(160)}done`;
+    const originalContent = `<file name="covered-old.md" mime="text/markdown">${fileText}</file>`;
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-covered-old-overlap"),
+      messages: [
+        makeMessage({ role: "user", content: originalContent }),
+        ...Array.from({ length: 70 }, (_, index) =>
+          makeMessage({ role: "assistant", content: `old tail ${index}` }),
+        ),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const batch = [makeMessage({ role: "user", content: originalContent })];
+    const aligned = await engine.getBatchDeduplicator().alignRuntimeBatchAgainstCoveredFrontier(
+      sessionId,
+      undefined,
+      batch,
+    );
+
+    expect(aligned).toEqual(batch);
+  });
+
+  it("does not trim changed multi-file messages on a partial externalized match", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+    const sessionId = "dedup-large-file-partial-match";
+    const sharedText = `${"shared file line\n".repeat(160)}done`;
+    const oldText = `${"old second file line\n".repeat(160)}done`;
+    const newText = `${"new second file line\n".repeat(160)}done`;
+    const oldContent = [
+      `<file name="shared.md" mime="text/markdown">${sharedText}</file>`,
+      "between files",
+      `<file name="old.md" mime="text/markdown">${oldText}</file>`,
+    ].join("\n");
+    const changedContent = [
+      `<file name="shared.md" mime="text/markdown">${sharedText}</file>`,
+      "between files",
+      `<file name="new.md" mime="text/markdown">${newText}</file>`,
+    ].join("\n");
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-partial-match"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: oldContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-large-file-partial-match-2"),
+      messages: [
+        makeMessage({ role: "user", content: "old A" }),
+        makeMessage({ role: "user", content: changedContent }),
+        makeMessage({ role: "assistant", content: "old C" }),
+        makeMessage({ role: "assistant", content: "new D" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(7);
+    expect(stored[4].content).toContain("[LCM File: file_");
+    expect(stored[4].content).not.toContain(sharedText.slice(0, 64));
+    expect(stored[4].content).not.toContain(newText.slice(0, 64));
+    expect(stored[6].content).toBe("new D");
   });
 
   it("preserves a legitimate repeated first new message", async () => {

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -536,7 +536,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     );
   });
 
-  it("skips oversized no-overlap batches that match the tail around auto-compaction summaries", async () => {
+  it("ingests oversized no-overlap batches that only timestamp-match around auto-compaction summaries", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
@@ -576,9 +576,8 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       autoCompactionSummary: "[summary] compacted older context",
     });
 
-    // The marked summary row breaks suffix alignment, but the runtime rows
-    // match the persisted tail around that summary. This is a stale replay, not
-    // a live no-overlap turn.
+    // The marked summary row breaks suffix alignment, and timestamp equality
+    // alone cannot distinguish a stale replay from a live no-overlap turn.
     await engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted-2"),
@@ -598,9 +597,11 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       "old C",
       "[summary] compacted older context",
       "last D",
+      "old B",
+      "last D",
     ]);
     expect(warnLog).toHaveBeenCalledWith(
-      `[lcm] dedup: oversized, storedCount=5 batchLen=2, no suffix overlap found but batch matches timestamp-proven persisted tail — skipping full batch`,
+      `[lcm] dedup: oversized, storedCount=5 batchLen=2, no overlap found — ingesting full batch`,
     );
   });
 
@@ -636,6 +637,56 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       messages: [
         { role: "user", content: "deploy?", timestamp: repeatedDeployTimestamp } as AgentMessage,
         { role: "assistant", content: "done", timestamp: repeatedDeployTimestamp + 1000 } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "deploy?",
+      "done",
+      "later tail",
+      "deploy?",
+      "done",
+    ]);
+    expect(warnLog).toHaveBeenCalledWith(
+      `[lcm] dedup: oversized, storedCount=3 batchLen=2, no overlap found — ingesting full batch`,
+    );
+  });
+
+  it("ingests oversized no-overlap repeated content with same-second timestamps", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "dedup-oversized-no-overlap-repeated-same-second";
+    const sharedTimestamp = Date.UTC(2026, 0, 1, 0, 1, 0);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-repeated-same-second"),
+      messages: [
+        { role: "user", content: "deploy?", timestamp: sharedTimestamp } as AgentMessage,
+        { role: "assistant", content: "done", timestamp: sharedTimestamp } as AgentMessage,
+        { role: "assistant", content: "later tail", timestamp: sharedTimestamp + 1000 } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-repeated-same-second-2"),
+      messages: [
+        { role: "user", content: "deploy?", timestamp: sharedTimestamp } as AgentMessage,
+        { role: "assistant", content: "done", timestamp: sharedTimestamp } as AgentMessage,
       ],
       prePromptMessageCount: 0,
       tokenBudget: 4096,
@@ -1091,6 +1142,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       tokenBudget: 4096,
     });
 
+    const getLargeFileContentSpy = vi.spyOn(engine.getSummaryStore(), "getLargeFileContent");
     await engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("dedup-large-file-raw-payload-file-block-replay-2"),
@@ -1110,6 +1162,10 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     expect(stored[1].content).toContain("[LCM Raw Payload: file_");
     expect(stored[1].content).not.toContain(fileText.slice(0, 64));
     expect(stored[3].content).toBe("new D");
+    expect(getLargeFileContentSpy).toHaveBeenCalledWith(expect.any(String), {
+      largeFilesDir: expect.any(String),
+      maxBytes: Buffer.byteLength(rawContent, "utf8"),
+    });
   });
 
   it("does not read raw payload sidecars when incoming content has no file blocks", async () => {

--- a/test/summary-store.test.ts
+++ b/test/summary-store.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { getLcmDbFeatures } from "../src/db/features.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
@@ -164,5 +167,75 @@ describe("SummaryStore shallow-tree helpers", () => {
         summaryId: "sum_regex_recent_content_older_compaction",
       },
     ]);
+  });
+
+  it("rejects large-file dedup reads outside the configured root", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-safe-root-"));
+    const outsideRoot = mkdtempSync(join(tmpdir(), "lcm-outside-root-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-safe-large-file-read",
+        title: "Summary store safe large file read",
+      });
+      const outsideFile = join(outsideRoot, "payload.txt");
+      writeFileSync(outsideFile, "outside payload", "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_1234567890abcdef",
+        conversationId: conversation.conversationId,
+        fileName: "payload.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength("outside payload", "utf8"),
+        storageUri: outsideFile,
+        explorationSummary: "outside payload",
+      });
+
+      await expect(
+        summaryStore.largeFileContentEquals("file_1234567890abcdef", "outside payload", {
+          largeFilesDir: safeRoot,
+        }),
+      ).resolves.toBe(false);
+      await expect(
+        summaryStore.getLargeFileContent("file_1234567890abcdef", {
+          largeFilesDir: safeRoot,
+        }),
+      ).resolves.toBeNull();
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+      rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("compares large-file dedup content above the describe read cap", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-safe-large-root-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-large-dedup-read",
+        title: "Summary store large dedup read",
+      });
+      const payload = `${"large payload line\n".repeat(36_000)}done`;
+      const payloadPath = join(safeRoot, "large-payload.txt");
+      writeFileSync(payloadPath, payload, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_abcdef1234567890",
+        conversationId: conversation.conversationId,
+        fileName: "large-payload.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(payload, "utf8"),
+        storageUri: payloadPath,
+        explorationSummary: "large payload",
+      });
+
+      await expect(
+        summaryStore.largeFileContentEquals("file_abcdef1234567890", payload, {
+          largeFilesDir: safeRoot,
+        }),
+      ).resolves.toBe(true);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #922.

Fixes afterTurn duplicate/loss behavior by moving the non-transcript-covered heuristic dedup path to a lossless default and tightening externalized replay matching.

## Changes

- Use identity-hash based batch alignment for persisted afterTurn history.
- Ingest oversized no-overlap runtime batches when transcript reconcile has not proven coverage, instead of silently skipping live messages.
- Skip timestamp-proven stale no-overlap replays when the runtime batch matches already-persisted historical rows, without dropping legitimate repeated live turns with newer timestamps.
- Deduplicate provenance-backed externalized tool-result replays by comparing the stored sidecar payload to the incoming tool output.
- Preserve native-image externalization metadata and deduplicate anchored native-image replays only when metadata plus binary sidecar equality proves the match.
- Add focused regressions for no-overlap live preservation, stale timestamp-proven replay skip, repeated-content live preservation, externalized tool-output replay dedup, and native-image replay dedup.

## Validation

Local, from `/Volumes/LEXAR/repos/lossless-claw-pr855-fix`:

- `npm test -- test/engine-compaction.test.ts -t "oversized no-overlap|tool output reference replays|native image reference replays"`
- `npm test -- test/engine-compaction.test.ts`
- `npm test -- test/summary-store.test.ts`
- `npm test -- test/summary-store.test.ts test/engine-ingest.test.ts -t "externalizes native user image blocks|externalizes native assistant image blocks|externalizes native tool-result image blocks|externalizes native system image blocks"`
- `npm run typecheck`
- `git diff --check`

Remote CI is running on head `e1f6975`.

