### PR TITLE
fix: progress-aware spend guard, sweep chaining, manual compaction bypass

### DIFF
--- a/.changeset/spend-guard-progress-policy.md
+++ b/.changeset/spend-guard-progress-policy.md
@@ -1,0 +1,20 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Stop punishing progressing compaction with the summary spend backoff.
+
+A threshold sweep that hit its per-sweep wall-clock deadline while still
+reducing tokens recorded "compacted but still over target" and opened a
+30-minute spend backoff, which then blocked emergency drains and silently
+no-opped user-initiated /compact. Recovery that was working was treated the
+same as recovery that could never work.
+
+Threshold sweeps now chain within the operation-wide deadline
+(`compactUntilUnderDeadlineMs`, capped by `maxSweepIterations`) instead of
+failing after one bounded sweep; the spend backoff only opens when a round
+makes no further progress; and manual compaction clears an open backoff
+(an explicit repair request is informed consent to spend). Telemetry: the
+compact done line gains `chainedSweeps=`/`spendBackoffOpened=`, plus
+"spend backoff skipped" and "manual request cleared summary spend backoff"
+lines for live monitoring.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3921,6 +3921,34 @@ export class LcmContextEngine implements ContextEngine {
     return new Date(state.backoffUntil);
   }
 
+  /**
+   * Operation-wide deadline for chaining threshold sweeps within a single
+   * compact() attempt. Reuses the compactUntilUnder operation deadline so
+   * both recovery loops share one wall-clock contract.
+   */
+  private resolveSweepChainDeadlineMs(): number {
+    return this.resolvePositiveConfigInteger(this.config.compactUntilUnderDeadlineMs, 300_000);
+  }
+
+  /**
+   * Clear an open spend backoff for a scope, returning the prior expiry if
+   * one was open. Used by user-initiated compaction: an explicit repair
+   * request is informed consent to spend, so it must not silently no-op
+   * behind a backoff opened by an earlier automatic attempt.
+   */
+  private clearSummarySpendBackoff(scopeKey: string): Date | null {
+    const state = this.summarySpendGuardStates.get(scopeKey);
+    if (!state?.backoffUntil || state.backoffUntil <= Date.now()) {
+      return null;
+    }
+    const previous = new Date(state.backoffUntil);
+    state.backoffUntil = null;
+    state.lastReason = null;
+    state.windowStartedAt = Date.now();
+    state.calls = 0;
+    return previous;
+  }
+
   private assertSummarySpendCallAllowed(params: {
     scopeKey: string;
     reason: string;
@@ -4710,6 +4738,14 @@ export class LcmContextEngine implements ContextEngine {
       kind: "compaction",
       scope: compactionScope,
     });
+    if (manualCompactionRequested) {
+      const clearedBackoffUntil = this.clearSummarySpendBackoff(summarySpendScopeKey);
+      if (clearedBackoffUntil) {
+        this.deps.log.info(
+          `[lcm] compact: manual request cleared summary spend backoff conversation=${params.conversationId} ${sessionLabel} scope=${summarySpendScopeKey} previousBackoffUntil=${clearedBackoffUntil.toISOString()}`,
+        );
+      }
+    }
     const { summarize, summaryModel, breakerKey } = await this.resolveSummarize({
       legacyParams: this.buildSummarizerLegacyParams({
         legacyParams,
@@ -4815,9 +4851,32 @@ export class LcmContextEngine implements ContextEngine {
         forceCompaction ||
         runtimeAdjustedSweepTargetTokens !== undefined ||
         projectedRawBacklogPressure;
-      let sweepResult: Awaited<ReturnType<CompactionEngine["compact"]>>;
-      try {
-        sweepResult = await this.compaction.compact({
+      const isThresholdSweep = params.compactionTarget === "threshold";
+      // Per-round helpers so the chain loop below can re-evaluate target
+      // pressure after every sweep with the same projection rules.
+      const resolveSweepTokensAfter = (
+        result: Awaited<ReturnType<CompactionEngine["compact"]>>,
+      ): number | undefined =>
+        typeof result.tokensAfter === "number" && Number.isFinite(result.tokensAfter)
+          ? result.tokensAfter
+          : undefined;
+      const projectSweepTokensAfter = (tokensAfter: number | undefined): number | undefined =>
+        tokensAfter !== undefined &&
+        (runtimeAdjustedSweepTargetTokens !== undefined || projectedRawBacklogPressure)
+          ? tokensAfter + observedRuntimeOverhead
+          : tokensAfter;
+      const isUnderTargetAfter = (
+        result: Awaited<ReturnType<CompactionEngine["compact"]>>,
+      ): boolean => {
+        const projected = projectSweepTokensAfter(resolveSweepTokensAfter(result));
+        return projected !== undefined
+          ? projected <= targetTokens
+          : isThresholdSweep
+            ? false
+            : !liveContextStillExceedsTarget;
+      };
+      const runSweepOnce = (): ReturnType<CompactionEngine["compact"]> =>
+        this.compaction.compact({
           conversationId,
           tokenBudget,
           summarize,
@@ -4828,6 +4887,10 @@ export class LcmContextEngine implements ContextEngine {
             ? { stopAtTokens: runtimeAdjustedSweepTargetTokens }
             : {}),
         });
+
+      let sweepResult: Awaited<ReturnType<CompactionEngine["compact"]>>;
+      try {
+        sweepResult = await runSweepOnce();
       } catch (err) {
         if (err instanceof LcmSummarySpendLimitError) {
           this.deps.log.warn(
@@ -4842,6 +4905,55 @@ export class LcmContextEngine implements ContextEngine {
         throw err;
       }
 
+      // A single sweep is bounded by its own wall-clock deadline and can end
+      // mid-recovery with real progress persisted. Chain further sweeps while
+      // each round keeps reducing tokens and the target is still above us,
+      // bounded by the operation-wide deadline, instead of failing the
+      // attempt and punishing progress with a spend backoff.
+      let chainedSweeps = 1;
+      let lastRoundMadeProgress = sweepResult.actionTaken === true;
+      const sweepChainDeadlineAt = startedAt + this.resolveSweepChainDeadlineMs();
+      const maxChainedSweeps = this.resolvePositiveConfigInteger(
+        this.config.maxSweepIterations,
+        12,
+      );
+      let previousTokensAfter = resolveSweepTokensAfter(sweepResult);
+      while (
+        isThresholdSweep &&
+        !sweepResult.authFailure &&
+        lastRoundMadeProgress &&
+        !isUnderTargetAfter(sweepResult) &&
+        chainedSweeps < maxChainedSweeps &&
+        Date.now() < sweepChainDeadlineAt
+      ) {
+        let next: Awaited<ReturnType<CompactionEngine["compact"]>>;
+        try {
+          next = await runSweepOnce();
+        } catch (err) {
+          if (err instanceof LcmSummarySpendLimitError) {
+            // The per-window call guard tripped mid-chain; keep the progress
+            // already persisted and let the normal result handling proceed.
+            this.deps.log.warn(
+              `[lcm] compact: spend guard stopped sweep chain conversation=${conversationId} ${sessionLabel} scope=${err.scopeKey} chainedSweeps=${chainedSweeps} backoffUntil=${err.backoffUntil.toISOString()}`,
+            );
+            break;
+          }
+          throw err;
+        }
+        chainedSweeps += 1;
+        const nextTokensAfter = resolveSweepTokensAfter(next);
+        lastRoundMadeProgress =
+          next.actionTaken === true &&
+          (previousTokensAfter === undefined ||
+            (nextTokensAfter !== undefined && nextTokensAfter < previousTokensAfter));
+        sweepResult = {
+          ...next,
+          actionTaken: sweepResult.actionTaken || next.actionTaken,
+          createdSummaryId: next.createdSummaryId ?? sweepResult.createdSummaryId,
+        };
+        previousTokensAfter = nextTokensAfter ?? previousTokensAfter;
+      }
+
       if (sweepResult.authFailure && breakerKey) {
         this.recordCompactionAuthFailure(breakerKey);
       } else if (sweepResult.actionTaken && breakerKey) {
@@ -4850,22 +4962,9 @@ export class LcmContextEngine implements ContextEngine {
       if (sweepResult.actionTaken) {
         await this.markLeafCompactionTelemetrySuccess({ conversationId });
       }
-      const sweepTokensAfter =
-        typeof sweepResult.tokensAfter === "number" && Number.isFinite(sweepResult.tokensAfter)
-          ? sweepResult.tokensAfter
-          : undefined;
-      const projectedTokensAfterSweep =
-        sweepTokensAfter !== undefined &&
-        (runtimeAdjustedSweepTargetTokens !== undefined || projectedRawBacklogPressure)
-          ? sweepTokensAfter + observedRuntimeOverhead
-          : sweepTokensAfter;
-      const isThresholdSweep = params.compactionTarget === "threshold";
-      const isUnderTargetAfterSweep =
-        projectedTokensAfterSweep !== undefined
-          ? projectedTokensAfterSweep <= targetTokens
-          : isThresholdSweep
-            ? false
-            : !liveContextStillExceedsTarget;
+      const sweepTokensAfter = resolveSweepTokensAfter(sweepResult);
+      const projectedTokensAfterSweep = projectSweepTokensAfter(sweepTokensAfter);
+      const isUnderTargetAfterSweep = isUnderTargetAfter(sweepResult);
       const thresholdSweepStillOverTarget =
         isThresholdSweep && sweepResult.actionTaken && !isUnderTargetAfterSweep;
       const thresholdSweepStoppedAtBudget =
@@ -4900,14 +4999,26 @@ export class LcmContextEngine implements ContextEngine {
             : manualCompactionRequested
               ? "nothing to compact"
               : "live context still exceeds target";
+      let spendBackoffOpened = false;
       if (thresholdSweepStillOverTarget && !sweepResult.authFailure) {
-        this.openSummarySpendBackoff({
-          scopeKey: summarySpendScopeKey,
-          reason: sweepReason,
-        });
+        if (lastRoundMadeProgress) {
+          // The attempt ended at a deadline while still reducing tokens.
+          // Progress is persisted; the deferred drain or next attempt
+          // continues from here, so opening a backoff would only punish
+          // a recovery that is working.
+          this.deps.log.info(
+            `[lcm] compact: spend backoff skipped conversation=${conversationId} ${sessionLabel} scope=${summarySpendScopeKey} reason=still_progressing chainedSweeps=${chainedSweeps} tokensAfter=${sweepResult.tokensAfter}`,
+          );
+        } else {
+          this.openSummarySpendBackoff({
+            scopeKey: summarySpendScopeKey,
+            reason: sweepReason,
+          });
+          spendBackoffOpened = true;
+        }
       }
       this.deps.log.info(
-        `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${sweepOk} compacted=${sweepResult.actionTaken} reason=${sweepReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${sweepResult.tokensAfter} createdSummaryId=${sweepResult.createdSummaryId ?? "none"} duration=${formatDurationMs(Date.now() - startedAt)}`,
+        `[lcm] compact: done conversation=${conversationId} ${sessionLabel} ok=${sweepOk} compacted=${sweepResult.actionTaken} reason=${sweepReason.replaceAll(" ", "_")} tokensBefore=${decision.currentTokens} tokensAfter=${sweepResult.tokensAfter} createdSummaryId=${sweepResult.createdSummaryId ?? "none"} chainedSweeps=${chainedSweeps} spendBackoffOpened=${spendBackoffOpened} duration=${formatDurationMs(Date.now() - startedAt)}`,
       );
 
       return {
@@ -4919,7 +5030,7 @@ export class LcmContextEngine implements ContextEngine {
           tokensBefore: decision.currentTokens,
           tokensAfter: sweepResult.tokensAfter,
           details: {
-            rounds: sweepResult.actionTaken ? 1 : 0,
+            rounds: sweepResult.actionTaken ? chainedSweeps : 0,
             targetTokens: runtimeAdjustedSweepTargetTokens ?? targetTokens,
             ...(runtimeAdjustedSweepTargetTokens !== undefined || projectedRawBacklogPressure
               ? {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -14817,7 +14817,9 @@ describe("LcmContextEngine fidelity and token budget", () => {
       });
       expect(first.changed).toBe(true);
       expect(first.reason).toBe("compacted but still over target");
-      expect(compactFullSweepSpy).toHaveBeenCalledTimes(1);
+      // The sweep chain retries once after the first partial round and stops
+      // when the second round shows no further reduction.
+      expect(compactFullSweepSpy).toHaveBeenCalledTimes(2);
 
       const second = await engine.maintain({
         sessionId,
@@ -14830,7 +14832,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
       });
       expect(second.changed).toBe(false);
       expect(second.reason).toBe("deferred compaction backoff active");
-      expect(compactFullSweepSpy).toHaveBeenCalledTimes(1);
+      expect(compactFullSweepSpy).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -17974,7 +17976,9 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.result?.tokensAfter).toBe(9_000);
     expect(result.result?.details).toEqual(
       expect.objectContaining({
-        rounds: 1,
+        // Two chained sweeps: the first makes progress, the second shows no
+        // further reduction and ends the chain.
+        rounds: 2,
         targetTokens: 8_200,
       }),
     );

--- a/test/spend-guard-policy.test.ts
+++ b/test/spend-guard-policy.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Regression tests for summary spend guard policy (lossless-claw-30b.3).
+ *
+ * Incident: a threshold sweep made real progress (395k -> 288k stored
+ * tokens) but hit its per-sweep wall-clock deadline, recorded "compacted
+ * but still over target", and opened a 30-minute spend backoff that then
+ * blocked emergency drains AND a user-initiated /compact (silent no-op).
+ *
+ * Policy under test:
+ *  - progress-making attempts never open the spend backoff;
+ *  - sweeps chain within the operation deadline instead of failing early;
+ *  - manual compaction clears an open backoff instead of no-opping.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const tempDirs: string[] = [];
+const engines: LcmContextEngine[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  engines.splice(0);
+  for (const db of dbs.splice(0)) {
+    try {
+      closeLcmConnection(db);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTestConfig(databasePath: string): LcmConfig {
+  return {
+    enabled: true,
+    databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 4,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
+    leafChunkTokens: 20_000,
+    leafTargetTokens: 600,
+    condensedTargetTokens: 900,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25_000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120_000,
+    summaryTimeoutMs: 60_000,
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    enableSummaryThinking: true,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2 * 1024 * 1024,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1_800_000,
+    replayFloodThresholdExternal: 3,
+    replayFloodThresholdInternal: 32,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.9,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40_000,
+    },
+    stripInjectedContextTags: [],
+  };
+}
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) {
+    return null;
+  }
+  const parts = trimmed.split(":");
+  if (parts.length < 3) {
+    return null;
+  }
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+type LogMock = { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn> };
+
+function createTestDeps(config: LcmConfig, log: LogMock): LcmDependencies {
+  return {
+    config,
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "summary output" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({ provider: "anthropic", model: "claude-opus-4-5" })),
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => tmpdir(),
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log,
+  } as unknown as LcmDependencies;
+}
+
+function createEngine(configOverrides?: Partial<LcmConfig>): { engine: LcmContextEngine; log: LogMock } {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-spend-"));
+  tempDirs.push(tempDir);
+  const config = { ...createTestConfig(join(tempDir, "lcm.db")), ...configOverrides };
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  const log: LogMock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const engine = new LcmContextEngine(createTestDeps(config, log), db);
+  engines.push(engine);
+  return { engine, log };
+}
+
+function createSessionFile(name: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-spend-session-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, `${name}.jsonl`);
+  writeFileSync(file, "");
+  return file;
+}
+
+type PrivateEngine = {
+  compaction: {
+    evaluate: (...args: unknown[]) => Promise<unknown>;
+    compact: (...args: unknown[]) => Promise<unknown>;
+    compactUntilUnder: (...args: unknown[]) => Promise<unknown>;
+  };
+  resolveSessionQueueKey: (sessionId: string, sessionKey?: string) => string;
+  resolveSummarySpendScope: (params: { kind: string; scope: string | undefined }) => string;
+  openSummarySpendBackoff: (params: { scopeKey: string; reason: string }) => Date;
+  getSummarySpendBackoffUntil: (scopeKey: string) => Date | null;
+};
+
+function privateEngine(engine: LcmContextEngine): PrivateEngine {
+  return engine as unknown as PrivateEngine;
+}
+
+function spendScopeKey(engine: LcmContextEngine, sessionId: string, sessionKey?: string): string {
+  const internals = privateEngine(engine);
+  return internals.resolveSummarySpendScope({
+    kind: "compaction",
+    scope: internals.resolveSessionQueueKey(sessionId, sessionKey),
+  });
+}
+
+async function seedConversation(engine: LcmContextEngine, sessionId: string): Promise<void> {
+  await engine.ingest({
+    sessionId,
+    message: {
+      role: "user",
+      content: "seed message for compaction tests",
+      timestamp: Date.now(),
+    } as unknown as AgentMessage,
+  });
+}
+
+const thresholdEvaluation = {
+  shouldCompact: true,
+  reason: "over threshold",
+  currentTokens: 5_000,
+  storedTokens: 5_000,
+  threshold: 3_000,
+};
+
+describe("summary spend guard policy", () => {
+  it("manual compaction clears an open spend backoff and proceeds", async () => {
+    const { engine, log } = createEngine();
+    const sessionId = "spend-manual-bypass";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    const scopeKey = spendScopeKey(engine, sessionId);
+    internals.openSummarySpendBackoff({ scopeKey, reason: "earlier automatic failure" });
+    expect(internals.getSummarySpendBackoffUntil(scopeKey)).not.toBeNull();
+
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(thresholdEvaluation);
+    const compactSpy = vi.spyOn(internals.compaction, "compact").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 5_000,
+      tokensAfter: 1_000,
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("spend-manual-bypass"),
+      tokenBudget: 4_096,
+      runtimeContext: { manualCompaction: true },
+    });
+
+    expect(result.reason).not.toBe("summary spend backoff open");
+    expect(result.compacted).toBe(true);
+    expect(compactSpy).toHaveBeenCalled();
+    expect(internals.getSummarySpendBackoffUntil(scopeKey)).toBeNull();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("manual request cleared summary spend backoff"),
+    );
+  });
+
+  it("does not open the spend backoff when a deadline-bounded sweep is still progressing", async () => {
+    // Tiny chain deadline: the first sweep "runs out of time" while making
+    // real progress, exactly like the production deadline-partial.
+    const { engine, log } = createEngine({ compactUntilUnderDeadlineMs: 1 });
+    const sessionId = "spend-progressing-no-backoff";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(thresholdEvaluation);
+    vi.spyOn(internals.compaction, "compact").mockImplementation(async () => {
+      // Outlast the 1ms chain deadline so the loop deterministically stops
+      // after this progress-making round.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return {
+        actionTaken: true,
+        tokensBefore: 5_000,
+        tokensAfter: 4_200,
+      };
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("spend-progressing"),
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("compacted but still over target");
+    expect(internals.getSummarySpendBackoffUntil(spendScopeKey(engine, sessionId))).toBeNull();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("spend backoff skipped"),
+    );
+  });
+
+  it("opens the spend backoff when the sweep chain stalls without progress", async () => {
+    const { engine } = createEngine();
+    const sessionId = "spend-stalled-backoff";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(thresholdEvaluation);
+    vi.spyOn(internals.compaction, "compact")
+      .mockResolvedValueOnce({ actionTaken: true, tokensBefore: 5_000, tokensAfter: 4_500 })
+      .mockResolvedValue({ actionTaken: true, tokensBefore: 4_500, tokensAfter: 4_500 });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("spend-stalled"),
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("compacted but still over target");
+    expect(internals.getSummarySpendBackoffUntil(spendScopeKey(engine, sessionId))).not.toBeNull();
+  });
+
+  it("chains threshold sweeps until the target is reached", async () => {
+    const { engine } = createEngine();
+    const sessionId = "spend-chained-success";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(thresholdEvaluation);
+    const compactSpy = vi
+      .spyOn(internals.compaction, "compact")
+      .mockResolvedValueOnce({ actionTaken: true, tokensBefore: 5_000, tokensAfter: 4_500 })
+      .mockResolvedValueOnce({ actionTaken: true, tokensBefore: 4_500, tokensAfter: 3_600 })
+      .mockResolvedValueOnce({ actionTaken: true, tokensBefore: 3_600, tokensAfter: 2_800 });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("spend-chained"),
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(compactSpy).toHaveBeenCalledTimes(3);
+    expect(result.result?.details?.rounds).toBe(3);
+    expect(internals.getSummarySpendBackoffUntil(spendScopeKey(engine, sessionId))).toBeNull();
+  });
+
+});


### PR DESCRIPTION
## What
Reworks the summary-spend guard so it throttles failure, not progress: threshold sweeps chain within the operation-wide deadline instead of failing after one wall-clock-bounded sweep, the 30-minute spend backoff opens only when a round makes no further reduction, and user-initiated compaction clears an open backoff instead of silently no-opping.

## Why
Production incident (phaedrus, topic 683, 2026-06-09): a sweep made real progress (395k→288k stored tokens) but hit its 120s per-sweep deadline, recorded "compacted but still over target", and opened a 30-minute backoff. That backoff then blocked the emergency assemble drain on the next message AND silently no-opped the user's manual /compact — the session went dark behind a guard punishing a recovery that was working.

## Changes
- Threshold sweeps chain while reducing tokens (bounded by `compactUntilUnderDeadlineMs` + `maxSweepIterations`)
- Spend backoff opens only on no-progress rounds
- `manualCompaction` requests clear an open backoff (explicit consent to spend)
- Mid-chain spend-cap trips keep persisted progress
- Convergence path (`compactUntilUnder`) backoff behavior unchanged
- `details.rounds` reports chained sweep count

## Testing
- `npx vitest run --dir test` (1209 tests green)
- New: `test/spend-guard-policy.test.ts` covers manual bypass, deadline-partial-no-backoff, stall-opens-backoff, chain-to-target
- Telemetry for phaedrus: `chainedSweeps=`/`spendBackoffOpened=` on the compact done line, `spend backoff skipped`, `manual request cleared summary spend backoff`