### PR TITLE
fix: surface terminal compaction exhaustion as a transcript-reset verdict

### DIFF
--- a/.changeset/transcript-wedge-terminal.md
+++ b/.changeset/transcript-wedge-terminal.md
@@ -1,0 +1,18 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Surface terminal compaction exhaustion as an explicit transcript-reset verdict.
+
+When a threshold sweep finds no eligible candidates while host-observed
+pressure keeps the session over target, the host is rebuilding prompts from
+live transcript state the engine cannot shrink — retrying stored compaction
+can never converge. This terminal state previously reported the generic
+"live context still exceeds target", which hosts answer with misleading
+reserve-tuning advice. compact() now returns "stored compaction exhausted but
+live context still exceeds target; transcript reset required" (alongside the
+existing exhausted flag that clears deferred debt). The verdict requires an
+explicit host-observed token count and never fires on budget-stopped sweeps,
+so estimator gaps or interrupted sweeps cannot condemn recoverable sessions.
+Telemetry: a "[lcm] compact: transcript wedge detected" warn line with
+stored/observed/overhead counts.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4843,6 +4843,17 @@ export class LcmContextEngine implements ContextEngine {
         !sweepResult.authFailure &&
         !thresholdSweepStoppedAtBudget &&
         !isUnderTargetAfterSweep;
+      // Transcript wedge (lossless-claw-30b.4): terminal exhaustion with an
+      // explicit host-observed token count means stored compaction has
+      // nothing left to shrink while the live transcript keeps the session
+      // over target. Surface a reset-required verdict instead of the generic
+      // failure so hosts and users learn the actual recovery (/new or
+      // re-bootstrap). Requires observedTokens so overhead inferred from
+      // estimator methodology gaps alone cannot condemn a recoverable
+      // session, and never fires on budget-stopped sweeps (more sweeps can
+      // still make progress there).
+      const thresholdSweepTranscriptWedge =
+        thresholdSweepExhaustedOverTarget && observedTokens !== undefined;
       const sweepOk =
         !sweepResult.authFailure &&
         (isUnderTargetAfterSweep || (sweepResult.actionTaken && !isThresholdSweep));
@@ -4856,9 +4867,16 @@ export class LcmContextEngine implements ContextEngine {
           ? "compacted"
           : isUnderTargetAfterSweep
             ? "already under target"
+            : thresholdSweepTranscriptWedge
+              ? "stored compaction exhausted but live context still exceeds target; transcript reset required"
             : manualCompactionRequested
               ? "nothing to compact"
               : "live context still exceeds target";
+      if (thresholdSweepTranscriptWedge) {
+        this.deps.log.warn(
+          `[lcm] compact: transcript wedge detected conversation=${conversationId} ${sessionLabel} storedTokensAfter=${sweepTokensAfter ?? "none"} targetTokens=${targetTokens} observedTokens=${observedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} projectedTokensAfter=${projectedTokensAfterSweep ?? "none"} — stored compaction cannot reduce the live transcript; reset the session (/new) or re-bootstrap`,
+        );
+      }
       let spendBackoffOpened = false;
       if (thresholdSweepStillOverTarget && !sweepResult.authFailure) {
         if (lastRoundMadeProgress) {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -17864,7 +17864,11 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 
     expect(result.ok).toBe(false);
     expect(result.compacted).toBe(false);
-    expect(result.reason).toBe("live context still exceeds target");
+    // Terminal exhaustion with a host-observed count is now surfaced as the
+    // transcript-wedge verdict instead of the generic failure.
+    expect(result.reason).toBe(
+      "stored compaction exhausted but live context still exceeds target; transcript reset required",
+    );
     expect(result.result?.tokensBefore).toBe(12_000);
     expect(result.result?.tokensAfter).toBe(7_000);
     expect(result.result?.details).toEqual(

--- a/test/transcript-wedge.test.ts
+++ b/test/transcript-wedge.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Regression tests for the transcript-wedge terminal verdict (lossless-claw-30b.4).
+ *
+ * Incident shape: the host rebuilds prompts from a live transcript the
+ * engine cannot shrink. Once stored compaction has no eligible candidates
+ * left while host-observed pressure stays over target, retrying can never
+ * converge — the failure must be surfaced as an explicit
+ * "transcript reset required" verdict (with the exhausted flag clearing
+ * deferred debt), not the generic still-over failure that hosts answer
+ * with reserve-tuning advice.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const tempDirs: string[] = [];
+const engines: LcmContextEngine[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  engines.splice(0);
+  for (const db of dbs.splice(0)) {
+    try {
+      closeLcmConnection(db);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTestConfig(databasePath: string): LcmConfig {
+  return {
+    enabled: true,
+    databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 4,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
+    leafChunkTokens: 20_000,
+    leafTargetTokens: 600,
+    condensedTargetTokens: 900,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25_000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120_000,
+    summaryTimeoutMs: 60_000,
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    enableSummaryThinking: true,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2 * 1024 * 1024,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1_800_000,
+    replayFloodThresholdExternal: 3,
+    replayFloodThresholdInternal: 32,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.9,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40_000,
+    },
+    stripInjectedContextTags: [],
+  };
+}
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) {
+    return null;
+  }
+  const parts = trimmed.split(":");
+  if (parts.length < 3) {
+    return null;
+  }
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+type LogMock = { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn> };
+
+function createTestDeps(config: LcmConfig, log: LogMock): LcmDependencies {
+  return {
+    config,
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "summary output" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({ provider: "anthropic", model: "claude-opus-4-5" })),
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => tmpdir(),
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log,
+  } as unknown as LcmDependencies;
+}
+
+function createEngine(configOverrides?: Partial<LcmConfig>): { engine: LcmContextEngine; log: LogMock } {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-wedge-"));
+  tempDirs.push(tempDir);
+  const config = { ...createTestConfig(join(tempDir, "lcm.db")), ...configOverrides };
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  const log: LogMock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const engine = new LcmContextEngine(createTestDeps(config, log), db);
+  engines.push(engine);
+  return { engine, log };
+}
+
+function createSessionFile(name: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-wedge-session-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, `${name}.jsonl`);
+  writeFileSync(file, "");
+  return file;
+}
+
+type PrivateEngine = {
+  compaction: {
+    evaluate: (...args: unknown[]) => Promise<unknown>;
+    compact: (...args: unknown[]) => Promise<unknown>;
+    compactUntilUnder: (...args: unknown[]) => Promise<unknown>;
+  };
+  resolveSessionQueueKey: (sessionId: string, sessionKey?: string) => string;
+  resolveSummarySpendScope: (params: { kind: string; scope: string | undefined }) => string;
+  openSummarySpendBackoff: (params: { scopeKey: string; reason: string }) => Date;
+  getSummarySpendBackoffUntil: (scopeKey: string) => Date | null;
+};
+
+function privateEngine(engine: LcmContextEngine): PrivateEngine {
+  return engine as unknown as PrivateEngine;
+}
+
+function spendScopeKey(engine: LcmContextEngine, sessionId: string, sessionKey?: string): string {
+  const internals = privateEngine(engine);
+  return internals.resolveSummarySpendScope({
+    kind: "compaction",
+    scope: internals.resolveSessionQueueKey(sessionId, sessionKey),
+  });
+}
+
+async function seedConversation(engine: LcmContextEngine, sessionId: string): Promise<void> {
+  await engine.ingest({
+    sessionId,
+    message: {
+      role: "user",
+      content: "seed message for compaction tests",
+      timestamp: Date.now(),
+    } as unknown as AgentMessage,
+  });
+}
+
+/**
+ * Host-observed live tokens (12000) far exceed stored tokens (7000); the
+ * sweep finds no eligible candidates (actionTaken=false).
+ */
+const wedgeEvaluation = {
+  shouldCompact: true,
+  reason: "threshold",
+  storedTokens: 7_000,
+  observedTokens: 12_000,
+  currentTokens: 12_000,
+  threshold: 8_200,
+};
+
+const WEDGE_REASON =
+  "stored compaction exhausted but live context still exceeds target; transcript reset required";
+
+describe("transcript wedge terminal verdict", () => {
+  it("reports transcript reset required when exhaustion has a host-observed count", async () => {
+    const { engine, log } = createEngine();
+    const sessionId = "wedge-verdict-observed";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(wedgeEvaluation);
+    const compactSpy = vi.spyOn(internals.compaction, "compact").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 7_000,
+      tokensAfter: 7_000,
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("wedge-verdict-observed"),
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe(WEDGE_REASON);
+    expect((result as { exhausted?: boolean }).exhausted).toBe(true);
+    expect(compactSpy).toHaveBeenCalledTimes(1);
+    // Terminal verdict: no spend backoff — throttling a non-retryable state
+    // only blocks a later manual repair attempt.
+    expect(internals.getSummarySpendBackoffUntil(spendScopeKey(engine, sessionId))).toBeNull();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("transcript wedge detected"),
+    );
+  });
+
+  it("keeps the generic failure when the sweep merely stopped at its budget", async () => {
+    const { engine, log } = createEngine();
+    const sessionId = "wedge-verdict-budget-stop";
+    await seedConversation(engine, sessionId);
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(wedgeEvaluation);
+    vi.spyOn(internals.compaction, "compact").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 7_000,
+      tokensAfter: 7_000,
+      stoppedAtBudget: true,
+    });
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFile("wedge-verdict-budget-stop"),
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+      compactionTarget: "threshold",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("live context still exceeds target");
+    expect((result as { exhausted?: boolean }).exhausted).toBeUndefined();
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("transcript wedge detected"),
+    );
+  });
+
+  it("clears deferred debt when the drain hits the wedge verdict", async () => {
+    const { engine, log } = createEngine();
+    const sessionId = "wedge-verdict-drain";
+    await seedConversation(engine, sessionId);
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation!.conversationId,
+      reason: "threshold",
+      tokenBudget: 10_000,
+      currentTokenCount: 12_000,
+    });
+
+    const internals = privateEngine(engine);
+    vi.spyOn(internals.compaction, "evaluate").mockResolvedValue(wedgeEvaluation);
+    vi.spyOn(internals.compaction, "compact").mockResolvedValue({
+      actionTaken: false,
+      tokensBefore: 7_000,
+      tokensAfter: 7_000,
+    });
+
+    const result = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFile("wedge-verdict-drain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 10_000,
+        currentTokenCount: 12_000,
+      },
+    });
+
+    expect(result.reason).toBe(WEDGE_REASON);
+    expect((result as { exhausted?: boolean }).exhausted).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("transcript wedge detected"),
+    );
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
When a threshold sweep finds no eligible candidates while host-observed pressure keeps the session over target, `compact()` now returns an explicit verdict — "stored compaction exhausted but live context still exceeds target; transcript reset required" — instead of the generic "live context still exceeds target". The existing exhausted flag (which clears deferred debt, #639) is unchanged.

**Stacked on #858** (spend-guard rework); retarget to `main` after it merges.

## Why
In the phaedrus incident the user-facing advice for an unrecoverable session was "increase reserveTokensFloor" — generic and wrong. When the host rebuilds prompts from a live transcript the engine cannot shrink, no amount of stored compaction or reserve tuning helps; the honest answer is /new or re-bootstrap, and hosts can only say that if the engine reports it distinctly.

## Changes
- Terminal exhaustion + host-observed count → explicit reset-required reason
- Guarded: never fires on budget-stopped sweeps or estimator-derived overhead
- Warn telemetry: `[lcm] compact: transcript wedge detected` with stored/observed/overhead counts

## Testing
- `npx vitest run --dir test` (1212 tests green)
- New: `test/transcript-wedge.test.ts` covers the verdict, the budget-stop guard, and drain-clears-debt