### PR TITLE
fix: chunk anchored reconcile imports instead of freezing at the import cap

### DIFF
--- a/.changeset/anchored-reconcile-chunked-import.md
+++ b/.changeset/anchored-reconcile-chunked-import.md
@@ -1,0 +1,31 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Unfreeze anchored transcript reconcile when the backlog exceeds the import cap.
+
+A session whose transcript grew past the reconcile import cap (e.g. heavy
+old-harness history) froze permanently: every pass logged "import cap
+exceeded ... Aborting to prevent flood", imported nothing, and afterTurn
+skipped persistence to avoid advancing the frontier — while the backlog kept
+growing faster than the cap ever could. The live incident left a main-topic
+conversation with 1,700+ unpersisted messages and silent data loss on every
+turn.
+
+When the missing tail is anchored (lineage proven by an identity anchor in
+this conversation), reconcile now imports a bounded oldest-first chunk per
+pass instead of aborting: order is preserved, per-pass flood exposure stays
+capped, the growing message count raises the cap, and repeated passes
+converge until the backlog drains. The checkpoint/frontier still does not
+advance while a pass is capped. No-anchor caps (unproven lineage, e.g.
+path-mismatched epochs) still block entirely. Telemetry: the warn line is now
+"import cap chunking ... importing N/M anchored backlog messages this pass".
+
+Extended after the entry-id reconciliation rework (#854): the same chunked
+drain now applies to the entry-id anchored path — which carries 100% of
+current-format traffic and had the same permanent-freeze shape — and to
+fully id-bearing no-anchor epochs (declared rollovers), where every entry
+adopts or imports by verified id, so a kept tail beyond the cap drains in
+bounded passes instead of freezing before stale-id adoption can heal it.
+After the first chunk persists ids, the entry-id anchor takes over on
+subsequent passes. Id-less no-anchor batches still block entirely.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6297,19 +6297,21 @@ export class LcmContextEngine implements ContextEngine {
       source: "reconcileSessionTail entry-id",
     });
 
-    if (
-      params.existingDbCount > 0 &&
-      missingTail.length > transcriptImportCap(params.existingDbCount)
-    ) {
+    // Entry-id anchored backlogs are exact — lineage is proven by the id
+    // anchor and every import is individually id-verified — so a backlog
+    // beyond the cap drains in bounded oldest-first chunks instead of
+    // freezing, mirroring the anchored content path. The checkpoint does
+    // not advance while a pass is capped, so repeated passes converge.
+    const entryIdImportCap = transcriptImportCap(params.existingDbCount);
+    const entryIdImportCapped =
+      params.existingDbCount > 0 && missingTail.length > entryIdImportCap;
+    const importableTail = entryIdImportCapped
+      ? missingTail.slice(0, entryIdImportCap)
+      : missingTail;
+    if (entryIdImportCapped) {
       this.deps.log.warn(
-        `[lcm] reconcileSessionTail: entry-id import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${params.existingDbCount}). Aborting to prevent flood.`,
+        `[lcm] reconcileSessionTail: entry-id import cap chunking for ${sessionContext} — importing ${importableTail.length}/${missingTail.length} anchored backlog messages this pass (existing: ${params.existingDbCount}, cap: ${entryIdImportCap}); remaining backlog continues next pass`,
       );
-      return {
-        blockedByImportCap: true,
-        blockedReason: "import-cap",
-        importedMessages: 0,
-        hasOverlap: true,
-      };
     }
 
     // Ids on the current leaf path. A persisted row whose entry id is NOT in
@@ -6320,7 +6322,7 @@ export class LcmContextEngine implements ContextEngine {
     let importedMessages = 0;
     let adoptedMessages = 0;
     let restampedMessages = 0;
-    for (const message of missingTail) {
+    for (const message of importableTail) {
       const entryId = getTranscriptEntryId(message)!;
       const stored = toStoredMessage(message);
       const adopted = await this.conversationStore.adoptTranscriptEntryId(
@@ -6358,8 +6360,16 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     this.deps.log.debug(
-      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages}`,
+      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages} capped=${entryIdImportCapped}`,
     );
+    if (entryIdImportCapped) {
+      return {
+        blockedByImportCap: true,
+        blockedReason: "import-cap",
+        importedMessages,
+        hasOverlap: true,
+      };
+    }
     return { blockedByImportCap: false, importedMessages, hasOverlap: true };
   }
 
@@ -6609,19 +6619,34 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           const importCap = transcriptImportCap(existingDbCount);
+          let noAnchorImportCapped = false;
           if (noAnchorImportMessages.length > importCap) {
-            this.deps.log.warn(
-              `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,
-            );
-            this.deps.log.debug(
-              `[lcm] reconcileSessionTail: blocked no-anchor import for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} existingDbCount=${existingDbCount} cap=${importCap} overlap=false`,
-            );
-            return {
-              blockedByImportCap: true,
-              blockedReason: "import-cap",
-              importedMessages: 0,
-              hasOverlap: false,
-            };
+            if (allEntryIdBearing) {
+              // A fully id-bearing new epoch is exact (every entry adopts or
+              // imports by verified id), so a large rollover — e.g. a host
+              // rewrite or compaction successor with a kept tail beyond the
+              // cap — drains in bounded oldest-first chunks instead of
+              // freezing before adoption can heal it. After the first chunk
+              // persists ids, the entry-id anchor takes over on later passes.
+              noAnchorImportCapped = true;
+              this.deps.log.warn(
+                `[lcm] reconcileSessionTail: no-anchor entry-id import cap chunking for ${sessionContext} — importing ${importCap}/${noAnchorImportMessages.length} new-epoch messages this pass (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}); remaining backlog continues next pass`,
+              );
+              noAnchorImportMessages = noAnchorImportMessages.slice(0, importCap);
+            } else {
+              this.deps.log.warn(
+                `[lcm] reconcileSessionTail: no anchor import cap exceeded for ${sessionContext} - would import ${noAnchorImportMessages.length} messages (existing: ${existingDbCount}, cap: ${importCap}, reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent flood.`,
+              );
+              this.deps.log.debug(
+                `[lcm] reconcileSessionTail: blocked no-anchor import for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} existingDbCount=${existingDbCount} cap=${importCap} overlap=false`,
+              );
+              return {
+                blockedByImportCap: true,
+                blockedReason: "import-cap",
+                importedMessages: 0,
+                hasOverlap: false,
+              };
+            }
           }
 
           if (params.noAnchorImportReason === "same-path-shrink") {
@@ -6696,8 +6721,19 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
           this.deps.log.warn(
-            `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} overlap=${adoptedMessages > 0}`,
+            `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} capped=${noAnchorImportCapped} overlap=${adoptedMessages > 0}`,
           );
+          if (noAnchorImportCapped) {
+            // Partial pass: keep the checkpoint un-advanced so the next pass
+            // continues the drain (via the entry-id anchor once this chunk's
+            // ids are persisted).
+            return {
+              blockedByImportCap: true,
+              blockedReason: "import-cap",
+              importedMessages,
+              hasOverlap: adoptedMessages > 0,
+            };
+          }
           // Adoption proves the "new epoch" overlaps persisted history (the
           // host re-issued ids for messages we already hold), so report the
           // overlap — the caller then refreshes the checkpoint instead of
@@ -6729,23 +6765,26 @@ export class LcmContextEngine implements ContextEngine {
       source: "reconcileSessionTail",
     });
 
-    if (existingDbCount > 0 && missingTail.length > transcriptImportCap(existingDbCount)) {
+    // Anchored missing tails are this conversation's own continuation
+    // (lineage proven by the identity anchor), so a tail larger than the
+    // cap must not freeze reconcile forever — that wedges afterTurn
+    // persistence while the backlog keeps growing. Import a capped
+    // oldest-first chunk per pass instead: order is preserved, per-pass
+    // flood exposure stays bounded, and the growing existing count raises
+    // the cap so repeated passes converge. The checkpoint/frontier still
+    // does not advance until the backlog fully drains (blockedByImportCap
+    // stays true on partial passes).
+    const anchoredImportCap = transcriptImportCap(existingDbCount);
+    const importCapped = existingDbCount > 0 && missingTail.length > anchoredImportCap;
+    const importableTail = importCapped ? missingTail.slice(0, anchoredImportCap) : missingTail;
+    if (importCapped) {
       this.deps.log.warn(
-        `[lcm] reconcileSessionTail: import cap exceeded for ${sessionContext} — would import ${missingTail.length} messages (existing: ${existingDbCount}). Aborting to prevent flood.`,
+        `[lcm] reconcileSessionTail: import cap chunking for ${sessionContext} — importing ${importableTail.length}/${missingTail.length} anchored backlog messages this pass (existing: ${existingDbCount}, cap: ${anchoredImportCap}); remaining backlog continues next pass`,
       );
-      this.deps.log.debug(
-        `[lcm] reconcileSessionTail: blocked for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} missingTail=${missingTail.length} existingDbCount=${existingDbCount}`,
-      );
-      return {
-        blockedByImportCap: true,
-        blockedReason: "import-cap",
-        importedMessages: 0,
-        hasOverlap: true,
-      };
     }
 
     let importedMessages = 0;
-    for (const [index, message] of missingTail.entries()) {
+    for (const [index, message] of importableTail.entries()) {
       const result = await this.ingestSingle({
         sessionId,
         sessionKey: params.sessionKey,
@@ -6756,6 +6795,18 @@ export class LcmContextEngine implements ContextEngine {
       if (result.ingested) {
         importedMessages += 1;
       }
+    }
+
+    if (importCapped) {
+      this.deps.log.debug(
+        `[lcm] reconcileSessionTail: capped chunk for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} existingDbCount=${existingDbCount} cap=${anchoredImportCap}`,
+      );
+      return {
+        blockedByImportCap: true,
+        blockedReason: "import-cap",
+        importedMessages,
+        hasOverlap: true,
+      };
     }
 
     this.deps.log.debug(
@@ -7766,7 +7817,14 @@ export class LcmContextEngine implements ContextEngine {
               : reason,
         });
         if (reconcile.blockedByImportCap) {
-          return { importedMessages: 0, blockedByImportCap: true, hasOverlap: reconcile.hasOverlap };
+          // Capped passes import a bounded chunk of anchored backlog; report
+          // the partial progress while leaving the checkpoint un-advanced so
+          // the next pass continues the drain.
+          return {
+            importedMessages: reconcile.importedMessages,
+            blockedByImportCap: true,
+            hasOverlap: reconcile.hasOverlap,
+          };
         }
         if (reconcile.importedMessages > 0) {
           this.recordRecentBootstrapImport(
@@ -8529,9 +8587,12 @@ export class LcmContextEngine implements ContextEngine {
           );
 
           if (reconcile.blockedByImportCap) {
+            // Anchored capped passes import a bounded chunk of backlog;
+            // report the partial progress while keeping the checkpoint
+            // un-advanced so the next pass continues the drain.
             return {
               bootstrapped: false,
-              importedMessages: 0,
+              importedMessages: reconcile.importedMessages,
               reason:
                 reconcile.blockedReason === "cross-conversation-raw-id"
                   ? "reconcile duplicate raw ids"

--- a/test/bootstrap-flood-regression.test.ts
+++ b/test/bootstrap-flood-regression.test.ts
@@ -349,8 +349,10 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
       } as AgentMessage);
     }
 
-    // Bootstrap again — should hit import cap because reconcileSessionTail
-    // would try to import more than max(existingDbCount * 0.2, 50) messages
+    // Bootstrap again — reconcileSessionTail finds more backlog than
+    // max(existingDbCount * 0.2, 50) and imports a bounded oldest-first
+    // chunk per pass instead of freezing reconcile.
+    const initialCap = Math.max(Math.floor(dbCountAfterBoot * 0.2), 50);
     const boot2 = await engine.bootstrap({ sessionId, sessionFile });
 
     expect(
@@ -359,17 +361,47 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
     ).toBe("reconcile import capped");
     expect(
       boot2.importedMessages,
-      "should import 0 messages when cap fires",
-    ).toBe(0);
+      "capped pass imports exactly one bounded chunk",
+    ).toBe(initialCap);
 
-    // Verify no new messages were added to DB
-    const dbCountAfterFlood = await engine
+    const dbCountAfterFirstChunk = await engine
       .getConversationStore()
       .getMessageCount(conversationId);
     expect(
-      dbCountAfterFlood,
-      "DB message count should not change after capped import",
-    ).toBe(dbCountAfterBoot);
+      dbCountAfterFirstChunk,
+      "DB grows by exactly the capped chunk",
+    ).toBe(dbCountAfterBoot + initialCap);
+
+    // Repeated passes converge: every pass stays under its cap and the
+    // backlog fully drains with no duplicates.
+    let lastResult = boot2;
+    let passes = 0;
+    while (lastResult.reason === "reconcile import capped" && passes < 10) {
+      const countBefore = await engine
+        .getConversationStore()
+        .getMessageCount(conversationId);
+      const cap = Math.max(Math.floor(countBefore * 0.2), 50);
+      lastResult = await engine.bootstrap({ sessionId, sessionFile });
+      expect(
+        lastResult.importedMessages,
+        "every pass stays within its import cap",
+      ).toBeLessThanOrEqual(cap);
+      passes += 1;
+    }
+
+    const dbCountAfterDrain = await engine
+      .getConversationStore()
+      .getMessageCount(conversationId);
+    expect(
+      dbCountAfterDrain,
+      "backlog fully drains across capped passes",
+    ).toBe(dbCountAfterBoot + 200);
+
+    // No duplicates: every flood message imported exactly once.
+    const allMessages = await engine.getConversationStore().getMessages(conversationId);
+    const floodMessages = allMessages.filter((m) => m.content.includes("extra flood message"));
+    expect(floodMessages).toHaveLength(200);
+    expect(new Set(floodMessages.map((m) => m.content)).size).toBe(200);
   });
 
   it("no duplicate messages or seq numbers after bootstrap-maintain-bootstrap cycle", async () => {
@@ -469,16 +501,21 @@ describe("bootstrap flood regression (PR #280) — round-trip integration", () =
       } as AgentMessage);
     }
 
-    // Phase 4: Bootstrap with stale checkpoint — import cap should block
+    // Phase 4: Bootstrap with stale checkpoint — the cap bounds the pass to
+    // one oldest-first chunk; the checkpoint must not advance while capped.
+    const countBeforeCappedPass = await engine
+      .getConversationStore()
+      .getMessageCount(conversationId);
+    const cap = Math.max(Math.floor(countBeforeCappedPass * 0.2), 50);
     const boot3 = await engine.bootstrap({ sessionId, sessionFile });
     expect(boot3.reason, "cap should fire with stale checkpoint").toBe("reconcile import capped");
-    expect(boot3.importedMessages, "no messages imported when capped").toBe(0);
+    expect(boot3.importedMessages, "capped pass imports one bounded chunk").toBe(cap);
 
-    // DB unchanged throughout
+    // DB grows by exactly the bounded chunk — no unbounded flood.
     const finalCount = await engine.getConversationStore().getMessageCount(conversationId);
     expect(
       finalCount,
-      "DB message count should be unchanged after capped flood attempt",
-    ).toBe(dbCountAfterBoot);
+      "DB message count grows by exactly the capped chunk",
+    ).toBe(countBeforeCappedPass + cap);
   });
 });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -6680,31 +6680,46 @@ describe("LcmContextEngine.bootstrap", () => {
     }
 
     const second = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    // Anchored backlog over the cap imports a bounded oldest-first chunk
+    // instead of freezing; the checkpoint must still not advance.
     expect(second).toEqual({
       bootstrapped: false,
-      importedMessages: 0,
+      importedMessages: 50,
       reason: "reconcile import capped",
     });
     expect(warnLog).toHaveBeenCalledWith(
-      `[lcm] reconcileSessionTail: entry-id import cap exceeded for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey} — would import 60 messages (existing: 2). Aborting to prevent flood.`,
+      `[lcm] reconcileSessionTail: entry-id import cap chunking for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey} — importing 50/60 anchored backlog messages this pass (existing: 2, cap: 50); remaining backlog continues next pass`,
     );
 
     const storedAfterCap = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(storedAfterCap.map((message) => message.content)).toEqual(["seed user", "seed assistant"]);
+    expect(storedAfterCap).toHaveLength(52);
+    expect(storedAfterCap.slice(0, 2).map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    expect(storedAfterCap[2]?.content).toBe("missing tail 0");
+    expect(storedAfterCap[51]?.content).toBe("missing tail 49");
 
     const secondBootstrapState = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);
     expect(secondBootstrapState).toEqual(staleBootstrapState);
 
+    // The next pass drains the remaining backlog and completes reconcile.
     const reconcileSpy = vi.spyOn(engine as any, "reconcileSessionTail");
     const third = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     expect(third).toEqual({
-      bootstrapped: false,
-      importedMessages: 0,
-      reason: "reconcile import capped",
+      bootstrapped: true,
+      importedMessages: 10,
+      reason: "reconciled missing session messages",
     });
     expect(reconcileSpy).toHaveBeenCalledTimes(1);
+
+    const storedAfterDrain = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(storedAfterDrain).toHaveLength(62);
+    expect(storedAfterDrain[61]?.content).toBe("missing tail 59");
   });
 
   it("uses the live ingest path for initial bootstrap", async () => {

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -925,4 +925,108 @@ describe("stale entry-id adoption after host history rewrites", () => {
     expect(rows.map((row) => row.content)).toEqual(["hello", "hi there", "hello"]);
     expect(rows.map((row) => row.transcript_entry_id)).toEqual(["a", "b", "c"]);
   });
+
+  it("drains an over-cap id-bearing new epoch via chunked no-anchor import, then entry-id takeover", async () => {
+    const sessionFile = createSessionFilePath("chunked-new-epoch");
+    const entryWithParent = (
+      id: string,
+      parentId: string | null,
+      role: AgentMessage["role"],
+      text: string,
+    ) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId,
+        timestamp: new Date().toISOString(),
+        message: { role, content: [{ type: "text", text }] },
+      });
+    const epochLines = (headerId: string, idPrefix: string, textPrefix: string) => [
+      headerLine(headerId),
+      ...Array.from({ length: 60 }, (_, index) =>
+        entryWithParent(
+          `${idPrefix}${index}`,
+          index === 0 ? null : `${idPrefix}${index - 1}`,
+          index % 2 === 0 ? "user" : "assistant",
+          `${textPrefix} ${index}`,
+        ),
+      ),
+    ];
+    writeFileSync(
+      sessionFile,
+      epochLines("chunked-epoch-one", "a", "old turn").join("\n") + "\n",
+      "utf8",
+    );
+
+    const logLines: string[] = [];
+    const logCapture = (message: unknown) => {
+      logLines.push(String(message));
+    };
+    const tempDir = createTempDir("lcm-chunked-epoch-");
+    const config = createTestConfig(join(tempDir, "lcm.db"));
+    const deps = createTestDeps(config);
+    deps.log = { info: logCapture, warn: logCapture, error: logCapture, debug: logCapture };
+    const engine = new LcmContextEngine(deps, createLcmDatabaseConnection(config.databasePath));
+    const sessionId = "chunked-new-epoch";
+    await engine.bootstrap({ sessionId, sessionFile });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const conversationId = conversation!.conversationId;
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(60);
+
+    // Declared rollover to an epoch that shares no content with the DB
+    // (e.g. a successor whose kept tail was fully rewritten): no content
+    // anchor exists and 60 id-bearing candidates exceed the cap (50). The
+    // first pass must import a bounded chunk instead of freezing.
+    writeFileSync(
+      sessionFile,
+      epochLines("chunked-epoch-two", "b", "rewritten turn longer text").join("\n") + "\n",
+      "utf8",
+    );
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    expect(
+      logLines.some((line) =>
+        line.includes(
+          "no-anchor entry-id import cap chunking for conversation=1 session=chunked-new-epoch — importing 50/60 new-epoch messages this pass",
+        ),
+      ),
+      "first pass logs the no-anchor chunk",
+    ).toBe(true);
+    const afterFirstPass = await readRows(engine, conversationId);
+    expect(afterFirstPass, "first pass imports exactly one bounded chunk").toHaveLength(110);
+    expect(afterFirstPass[60]?.transcript_entry_id).toBe("b0");
+    expect(afterFirstPass[109]?.transcript_entry_id).toBe("b49");
+
+    // Second pass: the persisted b-ids give the entry-id planner an anchor,
+    // so the remaining backlog drains through the anchored entry-id path.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const afterSecondPass = await readRows(engine, conversationId);
+    expect(afterSecondPass, "no duplicates across the chunked drain").toHaveLength(120);
+    expect(afterSecondPass.slice(60).map((row) => row.transcript_entry_id)).toEqual(
+      Array.from({ length: 60 }, (_, index) => `b${index}`),
+    );
+
+    // Third pass is a no-op: everything is persisted and the checkpoint has
+    // advanced past the rollover.
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+    expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(120);
+  });
 });


### PR DESCRIPTION
## What
When a transcript reconcile finds a missing tail larger than the import cap, it now imports a bounded oldest-first chunk per pass instead of aborting with zero imports — on every path where lineage is verified. Repeated passes converge (the growing message count raises the cap) while the checkpoint/frontier stays un-advanced until the backlog fully drains. Rebased onto the entry-id reconciliation rework (#854) and extended to cover its paths.

## Why
Production incident (phaedrus, conversation 1 / agent:main:main): the transcript backlog grew past the cap once, and from then on every turn logged "import cap exceeded … Aborting to prevent flood", imported nothing, and skipped afterTurn persistence — permanent silent data loss with a backlog (1,700+ messages) growing faster than the cap ever could. Refusing a verified backlog forever protects nothing; bounding per-pass volume preserves the flood protection the cap was built for.

## Changes
- Content-anchored slow path: chunks `transcriptImportCap(existing)` oldest messages per pass (lineage proven by identity anchor)
- Entry-id anchored path (#854): same chunking — lineage proven by the id anchor, every import individually id-verified
- No-anchor new-epoch path: chunks ONLY when every candidate bears an entry id (id-exact imports, duplicates impossible by the unique index, adoption heals after the first chunk); non-id-bearing no-anchor floods still block entirely
- `blockedByImportCap` stays true on partial passes — checkpoint/frontier held until the backlog drains; bootstrap reports partial progress
- Replay, duplicate-transcript, and cross-conversation raw-id guards unchanged (raw-id guard runs per chunk before import)
- Telemetry: "import cap chunking", "entry-id import cap chunking", "no-anchor entry-id import cap chunking" warn lines with per-pass counts, `capped=` on path debug lines

## Testing
- `npx vitest run --dir test`: 1266 tests green
- `test/bootstrap-flood-regression.test.ts`: capped passes import exactly one bounded chunk; repeated passes fully drain 200 backlog messages with zero duplicates
- `test/transcript-entry-id.test.ts`: chunking + convergence + frontier-hold regressions for the entry-id and id-bearing no-anchor paths
- Checkpoint-non-advancement regression in `test/engine.test.ts`
- On phaedrus this self-heals frozen anchored backlogs within a few turns; watch for the chunking warn lines followed by normal path lines