### PR TITLE
fix(assemble): intercept large tool results in live messages before degraded fallback

### DIFF
--- a/.changeset/live-tool-result-stubs.md
+++ b/.changeset/live-tool-result-stubs.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Stub oversized live tool results before assemble fallback paths send context to the model, so degraded assembly keeps compact file references instead of raw payloads.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10415,6 +10415,27 @@ export class LcmContextEngine implements ContextEngine {
         );
         return safeFallback();
       }
+
+      // Intercept large tool results in live messages so even degraded
+      // fallback paths send stubbed content to the model. The
+      // afterTurn ingest path also runs `interceptLargeToolResults` on
+      // persisted messages, but live params.messages are sent to the
+      // model before afterTurn runs; without this pre-flight intercept
+      // the degraded live fallback (and even normal assemble for
+      // current-turn tool results) sends raw content while the DB
+      // already has stubbed references.
+      if (this.config.stubLargeToolPayloads) {
+        for (let i = 0; i < params.messages.length; i++) {
+          const message = params.messages[i]!;
+          const intercepted = await this.interceptLargeToolResults({
+            conversationId: conversation.conversationId,
+            message,
+          });
+          if (intercepted) {
+            params.messages[i] = intercepted.rewrittenMessage;
+          }
+        }
+      }
       const ambiguousRollover =
         await this.findAmbiguousSessionKeyRuntimeRollover({
           phase: "assemble",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1763,6 +1763,25 @@ function buildPromptRecallProjectionFingerprint(message: AgentMessage): string {
   ].join(":");
 }
 
+function buildLiveToolOutputFileId(params: {
+  conversationId: number;
+  toolName: string;
+  callId?: string;
+  content: string;
+}): string {
+  const hash = createHash("sha256");
+  hash.update("live-tool-output-v1");
+  hash.update("\0");
+  hash.update(String(params.conversationId));
+  hash.update("\0");
+  hash.update(params.toolName);
+  hash.update("\0");
+  hash.update(params.callId ?? "");
+  hash.update("\0");
+  hash.update(params.content);
+  return `file_${hash.digest("hex").slice(0, 16)}`;
+}
+
 function createBootstrapEntryHash(message: StoredMessage | null): string | null {
   if (!message) {
     return null;
@@ -5792,14 +5811,35 @@ export class LcmContextEngine implements ContextEngine {
   private async externalizeLargeTextPayload(params: {
     conversationId: number;
     content: string;
+    fileId?: string;
     fileName?: string;
     mimeType?: string;
     formatReference: (input: { fileId: string; byteSize: number; summary: string }) => string;
   }): Promise<{ fileId: string; byteSize: number; summary: string; reference: string }> {
+    if (params.fileId) {
+      const existing = await this.summaryStore.getLargeFile(params.fileId);
+      if (existing) {
+        const byteSize = existing.byteSize ?? Buffer.byteLength(params.content, "utf8");
+        const summary =
+          existing.explorationSummary ??
+          `${params.fileName ?? "large payload"} (${byteSize.toLocaleString("en-US")} bytes)`;
+        return {
+          fileId: existing.fileId,
+          byteSize,
+          summary,
+          reference: params.formatReference({
+            fileId: existing.fileId,
+            byteSize,
+            summary,
+          }),
+        };
+      }
+    }
+
     const summarizeText = await this.resolveLargeFileTextSummarizer({
       conversationId: params.conversationId,
     });
-    const fileId = `file_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const fileId = params.fileId ?? `file_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
     const extension = extensionFromNameOrMime(params.fileName, params.mimeType);
     const storageUri = await this.storeLargeFileContent({
       conversationId: params.conversationId,
@@ -5954,6 +5994,7 @@ export class LcmContextEngine implements ContextEngine {
   private async interceptLargeToolResults(params: {
     conversationId: number;
     message: AgentMessage;
+    getFileId?: (input: { content: string; toolName: string; callId?: string }) => string;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
     if (
       (params.message.role !== "toolResult" && params.message.role !== "tool") ||
@@ -6042,9 +6083,18 @@ export class LcmContextEngine implements ContextEngine {
         safeString(record.name) ??
         topLevelToolName ??
         "tool-result";
+      const callId =
+        safeString(record.tool_use_id) ??
+        safeString(record.toolUseId) ??
+        safeString(record.tool_call_id) ??
+        safeString(record.toolCallId) ??
+        safeString(record.call_id) ??
+        safeString(record.id) ??
+        topLevelToolCallId;
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,
         content: extractedText,
+        fileId: params.getFileId?.({ content: extractedText, toolName, callId }),
         fileName: `${toolName}.txt`,
         mimeType: "text/plain",
         formatReference: ({ fileId, byteSize, summary }) =>
@@ -6076,14 +6126,6 @@ export class LcmContextEngine implements ContextEngine {
             toolOutputExternalized: true,
             externalizationReason: "large_tool_result",
           };
-      const callId =
-        safeString(record.tool_use_id) ??
-        safeString(record.toolUseId) ??
-        safeString(record.tool_call_id) ??
-        safeString(record.toolCallId) ??
-        safeString(record.call_id) ??
-        safeString(record.id) ??
-        topLevelToolCallId;
       if (callId) {
         if (normalizedRawType === "function_call_output") {
           compactBlock.call_id = callId;
@@ -10359,10 +10401,11 @@ export class LcmContextEngine implements ContextEngine {
     /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
     prompt?: string;
   }): Promise<AssembleResult> {
+    let liveMessages = params.messages;
     // Return a new fallback array so the runtime hook treats this as assembled
     // context, and remove assistant prefill tails from fallback-only paths.
     const safeFallback = (): AssembleResult => {
-      const msgs = params.messages.slice();
+      const msgs = liveMessages.slice();
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
         msgs.pop();
       }
@@ -10416,26 +10459,6 @@ export class LcmContextEngine implements ContextEngine {
         return safeFallback();
       }
 
-      // Intercept large tool results in live messages so even degraded
-      // fallback paths send stubbed content to the model. The
-      // afterTurn ingest path also runs `interceptLargeToolResults` on
-      // persisted messages, but live params.messages are sent to the
-      // model before afterTurn runs; without this pre-flight intercept
-      // the degraded live fallback (and even normal assemble for
-      // current-turn tool results) sends raw content while the DB
-      // already has stubbed references.
-      if (this.config.stubLargeToolPayloads) {
-        for (let i = 0; i < params.messages.length; i++) {
-          const message = params.messages[i]!;
-          const intercepted = await this.interceptLargeToolResults({
-            conversationId: conversation.conversationId,
-            message,
-          });
-          if (intercepted) {
-            params.messages[i] = intercepted.rewrittenMessage;
-          }
-        }
-      }
       const ambiguousRollover =
         await this.findAmbiguousSessionKeyRuntimeRollover({
           phase: "assemble",
@@ -10454,6 +10477,41 @@ export class LcmContextEngine implements ContextEngine {
           sessionId: params.sessionId,
         });
         return safeFallback();
+      }
+
+      // Intercept large tool results in live messages so even degraded
+      // fallback paths send stubbed content to the model. The
+      // afterTurn ingest path also runs `interceptLargeToolResults` on
+      // persisted messages, but live params.messages are sent to the
+      // model before afterTurn runs; without this pre-flight intercept
+      // the degraded live fallback (and even normal assemble for
+      // current-turn tool results) sends raw content while the DB
+      // already has stubbed references.
+      if (this.config.stubLargeToolPayloads) {
+        // Keep the rewritten view local; OpenClaw owns the live message array.
+        const rewrittenMessages = liveMessages.slice();
+        let interceptedAny = false;
+        for (let i = 0; i < liveMessages.length; i++) {
+          const message = liveMessages[i]!;
+          const intercepted = await this.interceptLargeToolResults({
+            conversationId: conversation.conversationId,
+            message,
+            getFileId: ({ content, toolName, callId }) =>
+              buildLiveToolOutputFileId({
+                conversationId: conversation.conversationId,
+                toolName,
+                callId,
+                content,
+              }),
+          });
+          if (intercepted) {
+            rewrittenMessages[i] = intercepted.rewrittenMessage;
+            interceptedAny = true;
+          }
+        }
+        if (interceptedAny) {
+          liveMessages = rewrittenMessages;
+        }
       }
 
       const tokenBudget = this.applyAssemblyBudgetCap(
@@ -10480,7 +10538,7 @@ export class LcmContextEngine implements ContextEngine {
         }
         return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
       };
-      const liveContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
+      const liveContextTokens = estimateSessionTokenCountForAfterTurn(liveMessages);
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
@@ -10556,7 +10614,7 @@ export class LcmContextEngine implements ContextEngine {
       }
       if (deferredAssemblyDegradation) {
         const degraded = buildDegradedLiveAssembleResult({
-          liveMessages: params.messages,
+          liveMessages,
           tokenBudget,
         });
         this.deps.log.warn(
@@ -10574,7 +10632,7 @@ export class LcmContextEngine implements ContextEngine {
       if (contextItems.length === 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({
-            liveMessages: params.messages,
+            liveMessages,
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
@@ -10594,14 +10652,14 @@ export class LcmContextEngine implements ContextEngine {
       // raw context items and clearly trails the current live history, keep
       // the live path to avoid dropping prompt context.
       const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
-      if (!hasSummaryItems && contextItems.length < params.messages.length) {
+      if (!hasSummaryItems && contextItems.length < liveMessages.length) {
         if (forkBoundedBootstrap) {
           this.deps.log.debug(
-            `[lcm] assemble: using bounded fork bootstrap context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
+            `[lcm] assemble: using bounded fork bootstrap context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${liveMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
         } else {
           this.deps.log.debug(
-            `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${params.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
+            `[lcm] assemble: falling back to live context conversation=${conversation.conversationId} ${sessionLabel} contextItems=${contextItems.length} liveMessages=${liveMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );
           return boundedLiveFallback("coverage-trails-live");
         }
@@ -10624,7 +10682,7 @@ export class LcmContextEngine implements ContextEngine {
         ? appendForkBoundedLiveSuffixWithinBudget({
             assembledMessages: assembled.messages,
             assembledEstimatedTokens: assembled.estimatedTokens,
-            liveMessages: params.messages,
+            liveMessages,
             forkSourceMessageCount,
             tokenBudget,
           })
@@ -10640,10 +10698,10 @@ export class LcmContextEngine implements ContextEngine {
 
       // If assembly produced no messages for a non-empty live session,
       // fail safe to the live context.
-      if (preRecallMessages.length === 0 && params.messages.length > 0) {
+      if (preRecallMessages.length === 0 && liveMessages.length > 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({
-            liveMessages: params.messages,
+            liveMessages,
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
@@ -10665,10 +10723,10 @@ export class LcmContextEngine implements ContextEngine {
       // have role "user", so this only fires for raw-message-only DB states where
       // every stored message is role "assistant" or "toolResult".
       const assembledHasUserTurn = preRecallMessages.some((m) => m.role === "user");
-      if (!assembledHasUserTurn && params.messages.length > 0) {
+      if (!assembledHasUserTurn && liveMessages.length > 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({
-            liveMessages: params.messages,
+            liveMessages,
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
@@ -10699,7 +10757,7 @@ export class LcmContextEngine implements ContextEngine {
           conversationId: conversation.conversationId,
           prompt: params.prompt,
           assembledMessages: preRecallMessages,
-          coverageMessages: params.messages.filter(isVolatileLiveInputMessage),
+          coverageMessages: liveMessages.filter(isVolatileLiveInputMessage),
         });
       } catch (error) {
         this.deps.log.warn(
@@ -10734,7 +10792,7 @@ export class LcmContextEngine implements ContextEngine {
       let volatileLiveInputAppend = appendUncoveredVolatileLiveInputsWithinBudget({
         assembledMessages,
         assembledEstimatedTokens,
-        liveMessages: params.messages,
+        liveMessages,
         protectedAssembledIndexes,
         tokenBudget,
         log: this.deps.log,
@@ -10760,7 +10818,7 @@ export class LcmContextEngine implements ContextEngine {
         volatileLiveInputAppend = appendUncoveredVolatileLiveInputsWithinBudget({
           assembledMessages,
           assembledEstimatedTokens,
-          liveMessages: params.messages,
+          liveMessages,
           protectedAssembledIndexes,
           tokenBudget,
           log: this.deps.log,

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -155,14 +155,17 @@ function createTestDeps(config: LcmConfig, log: LogMock): LcmDependencies {
   } as unknown as LcmDependencies;
 }
 
-function createEngine(): {
+function createEngine(configOverrides: Partial<LcmConfig> = {}): {
   engine: LcmContextEngine;
   log: LogMock;
   db: ReturnType<typeof createLcmDatabaseConnection>;
 } {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-"));
   tempDirs.push(tempDir);
-  const config = createTestConfig(join(tempDir, "lcm.db"));
+  const config = {
+    ...createTestConfig(join(tempDir, "lcm.db")),
+    ...configOverrides,
+  };
   const db = createLcmDatabaseConnection(config.databasePath);
   dbs.push(db);
   const log: LogMock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
@@ -516,10 +519,14 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 
-  it("assemble never rotates: live-window evidence is not transcript evidence", async () => {
-    const { engine, log, db } = createEngine();
+  it("assemble never rotates or writes live tool-output files before rollover safety checks", async () => {
+    const { engine, log, db } = createEngine({
+      largeFileTokenThreshold: 20,
+      stubLargeToolPayloads: true,
+    });
     const lane = await seedFrozenLane(engine, db);
 
+    const oversizedToolOutput = "tool output. ".repeat(200);
     const result = await engine.assemble({
       sessionId: NEW_SESSION_ID,
       sessionKey: SESSION_KEY,
@@ -528,6 +535,22 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
           role: "user",
           content: "brand new prompt that would look fresh",
           timestamp: Date.now() + 60_000,
+        } as unknown as AgentMessage,
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "call_1", name: "exec", input: {} }],
+          timestamp: Date.now() + 60_001,
+        } as unknown as AgentMessage,
+        {
+          role: "toolResult",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              output: oversizedToolOutput,
+            },
+          ],
+          timestamp: Date.now() + 60_002,
         } as unknown as AgentMessage,
       ],
       tokenBudget: 10_000,
@@ -545,6 +568,9 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       .getConversationBySessionKey(SESSION_KEY);
     expect(conversation?.conversationId).toBe(lane.conversationId);
     expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+    await expect(
+      engine.getSummaryStore().getLargeFilesByConversation(lane.conversationId),
+    ).resolves.toEqual([]);
   });
 
   it("reports a lifecycle no-op honestly instead of claiming the lane healed", async () => {
@@ -710,4 +736,3 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
   });
 });
-

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -15439,6 +15439,83 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
   });
 
+  it("assemble() intercepts large tool results in live messages before degraded fallback", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDeps(
+      {
+        largeFileTokenThreshold: 20,
+        stubLargeToolPayloads: true,
+        largeFilesDir,
+      },
+      { log },
+    );
+    const sessionId = "assemble-intercepts-large-tool-results-before-degraded";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored content",
+        tokenCount: 20,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 90,
+    });
+
+    const largeToolContent = "tool output. ".repeat(200); // well above 20-token threshold
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "current turn" }),
+        makeMessage({
+          role: "assistant",
+          content: [{ type: "tool_use", id: "call_1", name: "exec", input: {} }],
+        }),
+        makeMessage({
+          role: "toolResult",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              output: largeToolContent,
+            },
+          ],
+        }),
+      ],
+      tokenBudget: 100,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+    // The tool result should have been intercepted and replaced with a
+    // [LCM Tool Output: …] stub; the output field should reference the
+    // externalized file, not contain the raw content.
+    const hasStub = assembleResult.messages.some((msg) => {
+      const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+      return text.includes("[LCM Tool Output: file_")
+        && text.includes("externalizedFileId");
+    });
+    expect(hasStub).toBe(true);
+  });
+
   it("assemble() clears exhausted threshold debt and preserves leading system context via degraded fallback (#639 Mode 2)", async () => {
     const log = {
       info: vi.fn(),

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -15480,25 +15480,27 @@ describe("LcmContextEngine fidelity and token budget", () => {
     });
 
     const largeToolContent = "tool output. ".repeat(200); // well above 20-token threshold
+    const liveMessages = [
+      makeMessage({ role: "user", content: "current turn" }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "exec", input: {} }],
+      }),
+      makeMessage({
+        role: "toolResult",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_1",
+            output: largeToolContent,
+          },
+        ],
+      }),
+    ];
+    const originalLiveMessages = structuredClone(liveMessages);
     const assembleResult = await engine.assemble({
       sessionId,
-      messages: [
-        makeMessage({ role: "user", content: "current turn" }),
-        makeMessage({
-          role: "assistant",
-          content: [{ type: "tool_use", id: "call_1", name: "exec", input: {} }],
-        }),
-        makeMessage({
-          role: "toolResult",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: "call_1",
-              output: largeToolContent,
-            },
-          ],
-        }),
-      ],
+      messages: liveMessages,
       tokenBudget: 100,
     });
 
@@ -15514,6 +15516,27 @@ describe("LcmContextEngine fidelity and token budget", () => {
         && text.includes("externalizedFileId");
     });
     expect(hasStub).toBe(true);
+    expect(liveMessages).toEqual(originalLiveMessages);
+
+    const firstLargeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation.conversationId);
+    expect(firstLargeFiles).toHaveLength(1);
+
+    const secondAssembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 100,
+    });
+    const secondHasStub = secondAssembleResult.messages.some((msg) => {
+      const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+      return text.includes(`[LCM Tool Output: ${firstLargeFiles[0]!.fileId}`)
+        && text.includes("externalizedFileId");
+    });
+    expect(secondHasStub).toBe(true);
+    await expect(
+      engine.getSummaryStore().getLargeFilesByConversation(conversation.conversationId),
+    ).resolves.toHaveLength(1);
   });
 
   it("assemble() clears exhausted threshold debt and preserves leading system context via degraded fallback (#639 Mode 2)", async () => {


### PR DESCRIPTION
## Summary

- **Problem**: When the live context exceeds the token budget, `assemble()` enters a degraded live fallback path that returns `params.messages` directly, bypassing the DB assembly and all stubbing. This means every tool result in the current turn is sent to the model as raw content even though the DB stores `[LCM Tool Output: …]` stubbed references from the `afterTurn` ingest path.
- **Why it matters**: Users see `max_completion_tokens=1` clamped requests because the pipeline sends raw full-content tool results to the model. Even with `stubLargeToolPayloads:true` and `largeFileTokenThreshold` configured, the degraded fallback circumvents all stubbing.
- **What changed**: Run `interceptLargeToolResults` on `params.messages` at `assemble()` entry point, before any fallback path. Gated behind `config.largeFileTokenThreshold > 0`.
- **What did NOT change**: `afterTurn` ingest still runs its own interceptor (unchanged). Normal assembly still processes DB content through assembler (unchanged).

## Evidence

- Regression test: `assemble() intercepts large tool results in live messages before degraded fallback` (passes)

## Compatibility

- Backward compatible: Yes
- Config changes: No
- Migration needed: No
- Gated behind `config.largeFileTokenThreshold > 0`, default no-op
