### PR TITLE
fix: resolve ambiguous session-key rollovers via fresh-transcript rotation

### DIFF
--- a/.changeset/ambiguous-rollover-fresh-rotation.md
+++ b/.changeset/ambiguous-rollover-fresh-rotation.md
@@ -1,0 +1,29 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Resolve ambiguous session-key runtime rollovers when the new transcript is provably fresh.
+
+When a runtime session rolls to a new sessionId while the key's conversation
+still tracks an existing transcript file, the ambiguity guard froze the lane
+entirely: no adoption, no rotation, no persistence — indefinitely. On a live
+instance two agent main lanes ran frozen for a week, silently recording
+nothing while their transcripts grew.
+
+bootstrap and afterTurn now attempt a tier-2 resolution using full-transcript
+evidence: when the rolled transcript is provably fresh — every entry carries
+a usable timestamp (message or envelope) postdating the conversation's last
+persisted message, and no entry's identity overlaps the conversation's recent
+persisted history — the rollover is a legitimate reset, so the old
+conversation is archived (fully preserved and queryable) and the new session
+binds and bootstraps normally. Freshness is judged on content+time evidence,
+never transcript size, so lanes that ran frozen for days self-heal on their
+first turn after upgrade. Anything short of proof (overlap, stale or missing
+timestamps, no comparable persisted content) stays frozen exactly as before,
+and a rotation that lands as a lifecycle no-op is reported honestly instead
+of claiming the lane healed. assemble deliberately does NOT rotate: it only
+sees the host's live window, which is not transcript evidence.
+
+Telemetry: "ambiguous rollover resolved by fresh-transcript rotation",
+"ambiguous rollover not provably fresh (freshness=...)", and "rotation had
+no effect" warn lines.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7883,6 +7883,15 @@ export class LcmContextEngine implements ContextEngine {
     lastPersistedAt: Date | null;
     firstCandidateAt: number | null;
   }> {
+    if (isLikelyInjectedDeliveryOnlyTranscript(params.candidateMessages)) {
+      return {
+        fresh: false,
+        reason: "delivery-only-synthetic-transcript",
+        lastPersistedAt: null,
+        firstCandidateAt: null,
+      };
+    }
+
     // Every candidate must carry a usable timestamp (message timestamp or
     // transcript envelope timestamp); any untimestamped entry means the
     // transcript's age cannot be proven, so fail closed.
@@ -7957,11 +7966,13 @@ export class LcmContextEngine implements ContextEngine {
         firstCandidateAt,
       };
     }
+    let checkedCandidateIdentity = false;
     for (const message of params.candidateMessages) {
       const stored = toStoredMessage(message);
       if (stored.content.trim().length === 0) {
         continue;
       }
+      checkedCandidateIdentity = true;
       if (persistedIdentities.has(messageIdentity(stored.role, stored.content))) {
         return {
           fresh: false,
@@ -7970,6 +7981,14 @@ export class LcmContextEngine implements ContextEngine {
           firstCandidateAt,
         };
       }
+    }
+    if (!checkedCandidateIdentity) {
+      return {
+        fresh: false,
+        reason: "no-comparable-candidate-content",
+        lastPersistedAt: lastPersisted.createdAt,
+        firstCandidateAt,
+      };
     }
 
     return { fresh: true, reason: "fresh", lastPersistedAt: lastPersisted.createdAt, firstCandidateAt };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -89,6 +89,7 @@ import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 import {
   extractBootstrapMessageCandidate,
   getTranscriptEntryId,
+  getTranscriptEntryMeta,
   isBootstrapMessage,
   parseBootstrapJsonl,
   readAppendedLeafPathMessages,
@@ -132,6 +133,13 @@ const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
 const AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON =
   "ambiguous session-key runtime rollover";
+/**
+ * How many recent persisted messages an ambiguous-rollover freshness check
+ * compares against the new transcript. Wide enough that a continuation of
+ * this conversation cannot plausibly avoid every recent message, small
+ * enough to stay cheap on conversations with thousands of rows.
+ */
+const AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW = 50;
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
@@ -3289,7 +3297,8 @@ type TranscriptReconcileResult = {
     | "import-cap"
     | "cross-conversation-raw-id"
     | "duplicate-transcript-replay"
-    | "ambiguous-session-key-runtime-rollover";
+    | "ambiguous-session-key-runtime-rollover"
+    | "ambiguous-rollover-rotated-fresh-transcript";
   importedMessages: number;
   hasOverlap: boolean;
   /**
@@ -7376,6 +7385,26 @@ export class LcmContextEngine implements ContextEngine {
                 checkpointEntryHash: activeBootstrapState?.lastProcessedEntryHash,
               });
             if (!hasFrontierAnchor) {
+              // Tier-2 resolution: archive the frozen conversation and
+              // create the replacement now. This turn's persistence is
+              // skipped (unsafe-to-advance), and the next turn reconciles
+              // the full transcript into the fresh conversation.
+              const rotatedForFreshTranscript =
+                await this.rotateAmbiguousRolloverForProvablyFreshTranscript({
+                  phase: "afterTurn",
+                  sessionId: params.sessionId,
+                  rollover: ambiguousRollover,
+                  candidateMessages: historicalMessages,
+                  createReplacement: true,
+                });
+              if (rotatedForFreshTranscript) {
+                return {
+                  importedMessages: 0,
+                  blockedByImportCap: false,
+                  blockedReason: "ambiguous-rollover-rotated-fresh-transcript",
+                  hasOverlap: false,
+                };
+              }
               this.logAmbiguousSessionKeyRuntimeRollover({
                 phase: "afterTurn",
                 rollover: ambiguousRollover,
@@ -7836,6 +7865,183 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  /**
+   * Judge whether the new runtime's transcript is provably FRESH relative to
+   * a key-conflicting conversation: zero identity overlap with the
+   * conversation's recent persisted history AND every timestamped candidate
+   * entry postdates the conversation's last persisted message. Freshness is
+   * judged on content+time evidence — never on transcript size — so lanes
+   * that ran frozen for days (and accumulated history) still qualify.
+   * Fails closed on missing evidence.
+   */
+  private async evaluateAmbiguousRolloverFreshness(params: {
+    conversationId: number;
+    candidateMessages: AgentMessage[];
+  }): Promise<{
+    fresh: boolean;
+    reason: string;
+    lastPersistedAt: Date | null;
+    firstCandidateAt: number | null;
+  }> {
+    // Every candidate must carry a usable timestamp (message timestamp or
+    // transcript envelope timestamp); any untimestamped entry means the
+    // transcript's age cannot be proven, so fail closed.
+    let firstCandidateAt: number | null = null;
+    for (const message of params.candidateMessages) {
+      const ts = (message as { timestamp?: unknown }).timestamp;
+      let resolved: number | null =
+        typeof ts === "number" && Number.isFinite(ts) && ts > 0 ? ts : null;
+      if (resolved === null) {
+        const envelopeTimestamp = getTranscriptEntryMeta(message)?.timestamp;
+        if (typeof envelopeTimestamp === "string") {
+          const parsed = Date.parse(envelopeTimestamp);
+          if (Number.isFinite(parsed) && parsed > 0) {
+            resolved = parsed;
+          }
+        }
+      }
+      if (resolved === null) {
+        return {
+          fresh: false,
+          reason: "candidate-missing-timestamp",
+          lastPersistedAt: null,
+          firstCandidateAt,
+        };
+      }
+      firstCandidateAt = firstCandidateAt === null ? resolved : Math.min(firstCandidateAt, resolved);
+    }
+    if (firstCandidateAt === null) {
+      return {
+        fresh: false,
+        reason: "no-candidate-timestamps",
+        lastPersistedAt: null,
+        firstCandidateAt,
+      };
+    }
+
+    const lastPersisted = await this.conversationStore.getLastMessage(params.conversationId);
+    if (!lastPersisted) {
+      // Nothing persisted to protect: time evidence alone is sufficient and
+      // archiving an empty conversation is harmless.
+      return { fresh: true, reason: "empty-conversation", lastPersistedAt: null, firstCandidateAt };
+    }
+    if (firstCandidateAt <= lastPersisted.createdAt.getTime()) {
+      return {
+        fresh: false,
+        reason: "candidate-entries-predate-last-persisted",
+        lastPersistedAt: lastPersisted.createdAt,
+        firstCandidateAt,
+      };
+    }
+
+    // Identity overlap against the recent persisted tail. Empty stored
+    // content (pure tool rows) is skipped on both sides: it matches
+    // trivially and proves nothing about lineage.
+    const recentPersisted = await this.conversationStore.getLastMessages(
+      params.conversationId,
+      AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW,
+    );
+    const persistedIdentities = new Set<string>();
+    for (const record of recentPersisted) {
+      if (record.content.trim().length > 0) {
+        persistedIdentities.add(messageIdentity(record.role, record.content));
+      }
+    }
+    if (persistedIdentities.size === 0) {
+      // Nothing comparable persisted (e.g. only empty tool rows): the
+      // overlap test would pass vacuously, which is not proof. Fail closed.
+      return {
+        fresh: false,
+        reason: "no-comparable-persisted-content",
+        lastPersistedAt: lastPersisted.createdAt,
+        firstCandidateAt,
+      };
+    }
+    for (const message of params.candidateMessages) {
+      const stored = toStoredMessage(message);
+      if (stored.content.trim().length === 0) {
+        continue;
+      }
+      if (persistedIdentities.has(messageIdentity(stored.role, stored.content))) {
+        return {
+          fresh: false,
+          reason: "identity-overlap-with-persisted-history",
+          lastPersistedAt: lastPersisted.createdAt,
+          firstCandidateAt,
+        };
+      }
+    }
+
+    return { fresh: true, reason: "fresh", lastPersistedAt: lastPersisted.createdAt, firstCandidateAt };
+  }
+
+  /**
+   * Tier-2 resolution for ambiguous session-key runtime rollovers
+   * (lossless-claw-30b.8): a provably fresh new transcript means the
+   * rollover is a legitimate reset, not a foreign transcript sharing the
+   * key. Archive the old conversation (fully preserved and queryable) so
+   * the new session can bind and bootstrap normally instead of leaving the
+   * lane frozen outside LCM indefinitely. Returns true when rotated;
+   * false leaves the existing freeze-and-preserve behavior in place.
+   */
+  private async rotateAmbiguousRolloverForProvablyFreshTranscript(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    sessionId: string;
+    rollover: AmbiguousSessionKeyRuntimeRollover;
+    candidateMessages: AgentMessage[];
+    createReplacement: boolean;
+  }): Promise<boolean> {
+    let verdict: Awaited<ReturnType<LcmContextEngine["evaluateAmbiguousRolloverFreshness"]>>;
+    try {
+      verdict = await this.evaluateAmbiguousRolloverFreshness({
+        conversationId: params.rollover.conversationId,
+        candidateMessages: params.candidateMessages,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: ambiguous rollover freshness check failed conversation=${params.rollover.conversationId} error=${describeLogError(err)}`,
+      );
+      return false;
+    }
+    if (!verdict.fresh) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
+      );
+      return false;
+    }
+
+    await this.applySessionReplacement({
+      reason: `${params.phase} ambiguous rollover fresh-transcript rotation`,
+      sessionId: params.rollover.activeSessionId,
+      sessionKey: params.rollover.sessionKey,
+      nextSessionId: params.sessionId,
+      nextSessionKey: params.rollover.sessionKey,
+      createReplacement: params.createReplacement,
+    });
+    // Postcondition: applySessionReplacement has internal no-op paths (e.g.
+    // a fresh lifecycle row is left in place). Claiming "resolved" while the
+    // key is still bound to the old session would hide a live freeze behind
+    // healed-looking logs, so verify the binding actually moved.
+    const bindingAfter = await this.conversationStore.getConversationBySessionKey(
+      params.rollover.sessionKey,
+    );
+    if (
+      bindingAfter &&
+      bindingAfter.conversationId === params.rollover.conversationId &&
+      bindingAfter.sessionId === params.rollover.activeSessionId
+    ) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: ambiguous rollover rotation had no effect (lifecycle no-op) conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId}; leaving lane frozen`,
+      );
+      return false;
+    }
+
+    this.deps.log.warn(
+      `[lcm] ${params.phase}: ambiguous rollover resolved by fresh-transcript rotation conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId} candidateMessages=${params.candidateMessages.length} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
+    );
+    return true;
+  }
+
   private async transcriptContainsCurrentConversationTailAnchor(params: {
     conversationId: number;
     historicalMessages: AgentMessage[];
@@ -7975,17 +8181,31 @@ export class LcmContextEngine implements ContextEngine {
                 checkpointEntryHash: activeBootstrapState?.lastProcessedEntryHash,
               });
             if (!hasFrontierAnchor) {
-              this.logAmbiguousSessionKeyRuntimeRollover({
-                phase: "bootstrap",
-                rollover: ambiguousRollover,
-                sessionId: params.sessionId,
-                sessionFile: params.sessionFile,
-              });
-              return {
-                bootstrapped: false,
-                importedMessages: 0,
-                reason: AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON,
-              };
+              // Tier-2 resolution: a provably fresh new transcript means
+              // this is a legitimate reset; archive the old conversation
+              // and fall through so getOrCreateConversation below binds the
+              // new session and the initial import ingests its transcript.
+              const rotatedForFreshTranscript =
+                await this.rotateAmbiguousRolloverForProvablyFreshTranscript({
+                  phase: "bootstrap",
+                  sessionId: params.sessionId,
+                  rollover: ambiguousRollover,
+                  candidateMessages: preloadedHistoricalMessages,
+                  createReplacement: false,
+                });
+              if (!rotatedForFreshTranscript) {
+                this.logAmbiguousSessionKeyRuntimeRollover({
+                  phase: "bootstrap",
+                  rollover: ambiguousRollover,
+                  sessionId: params.sessionId,
+                  sessionFile: params.sessionFile,
+                });
+                return {
+                  bootstrapped: false,
+                  importedMessages: 0,
+                  reason: AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON,
+                };
+              }
             }
           }
 
@@ -9259,7 +9479,11 @@ export class LcmContextEngine implements ContextEngine {
       transcriptReconcileResult.blockedByImportCap ||
       (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
     const transcriptReconcileBlockedByAmbiguousRollover =
-      transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover";
+      transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover" ||
+      // Rotated-fresh skips this turn the same way: the replacement
+      // conversation is empty, so telemetry/compaction work below would run
+      // against it for nothing; the next turn binds and reconciles normally.
+      transcriptReconcileResult.blockedReason === "ambiguous-rollover-rotated-fresh-transcript";
     let dedupedNewMessages: AgentMessage[] = [];
     if (transcriptReconcileUnsafeToAdvance) {
       if (newMessages.length > 0 || params.autoCompactionSummary) {
@@ -9729,6 +9953,11 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
         });
       if (ambiguousRollover) {
+        // No tier-2 resolution here: assemble only sees the host's live
+        // window (often just the new prompt), which is not transcript
+        // evidence — judging freshness on it could wrongly archive a
+        // continuing conversation. bootstrap/afterTurn heal with the full
+        // transcript file on the next call.
         this.logAmbiguousSessionKeyRuntimeRollover({
           phase: "assemble",
           rollover: ambiguousRollover,

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -238,7 +238,7 @@ async function seedFrozenLane(
  */
 function writeRolledTranscript(params: {
   name: string;
-  entries: Array<{ role: string; text: string; timestamp?: number }>;
+  entries: Array<{ role: string; text?: string; content?: unknown; timestamp?: number }>;
 }): string {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-file-"));
   tempDirs.push(tempDir);
@@ -253,7 +253,7 @@ function writeRolledTranscript(params: {
       timestamp: new Date(entry.timestamp ?? Date.now()).toISOString(),
       message: {
         role: entry.role,
-        content: [{ type: "text", text: entry.text }],
+        content: entry.content ?? [{ type: "text", text: entry.text ?? "" }],
         ...(entry.timestamp !== undefined ? { timestamp: entry.timestamp } : {}),
       },
     });
@@ -432,6 +432,88 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       .getConversationStore()
       .getConversationBySessionKey(SESSION_KEY);
     expect(conversation?.conversationId).toBe(lane.conversationId);
+  });
+
+  it("stays frozen when the rolled transcript contains only delivery/config traffic", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-delivery-only`,
+      entries: [
+        {
+          role: "system",
+          text: "delivery-mirror: delivered pending runtime notification",
+          timestamp: Date.now() + 60_000,
+        },
+        {
+          role: "system",
+          text: "config audit: refreshed runtime delivery settings",
+          timestamp: Date.now() + 60_001,
+        },
+      ],
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=delivery-only-synthetic-transcript"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("stays frozen when the rolled transcript has no comparable message content", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-empty-content`,
+      entries: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu-empty", name: "noop", input: {} }],
+          timestamp: Date.now() + 60_000,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "reasoning", text: "private chain" }],
+          timestamp: Date.now() + 60_001,
+        },
+      ],
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=no-comparable-candidate-content"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 
   it("assemble never rotates: live-window evidence is not transcript evidence", async () => {

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -1,0 +1,510 @@
+/**
+ * Regression tests for tier-2 ambiguous-rollover resolution (lossless-claw-30b.8).
+ *
+ * Live incident shape (phaedrus, conversations 1 and 4): the runtime session
+ * under a key rolled to a new sessionId while the old conversation's tracked
+ * transcript file still existed. The ambiguous-rollover guard froze every
+ * bootstrap/assemble/afterTurn — no adoption, no rotation — leaving the lane
+ * outside LCM indefinitely while its transcript grew.
+ *
+ * Policy under test: when the new transcript is PROVABLY FRESH — zero
+ * identity overlap with the frozen conversation's recent persisted history
+ * and every timestamped entry postdating its last persisted message — the
+ * rollover resolves by archive-and-rotate. Freshness is content+time
+ * evidence, never transcript size, so lanes frozen for days (aged, with
+ * accumulated history) still heal. Anything short of proof stays frozen.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { LcmDependencies } from "../src/types.js";
+
+const tempDirs: string[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const db of dbs.splice(0)) {
+    try {
+      closeLcmConnection(db);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTestConfig(databasePath: string): LcmConfig {
+  return {
+    enabled: true,
+    databasePath,
+    largeFilesDir: join(databasePath, "..", "lcm-files"),
+    ignoreSessionPatterns: [],
+    statelessSessionPatterns: [],
+    skipStatelessSessions: true,
+    contextThreshold: 0.75,
+    freshTailCount: 4,
+    promptAwareEviction: false,
+    stubLargeToolPayloads: false,
+    newSessionRetainDepth: 2,
+    leafMinFanout: 8,
+    condensedMinFanout: 4,
+    condensedMinFanoutHard: 2,
+    sweepMaxDepth: 1,
+    incrementalMaxDepth: 0,
+    maxSweepIterations: 12,
+    sweepDeadlineMs: 120_000,
+    compactUntilUnderDeadlineMs: 300_000,
+    leafChunkTokens: 20_000,
+    leafTargetTokens: 600,
+    condensedTargetTokens: 900,
+    maxExpandTokens: 4000,
+    largeFileTokenThreshold: 25_000,
+    summaryProvider: "",
+    summaryModel: "",
+    largeFileSummaryProvider: "",
+    largeFileSummaryModel: "",
+    expansionProvider: "",
+    expansionModel: "",
+    delegationTimeoutMs: 120_000,
+    summaryTimeoutMs: 60_000,
+    timezone: "UTC",
+    pruneHeartbeatOk: false,
+    transcriptGcEnabled: false,
+    enableSummaryThinking: true,
+    proactiveThresholdCompactionMode: "deferred",
+    autoRotateSessionFiles: {
+      enabled: true,
+      createBackups: false,
+      sizeBytes: 2 * 1024 * 1024,
+      startup: "rotate",
+      runtime: "rotate",
+    },
+    independentLogFile: {
+      enabled: false,
+      maxFileBytes: 100 * 1024 * 1024,
+    },
+    summaryMaxOverageFactor: 3,
+    customInstructions: "",
+    circuitBreakerThreshold: 5,
+    circuitBreakerCooldownMs: 1_800_000,
+    replayFloodThresholdExternal: 3,
+    replayFloodThresholdInternal: 32,
+    fallbackProviders: [],
+    cacheAwareCompaction: {
+      enabled: true,
+      cacheTTLSeconds: 300,
+      maxColdCacheCatchupPasses: 2,
+      hotCachePressureFactor: 4,
+      hotCacheBudgetHeadroomRatio: 0.2,
+      coldCacheObservationThreshold: 3,
+      criticalBudgetPressureRatio: 0.9,
+    },
+    dynamicLeafChunkTokens: {
+      enabled: true,
+      max: 40_000,
+    },
+    stripInjectedContextTags: [],
+  };
+}
+
+function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: string } | null {
+  const trimmed = sessionKey.trim();
+  if (!trimmed.startsWith("agent:")) {
+    return null;
+  }
+  const parts = trimmed.split(":");
+  if (parts.length < 3) {
+    return null;
+  }
+  return { agentId: parts[1] ?? "main", suffix: parts.slice(2).join(":") };
+}
+
+type LogMock = {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+};
+
+function createTestDeps(config: LcmConfig, log: LogMock): LcmDependencies {
+  return {
+    config,
+    complete: vi.fn(async () => ({
+      content: [{ type: "text", text: "summary output" }],
+    })),
+    callGateway: vi.fn(async () => ({})),
+    resolveModel: vi.fn(() => ({ provider: "anthropic", model: "claude-opus-4-5" })),
+    parseAgentSessionKey,
+    isSubagentSessionKey: (sessionKey: string) => sessionKey.includes(":subagent:"),
+    normalizeAgentId: (id?: string) => (id?.trim() ? id : "main"),
+    buildSubagentSystemPrompt: () => "subagent prompt",
+    readLatestAssistantReply: () => undefined,
+    resolveAgentDir: () => tmpdir(),
+    resolveSessionIdFromSessionKey: async () => undefined,
+    resolveSessionTranscriptFile: async () => undefined,
+    agentLaneSubagent: "subagent",
+    log,
+  } as unknown as LcmDependencies;
+}
+
+function createEngine(): {
+  engine: LcmContextEngine;
+  log: LogMock;
+  db: ReturnType<typeof createLcmDatabaseConnection>;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-"));
+  tempDirs.push(tempDir);
+  const config = createTestConfig(join(tempDir, "lcm.db"));
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  const log: LogMock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const engine = new LcmContextEngine(createTestDeps(config, log), db);
+  return { engine, log, db };
+}
+
+function createTempFile(name: string, contents = ""): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-files-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, name);
+  writeFileSync(file, contents);
+  return file;
+}
+
+function makeMessage(role: string, content: string, timestamp: number): AgentMessage {
+  return { role, content, timestamp } as unknown as AgentMessage;
+}
+
+const SESSION_KEY = "agent:main:main";
+const OLD_SESSION_ID = "old-session-1debb14a";
+const NEW_SESSION_ID = "new-session-043c1ec8";
+
+/**
+ * Builds the aged frozen-lane shape from the live incident: an active
+ * conversation pinned to OLD_SESSION_ID under SESSION_KEY with a week-old
+ * persisted history WIDER than the freshness overlap window (so healing
+ * cannot depend on lane size), and a bootstrap checkpoint tracking a
+ * transcript file that still exists and differs from whatever the new
+ * runtime presents.
+ */
+async function seedFrozenLane(
+  engine: LcmContextEngine,
+  db: ReturnType<typeof createLcmDatabaseConnection>,
+  messageCount = 60,
+): Promise<{ conversationId: number; persistedContents: string[]; trackedFile: string }> {
+  const persistedContents = Array.from(
+    { length: messageCount },
+    (_, index) => `frozen lane turn ${index} about deployment details`,
+  );
+  const base = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const [index, content] of persistedContents.entries()) {
+    await engine.ingest({
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage(index % 2 === 0 ? "user" : "assistant", content, base + index),
+    });
+  }
+  const conversation = await engine
+    .getConversationStore()
+    .getConversationBySessionKey(SESSION_KEY);
+  expect(conversation).not.toBeNull();
+  // Age the lane for real: created_at is what the freshness time gate reads.
+  db.prepare("UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?").run(
+    conversation!.conversationId,
+  );
+  const trackedFile = createTempFile("old-rotated-transcript.jsonl", "{}\n");
+  await engine.getSummaryStore().upsertConversationBootstrapState({
+    conversationId: conversation!.conversationId,
+    sessionFilePath: trackedFile,
+    lastSeenSize: 3,
+    lastSeenMtimeMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
+    lastProcessedOffset: 3,
+    lastProcessedEntryHash: "0".repeat(64),
+  });
+  return { conversationId: conversation!.conversationId, persistedContents, trackedFile };
+}
+
+/**
+ * Write a rolled-session transcript as envelope JSONL directly (the
+ * `{type:"message", id, parentId, timestamp, message}` shape OpenClaw
+ * writes), chained by parentId so the leaf path covers every entry.
+ */
+function writeRolledTranscript(params: {
+  name: string;
+  entries: Array<{ role: string; text: string; timestamp?: number }>;
+}): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-file-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, `${params.name}.jsonl`);
+  let parentId: string | null = null;
+  const lines = params.entries.map((entry, index) => {
+    const id = `${params.name}-entry-${index}`;
+    const line = JSON.stringify({
+      type: "message",
+      id,
+      parentId,
+      timestamp: new Date(entry.timestamp ?? Date.now()).toISOString(),
+      message: {
+        role: entry.role,
+        content: [{ type: "text", text: entry.text }],
+        ...(entry.timestamp !== undefined ? { timestamp: entry.timestamp } : {}),
+      },
+    });
+    parentId = id;
+    return line;
+  });
+  writeFileSync(file, `${lines.join("\n")}\n`);
+  return file;
+}
+
+function freshEntries(count = 6): Array<{ role: string; text: string; timestamp: number }> {
+  const base = Date.now() + 60_000;
+  return Array.from({ length: count }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    text: `fresh rolled-session turn ${index}`,
+    timestamp: base + index,
+  }));
+}
+
+describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
+  it("bootstrap heals an aged frozen lane: archives it and imports the rolled transcript", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      entries: freshEntries(),
+    });
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBeGreaterThan(0);
+
+    // Old conversation archived, fully preserved.
+    const oldConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(OLD_SESSION_ID);
+    expect(oldConversation?.active).toBe(false);
+    const preserved = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(preserved.map((m) => m.content)).toEqual(lane.persistedContents);
+
+    // The key now binds the new session, with the transcript imported.
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    expect(rebound?.conversationId).not.toBe(lane.conversationId);
+    const imported = await engine.getConversationStore().getMessages(rebound!.conversationId);
+    expect(imported.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
+  });
+
+  it("afterTurn rotates the lane; the host's next bootstrap imports the transcript", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const entries = freshEntries(4);
+    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries });
+    const liveMessages = entries.map(
+      (entry) =>
+        ({
+          role: entry.role,
+          content: [{ type: "text", text: entry.text }],
+          timestamp: entry.timestamp,
+        }) as unknown as AgentMessage,
+    );
+
+    await engine.afterTurn({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+      messages: liveMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 10_000,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    const reboundAfterFirst = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(reboundAfterFirst?.sessionId).toBe(NEW_SESSION_ID);
+
+    // Production sequence: the host calls bootstrap before each run; with
+    // the rollover resolved it imports the rolled transcript.
+    const boot = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+    expect(boot.importedMessages).toBeGreaterThan(0);
+    const persisted = await engine
+      .getConversationStore()
+      .getMessages(reboundAfterFirst!.conversationId);
+    expect(persisted.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
+
+    const preserved = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(preserved.map((m) => m.content)).toEqual(lane.persistedContents);
+  });
+
+  it("stays frozen when the rolled transcript overlaps the lane's persisted history", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      entries: [
+        ...freshEntries(3),
+        // Same content as a recent persisted message: lineage is plausible,
+        // so the rollover is NOT provably fresh.
+        { role: "user", text: lane.persistedContents[56]!, timestamp: Date.now() + 90_000 },
+      ],
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("stays frozen when transcript timestamps predate the lane or are missing", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    // Message timestamps a month old: predate the week-old persisted lane.
+    const stale = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const staleFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-stale`,
+      entries: [{ role: "user", text: "suspiciously old entry", timestamp: stale }],
+    });
+    const staleResult = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: staleFile,
+    });
+    expect(staleResult.bootstrapped).toBe(false);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=candidate-entries-predate-last-persisted"),
+    );
+
+    // Bare-line transcript: no envelope, no message timestamp → fail closed.
+    const bareFile = createTempFile(
+      "bare-lines.jsonl",
+      `${JSON.stringify({ role: "user", content: [{ type: "text", text: "no timestamps at all" }] })}\n`,
+    );
+    const bareResult = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: bareFile,
+    });
+    expect(bareResult.bootstrapped).toBe(false);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=candidate-missing-timestamp"),
+    );
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+  });
+
+  it("assemble never rotates: live-window evidence is not transcript evidence", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    const result = await engine.assemble({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      messages: [
+        {
+          role: "user",
+          content: "brand new prompt that would look fresh",
+          timestamp: Date.now() + 60_000,
+        } as unknown as AgentMessage,
+      ],
+      tokenBudget: 10_000,
+    });
+
+    expect(result.messages.length).toBeGreaterThan(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("reports a lifecycle no-op honestly instead of claiming the lane healed", async () => {
+    const { engine, log } = createEngine();
+    // Empty conversation pinned to the old session: applySessionReplacement
+    // treats a fresh lifecycle row as a no-op, so rotation cannot land.
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(OLD_SESSION_ID, { sessionKey: SESSION_KEY });
+    const trackedFile = createTempFile("old-empty-tracked.jsonl", "{}\n");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: trackedFile,
+      lastSeenSize: 3,
+      lastSeenMtimeMs: Date.now() - 1000,
+      lastProcessedOffset: 3,
+      lastProcessedEntryHash: "0".repeat(64),
+    });
+
+    const entries = freshEntries(2);
+    const newSessionFile = writeRolledTranscript({ name: `${NEW_SESSION_ID}-noop`, entries });
+    await engine.afterTurn({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+      messages: entries.map(
+        (entry) =>
+          ({
+            role: entry.role,
+            content: [{ type: "text", text: entry.text }],
+            timestamp: entry.timestamp,
+          }) as unknown as AgentMessage,
+      ),
+      prePromptMessageCount: 0,
+      tokenBudget: 10_000,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("rotation had no effect"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+  });
+});


### PR DESCRIPTION
## What
Adds a tier-2 resolution to the ambiguous session-key runtime rollover guard. When a session rolls to a new sessionId while the key's conversation still tracks an existing transcript file, the guard previously froze the lane permanently (no adoption, no rotation, no persistence). Now `bootstrap` and `afterTurn` judge the rolled transcript against full-file evidence and, when it is **provably fresh**, archive the old conversation (fully preserved and queryable) so the new session binds and bootstraps normally.

## Why
Live incident (phaedrus): `agent:main:main` (conversation 1, frozen since 2026-06-03) and `agent:daft-ops:main` (conversation 4, since 2026-06-05) silently recorded nothing for a week — every turn logged "ambiguous session-key runtime rollover; preserving" and skipped persistence, while the unmanaged transcripts grew back toward the unbounded-prompt incident class. The guard's caution is correct when lineage is uncertain; the bug was resolving the dilemma by doing *neither* adopt nor rotate, forever. Both lanes were deliberately left frozen as the reproduction case for this fix and self-heal on their first turn after deploy.

## Changes
- Freshness proof: every transcript entry timestamped (message or envelope timestamp) after the conversation's last persisted message, plus zero identity overlap with its recent persisted history (50-message window, empty stored content excluded on both sides)
- Evidence is content+time, never transcript size — aged frozen lanes heal
- Fail-closed on missing timestamps, vacuous overlap windows, and predating entries
- Rotation postcondition check: a lifecycle no-op is reported honestly ("rotation had no effect"), never as healed
- `assemble` deliberately does NOT rotate — it only sees the host's live window, which is not transcript evidence (an earlier draft rotated there; adversarial review showed a single fresh prompt could wrongly archive a continuing conversation)
- Existing tier-1 adoption (tail-anchor continuation proof) and the freeze-by-default for genuinely ambiguous cases are unchanged

## Testing
- `npx vitest run --dir test`: 1251 tests green (includes the pre-existing fail-closed rollover regressions, unchanged)
- New `test/ambiguous-rollover-rotation.test.ts` (6 tests) pins: bootstrap heal with import, afterTurn rotate + next-bootstrap import, frozen-on-overlap, frozen-on-stale/missing-timestamps, assemble-never-rotates, honest lifecycle no-op — fixtures model the aged live lane (week-old rows, history wider than the overlap window)
- Live verification after deploy: expect "ambiguous rollover resolved by fresh-transcript rotation" once per frozen lane, then normal bootstrap imports; conversations 1 and 4 remain queryable archived