### PR TITLE
fix: exclude template noise from rollover freshness overlap check

### DIFF
--- a/.changeset/rollover-freshness-noise-exclusion.md
+++ b/.changeset/rollover-freshness-noise-exclusion.md
@@ -1,0 +1,21 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Exclude template noise from the ambiguous-rollover freshness overlap check.
+
+The tier-2 rollover resolution false-blocked on the very lane it was built
+for: a week-idle conversation whose entire recent history was synthetic
+heartbeat traffic. Every session's transcript contains identical
+"[OpenClaw heartbeat poll]" / "HEARTBEAT_OK" lines, so the identity-overlap
+test matched 46 heartbeat rows and reported plausible lineage where there
+was none.
+
+The overlap comparison now considers only lineage-discriminating content:
+synthetic heartbeat traffic and content that recurs within the window are
+excluded from both sides, and the window widens (50 -> 500) when the recent
+history yields nothing comparable. When even the widened window is pure
+template noise, the overlap test is acknowledged as no-signal and the
+strict per-entry time gate decides alone — every new entry must still
+postdate the conversation's last persisted message. Real unique-content
+overlap still freezes the lane exactly as before.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -144,6 +144,12 @@ const AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON =
  * enough to stay cheap on conversations with thousands of rows.
  */
 const AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW = 50;
+/**
+ * Widened fallback window used when the recent window contains no
+ * lineage-discriminating content (e.g. a lane that idled on heartbeat
+ * traffic before freezing).
+ */
+const AMBIGUOUS_ROLLOVER_OVERLAP_WIDE_WINDOW = 500;
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
@@ -8234,25 +8240,55 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
 
-    // Identity overlap against the recent persisted tail. Empty stored
-    // content (pure tool rows) is skipped on both sides: it matches
-    // trivially and proves nothing about lineage.
-    const recentPersisted = await this.conversationStore.getLastMessages(
-      params.conversationId,
+    // Identity overlap against recent persisted history. Only
+    // lineage-DISCRIMINATING content participates: synthetic heartbeat
+    // traffic and content that recurs within the window appear identically
+    // in every session and prove nothing (live incident: a week-idle lane's
+    // entire recent window was heartbeat polls, false-blocking the heal).
+    // Empty stored content (pure tool rows) is likewise skipped.
+    const collectDiscriminatingIdentities = async (window: number): Promise<Set<string>> => {
+      const records = await this.conversationStore.getLastMessages(
+        params.conversationId,
+        window,
+      );
+      const counts = new Map<string, number>();
+      for (const record of records) {
+        if (
+          record.content.trim().length === 0 ||
+          isHeartbeatNoiseContent(record.role, record.content)
+        ) {
+          continue;
+        }
+        const identity = messageIdentity(record.role, record.content);
+        counts.set(identity, (counts.get(identity) ?? 0) + 1);
+      }
+      const identities = new Set<string>();
+      for (const [identity, count] of counts) {
+        if (count === 1) {
+          identities.add(identity);
+        }
+      }
+      return identities;
+    };
+    let persistedIdentities = await collectDiscriminatingIdentities(
       AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW,
     );
-    const persistedIdentities = new Set<string>();
-    for (const record of recentPersisted) {
-      if (record.content.trim().length > 0) {
-        persistedIdentities.add(messageIdentity(record.role, record.content));
-      }
+    if (persistedIdentities.size === 0) {
+      persistedIdentities = await collectDiscriminatingIdentities(
+        AMBIGUOUS_ROLLOVER_OVERLAP_WIDE_WINDOW,
+      );
     }
     if (persistedIdentities.size === 0) {
-      // Nothing comparable persisted (e.g. only empty tool rows): the
-      // overlap test would pass vacuously, which is not proof. Fail closed.
+      // Even the widened window holds nothing but template noise: the
+      // overlap test has no signal in either direction. The per-entry time
+      // gate above already proved every new entry postdates the last
+      // persisted message — a transcript wholly created after persistence
+      // stopped cannot be a lost continuation of stored content. A wrongful
+      // rotation only archives (fully reversible, still queryable) while
+      // staying frozen silently loses data, so proceed on time evidence.
       return {
-        fresh: false,
-        reason: "no-comparable-persisted-content",
+        fresh: true,
+        reason: "fresh-time-evidence-only-no-comparable-history",
         lastPersistedAt: lastPersisted.createdAt,
         firstCandidateAt,
       };
@@ -8260,7 +8296,10 @@ export class LcmContextEngine implements ContextEngine {
     let checkedCandidateIdentity = false;
     for (const message of params.candidateMessages) {
       const stored = toStoredMessage(message);
-      if (stored.content.trim().length === 0) {
+      if (
+        stored.content.trim().length === 0 ||
+        isHeartbeatNoiseContent(stored.role, stored.content)
+      ) {
         continue;
       }
       checkedCandidateIdentity = true;
@@ -12601,6 +12640,19 @@ const OPENCLAW_HEARTBEAT_POLL = "[openclaw heartbeat poll]";
  */
 function isHeartbeatOkContent(content: string): boolean {
   return content.trim().toLowerCase() === HEARTBEAT_OK_TOKEN;
+}
+
+/**
+ * Synthetic heartbeat traffic (poll prompts and HEARTBEAT_OK acks) recurs
+ * identically in every session, so it can never discriminate lineage in
+ * the ambiguous-rollover freshness check.
+ */
+function isHeartbeatNoiseContent(role: string, content: string): boolean {
+  const normalized = content.trim().toLowerCase();
+  if (role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
+    return true;
+  }
+  return role === "assistant" && normalized === HEARTBEAT_OK_TOKEN;
 }
 
 function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -589,4 +589,125 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       expect.stringContaining("resolved by fresh-transcript rotation"),
     );
   });
+  it("heals a heartbeat-idle lane on time evidence alone (live conv-1 shape)", async () => {
+    const { engine, log, db } = createEngine();
+    // The lane's entire recent history is synthetic heartbeat traffic —
+    // the live incident shape: no lineage-discriminating content at all.
+    const heartbeatContents: Array<{ role: string; content: string }> = [];
+    for (let index = 0; index < 60; index += 1) {
+      heartbeatContents.push(
+        index % 2 === 0
+          ? { role: "user", content: "[OpenClaw heartbeat poll]" }
+          : { role: "assistant", content: "HEARTBEAT_OK" },
+      );
+    }
+    const base = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    for (const [index, entry] of heartbeatContents.entries()) {
+      await engine.ingest({
+        sessionId: OLD_SESSION_ID,
+        sessionKey: SESSION_KEY,
+        message: makeMessage(entry.role, entry.content, base + index),
+      });
+    }
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation).not.toBeNull();
+    db.prepare(
+      "UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?",
+    ).run(conversation!.conversationId);
+    const trackedFile = createTempFile("old-heartbeat-tracked.jsonl", "{}\n");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: trackedFile,
+      lastSeenSize: 3,
+      lastSeenMtimeMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      lastProcessedOffset: 3,
+      lastProcessedEntryHash: "0".repeat(64),
+    });
+
+    // The rolled transcript also carries heartbeat polls (every session
+    // does) plus genuinely new content.
+    const rolledBase = Date.now() + 60_000;
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-heartbeat-idle`,
+      entries: [
+        { role: "user", text: "[OpenClaw heartbeat poll]", timestamp: rolledBase },
+        { role: "assistant", text: "HEARTBEAT_OK", timestamp: rolledBase + 1 },
+        { role: "user", text: "real new work after the roll", timestamp: rolledBase + 2 },
+      ],
+    });
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    // The heartbeat history is archived intact, not deleted.
+    const preserved = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(preserved).toHaveLength(60);
+  });
+
+  it("heartbeat polls and recurring template content never block the heal", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+    // Add recurring template noise on top of the unique history: heartbeat
+    // polls and a thrice-repeated boilerplate line.
+    const base = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    const noise = [
+      { role: "user", content: "[OpenClaw heartbeat poll]" },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "Daily status template line" },
+      { role: "user", content: "[OpenClaw heartbeat poll]" },
+      { role: "user", content: "Daily status template line" },
+      { role: "user", content: "Daily status template line" },
+    ];
+    for (const [index, entry] of noise.entries()) {
+      await engine.ingest({
+        sessionId: OLD_SESSION_ID,
+        sessionKey: SESSION_KEY,
+        message: makeMessage(entry.role, entry.content, base + index),
+      });
+    }
+    db.prepare(
+      "UPDATE messages SET created_at = datetime('now', '-6 days') WHERE conversation_id = ?",
+    ).run(lane.conversationId);
+
+    // The rolled transcript shares ONLY the template noise — heartbeats and
+    // the recurring boilerplate — plus fresh content. No unique overlap.
+    const rolledBase = Date.now() + 60_000;
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-template-noise`,
+      entries: [
+        { role: "user", text: "[OpenClaw heartbeat poll]", timestamp: rolledBase },
+        { role: "user", text: "Daily status template line", timestamp: rolledBase + 1 },
+        { role: "user", text: "fresh post-roll question", timestamp: rolledBase + 2 },
+      ],
+    });
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+  });
 });
+


### PR DESCRIPTION
## What
Makes the tier-2 rollover freshness check (#864) compare identity overlap on lineage-discriminating content only. Synthetic heartbeat traffic and content that recurs within the comparison window are excluded from both sides; the window widens (50 → 500) when the recent history yields nothing comparable; and when even the widened window is pure template noise, the overlap test is treated as no-signal and the strict per-entry time gate decides alone.

## Why
Live verification after deploying #864 to phaedrus: the heal false-blocked on the exact lane it was built for. `agent:main:main` idled on heartbeats before freezing — its entire recent persisted window (checked out to 500 rows) is `[OpenClaw heartbeat poll]` / `HEARTBEAT_OK` lines, and every session's transcript contains the identical strings. The overlap check matched 46 heartbeat rows and reported `identity-overlap-with-persisted-history`, i.e. plausible lineage from content that appears in literally every session and proves nothing.

## Changes
- Heartbeat poll/ack content excluded from both sides of the overlap comparison
- Intra-window recurring identities excluded (repeats are template noise, not lineage)
- Window widens 50 → 500 when no discriminating content found
- Provably non-discriminating history → proceed on the per-entry time gate alone (`freshness=fresh-time-evidence-only-no-comparable-history`); rationale: a transcript wholly created after persistence stopped cannot be a lost continuation, and a wrongful rotation only archives (reversible) while freezing silently loses data
- Real unique-content overlap still freezes exactly as before

## Testing
- `npx vitest run --dir test`: 1276 tests green
- New regressions model the live shape: a 60-row all-heartbeat lane heals on time evidence; heartbeats + thrice-repeated boilerplate shared with the rolled transcript never block; unique-content overlap still freezes
- Live evidence in PR #864's deploy notes: `freshness=identity-overlap-with-persisted-history lastPersistedAt=2026-06-03 firstCandidateAt=2026-06-09` on conv 1 with all 46 overlaps being heartbeat polls