### PR TITLE
fix: judge append-only transcript imports by entry id, not content identity

### DIFF
--- a/.changeset/entry-id-aware-append-guard.md
+++ b/.changeset/entry-id-aware-append-guard.md
@@ -1,0 +1,22 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Judge append-only transcript imports by entry id, not content identity.
+
+A tool loop that re-issues a byte-identical tool call every iteration made
+the append-only import guard declare each appended pair "already persisted"
+(content identity matched the previous iteration), forcing a full transcript
+re-read per tool call while the covered-frontier alignment refused every
+runtime batch — reconcile churned on every iteration of the loop while the
+model's context stopped advancing (live incident lossless-claw-3071).
+
+The guard now reasons in transcript entry ids: a fresh entry id is a new
+entry regardless of content. Full reconciliation is still required for the
+three cases that genuinely need it — an already-persisted entry id (replay),
+a fresh id whose content matches an unstamped persisted row (flush-lag
+catch-up that must adopt, not duplicate), and an entry reparenting onto a
+non-tip persisted entry (host suffix rewrite needing stale-id re-stamping).
+Parents unknown to the DB (pruned rows, replay-filtered entries) are treated
+as genuine continuation since the append-only checkpoint already verified
+the file prefix.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6225,19 +6225,119 @@ export class LcmContextEngine implements ContextEngine {
   private async appendOnlyMessagesOverlapPersistedTranscript(params: {
     conversationId: number;
     messages: AgentMessage[];
+    /**
+     * The appended slice BEFORE replay/heartbeat filtering. Filtered-out
+     * entries are legitimate parents for surviving entries, so the linear-
+     * chain check consults their ids to avoid false rewrite verdicts.
+     */
+    unfilteredMessages?: AgentMessage[];
     sessionContext: string;
     source: string;
   }): Promise<boolean> {
+    // Entry-id-bearing messages are judged by id, not content identity: a
+    // fresh entry id is a NEW entry even when its content is byte-identical
+    // to persisted history. Repeated identical tool calls are legitimate
+    // (lossless-claw-3071: a tool loop re-reading the same file made the
+    // identity check scream "already persisted" every iteration, forcing a
+    // full re-read per tool call). Two cases still defer to full
+    // reconciliation: an already-persisted entry id (genuine replay), and a
+    // fresh id whose content matches an UNSTAMPED persisted row (flush-lag
+    // catch-up — the full path adopts the id onto that row instead of
+    // importing a duplicate).
+    const idLessMessages: AgentMessage[] = [];
+    let persistedEntryIdOverlaps = 0;
+    let adoptableFlushLagOverlaps = 0;
+    for (const message of params.messages) {
+      const entryId = getTranscriptEntryId(message);
+      if (entryId === null) {
+        idLessMessages.push(message);
+        continue;
+      }
+      if (
+        await this.conversationStore.hasMessageByTranscriptEntryId(
+          params.conversationId,
+          entryId,
+        )
+      ) {
+        persistedEntryIdOverlaps += 1;
+        continue;
+      }
+      const stored = toStoredMessage(message);
+      if (
+        await this.conversationStore.hasUnstampedMessageByIdentity(
+          params.conversationId,
+          stored.role,
+          stored.content,
+        )
+      ) {
+        adoptableFlushLagOverlaps += 1;
+      }
+    }
+    if (persistedEntryIdOverlaps > 0 || adoptableFlushLagOverlaps > 0) {
+      this.deps.log.warn(
+        `[lcm] transcript import guard: ${params.source} found ${persistedEntryIdOverlaps} already-persisted transcript entry ids and ${adoptableFlushLagOverlaps} adoptable flush-lagged identities across ${params.messages.length} messages for ${params.sessionContext}; falling back to full reconciliation`,
+      );
+      return true;
+    }
+    // Fresh ids must also EXTEND the persisted tail rather than branch from
+    // an ancestor: a host history rewrite re-issues content under new ids by
+    // reparenting onto an OLDER persisted entry, and those entries need the
+    // full path's stale-id re-stamping, not a blind append. The rewrite
+    // signature is a parent that IS persisted but is NOT the tip and not
+    // part of this appended slice. Parents unknown to the DB are benign —
+    // the append-only checkpoint already verified the file prefix, and
+    // pruned rows, replay-filtered entries, and flush gaps all leave
+    // unknown-parent links that are genuine continuation.
+    if (params.messages.length > idLessMessages.length) {
+      const newestPersistedEntryId = await this.conversationStore.getNewestTranscriptEntryId(
+        params.conversationId,
+      );
+      if (newestPersistedEntryId !== null) {
+        const sliceEntryIds = new Set<string>();
+        for (const message of params.unfilteredMessages ?? params.messages) {
+          const entryId = getTranscriptEntryMeta(message)?.entryId;
+          if (entryId) {
+            sliceEntryIds.add(entryId);
+          }
+        }
+        for (const message of params.messages) {
+          const meta = getTranscriptEntryMeta(message);
+          const parentId = meta?.parentId ?? null;
+          if (
+            parentId === null ||
+            parentId === newestPersistedEntryId ||
+            sliceEntryIds.has(parentId)
+          ) {
+            continue;
+          }
+          if (
+            await this.conversationStore.hasMessageByTranscriptEntryId(
+              params.conversationId,
+              parentId,
+            )
+          ) {
+            this.deps.log.warn(
+              `[lcm] transcript import guard: ${params.source} appended entry reparents onto a non-tip persisted entry (suffix rewrite) for ${params.sessionContext}; falling back to full reconciliation`,
+            );
+            return true;
+          }
+        }
+      }
+    }
+    if (idLessMessages.length === 0) {
+      return false;
+    }
+
     const overlaps = await this.countPersistedTranscriptIdentityOverlaps({
       conversationId: params.conversationId,
-      messages: params.messages,
+      messages: idLessMessages,
     });
     if (overlaps === 0) {
       return false;
     }
 
     this.deps.log.warn(
-      `[lcm] transcript import guard: ${params.source} found ${overlaps}/${params.messages.length} already-persisted message identities for ${params.sessionContext}; falling back to full reconciliation`,
+      `[lcm] transcript import guard: ${params.source} found ${overlaps}/${idLessMessages.length} already-persisted message identities (id-less entries) for ${params.sessionContext}; falling back to full reconciliation`,
     );
     return true;
   }
@@ -7518,6 +7618,7 @@ export class LcmContextEngine implements ContextEngine {
             const appendOnlyOverlapsPersisted = await this.appendOnlyMessagesOverlapPersistedTranscript({
               conversationId: conversation.conversationId,
               messages: replayFilteredMessages,
+              unfilteredMessages: appended.messages,
               sessionContext: appendOnlySessionContext,
               source: "afterTurn transcript reconcile append-only",
             });
@@ -8661,6 +8762,7 @@ export class LcmContextEngine implements ContextEngine {
                 const appendOnlyOverlapsPersisted = await this.appendOnlyMessagesOverlapPersistedTranscript({
                   conversationId,
                   messages: replayFilteredMessages,
+                  unfilteredMessages: appended.messages,
                   sessionContext: appendOnlySessionContext,
                   source: "bootstrap append-only",
                 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -144,6 +144,13 @@ const AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON =
  * enough to stay cheap on conversations with thousands of rows.
  */
 const AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW = 50;
+/**
+ * How deep into the conversation tail a flush-lagged runtime row can sit.
+ * Flush lag is a same-turn phenomenon (the runtime persisted a row moments
+ * before the transcript caught up), so matches deeper than this are legacy
+ * unstamped rows, not flush lag.
+ */
+const FLUSH_LAG_ADOPTION_TAIL_WINDOW = 16;
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CircuitBreakerState = {
@@ -6271,10 +6278,11 @@ export class LcmContextEngine implements ContextEngine {
         continue;
       }
       if (
-        await this.conversationStore.hasUnstampedMessageByIdentity(
+        await this.conversationStore.hasRecentUnstampedMessageByIdentity(
           params.conversationId,
           stored.role,
           stored.content,
+          FLUSH_LAG_ADOPTION_TAIL_WINDOW,
         )
       ) {
         adoptableFlushLagOverlaps += 1;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -6263,6 +6263,13 @@ export class LcmContextEngine implements ContextEngine {
         continue;
       }
       const stored = toStoredMessage(message);
+      // Empty stored content (pure tool-call rows) matches trivially against
+      // legacy unstamped rows and proves nothing — and "adopting" onto a
+      // random old empty row would mis-stamp it. Only non-empty identities
+      // indicate a real flush-lagged runtime row.
+      if (stored.content.trim().length === 0) {
+        continue;
+      }
       if (
         await this.conversationStore.hasUnstampedMessageByIdentity(
           params.conversationId,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -916,28 +916,40 @@ export class ConversationStore {
   }
 
   /**
-   * Whether an identity-matching row exists that has NOT been stamped with a
-   * transcript entry id — i.e. a flush-lagged runtime row that a transcript
-   * catch-up entry should adopt instead of importing a duplicate.
+   * Whether an identity-matching row WITHIN THE TAIL WINDOW exists that has
+   * NOT been stamped with a transcript entry id — i.e. a flush-lagged
+   * runtime row (persisted moments ago, always tail-adjacent) that a
+   * transcript catch-up entry should adopt instead of importing a
+   * duplicate. Legacy pre-migration rows deeper in history also lack entry
+   * ids but are NOT flush lag; matching them would defer every repeated
+   * content and mis-target adoption.
    */
-  async hasUnstampedMessageByIdentity(
+  async hasRecentUnstampedMessageByIdentity(
     conversationId: ConversationId,
     role: MessageRole,
     content: string,
+    tailWindow: number,
   ): Promise<boolean> {
     const identityHash = buildMessageIdentityHash(role, content);
     const row = this.db
       .prepare(
         `SELECT 1 AS found
-       FROM messages
-       WHERE conversation_id = ?
-         AND transcript_entry_id IS NULL
+       FROM (
+         SELECT message_id, transcript_entry_id, identity_hash, role, content
+         FROM messages
+         WHERE conversation_id = ?
+         ORDER BY seq DESC
+         LIMIT ?
+       )
+       WHERE transcript_entry_id IS NULL
          AND identity_hash = ?
          AND role = ?
          AND content = ?
        LIMIT 1`,
       )
-      .get(conversationId, identityHash, role, content) as unknown as { found?: number } | undefined;
+      .get(conversationId, Math.max(1, Math.floor(tailWindow)), identityHash, role, content) as unknown as
+      | { found?: number }
+      | undefined;
     return row?.found === 1;
   }
 

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -901,6 +901,46 @@ export class ConversationStore {
     return row?.count ?? 0;
   }
 
+  /** Newest persisted transcript entry id (by seq), or null when none. */
+  async getNewestTranscriptEntryId(conversationId: ConversationId): Promise<string | null> {
+    const row = this.db
+      .prepare(
+        `SELECT transcript_entry_id AS id
+       FROM messages
+       WHERE conversation_id = ? AND transcript_entry_id IS NOT NULL
+       ORDER BY seq DESC
+       LIMIT 1`,
+      )
+      .get(conversationId) as unknown as { id?: string } | undefined;
+    return row?.id ?? null;
+  }
+
+  /**
+   * Whether an identity-matching row exists that has NOT been stamped with a
+   * transcript entry id — i.e. a flush-lagged runtime row that a transcript
+   * catch-up entry should adopt instead of importing a duplicate.
+   */
+  async hasUnstampedMessageByIdentity(
+    conversationId: ConversationId,
+    role: MessageRole,
+    content: string,
+  ): Promise<boolean> {
+    const identityHash = buildMessageIdentityHash(role, content);
+    const row = this.db
+      .prepare(
+        `SELECT 1 AS found
+       FROM messages
+       WHERE conversation_id = ?
+         AND transcript_entry_id IS NULL
+         AND identity_hash = ?
+         AND role = ?
+         AND content = ?
+       LIMIT 1`,
+      )
+      .get(conversationId, identityHash, role, content) as unknown as { found?: number } | undefined;
+    return row?.found === 1;
+  }
+
   async countMessagesByIdentityHash(
     conversationId: ConversationId,
     role: MessageRole,

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -1030,3 +1030,145 @@ describe("stale entry-id adoption after host history rewrites", () => {
     expect(await engine.getConversationStore().getMessageCount(conversationId)).toBe(120);
   });
 });
+
+// ── lossless-claw-3071: repeated identical content must not defeat the
+// append-only import path ─────────────────────────────────────────────────────
+describe("repeated identical tool calls (lossless-claw-3071)", () => {
+  const header = JSON.stringify({
+    type: "session",
+    version: 3,
+    id: "repeat-loop-header",
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+  });
+  const entryLine = (
+    id: string,
+    parentId: string | null,
+    role: AgentMessage["role"],
+    text: string,
+  ) =>
+    JSON.stringify({
+      type: "message",
+      id,
+      parentId,
+      timestamp: new Date().toISOString(),
+      message: { role, content: [{ type: "text", text }] },
+    });
+
+  function engineWarn(engine: LcmContextEngine): ReturnType<typeof vi.fn> {
+    return (engine as unknown as { deps: { log: { warn: ReturnType<typeof vi.fn> } } }).deps.log
+      .warn;
+  }
+
+  it("imports byte-identical repeated turns once per entry id via the append-only path", async () => {
+    const sessionFile = createSessionFilePath("repeat-identical-turns");
+    // Live incident shape: a tool loop appends a byte-identical
+    // tool_use/result pair (fresh entry ids) every iteration. The old
+    // identity-based guard declared each appended pair "already persisted"
+    // and forced a full re-read per iteration.
+    const callText = "Read first 200 lines of SKILL.md";
+    const resultText = "---\nname: github\ndescription: GitHub CLI skill";
+
+    let parent: string | null = null;
+    let lines = `${header}\n`;
+    const appendPair = (iteration: number): void => {
+      const callId = `repeat-call-${iteration}`;
+      const resultId = `repeat-result-${iteration}`;
+      lines += `${entryLine(callId, parent, "assistant", callText)}\n`;
+      lines += `${entryLine(resultId, callId, "toolResult", resultText)}\n`;
+      parent = resultId;
+      writeFileSync(sessionFile, lines, "utf8");
+    };
+
+    const engine = createEngine();
+    const sessionId = "repeat-identical-turns";
+    const runtimePair = [
+      { role: "assistant", content: [{ type: "text", text: callText }] } as AgentMessage,
+      { role: "toolResult", content: [{ type: "text", text: resultText }] } as AgentMessage,
+    ];
+
+    for (let iteration = 1; iteration <= 4; iteration += 1) {
+      appendPair(iteration);
+      await engine.afterTurn({
+        sessionId,
+        sessionFile,
+        messages: runtimePair,
+        prePromptMessageCount: 0,
+      });
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationForSession({ sessionId });
+      const persisted = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      // Every iteration lands exactly its own pair: no refusal, no dupes.
+      expect(persisted).toHaveLength(iteration * 2);
+    }
+
+    // The append-only path must never have been disqualified by content
+    // identity: fresh entry ids are new entries by definition.
+    const fullReconcileFallbacks = engineWarn(engine).mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .filter((message: string) => message.includes("falling back to full reconciliation"));
+    expect(fullReconcileFallbacks).toEqual([]);
+  });
+
+  it("still falls back to full reconciliation when an appended entry id is already persisted", async () => {
+    const sessionFile = createSessionFilePath("repeat-replayed-entry-id");
+    let lines = `${header}\n${entryLine("replay-1", null, "user", "question one")}\n${entryLine(
+      "replay-2",
+      "replay-1",
+      "assistant",
+      "answer one",
+    )}\n`;
+    writeFileSync(sessionFile, lines, "utf8");
+
+    const engine = createEngine();
+    const sessionId = "repeat-replayed-entry-id";
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "question one" }] } as AgentMessage,
+        { role: "assistant", content: [{ type: "text", text: "answer one" }] } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    // A replay snapshot re-appends an ALREADY-persisted entry id: that is a
+    // genuine overlap and must still route through full reconciliation
+    // (which dedupes by id) instead of blind append-only ingest.
+    lines += `${entryLine("replay-2", "replay-1", "assistant", "answer one")}\n`;
+    lines += `${entryLine("replay-3", "replay-2", "user", "question two")}\n`;
+    writeFileSync(sessionFile, lines, "utf8");
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "question two" }] } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+    });
+
+    expect(
+      engineWarn(engine).mock.calls
+        .map((call: unknown[]) => String(call[0]))
+        .some((message: string) =>
+          message.includes("already-persisted transcript entry ids"),
+        ),
+    ).toBe(true);
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const persisted = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    // No duplicate rows from the replayed id; the new question imports once.
+    expect(persisted.map((message) => message.content)).toEqual([
+      "question one",
+      "answer one",
+      "question two",
+    ]);
+  });
+});

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -1171,4 +1171,67 @@ describe("repeated identical tool calls (lossless-claw-3071)", () => {
       "question two",
     ]);
   });
+
+  it("legacy unstamped empty-content rows do not false-flag flush-lag adoption", async () => {
+    const sessionFile = createSessionFilePath("repeat-empty-content-legacy");
+    // Conversation with a LEGACY unstamped empty-content assistant row (the
+    // stored shape of pre-migration pure tool-call messages). On the live
+    // incident lane, thousands of these matched every appended tool-call
+    // message by identity and forced full reconciliation per iteration.
+    const engine = createEngine();
+    const sessionId = "repeat-empty-content-legacy";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getConversationStore().createMessage({
+      conversationId: conversation.conversationId,
+      seq: 1,
+      role: "assistant",
+      content: "",
+      tokenCount: 0,
+    });
+    await engine.getConversationStore().createMessage({
+      conversationId: conversation.conversationId,
+      seq: 2,
+      role: "user",
+      content: "anchor question",
+      tokenCount: 4,
+    });
+
+    const callText = "";
+    let lines = `${header}\n${entryLine("legacy-1", null, "user", "anchor question")}\n`;
+    writeFileSync(sessionFile, lines, "utf8");
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    // Appended pure-tool-call pair: assistant content stores as empty.
+    lines += `${JSON.stringify({
+      type: "message",
+      id: "legacy-2",
+      parentId: "legacy-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_x", name: "read", arguments: { path: "f" } },
+        ],
+      },
+    })}\n${entryLine("legacy-3", "legacy-2", "toolResult", "file contents here")}\n`;
+    writeFileSync(sessionFile, lines, "utf8");
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+    });
+
+    const fallbacks = engineWarn(engine).mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .filter((message: string) => message.includes("falling back to full reconciliation"));
+    expect(fallbacks).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What
The append-only transcript import guard now reasons in transcript entry ids instead of content identity. A fresh entry id is a new entry regardless of content; full reconciliation is reserved for the three cases that genuinely need it: an already-persisted entry id (replay), a fresh id whose content matches an **unstamped** persisted row (flush-lag catch-up that must adopt rather than duplicate), and an entry reparenting onto a **non-tip persisted** entry (host suffix rewrite needing stale-id re-stamping).

## Why
Live incident (phaedrus, topic 683, lossless-claw-3071): a tool loop re-issued a byte-identical Read every ~5s. Each iteration's appended pair content-matched the previous iteration, so the identity-based guard declared it "already persisted" and forced a full transcript re-read per tool call, while covered-frontier alignment refused every runtime batch. The two halves of #854 fought each other: identity guards said "replay," the entry-id importer said "new" — per-iteration churn until the user aborted. Entry ids exist precisely to make this distinction; the guard just wasn't consulting them.

## Changes
- Entry-id-bearing appended messages: persisted-ness judged by `hasMessageByTranscriptEntryId`
- Flush-lag catch-up still defers (new `hasUnstampedMessageByIdentity` store helper) so adoption, not duplication, handles it
- Suffix-rewrite detection: parent pointing at a persisted entry that is neither the tip (`getNewestTranscriptEntryId`) nor in the appended slice → defer for stale-id re-stamping
- Parents unknown to the DB (pruned rows, replay-filtered entries, flush gaps) are genuine continuation — the append-only checkpoint already verified the file prefix
- Id-less entries keep the existing occurrence-aware identity check

## Testing
- `npx vitest run --dir test`: 1276 tests green — including the pre-existing rewrite re-stamping, flush-lag adoption, replay-prefix dropping, and heartbeat-prune fast-path regressions, all of which shaped the final guard rules
- New in `test/transcript-entry-id.test.ts`: byte-identical repeated turns import once per entry id through the append-only path with zero full-reconcile fallbacks (the incident shape), and a replayed already-persisted entry id still defers and dedupes