### PR TITLE
fix: preserve assembly while transcript coverage recovers

### DIFF
--- a/.changeset/placeholder-debt-assembly.md
+++ b/.changeset/placeholder-debt-assembly.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip deferred assembly debt degradation while placeholder transcript coverage is still recovering.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3395,6 +3395,13 @@ export class LcmContextEngine implements ContextEngine {
         return degraded;
       }
 
+      if (incompleteTranscriptCoverage) {
+        this.deps.log.warn(
+          `[lcm] assemble: bounded live fallback while transcript coverage recovers conversation=${conversation.conversationId} ${sessionLabel} reason=incomplete-transcript-coverage contextItems=${contextItems.length} liveMessages=${liveMessages.length} placeholderBootstrapState=${placeholderBootstrapState} hasSummaryItems=${hasSummaryItems} tokenBudget=${tokenBudget}`,
+        );
+        return boundedLiveFallback("incomplete-transcript-coverage");
+      }
+
       if (contextItems.length === 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3280,22 +3280,33 @@ export class LcmContextEngine implements ContextEngine {
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
-      const bootstrapState = await this.summaryStore.getConversationBootstrapState(
-        conversation.conversationId,
-      );
-      const forkBoundedBootstrap = bootstrapState?.forkBounded === true;
-      const forkSourceMessageCount = bootstrapState?.forkSourceMessageCount ?? 0;
-      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
-      const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
-      const placeholderBootstrapState =
-        bootstrapState !== null &&
-        bootstrapState.lastSeenSize === 0 &&
-        bootstrapState.lastSeenMtimeMs === 0 &&
-        bootstrapState.lastProcessedOffset === 0 &&
-        bootstrapState.lastProcessedEntryHash === null;
-      const incompleteTranscriptCoverage =
-        !hasSummaryItems &&
-        placeholderBootstrapState;
+      let forkBoundedBootstrap = false;
+      let forkSourceMessageCount = 0;
+      let contextItems: ContextItemRecord[] = [];
+      let hasSummaryItems = false;
+      let placeholderBootstrapState = false;
+      let incompleteTranscriptCoverage = false;
+      // Emergency compaction can rewrite context items before assemble proceeds,
+      // so keep this snapshot refreshable instead of relying on a stale read.
+      const refreshAssemblyContextSnapshot = async (): Promise<void> => {
+        const bootstrapState = await this.summaryStore.getConversationBootstrapState(
+          conversation.conversationId,
+        );
+        forkBoundedBootstrap = bootstrapState?.forkBounded === true;
+        forkSourceMessageCount = bootstrapState?.forkSourceMessageCount ?? 0;
+        contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+        hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
+        placeholderBootstrapState =
+          bootstrapState !== null &&
+          bootstrapState.lastSeenSize === 0 &&
+          bootstrapState.lastSeenMtimeMs === 0 &&
+          bootstrapState.lastProcessedOffset === 0 &&
+          bootstrapState.lastProcessedEntryHash === null;
+        incompleteTranscriptCoverage =
+          !hasSummaryItems &&
+          placeholderBootstrapState;
+      };
+      await refreshAssemblyContextSnapshot();
       let deferredAssemblyDegradation:
         | {
             reason:
@@ -3358,6 +3369,9 @@ export class LcmContextEngine implements ContextEngine {
               reason: "emergency-debt-exhausted",
               pressure,
             };
+          }
+          if (!latestMaintenance?.pending && !latestMaintenance?.running) {
+            await refreshAssemblyContextSnapshot();
           }
         } else if (pressure.pressureTokenCount > pressureThreshold) {
           deferredAssemblyDegradation = {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3280,6 +3280,22 @@ export class LcmContextEngine implements ContextEngine {
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
+      const bootstrapState = await this.summaryStore.getConversationBootstrapState(
+        conversation.conversationId,
+      );
+      const forkBoundedBootstrap = bootstrapState?.forkBounded === true;
+      const forkSourceMessageCount = bootstrapState?.forkSourceMessageCount ?? 0;
+      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+      const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
+      const placeholderBootstrapState =
+        bootstrapState !== null &&
+        bootstrapState.lastSeenSize === 0 &&
+        bootstrapState.lastSeenMtimeMs === 0 &&
+        bootstrapState.lastProcessedOffset === 0 &&
+        bootstrapState.lastProcessedEntryHash === null;
+      const incompleteTranscriptCoverage =
+        !hasSummaryItems &&
+        placeholderBootstrapState;
       let deferredAssemblyDegradation:
         | {
             reason:
@@ -3297,7 +3313,11 @@ export class LcmContextEngine implements ContextEngine {
           liveContextTokens,
           maintenance,
         });
-        if (pressure.pressureTokenCount > tokenBudget) {
+        if (incompleteTranscriptCoverage) {
+          this.deps.log.warn(
+            `[lcm] assemble: deferred compaction debt ignored for assembly conversation=${conversation.conversationId} ${sessionLabel} reason=incomplete-transcript-coverage contextItems=${contextItems.length} liveMessages=${liveMessages.length} placeholderBootstrapState=${placeholderBootstrapState} hasSummaryItems=${hasSummaryItems} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget}`,
+          );
+        } else if (pressure.pressureTokenCount > tokenBudget) {
           this.deps.log.warn(
             `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
           );
@@ -3361,12 +3381,6 @@ export class LcmContextEngine implements ContextEngine {
         return degraded;
       }
 
-      const bootstrapState = await this.summaryStore.getConversationBootstrapState(
-        conversation.conversationId,
-      );
-      const forkBoundedBootstrap = bootstrapState?.forkBounded === true;
-      const forkSourceMessageCount = bootstrapState?.forkSourceMessageCount ?? 0;
-      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
       if (contextItems.length === 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({
@@ -3389,7 +3403,6 @@ export class LcmContextEngine implements ContextEngine {
       // Guard against incomplete bootstrap/coverage: if the DB only has
       // raw context items and clearly trails the current live history, keep
       // the live path to avoid dropping prompt context.
-      const hasSummaryItems = contextItems.some((item) => item.itemType === "summary");
       if (!hasSummaryItems && contextItems.length < liveMessages.length) {
         if (forkBoundedBootstrap) {
           this.deps.log.debug(

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1363,6 +1363,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const summaryStore = engine.getSummaryStore();
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1372,10 +1373,24 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const executeCompactionCoreSpy = vi.spyOn(
       privateEngine,
       "executeCompactionCore",
-    ).mockResolvedValue({
-      ok: true,
-      compacted: true,
-      reason: "compacted",
+    ).mockImplementation(async () => {
+      await summaryStore.insertSummary({
+        summaryId: "sum_emergency_drain_refresh",
+        conversationId: conversation.conversationId,
+        kind: "condensed",
+        depth: 1,
+        content: "fresh emergency drain summary",
+        tokenCount: 10,
+      });
+      await summaryStore.appendContextSummary(
+        conversation.conversationId,
+        "sum_emergency_drain_refresh",
+      );
+      return {
+        ok: true,
+        compacted: true,
+        reason: "compacted",
+      };
     });
 
     const assembleResult = await engine.assemble({
@@ -1398,6 +1413,9 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(maintenance?.pending).toBe(false);
     expect(maintenance?.running).toBe(false);
     expect(assembleResult.messages).toHaveLength(1);
+    expect(log.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: no context items"),
+    );
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "[lcm] assemble: emergency deferred compaction debt draining pre-assembly",

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -998,6 +998,83 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
   });
 
+  it("assemble() ignores deferred debt while placeholder transcript coverage recovers", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-placeholder-checkpoint-ignores-debt";
+    const sessionFile = createSessionFilePath("assemble-placeholder-checkpoint-ignores-debt");
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "only metadata anchor, not usable transcript coverage",
+        tokenCount: 12,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 2_000,
+      currentTokenCount: 1_900,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(privateEngine, "executeCompactionCore");
+    const liveMessages = [
+      makeMessage({ role: "system", content: "critical runtime policy" }),
+      makeMessage({
+        role: "user",
+        content: `older live context that would be lost ${"x ".repeat(250)}`,
+      }),
+      makeMessage({
+        role: "assistant",
+        content: `assistant reply in live context ${"y ".repeat(250)}`,
+      }),
+      makeMessage({ role: "user", content: "current delivery turn" }),
+    ];
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 2_000,
+    });
+
+    expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
+    expect(assembleResult.messages.map((message) => message.content)).toEqual(
+      liveMessages.map((message) => message.content),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("deferred compaction debt ignored for assembly"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("reason=incomplete-transcript-coverage"),
+    );
+  });
+
   it("assemble() intercepts large tool results in live messages before degraded fallback", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1014,18 +1014,42 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
-    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+    const storedMessages = await engine.getConversationStore().createMessagesBulk([
       {
         conversationId: conversation.conversationId,
         seq: 0,
         role: "user",
-        content: "only metadata anchor, not usable transcript coverage",
+        content: "metadata anchor one, not usable transcript coverage",
+        tokenCount: 12,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "metadata anchor two, not usable transcript coverage",
+        tokenCount: 12,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 2,
+        role: "user",
+        content: "metadata anchor three, not usable transcript coverage",
+        tokenCount: 12,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 3,
+        role: "assistant",
+        content: "metadata anchor four, not usable transcript coverage",
         tokenCount: 12,
       },
     ]);
     await engine
       .getSummaryStore()
-      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+      .appendContextMessages(
+        conversation.conversationId,
+        storedMessages.map((message) => message.messageId),
+      );
     await engine.getSummaryStore().upsertConversationBootstrapState({
       conversationId: conversation.conversationId,
       sessionFilePath: sessionFile,


### PR DESCRIPTION
## Summary

- detect all-zero placeholder bootstrap checkpoints before deferred-debt assembly handling
- skip emergency deferred compaction drain / degraded live fallback while transcript coverage is still placeholder-only and summaryless
- add a regression test for the placeholder-checkpoint + pending-threshold-debt shape
- add a patch changeset

## Why

This is the user-visible fallout from the transcript-ingestion wedge family around #822/#639: if a conversation has only placeholder transcript coverage, a pending threshold-maintenance retry can run during `assemble()` and force the degraded live fallback before the transcript recovery path has advanced the checkpoint. In production that presents as a final round with a collapsed prompt even though the tool rounds were coherent.

Current `main` already has the newer entry-id reconciliation and bounded fallback work; this patch is intentionally narrower. It does not loosen the bounded fallback policy. It only prevents deferred debt from driving emergency compaction or degraded assembly while LCM has no summary coverage and the checkpoint is still the all-zero placeholder.

## Tests

- `npm run typecheck`
- `npm run build`
- `npx vitest run test/engine.test.ts`
- `npx vitest run test/engine.test.ts -t "assemble\\(\\) (uses bounded live context when pending maintenance is near budget|ignores deferred debt while placeholder transcript coverage recovers|intercepts large tool results in live messages before degraded fallback|degrades to bounded live context if emergency compaction leaves debt pending)"`
- `npx vitest run test/ambiguous-rollover-rotation.test.ts`
- `npx vitest run --dir test --pool=forks --maxWorkers=1 --minWorkers=1` (60 files / 1281 tests passed)
