### PR TITLE
fix(engine): allow no-anchor import in placeholder-checkpoint and checkpoint-missing reconcile paths

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7647,6 +7647,7 @@ export class LcmContextEngine implements ContextEngine {
                 sessionKey: params.sessionKey,
                 conversationId: conversation.conversationId,
                 historicalMessages: appended.messages,
+                allowNoAnchorImport: true,
                 noAnchorImportReason: "placeholder-checkpoint-recovery",
               });
               if (reconcile.importedMessages > 0) {
@@ -7953,6 +7954,7 @@ export class LcmContextEngine implements ContextEngine {
         // import path is itself guarded (replay-overlap detection, import cap,
         // delivery-only block).
         let checkpointMissingMetadataFrontier = false;
+        let checkpointMissingLowMessageCount = false;
         if (
           reason === "checkpoint-missing" &&
           conversation.sessionId === params.sessionId &&
@@ -7966,11 +7968,13 @@ export class LcmContextEngine implements ContextEngine {
             existingMessageCount === 1 &&
             latestPersistedMessage !== null &&
             isLikelyInjectedMetadataPreambleRecord(latestPersistedMessage);
+          checkpointMissingLowMessageCount = existingMessageCount <= 3;
         }
         const recoverCheckpointMissingNoAnchor =
           reason === "checkpoint-missing" &&
           (params.allowNoAnchorImportOnCheckpointMissing === true ||
-            checkpointMissingMetadataFrontier);
+            checkpointMissingMetadataFrontier ||
+            checkpointMissingLowMessageCount);
         // A transcript whose session header id differs from the checkpoint's
         // is a *declared* epoch change (rewrite/rotation) — no heuristics
         // needed, so a same-path full rewrite may import as a new epoch

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -12561,6 +12561,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
     writeLeafTranscript(oldSessionFile, [
       { role: "user", content: "old checkpoint-missing real-history question" },
       { role: "assistant", content: "old checkpoint-missing real-history answer" },
+      { role: "user", content: "old checkpoint-missing real-history followup" },
+      { role: "assistant", content: "old checkpoint-missing real-history followup answer" },
     ]);
     await engine.bootstrap({
       sessionId,
@@ -12613,10 +12615,159 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "old checkpoint-missing real-history question",
       "old checkpoint-missing real-history answer",
+      "old checkpoint-missing real-history followup",
+      "old checkpoint-missing real-history followup answer",
     ]);
     expect(
       await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
     ).toBeNull();
+  });
+
+  it("placeholder checkpoint recovery allows no-anchor import for new sessions (#875)", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "placeholder-checkpoint-no-anchor-875";
+    const sessionKey = "agent:main:test:placeholder-checkpoint-no-anchor-875";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "non-anchoring primer 875" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("placeholder-checkpoint-no-anchor-875");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "875 transcript user turn one" },
+      { role: "assistant", content: "875 transcript assistant turn one" },
+      { role: "user", content: "875 transcript user turn two" },
+      { role: "assistant", content: "875 transcript assistant turn two" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "875 transcript assistant turn two" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("875 transcript user turn one");
+    expect(contents).toContain("875 transcript assistant turn one");
+    expect(contents).toContain("875 transcript user turn two");
+    expect(contents).toContain("875 transcript assistant turn two");
+
+    const advancedState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advancedState).not.toBeNull();
+    expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("did not cover the transcript frontier")),
+    ).toBe(false);
+  });
+
+  it("checkpoint-missing allows no-anchor import when existingMessageCount <= 3 (#875)", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "checkpoint-missing-low-count-875";
+    const sessionKey = "agent:main:test:checkpoint-missing-low-count-875";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "low count primer one 875" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "low count primer two 875" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(conversation!.conversationId);
+
+    const refreshed = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(refreshed?.bootstrappedAt).toBeTruthy();
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+
+    const sessionFile = createSessionFilePath("checkpoint-missing-low-count-875");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "875 low count transcript user" },
+      { role: "assistant", content: "875 low count transcript assistant" },
+      { role: "user", content: "875 low count transcript followup" },
+      { role: "assistant", content: "875 low count transcript followup reply" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "assistant", content: "875 low count transcript followup reply" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const recoveredState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(recoveredState).not.toBeNull();
+    expect(recoveredState?.sessionFilePath).toBe(sessionFile);
+    expect(recoveredState?.lastProcessedOffset).toBeGreaterThan(0);
+
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("875 low count transcript user");
+    expect(contents).toContain("875 low count transcript followup reply");
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("did not cover the transcript frontier")),
+    ).toBe(false);
   });
 
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {


### PR DESCRIPTION
## Summary

Fix JSONL/DB mismatch bug where new sessions get stuck with only 1 message in LCM DB while JSONL has many.

**Root cause:** Two places in `engine.ts` call `reconcileSessionTail` without `allowNoAnchorImport: true`:

1. **Append-only placeholder-checkpoint-recovery** — when a placeholder checkpoint is seeded (stat failure on first turn) and the next turn reads the transcript, the reconcile call lacked `allowNoAnchorImport`, so non-anchoring content was never imported.

2. **Slow path checkpoint-missing** — when `reason === "checkpoint-missing"` and the conversation has ≤ 3 messages (new session), the no-anchor import is now allowed. Sessions with substantial history (> 3 messages) remain protected from divergent transcript overwrites.

## Changes

- `src/engine.ts`: Add `allowNoAnchorImport: true` to placeholder-checkpoint reconcile call
- `src/engine.ts`: Add `checkpointMissingLowMessageCount` condition for sessions with ≤ 3 messages
- `test/engine.test.ts`: Two regression tests covering both paths

## Verification

- All checkpoint-related tests pass (8/8)
- Existing "does not recover checkpoint-missing divergent transcript over real history" test updated to 4+ messages to validate the protection boundary

Closes #875