### PR TITLE
fix: preserve transcript timestamps during recovery imports

### DIFF
--- a/.changeset/preserve-recovered-transcript-timestamps.md
+++ b/.changeset/preserve-recovered-transcript-timestamps.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve original transcript timestamps during recovery imports instead of stamping import time.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -44,7 +44,7 @@ import { createLcmSummarizeFromLegacyParams, FALLBACK_SUMMARY_MARKER, LcmProvide
 import type { LcmDependencies } from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 import { buildDeterministicFallbackSummary } from "./summary-fallback.js";
-import { getTranscriptEntryId, readAppendedLeafPathMessages, readLastJsonlEntryBeforeOffset, readLeafPathMessages, readSessionParentSessionReference } from "./transcript.js";
+import { getTranscriptEntryId, readAppendedLeafPathMessages, readLastJsonlEntryBeforeOffset, readLeafPathMessages, readSessionParentSessionReference, resolveTranscriptMessageCreatedAt } from "./transcript.js";
 import { type TranscriptReconcileResult } from "./reconcile-plan.js";
 import { checkpointIsPastTranscriptEof, TranscriptReconciler } from "./transcript-reconciler.js";
 import { AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON, SessionRolloverDetector } from "./session-rollover.js";
@@ -1901,6 +1901,7 @@ export class LcmContextEngine implements ContextEngine {
                       sessionId: params.sessionId,
                       sessionKey: params.sessionKey,
                       message,
+                      createdAt: resolveTranscriptMessageCreatedAt(message),
                       skipReplayTimestampFloodGuard:
                         index < replayFiltered.replayGuardExemptPrefixLength,
                     });
@@ -1991,6 +1992,7 @@ export class LcmContextEngine implements ContextEngine {
                 sessionId: params.sessionId,
                 sessionKey: params.sessionKey,
                 message,
+                createdAt: resolveTranscriptMessageCreatedAt(message),
                 skipReplayTimestampFloodGuard: true,
               });
               if (result.ingested) {
@@ -2412,9 +2414,10 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     message: AgentMessage;
     isHeartbeat?: boolean;
+    createdAt?: Date | string;
     skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult> {
-    const { sessionId, sessionKey, message, isHeartbeat, skipReplayTimestampFloodGuard } = params;
+    const { sessionId, sessionKey, message, isHeartbeat, createdAt, skipReplayTimestampFloodGuard } = params;
     if (isHeartbeat) {
       return { ingested: false };
     }
@@ -2562,6 +2565,7 @@ export class LcmContextEngine implements ContextEngine {
       content: stored.content,
       tokenCount: stored.tokenCount,
       transcriptEntryId,
+      createdAt,
       skipReplayTimestampFloodGuard,
     });
     await this.conversationStore.createMessageParts(

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -250,7 +250,7 @@ function formatMessageCreatedAt(value: Date | string | undefined): string | unde
     return undefined;
   }
   const parsed = parseUtcTimestampOrNull(trimmed);
-  if (parsed) {
+  if (parsed && Number.isFinite(parsed.getTime())) {
     return parsed.toISOString().slice(0, 19).replace("T", " ");
   }
   return undefined;

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -34,6 +34,11 @@ export type CreateMessageInput = {
   tokenCount: number;
   identityHash?: string;
   /**
+   * Optional historical message timestamp, used by transcript recovery imports.
+   * Runtime ingests omit this and keep the store's current timestamp behavior.
+   */
+  createdAt?: Date | string;
+  /**
    * Stable JSONL envelope id of the transcript entry this message was
    * imported from. Enforced unique per conversation (partial index), so
    * transcript replays cannot duplicate rows. Null/undefined for runtime
@@ -229,6 +234,26 @@ function toConversationRecord(row: ConversationRow): ConversationRecord {
     createdAt: parseUtcTimestamp(row.created_at),
     updatedAt: parseUtcTimestamp(row.updated_at),
   };
+}
+
+function formatMessageCreatedAt(value: Date | string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime())
+      ? value.toISOString().slice(0, 19).replace("T", " ")
+      : undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = parseUtcTimestampOrNull(trimmed);
+  if (parsed) {
+    return parsed.toISOString().slice(0, 19).replace("T", " ");
+  }
+  return undefined;
 }
 
 function toMessageRecord(row: MessageRow): MessageRecord {
@@ -1237,7 +1262,7 @@ export class ConversationStore {
   ): PreparedMessageInsert {
     return {
       ...input,
-      createdAt,
+      createdAt: formatMessageCreatedAt(input.createdAt) ?? createdAt,
       identityHash: input.identityHash ?? buildMessageIdentityHash(input.role, input.content),
     };
   }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -50,6 +50,7 @@ import {
   readLastJsonlEntryBeforeOffset,
   readLeafPathMessages,
   readTranscriptHeader,
+  resolveTranscriptMessageCreatedAt,
 } from "./transcript.js";
 import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./value-utils.js";
 
@@ -105,6 +106,7 @@ export type ReconcileHost = {
     sessionKey?: string;
     message: AgentMessage;
     isHeartbeat?: boolean;
+    createdAt?: Date | string;
     skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult>;
 };
@@ -423,6 +425,7 @@ export class TranscriptReconciler {
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         message,
+        createdAt: resolveTranscriptMessageCreatedAt(message),
         skipReplayTimestampFloodGuard: true,
       });
       if (result.ingested) {
@@ -887,6 +890,7 @@ export class TranscriptReconciler {
         sessionId,
         sessionKey: params.sessionKey,
         message,
+        createdAt: resolveTranscriptMessageCreatedAt(message),
         skipReplayTimestampFloodGuard: true,
       });
       if (result.ingested) {
@@ -1423,6 +1427,7 @@ export class TranscriptReconciler {
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         message,
+        createdAt: resolveTranscriptMessageCreatedAt(message),
         skipReplayTimestampFloodGuard: index < params.replayGuardExemptPrefixLength,
       });
       if (result.ingested) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -44,6 +44,27 @@ export function getTranscriptEntryId(message: AgentMessage): string | null {
   return getTranscriptEntryMeta(message)?.entryId ?? null;
 }
 
+export function resolveTranscriptMessageCreatedAt(message: AgentMessage): Date | string | undefined {
+  const envelopeTimestamp = getTranscriptEntryMeta(message)?.timestamp;
+  if (envelopeTimestamp) {
+    return envelopeTimestamp;
+  }
+
+  const raw = message as unknown as Record<string, unknown>;
+  const value = raw.timestamp ?? raw.createdAt ?? raw.created_at;
+  if (typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isFinite(parsed.getTime()) ? parsed : undefined;
+  }
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : undefined;
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  return undefined;
+}
+
 function normalizeEnvelopeString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3496,7 +3496,7 @@ describe("LcmContextEngine.bootstrap", () => {
       role: "user",
       content: [{ type: "text", text: "seed user" }],
     } as AgentMessage);
-    appendSessionMessage(sm, {
+    const seedAssistantId = appendSessionMessage(sm, {
       role: "assistant",
       content: [{ type: "text", text: "seed assistant" }],
     } as AgentMessage);
@@ -3548,12 +3548,27 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(staleBootstrapState).not.toBeNull();
     expect(staleBootstrapState?.lastProcessedEntryHash).toBe("mismatch");
 
-    for (let index = 0; index < 60; index += 1) {
-      appendSessionMessage(sm, {
+    const recoveredTailContents = Array.from({ length: 60 }, (_, index) =>
+      index < 3 ? "repeat ack" : `missing tail ${index}`,
+    );
+    const recoveredTailTimestamps = recoveredTailContents.map(
+      (_content, index) => `2026-06-10T18:${String(index).padStart(2, "0")}:00.000Z`,
+    );
+    const recoveredTailEntries = recoveredTailContents.map((content, index) => ({
+      type: "message",
+      id: `recovered-tail-${index}`,
+      parentId: index === 0 ? seedAssistantId : `recovered-tail-${index - 1}`,
+      timestamp: recoveredTailTimestamps[index],
+      message: {
         role: index % 2 === 0 ? "user" : "assistant",
-        content: [{ type: "text", text: `missing tail ${index}` }],
-      } as AgentMessage);
-    }
+        content: [{ type: "text", text: content }],
+      },
+    }));
+    appendFileSync(
+      sessionFile,
+      recoveredTailEntries.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+      "utf8",
+    );
 
     const second = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
     // Anchored backlog over the cap imports a bounded oldest-first chunk
@@ -3573,7 +3588,7 @@ describe("LcmContextEngine.bootstrap", () => {
       "seed user",
       "seed assistant",
     ]);
-    expect(storedAfterCap[2]?.content).toBe("missing tail 0");
+    expect(storedAfterCap[2]?.content).toBe("repeat ack");
     expect(storedAfterCap[51]?.content).toBe("missing tail 49");
 
     const secondBootstrapState = await engine
@@ -3596,6 +3611,9 @@ describe("LcmContextEngine.bootstrap", () => {
       .getMessages(conversation!.conversationId);
     expect(storedAfterDrain).toHaveLength(62);
     expect(storedAfterDrain[61]?.content).toBe("missing tail 59");
+    expect(
+      storedAfterDrain.slice(2, 5).map((message) => message.createdAt.toISOString()),
+    ).toEqual(recoveredTailTimestamps.slice(0, 3));
   });
 
   it("uses the live ingest path for initial bootstrap", async () => {
@@ -4197,4 +4215,3 @@ describe("LcmContextEngine.bootstrap", () => {
 });
 
 // ── Assemble canonical path with fallback ───────────────────────────────────
-

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3554,11 +3554,13 @@ describe("LcmContextEngine.bootstrap", () => {
     const recoveredTailTimestamps = recoveredTailContents.map(
       (_content, index) => `2026-06-10T18:${String(index).padStart(2, "0")}:00.000Z`,
     );
+    const invalidTimestampIndex = 4;
     const recoveredTailEntries = recoveredTailContents.map((content, index) => ({
       type: "message",
       id: `recovered-tail-${index}`,
       parentId: index === 0 ? seedAssistantId : `recovered-tail-${index - 1}`,
-      timestamp: recoveredTailTimestamps[index],
+      timestamp:
+        index === invalidTimestampIndex ? "not-a-valid-transcript-timestamp" : recoveredTailTimestamps[index],
       message: {
         role: index % 2 === 0 ? "user" : "assistant",
         content: [{ type: "text", text: content }],
@@ -3614,6 +3616,12 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(
       storedAfterDrain.slice(2, 5).map((message) => message.createdAt.toISOString()),
     ).toEqual(recoveredTailTimestamps.slice(0, 3));
+    expect(storedAfterDrain[2 + invalidTimestampIndex]?.content).toBe(
+      recoveredTailContents[invalidTimestampIndex],
+    );
+    expect(
+      Number.isFinite(storedAfterDrain[2 + invalidTimestampIndex]!.createdAt.getTime()),
+    ).toBe(true);
   });
 
   it("uses the live ingest path for initial bootstrap", async () => {


### PR DESCRIPTION
## Summary

- Add an optional historical `createdAt` path for message inserts while preserving the existing current-timestamp default for runtime ingests.
- Resolve recovered transcript message timestamps from JSONL envelope metadata, with message-level timestamp fields as a fallback.
- Use those timestamps when bootstrap/reconciliation imports transcript history so recovered rows retain their original chronology.

## Why

The stable-entry-id reconciliation (#854, #866) makes transcript recovery idempotent and avoids content-identity ambiguity, but recovered rows still received the import-time SQLite timestamp. That flattens historical transcript ranges to the recovery moment, which can distort recency-ordered recall, telemetry, and timeline inspection.

Because entry-id-verified imports bypass the replay-timestamp flood guard, the flattening is silent — there is no longer any code path that surfaces it.

This keeps the stable-entry-id behavior while preserving the transcript's original chronology.

## Tests

- `npm run typecheck`
- `npm run build`
- `npx vitest run test/engine-bootstrap.test.ts --testNamePattern "does not advance the bootstrap checkpoint when reconcile aborts at the import cap"`
- `npx vitest run test/engine-bootstrap.test.ts test/transcript-entry-id.test.ts test/anti-replay-burst-regression.test.ts`
- `npm test`