### PR TITLE
fix(reconcile): recover non-anchoring-frontier conversations past the no-anchor import cap (#822)

### DIFF
--- a/.changeset/822-placeholder-noanchor-recovery.md
+++ b/.changeset/822-placeholder-noanchor-recovery.md
@@ -1,0 +1,9 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix a `#822` `afterTurn` deadlock where a conversation with an all-zero placeholder `conversation_bootstrap_state` row and a persisted frontier of only non-anchoring rows (e.g. one or more injected `Conversation info (untrusted metadata)` preambles) never re-imported its on-disk transcript. The placeholder-checkpoint-recovery reconcile ran without `allowNoAnchorImport`, so it imported 0 messages and never advanced the checkpoint; every turn then emitted the `did not cover the transcript frontier` warning, `assemble()` fell back to the raw transcript, and compaction never ran for that conversation.
+
+The placeholder recovery now opens a no-anchor import, but only when the persisted frontier is proven to hold no real conversation content — generalizing #837's single-injected-metadata-preamble check to a frontier composed entirely of non-anchoring injected-metadata rows (any count, via a bounded scan). A frontier with real anchoring rows conservatively freezes per #649's no-proof-no-advance guard, so an unrelated/rotated transcript can never be stitched onto real history (the failure mode that closed #824). For the proven-safe case the no-anchor import cap is lifted so a transcript larger than the cap recovers fully, bounded by the transcript length rather than left unbounded. The downstream import remains guarded by replay-overlap detection, the delivery-only block (now also applied to this lane), and the cross-conversation raw-id guard.
+
+The same generalized non-anchoring-frontier gate now also drives the afterTurn checkpoint-missing lane (#837), which previously required exactly one persisted frontier row: a conversation that accumulated several injected-metadata preambles before losing its checkpoint recovers there too, and the cap lift applies under the same proof.

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -62,6 +62,12 @@ import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./va
  */
 const FLUSH_LAG_ADOPTION_TAIL_WINDOW = 16;
 
+// Upper bound on the persisted-frontier scan used to decide placeholder-checkpoint
+// recovery eligibility (#822). A genuinely stuck placeholder frontier is a handful
+// of injected-metadata rows; a frontier larger than this conservatively freezes
+// rather than scan an arbitrarily large real DB tail (#649 no-proof-no-advance).
+const NON_ANCHORING_FRONTIER_SCAN_LIMIT = 32;
+
 export type BootstrapCheckpointFileState = {
   lastProcessedOffset: number;
   lastSeenSize: number;
@@ -483,6 +489,35 @@ export class TranscriptReconciler {
     return false;
   }
 
+  /**
+   * Decide whether a placeholder-checkpoint conversation may recover by importing
+   * its on-disk transcript as a new epoch (#822). Safe ONLY when the persisted
+   * frontier holds no real conversation content that a rotated/unrelated transcript
+   * could overwrite. Generalizes #837's single-injected-metadata-preamble check to
+   * any frontier composed entirely of non-anchoring injected-metadata rows; an
+   * empty frontier is trivially safe, and a larger or non-metadata frontier
+   * conservatively returns false so the conversation freezes (#649) rather than
+   * risk contaminating real history (the failure that closed #824).
+   */
+  private async conversationFrontierIsEntirelyNonAnchoring(
+    conversationId: number,
+  ): Promise<boolean> {
+    const existingMessageCount = await this.host.conversationStore.getMessageCount(conversationId);
+    if (existingMessageCount === 0) {
+      return true;
+    }
+    if (existingMessageCount > NON_ANCHORING_FRONTIER_SCAN_LIMIT) {
+      return false;
+    }
+    const frontier = await this.host.conversationStore.getMessages(conversationId, {
+      limit: NON_ANCHORING_FRONTIER_SCAN_LIMIT,
+    });
+    return (
+      frontier.length === existingMessageCount &&
+      frontier.every((message) => isLikelyInjectedMetadataPreambleRecord(message))
+    );
+  }
+
   async reconcileSessionTail(params: {
     sessionId: string;
     sessionKey?: string;
@@ -492,6 +527,10 @@ export class TranscriptReconciler {
     lastProcessedEntryId?: string | null;
     skipContentAnchorScan?: boolean;
     allowNoAnchorImport?: boolean;
+    // Lift the no-anchor import cap because the persisted frontier was proven to
+    // hold no real conversation content (#822). Bounded by the transcript length,
+    // never unbounded — set ONLY together with a proven non-anchoring frontier.
+    allowFullNonAnchoringFrontierImport?: boolean;
     noAnchorImportReason?: string;
   }): Promise<TranscriptReconcileResult> {
     const { sessionId, conversationId, historicalMessages } = params;
@@ -635,6 +674,7 @@ export class TranscriptReconciler {
             conversationId,
             historicalMessages,
             noAnchorImportReason: params.noAnchorImportReason,
+            allowFullNonAnchoringFrontierImport: params.allowFullNonAnchoringFrontierImport,
             existingDbCount,
             sessionContext,
             startedAt,
@@ -724,6 +764,7 @@ export class TranscriptReconciler {
     conversationId: number;
     historicalMessages: AgentMessage[];
     noAnchorImportReason?: string;
+    allowFullNonAnchoringFrontierImport?: boolean;
     existingDbCount: number;
     sessionContext: string;
     startedAt: number;
@@ -733,7 +774,8 @@ export class TranscriptReconciler {
 
     if (
       (params.noAnchorImportReason === "path-mismatch" ||
-        params.noAnchorImportReason === "checkpoint-missing-recovery") &&
+        params.noAnchorImportReason === "checkpoint-missing-recovery" ||
+        params.noAnchorImportReason === "placeholder-checkpoint-recovery") &&
       isLikelyInjectedDeliveryOnlyTranscript(historicalMessages)
     ) {
       this.host.deps.log.warn(
@@ -796,7 +838,13 @@ export class TranscriptReconciler {
 
     const importCap = transcriptImportCap(existingDbCount);
     let noAnchorImportCapped = false;
-    if (noAnchorImportMessages.length > importCap) {
+    // #822: when the caller proved the persisted frontier holds no real
+    // conversation content (entirely injected-metadata rows), the cap serves
+    // no anti-flood purpose — there is nothing real to flood or duplicate —
+    // and chunked draining would leave the conversation degraded for many
+    // turns. Import the whole transcript in one bounded pass instead (bounded
+    // by the transcript length, never unbounded).
+    if (!params.allowFullNonAnchoringFrontierImport && noAnchorImportMessages.length > importCap) {
       if (allEntryIdBearing) {
         // A fully id-bearing new epoch is exact (every entry adopts or
         // imports by verified id), so a large rollover — e.g. a host
@@ -1621,11 +1669,26 @@ export class TranscriptReconciler {
           };
         }
         if (placeholderCheckpoint && appended.messages.length > 0) {
+          // #822: a placeholder checkpoint means this conversation was never
+          // ingested, so its on-disk transcript is the source of truth and
+          // importing it as a new epoch is the correct recovery — but ONLY when
+          // the persisted frontier holds no real conversation content a
+          // rotated/unrelated transcript could overwrite. When eligible we also
+          // lift the no-anchor import cap because there is no real content to
+          // flood/duplicate (bounded by the transcript, never unbounded — the
+          // failure that closed #824). Otherwise allowNoAnchorImport stays false
+          // and the conversation freezes exactly as before (#649).
+          const placeholderFrontierIsNonAnchoring =
+            await this.conversationFrontierIsEntirelyNonAnchoring(
+              conversation.conversationId,
+            );
           const reconcile = await this.reconcileSessionTail({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             conversationId: conversation.conversationId,
             historicalMessages: appended.messages,
+            allowNoAnchorImport: placeholderFrontierIsNonAnchoring,
+            allowFullNonAnchoringFrontierImport: placeholderFrontierIsNonAnchoring,
             noAnchorImportReason: "placeholder-checkpoint-recovery",
           });
           await this.recordImportAndRefreshCheckpoint({
@@ -1913,14 +1976,16 @@ export class TranscriptReconciler {
     }
     // #837: a conversation with bootstrapped_at SET but no bootstrap_state
     // row reaches reason="checkpoint-missing" with a non-anchoring frontier
-    // (e.g. a single injected metadata preamble). Without a no-anchor import
-    // it imports 0 messages and never persists a checkpoint, so afterTurn
+    // (e.g. injected metadata preambles). Without a no-anchor import it
+    // imports 0 messages and never persists a checkpoint, so afterTurn
     // loops the "did not cover the transcript frontier" warning forever and
     // compaction never runs. The rotate lane already recovers via
     // allowNoAnchorImportOnCheckpointMissing; mirror that on the afterTurn
-    // lane, but ONLY for the observed injected-metadata frontier. A real
-    // historical DB tail with a divergent rewritten transcript must still
-    // freeze per #649's no-proof-no-advance guard, so do not treat
+    // lane, but ONLY for a frontier composed entirely of injected-metadata
+    // rows (#822 generalizes #837's single-row check: hosts inject one
+    // metadata preamble per delivery, so stuck frontiers can hold several).
+    // A real historical DB tail with a divergent rewritten transcript must
+    // still freeze per #649's no-proof-no-advance guard, so do not treat
     // bootstrapped_at alone as lineage proof. The downstream no-anchor
     // import path is itself guarded (replay-overlap detection, import cap,
     // delivery-only block).
@@ -1930,14 +1995,8 @@ export class TranscriptReconciler {
       conversation.sessionId === params.sessionId &&
       conversation.bootstrappedAt !== null
     ) {
-      const [existingMessageCount, latestPersistedMessage] = await Promise.all([
-        this.host.conversationStore.getMessageCount(conversation.conversationId),
-        this.host.conversationStore.getLastMessage(conversation.conversationId),
-      ]);
       checkpointMissingMetadataFrontier =
-        existingMessageCount === 1 &&
-        latestPersistedMessage !== null &&
-        isLikelyInjectedMetadataPreambleRecord(latestPersistedMessage);
+        await this.conversationFrontierIsEntirelyNonAnchoring(conversation.conversationId);
     }
     const recoverCheckpointMissingNoAnchor =
       reason === "checkpoint-missing" &&
@@ -1973,6 +2032,13 @@ export class TranscriptReconciler {
         reason === "same-path-shrink" ||
         declaredEpochRollover ||
         recoverCheckpointMissingNoAnchor,
+      // #822: when the checkpoint-missing frontier is a proven non-anchoring
+      // metadata frontier, lift the no-anchor import cap too. Otherwise a large
+      // real transcript (hundreds of messages) is blocked by the cap, stays
+      // unimported, and the host keeps sending it raw until the provider context
+      // window overflows. Same safety property as the placeholder lane; gated on
+      // the proven metadata frontier, never the caller-asserted rotate flag.
+      allowFullNonAnchoringFrontierImport: checkpointMissingMetadataFrontier,
       noAnchorImportReason: recoverCheckpointMissingNoAnchor
         ? params.allowNoAnchorImportOnCheckpointMissing === true
           ? "rotate-checkpoint-missing"

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -68,6 +68,16 @@ const FLUSH_LAG_ADOPTION_TAIL_WINDOW = 16;
 // rather than scan an arbitrarily large real DB tail (#649 no-proof-no-advance).
 const NON_ANCHORING_FRONTIER_SCAN_LIMIT = 32;
 
+// No-anchor recovery reasons that can proceed from checkpoint/frontier metadata
+// instead of a content anchor. Block them if raw IDs are already owned by another
+// active conversation.
+const CROSS_CONVERSATION_RAW_ID_GUARDED_NO_ANCHOR_REASONS = new Set([
+  "same-path-shrink",
+  "checkpoint-missing-recovery",
+  "rotate-checkpoint-missing",
+  "placeholder-checkpoint-recovery",
+]);
+
 export type BootstrapCheckpointFileState = {
   lastProcessedOffset: number;
   lastSeenSize: number;
@@ -873,7 +883,10 @@ export class TranscriptReconciler {
       }
     }
 
-    if (params.noAnchorImportReason === "same-path-shrink") {
+    if (
+      params.noAnchorImportReason &&
+      CROSS_CONVERSATION_RAW_ID_GUARDED_NO_ANCHOR_REASONS.has(params.noAnchorImportReason)
+    ) {
       const rawIdMatches = this.countActiveCrossConversationRawIdMatches({
         conversationId,
         sessionId,
@@ -881,7 +894,7 @@ export class TranscriptReconciler {
       });
       if (rawIdMatches.matchedRawIds > 0) {
         this.host.deps.log.warn(
-          `[lcm] reconcileSessionTail: blocked same-path-shrink no-anchor import for ${sessionContext} because ${rawIdMatches.matchedRawIds}/${rawIdMatches.candidateRawIds} candidate raw ids already exist in other active conversations`,
+          `[lcm] reconcileSessionTail: blocked ${params.noAnchorImportReason} no-anchor import for ${sessionContext} because ${rawIdMatches.matchedRawIds}/${rawIdMatches.candidateRawIds} candidate raw ids already exist in other active conversations`,
         );
         this.host.deps.log.debug(
           `[lcm] reconcileSessionTail: blocked cross-conversation raw-id duplicate for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateRawIds=${rawIdMatches.candidateRawIds} matchedRawIds=${rawIdMatches.matchedRawIds} overlap=false`,

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1579,6 +1579,163 @@ describe("LcmContextEngine afterTurn", () => {
     expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
   });
 
+  it("blocks placeholder-checkpoint recovery when raw ids belong to another active conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const ownedMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "placeholder-cross-user", text: "owned user turn" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "placeholder-cross-assistant", text: "owned answer" }],
+      }),
+    ];
+    const ownerSessionFile = createSessionFilePath("placeholder-rawid-owner");
+    writeLeafTranscriptMessages(ownerSessionFile, ownedMessages);
+    await engine.bootstrap({
+      sessionId: "placeholder-rawid-owner",
+      sessionKey: "agent:main:placeholder-rawid-owner",
+      sessionFile: ownerSessionFile,
+    });
+
+    const placeholderSessionId = "placeholder-rawid-candidate";
+    const placeholderSessionKey = "agent:main:placeholder-rawid-candidate";
+    await engine.ingest({
+      sessionId: placeholderSessionId,
+      sessionKey: placeholderSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder raw-id candidate",
+      }),
+    });
+    const placeholderConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: placeholderSessionId,
+      sessionKey: placeholderSessionKey,
+    });
+    expect(placeholderConversation).not.toBeNull();
+
+    const candidateSessionFile = createSessionFilePath("placeholder-rawid-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, ownedMessages);
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: placeholderConversation!.conversationId,
+      sessionFilePath: candidateSessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId: placeholderSessionId,
+      sessionKey: placeholderSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const placeholderMessages = await engine
+      .getConversationStore()
+      .getMessages(placeholderConversation!.conversationId);
+    expect(placeholderMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder raw-id candidate",
+    ]);
+    const state = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(placeholderConversation!.conversationId);
+    expect(state?.lastProcessedOffset).toBe(0);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked placeholder-checkpoint-recovery no-anchor import")),
+    ).toBe(true);
+  });
+
+  it("blocks checkpoint-missing recovery when raw ids belong to another active conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const ownedMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "checkpoint-cross-user", text: "owned checkpoint user" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "checkpoint-cross-assistant", text: "owned checkpoint answer" }],
+      }),
+    ];
+    const ownerSessionFile = createSessionFilePath("checkpoint-rawid-owner");
+    writeLeafTranscriptMessages(ownerSessionFile, ownedMessages);
+    await engine.bootstrap({
+      sessionId: "checkpoint-rawid-owner",
+      sessionKey: "agent:main:checkpoint-rawid-owner",
+      sessionFile: ownerSessionFile,
+    });
+
+    const checkpointSessionId = "checkpoint-rawid-candidate";
+    const checkpointSessionKey = "agent:main:checkpoint-rawid-candidate";
+    await engine.ingest({
+      sessionId: checkpointSessionId,
+      sessionKey: checkpointSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): checkpoint raw-id candidate",
+      }),
+    });
+    const checkpointConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: checkpointSessionId,
+      sessionKey: checkpointSessionKey,
+    });
+    expect(checkpointConversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(checkpointConversation!.conversationId);
+    expect(
+      await engine
+        .getSummaryStore()
+        .getConversationBootstrapState(checkpointConversation!.conversationId),
+    ).toBeNull();
+
+    const candidateSessionFile = createSessionFilePath("checkpoint-rawid-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, ownedMessages);
+
+    await engine.afterTurn({
+      sessionId: checkpointSessionId,
+      sessionKey: checkpointSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const checkpointMessages = await engine
+      .getConversationStore()
+      .getMessages(checkpointConversation!.conversationId);
+    expect(checkpointMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): checkpoint raw-id candidate",
+    ]);
+    expect(
+      await engine
+        .getSummaryStore()
+        .getConversationBootstrapState(checkpointConversation!.conversationId),
+    ).toBeNull();
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked checkpoint-missing-recovery no-anchor import")),
+    ).toBe(true);
+  });
+
   it("does NOT import an unrelated transcript onto a placeholder-checkpoint conversation that already holds real anchoring rows (#824 contamination guard)", async () => {
     // The failure that closed PR #824: a placeholder checkpoint can coexist with
     // real persisted rows; blindly opening an unbounded no-anchor import would

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1485,6 +1485,345 @@ describe("LcmContextEngine afterTurn", () => {
     expect(warns.some((m) => m.includes("transcript reconcile failed"))).toBe(true);
   });
 
+  it("recovers a placeholder-checkpoint conversation with a multi-row non-anchoring metadata frontier, importing the full transcript past the no-anchor cap (#822)", async () => {
+    // #822 generalized beyond #837's single-row frontier: conv-3893 in
+    // production was stuck with TWO non-anchoring injected-metadata rows and a
+    // transcript far larger than the no-anchor cap (50). The fix keys on the
+    // PROPERTY "the persisted frontier holds no real content" (any count of
+    // injected-metadata rows), not a magic count, and lifts the cap for that
+    // proven-safe case so a transcript larger than the cap still recovers fully.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "placeholder-multi-metadata-frontier-recovery";
+    const sessionKey = "agent:opsos:telegram:placeholder-multi-metadata-frontier";
+
+    // Two non-anchoring injected-metadata rows (generalizes #837's count===1).
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble one",
+      }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble two",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    // A real transcript of 60 messages (> the no-anchor cap of 50) that does NOT
+    // anchor to the metadata rows.
+    const sessionFile = createSessionFilePath("placeholder-multi-metadata-frontier");
+    const bigTranscript: Array<{ role: AgentMessage["role"]; content: string }> = Array.from(
+      { length: 60 },
+      (_, i) => ({
+        role: (i % 2 === 0 ? "user" : "assistant") as AgentMessage["role"],
+        content: `general recovery transcript turn ${i}`,
+      }),
+    );
+    writeLeafTranscript(sessionFile, bigTranscript);
+
+    // Seed the all-zero placeholder checkpoint pointing at the transcript.
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "general recovery transcript turn 58" }),
+        makeMessage({ role: "assistant", content: "general recovery transcript turn 59" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const contents = messages.map((m) => m.content);
+    // Full transcript imported, including content PAST the cap of 50 — proving
+    // the cap bypass for the proven-non-anchoring frontier.
+    expect(contents).toContain("general recovery transcript turn 0");
+    expect(contents).toContain("general recovery transcript turn 59");
+    expect(messages.length).toBeGreaterThan(50);
+
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    // The cap-abort must NOT have fired, and the conversation must not be frozen.
+    expect(warns.some((m) => m.includes("no anchor import cap exceeded"))).toBe(false);
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(false);
+
+    // Checkpoint advanced off the placeholder so future turns take the fast path.
+    const advancedState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
+  });
+
+  it("does NOT import an unrelated transcript onto a placeholder-checkpoint conversation that already holds real anchoring rows (#824 contamination guard)", async () => {
+    // The failure that closed PR #824: a placeholder checkpoint can coexist with
+    // real persisted rows; blindly opening an unbounded no-anchor import would
+    // stitch an unrelated/rotated transcript onto real history. Eligibility is
+    // gated on the frontier being entirely non-anchoring, so a real DB tail must
+    // freeze (#649) rather than import.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "placeholder-real-frontier-no-contaminate";
+    const sessionKey = "agent:main:placeholder-real-frontier-no-contaminate";
+
+    // Real (anchoring) conversation rows — NOT injected metadata.
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "real history turn zero" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "real history turn one" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    // An UNRELATED transcript sharing zero identity with the real DB rows.
+    const sessionFile = createSessionFilePath("placeholder-real-frontier-no-contaminate");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "alien transcript turn zero" },
+      { role: "assistant", content: "alien transcript turn one" },
+      { role: "user", content: "alien transcript turn two" },
+    ]);
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "alien transcript turn one" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    // The real rows are untouched and NONE of the alien transcript was imported.
+    expect(contents.slice(0, 2)).toEqual(["real history turn zero", "real history turn one"]);
+    expect(contents.some((c) => c.startsWith("alien transcript turn zero"))).toBe(false);
+    expect(contents.some((c) => c.startsWith("alien transcript turn two"))).toBe(false);
+
+    // The placeholder checkpoint must NOT have advanced (conversation frozen, safe).
+    const state = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(state?.lastProcessedOffset).toBe(0);
+  });
+
+  it("freezes a placeholder-checkpoint recovery whose transcript is only injected delivery/config traffic (#822 parity with #837)", async () => {
+    // Parity with the checkpoint-missing and path-mismatch lanes: a recovery
+    // transcript that is purely injected delivery-only traffic must be blocked,
+    // not imported as conversation content.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "placeholder-delivery-only-frozen";
+    const sessionKey = "agent:main:signal:placeholder-delivery-only-frozen";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("placeholder-delivery-only-frozen");
+    writeLeafTranscript(sessionFile, [
+      { role: "system", content: "delivery-mirror config-audit: refreshed host policy" },
+      { role: "system", content: "config-audit delivery-mirror: no user turn" },
+    ]);
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "assistant delta" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("delivery-only path-mismatched transcript")),
+    ).toBe(true);
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("Conversation info (untrusted metadata): injected preamble");
+    expect(contents.some((c) => c.includes("delivery-mirror"))).toBe(false);
+  });
+
+  it("recovers a checkpoint-missing metadata frontier whose transcript exceeds the no-anchor import cap (#822)", async () => {
+    // Sibling of the placeholder cap-lift: a checkpoint-missing conversation (#837)
+    // with a single injected-metadata frontier and a transcript LARGER than the
+    // no-anchor cap (50) would otherwise import 0 (cap-blocked), so the host keeps
+    // sending the raw transcript every turn until the provider context window
+    // overflows. The proven non-anchoring metadata frontier lifts the cap so the
+    // full real history recovers and becomes compactable — without losing it.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "checkpoint-missing-large-transcript";
+    const sessionKey = "agent:main:checkpoint-missing-large-transcript";
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+    // checkpoint-missing: deliberately do NOT seed a bootstrap_state row.
+    const sessionFile = createSessionFilePath("checkpoint-missing-large-transcript");
+    const bigTranscript: Array<{ role: AgentMessage["role"]; content: string }> = Array.from(
+      { length: 64 },
+      (_, i) => ({
+        role: (i % 2 === 0 ? "user" : "assistant") as AgentMessage["role"],
+        content: `checkpoint-missing recovery turn ${i}`,
+      }),
+    );
+    writeLeafTranscript(sessionFile, bigTranscript);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "checkpoint-missing recovery turn 63" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("checkpoint-missing recovery turn 0");
+    expect(contents).toContain("checkpoint-missing recovery turn 63");
+    expect(contents.length).toBeGreaterThan(50);
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("no anchor import cap exceeded"))).toBe(false);
+  });
+
+  it("recovers a checkpoint-missing conversation whose frontier holds MULTIPLE non-anchoring metadata rows (#822 generalizes #837's count===1 gate)", async () => {
+    // Hosts inject one metadata preamble per delivery, so a stuck conversation
+    // can accumulate several non-anchoring rows before anything real persists.
+    // #837's gate required exactly ONE frontier row, so this shape looped
+    // forever ("found no anchor and imported 0 messages") despite holding no
+    // real content a recovery could damage.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "checkpoint-missing-multi-metadata-frontier";
+    const sessionKey = "agent:main:checkpoint-missing-multi-metadata-frontier";
+    for (const suffix of ["delivery one", "delivery two"]) {
+      await engine.ingest({
+        sessionId,
+        sessionKey,
+        message: makeMessage({
+          role: "user",
+          content: `Conversation info (untrusted metadata): injected preamble ${suffix}`,
+        }),
+      });
+    }
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+    // checkpoint-missing: deliberately no bootstrap_state row.
+    const sessionFile = createSessionFilePath("checkpoint-missing-multi-metadata-frontier");
+    const transcript: Array<{ role: AgentMessage["role"]; content: string }> = Array.from(
+      { length: 64 },
+      (_, i) => ({
+        role: (i % 2 === 0 ? "user" : "assistant") as AgentMessage["role"],
+        content: `multi-frontier recovery turn ${i}`,
+      }),
+    );
+    writeLeafTranscript(sessionFile, transcript);
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "multi-frontier recovery turn 63" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).toContain("multi-frontier recovery turn 0");
+    expect(contents).toContain("multi-frontier recovery turn 63");
+    expect(contents.length).toBeGreaterThan(50);
+  });
+
   it("afterTurn recovers a checkpoint-missing conversation with a non-anchoring frontier instead of looping forever (#837)", async () => {
     // #837: a conversation with bootstrapped_at set but NO
     // conversation_bootstrap_state row classifies as reason="checkpoint-missing"


### PR DESCRIPTION
### What

Narrow follow-up to #824's closure ("the underlying #822-class bug is still valid and needs a narrower follow-up fix"). The unlocking condition is now proven from the DB shape itself, never from the recovery reason:

- New predicate `conversationFrontierIsEntirelyNonAnchoring` (in `TranscriptReconciler`): true only when every persisted row (bounded scan, ≤32 rows) is an injected `Conversation info (untrusted metadata)` preamble. This generalizes the `existingMessageCount === 1` gate from #837/#838 — hosts inject one metadata preamble per delivery, so a stuck conversation accumulates several before anything real persists (we hit a 2-row frontier in production; the count===1 gate rejects it).
- **Placeholder lane** (#822's literal shape): `placeholder-checkpoint-recovery` now actually opens `allowNoAnchorImport`, but only under that proof. On main the reason string is passed while `allowNoAnchorImport` stays unset, so the recovery is dead code (`handlePlaceholderRecovery` passes only `noAnchorImportReason`; `reconcileSessionTail` checks `params.allowNoAnchorImport`).
- **checkpoint-missing lane**: the same predicate replaces the count===1 gate; the runtime-session-match and `bootstrappedAt` requirements are unchanged.
- **Cap lift under proof only**: with a proven non-anchoring frontier there is no real content to flood or contaminate, so the no-anchor import cap no longer blocks large id-less transcripts — the second half of #822, where a 647-message transcript stays unimported forever at cap 50. (Entry-id-bearing epochs already chunk-drain since #860; id-less ones still froze.) The import stays bounded by the transcript length; a frontier holding any real row keeps the cap and the #649 freeze exactly as today.
- The delivery-only guard now also covers the placeholder reason.

### Safety vs the #824 failure

An unrelated/rotated transcript can only be imported when the conversation provably holds nothing but injected metadata — there is no real history to contaminate. The regression test "does NOT import an unrelated transcript onto a placeholder-checkpoint conversation that already holds real anchoring rows (#824 contamination guard)" pins this: with real rows present the conversation freezes and the placeholder checkpoint is not advanced.

### Related reports

- #875 / #876 propose opening the same two lanes with a `count <= 3` gate. A count-based gate still admits conversations whose few rows are real history — the same contamination class that closed #824 — while the shape-proven gate admits only frontiers that contain no real content at all, with no magic count, and under that proof can also lift the cap safely.
- #874 looks like the same family (every conversation stuck at 1 DB message while the JSONL grows).

### Tests

5 new regression tests (all fail on main, pass here): multi-row placeholder recovery past the cap; the #824 contamination guard; delivery-only freeze parity; checkpoint-missing recovery past the cap; checkpoint-missing multi-row frontier. Full suite 1308/1308, typecheck clean. Patch changeset included.

### Production validation

Validated against production data (copy of the live DB + the real ~1MB session transcript, current main + this patch): a stuck conversation holding 2 metadata rows against a 647-message transcript recovers fully in one pass through the checkpoint-missing lane (2→649 messages, `capped=false`, checkpoint advanced only after full coverage). The build has been running in production since 2026-06-12.

Closes #822
