### PR TITLE
fix(engine): fail closed when the afterTurn transcript reconcile throws

### DIFF
--- a/.changeset/afterturn-reconcile-failclosed.md
+++ b/.changeset/afterturn-reconcile-failclosed.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+`afterTurn` now fails closed when the transcript reconcile throws. The catch handler previously left the initialized in-sync default (`hasOverlap: true`) in place, so a thrown reconcile persisted the live batch AND refreshed the checkpoint to EOF — silently advancing past transcript history that was never reconciled into the DB. The catch now reports the turn as not covered, skipping batch persistence and checkpoint refresh for that turn; nothing is lost because the transcript retains the turn and the next successful reconcile imports it.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2800,6 +2800,16 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.warn(
         `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
       );
+      // Fail closed: without reconcile proof, the initialized in-sync default
+      // would persist this batch and refresh the checkpoint to EOF, advancing
+      // past transcript history that was never reconciled. Skipping persistence
+      // loses nothing — the transcript retains the turn and a later successful
+      // reconcile imports it.
+      transcriptReconcileResult = {
+        importedMessages: 0,
+        blockedByImportCap: false,
+        hasOverlap: false,
+      };
     }
     const transcriptReconcileUnsafeToAdvance =
       transcriptReconcileResult.blockedByImportCap ||

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1432,6 +1432,59 @@ describe("LcmContextEngine afterTurn", () => {
     ).toBe(false);
   });
 
+  it("afterTurn fails closed when the transcript reconcile throws: no batch persistence, no checkpoint advance", async () => {
+    // The catch handler used to leave the initialized in-sync default in place,
+    // so a thrown reconcile persisted the live batch AND refreshed the
+    // checkpoint to EOF — silently advancing past transcript history that was
+    // never reconciled.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "reconcile-throw-fail-closed";
+    const sessionKey = "agent:main:reconcile-throw-fail-closed";
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "seeded row before the failure" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const sessionFile = createSessionFilePath("reconcile-throw-fail-closed");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "seeded row before the failure" },
+    ]);
+    vi.spyOn(
+      (
+        engine as unknown as {
+          transcriptReconciler: { reconcileTranscriptTailForAfterTurn: () => Promise<unknown> };
+        }
+      ).transcriptReconciler,
+      "reconcileTranscriptTailForAfterTurn",
+    ).mockRejectedValueOnce(new Error("synthetic reconcile failure"));
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "batch during the failure" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+    const contents = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).map((m) => m.content);
+    expect(contents).not.toContain("batch during the failure");
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("transcript reconcile failed"))).toBe(true);
+  });
+
   it("afterTurn recovers a checkpoint-missing conversation with a non-anchoring frontier instead of looping forever (#837)", async () => {
     // #837: a conversation with bootstrapped_at set but NO
     // conversation_bootstrap_state row classifies as reason="checkpoint-missing"


### PR DESCRIPTION
### What

`afterTurn` initializes its reconcile result to an in-sync default (`hasOverlap: true`) and the catch around `reconcileTranscriptTailForAfterTurn` only logs the failure. A thrown reconcile therefore leaves the in-sync default in place: the live batch is persisted AND the checkpoint refreshes to EOF — silently advancing past transcript history that was never reconciled into the DB. Subsequent reads are append-only, so the skipped span becomes permanently unreachable.

The catch now reports the turn as not covered (`hasOverlap: false, importedMessages: 0`): batch persistence and checkpoint refresh are skipped for that turn. Nothing is lost — the transcript retains the turn and the next successful reconcile imports it. This matches the no-proof-no-advance doctrine (#649) and the fail-closed direction of the entry-id rework.

### Tests

New regression test (fails on main): the reconcile mock-throws → the live batch is NOT persisted, no checkpoint row is created, and the failure warn is logged. Full suite 1304/1304, typecheck clean. Patch changeset included.
