### PR TITLE
fix(store): normalize injected user-turn decoration before computing message identity

### DIFF
--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -9,6 +9,7 @@ import type { CreateMessagePartInput } from "./store/conversation-store.js";
 import { extractToolResultIdForPairing } from "./tool-pairing.js";
 import { extractBootstrapMessageCandidate } from "./transcript.js";
 import { createHash } from "node:crypto";
+import { buildMessageIdentityKey } from "./store/message-identity.js";
 
 export function createBootstrapEntryHash(message: StoredMessage | null): string | null {
   if (!message) {
@@ -31,7 +32,7 @@ export function readBootstrapMessageFromJsonLine(line: string | null): AgentMess
 }
 
 export function messageIdentity(role: string, content: string): string {
-  return `${role}\u0000${content}`;
+  return buildMessageIdentityKey(role, content);
 }
 
 export function isBootstrapReplayCandidateMessage(message: AgentMessage): boolean {

--- a/src/store/message-identity.ts
+++ b/src/store/message-identity.ts
@@ -16,8 +16,8 @@ export function normalizeIdentityContent(content: string): string {
   if (typeof content !== "string") return content;
   let s = content;
   s = s.replace(/^\s*\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}[^\]]*GMT[^\]]*\]\s*/, "");
-  s = s.replace(/Conversation info \(untrusted metadata\):\s*\{[\s\S]*?\}\s*/g, "");
-  s = s.replace(/Sender \(untrusted metadata\):\s*\{[\s\S]*?\}\s*/g, "");
+  s = s.replace(/Conversation info \(untrusted metadata\):\s*(?:```[a-zA-Z]*\s*[\s\S]*?```|\{[\s\S]*?\})\s*/g, "");
+  s = s.replace(/Sender \(untrusted metadata\):\s*(?:```[a-zA-Z]*\s*[\s\S]*?```|\{[\s\S]*?\})\s*/g, "");
   s = s.replace(/\[message_id:[^\]]*\]\s*/g, "");
   return s.trim();
 }

--- a/src/store/message-identity.ts
+++ b/src/store/message-identity.ts
@@ -1,13 +1,37 @@
 import { createHash } from "node:crypto";
 
+/**
+ * Strip host-injected decoration before computing message identity.
+ * OpenClaw >=2026.5.26 "cleaned user-turn persistence"
+ * stores the transcript copy of a user turn RAW while the afterTurn/model-facing
+ * copy keeps its decoration (inline "[Wkdy YYYY-MM-DD HH:MM GMT+N]" timestamp on
+ * dashboard, "Conversation info (untrusted metadata): {...}" wrapper on Slack).
+ * Verbatim hashing makes the two copies distinct identities, so every user turn
+ * persists twice (lossless-claw #889; the #854/#866 entry-id rework does not cover
+ * this because its convergence still matches by content). Normalizing both copies
+ * to the same core text lets dedup collapse them to one row, while the
+ * user-visible timestamp stays intact (injected live at prompt-build).
+ */
+export function normalizeIdentityContent(content: string): string {
+  if (typeof content !== "string") return content;
+  let s = content;
+  s = s.replace(/^\s*\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}[^\]]*GMT[^\]]*\]\s*/, "");
+  s = s.replace(/Conversation info \(untrusted metadata\):\s*\{[\s\S]*?\}\s*/g, "");
+  s = s.replace(/Sender \(untrusted metadata\):\s*\{[\s\S]*?\}\s*/g, "");
+  s = s.replace(/\[message_id:[^\]]*\]\s*/g, "");
+  return s.trim();
+}
+
+const IDENTITY_SEP = String.fromCharCode(0);
+
 export function buildMessageIdentityKey(role: string, content: string): string {
-  return `${role}\u0000${content}`;
+  return role + IDENTITY_SEP + normalizeIdentityContent(content);
 }
 
 export function buildMessageIdentityHash(role: string, content: string): string {
   return createHash("sha256")
     .update(role)
-    .update("\u0000")
-    .update(content)
+    .update(IDENTITY_SEP)
+    .update(normalizeIdentityContent(content))
     .digest("hex");
 }

--- a/test/message-identity.test.ts
+++ b/test/message-identity.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getLcmDbFeatures } from "../src/db/features.js";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
-import { buildMessageIdentityHash } from "../src/store/message-identity.js";
+import { buildMessageIdentityHash, normalizeIdentityContent } from "../src/store/message-identity.js";
 
 function createStoreFixture() {
   const db = new DatabaseSync(":memory:");
@@ -56,5 +56,45 @@ describe("ConversationStore message identity lookups", () => {
     } finally {
       db.close();
     }
+  });
+});
+
+describe("normalizeIdentityContent — Slack untrusted-metadata wrapper", () => {
+  const raw =
+    "Hello again, we were testing message duplication issue. is it still the case? are you getting my messages multiple times?";
+
+  // The Slack runtime copy: metadata wrapped in a ```json fenced block, then the raw text.
+  // (matches the on-disk bytes of lcm conv528 seq1)
+  const fencedWrapper = [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    "{",
+    '  "chat_id": "user:U02V2TNFK2R",',
+    '  "message_id": "1781693435.927299",',
+    '  "sender_id": "U02V2TNFK2R",',
+    '  "sender": "gorkem.erdogan",',
+    '  "timestamp": 1781693437307',
+    "}",
+    "```",
+    "",
+    raw,
+  ].join("\n");
+
+  it("collapses the fenced ```json wrapper so the runtime copy and the transcript-raw copy share one identity", () => {
+    expect(normalizeIdentityContent(fencedWrapper)).toBe(raw);
+    expect(buildMessageIdentityHash("user", fencedWrapper)).toBe(
+      buildMessageIdentityHash("user", raw),
+    );
+  });
+
+  it("still collapses the legacy bare-brace wrapper form (no regression of the timestamp-era handling)", () => {
+    const bare = `Conversation info (untrusted metadata): { "chat_id": "x", "sender": "y" }\n\n${raw}`;
+    expect(normalizeIdentityContent(bare)).toBe(raw);
+  });
+
+  it("still strips the leading [Wkdy YYYY-MM-DD HH:MM GMT+N] timestamp prefix", () => {
+    const stamped = `[Sat 2026-06-13 23:14 GMT+3] ${raw}`;
+    expect(normalizeIdentityContent(stamped)).toBe(raw);
+    expect(buildMessageIdentityHash("user", stamped)).toBe(buildMessageIdentityHash("user", raw));
   });
 });


### PR DESCRIPTION
## Summary

Fixes #889.

OpenClaw v2026.5.26+ "cleaned user-turn persistence" writes the transcript copy of a user message without the host-injected decoration, while the copy handed to `afterTurn` still carries it. Because message identity is computed over verbatim content, the two copies of the same turn hash differently, so reconcile never matches them.

This PR normalizes message content before the identity hash is computed, so the decorated and cleaned copies of a turn collapse to a single identity. This is option 1 from the issue's own suggested fixes.

## Root cause (confirming the issue analysis)

Exactly as described in the issue:

1. Bootstrap reads the cleaned session JSONL and stores the user turn with identity hash A (no decoration).
2. `afterTurn` receives the decorated copy from the OpenClaw runtime, identity hash B.
3. `reconcileSessionTail` compares A and B, finds no overlap, and treats the transcript tail as unreconciled.

The decoration that differs between the two copies includes the `Conversation info (untrusted metadata)` block, the `Sender (untrusted metadata)` block, the `[message_id: ...]` line, and, on the dashboard/webchat surface, an inline `[Wkdy YYYY-MM-DD HH:MM GMT+N]` timestamp.

## Two symptoms, one cause

The same identity mismatch surfaces differently by environment:

- **Stuck at 1 DB message** (the Lark/Feishu reports in this issue): reconcile skips persistence to avoid anchoring past unreconciled history, so the checkpoint never advances.
- **Duplicate rows** (our OpenClaw 2026.6.1 dashboard + Slack environment): both the decorated and the cleaned copy persist, producing two DB rows per user turn.

Both resolve once the two copies normalize to the same identity.

## Change

- `src/store/message-identity.ts`: add `normalizeIdentityContent()`, which strips the host-injected decoration listed above, and route both `buildMessageIdentityKey` and `buildMessageIdentityHash` through it.
- `src/message-signatures.ts`: `messageIdentity` delegates to `buildMessageIdentityKey`, centralizing normalization in one place rather than duplicating it at each call site.

Centralizing at the identity functions means every caller (bootstrap/ingest and afterTurn/reconcile) compares on the same normalized form, so the fix covers both paths the issue calls out. Only the value fed into the identity hash is normalized; the stored and displayed content (including the user-visible timestamp) is untouched.

## Verification

Deployed and live-verified in our environment (OpenClaw 2026.6.1, dashboard + Slack): user turns now persist exactly once, where previously each turn produced two rows, and reconcile advances normally. Verified across both channels with no session reset required. Happy to add a regression test for `normalizeIdentityContent` matching the repo's test conventions if that would help review.

## Relationship to prior work

The entry-id reconciliation rework ([#854](https://github.com/Martian-Engineering/lossless-claw/pull/854), [#866](https://github.com/Martian-Engineering/lossless-claw/pull/866)) reduced reconcile churn but does not cover this case, because its convergence still compares by content identity, which the decoration defeats. Normalizing content before hashing is complementary to that work.
