### PR TITLE
docs: add changeset for summarizer retry headroom

### DIFF
--- a/.changeset/summarizer-retry-token-headroom.md
+++ b/.changeset/summarizer-retry-token-headroom.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use the configured leaf or condensed target token budget when retrying empty compaction summaries, giving high-reasoning summary models enough headroom to emit text instead of falling back to deterministic truncation.


### PR DESCRIPTION
## What
Adds the missing Changeset for the summarizer retry token-budget fix landed in #845.

## Why
#845 changes package-visible compaction behavior for high-reasoning summary models and needs release notes for the next package publish.

## Changes
- Add patch Changeset

## Testing
- `npm exec changeset status -- --since origin/main`
- `AUTOREVIEW_ENGINE=codex /Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "npm exec changeset status -- --since origin/main"`