### PR TITLE
Improve LCM long-run diagnostics and stub drilldown

### DIFF
--- a/.changeset/lcm-long-run-diagnostics.md
+++ b/.changeset/lcm-long-run-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Improve long-run LCM diagnostics for summary env overrides and large-tool stub readiness, clarify runtime `large_files` externalization versus `messages.large_content` migration stubs, and allow `lcm_describe` to accept full `[LCM Tool Output: file_xxx ...]` references.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Plugin config equivalents:
 - `delegationTimeoutMs`
 - `summaryTimeoutMs`
 
-Environment variables still win over plugin config when both are set.
+Environment variables still win over plugin config when both are set. `/lossless status` reports the resolved summary provider/model and warns when `LCM_SUMMARY_MODEL` or `LCM_SUMMARY_PROVIDER` differs from the plugin's configured summary target, which usually means the running service inherited stale env and should be restarted with those overrides cleared.
 
 ### Summary model priority
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -80,7 +80,7 @@ Look up metadata and content for a specific summary or stored file.
 
 | Param | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `id` | string | ✅ | — | `sum_xxx` for summaries, `file_xxx` for files |
+| `id` | string | ✅ | — | `sum_xxx` for summaries, `file_xxx` for files, or the full `[LCM Tool Output: file_xxx ...]` reference string |
 | `conversationId` | number | | current session family | Scope to a specific physical conversation |
 | `allConversations` | boolean | | `false` | Allow cross-conversation lookups |
 
@@ -108,6 +108,9 @@ lcm_describe(id: "sum_abc123def456")
 
 # Retrieve a stored large file
 lcm_describe(id: "file_789abc012345")
+
+# Retrieve a file from a compact tool-output reference
+lcm_describe(id: "[LCM Tool Output: file_789abc012345 | tool=exec | 12,345 bytes]")
 ```
 
 ### lcm_expand_query

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,8 @@ Files embedded in user messages (typically via `<file>` blocks from tool output)
 
 This prevents a single large file paste from consuming the entire context window while keeping the content accessible.
 
+Runtime large-file externalization and the `messages.large_content` stub tier are related but distinct. Runtime externalization writes `large_files` records and replaces newly ingested large payloads with compact `[LCM Tool Output: file_xxx ...]` references or metadata immediately. The `messages.large_content` column is populated by `scripts/lcm-blob-migrate.mjs` for legacy tool-result rows so the assembler can stub older evictable rows later. A zero `messages.large_content` count does not mean runtime large-file externalization is absent; check `large_files` for that tier.
+
 ## Session reconciliation
 
 LCM handles crash recovery through **bootstrap reconciliation**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,7 @@ Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rot
 | `freshTailCount` | `integer` | `64` | `LCM_FRESH_TAIL_COUNT` | Number of newest messages always kept raw. |
 | `freshTailMaxTokens` | `integer` | unset | `LCM_FRESH_TAIL_MAX_TOKENS` | Optional token cap for the protected fresh tail. The newest message is always preserved even if it exceeds the cap. |
 | `promptAwareEviction` | `boolean` | `false` | `LCM_PROMPT_AWARE_EVICTION_ENABLED` | When enabled, budget-constrained assembly keeps older evictable items by prompt relevance instead of pure chronology. This improves retrieval under tight budgets, but it can reduce prompt-cache hit rates because the preserved prefix changes as prompts change. |
-| `stubLargeToolPayloads` | `boolean` | `false` | `LCM_STUB_LARGE_TOOL_PAYLOADS` | When enabled, evictable tool-result rows backfilled with `messages.large_content` are assembled as `[LCM Tool Output: file_xxx ...]` stubs while the fresh tail stays inline. Requires `scripts/lcm-blob-migrate.mjs`, which defaults to the same large-files root as runtime LCM (`LCM_LARGE_FILES_DIR` or `${OPENCLAW_STATE_DIR}/lcm-files`). |
+| `stubLargeToolPayloads` | `boolean` | `false` | `LCM_STUB_LARGE_TOOL_PAYLOADS` | When enabled, evictable legacy tool-result rows backfilled with `messages.large_content` are assembled as `[LCM Tool Output: file_xxx ...]` stubs while the fresh tail stays inline. This is separate from runtime large-tool externalization, which writes `large_files` records and compact references during ingest. Requires `scripts/lcm-blob-migrate.mjs`, which defaults to the same large-files root as runtime LCM (`LCM_LARGE_FILES_DIR` or `${OPENCLAW_STATE_DIR}/lcm-files`). |
 | `leafMinFanout` | `integer` | `8` | `LCM_LEAF_MIN_FANOUT` | Minimum number of raw messages required before a leaf pass runs. |
 | `condensedMinFanout` | `integer` | `4` | `LCM_CONDENSED_MIN_FANOUT` | Number of same-depth summaries needed before condensation is attempted. |
 | `condensedMinFanoutHard` | `integer` | `2` | `LCM_CONDENSED_MIN_FANOUT_HARD` | Hard floor for condensation grouping during maintenance and repair flows. |
@@ -327,6 +327,8 @@ Compaction summarization resolves candidates in this order:
 5. `fallbackProviders`
 
 If `summaryModel` already contains a provider prefix such as `anthropic/claude-sonnet-4-20250514`, `summaryProvider` is ignored for that candidate.
+
+`LCM_SUMMARY_MODEL` and `LCM_SUMMARY_PROVIDER` are process environment overrides. They intentionally win over plugin config, so `/lossless status` reports the resolved summary provider/model and warns when those env values differ from `plugins.entries.lossless-claw.config.summaryModel` or `summaryProvider`. If status shows an unexpected env override after editing durable config, restart the service with the stale env cleared.
 
 Lossless does not resolve provider credentials directly for compaction summaries. OpenClaw's runtime LLM layer owns provider/model preparation, auth profiles, OAuth refresh, base URLs, and dispatch. Lossless only selects the requested summary target and passes it to the host runtime, where model override policy is enforced.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -51,7 +51,7 @@
     },
     "stubLargeToolPayloads": {
       "label": "Stub Large Tool Payloads",
-      "help": "When enabled, evictable tool-result rows whose payload was externalized via lcm-blob-migrate are replaced with a [LCM Tool Output: file_xxx | …] reference at assemble time. Fresh tail is never stubbed. The agent recovers the original output via lcm_describe(id=file_xxx, expandFile=true). Default off; requires running scripts/lcm-blob-migrate.mjs first to populate messages.large_content."
+      "help": "When enabled, evictable legacy tool-result rows whose messages.large_content sidecar was populated by lcm-blob-migrate are replaced with a [LCM Tool Output: file_xxx | …] reference at assemble time. Runtime large-tool externalization writes large_files directly and is reported separately. Fresh tail is never stubbed. The agent recovers the original output via lcm_describe(id=file_xxx, expandFile=true). Default off; requires running scripts/lcm-blob-migrate.mjs first to populate messages.large_content."
     },
     "leafChunkTokens": {
       "label": "Leaf Chunk Tokens",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -112,13 +112,14 @@ Good default:
 
 ### `stubLargeToolPayloads`
 
-Controls whether older, evictable tool-result rows that were backfilled into the `large_files` store are assembled as compact `[LCM Tool Output: file_xxx ...]` stubs instead of full inline payloads.
+Controls whether older, evictable legacy tool-result rows whose `messages.large_content` sidecar was populated by `scripts/lcm-blob-migrate.mjs` are assembled as compact `[LCM Tool Output: file_xxx ...]` stubs instead of full inline payloads. This is separate from runtime large-tool externalization, which writes `large_files` records and compact references during ingest.
 
 Why it matters:
 
 - it reuses the existing `large_files` drilldown path for old tool output without changing the fresh tail
 - it can recover substantially more historical context at the same token budget in tool-heavy sessions
 - it should stay off until the operator has run `scripts/lcm-blob-migrate.mjs` for the target database
+- `/lossless status` reports `messages.large_content` sidecar readiness separately from runtime `large_files` records
 
 Good default:
 
@@ -436,6 +437,7 @@ Boolean toggle for assemble-time stub substitution of migrated tool-result paylo
 Why it matters:
 
 - only affects rows whose `messages.large_content` sidecar points at a `file_xxx` record
+- runtime large-tool externalization writes `large_files` directly; zero `messages.large_content` rows does not mean runtime externalization is absent
 - the fresh tail is still emitted verbatim
 - drilldown uses `lcm_describe(id=file_xxx, expandFile=true)`
 - `scripts/lcm-blob-migrate.mjs` defaults to the same storage root as runtime LCM: `LCM_LARGE_FILES_DIR` or `${OPENCLAW_STATE_DIR}/lcm-files`

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -40,6 +40,7 @@ const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
 const DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD = 1_000;
 const DOCTOR_APPLY_LARGE_TARGET_THRESHOLD = 25;
 const DOCTOR_APPLY_BUDGET_PRESSURE_RATIO = 0.75;
+const STUB_MIGRATION_THRESHOLD_BYTES = 8_000;
 
 type LcmStatusStats = {
   conversationCount: number;
@@ -48,6 +49,12 @@ type LcmStatusStats = {
   summarizedSourceTokens: number;
   leafSummaryCount: number;
   condensedSummaryCount: number;
+};
+
+type LargeToolPayloadStubStats = {
+  stubReadySidecars: number;
+  legacyRawToolRowsOverThreshold: number;
+  largeFileCount: number;
 };
 
 type LcmConversationStatusStats = {
@@ -127,6 +134,14 @@ function readCommandRuntimeContext(ctx: PluginCommandContext): Record<string, un
   return asRecord(asRecord(ctx)?.runtimeContext);
 }
 
+function readNestedString(root: unknown, path: string[]): string {
+  let current: unknown = root;
+  for (const segment of path) {
+    current = asRecord(current)?.[segment];
+  }
+  return typeof current === "string" ? current.trim() : "";
+}
+
 function formatBoolean(value: boolean): string {
   return value ? "yes" : "no";
 }
@@ -170,6 +185,20 @@ function buildSection(title: string, lines: string[]): string {
 
 function buildStatLine(label: string, value: string): string {
   return `${label}: ${value}`;
+}
+
+function formatConfigPair(provider: string, model: string): string {
+  if (!provider && !model) {
+    return "unset";
+  }
+  return `${provider || "default"} / ${model || "default"}`;
+}
+
+function resolveEnvBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value === "true";
 }
 
 function formatFailureReason(error: unknown): string {
@@ -373,6 +402,142 @@ function getLcmStatusStats(db: DatabaseSync): LcmStatusStats {
     leafSummaryCount: row?.leaf_summary_count ?? 0,
     condensedSummaryCount: row?.condensed_summary_count ?? 0,
   };
+}
+
+function getLargeToolPayloadStubStats(db: DatabaseSync): LargeToolPayloadStubStats {
+  const row = db
+    .prepare(
+      `SELECT
+         COALESCE(SUM(CASE WHEN large_content IS NOT NULL THEN 1 ELSE 0 END), 0) AS stub_ready_sidecars,
+         COALESCE(SUM(
+           CASE
+             WHEN role = 'tool'
+              AND large_content IS NULL
+              AND length(CAST(content AS BLOB)) > ?
+             THEN 1
+             ELSE 0
+           END
+         ), 0) AS legacy_raw_tool_rows_over_threshold
+       FROM messages`,
+    )
+    .get(STUB_MIGRATION_THRESHOLD_BYTES) as
+    | {
+        stub_ready_sidecars: number;
+        legacy_raw_tool_rows_over_threshold: number;
+      }
+    | undefined;
+  const largeFileRow = db
+    .prepare(`SELECT COALESCE(COUNT(*), 0) AS large_file_count FROM large_files`)
+    .get() as { large_file_count: number } | undefined;
+
+  return {
+    stubReadySidecars: row?.stub_ready_sidecars ?? 0,
+    legacyRawToolRowsOverThreshold: row?.legacy_raw_tool_rows_over_threshold ?? 0,
+    largeFileCount: largeFileRow?.large_file_count ?? 0,
+  };
+}
+
+function buildRuntimeConfigLines(params: {
+  ctx: PluginCommandContext;
+  config: LcmConfig;
+}): string[] {
+  const pluginSummaryProvider = readNestedString(params.ctx.config, [
+    "plugins",
+    "entries",
+    "lossless-claw",
+    "config",
+    "summaryProvider",
+  ]);
+  const pluginSummaryModel = readNestedString(params.ctx.config, [
+    "plugins",
+    "entries",
+    "lossless-claw",
+    "config",
+    "summaryModel",
+  ]);
+  const envSummaryProvider = process.env.LCM_SUMMARY_PROVIDER?.trim() ?? "";
+  const envSummaryModel = process.env.LCM_SUMMARY_MODEL?.trim() ?? "";
+  const resolvedSummaryProvider = envSummaryProvider || params.config.summaryProvider;
+  const resolvedSummaryModel = envSummaryModel || params.config.summaryModel;
+  const envOverridesPlugin =
+    (envSummaryProvider !== "" && pluginSummaryProvider !== "" && envSummaryProvider !== pluginSummaryProvider)
+    || (envSummaryModel !== "" && pluginSummaryModel !== "" && envSummaryModel !== pluginSummaryModel);
+  const lines = [
+    buildStatLine(
+      "summary provider/model",
+      formatConfigPair(resolvedSummaryProvider, resolvedSummaryModel),
+    ),
+  ];
+
+  if (pluginSummaryProvider || pluginSummaryModel) {
+    lines.push(
+      buildStatLine(
+        "plugin summary provider/model",
+        formatConfigPair(pluginSummaryProvider, pluginSummaryModel),
+      ),
+    );
+  }
+  if (envSummaryProvider || envSummaryModel) {
+    lines.push(
+      buildStatLine(
+        "env summary override",
+        [
+          envSummaryProvider ? `LCM_SUMMARY_PROVIDER=${envSummaryProvider}` : "",
+          envSummaryModel ? `LCM_SUMMARY_MODEL=${envSummaryModel}` : "",
+        ].filter(Boolean).join(", "),
+      ),
+    );
+  }
+  if (envOverridesPlugin) {
+    lines.push(
+      buildStatLine(
+        "warning",
+        "LCM_SUMMARY_PROVIDER/LCM_SUMMARY_MODEL override plugin summary config; restart or clear stale service env if this is unexpected",
+      ),
+    );
+  }
+
+  return lines;
+}
+
+function buildLargeToolPayloadStubLines(params: {
+  config: LcmConfig;
+  stats: LargeToolPayloadStubStats;
+}): string[] {
+  const stubLargeToolPayloads =
+    resolveEnvBoolean(process.env.LCM_STUB_LARGE_TOOL_PAYLOADS) ?? params.config.stubLargeToolPayloads;
+  const lines = [
+    buildStatLine("stubLargeToolPayloads", stubLargeToolPayloads ? "enabled" : "disabled"),
+    buildStatLine("stub-ready sidecars", formatNumber(params.stats.stubReadySidecars)),
+    buildStatLine(
+      `legacy raw tool rows over ${formatNumber(STUB_MIGRATION_THRESHOLD_BYTES)} bytes`,
+      formatNumber(params.stats.legacyRawToolRowsOverThreshold),
+    ),
+    buildStatLine("large_files records", formatNumber(params.stats.largeFileCount)),
+    buildStatLine(
+      "note",
+      "runtime large-file references use large_files directly; messages.large_content only tracks migration-populated stub tier",
+    ),
+  ];
+
+  if (stubLargeToolPayloads && params.stats.stubReadySidecars === 0) {
+    lines.push(
+      buildStatLine(
+        "warning",
+        "enabled, but no rows are stub-ready; run scripts/lcm-blob-migrate.mjs for legacy tool rows before expecting assembler stubs",
+      ),
+    );
+  }
+  if (params.stats.legacyRawToolRowsOverThreshold > 0) {
+    lines.push(
+      buildStatLine(
+        "migration",
+        `${formatNumber(params.stats.legacyRawToolRowsOverThreshold)} legacy tool row(s) still need scripts/lcm-blob-migrate.mjs`,
+      ),
+    );
+  }
+
+  return lines;
 }
 
 function getConversationStatusStats(
@@ -904,6 +1069,7 @@ async function buildStatusText(params: {
   config: LcmConfig;
 }): Promise<string> {
   const status = getLcmStatusStats(params.db);
+  const largeToolPayloadStubStats = getLargeToolPayloadStubStats(params.db);
   const doctor = getDoctorSummaryStats(params.db);
   const enabled = resolvePluginEnabled(params.ctx.config);
   const selected = resolvePluginSelected(params.ctx.config);
@@ -924,6 +1090,8 @@ async function buildStatusText(params: {
       buildStatLine("db size", dbSize),
     ]),
     "",
+    buildSection("⚙️ Runtime config", buildRuntimeConfigLines(params)),
+    "",
     buildSection("🌐 Global", [
       buildStatLine("conversations", formatNumber(status.conversationCount)),
       buildStatLine(
@@ -933,6 +1101,14 @@ async function buildStatusText(params: {
       buildStatLine("stored summary tokens", formatNumber(status.storedSummaryTokens)),
       buildStatLine("summarized source tokens", formatNumber(status.summarizedSourceTokens)),
     ]),
+    "",
+    buildSection(
+      "🧱 Large tool payload stubs",
+      buildLargeToolPayloadStubLines({
+        config: params.config,
+        stats: largeToolPayloadStubStats,
+      }),
+    ),
     "",
   ];
 

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -75,6 +75,12 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
   return Math.max(1, Math.trunc(value));
 }
 
+function normalizeDescribeId(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^\[LCM Tool Output:\s*(file_[A-Za-z0-9_-]+)(?:\s*\||\s*\])[\s\S]*\]$/);
+  return match?.[1] ?? trimmed;
+}
+
 function compactDescribeDetails(result: DescribeResult | null) {
   if (!result) {
     return result;
@@ -130,7 +136,7 @@ export function createLcmDescribeTool(input: {
       const retrieval = lcm.getRetrieval();
       const timezone = lcm.timezone;
       const p = params as Record<string, unknown>;
-      const id = (p.id as string).trim();
+      const id = normalizeDescribeId(p.id as string);
       const conversationScope = await resolveLcmConversationScope({
         lcm,
         deps: input.deps,

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -72,6 +72,7 @@ describe("lcm command", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     for (const dbPath of dbPaths) {
       closeLcmConnection(dbPath);
     }
@@ -149,6 +150,80 @@ describe("lcm command", () => {
     expect(result.text).toContain("**📍 Current conversation**");
     expect(result.text).toContain("status: unavailable");
     expect(result.text).toContain("OpenClaw did not expose an active session key or session id here");
+  });
+
+  it("warns when summary env overrides differ from plugin summary config", async () => {
+    vi.stubEnv("LCM_SUMMARY_PROVIDER", "openai-codex");
+    vi.stubEnv("LCM_SUMMARY_MODEL", "gpt-5.5");
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext("status", {
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+                config: {
+                  summaryProvider: "openai",
+                  summaryModel: "gpt-5.4-mini",
+                },
+              },
+            },
+            slots: {
+              contextEngine: "lossless-claw",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.text).toContain("**⚙️ Runtime config**");
+    expect(result.text).toContain("summary provider/model: openai-codex / gpt-5.5");
+    expect(result.text).toContain(
+      "warning: LCM_SUMMARY_PROVIDER/LCM_SUMMARY_MODEL override plugin summary config",
+    );
+    expect(result.text).toContain("plugin summary provider/model: openai / gpt-5.4-mini");
+    expect(result.text).toContain("restart or clear stale service env");
+  });
+
+  it("reports stub readiness when stubLargeToolPayloads has no migrated sidecars", async () => {
+    vi.stubEnv("LCM_STUB_LARGE_TOOL_PAYLOADS", "true");
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "stub-readiness-session",
+      sessionKey: "agent:main:telegram:stub-readiness",
+      title: "Stub readiness fixture",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "tool",
+        content: "x".repeat(8_001),
+        tokenCount: 2_100,
+      },
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("status", {
+        sessionId: "stub-readiness-session",
+        sessionKey: "agent:main:telegram:stub-readiness",
+      }),
+    );
+
+    expect(result.text).toContain("**🧱 Large tool payload stubs**");
+    expect(result.text).toContain("stubLargeToolPayloads: enabled");
+    expect(result.text).toContain("stub-ready sidecars: 0");
+    expect(result.text).toContain("legacy raw tool rows over 8,000 bytes: 1");
+    expect(result.text).toContain("warning: enabled, but no rows are stub-ready");
+    expect(result.text).toContain("scripts/lcm-blob-migrate.mjs");
+    expect(result.text).toContain("runtime large-file references use large_files directly");
   });
 
   it("resolves current conversation stats when the host provides a session key", async () => {

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -774,6 +774,60 @@ describe("LCM tools session scoping", () => {
     expect(JSON.stringify(cross.details)).not.toContain("subtree");
   });
 
+  it("lcm_describe accepts a full LCM Tool Output reference string as a file id", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "file_abc123",
+        type: "file",
+        file: {
+          conversationId: 42,
+          fileName: "tool-output.txt",
+          mimeType: "text/plain",
+          byteSize: 1234,
+          storageUri: "/safe/lcm-files/file_abc123.txt",
+          explorationSummary: "Tool: exec | (command elided)",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+    });
+    const result = await tool.execute("call-tool-output-ref", {
+      id: "[LCM Tool Output: file_abc123 | tool=exec | 1,234 bytes]",
+      allConversations: true,
+    });
+
+    expect(retrieval.describe).toHaveBeenCalledWith("file_abc123", expect.any(Object));
+    expect((result.content[0] as { text: string }).text).toContain("## LCM File: file_abc123");
+    expect(result.details).toMatchObject({ id: "file_abc123", type: "file" });
+  });
+
+  it("lcm_describe does not extract file ids from arbitrary malformed text", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => null),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval }) as never,
+    });
+    const malformed = "please describe file_abc123 from this sentence";
+    const result = await tool.execute("call-malformed-ref", {
+      id: malformed,
+      allConversations: true,
+    });
+
+    expect(retrieval.describe).toHaveBeenCalledWith(malformed, expect.any(Object));
+    expect((result.details as { error?: string }).error).toBe(`Not found: ${malformed}`);
+  });
+
   it("lcm_describe rejects allConversations results outside a delegated grant", async () => {
     const retrieval = {
       grep: vi.fn(),


### PR DESCRIPTION
## Summary

- Add `/lossless status` runtime config diagnostics that show the resolved summary provider/model and warn when `LCM_SUMMARY_PROVIDER` or `LCM_SUMMARY_MODEL` overrides the plugin summary config.
- Add large-tool stub readiness diagnostics that count `messages.large_content` sidecars, likely legacy raw tool rows over the migration threshold, and `large_files` rows separately.
- Clarify docs/help text for runtime `large_files` externalization versus migration-populated `messages.large_content` assembler stubs.
- Allow `lcm_describe` to accept full `[LCM Tool Output: file_xxx ...]` reference strings while leaving arbitrary malformed text untouched.

## Issues

Closes #892
Closes #893
Closes #894
Closes #895

## Validation

Local validation from `/Volumes/LEXAR/repos/worktrees/lossless-claw-lcm-long-run-diagnostics`:

- `npm ci`
- `npx vitest run test/lcm-command.test.ts test/lcm-tools.test.ts --pool=forks --poolOptions.forks.maxForks=1 --poolOptions.forks.minForks=1`
- `npm run typecheck`
- `npm run build`
- `node -e "JSON.parse(require('node:fs').readFileSync('openclaw.plugin.json','utf8')); console.log('openclaw.plugin.json ok')"`

GitHub Actions validation on PR #896:

- CI `test`: passed
- CI `plugin-inspector`: passed
- CI `smoke-latest-openclaw`: passed

## Risk and rollback

- Runtime behavior change is limited to status text and conservative `lcm_describe` input normalization for canonical LCM tool-output references.
- No database schema, migration, gateway, launchd, or service env changes.
- Rollback is a normal revert of this PR; existing direct `file_xxx` and `sum_xxx` describe calls remain unchanged.
