### PR TITLE
fix(lcm): unify message redaction timing in afterTurn to prevent dupl…

### DIFF
--- a/.changeset/afterturn-unified-redact.md
+++ b/.changeset/afterturn-unified-redact.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Unify message redaction timing in afterTurn to fix duplicate message ingestion caused by inconsistent identity_hash across the transcript reconcile and live dedup paths.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1491,6 +1491,28 @@ function filterPersistableMessages(messages: AgentMessage[]): AgentMessage[] {
   return messages.filter(hasPersistableMessageRole);
 }
 
+// ── Transcript redaction bridge ──────────────────────────────────────
+// The host exposes redactTranscriptMessage through openclaw/plugin-sdk/redact
+// so LCM can apply the same redaction rules as the transcript writing layer.
+// This ensures identity_hash consistency between the transcript reconcile
+// path (reads redacted content from file) and the live dedup path.
+let redactTranscriptMessageFn: ((message: AgentMessage) => AgentMessage) | null | undefined;
+
+async function loadRedactTranscriptMessage(): Promise<
+  ((message: AgentMessage) => AgentMessage) | undefined
+> {
+  if (redactTranscriptMessageFn !== undefined) return redactTranscriptMessageFn ?? undefined;
+  try {
+    const mod = await import("openclaw/plugin-sdk/redact");
+    const fn = mod.redactTranscriptMessage as unknown as (message: AgentMessage) => AgentMessage;
+    redactTranscriptMessageFn = fn;
+    return fn;
+  } catch {
+    redactTranscriptMessageFn = null;
+    return undefined;
+  }
+}
+
 type StoredMessage = {
   role: "user" | "assistant" | "system" | "tool";
   content: string;
@@ -9098,6 +9120,14 @@ export class LcmContextEngine implements ContextEngine {
     const newMessages = filterPersistableMessages(
       params.messages.slice(params.prePromptMessageCount),
     );
+    // Apply transcript-level redaction so identity_hash calculation matches
+    // the transcript reconcile path (which reads redacted content from file).
+    // Without this, the same message would produce different hashes on the
+    // two paths and dedup would fail to detect duplicates.
+    const redactMessage = await loadRedactTranscriptMessage();
+    const sanitizedNewMessages = redactMessage
+      ? newMessages.map((m) => redactMessage(m))
+      : newMessages;
     let transcriptReconcileResult: TranscriptReconcileResult = {
       importedMessages: 0,
       blockedByImportCap: false,
@@ -9135,7 +9165,7 @@ export class LcmContextEngine implements ContextEngine {
       dedupedNewMessages = await this.deduplicateAfterTurnBatch(
         params.sessionId,
         params.sessionKey,
-        newMessages,
+        sanitizedNewMessages,
         {
           oversizedNoOverlap: transcriptReconcileResult.importedMessages > 0 ? "ingest" : "skip",
         },

--- a/src/openclaw-plugin-sdk-redact.d.ts
+++ b/src/openclaw-plugin-sdk-redact.d.ts
@@ -1,0 +1,12 @@
+declare module "openclaw/plugin-sdk/redact" {
+  /**
+   * Redact sensitive content from an agent message using the same redaction
+   * rules applied by the transcript writing layer.
+   *
+   * Returns a new object; does not mutate the input message.
+   * When logging.redactSensitive is "off", returns the message unchanged.
+   */
+  export function redactTranscriptMessage(
+    message: Record<string, unknown>,
+  ): Record<string, unknown>;
+}

--- a/test/__stubs__/openclaw-plugin-sdk-redact.ts
+++ b/test/__stubs__/openclaw-plugin-sdk-redact.ts
@@ -1,0 +1,7 @@
+// Stub for openclaw/plugin-sdk/redact in test environments.
+// The real module is provided by the host at runtime.
+export function redactTranscriptMessage(
+  message: Record<string, unknown>,
+): Record<string, unknown> {
+  return message;
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,5 @@
+import { vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/redact", () => ({
+  redactTranscriptMessage: (message: Record<string, unknown>) => message,
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 const testHome = mkdtempSync(join(tmpdir(), "lossless-claw-vitest-home-"));
@@ -10,10 +10,19 @@ const testDbPath = join(testOpenClawDir, "lcm.db");
 mkdirSync(testOpenClawDir, { recursive: true });
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "openclaw/plugin-sdk/redact": resolve(
+        __dirname,
+        "test/__stubs__/openclaw-plugin-sdk-redact.ts",
+      ),
+    },
+  },
   test: {
     dir: "test",
     include: ["**/*.test.ts"],
     exclude: ["**/.worktrees/**"],
+    setupFiles: ["./test/setup.ts"],
     env: {
       HOME: testHome,
     },


### PR DESCRIPTION
…icate ingestion

Apply transcript-level redaction to live messages before dedup so that identity_hash matches the transcript reconcile path (which reads already- redacted content from file). Without this, the same message produces different hashes on the two paths and dedup fails to detect duplicates, causing every message in a turn to be ingested twice.

The host exposes redactTranscriptMessage through the openclaw/plugin-sdk/redact module (new plugin-sdk boundary). LCM loads it lazily with graceful fallback when the module is unavailable.