### PR TITLE
fix(engine): reorder afterTurn to ingest live messages before transcr…

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -73,6 +73,7 @@ import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./me
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
 import { listTranscriptToolResultEntryIdsByCallId } from "./replay-metadata.js";
 import { estimateSessionTokenCountForAfterTurn, extractRuntimePromptTokenCount } from "./token-accounting.js";
+import { extractDedupKeys } from "./live-dedup-key.js";
 import { asRecord, formatDurationMs, resolvePositiveInteger } from "./value-utils.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
@@ -2793,73 +2794,20 @@ export class LcmContextEngine implements ContextEngine {
       blockedByImportCap: false,
       hasOverlap: true,
     };
-    try {
-      transcriptReconcileResult = await this.transcriptReconciler.reconcileTranscriptTailForAfterTurn({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        isHeartbeat: params.isHeartbeat,
-      });
-    } catch (err) {
-      this.deps.log.warn(
-        `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
-      );
-      // Fail closed: without reconcile proof, the initialized in-sync default
-      // would persist this batch and refresh the checkpoint to EOF, advancing
-      // past transcript history that was never reconciled. Skipping persistence
-      // loses nothing — the transcript retains the turn and a later successful
-      // reconcile imports it.
-      transcriptReconcileResult = {
-        importedMessages: 0,
-        blockedByImportCap: false,
-        hasOverlap: false,
-      };
-    }
-    const transcriptReconcileUnsafeToAdvance =
-      transcriptReconcileResult.blockedByImportCap ||
-      (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
-    const transcriptReconcileBlockedByAmbiguousRollover =
-      transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover" ||
-      // Rotated-fresh skips this turn the same way: the replacement
-      // conversation is empty, so telemetry/compaction work below would run
-      // against it for nothing; the next turn binds and reconciles normally.
-      transcriptReconcileResult.blockedReason === "ambiguous-rollover-rotated-fresh-transcript";
-    let dedupedNewMessages: AgentMessage[] = [];
-    if (transcriptReconcileUnsafeToAdvance) {
-      if (newMessages.length > 0 || params.autoCompactionSummary) {
-        this.deps.log.warn(
-          `[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`,
-        );
-      }
-      if (transcriptReconcileBlockedByAmbiguousRollover) {
-        await runRuntimeAutoRotate();
-        return;
-      }
-    } else if (transcriptReconcileResult.transcriptCovered) {
-      // The transcript reconcile read the file to its frontier, so the DB
-      // tail is exact — use precise alignment instead of the heuristic
-      // dedup stack, and persist only what the transcript flush has not
-      // delivered yet.
-      dedupedNewMessages = await this.batchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier(
-        params.sessionId,
-        params.sessionKey,
-        newMessages,
-      );
-      if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
-        this.deps.log.debug(
-          `[lcm] afterTurn: transcript covered the frontier; runtime batch aligned to ${dedupedNewMessages.length}/${newMessages.length} unflushed messages ${sessionLabel}`,
-        );
-      }
-    } else {
-      dedupedNewMessages = await this.batchDeduplicator.deduplicateAfterTurnBatch(
-        params.sessionId,
-        params.sessionKey,
-        newMessages,
-        {
-          oversizedNoOverlap: transcriptReconcileResult.importedMessages > 0 ? "ingest" : "skip",
-        },
-      );
-    }
+
+    // ====== Phase 1: dedup + live ingest FIRST (before reconcile) ======
+    // Live messages carry raw (unredacted) content — ingest them immediately
+    // so the DB holds the high-quality original.  Collect dedup keys so the
+    // later transcript reconcile (which reads redacted content from the file)
+    // can skip messages that were already persisted by this path.
+
+    const dedupedNewMessages = await this.batchDeduplicator.deduplicateAfterTurnBatch(
+      params.sessionId,
+      params.sessionKey,
+      newMessages,
+      { oversizedNoOverlap: "ingest" },
+    );
+
     const summaryCoveredMessages: AgentMessage[] = [];
     const summaryDedupedNewMessages: AgentMessage[] = [];
     if (params.autoCompactionSummary) {
@@ -2884,38 +2832,31 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
 
-    const ingestBatch: AgentMessage[] = [];
-    if (!transcriptReconcileUnsafeToAdvance && params.autoCompactionSummary) {
-      ingestBatch.push({
+    const ingestBatchMessages: AgentMessage[] = [];
+    if (params.autoCompactionSummary) {
+      ingestBatchMessages.push({
         role: "user",
         content: params.autoCompactionSummary,
       } as AgentMessage);
     }
+    ingestBatchMessages.push(...summaryDedupedNewMessages);
 
-    ingestBatch.push(...summaryDedupedNewMessages);
-    if (ingestBatch.length === 0) {
-      // Nothing to ingest in *this* afterTurn call — but the conversation may
-      // still be over threshold from prior turns, especially when the host
-      // path (e.g. afterTurnTranscriptReconcile, or external `engine.ingest`
-      // calls during the turn) already imported the new messages before
-      // afterTurn's dedup ran. Log and fall through to compaction evaluation
-      // rather than early-returning, otherwise compaction would never fire
-      // once dedup begins consistently swallowing new turn deltas.
-      this.deps.log.debug(
-        `[lcm] afterTurn: nothing to ingest ${sessionLabel} newMessages=${newMessages.length} (continuing to compaction evaluation; transcript reconcile may have already ingested) duration=${formatDurationMs(Date.now() - startedAt)}`,
-      );
-    } else {
+    // Collect content-independent dedup keys so the downstream reconcile can
+    // skip messages that were already ingested via this live path.
+    const preIngestedKeys = extractDedupKeys(ingestBatchMessages);
+
+    // --- live ingest ---
+    if (ingestBatchMessages.length > 0) {
       try {
         await this.ingestBatch({
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
-          messages: ingestBatch,
+          messages: ingestBatchMessages,
           isHeartbeat: params.isHeartbeat === true,
         });
       } catch (err) {
-        // Never compact a stale or partially ingested frontier.
         this.deps.log.error(
-          `[lcm] afterTurn: ingest failed, skipping compaction: ${describeLogError(err)}`,
+          `[lcm] afterTurn: live ingest failed, skipping compaction: ${describeLogError(err)}`,
         );
         this.sessionRotation.logAutoRotateSessionFileDecision({
           phase: "runtime",
@@ -2932,6 +2873,54 @@ export class LcmContextEngine implements ContextEngine {
         return;
       }
     }
+
+    // ====== Phase 2: transcript reconcile AFTER live ingest ======
+    // The transcript file stores redacted content — reconcile reads it and
+    // imports any messages that were NOT already ingested by the live path
+    // above, using the content-independent dedup keys to skip duplicates.
+    try {
+      transcriptReconcileResult = await this.transcriptReconciler.reconcileTranscriptTailForAfterTurn({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        isHeartbeat: params.isHeartbeat,
+        preIngestedKeys,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] afterTurn: transcript reconcile failed for ${sessionLabel}: ${describeLogError(err)}`,
+      );
+      // Fail closed: live messages are already persisted above.  Without
+      // reconcile proof we skip compaction to avoid advancing past
+      // unreconciled transcript history.
+      transcriptReconcileResult = {
+        importedMessages: 0,
+        blockedByImportCap: false,
+        hasOverlap: false,
+      };
+    }
+
+    const transcriptReconcileUnsafeToAdvance =
+      transcriptReconcileResult.blockedByImportCap ||
+      (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
+    const transcriptReconcileBlockedByAmbiguousRollover =
+      transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover" ||
+      transcriptReconcileResult.blockedReason === "ambiguous-rollover-rotated-fresh-transcript";
+
+    if (transcriptReconcileUnsafeToAdvance) {
+      if (transcriptReconcileBlockedByAmbiguousRollover) {
+        // Live messages are already ingested — auto-rotate so the next turn
+        // binds to the correct conversation.
+        await runRuntimeAutoRotate();
+      }
+      // Live messages already persisted above; only skip compaction.
+      this.deps.log.warn(
+        `[lcm] afterTurn: transcript reconcile did not cover the frontier; live messages already ingested, skipping compaction to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`,
+      );
+      return;
+    }
+
+    const ingestBatch = ingestBatchMessages;
 
     if (batchLooksLikeHeartbeatAckTurn(ingestBatch)) {
       try {

--- a/src/live-dedup-key.ts
+++ b/src/live-dedup-key.ts
@@ -1,0 +1,85 @@
+import type { AgentMessage } from "./openclaw-bridge.js";
+import { safeString } from "./value-utils.js";
+
+/**
+ * Extract a content-independent deduplication key from an AgentMessage.
+ *
+ * These keys are immune to sanitization/redaction — they rely on IDs that
+ * are assigned by the LLM API or tool-calling framework, not on message
+ * content, so they match identically between the live (raw) path and the
+ * transcript-reconcile (redacted) path.
+ *
+ * Fallback chain, by role:
+ *
+ *   assistant:
+ *     1) responseId / response_id  (API-level unique response id)
+ *     2) toolUseId                 (tool-use event id within an assistant turn)
+ *     3) null → caller falls back to content-hash dedup
+ *
+ *   tool / toolResult:
+ *     1) toolCallId / tool_call_id / toolUseId / tool_use_id
+ *
+ *   user:
+ *     1) timestamp
+ *
+ * Returns a namespaced string key (`assistant:<id>`, `tool:<id>`,
+ * `user:<ts>`) so that ids from different roles cannot collide.
+ * Returns null when no content-independent key can be extracted,
+ * signalling the caller to fall back to content-hash dedup.
+ */
+export function extractDedupKey(message: AgentMessage): string | null {
+  // AgentMessage is a structural type; runtime messages may carry extra
+  // top-level properties (e.g. responseId / response_id) that are not
+  // declared.  Read them through a Record<string, unknown> view.
+  const raw = message as Record<string, unknown>;
+
+  // --- assistant ---
+  if (message.role === "assistant") {
+    const responseId =
+      safeString(raw.responseId) ?? safeString(raw.response_id);
+    if (responseId) {
+      return `assistant:${responseId}`;
+    }
+    if (message.toolUseId) {
+      return `tool_use:${message.toolUseId}`;
+    }
+    return null; // pure-text reply — fall back to content-hash dedup
+  }
+
+  // --- tool / toolResult ---
+  if (message.role === "toolResult" || message.role === "tool") {
+    const toolId =
+      safeString(raw.toolCallId) ??
+      safeString(raw.tool_call_id) ??
+      safeString(raw.toolUseId) ??
+      safeString(raw.tool_use_id);
+    if (toolId) {
+      return `tool:${toolId}`;
+    }
+    return null;
+  }
+
+  // --- user ---
+  if (message.role === "user") {
+    const ts = typeof raw.timestamp === "number" ? raw.timestamp : undefined;
+    if (ts !== undefined) {
+      return `user:${ts}`;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Batch extract dedup keys from an array of messages.
+ * Messages that cannot produce a key are silently skipped.
+ */
+export function extractDedupKeys(messages: AgentMessage[]): Set<string> {
+  const keys = new Set<string>();
+  for (const msg of messages) {
+    const key = extractDedupKey(msg);
+    if (key) keys.add(key);
+  }
+  return keys;
+}

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -42,6 +42,7 @@ import {
   extractRawBlockSignatureFromPartMetadata,
   extractRawIdsFromPartMetadata,
 } from "./replay-metadata.js";
+import { extractDedupKey } from "./live-dedup-key.js";
 import { buildMessageIdentityHash } from "./store/message-identity.js";
 import {
   getTranscriptEntryId,
@@ -349,6 +350,7 @@ export class TranscriptReconciler {
     existingDbCount: number;
     sessionContext: string;
     startedAt: number;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult | null> {
     const { conversationId, historicalMessages, entryIds, sessionContext, startedAt } = params;
 
@@ -437,6 +439,13 @@ export class TranscriptReconciler {
       }
       // Entry-id-verified imports are exact (the id is proven absent), so the
       // same-second replay flood heuristic does not apply.
+      // Content-independent dedup: skip messages already ingested via the live path.
+      if (params.preIngestedKeys) {
+        const dedupKey = extractDedupKey(message);
+        if (dedupKey && params.preIngestedKeys.has(dedupKey)) {
+          continue;
+        }
+      }
       const result = await this.host.ingestSingle({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
@@ -542,6 +551,9 @@ export class TranscriptReconciler {
     // never unbounded — set ONLY together with a proven non-anchoring frontier.
     allowFullNonAnchoringFrontierImport?: boolean;
     noAnchorImportReason?: string;
+    // Content-independent dedup keys from the live-ingest path so transcript
+    // reconcile can skip messages that were already persisted with raw content.
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult> {
     const { sessionId, conversationId, historicalMessages } = params;
     const startedAt = Date.now();
@@ -580,6 +592,7 @@ export class TranscriptReconciler {
         existingDbCount,
         sessionContext,
         startedAt,
+        preIngestedKeys: params.preIngestedKeys,
       });
       if (entryIdResult) {
         return entryIdResult;
@@ -688,6 +701,7 @@ export class TranscriptReconciler {
             existingDbCount,
             sessionContext,
             startedAt,
+            preIngestedKeys: params.preIngestedKeys,
           });
         }
         this.host.deps.log.debug(
@@ -738,6 +752,7 @@ export class TranscriptReconciler {
       sessionKey: params.sessionKey,
       messages: importableTail,
       replayGuardExemptPrefixLength: missingTailFiltered.replayGuardExemptPrefixLength,
+      preIngestedKeys: params.preIngestedKeys,
     });
 
     if (importCapped) {
@@ -778,6 +793,7 @@ export class TranscriptReconciler {
     existingDbCount: number;
     sessionContext: string;
     startedAt: number;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult> {
     const { sessionId, conversationId, historicalMessages, existingDbCount } = params;
     const { startedAt, sessionContext } = params;
@@ -944,6 +960,13 @@ export class TranscriptReconciler {
           }));
         if (adopted) {
           adoptedMessages += 1;
+          continue;
+        }
+      }
+      // Content-independent dedup: skip messages already ingested via the live path.
+      if (params.preIngestedKeys) {
+        const dedupKey = extractDedupKey(message);
+        if (dedupKey && params.preIngestedKeys.has(dedupKey)) {
           continue;
         }
       }
@@ -1481,9 +1504,17 @@ export class TranscriptReconciler {
     sessionKey?: string;
     messages: AgentMessage[];
     replayGuardExemptPrefixLength: number;
+    preIngestedKeys?: Set<string>;
   }): Promise<number> {
     let importedMessages = 0;
     for (const [index, message] of params.messages.entries()) {
+      // Content-independent dedup: skip messages already ingested via the live path.
+      if (params.preIngestedKeys) {
+        const dedupKey = extractDedupKey(message);
+        if (dedupKey && params.preIngestedKeys.has(dedupKey)) {
+          continue;
+        }
+      }
       const result = await this.host.ingestSingle({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
@@ -1644,6 +1675,7 @@ export class TranscriptReconciler {
     conversation: ConversationRecord;
     checkpoint: Awaited<ReturnType<SummaryStore["getConversationBootstrapState"]>>;
     transcriptEpochShrank: boolean;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult | null> {
     const { conversation, checkpoint, transcriptEpochShrank } = params;
     if (
@@ -1703,6 +1735,7 @@ export class TranscriptReconciler {
             allowNoAnchorImport: placeholderFrontierIsNonAnchoring,
             allowFullNonAnchoringFrontierImport: placeholderFrontierIsNonAnchoring,
             noAnchorImportReason: "placeholder-checkpoint-recovery",
+            preIngestedKeys: params.preIngestedKeys,
           });
           await this.recordImportAndRefreshCheckpoint({
             conversationId: conversation.conversationId,
@@ -1740,6 +1773,7 @@ export class TranscriptReconciler {
             sessionKey: params.sessionKey,
             messages: replayFilteredMessages,
             replayGuardExemptPrefixLength: replayFiltered.replayGuardExemptPrefixLength,
+            preIngestedKeys: params.preIngestedKeys,
           });
           await this.recordImportAndRefreshCheckpoint({
             conversationId: conversation.conversationId,
@@ -1779,6 +1813,7 @@ export class TranscriptReconciler {
     sessionFileState: { size: number; mtimeMs: number } | undefined;
     sessionFileStatError: unknown;
     transcriptEpochShrank: boolean;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult> {
     const {
       queueKey,
@@ -2059,6 +2094,7 @@ export class TranscriptReconciler {
         : declaredEpochRollover && reason === "append-only-ineligible"
           ? "declared-epoch-rollover"
           : reason,
+      preIngestedKeys: params.preIngestedKeys,
     });
     if (reconcile.blockedByImportCap) {
       // Capped passes import a bounded chunk of anchored backlog; report
@@ -2108,6 +2144,7 @@ export class TranscriptReconciler {
     sessionFile: string;
     isHeartbeat?: boolean;
     allowNoAnchorImportOnCheckpointMissing?: boolean;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult> {
     const queueKey = this.host.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     await this.host.conversationStore.withTransaction(async () => {
@@ -2169,6 +2206,7 @@ export class TranscriptReconciler {
       conversation,
       checkpoint,
       transcriptEpochShrank,
+      preIngestedKeys: params.preIngestedKeys,
     });
     if (appendOnlyResult) {
       return appendOnlyResult;
@@ -2185,6 +2223,7 @@ export class TranscriptReconciler {
       sessionFileState,
       sessionFileStatError,
       transcriptEpochShrank,
+      preIngestedKeys: params.preIngestedKeys,
     });
   }
 
@@ -2208,6 +2247,7 @@ export class TranscriptReconciler {
     sessionFile: string;
     isHeartbeat?: boolean;
     allowNoAnchorImportOnCheckpointMissing?: boolean;
+    preIngestedKeys?: Set<string>;
   }): Promise<TranscriptReconcileResult> {
     const queueKey = this.host.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     return await this.host.withSessionQueue(


### PR DESCRIPTION
…ipt reconcile, with content-independent dedup keys

Live messages carry raw (unredacted) content while the transcript file holds redacted content. Previously, transcript reconcile ran first and ingested redacted messages, then the live-path dedup failed because SHA256(role + "\0"
+ content) differed between redacted and raw versions — causing duplicate rows in the messages table.

Reorder afterTurn so the live path ingests first, then transcript reconcile skips messages already persisted by matching on content-independent keys (responseId, toolCallId, toolUseId, timestamp) that are immune to redaction.