### PR TITLE
fix: keep heartbeat transcript reconciliation non-durable

### DIFF
--- a/.changeset/heartbeat-control-reconcile.md
+++ b/.changeset/heartbeat-control-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep heartbeat/control transcript turns non-durable while still advancing transcript reconciliation checkpoints.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -69,6 +69,7 @@ import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./boot
 import {
   batchLooksLikeHeartbeatAckTurn,
   filterSyntheticHeartbeatMessages,
+  isAssistantControlAckContent,
   pruneHeartbeatOkTurns,
 } from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
@@ -2843,16 +2844,25 @@ export class LcmContextEngine implements ContextEngine {
       }
     } else if (transcriptOnlyNonDurableControl) {
       const runtimeFiltered = filterSyntheticHeartbeatMessages(newMessages);
-      if (runtimeFiltered.skipped > 0) {
+      let skippedRuntimeControlMessages = runtimeFiltered.skipped;
+      const runtimeAlignmentMessages = runtimeFiltered.messages.filter((message) => {
+        const stored = toStoredMessage(message);
+        if (stored.role === "assistant" && isAssistantControlAckContent(stored.content)) {
+          skippedRuntimeControlMessages += 1;
+          return false;
+        }
+        return true;
+      });
+      if (skippedRuntimeControlMessages > 0) {
         this.deps.log.debug(
-          `[lcm] afterTurn: skipped ${runtimeFiltered.skipped}/${newMessages.length} runtime heartbeat/control messages already reconciled as non-durable transcript traffic ${sessionLabel} skippedTranscriptMessages=${transcriptReconcileResult.nonDurableTranscriptMessages ?? 0}`,
+          `[lcm] afterTurn: skipped ${skippedRuntimeControlMessages}/${newMessages.length} runtime heartbeat/control messages already reconciled as non-durable transcript traffic ${sessionLabel} skippedTranscriptMessages=${transcriptReconcileResult.nonDurableTranscriptMessages ?? 0}`,
         );
       }
       dedupedNewMessages =
         await this.batchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier(
           params.sessionId,
           params.sessionKey,
-          runtimeFiltered.messages,
+          runtimeAlignmentMessages,
         );
     } else if (transcriptReconcileResult.transcriptCovered) {
       // The transcript reconcile read the file to its frontier, so the DB

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -69,8 +69,10 @@ import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./boot
 import {
   batchLooksLikeHeartbeatAckTurn,
   filterSyntheticHeartbeatMessages,
-  isAssistantControlAckContent,
+  isHeartbeatOkContent,
+  NO_REPLY_TOKEN,
   pruneHeartbeatOkTurns,
+  turnLooksLikeHeartbeatTurn,
 } from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
 import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
@@ -2845,9 +2847,46 @@ export class LcmContextEngine implements ContextEngine {
     } else if (transcriptOnlyNonDurableControl) {
       const runtimeFiltered = filterSyntheticHeartbeatMessages(newMessages);
       let skippedRuntimeControlMessages = runtimeFiltered.skipped;
-      const runtimeAlignmentMessages = runtimeFiltered.messages.filter((message) => {
+      const runtimeNoReplySkipIndexes = new Set<number>();
+      if (params.isHeartbeat === true) {
+        for (let index = 0; index < runtimeFiltered.messages.length; index += 1) {
+          const stored = toStoredMessage(runtimeFiltered.messages[index]!);
+          if (
+            stored.role !== "assistant" ||
+            stored.content.trim().toLowerCase() !== NO_REPLY_TOKEN
+          ) {
+            continue;
+          }
+          let turnStart = -1;
+          for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+            const previous = toStoredMessage(runtimeFiltered.messages[cursor]!);
+            if (previous.role === "user") {
+              turnStart = cursor;
+              break;
+            }
+          }
+          if (turnStart < 0) {
+            runtimeNoReplySkipIndexes.add(index);
+            continue;
+          }
+          const turnMessages = runtimeFiltered.messages
+            .slice(turnStart, index + 1)
+            .map((message) => toStoredMessage(message));
+          if (!turnLooksLikeHeartbeatTurn(turnMessages)) {
+            continue;
+          }
+          for (let cursor = turnStart; cursor <= index; cursor += 1) {
+            runtimeNoReplySkipIndexes.add(cursor);
+          }
+        }
+      }
+      const runtimeAlignmentMessages = runtimeFiltered.messages.filter((message, index) => {
+        if (runtimeNoReplySkipIndexes.has(index)) {
+          skippedRuntimeControlMessages += 1;
+          return false;
+        }
         const stored = toStoredMessage(message);
-        if (stored.role === "assistant" && isAssistantControlAckContent(stored.content)) {
+        if (stored.role === "assistant" && isHeartbeatOkContent(stored.content)) {
           skippedRuntimeControlMessages += 1;
           return false;
         }
@@ -2942,7 +2981,7 @@ export class LcmContextEngine implements ContextEngine {
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           messages: ingestBatch,
-          isHeartbeat: params.isHeartbeat === true,
+          isHeartbeat: params.isHeartbeat === true && !transcriptOnlyNonDurableControl,
         });
       } catch (err) {
         // Never compact a stale or partially ingested frontier.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -66,7 +66,11 @@ import {
 import { describeAssembledPrefixChange, formatOverflowDiagnosticsForLog, shouldLogOverflowDiagnostics, type AssemblePrefixSnapshot, type BootstrapImportObservation } from "./assemble-debug.js";
 import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResult, buildForkBoundedLiveFallback, clampMessagesToSerializedBudget, resolveDeferredAssemblyPressure } from "./assemble-fallback.js";
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
-import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
+import {
+  batchLooksLikeHeartbeatAckTurn,
+  filterSyntheticHeartbeatMessages,
+  pruneHeartbeatOkTurns,
+} from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
 import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
@@ -2824,6 +2828,8 @@ export class LcmContextEngine implements ContextEngine {
       // conversation is empty, so telemetry/compaction work below would run
       // against it for nothing; the next turn binds and reconciles normally.
       transcriptReconcileResult.blockedReason === "ambiguous-rollover-rotated-fresh-transcript";
+    const transcriptOnlyNonDurableControl =
+      transcriptReconcileResult.runtimeBatchDisposition === "skip-non-durable-control";
     let dedupedNewMessages: AgentMessage[] = [];
     if (transcriptReconcileUnsafeToAdvance) {
       if (newMessages.length > 0 || params.autoCompactionSummary) {
@@ -2835,6 +2841,19 @@ export class LcmContextEngine implements ContextEngine {
         await runRuntimeAutoRotate();
         return;
       }
+    } else if (transcriptOnlyNonDurableControl) {
+      const runtimeFiltered = filterSyntheticHeartbeatMessages(newMessages);
+      if (runtimeFiltered.skipped > 0) {
+        this.deps.log.debug(
+          `[lcm] afterTurn: skipped ${runtimeFiltered.skipped}/${newMessages.length} runtime heartbeat/control messages already reconciled as non-durable transcript traffic ${sessionLabel} skippedTranscriptMessages=${transcriptReconcileResult.nonDurableTranscriptMessages ?? 0}`,
+        );
+      }
+      dedupedNewMessages =
+        await this.batchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier(
+          params.sessionId,
+          params.sessionKey,
+          runtimeFiltered.messages,
+        );
     } else if (transcriptReconcileResult.transcriptCovered) {
       // The transcript reconcile read the file to its frontier, so the DB
       // tail is exact — use precise alignment instead of the heuristic
@@ -2885,7 +2904,10 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const ingestBatch: AgentMessage[] = [];
-    if (!transcriptReconcileUnsafeToAdvance && params.autoCompactionSummary) {
+    if (
+      !transcriptReconcileUnsafeToAdvance &&
+      params.autoCompactionSummary
+    ) {
       ingestBatch.push({
         role: "user",
         content: params.autoCompactionSummary,

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -9,6 +9,8 @@ import type { ConversationStore } from "./store/conversation-store.js";
 
 export const HEARTBEAT_OK_TOKEN = "heartbeat_ok";
 
+export const NO_REPLY_TOKEN = "no_reply";
+
 export const HEARTBEAT_TURN_MARKER = "heartbeat.md";
 
 export const OPENCLAW_HEARTBEAT_POLL = "[openclaw heartbeat poll]";
@@ -21,6 +23,16 @@ export const OPENCLAW_HEARTBEAT_POLL = "[openclaw heartbeat poll]";
  */
 export function isHeartbeatOkContent(content: string): boolean {
   return content.trim().toLowerCase() === HEARTBEAT_OK_TOKEN;
+}
+
+/**
+ * Assistant-only control acknowledgements are safe to drop only after
+ * transcript reconciliation already classified the matching suffix as
+ * non-durable control traffic.
+ */
+export function isAssistantControlAckContent(content: string): boolean {
+  const normalized = content.trim().toLowerCase();
+  return normalized === HEARTBEAT_OK_TOKEN || normalized === NO_REPLY_TOKEN;
 }
 
 /**

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -156,11 +156,13 @@ export function filterSyntheticHeartbeatMessages(
   };
 }
 
-export function turnLooksLikeHeartbeatTurn(turnMessages: Array<{ content: string }>): boolean {
+export function turnLooksLikeHeartbeatTurn(
+  turnMessages: Array<{ role?: string; content: string }>,
+): boolean {
   return turnMessages.some((message) => {
     const normalized = message.content.trim().toLowerCase();
     return (
-      normalized === OPENCLAW_HEARTBEAT_POLL ||
+      (message.role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) ||
       normalized.includes(HEARTBEAT_TURN_MARKER)
     );
   });

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -25,6 +25,10 @@ export function isHeartbeatOkContent(content: string): boolean {
   return content.trim().toLowerCase() === HEARTBEAT_OK_TOKEN;
 }
 
+function isNoReplyContent(content: string): boolean {
+  return content.trim().toLowerCase() === NO_REPLY_TOKEN;
+}
+
 /**
  * Assistant-only control acknowledgements are safe to drop only after
  * transcript reconciliation already classified the matching suffix as
@@ -51,7 +55,8 @@ export function isHeartbeatNoiseContent(role: string, content: string): boolean 
 export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {
   let sawHeartbeatMdMarker = false;
   let sawExactHeartbeatPoll = false;
-  let sawHeartbeatAck = false;
+  let sawHeartbeatOkAck = false;
+  let sawNoReplyAck = false;
   let sawNonExactPollTurnContent = false;
 
   for (const message of messages) {
@@ -63,12 +68,11 @@ export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolea
     if (stored.role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
       sawExactHeartbeatPoll = true;
     }
-    if (
-      !sawHeartbeatAck &&
-      stored.role === "assistant" &&
-      isAssistantControlAckContent(stored.content)
-    ) {
-      sawHeartbeatAck = true;
+    if (stored.role === "assistant" && isHeartbeatOkContent(stored.content)) {
+      sawHeartbeatOkAck = true;
+    }
+    if (stored.role === "assistant" && isNoReplyContent(stored.content)) {
+      sawNoReplyAck = true;
     }
     if (
       normalized !== OPENCLAW_HEARTBEAT_POLL &&
@@ -76,12 +80,19 @@ export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolea
     ) {
       sawNonExactPollTurnContent = true;
     }
-    if (sawHeartbeatMdMarker && sawHeartbeatAck) {
+    if (
+      sawHeartbeatMdMarker &&
+      (sawHeartbeatOkAck || (sawNoReplyAck && sawExactHeartbeatPoll))
+    ) {
       return true;
     }
   }
 
-  return sawExactHeartbeatPoll && sawHeartbeatAck && !sawNonExactPollTurnContent;
+  return (
+    sawExactHeartbeatPoll &&
+    (sawHeartbeatOkAck || sawNoReplyAck) &&
+    !sawNonExactPollTurnContent
+  );
 }
 
 export function filterSyntheticHeartbeatMessages(
@@ -126,6 +137,9 @@ export function filterSyntheticHeartbeatMessages(
     if (!turnLooksLikeHeartbeatTurn(turnMessages)) {
       continue;
     }
+    if (isNoReplyContent(stored.content) && !turnHasExactHeartbeatPoll(turnMessages)) {
+      continue;
+    }
 
     for (let cursor = turnStart; cursor <= index; cursor += 1) {
       skipIndexes.add(cursor);
@@ -152,18 +166,20 @@ export function turnLooksLikeHeartbeatTurn(turnMessages: Array<{ content: string
   });
 }
 
+function turnHasExactHeartbeatPoll(turnMessages: Array<{ role?: string; content: string }>): boolean {
+  return turnMessages.some(
+    (message) =>
+      message.role === "user" &&
+      message.content.trim().toLowerCase() === OPENCLAW_HEARTBEAT_POLL,
+  );
+}
 
 /**
- * Detect HEARTBEAT_OK turn cycles in a conversation and delete them.
+ * Detect heartbeat/control acknowledgement turn cycles in a conversation and delete them.
  *
- * A HEARTBEAT_OK turn is: a user message (the heartbeat prompt), followed by
- * any tool call/result messages, ending with an assistant message that is a
- * heartbeat ack. The entire sequence has no durable information value for LCM.
- *
- * Detection: assistant content (trimmed, lowercased) starts with "heartbeat_ok"
- * and any text after is not alphanumeric (matches OpenClaw core's ack detection).
- * This catches both exact "HEARTBEAT_OK" and chatty variants like
- * "HEARTBEAT_OK — weekend, no market".
+ * A control acknowledgement turn is: a user message (the heartbeat prompt),
+ * followed by any tool call/result messages, ending with an assistant control
+ * acknowledgement. The entire sequence has no durable information value for LCM.
  *
  * Returns the number of messages deleted.
  */
@@ -178,19 +194,18 @@ conversationId: number,
 
   const toDelete: number[] = [];
 
-  // Walk through messages finding HEARTBEAT_OK assistant replies, then
+  // Walk through messages finding assistant control replies, then
   // collect the entire turn (back to the preceding user message).
   for (let i = 0; i < allMessages.length; i++) {
     const msg = allMessages[i];
     if (msg.role !== "assistant") {
       continue;
     }
-    if (!isHeartbeatOkContent(msg.content)) {
+    if (!isAssistantControlAckContent(msg.content)) {
       continue;
     }
 
-    // Found an exact HEARTBEAT_OK reply. Walk backward to find the turn start
-    // (the preceding user message).
+    // Found a control ack. Walk backward to find the turn start.
     const turnMessages = [msg];
     for (let j = i - 1; j >= 0; j--) {
       const prev = allMessages[j];
@@ -204,6 +219,9 @@ conversationId: number,
       continue;
     }
     if (!turnLooksLikeHeartbeatTurn(turnMessages)) {
+      continue;
+    }
+    if (isNoReplyContent(msg.content) && !turnHasExactHeartbeatPoll(turnMessages)) {
       continue;
     }
 

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -40,7 +40,7 @@ export function isAssistantControlAckContent(content: string): boolean {
 }
 
 /**
- * Synthetic heartbeat traffic (poll prompts and control acks) recurs
+ * Synthetic heartbeat traffic (poll prompts and HEARTBEAT_OK acks) recurs
  * identically in every session, so it can never discriminate lineage in
  * the ambiguous-rollover freshness check.
  */
@@ -49,7 +49,7 @@ export function isHeartbeatNoiseContent(role: string, content: string): boolean 
   if (role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
     return true;
   }
-  return role === "assistant" && isAssistantControlAckContent(normalized);
+  return role === "assistant" && normalized === HEARTBEAT_OK_TOKEN;
 }
 
 export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -37,23 +37,35 @@ export function isHeartbeatNoiseContent(role: string, content: string): boolean 
 }
 
 export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {
-  let sawHeartbeatMarker = false;
+  let sawHeartbeatMdMarker = false;
+  let sawExactHeartbeatPoll = false;
   let sawHeartbeatAck = false;
+  let sawNonExactPollTurnContent = false;
 
   for (const message of messages) {
     const stored = toStoredMessage(message);
-    if (!sawHeartbeatMarker && stored.content.toLowerCase().includes(HEARTBEAT_TURN_MARKER)) {
-      sawHeartbeatMarker = true;
+    const normalized = stored.content.trim().toLowerCase();
+    if (!sawHeartbeatMdMarker && normalized.includes(HEARTBEAT_TURN_MARKER)) {
+      sawHeartbeatMdMarker = true;
+    }
+    if (stored.role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
+      sawExactHeartbeatPoll = true;
     }
     if (!sawHeartbeatAck && stored.role === "assistant" && isHeartbeatOkContent(stored.content)) {
       sawHeartbeatAck = true;
     }
-    if (sawHeartbeatMarker && sawHeartbeatAck) {
+    if (
+      normalized !== OPENCLAW_HEARTBEAT_POLL &&
+      !(stored.role === "assistant" && isHeartbeatOkContent(stored.content))
+    ) {
+      sawNonExactPollTurnContent = true;
+    }
+    if (sawHeartbeatMdMarker && sawHeartbeatAck) {
       return true;
     }
   }
 
-  return false;
+  return sawExactHeartbeatPoll && sawHeartbeatAck && !sawNonExactPollTurnContent;
 }
 
 export function filterSyntheticHeartbeatMessages(
@@ -115,9 +127,13 @@ export function filterSyntheticHeartbeatMessages(
 }
 
 export function turnLooksLikeHeartbeatTurn(turnMessages: Array<{ content: string }>): boolean {
-  return turnMessages.some((message) =>
-    message.content.toLowerCase().includes(HEARTBEAT_TURN_MARKER),
-  );
+  return turnMessages.some((message) => {
+    const normalized = message.content.trim().toLowerCase();
+    return (
+      normalized === OPENCLAW_HEARTBEAT_POLL ||
+      normalized.includes(HEARTBEAT_TURN_MARKER)
+    );
+  });
 }
 
 

--- a/src/heartbeat-filter.ts
+++ b/src/heartbeat-filter.ts
@@ -36,7 +36,7 @@ export function isAssistantControlAckContent(content: string): boolean {
 }
 
 /**
- * Synthetic heartbeat traffic (poll prompts and HEARTBEAT_OK acks) recurs
+ * Synthetic heartbeat traffic (poll prompts and control acks) recurs
  * identically in every session, so it can never discriminate lineage in
  * the ambiguous-rollover freshness check.
  */
@@ -45,7 +45,7 @@ export function isHeartbeatNoiseContent(role: string, content: string): boolean 
   if (role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
     return true;
   }
-  return role === "assistant" && normalized === HEARTBEAT_OK_TOKEN;
+  return role === "assistant" && isAssistantControlAckContent(normalized);
 }
 
 export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolean {
@@ -63,12 +63,16 @@ export function batchLooksLikeHeartbeatAckTurn(messages: AgentMessage[]): boolea
     if (stored.role === "user" && normalized === OPENCLAW_HEARTBEAT_POLL) {
       sawExactHeartbeatPoll = true;
     }
-    if (!sawHeartbeatAck && stored.role === "assistant" && isHeartbeatOkContent(stored.content)) {
+    if (
+      !sawHeartbeatAck &&
+      stored.role === "assistant" &&
+      isAssistantControlAckContent(stored.content)
+    ) {
       sawHeartbeatAck = true;
     }
     if (
       normalized !== OPENCLAW_HEARTBEAT_POLL &&
-      !(stored.role === "assistant" && isHeartbeatOkContent(stored.content))
+      !(stored.role === "assistant" && isAssistantControlAckContent(stored.content))
     ) {
       sawNonExactPollTurnContent = true;
     }
@@ -100,7 +104,7 @@ export function filterSyntheticHeartbeatMessages(
 
   for (let index = 0; index < messages.length; index += 1) {
     const stored = toStoredMessage(messages[index]!);
-    if (stored.role !== "assistant" || !isHeartbeatOkContent(stored.content)) {
+    if (stored.role !== "assistant" || !isAssistantControlAckContent(stored.content)) {
       continue;
     }
 

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -115,4 +115,11 @@ export type TranscriptReconcileResult = {
    * transcript was missing, unreadable, or skipped.
    */
   transcriptCovered?: boolean;
+  /**
+   * The transcript frontier was reconciled, but the reconciled tail contained
+   * only non-durable heartbeat/control traffic. afterTurn should skip the
+   * matching runtime batch instead of asking generic dedup to infer that.
+   */
+  runtimeBatchDisposition?: "skip-non-durable-control";
+  nonDurableTranscriptMessages?: number;
 };

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -7,7 +7,11 @@
  * Extracted from engine.ts (Phase 3 of the engine decomposition).
  */
 import { stat } from "node:fs/promises";
-import { isHeartbeatNoiseContent } from "./heartbeat-filter.js";
+import {
+  isHeartbeatNoiseContent,
+  NO_REPLY_TOKEN,
+  OPENCLAW_HEARTBEAT_POLL,
+} from "./heartbeat-filter.js";
 import { describeLogError } from "./lcm-log.js";
 import { isLikelyInjectedDeliveryOnlyTranscript, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, messageIdentity } from "./message-signatures.js";
@@ -33,6 +37,44 @@ const AMBIGUOUS_ROLLOVER_OVERLAP_WINDOW = 50;
  * traffic before freezing).
  */
 const AMBIGUOUS_ROLLOVER_OVERLAP_WIDE_WINDOW = 500;
+
+type RolloverIdentityMessage = {
+  role: string;
+  content: string;
+};
+
+function isExactHeartbeatNoReplyTurnMessage(
+  messages: RolloverIdentityMessage[],
+  index: number,
+): boolean {
+  const message = messages[index];
+  if (
+    !message ||
+    message.role !== "assistant" ||
+    message.content.trim().toLowerCase() !== NO_REPLY_TOKEN
+  ) {
+    return false;
+  }
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    const previous = messages[cursor]!;
+    if (previous.role !== "user") {
+      continue;
+    }
+    return previous.content.trim().toLowerCase() === OPENCLAW_HEARTBEAT_POLL;
+  }
+  return false;
+}
+
+function isRolloverHeartbeatNoiseMessage(
+  messages: RolloverIdentityMessage[],
+  index: number,
+): boolean {
+  const message = messages[index]!;
+  return (
+    isHeartbeatNoiseContent(message.role, message.content) ||
+    isExactHeartbeatNoReplyTurnMessage(messages, index)
+  );
+}
 
 export type AmbiguousSessionKeyRuntimeRollover = {
   conversationId: number;
@@ -321,15 +363,18 @@ export class SessionRolloverDetector {
     // entire recent window was heartbeat polls, false-blocking the heal).
     // Empty stored content (pure tool rows) is likewise skipped.
     const collectDiscriminatingIdentities = async (window: number): Promise<Set<string>> => {
-      const records = await this.conversationStore.getLastMessages(
+      const recordsWithContext = await this.conversationStore.getLastMessages(
         params.conversationId,
-        window,
+        window + 1,
       );
+      const comparisonStart = Math.max(0, recordsWithContext.length - window);
+      const records = recordsWithContext.slice(comparisonStart);
       const counts = new Map<string, number>();
-      for (const record of records) {
+      for (const [index, record] of records.entries()) {
+        const contextIndex = comparisonStart + index;
         if (
           record.content.trim().length === 0 ||
-          isHeartbeatNoiseContent(record.role, record.content)
+          isRolloverHeartbeatNoiseMessage(recordsWithContext, contextIndex)
         ) {
           continue;
         }
@@ -368,11 +413,11 @@ export class SessionRolloverDetector {
       };
     }
     let checkedCandidateIdentity = false;
-    for (const message of params.candidateMessages) {
-      const stored = toStoredMessage(message);
+    const candidateRecords = params.candidateMessages.map((message) => toStoredMessage(message));
+    for (const [index, stored] of candidateRecords.entries()) {
       if (
         stored.content.trim().length === 0 ||
-        isHeartbeatNoiseContent(stored.role, stored.content)
+        isRolloverHeartbeatNoiseMessage(candidateRecords, index)
       ) {
         continue;
       }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -20,7 +20,10 @@ import type { LcmDependencies } from "./types.js";
 import { readFileSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { trimBootstrapMessagesToBudget, resolveBootstrapMaxTokens } from "./bootstrap-budget.js";
-import { filterSyntheticHeartbeatMessages } from "./heartbeat-filter.js";
+import {
+  filterSyntheticHeartbeatMessages,
+  isAssistantControlAckContent,
+} from "./heartbeat-filter.js";
 import {
   buildMessageParts,
   isLikelyInjectedDeliveryOnlyTranscript,
@@ -1736,11 +1739,35 @@ export class TranscriptReconciler {
             await this.conversationFrontierIsEntirelyNonAnchoring(
               conversation.conversationId,
             );
+          const placeholderSessionContext = this.host.formatSessionLogContext({
+            conversationId: conversation.conversationId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          });
+          const placeholderHeartbeatFiltered = this.filterHeartbeatFlaggedPlaceholderSuffix({
+            messages: appended.messages,
+            isHeartbeat: params.isHeartbeat,
+            sessionContext: placeholderSessionContext,
+          });
+          if (placeholderHeartbeatFiltered.messages.length === 0) {
+            await this.refreshBootstrapState({
+              conversationId: conversation.conversationId,
+              sessionFile: params.sessionFile,
+            });
+            return {
+              importedMessages: 0,
+              blockedByImportCap: false,
+              hasOverlap: true,
+              transcriptCovered: true,
+              runtimeBatchDisposition: "skip-non-durable-control",
+              nonDurableTranscriptMessages: placeholderHeartbeatFiltered.skipped,
+            };
+          }
           const reconcile = await this.reconcileSessionTail({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             conversationId: conversation.conversationId,
-            historicalMessages: appended.messages,
+            historicalMessages: placeholderHeartbeatFiltered.messages,
             allowNoAnchorImport: placeholderFrontierIsNonAnchoring,
             allowFullNonAnchoringFrontierImport: placeholderFrontierIsNonAnchoring,
             noAnchorImportReason: "placeholder-checkpoint-recovery",
@@ -1761,6 +1788,14 @@ export class TranscriptReconciler {
           }
           return {
             ...reconcile,
+            ...(placeholderHeartbeatFiltered.skipped > 0
+              ? {
+                  runtimeBatchDisposition: "skip-non-durable-control" as const,
+                  nonDurableTranscriptMessages:
+                    (reconcile.nonDurableTranscriptMessages ?? 0) +
+                    placeholderHeartbeatFiltered.skipped,
+                }
+              : {}),
             transcriptCovered: reconcile.hasOverlap || reconcile.importedMessages > 0,
           };
         }
@@ -2322,6 +2357,48 @@ export class TranscriptReconciler {
     return {
       messages: params.messages.slice(0, turnStart),
       skipped,
+    };
+  }
+
+  /**
+   * Placeholder checkpoints read from offset 0, so the slice may include older
+   * unreconciled durable history. Never drop a broad user-started suffix unless
+   * it is a recognized synthetic heartbeat turn; otherwise drop only the final
+   * assistant control ack for explicit heartbeat calls.
+   */
+  private filterHeartbeatFlaggedPlaceholderSuffix(params: {
+    messages: AgentMessage[];
+    isHeartbeat?: boolean;
+    sessionContext: string;
+  }): { messages: AgentMessage[]; skipped: number } {
+    if (params.isHeartbeat !== true || params.messages.length === 0) {
+      return { messages: params.messages, skipped: 0 };
+    }
+
+    const syntheticFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
+      messages: params.messages,
+      sessionContext: params.sessionContext,
+      source: "afterTurn transcript reconcile placeholder",
+    });
+    if (syntheticFiltered.skipped > 0) {
+      return syntheticFiltered;
+    }
+
+    const lastMessage = params.messages[params.messages.length - 1]!;
+    const lastStored = toStoredMessage(lastMessage);
+    if (
+      lastStored.role !== "assistant" ||
+      !isAssistantControlAckContent(lastStored.content)
+    ) {
+      return { messages: params.messages, skipped: 0 };
+    }
+
+    this.host.deps.log.debug(
+      `[lcm] afterTurn transcript reconcile placeholder: skipped 1/${params.messages.length} heartbeat-flagged assistant transcript suffix message for ${params.sessionContext}`,
+    );
+    return {
+      messages: params.messages.slice(0, -1),
+      skipped: 1,
     };
   }
 

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2339,13 +2339,39 @@ export class TranscriptReconciler {
       return { messages: params.messages, skipped: 0 };
     }
 
-    let turnStart = 0;
+    let turnStart = -1;
     for (let index = params.messages.length - 1; index >= 0; index -= 1) {
       const stored = toStoredMessage(params.messages[index]!);
       if (stored.role === "user") {
         turnStart = index;
         break;
       }
+    }
+
+    if (turnStart < 0) {
+      let controlRunStart = params.messages.length;
+      for (let index = params.messages.length - 1; index >= 0; index -= 1) {
+        const stored = toStoredMessage(params.messages[index]!);
+        if (
+          stored.role !== "assistant" ||
+          !isAssistantControlAckContent(stored.content)
+        ) {
+          break;
+        }
+        controlRunStart = index;
+      }
+
+      const skipped = params.messages.length - controlRunStart;
+      if (skipped === 0) {
+        return { messages: params.messages, skipped: 0 };
+      }
+      this.host.deps.log.debug(
+        `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged assistant transcript suffix messages for ${params.sessionContext}`,
+      );
+      return {
+        messages: params.messages.slice(0, controlRunStart),
+        skipped,
+      };
     }
 
     const skipped = params.messages.length - turnStart;

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1895,6 +1895,7 @@ export class TranscriptReconciler {
     sessionKey?: string;
     sessionFile: string;
     allowNoAnchorImportOnCheckpointMissing?: boolean;
+    isHeartbeat?: boolean;
     queueKey: string;
     conversation: ConversationRecord;
     checkpoint: Awaited<ReturnType<SummaryStore["getConversationBootstrapState"]>>;
@@ -2153,11 +2154,36 @@ export class TranscriptReconciler {
         `[lcm] afterTurn: transcript session header changed (${checkpoint?.sessionHeaderId} -> ${transcriptHeader.sessionHeaderId}); treating as declared epoch rollover conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
       );
     }
+    const fullReadSessionContext = this.host.formatSessionLogContext({
+      conversationId: conversation.conversationId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    const heartbeatFlagFiltered = this.filterHeartbeatFlaggedPlaceholderSuffix({
+      messages: historicalMessages,
+      isHeartbeat: params.isHeartbeat,
+      sessionContext: fullReadSessionContext,
+    });
+    if (heartbeatFlagFiltered.messages.length === 0 && heartbeatFlagFiltered.skipped > 0) {
+      await this.refreshBootstrapState({
+        conversationId: conversation.conversationId,
+        sessionFile: params.sessionFile,
+      });
+      rememberSlowReadState();
+      return {
+        importedMessages: 0,
+        blockedByImportCap: false,
+        hasOverlap: true,
+        transcriptCovered: true,
+        runtimeBatchDisposition: "skip-non-durable-control",
+        nonDurableTranscriptMessages: heartbeatFlagFiltered.skipped,
+      };
+    }
     const reconcile = await this.reconcileSessionTail({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       conversationId: conversation.conversationId,
-      historicalMessages,
+      historicalMessages: heartbeatFlagFiltered.messages,
       lastProcessedEntryId: declaredEpochRollover
         ? null
         : checkpoint?.lastProcessedEntryId ?? null,
@@ -2218,6 +2244,13 @@ export class TranscriptReconciler {
     );
     return {
       ...reconcile,
+      ...(heartbeatFlagFiltered.skipped > 0
+        ? {
+            runtimeBatchDisposition: "skip-non-durable-control" as const,
+            nonDurableTranscriptMessages:
+              (reconcile.nonDurableTranscriptMessages ?? 0) + heartbeatFlagFiltered.skipped,
+          }
+        : {}),
       importedMessages: reconcile.importedMessages,
       blockedByImportCap: false,
       hasOverlap: reconcile.hasOverlap,
@@ -2301,6 +2334,7 @@ export class TranscriptReconciler {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       sessionFile: params.sessionFile,
+      isHeartbeat: params.isHeartbeat,
       allowNoAnchorImportOnCheckpointMissing: params.allowNoAnchorImportOnCheckpointMissing,
       queueKey,
       conversation,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1779,8 +1779,12 @@ export class TranscriptReconciler {
             importedMessages: reconcile.importedMessages,
           });
           if (
-            reconcile.importedMessages === 0 &&
-            reconcile.runtimeBatchDisposition === "skip-non-durable-control"
+            (reconcile.importedMessages === 0 &&
+              reconcile.runtimeBatchDisposition === "skip-non-durable-control") ||
+            (placeholderHeartbeatFiltered.skipped > 0 &&
+              !reconcile.blockedByImportCap &&
+              reconcile.importedMessages === 0 &&
+              reconcile.hasOverlap)
           ) {
             await this.refreshBootstrapState({
               conversationId: conversation.conversationId,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -23,6 +23,7 @@ import { trimBootstrapMessagesToBudget, resolveBootstrapMaxTokens } from "./boot
 import {
   filterSyntheticHeartbeatMessages,
   isAssistantControlAckContent,
+  turnLooksLikeHeartbeatTurn,
 } from "./heartbeat-filter.js";
 import {
   buildMessageParts,
@@ -2349,39 +2350,56 @@ export class TranscriptReconciler {
     }
 
     if (turnStart < 0) {
-      let controlRunStart = params.messages.length;
-      for (let index = params.messages.length - 1; index >= 0; index -= 1) {
-        const stored = toStoredMessage(params.messages[index]!);
-        if (
-          stored.role !== "assistant" ||
-          !isAssistantControlAckContent(stored.content)
-        ) {
-          break;
-        }
-        controlRunStart = index;
-      }
+      return this.filterHeartbeatFlaggedAssistantControlSuffix(params);
+    }
 
-      const skipped = params.messages.length - controlRunStart;
-      if (skipped === 0) {
-        return { messages: params.messages, skipped: 0 };
-      }
+    const turnMessages = params.messages
+      .slice(turnStart)
+      .map((message) => toStoredMessage(message));
+    const lastTurnMessage = turnMessages[turnMessages.length - 1]!;
+    const endsWithControlAck =
+      lastTurnMessage.role === "assistant" &&
+      isAssistantControlAckContent(lastTurnMessage.content);
+    if (endsWithControlAck && turnLooksLikeHeartbeatTurn(turnMessages)) {
+      const skipped = params.messages.length - turnStart;
       this.host.deps.log.debug(
-        `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged assistant transcript suffix messages for ${params.sessionContext}`,
+        `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged transcript suffix messages for ${params.sessionContext}`,
       );
       return {
-        messages: params.messages.slice(0, controlRunStart),
+        messages: params.messages.slice(0, turnStart),
         skipped,
       };
     }
 
-    const skipped = params.messages.length - turnStart;
-    if (skipped > 0) {
-      this.host.deps.log.debug(
-        `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged transcript suffix messages for ${params.sessionContext}`,
-      );
+    return this.filterHeartbeatFlaggedAssistantControlSuffix(params);
+  }
+
+  /** Strip only trailing assistant control acknowledgements from heartbeat-flagged slices. */
+  private filterHeartbeatFlaggedAssistantControlSuffix(params: {
+    messages: AgentMessage[];
+    sessionContext: string;
+  }): { messages: AgentMessage[]; skipped: number } {
+    let controlRunStart = params.messages.length;
+    for (let index = params.messages.length - 1; index >= 0; index -= 1) {
+      const stored = toStoredMessage(params.messages[index]!);
+      if (
+        stored.role !== "assistant" ||
+        !isAssistantControlAckContent(stored.content)
+      ) {
+        break;
+      }
+      controlRunStart = index;
     }
+
+    const skipped = params.messages.length - controlRunStart;
+    if (skipped === 0) {
+      return { messages: params.messages, skipped: 0 };
+    }
+    this.host.deps.log.debug(
+      `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged assistant transcript suffix messages for ${params.sessionContext}`,
+    );
     return {
-      messages: params.messages.slice(0, turnStart),
+      messages: params.messages.slice(0, controlRunStart),
       skipped,
     };
   }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -125,7 +125,6 @@ export type ReconcileHost = {
     sessionId: string;
     sessionKey?: string;
     message: AgentMessage;
-    isHeartbeat?: boolean;
     createdAt?: Date | string;
     skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult>;
@@ -2159,10 +2158,10 @@ export class TranscriptReconciler {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
     });
-    const heartbeatFlagFiltered = this.filterHeartbeatFlaggedPlaceholderSuffix({
+    const heartbeatFlagFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
       messages: historicalMessages,
-      isHeartbeat: params.isHeartbeat,
       sessionContext: fullReadSessionContext,
+      source: "afterTurn transcript reconcile full-read",
     });
     if (heartbeatFlagFiltered.messages.length === 0 && heartbeatFlagFiltered.skipped > 0) {
       await this.refreshBootstrapState({
@@ -2334,7 +2333,6 @@ export class TranscriptReconciler {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       sessionFile: params.sessionFile,
-      isHeartbeat: params.isHeartbeat,
       allowNoAnchorImportOnCheckpointMissing: params.allowNoAnchorImportOnCheckpointMissing,
       queueKey,
       conversation,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2428,25 +2428,29 @@ export class TranscriptReconciler {
       sessionContext: params.sessionContext,
       source: "afterTurn transcript reconcile placeholder",
     });
-    if (syntheticFiltered.skipped > 0) {
+    if (syntheticFiltered.messages.length === 0) {
       return syntheticFiltered;
     }
 
-    const lastMessage = params.messages[params.messages.length - 1]!;
+    const originalTail = params.messages[params.messages.length - 1]!;
+    const lastMessage = syntheticFiltered.messages[syntheticFiltered.messages.length - 1]!;
+    if (lastMessage !== originalTail) {
+      return syntheticFiltered;
+    }
     const lastStored = toStoredMessage(lastMessage);
     if (
       lastStored.role !== "assistant" ||
       !isAssistantControlAckContent(lastStored.content)
     ) {
-      return { messages: params.messages, skipped: 0 };
+      return syntheticFiltered;
     }
 
     this.host.deps.log.debug(
-      `[lcm] afterTurn transcript reconcile placeholder: skipped 1/${params.messages.length} heartbeat-flagged assistant transcript suffix message for ${params.sessionContext}`,
+      `[lcm] afterTurn transcript reconcile placeholder: skipped 1/${syntheticFiltered.messages.length} heartbeat-flagged assistant transcript suffix message for ${params.sessionContext}`,
     );
     return {
-      messages: params.messages.slice(0, -1),
-      skipped: 1,
+      messages: syntheticFiltered.messages.slice(0, -1),
+      skipped: syntheticFiltered.skipped + 1,
     };
   }
 

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1750,6 +1750,15 @@ export class TranscriptReconciler {
             sessionFile: params.sessionFile,
             importedMessages: reconcile.importedMessages,
           });
+          if (
+            reconcile.importedMessages === 0 &&
+            reconcile.runtimeBatchDisposition === "skip-non-durable-control"
+          ) {
+            await this.refreshBootstrapState({
+              conversationId: conversation.conversationId,
+              sessionFile: params.sessionFile,
+            });
+          }
           return {
             ...reconcile,
             transcriptCovered: reconcile.hasOverlap || reconcile.importedMessages > 0,
@@ -1818,6 +1827,12 @@ export class TranscriptReconciler {
             blockedByImportCap: false,
             hasOverlap: true,
             transcriptCovered: true,
+            ...(skippedNonDurableMessages > 0
+              ? {
+                  runtimeBatchDisposition: "skip-non-durable-control" as const,
+                  nonDurableTranscriptMessages: skippedNonDurableMessages,
+                }
+              : {}),
           };
         }
       }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -20,7 +20,7 @@ import type { LcmDependencies } from "./types.js";
 import { readFileSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import { trimBootstrapMessagesToBudget, resolveBootstrapMaxTokens } from "./bootstrap-budget.js";
-import { batchLooksLikeHeartbeatAckTurn, filterSyntheticHeartbeatMessages } from "./heartbeat-filter.js";
+import { filterSyntheticHeartbeatMessages } from "./heartbeat-filter.js";
 import {
   buildMessageParts,
   isLikelyInjectedDeliveryOnlyTranscript,
@@ -380,11 +380,21 @@ export class TranscriptReconciler {
 
     const anchorIndex = selection.anchorIndex;
     const candidates = selection.missingIndexes.map((index) => historicalMessages[index]!);
-    const missingTail = this.filterSyntheticHeartbeatTranscriptMessages({
+    const heartbeatFilteredMissingTail = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
       messages: candidates,
       sessionContext,
       source: "reconcileSessionTail entry-id",
     });
+    const missingTail = heartbeatFilteredMissingTail.messages;
+    if (missingTail.length === 0 && heartbeatFilteredMissingTail.skipped > 0) {
+      return {
+        blockedByImportCap: false,
+        importedMessages: 0,
+        hasOverlap: true,
+        runtimeBatchDisposition: "skip-non-durable-control",
+        nonDurableTranscriptMessages: heartbeatFilteredMissingTail.skipped,
+      };
+    }
 
     // Entry-id anchored backlogs are exact — lineage is proven by the id
     // anchor and every import is individually id-verified — so a backlog
@@ -709,11 +719,21 @@ export class TranscriptReconciler {
       source: "reconcileSessionTail",
       priorMessages: historicalMessages.slice(0, anchorIndex + 1),
     });
-    const missingTail = this.filterSyntheticHeartbeatTranscriptMessages({
+    const heartbeatFilteredMissingTail = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
       messages: missingTailFiltered.messages,
       sessionContext,
       source: "reconcileSessionTail",
     });
+    const missingTail = heartbeatFilteredMissingTail.messages;
+    if (missingTail.length === 0 && heartbeatFilteredMissingTail.skipped > 0) {
+      return {
+        blockedByImportCap: false,
+        importedMessages: 0,
+        hasOverlap: true,
+        runtimeBatchDisposition: "skip-non-durable-control",
+        nonDurableTranscriptMessages: heartbeatFilteredMissingTail.skipped,
+      };
+    }
 
     // Anchored missing tails are this conversation's own continuation
     // (lineage proven by the identity anchor), so a tail larger than the
@@ -802,11 +822,21 @@ export class TranscriptReconciler {
       messages: historicalMessages,
     });
     const persistedIdentityOverlaps = replayAnalysis.overlaps;
-    let noAnchorImportMessages = this.filterSyntheticHeartbeatTranscriptMessages({
+    let noAnchorHeartbeatFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
       messages: historicalMessages,
       sessionContext,
       source: "reconcileSessionTail no-anchor",
     });
+    let noAnchorImportMessages = noAnchorHeartbeatFiltered.messages;
+    if (noAnchorImportMessages.length === 0 && noAnchorHeartbeatFiltered.skipped > 0) {
+      return {
+        blockedByImportCap: false,
+        importedMessages: 0,
+        hasOverlap: true,
+        runtimeBatchDisposition: "skip-non-durable-control",
+        nonDurableTranscriptMessages: noAnchorHeartbeatFiltered.skipped,
+      };
+    }
     // A fully id-bearing batch resolves identity overlaps exactly:
     // identity matches adopt the re-issued entry id (host rewrites and
     // rotations re-append the surviving suffix under new ids) and only
@@ -835,11 +865,21 @@ export class TranscriptReconciler {
       }
 
       if (replayAnalysis.firstNonOverlappingIndex > 0) {
-        noAnchorImportMessages = this.filterSyntheticHeartbeatTranscriptMessages({
+        noAnchorHeartbeatFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
           messages: historicalMessages.slice(replayAnalysis.firstNonOverlappingIndex),
           sessionContext,
           source: "reconcileSessionTail no-anchor replay-prefix",
         });
+        noAnchorImportMessages = noAnchorHeartbeatFiltered.messages;
+        if (noAnchorImportMessages.length === 0 && noAnchorHeartbeatFiltered.skipped > 0) {
+          return {
+            blockedByImportCap: false,
+            importedMessages: 0,
+            hasOverlap: true,
+            runtimeBatchDisposition: "skip-non-durable-control",
+            nonDurableTranscriptMessages: noAnchorHeartbeatFiltered.skipped,
+          };
+        }
         this.host.deps.log.warn(
           `[lcm] reconcileSessionTail: duplicate transcript replay guard dropped ${replayAnalysis.firstNonOverlappingIndex}/${historicalMessages.length} already-persisted prefix messages for ${sessionContext} before no-anchor import (reason: ${params.noAnchorImportReason ?? "unspecified"})`,
         );
@@ -1560,7 +1600,13 @@ export class TranscriptReconciler {
     isHeartbeat?: boolean;
   }): Promise<TranscriptReconcileResult> {
       if (params.isHeartbeat) {
-        return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+        return {
+          importedMessages: 0,
+          blockedByImportCap: false,
+          hasOverlap: true,
+          transcriptCovered: true,
+          runtimeBatchDisposition: "skip-non-durable-control",
+        };
       }
       // No persisted conversation exists yet. Prefer the transcript over
       // the runtime delta so foreground prompts that are omitted from
@@ -1583,13 +1629,27 @@ export class TranscriptReconciler {
         }
         return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
       }
-      if (batchLooksLikeHeartbeatAckTurn(historicalMessages)) {
-        // Not covered: the runtime batch path owns conversation creation
-        // and heartbeat-ack pruning for brand-new sessions.
-        return { importedMessages: 0, blockedByImportCap: false, hasOverlap: true };
+      const initialSessionContext = [
+        `session=${params.sessionId}`,
+        ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
+      ].join(" ");
+      const heartbeatFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
+        messages: historicalMessages,
+        sessionContext: initialSessionContext,
+        source: "afterTurn initial transcript",
+      });
+      if (heartbeatFiltered.messages.length === 0 && heartbeatFiltered.skipped > 0) {
+        return {
+          importedMessages: 0,
+          blockedByImportCap: false,
+          hasOverlap: true,
+          transcriptCovered: true,
+          runtimeBatchDisposition: "skip-non-durable-control",
+          nonDurableTranscriptMessages: heartbeatFiltered.skipped,
+        };
       }
       const bootstrapMessages = trimBootstrapMessagesToBudget(
-        historicalMessages,
+        heartbeatFiltered.messages,
         resolveBootstrapMaxTokens(this.host.config),
       );
       if (bootstrapMessages.length === 0) {
@@ -1623,7 +1683,7 @@ export class TranscriptReconciler {
       }
       return {
         importedMessages,
-        blockedByImportCap: bootstrapMessages.length < historicalMessages.length,
+        blockedByImportCap: bootstrapMessages.length < heartbeatFiltered.messages.length,
         hasOverlap: true,
         transcriptCovered: true,
       };
@@ -1662,25 +1722,6 @@ export class TranscriptReconciler {
           checkpoint.lastSeenMtimeMs === 0 &&
           checkpoint.lastProcessedOffset === 0 &&
           checkpoint.lastProcessedEntryHash === null;
-        if (params.isHeartbeat) {
-          if (!placeholderCheckpoint) {
-            await this.refreshBootstrapState({
-              conversationId: conversation.conversationId,
-              sessionFile: params.sessionFile,
-            });
-            this.host.deps.log.debug(
-              `[lcm] afterTurn: skipped heartbeat transcript append-only delta and refreshed checkpoint conversation=${conversation.conversationId} sessionFile=${params.sessionFile} appendedMessages=${appended.messages.length}`,
-            );
-          }
-          // Heartbeat turns are never persisted; the append-only delta is
-          // intentionally skipped, so the transcript counts as covered.
-          return {
-            importedMessages: 0,
-            blockedByImportCap: false,
-            hasOverlap: true,
-            transcriptCovered: true,
-          };
-        }
         if (placeholderCheckpoint && appended.messages.length > 0) {
           // #822: a placeholder checkpoint means this conversation was never
           // ingested, so its on-disk transcript is the source of truth and
@@ -1726,7 +1767,33 @@ export class TranscriptReconciler {
           source: "afterTurn transcript reconcile append-only",
           sessionFile: params.sessionFile,
         });
-        const replayFilteredMessages = replayFiltered.messages;
+        const heartbeatFiltered = this.filterSyntheticHeartbeatTranscriptMessagesWithStats({
+          messages: replayFiltered.messages,
+          sessionContext: appendOnlySessionContext,
+          source: "afterTurn transcript reconcile append-only",
+        });
+        const heartbeatFlagFiltered = this.filterHeartbeatFlaggedAppendOnlySuffix({
+          messages: heartbeatFiltered.messages,
+          isHeartbeat: params.isHeartbeat,
+          sessionContext: appendOnlySessionContext,
+        });
+        const replayFilteredMessages = heartbeatFlagFiltered.messages;
+        const skippedNonDurableMessages =
+          heartbeatFiltered.skipped + heartbeatFlagFiltered.skipped;
+        if (replayFilteredMessages.length === 0 && skippedNonDurableMessages > 0) {
+          await this.refreshBootstrapState({
+            conversationId: conversation.conversationId,
+            sessionFile: params.sessionFile,
+          });
+          return {
+            importedMessages: 0,
+            blockedByImportCap: false,
+            hasOverlap: true,
+            transcriptCovered: true,
+            runtimeBatchDisposition: "skip-non-durable-control",
+            nonDurableTranscriptMessages: skippedNonDurableMessages,
+          };
+        }
         const appendOnlyOverlapsPersisted = await this.appendOnlyMessagesOverlapPersistedTranscript({
           conversationId: conversation.conversationId,
           messages: replayFilteredMessages,
@@ -2095,6 +2162,7 @@ export class TranscriptReconciler {
       `[lcm] afterTurn: transcript reconcile slow path (full re-read) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile} historicalMessages=${historicalMessages.length} importedMessages=${reconcile.importedMessages} duration=${formatDurationMs(Date.now() - slowPathStartedAt)}`,
     );
     return {
+      ...reconcile,
       importedMessages: reconcile.importedMessages,
       blockedByImportCap: false,
       hasOverlap: reconcile.hasOverlap,
@@ -2193,13 +2261,53 @@ export class TranscriptReconciler {
     sessionContext: string;
     source: string;
   }): AgentMessage[] {
+    return this.filterSyntheticHeartbeatTranscriptMessagesWithStats(params).messages;
+  }
+
+  /** Filter synthetic heartbeat/control transcript entries and report skipped count. */
+  private filterSyntheticHeartbeatTranscriptMessagesWithStats(params: {
+    messages: AgentMessage[];
+    sessionContext: string;
+    source: string;
+  }): { messages: AgentMessage[]; skipped: number } {
     const filtered = filterSyntheticHeartbeatMessages(params.messages);
     if (filtered.skipped > 0) {
       this.host.deps.log.debug(
         `[lcm] ${params.source}: skipped ${filtered.skipped}/${params.messages.length} synthetic heartbeat transcript messages for ${params.sessionContext}`,
       );
     }
-    return filtered.messages;
+    return filtered;
+  }
+
+  /** For explicit heartbeat turns, skip only the trailing runtime turn. */
+  private filterHeartbeatFlaggedAppendOnlySuffix(params: {
+    messages: AgentMessage[];
+    isHeartbeat?: boolean;
+    sessionContext: string;
+  }): { messages: AgentMessage[]; skipped: number } {
+    if (params.isHeartbeat !== true || params.messages.length === 0) {
+      return { messages: params.messages, skipped: 0 };
+    }
+
+    let turnStart = 0;
+    for (let index = params.messages.length - 1; index >= 0; index -= 1) {
+      const stored = toStoredMessage(params.messages[index]!);
+      if (stored.role === "user") {
+        turnStart = index;
+        break;
+      }
+    }
+
+    const skipped = params.messages.length - turnStart;
+    if (skipped > 0) {
+      this.host.deps.log.debug(
+        `[lcm] afterTurn transcript reconcile append-only: skipped ${skipped}/${params.messages.length} heartbeat-flagged transcript suffix messages for ${params.sessionContext}`,
+      );
+    }
+    return {
+      messages: params.messages.slice(0, turnStart),
+      skipped,
+    };
   }
 
   async reconcileTranscriptTailForAfterTurn(params: {

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
+import { OPENCLAW_HEARTBEAT_POLL } from "../src/heartbeat-filter.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import type { LcmDependencies } from "../src/types.js";
 import { createTestConfig as createSharedTestConfig, createTestDeps as createSharedTestDeps } from "./helpers.js";
@@ -254,6 +255,165 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     expect(rebound?.conversationId).not.toBe(lane.conversationId);
     const imported = await engine.getConversationStore().getMessages(rebound!.conversationId);
     expect(imported.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
+  });
+
+  it("bootstrap treats exact heartbeat poll NO_REPLY pairs as rollover noise", async () => {
+    const { engine, log, db } = createEngine();
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage("user", OPENCLAW_HEARTBEAT_POLL, Date.now() - 120_000),
+    });
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage("assistant", "NO_REPLY", Date.now() - 119_000),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation).not.toBeNull();
+    db.prepare("UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?").run(
+      conversation!.conversationId,
+    );
+    const trackedFile = createTempFile("old-no-reply-transcript.jsonl", "{}\n");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: trackedFile,
+      lastSeenSize: 3,
+      lastSeenMtimeMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      lastProcessedOffset: 3,
+      lastProcessedEntryHash: "0".repeat(64),
+    });
+
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      entries: [
+        { role: "user", text: OPENCLAW_HEARTBEAT_POLL, timestamp: Date.now() + 60_000 },
+        { role: "assistant", text: "NO_REPLY", timestamp: Date.now() + 61_000 },
+      ],
+    });
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    const oldConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(OLD_SESSION_ID);
+    expect(oldConversation?.active).toBe(false);
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("bootstrap ignores orphaned NO_REPLY at the rollover comparison window boundary", async () => {
+    const { engine, log, db } = createEngine();
+    const oldBase = Date.now() - 120_000;
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage("user", OPENCLAW_HEARTBEAT_POLL, oldBase),
+    });
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage("assistant", "NO_REPLY", oldBase + 1),
+    });
+    for (let index = 0; index < 49; index += 1) {
+      await seedHistoricalMessage(engine, {
+        sessionId: OLD_SESSION_ID,
+        sessionKey: SESSION_KEY,
+        message: makeMessage("user", OPENCLAW_HEARTBEAT_POLL, oldBase + index + 2),
+      });
+    }
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation).not.toBeNull();
+    db.prepare("UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?").run(
+      conversation!.conversationId,
+    );
+    const trackedFile = createTempFile("old-boundary-no-reply-transcript.jsonl", "{}\n");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: trackedFile,
+      lastSeenSize: 3,
+      lastSeenMtimeMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      lastProcessedOffset: 3,
+      lastProcessedEntryHash: "0".repeat(64),
+    });
+
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      entries: [
+        { role: "user", text: OPENCLAW_HEARTBEAT_POLL, timestamp: Date.now() + 60_000 },
+        { role: "assistant", text: "NO_REPLY", timestamp: Date.now() + 61_000 },
+      ],
+    });
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rotation"),
+    );
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("bootstrap keeps candidate-leading durable NO_REPLY comparable", async () => {
+    const { engine, log, db } = createEngine();
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage("assistant", "NO_REPLY", Date.now() - 120_000),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation).not.toBeNull();
+    db.prepare("UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?").run(
+      conversation!.conversationId,
+    );
+    const trackedFile = createTempFile("old-durable-no-reply-transcript.jsonl", "{}\n");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: trackedFile,
+      lastSeenSize: 3,
+      lastSeenMtimeMs: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      lastProcessedOffset: 3,
+      lastProcessedEntryHash: "0".repeat(64),
+    });
+
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      entries: [
+        { role: "assistant", text: "NO_REPLY", timestamp: Date.now() + 60_000 },
+        { role: "user", text: "fresh candidate content", timestamp: Date.now() + 61_000 },
+      ],
+    });
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
   });
 
   it("afterTurn rotates the lane; the host's next bootstrap imports the transcript", async () => {

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -5329,7 +5329,7 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
-  it("afterTurn full-read heartbeat reconcile skips assistant-only control suffixes", async () => {
+  it("afterTurn full-read heartbeat reconcile preserves unproven assistant-only exact tokens", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-heartbeat-full-read-assistant-control";
     const sessionKey = "agent:main:test:after-turn-heartbeat-full-read-assistant-control";
@@ -5372,6 +5372,7 @@ describe("LcmContextEngine afterTurn", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "seed user",
       "seed assistant",
+      "HEARTBEAT_OK",
     ]);
     const checkpoint = await engine
       .getSummaryStore()

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4084,6 +4084,64 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
+  for (const controlAck of ["HEARTBEAT_OK", "NO_REPLY"]) {
+    it(`afterTurn skips singleton assistant ${controlAck} runtime batch after non-durable transcript suffix`, async () => {
+      const warnLog = vi.fn();
+      const engine = createEngineWithDepsOverrides({
+        log: {
+          info: vi.fn(),
+          warn: warnLog,
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      });
+      const sessionId = `after-turn-heartbeat-singleton-${controlAck.toLowerCase()}`;
+      const sessionKey = `agent:main:test:${sessionId}`;
+      const sessionFile = createSessionFilePath(sessionId);
+      const sm = SessionManager.open(sessionFile);
+      appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+      appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+      const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+      expect(first.bootstrapped).toBe(true);
+
+      appendSessionMessage(sm, makeMessage({ role: "assistant", content: controlAck }));
+
+      const conversation = await engine.getConversationStore().getConversationForSession({
+        sessionId,
+        sessionKey,
+      });
+      expect(conversation).not.toBeNull();
+
+      await engine.afterTurn({
+        sessionId,
+        sessionKey,
+        sessionFile,
+        messages: [makeMessage({ role: "assistant", content: controlAck })],
+        isHeartbeat: true,
+        prePromptMessageCount: 0,
+        tokenBudget: 4096,
+      });
+
+      expect(
+        warnLog.mock.calls.some((call) =>
+          String(call[0]).includes(
+            "runtime batch does not align with the covered transcript frontier",
+          ),
+        ),
+      ).toBe(false);
+      const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+      expect(stored.map((message) => message.content)).toEqual([
+        "seed user",
+        "seed assistant",
+      ]);
+      const checkpoint = await engine
+        .getSummaryStore()
+        .getConversationBootstrapState(conversation!.conversationId);
+      expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+    });
+  }
+
   it("afterTurn heartbeat flag imports real append-only prefix before a flagged control suffix", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-heartbeat-flag-real-prefix";

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -10,6 +10,7 @@ import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateSerializedMessageTokens, estimateSerializedMessagesTokens, estimateTokens } from "../src/estimate-tokens.js";
+import { OPENCLAW_HEARTBEAT_POLL } from "../src/heartbeat-filter.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import { applyScopedDoctorRepair } from "../src/plugin/lcm-doctor-apply.js";
 import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
@@ -3800,7 +3801,7 @@ describe("LcmContextEngine afterTurn", () => {
     );
   });
 
-  it("afterTurn prunes heartbeat-shaped ACK turns before compaction even without the heartbeat flag", async () => {
+  it("afterTurn keeps heartbeat-shaped ACK turns non-durable before compaction even without the heartbeat flag", async () => {
     const infoLog = vi.fn();
     const debugLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
@@ -3844,17 +3845,14 @@ describe("LcmContextEngine afterTurn", () => {
     });
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
-    expect(conversation).not.toBeNull();
-
-    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(stored).toHaveLength(0);
+    expect(conversation).toBeNull();
     expect(evaluateLeafTriggerSpy).not.toHaveBeenCalled();
     expect(compactSpy).not.toHaveBeenCalled();
-    expect(infoLog).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `heartbeat ack messages for conversation=${conversation!.conversationId} session=${sessionId} sessionKey=${sessionKey}`,
+    expect(
+      infoLog.mock.calls.some((call) =>
+        String(call[0]).includes("heartbeat ack messages"),
       ),
-    );
+    ).toBe(false);
   });
 
   it("afterTurn heartbeat flag skips non-empty transcript imports", async () => {
@@ -3884,8 +3882,80 @@ describe("LcmContextEngine afterTurn", () => {
     expect(conversation).toBeNull();
   });
 
-  it("afterTurn heartbeat flag skips append-only transcript deltas and advances the checkpoint", async () => {
+  it("afterTurn keeps exact heartbeat poll first-contact turns non-durable", async () => {
     const engine = createEngine();
+    const sessionId = "after-turn-exact-heartbeat-first-contact";
+    const sessionKey = "agent:main:test:after-turn-exact-heartbeat-first-contact";
+    const sessionFile = createSessionFilePath("after-turn-exact-heartbeat-first-contact");
+    const heartbeatMessages = [
+      makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, heartbeatMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: heartbeatMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).toBeNull();
+  });
+
+  it("afterTurn first-contact import keeps real history while skipping exact heartbeat poll traffic", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-exact-heartbeat-first-contact-mixed";
+    const sessionKey = "agent:main:test:after-turn-exact-heartbeat-first-contact-mixed";
+    const sessionFile = createSessionFilePath("after-turn-exact-heartbeat-first-contact-mixed");
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "real user" }),
+      makeMessage({ role: "assistant", content: "real assistant" }),
+      makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "real user",
+      "real assistant",
+    ]);
+  });
+
+  it("afterTurn heartbeat flag skips append-only transcript deltas and advances the checkpoint", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
     const sessionId = "after-turn-heartbeat-flag-append-only-skip";
     const sessionKey = "agent:main:test:after-turn-heartbeat-flag-append-only-skip";
     const sessionFile = createSessionFilePath("after-turn-heartbeat-flag-append-only-skip");
@@ -3916,11 +3986,22 @@ describe("LcmContextEngine afterTurn", () => {
       sessionId,
       sessionKey,
       sessionFile,
-      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "seed assistant" }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+      ],
       isHeartbeat: true,
       prePromptMessageCount: 0,
       tokenBudget: 4096,
     });
+    expect(
+      warnLog.mock.calls.some((call) =>
+        String(call[0]).includes(
+          "runtime batch does not align with the covered transcript frontier",
+        ),
+      ),
+    ).toBe(false);
 
     const conversation = await engine.getConversationStore().getConversationForSession({
       sessionId,
@@ -3932,6 +4013,10 @@ describe("LcmContextEngine afterTurn", () => {
       "seed user",
       "seed assistant",
     ]);
+    const checkpointAfterHeartbeat = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpointAfterHeartbeat?.lastProcessedOffset).toBe(statSync(sessionFile).size);
 
     appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
     appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
@@ -3952,5 +4037,255 @@ describe("LcmContextEngine afterTurn", () => {
       "real user",
       "real assistant",
     ]);
+  });
+
+  it("afterTurn heartbeat flag keeps unrecognized append-only heartbeat deltas non-durable", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-flag-unrecognized-append-only";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-flag-unrecognized-append-only";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-flag-unrecognized-append-only");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "control prompt" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "not a durable reply" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "control prompt" }),
+        makeMessage({ role: "assistant", content: "not a durable reply" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn heartbeat flag imports real append-only prefix before a flagged control suffix", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-flag-real-prefix";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-flag-real-prefix";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-flag-real-prefix");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "control prompt" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "not a durable reply" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "control prompt" }),
+        makeMessage({ role: "assistant", content: "not a durable reply" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real user",
+      "real assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn append-only reconcile skips heartbeat control entries while importing mixed real deltas", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-mixed-append-only";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-mixed-append-only";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-mixed-append-only");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "real assistant" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real user",
+      "real assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn keeps durable runtime messages when only the transcript delta is heartbeat control", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-runtime-real-remainder";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-runtime-real-remainder";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-runtime-real-remainder");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+        makeMessage({ role: "assistant", content: "real runtime assistant" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real runtime assistant",
+    ]);
+  });
+
+  it("afterTurn full-read reconcile propagates heartbeat control disposition after checkpoint loss", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "after-turn-heartbeat-full-read-control-skip";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-full-read-control-skip";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-full-read-control-skip");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const config = getEngineConfig(engine);
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(
+        conversation!.conversationId,
+      );
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "seed assistant" }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    expect(
+      warnLog.mock.calls.some((call) =>
+        String(call[0]).includes(
+          "runtime batch does not align with the covered transcript frontier",
+        ),
+      ),
+    ).toBe(false);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 });

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1633,6 +1633,158 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
+  it("preserves placeholder durable history before assistant-only control suffixes", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-flag-assistant-only-checkpoint";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-flag-assistant-only-checkpoint";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-flag-assistant-only-checkpoint");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "durable user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder frontier",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder frontier",
+      "durable user",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("does not drop durable assistant tails during heartbeat placeholder recovery", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-preserve-assistant-tail";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-preserve-assistant-tail";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-preserve-assistant-tail");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "durable user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "durable assistant" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder frontier",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder frontier",
+      "durable user",
+      "durable assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("does not advance placeholder checkpoints after filtering control noise from unreconciled durable history", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-no-anchor-no-advance";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-no-anchor-no-advance";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-no-anchor-no-advance");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "unanchored durable user" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "existing real frontier" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["existing real frontier"]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(0);
+  });
+
   it("blocks placeholder-checkpoint recovery when raw ids belong to another active conversation", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -5328,4 +5328,54 @@ describe("LcmContextEngine afterTurn", () => {
       .getConversationBootstrapState(conversation!.conversationId);
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
+
+  it("afterTurn full-read heartbeat reconcile skips assistant-only control suffixes", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-full-read-assistant-control";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-full-read-assistant-control";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-full-read-assistant-control");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const config = getEngineConfig(engine);
+    const db = createLcmDatabaseConnection(config.databasePath);
+    try {
+      db.prepare(`DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?`).run(
+        conversation!.conversationId,
+      );
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
 });

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4669,63 +4669,228 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
-  for (const controlAck of ["HEARTBEAT_OK", "NO_REPLY"]) {
-    it(`afterTurn skips singleton assistant ${controlAck} runtime batch after non-durable transcript suffix`, async () => {
-      const warnLog = vi.fn();
-      const engine = createEngineWithDepsOverrides({
-        log: {
-          info: vi.fn(),
-          warn: warnLog,
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-      });
-      const sessionId = `after-turn-heartbeat-singleton-${controlAck.toLowerCase()}`;
-      const sessionKey = `agent:main:test:${sessionId}`;
-      const sessionFile = createSessionFilePath(sessionId);
-      const sm = SessionManager.open(sessionFile);
-      appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
-      appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
-
-      const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
-      expect(first.bootstrapped).toBe(true);
-
-      appendSessionMessage(sm, makeMessage({ role: "assistant", content: controlAck }));
-
-      const conversation = await engine.getConversationStore().getConversationForSession({
-        sessionId,
-        sessionKey,
-      });
-      expect(conversation).not.toBeNull();
-
-      await engine.afterTurn({
-        sessionId,
-        sessionKey,
-        sessionFile,
-        messages: [makeMessage({ role: "assistant", content: controlAck })],
-        isHeartbeat: true,
-        prePromptMessageCount: 0,
-        tokenBudget: 4096,
-      });
-
-      expect(
-        warnLog.mock.calls.some((call) =>
-          String(call[0]).includes(
-            "runtime batch does not align with the covered transcript frontier",
-          ),
-        ),
-      ).toBe(false);
-      const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-      expect(stored.map((message) => message.content)).toEqual([
-        "seed user",
-        "seed assistant",
-      ]);
-      const checkpoint = await engine
-        .getSummaryStore()
-        .getConversationBootstrapState(conversation!.conversationId);
-      expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  it("afterTurn skips singleton assistant HEARTBEAT_OK runtime batch after non-durable transcript suffix", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
     });
-  }
+    const sessionId = "after-turn-heartbeat-singleton-heartbeat-ok";
+    const sessionKey = `agent:main:test:${sessionId}`;
+    const sessionFile = createSessionFilePath(sessionId);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    expect(
+      warnLog.mock.calls.some((call) =>
+        String(call[0]).includes(
+          "runtime batch does not align with the covered transcript frontier",
+        ),
+      ),
+    ).toBe(false);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn skips heartbeat-flagged singleton assistant NO_REPLY runtime batch", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-singleton-no-reply";
+    const sessionKey = `agent:main:test:${sessionId}`;
+    const sessionFile = createSessionFilePath(sessionId);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "NO_REPLY" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn skips heartbeat-flagged marker NO_REPLY runtime suffixes", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-marker-no-reply-runtime";
+    const sessionKey = `agent:main:test:${sessionId}`;
+    const sessionFile = createSessionFilePath(sessionId);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run heartbeat.md" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "run heartbeat.md" }),
+        makeMessage({ role: "assistant", content: "NO_REPLY" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn skips heartbeat-flagged marker NO_REPLY runtime turns before real content", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-marker-no-reply-runtime-prefix";
+    const sessionKey = `agent:main:test:${sessionId}`;
+    const sessionFile = createSessionFilePath(sessionId);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run heartbeat.md" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "run heartbeat.md" }),
+        makeMessage({ role: "assistant", content: "NO_REPLY" }),
+        makeMessage({ role: "assistant", content: "real runtime assistant" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real runtime assistant",
+    ]);
+  });
+
+  it("afterTurn preserves singleton runtime NO_REPLY after unrelated control reconcile", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-runtime-no-reply-durable";
+    const sessionKey = `agent:main:test:${sessionId}`;
+    const sessionFile = createSessionFilePath(sessionId);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "NO_REPLY" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "NO_REPLY",
+    ]);
+  });
 
   it("afterTurn heartbeat flag imports real append-only prefix before a flagged control suffix", async () => {
     const engine = createEngine();

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4244,7 +4244,7 @@ describe("LcmContextEngine afterTurn", () => {
     ]);
   });
 
-  it("afterTurn heartbeat flag keeps unrecognized append-only heartbeat deltas non-durable", async () => {
+  it("afterTurn heartbeat flag imports unrecognized append-only deltas", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-heartbeat-flag-unrecognized-append-only";
     const sessionKey = "agent:main:test:after-turn-heartbeat-flag-unrecognized-append-only";
@@ -4282,6 +4282,8 @@ describe("LcmContextEngine afterTurn", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "seed user",
       "seed assistant",
+      "control prompt",
+      "not a durable reply",
     ]);
     const checkpoint = await engine
       .getSummaryStore()
@@ -4361,8 +4363,8 @@ describe("LcmContextEngine afterTurn", () => {
 
     appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
     appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
-    appendSessionMessage(sm, makeMessage({ role: "user", content: "control prompt" }));
-    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "not a durable reply" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run heartbeat.md" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
 
     const conversation = await engine.getConversationStore().getConversationForSession({
       sessionId,
@@ -4375,8 +4377,8 @@ describe("LcmContextEngine afterTurn", () => {
       sessionKey,
       sessionFile,
       messages: [
-        makeMessage({ role: "user", content: "control prompt" }),
-        makeMessage({ role: "assistant", content: "not a durable reply" }),
+        makeMessage({ role: "user", content: "run heartbeat.md" }),
+        makeMessage({ role: "assistant", content: "NO_REPLY" }),
       ],
       isHeartbeat: true,
       prePromptMessageCount: 0,
@@ -4472,6 +4474,96 @@ describe("LcmContextEngine afterTurn", () => {
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual(["seed user", "seed assistant"]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn heartbeat flag preserves durable user prefixes before a control ack", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-user-prefix";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-user-prefix";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-user-prefix");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real question" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real question",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn heartbeat flag imports heartbeat-marker turns with durable responses", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-marker-durable-response";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-marker-durable-response";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-marker-durable-response");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run heartbeat.md" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "durable response" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "run heartbeat.md" }),
+        makeMessage({ role: "assistant", content: "durable response" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "run heartbeat.md",
+      "durable response",
+    ]);
     const checkpoint = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -10,7 +10,7 @@ import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateSerializedMessageTokens, estimateSerializedMessagesTokens, estimateTokens } from "../src/estimate-tokens.js";
-import { OPENCLAW_HEARTBEAT_POLL } from "../src/heartbeat-filter.js";
+import { isHeartbeatNoiseContent, OPENCLAW_HEARTBEAT_POLL } from "../src/heartbeat-filter.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import { applyScopedDoctorRepair } from "../src/plugin/lcm-doctor-apply.js";
 import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
@@ -34,6 +34,12 @@ import {
 
 afterEach(cleanupEngineTestState);
 describe("LcmContextEngine afterTurn", () => {
+  it("does not treat durable NO_REPLY as context-free heartbeat noise", () => {
+    expect(isHeartbeatNoiseContent("assistant", "NO_REPLY")).toBe(false);
+    expect(isHeartbeatNoiseContent("assistant", "HEARTBEAT_OK")).toBe(true);
+    expect(isHeartbeatNoiseContent("user", OPENCLAW_HEARTBEAT_POLL)).toBe(true);
+  });
+
   it("afterTurn ingests auto-compaction summary and new turn messages", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-ingest";
@@ -1731,6 +1737,115 @@ describe("LcmContextEngine afterTurn", () => {
     expect(stored.map((message) => message.content)).toEqual([
       "durable user",
       "durable assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("strips trailing placeholder control suffixes after older synthetic heartbeat traffic", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-synthetic-plus-trailing-ack";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-synthetic-plus-trailing-ack";
+    const sessionFile = createSessionFilePath(
+      "placeholder-heartbeat-synthetic-plus-trailing-ack",
+    );
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "durable user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder frontier",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder frontier",
+      "durable user",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("preserves placeholder durable exact-token messages before later synthetic traffic", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-preserve-leading-token";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-preserve-leading-token";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-preserve-leading-token");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder frontier",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder frontier",
+      "HEARTBEAT_OK",
     ]);
     const checkpoint = await engine
       .getSummaryStore()

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1685,6 +1685,59 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
+  it("advances placeholder checkpoints over control suffixes after anchored durable history", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-anchored-control-suffix";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-anchored-control-suffix";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-anchored-control-suffix");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "durable user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "durable assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+      ],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "durable user",
+      "durable assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
   it("does not drop durable assistant tails during heartbeat placeholder recovery", async () => {
     const engine = createEngine();
     const sessionId = "placeholder-heartbeat-preserve-assistant-tail";

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4396,6 +4396,88 @@ describe("LcmContextEngine afterTurn", () => {
     expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
+  it("afterTurn heartbeat flag preserves assistant-only durable prefixes before a control ack", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-assistant-only-prefix";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-assistant-only-prefix";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-assistant-only-prefix");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "durable assistant" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "durable assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn heartbeat flag skips delayed assistant-only control ack runs", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-assistant-only-acks";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-assistant-only-acks";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-assistant-only-acks");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      isHeartbeat: true,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual(["seed user", "seed assistant"]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
   it("afterTurn filters singleton runtime ack when mixed append-only transcript skips a control suffix", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDepsOverrides({

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4167,6 +4167,33 @@ describe("LcmContextEngine afterTurn", () => {
     expect(conversation).toBeNull();
   });
 
+  it("afterTurn keeps exact heartbeat poll NO_REPLY first-contact turns non-durable", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-exact-heartbeat-no-reply-first-contact";
+    const sessionKey = "agent:main:test:after-turn-exact-heartbeat-no-reply-first-contact";
+    const sessionFile = createSessionFilePath("after-turn-exact-heartbeat-no-reply-first-contact");
+    const heartbeatMessages = [
+      makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "NO_REPLY" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, heartbeatMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: heartbeatMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).toBeNull();
+  });
+
   it("afterTurn first-contact import keeps real history while skipping exact heartbeat poll traffic", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-exact-heartbeat-first-contact-mixed";
@@ -4202,6 +4229,50 @@ describe("LcmContextEngine afterTurn", () => {
       "real user",
       "real assistant",
     ]);
+  });
+
+  it("afterTurn append-only reconcile skips exact heartbeat poll NO_REPLY turns without the heartbeat flag", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-exact-heartbeat-no-reply-append-only";
+    const sessionKey = "agent:main:test:after-turn-exact-heartbeat-no-reply-append-only";
+    const sessionFile = createSessionFilePath("after-turn-exact-heartbeat-no-reply-append-only");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "NO_REPLY" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "NO_REPLY" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
   it("afterTurn heartbeat flag skips append-only transcript deltas and advances the checkpoint", async () => {

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4451,6 +4451,40 @@ describe("LcmContextEngine afterTurn", () => {
     ]);
   });
 
+  it("afterTurn keeps HEARTBEAT_OK turns durable when non-user content quotes the exact poll", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-ok-tool-quoted-poll-durable";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-ok-tool-quoted-poll-durable";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-ok-tool-quoted-poll-durable");
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "Explain this control token" }),
+      makeMessage({ role: "tool", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: transcriptMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Explain this control token",
+      OPENCLAW_HEARTBEAT_POLL,
+      "HEARTBEAT_OK",
+    ]);
+  });
+
   it("afterTurn append-only reconcile skips exact heartbeat poll NO_REPLY turns without the heartbeat flag", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-exact-heartbeat-no-reply-append-only";

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4231,6 +4231,111 @@ describe("LcmContextEngine afterTurn", () => {
     ]);
   });
 
+  it("afterTurn first-contact import prunes NO_REPLY runtime control turns", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-exact-heartbeat-no-reply-first-contact-mixed";
+    const sessionKey = "agent:main:test:after-turn-exact-heartbeat-no-reply-first-contact-mixed";
+    const sessionFile = createSessionFilePath(
+      "after-turn-exact-heartbeat-no-reply-first-contact-mixed",
+    );
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "real user" }),
+      makeMessage({ role: "assistant", content: "real assistant" }),
+      makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "NO_REPLY" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "NO_REPLY" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "real user",
+      "real assistant",
+    ]);
+  });
+
+  it("afterTurn keeps heartbeat-marker NO_REPLY turns durable without an exact poll", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-heartbeat-marker-no-reply-durable";
+    const sessionKey = "agent:main:test:after-turn-heartbeat-marker-no-reply-durable";
+    const sessionFile = createSessionFilePath("after-turn-heartbeat-marker-no-reply-durable");
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "What does heartbeat.md say?" }),
+      makeMessage({ role: "assistant", content: "NO_REPLY" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: transcriptMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "What does heartbeat.md say?",
+      "NO_REPLY",
+    ]);
+  });
+
+  it("afterTurn keeps NO_REPLY turns durable when non-user content quotes the exact poll", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-no-reply-tool-quoted-poll-durable";
+    const sessionKey = "agent:main:test:after-turn-no-reply-tool-quoted-poll-durable";
+    const sessionFile = createSessionFilePath("after-turn-no-reply-tool-quoted-poll-durable");
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "What does heartbeat.md say?" }),
+      makeMessage({ role: "tool", content: OPENCLAW_HEARTBEAT_POLL }),
+      makeMessage({ role: "assistant", content: "NO_REPLY" }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: transcriptMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "What does heartbeat.md say?",
+      OPENCLAW_HEARTBEAT_POLL,
+      "NO_REPLY",
+    ]);
+  });
+
   it("afterTurn append-only reconcile skips exact heartbeat poll NO_REPLY turns without the heartbeat flag", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-exact-heartbeat-no-reply-append-only";

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1580,6 +1580,59 @@ describe("LcmContextEngine afterTurn", () => {
     expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
   });
 
+  it("advances placeholder checkpoints over all-control append-only transcript slices", async () => {
+    const engine = createEngine();
+    const sessionId = "placeholder-heartbeat-control-checkpoint";
+    const sessionKey = "agent:main:test:placeholder-heartbeat-control-checkpoint";
+    const sessionFile = createSessionFilePath("placeholder-heartbeat-control-checkpoint");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): placeholder frontier",
+      }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }),
+        makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): placeholder frontier",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
   it("blocks placeholder-checkpoint recovery when raw ids belong to another active conversation", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(
@@ -4178,6 +4231,66 @@ describe("LcmContextEngine afterTurn", () => {
       tokenBudget: 4096,
     });
 
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "seed user",
+      "seed assistant",
+      "real user",
+      "real assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
+  it("afterTurn filters singleton runtime ack when mixed append-only transcript skips a control suffix", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: {
+        info: vi.fn(),
+        warn: warnLog,
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    });
+    const sessionId = "after-turn-mixed-transcript-singleton-ack";
+    const sessionKey = "agent:main:test:after-turn-mixed-transcript-singleton-ack";
+    const sessionFile = createSessionFilePath("after-turn-mixed-transcript-singleton-ack");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "seed user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "seed assistant" }));
+
+    const first = await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "real user" }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "real assistant" }));
+    appendSessionMessage(sm, makeMessage({ role: "user", content: OPENCLAW_HEARTBEAT_POLL }));
+    appendSessionMessage(sm, makeMessage({ role: "assistant", content: "HEARTBEAT_OK" }));
+
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "HEARTBEAT_OK" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    expect(
+      warnLog.mock.calls.some((call) =>
+        String(call[0]).includes(
+          "runtime batch does not align with the covered transcript frontier",
+        ),
+      ),
+    ).toBe(false);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual([
       "seed user",


### PR DESCRIPTION
## What

This PR keeps proven heartbeat/control transcript entries out of durable Lossless memory while still advancing transcript reconciliation checkpoints over those entries.

## Why

Heartbeat/control turns can appear in the OpenClaw transcript and runtime afterTurn batch, but they should not enter memory, summaries, search, or replay when they are proven control traffic. The important invariant is that Lossless may skip those entries durably, but it must still remember that the transcript frontier was reconciled so later real turns import normally and do not emit stale covered-frontier overlap warnings.

## Changes

- Add non-durable reconcile disposition
- Filter proven control transcript tails before import
- Preserve real mixed transcript deltas
- Preserve assistant-only durable prefixes
- Preserve unrecognized durable heartbeat-marked content
- Advance anchored placeholder checkpoints over control suffixes
- Treat `NO_REPLY` as exact-poll control traffic
- Keep rollover `NO_REPLY` checks turn-aware
- Require user-role exact heartbeat polls
- Preserve durable runtime `NO_REPLY` boundaries
- Keep full-read heartbeat filtering proof-based
- Propagate control disposition after mixed real/control reconcile
- Advance placeholder checkpoints over covered all-control slices
- Preserve placeholder durable history before heartbeat suffix filtering
- Filter runtime control messages before alignment
- Add regression coverage and changeset

## Testing

- `npx vitest run test/engine-after-turn.test.ts -t "full-read heartbeat reconcile preserves|full-read reconcile propagates"` passes
- `npx vitest run test/engine-after-turn.test.ts test/transcript-entry-id.test.ts test/ambiguous-rollover-rotation.test.ts` passes: 129 tests
- `npm run typecheck` passes
- `npm run build` passes
- `git diff --check` passes
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode local` passes with no accepted/actionable findings
