### PR TITLE
fix: canonicalize OpenClaw inbound metadata for message identity

### DIFF
--- a/.changeset/openclaw-inbound-metadata-identity.md
+++ b/.changeset/openclaw-inbound-metadata-identity.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Canonicalize OpenClaw inbound metadata when computing message identity and bootstrap hashes so volatile message metadata does not stall context continuity while raw transcript content stays lossless.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1,5 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
+import { createHash } from "node:crypto";
 import { getLcmDbFeatures } from "./features.js";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "../openclaw-inbound-metadata.js";
 import { buildMessageIdentityHash } from "../store/message-identity.js";
 import { parseUtcTimestampOrNull } from "../store/parse-utc-timestamp.js";
 
@@ -42,6 +44,14 @@ type MessageIdentityBackfillRow = {
   content: string;
 };
 
+type OpenClawMetadataIdentityRepairRow = {
+  message_id: number;
+  conversation_id: number;
+  role: string;
+  content: string;
+  identity_hash: string | null;
+};
+
 type FtsTableSpec = {
   tableName: string;
   createSql: string;
@@ -54,6 +64,7 @@ const VERSIONED_BACKFILL_STEPS = {
   backfillSummaryDepths: 1,
   backfillSummaryMetadata: 1,
   backfillToolCallColumns: 1,
+  repairOpenClawMetadataIdentityState: 1,
 } as const;
 
 type VersionedBackfillStepName = keyof typeof VERSIONED_BACKFILL_STEPS;
@@ -445,6 +456,79 @@ function backfillMessageIdentityHashes(
       }
       throw error;
     }
+    lastProcessedMessageId = rows[rows.length - 1]?.message_id ?? lastProcessedMessageId;
+  }
+}
+
+function buildLegacyRawMessageIdentityHash(role: string, content: string): string {
+  return createHash("sha256")
+    .update(role)
+    .update("\u0000")
+    .update(content)
+    .digest("hex");
+}
+
+function buildBootstrapEntryHash(role: string, content: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ role, content }))
+    .digest("hex");
+}
+
+function buildCanonicalBootstrapEntryHash(role: string, content: string): string {
+  return buildBootstrapEntryHash(
+    role,
+    canonicalizeOpenClawInboundMetadataIdentityContent(role, content),
+  );
+}
+
+function repairOpenClawMetadataIdentityState(db: DatabaseSync): void {
+  const selectStmt = db.prepare(
+    `SELECT message_id, conversation_id, role, content, identity_hash
+     FROM messages
+     WHERE message_id > ? AND role = 'user'
+     ORDER BY message_id
+     LIMIT ?`,
+  );
+  const updateIdentityStmt = db.prepare(
+    `UPDATE messages SET identity_hash = ? WHERE message_id = ?`,
+  );
+  const updateCheckpointStmt = db.prepare(
+    `UPDATE conversation_bootstrap_state
+     SET last_processed_entry_hash = ?
+     WHERE conversation_id = ? AND last_processed_entry_hash = ?`,
+  );
+  let lastProcessedMessageId = 0;
+
+  while (true) {
+    const rows = selectStmt.all(
+      lastProcessedMessageId,
+      1_000,
+    ) as OpenClawMetadataIdentityRepairRow[];
+    if (rows.length === 0) {
+      return;
+    }
+
+    for (const row of rows) {
+      const canonicalContent = canonicalizeOpenClawInboundMetadataIdentityContent(
+        row.role,
+        row.content,
+      );
+      if (canonicalContent === row.content) {
+        continue;
+      }
+
+      const legacyMessageHash = buildLegacyRawMessageIdentityHash(row.role, row.content);
+      if (row.identity_hash === legacyMessageHash) {
+        updateIdentityStmt.run(buildMessageIdentityHash(row.role, row.content), row.message_id);
+      }
+
+      updateCheckpointStmt.run(
+        buildCanonicalBootstrapEntryHash(row.role, row.content),
+        row.conversation_id,
+        buildBootstrapEntryHash(row.role, row.content),
+      );
+    }
+
     lastProcessedMessageId = rows[rows.length - 1]?.message_id ?? lastProcessedMessageId;
   }
 }
@@ -1274,6 +1358,9 @@ export function runLcmMigrations(
     runMigrationStep("ensureMessagePartsTable", log, () => ensureMessagePartsTable(db));
     runMigrationStep("backfillMessageIdentityHashes", log, () =>
       backfillMessageIdentityHashes(db, { managesOwnTransaction: false }),
+    );
+    runVersionedBackfillStep(db, "repairOpenClawMetadataIdentityState", log, () =>
+      repairOpenClawMetadataIdentityState(db),
     );
     runMigrationStep("createMessagesIdentityHashIndex", log, () =>
       db.exec(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -70,6 +70,7 @@ import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbe
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
 import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
 import { listTranscriptToolResultEntryIdsByCallId } from "./replay-metadata.js";
 import { estimateSessionTokenCountForAfterTurn, extractRuntimePromptTokenCount } from "./token-accounting.js";
@@ -1938,6 +1939,13 @@ export class LcmContextEngine implements ContextEngine {
                 })
               : null;
             const frontierHash = latestDbHash ?? bootstrapState.lastProcessedEntryHash;
+            const latestDbHashNeedsEntryId =
+              latestDbMessage
+                ? canonicalizeOpenClawInboundMetadataIdentityContent(
+                    latestDbMessage.role,
+                    latestDbMessage.content,
+                  ) !== latestDbMessage.content
+                : false;
             // Short-circuit before the expensive backward scan: the fast-path can
             // only succeed when the current frontier still matches the checkpoint.
             // A freshly rotated row may have no DB messages yet, so in that case
@@ -1945,7 +1953,9 @@ export class LcmContextEngine implements ContextEngine {
             // frontier no longer matches, skip straight to the async full-read
             // slow path below and avoid a backward scan that cannot succeed.
             const canTryAppendOnlyFastPath =
-              frontierHash !== null && frontierHash === bootstrapState.lastProcessedEntryHash;
+              frontierHash !== null &&
+              frontierHash === bootstrapState.lastProcessedEntryHash &&
+              (!latestDbHashNeedsEntryId || bootstrapState.lastProcessedEntryId !== null);
 
             const tailEntryRaw = canTryAppendOnlyFastPath
               ? await readLastJsonlEntryBeforeOffset(

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -5,6 +5,7 @@
  */
 import { buildMessageParts, toStoredMessage, type StoredMessage } from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import type { CreateMessagePartInput } from "./store/conversation-store.js";
 import { extractToolResultIdForPairing } from "./tool-pairing.js";
 import { extractBootstrapMessageCandidate } from "./transcript.js";
@@ -14,8 +15,12 @@ export function createBootstrapEntryHash(message: StoredMessage | null): string 
   if (!message) {
     return null;
   }
+  const content = canonicalizeOpenClawInboundMetadataIdentityContent(
+    message.role,
+    message.content,
+  );
   return createHash("sha256")
-    .update(JSON.stringify({ role: message.role, content: message.content }))
+    .update(JSON.stringify({ role: message.role, content }))
     .digest("hex");
 }
 

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -1,5 +1,5 @@
 const OPENCLAW_INBOUND_METADATA_BLOCK_RE =
-  /^(Conversation info \(untrusted metadata\)|Sender \(untrusted metadata\)):\r?\n```json\r?\n([\s\S]*?)\r?\n```\s*/;
+  /^(Conversation info \(untrusted metadata\)|Sender \(untrusted metadata\)):\r?\n```json\r?\n([\s\S]*?)\r?\n```/;
 
 const CONVERSATION_INFO_KEYS = new Set([
   "chat_id",
@@ -30,6 +30,12 @@ const CONVERSATION_INFO_KEYS = new Set([
   "history_truncated",
 ]);
 
+const VOLATILE_CONVERSATION_INFO_KEYS = new Set([
+  "message_id",
+  "reply_to_id",
+  "timestamp",
+]);
+
 const SENDER_INFO_KEYS = new Set([
   "label",
   "id",
@@ -39,6 +45,9 @@ const SENDER_INFO_KEYS = new Set([
   "e164",
 ]);
 
+/**
+ * Canonicalizes OpenClaw's injected inbound metadata preamble for user-message identity input.
+ */
 export function canonicalizeOpenClawInboundMetadataIdentityContent(
   role: string,
   content: string,
@@ -47,42 +56,109 @@ export function canonicalizeOpenClawInboundMetadataIdentityContent(
     return content;
   }
 
-  let remaining = content;
-  let strippedBlock = false;
-  for (;;) {
-    const candidate = remaining.trimStart();
-    const match = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(candidate);
-    if (!match) {
-      break;
-    }
-    if (!isOpenClawInboundMetadataRecord(match[1] ?? "", match[2] ?? "")) {
-      return content;
-    }
-    remaining = candidate.slice(match[0].length);
-    strippedBlock = true;
+  const conversationCandidate = content.trimStart();
+  const conversationMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(conversationCandidate);
+  const conversationHeading = conversationMatch?.[1] ?? "";
+  const conversationRecord = conversationMatch
+    ? parseOpenClawInboundMetadataRecord(conversationHeading, conversationMatch[2] ?? "")
+    : null;
+  const canonicalConversationJson = conversationRecord
+    ? canonicalizeMetadataJson(conversationRecord, VOLATILE_CONVERSATION_INFO_KEYS)
+    : null;
+  if (
+    !conversationMatch ||
+    conversationHeading !== "Conversation info (untrusted metadata)" ||
+    !canonicalConversationJson
+  ) {
+    return content;
   }
 
-  return strippedBlock && remaining.trim().length > 0 ? remaining : content;
+  let remaining = conversationCandidate.slice(conversationMatch[0].length);
+  const canonicalBlocks = [
+    formatCanonicalMetadataBlock(conversationHeading, canonicalConversationJson),
+  ];
+  const senderCandidate = remaining.trimStart();
+  const senderMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(senderCandidate);
+  const senderHeading = senderMatch?.[1] ?? "";
+  const senderRecord = senderMatch
+    ? parseOpenClawInboundMetadataRecord(senderHeading, senderMatch[2] ?? "")
+    : null;
+  const canonicalSenderJson = senderRecord
+    ? canonicalizeMetadataJson(senderRecord, new Set())
+    : null;
+  if (
+    senderMatch &&
+    senderHeading === "Sender (untrusted metadata)" &&
+    canonicalSenderJson
+  ) {
+    remaining = stripMetadataSeparator(senderCandidate.slice(senderMatch[0].length));
+    canonicalBlocks.push(formatCanonicalMetadataBlock(senderHeading, canonicalSenderJson));
+  } else {
+    remaining = stripMetadataSeparator(remaining);
+  }
+
+  return remaining.trim().length > 0 ? `${canonicalBlocks.join("\n\n")}\n\n${remaining}` : content;
 }
 
-function isOpenClawInboundMetadataRecord(heading: string, json: string): boolean {
+function parseOpenClawInboundMetadataRecord(
+  heading: string,
+  json: string,
+): Record<string, unknown> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
   } catch {
-    return false;
+    return null;
   }
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return false;
+    return null;
   }
 
   const knownKeys = getKnownKeysForHeading(heading);
   if (!knownKeys) {
-    return false;
+    return null;
   }
 
-  return Object.keys(parsed).some((key) => knownKeys.has(key));
+  return Object.keys(parsed).some((key) => knownKeys.has(key))
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+function canonicalizeMetadataJson(
+  record: Record<string, unknown>,
+  volatileKeys: Set<string>,
+): string | null {
+  const stableEntries = Object.entries(record)
+    .filter(([key]) => !volatileKeys.has(key))
+    .map(([key, value]) => [key, canonicalizeJsonValue(value)] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (stableEntries.length === 0) {
+    return null;
+  }
+  return JSON.stringify(Object.fromEntries(stableEntries));
+}
+
+function canonicalizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalizeJsonValue(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .map(([key, nestedValue]) => [key, canonicalizeJsonValue(nestedValue)] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function formatCanonicalMetadataBlock(heading: string, json: string): string {
+  return [heading + ":", "```json", json, "```"].join("\n");
+}
+
+function stripMetadataSeparator(content: string): string {
+  return content.replace(/^[ \t]*(?:\r?\n)(?:[ \t]*(?:\r?\n))?/, "");
 }
 
 function getKnownKeysForHeading(heading: string): Set<string> | undefined {

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -56,7 +56,8 @@ export function canonicalizeOpenClawInboundMetadataIdentityContent(
     return content;
   }
 
-  const conversationCandidate = content.trimStart();
+  const { prelude, metadataCandidate } = splitOpenClawInboundMetadataPrelude(content);
+  const conversationCandidate = metadataCandidate.trimStart();
   const conversationMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(conversationCandidate);
   const conversationHeading = conversationMatch?.[1] ?? "";
   const conversationRecord = conversationMatch
@@ -97,7 +98,30 @@ export function canonicalizeOpenClawInboundMetadataIdentityContent(
     remaining = stripMetadataSeparator(remaining);
   }
 
-  return remaining.trim().length > 0 ? `${canonicalBlocks.join("\n\n")}\n\n${remaining}` : content;
+  return remaining.trim().length > 0
+    ? `${prelude}${canonicalBlocks.join("\n\n")}\n\n${remaining}`
+    : content;
+}
+
+function splitOpenClawInboundMetadataPrelude(content: string): {
+  prelude: string;
+  metadataCandidate: string;
+} {
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith("Conversation info (untrusted metadata):")) {
+    return { prelude: "", metadataCandidate: trimmed };
+  }
+
+  const deliveryPrelude = /^Delivery:[\s\S]*?\r?\n\r?\n(?=Conversation info \(untrusted metadata\):)/.exec(
+    trimmed,
+  );
+  if (!deliveryPrelude) {
+    return { prelude: "", metadataCandidate: trimmed };
+  }
+  return {
+    prelude: deliveryPrelude[0],
+    metadataCandidate: trimmed.slice(deliveryPrelude[0].length),
+  };
 }
 
 function parseOpenClawInboundMetadataRecord(

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -1,0 +1,96 @@
+const OPENCLAW_INBOUND_METADATA_BLOCK_RE =
+  /^(Conversation info \(untrusted metadata\)|Sender \(untrusted metadata\)):\r?\n```json\r?\n([\s\S]*?)\r?\n```\s*/;
+
+const CONVERSATION_INFO_KEYS = new Set([
+  "chat_id",
+  "message_id",
+  "reply_to_id",
+  "sender_id",
+  "conversation_label",
+  "sender",
+  "timestamp",
+  "group_subject",
+  "group_channel",
+  "group_space",
+  "group_members",
+  "thread_label",
+  "inbound_event_kind",
+  "topic_id",
+  "topic_name",
+  "is_forum",
+  "mention_reason",
+  "mention_target",
+  "mentioned_user_ids",
+  "mentioned_usernames",
+  "has_reply_context",
+  "has_forwarded_context",
+  "has_thread_starter",
+  "history_count",
+  "history_media_count",
+  "history_truncated",
+]);
+
+const SENDER_INFO_KEYS = new Set([
+  "label",
+  "id",
+  "name",
+  "username",
+  "tag",
+  "e164",
+]);
+
+export function canonicalizeOpenClawInboundMetadataIdentityContent(
+  role: string,
+  content: string,
+): string {
+  if (role !== "user") {
+    return content;
+  }
+
+  let remaining = content;
+  let strippedBlock = false;
+  for (;;) {
+    const candidate = remaining.trimStart();
+    const match = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(candidate);
+    if (!match) {
+      break;
+    }
+    if (!isOpenClawInboundMetadataRecord(match[1] ?? "", match[2] ?? "")) {
+      return content;
+    }
+    remaining = candidate.slice(match[0].length);
+    strippedBlock = true;
+  }
+
+  return strippedBlock && remaining.trim().length > 0 ? remaining : content;
+}
+
+function isOpenClawInboundMetadataRecord(heading: string, json: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return false;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+
+  const knownKeys = getKnownKeysForHeading(heading);
+  if (!knownKeys) {
+    return false;
+  }
+
+  return Object.keys(parsed).some((key) => knownKeys.has(key));
+}
+
+function getKnownKeysForHeading(heading: string): Set<string> | undefined {
+  if (heading === "Conversation info (untrusted metadata)") {
+    return CONVERSATION_INFO_KEYS;
+  }
+  if (heading === "Sender (untrusted metadata)") {
+    return SENDER_INFO_KEYS;
+  }
+  return undefined;
+}

--- a/src/store/message-identity.ts
+++ b/src/store/message-identity.ts
@@ -1,13 +1,15 @@
 import { createHash } from "node:crypto";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "../openclaw-inbound-metadata.js";
 
 export function buildMessageIdentityKey(role: string, content: string): string {
-  return `${role}\u0000${content}`;
+  return `${role}\u0000${canonicalizeOpenClawInboundMetadataIdentityContent(role, content)}`;
 }
 
 export function buildMessageIdentityHash(role: string, content: string): string {
+  const identityContent = canonicalizeOpenClawInboundMetadataIdentityContent(role, content);
   return createHash("sha256")
     .update(role)
     .update("\u0000")
-    .update(content)
+    .update(identityContent)
     .digest("hex");
 }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -161,17 +161,16 @@ export class TranscriptReconciler {
 
     for (const [index, message] of params.messages.entries()) {
       const stored = toStoredMessage(message);
-      const identityHash = buildMessageIdentityHash(stored.role, stored.content);
-      const key = `${stored.role}\u0000${identityHash}`;
+      const key = `${stored.role}\u0000${stored.content}`;
       const seen = (seenCounts.get(key) ?? 0) + 1;
       seenCounts.set(key, seen);
 
       let existing = existingCounts.get(key);
       if (existing === undefined) {
-        existing = await this.host.conversationStore.countMessagesByIdentityHash(
+        existing = await this.host.conversationStore.countMessagesByIdentity(
           params.conversationId,
           stored.role,
-          identityHash,
+          stored.content,
         );
         existingCounts.set(key, existing);
       }
@@ -672,12 +671,23 @@ export class TranscriptReconciler {
       const checkpointEntryHash = params.checkpointEntryHash;
       if (checkpointEntryHash) {
         // Externalized bootstrap rows no longer match raw JSONL content, so
-        // fall back to the raw transcript checkpoint before declaring no overlap.
+        // fall back to the transcript checkpoint before declaring no overlap.
+        // Refuse duplicate hash matches: canonical OpenClaw metadata can make
+        // repeated same-text inbound entries share a hash, and anchoring the
+        // later occurrence would skip intervening transcript history.
+        let checkpointHashAnchorIndex = -1;
+        let checkpointHashAmbiguous = false;
         for (let index = storedHistoricalMessages.length - 1; index >= 0; index--) {
           if (createBootstrapEntryHash(storedHistoricalMessages[index]) === checkpointEntryHash) {
-            anchorIndex = index;
-            break;
+            if (checkpointHashAnchorIndex >= 0) {
+              checkpointHashAmbiguous = true;
+              break;
+            }
+            checkpointHashAnchorIndex = index;
           }
+        }
+        if (!checkpointHashAmbiguous) {
+          anchorIndex = checkpointHashAnchorIndex;
         }
       }
 

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -34,6 +34,31 @@ import {
 } from "./helpers.js";
 
 afterEach(cleanupEngineTestState);
+
+function openClawInboundMetadataContent(params: {
+  messageId: string;
+  senderName: string;
+  text: string;
+}): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:chat-1",
+      message_id: params.messageId,
+      timestamp: "2026-06-16T00:00:00.000Z",
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({ name: params.senderName }),
+    "```",
+    "",
+    params.text,
+  ].join("\n");
+}
+
 describe("LcmContextEngine.bootstrap", () => {
   it("imports only active leaf-path messages from SessionManager context", async () => {
     const sessionFile = createSessionFilePath("branched");
@@ -2579,6 +2604,73 @@ describe("LcmContextEngine.bootstrap", () => {
       reason: "reconciled missing session messages",
     });
     expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps append-only bootstrap moving when OpenClaw inbound metadata changes around the same user text", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("append-only-openclaw-inbound-metadata");
+    const initialContent = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+    writeLeafTranscriptMessages(sessionFile, [
+      makeMessage({ role: "user", content: initialContent }),
+    ]);
+
+    const engine = createEngineAtDatabasePath(dbPath);
+    const sessionId = "bootstrap-append-only-openclaw-inbound-metadata";
+
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first).toEqual({ bootstrapped: true, importedMessages: 1 });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const storedBefore = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(storedBefore[0]?.content).toBe(initialContent);
+
+    const volatileContent = openClawInboundMetadataContent({
+      messageId: "telegram-2",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+    const rawDb = createLcmDatabaseConnection(dbPath);
+    try {
+      rawDb
+        .prepare(`UPDATE messages SET content = ? WHERE conversation_id = ?`)
+        .run(volatileContent, conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const reconcileSpy = vi.spyOn(engine.getTranscriptReconciler(), "reconcileSessionTail");
+    appendFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        message: { role: "assistant", content: [{ type: "text", text: "tail assistant" }] },
+      })}\n`,
+      "utf8",
+    );
+
+    const second = await engine.bootstrap({ sessionId, sessionFile });
+    expect(second).toEqual({
+      bootstrapped: true,
+      importedMessages: 1,
+      reason: "reconciled missing session messages",
+    });
+    expect(reconcileSpy).not.toHaveBeenCalled();
+
+    const storedAfter = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(storedAfter.map((message) => message.content)).toEqual([
+      volatileContent,
+      "tail assistant",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
   });
 
   it("falls back to full reconciliation when append-only suffix overlaps persisted history", async () => {

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -2660,7 +2660,7 @@ describe("LcmContextEngine.bootstrap", () => {
       importedMessages: 1,
       reason: "reconciled missing session messages",
     });
-    expect(reconcileSpy).not.toHaveBeenCalled();
+    expect(reconcileSpy).toHaveBeenCalledTimes(1);
 
     const storedAfter = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(storedAfter.map((message) => message.content)).toEqual([
@@ -3222,6 +3222,140 @@ describe("LcmContextEngine.bootstrap", () => {
       reason: "reconciled missing session messages",
     });
     expect(reconcileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not anchor hash-only checkpoint recovery on an ambiguous repeated inbound message", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const sessionFile = createSessionFilePath("ambiguous-canonical-checkpoint");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, {
+      role: "user",
+      content: [{ type: "text", text: openClawInboundMetadataContent({
+        messageId: "telegram-1",
+        senderName: "Syu",
+        text: "repeat me",
+      }) }],
+    } as AgentMessage);
+    appendSessionMessage(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "middle assistant" }],
+    } as AgentMessage);
+    appendSessionMessage(sm, {
+      role: "user",
+      content: [{ type: "text", text: openClawInboundMetadataContent({
+        messageId: "telegram-2",
+        senderName: "Syu",
+        text: "repeat me",
+      }) }],
+    } as AgentMessage);
+
+    const engine = createEngineAtDatabasePath(dbPath);
+    const sessionId = "ambiguous-canonical-checkpoint";
+    const first = await engine.bootstrap({ sessionId, sessionFile });
+    expect(first.bootstrapped).toBe(true);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const rawDb = createLcmDatabaseConnection(dbPath);
+    try {
+      rawDb
+        .prepare(
+          `DELETE FROM context_items
+           WHERE conversation_id = ?
+             AND message_id IN (
+               SELECT message_id FROM messages WHERE conversation_id = ? AND seq > 1
+             )`,
+        )
+        .run(conversation!.conversationId, conversation!.conversationId);
+      rawDb
+        .prepare(
+          `DELETE FROM message_parts
+           WHERE message_id IN (
+             SELECT message_id FROM messages WHERE conversation_id = ? AND seq > 1
+           )`,
+        )
+        .run(conversation!.conversationId);
+      rawDb
+        .prepare(
+          `DELETE FROM messages
+           WHERE conversation_id = ?
+             AND seq > 1`,
+        )
+        .run(conversation!.conversationId);
+      rawDb
+        .prepare(
+          `UPDATE conversation_bootstrap_state
+           SET last_processed_entry_id = NULL,
+               last_seen_size = 0,
+               last_seen_mtime_ms = 0
+           WHERE conversation_id = ?`,
+        )
+        .run(conversation!.conversationId);
+      rawDb
+        .prepare(
+          `UPDATE messages
+           SET transcript_entry_id = NULL
+           WHERE conversation_id = ?`,
+        )
+        .run(conversation!.conversationId);
+    } finally {
+      closeLcmConnection(rawDb);
+    }
+
+    const secondEngine = createEngineAtDatabasePath(dbPath);
+    const second = await secondEngine.bootstrap({ sessionId, sessionFile });
+
+    expect(second.importedMessages).toBe(2);
+    const stored = await secondEngine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      openClawInboundMetadataContent({
+        messageId: "telegram-1",
+        senderName: "Syu",
+        text: "repeat me",
+      }),
+      "middle assistant",
+      openClawInboundMetadataContent({
+        messageId: "telegram-2",
+        senderName: "Syu",
+        text: "repeat me",
+      }),
+    ]);
+  });
+
+  it("does not count distinct OpenClaw metadata variants as no-anchor replay overlaps", async () => {
+    const engine = createEngine();
+    const conversation = await engine
+      .getConversationStore()
+      .createConversation({ sessionId: "no-anchor-openclaw-overlap" });
+    const persisted = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: "repeat me",
+    });
+    await engine.getConversationStore().createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: persisted,
+      tokenCount: 1,
+    });
+
+    const candidate = openClawInboundMetadataContent({
+      messageId: "telegram-2",
+      senderName: "Syu",
+      text: "repeat me",
+    });
+    const analysis = await engine
+      .getTranscriptReconciler()
+      .analyzePersistedTranscriptIdentityOverlaps({
+        conversationId: conversation.conversationId,
+        messages: [makeMessage({ role: "user", content: candidate })],
+      });
+
+    expect(analysis).toEqual({ overlaps: 0, firstNonOverlappingIndex: 0 });
   });
 
   it("reconciles missing structured tool-call tail when prior empty tool content exists", async () => {

--- a/test/message-identity.test.ts
+++ b/test/message-identity.test.ts
@@ -36,9 +36,12 @@ describe("ConversationStore message identity lookups", () => {
     expect(buildMessageIdentityHash("user", first)).toBe(
       buildMessageIdentityHash("user", second),
     );
-    expect(buildMessageIdentityKey("user", first)).toBe(
-      "user\u0000please keep this context",
-    );
+    const canonicalFirst = canonicalizeOpenClawInboundMetadataIdentityContent("user", first);
+    expect(buildMessageIdentityKey("user", first)).toBe(`user\u0000${canonicalFirst}`);
+    expect(canonicalFirst).toContain('"chat_id":"telegram:chat-1"');
+    expect(canonicalFirst).toContain('"name":"Syu"');
+    expect(canonicalFirst).toContain("please keep this context");
+    expect(canonicalFirst).not.toContain("telegram-1");
     expect(buildMessageIdentityHash("assistant", first)).not.toBe(
       buildMessageIdentityHash("assistant", second),
     );
@@ -120,6 +123,109 @@ describe("ConversationStore message identity lookups", () => {
     expect(
       canonicalizeOpenClawInboundMetadataIdentityContent("user", metadataOnly),
     ).toBe(metadataOnly);
+  });
+
+  it("does not strip user-authored metadata-looking blocks after the injected preamble", () => {
+    const userAuthoredBlock = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        chat_id: "quoted-chat",
+        message_id: "quoted-message",
+      }),
+      "```",
+      "",
+      "please analyze why this exact block appears in the prompt",
+    ].join("\n");
+    const content = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: userAuthoredBlock,
+    });
+
+    const canonical = canonicalizeOpenClawInboundMetadataIdentityContent("user", content);
+    expect(canonical).toContain(userAuthoredBlock);
+    expect(canonical).not.toBe("please analyze why this exact block appears in the prompt");
+  });
+
+  it("keeps stable OpenClaw metadata in identity to avoid global text-prefix collapse", () => {
+    const first = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        chat_id: "quoted-chat-a",
+        message_id: "quoted-message-1",
+      }),
+      "```",
+      "",
+      "please analyze why this exact block appears in the prompt",
+    ].join("\n");
+    const second = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        chat_id: "quoted-chat-b",
+        message_id: "quoted-message-2",
+      }),
+      "```",
+      "",
+      "please analyze why this exact block appears in the prompt",
+    ].join("\n");
+
+    expect(buildMessageIdentityHash("user", first)).not.toBe(
+      buildMessageIdentityHash("user", second),
+    );
+  });
+
+  it("preserves leading whitespace on the user payload after the metadata preamble", () => {
+    const indented = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: "  indented code",
+    });
+    const unindented = openClawInboundMetadataContent({
+      messageId: "telegram-2",
+      senderName: "Syu",
+      text: "indented code",
+    });
+
+    expect(canonicalizeOpenClawInboundMetadataIdentityContent("user", indented)).toContain(
+      "\n\n  indented code",
+    );
+    expect(buildMessageIdentityHash("user", indented)).not.toBe(
+      buildMessageIdentityHash("user", unindented),
+    );
+  });
+
+  it("canonicalizes nested metadata object key order", () => {
+    const first = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        chat_id: "telegram:chat-1",
+        message_id: "telegram-1",
+        sender: { username: "syu", id: "sender-1" },
+      }),
+      "```",
+      "",
+      "please keep this context",
+    ].join("\n");
+    const second = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        message_id: "telegram-2",
+        sender: { id: "sender-1", username: "syu" },
+        chat_id: "telegram:chat-1",
+      }),
+      "```",
+      "",
+      "please keep this context",
+    ].join("\n");
+
+    expect(buildMessageIdentityHash("user", first)).toBe(
+      buildMessageIdentityHash("user", second),
+    );
   });
 
   it("stores the raw OpenClaw metadata-prefixed content while hashing canonical identity", async () => {

--- a/test/message-identity.test.ts
+++ b/test/message-identity.test.ts
@@ -47,6 +47,28 @@ describe("ConversationStore message identity lookups", () => {
     );
   });
 
+  it("canonicalizes OpenClaw inbound metadata after a delivery prelude", () => {
+    const first = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: "please keep this context",
+      deliveryPrelude: "Delivery:\nRoute this inbound message through the Telegram channel.",
+    });
+    const second = openClawInboundMetadataContent({
+      messageId: "telegram-2",
+      senderName: "Syu",
+      text: "please keep this context",
+      deliveryPrelude: "Delivery:\nRoute this inbound message through the Telegram channel.",
+    });
+
+    expect(buildMessageIdentityHash("user", first)).toBe(
+      buildMessageIdentityHash("user", second),
+    );
+    const canonical = canonicalizeOpenClawInboundMetadataIdentityContent("user", first);
+    expect(canonical).toContain("Delivery:\nRoute this inbound message through the Telegram channel.");
+    expect(canonical).not.toContain("telegram-1");
+  });
+
   it("does not strip ordinary user-authored text that resembles an inbound metadata heading", () => {
     const ordinaryText = [
       "Conversation info (untrusted metadata):",
@@ -311,8 +333,10 @@ function openClawInboundMetadataContent(params: {
   messageId: string;
   senderName: string;
   text: string;
+  deliveryPrelude?: string;
 }): string {
   return [
+    ...(params.deliveryPrelude ? [params.deliveryPrelude, ""] : []),
     "Conversation info (untrusted metadata):",
     "```json",
     JSON.stringify({

--- a/test/message-identity.test.ts
+++ b/test/message-identity.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "vitest";
 import { getLcmDbFeatures } from "../src/db/features.js";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
-import { buildMessageIdentityHash } from "../src/store/message-identity.js";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "../src/openclaw-inbound-metadata.js";
+import {
+  buildMessageIdentityHash,
+  buildMessageIdentityKey,
+} from "../src/store/message-identity.js";
 
 function createStoreFixture() {
   const db = new DatabaseSync(":memory:");
@@ -17,6 +21,144 @@ function createStoreFixture() {
 }
 
 describe("ConversationStore message identity lookups", () => {
+  it("canonicalizes OpenClaw inbound metadata only for user identity", () => {
+    const first = openClawInboundMetadataContent({
+      messageId: "telegram-1",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+    const second = openClawInboundMetadataContent({
+      messageId: "telegram-2",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+
+    expect(buildMessageIdentityHash("user", first)).toBe(
+      buildMessageIdentityHash("user", second),
+    );
+    expect(buildMessageIdentityKey("user", first)).toBe(
+      "user\u0000please keep this context",
+    );
+    expect(buildMessageIdentityHash("assistant", first)).not.toBe(
+      buildMessageIdentityHash("assistant", second),
+    );
+  });
+
+  it("does not strip ordinary user-authored text that resembles an inbound metadata heading", () => {
+    const ordinaryText = [
+      "Conversation info (untrusted metadata):",
+      "```text",
+      "this is not an OpenClaw JSON metadata block",
+      "```",
+      "",
+      "please keep this whole note",
+    ].join("\n");
+
+    expect(
+      canonicalizeOpenClawInboundMetadataIdentityContent("user", ordinaryText),
+    ).toBe(ordinaryText);
+  });
+
+  it("does not strip valid JSON blocks without OpenClaw metadata keys", () => {
+    const ordinaryText = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ example: true }),
+      "```",
+      "",
+      "please keep this whole note",
+    ].join("\n");
+
+    expect(
+      canonicalizeOpenClawInboundMetadataIdentityContent("user", ordinaryText),
+    ).toBe(ordinaryText);
+    expect(buildMessageIdentityKey("user", ordinaryText)).toBe(
+      `user\u0000${ordinaryText}`,
+    );
+  });
+
+  it("does not strip non-object JSON blocks", () => {
+    const contents = [
+      [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        JSON.stringify(["message_id", "telegram-1"]),
+        "```",
+        "",
+        "please keep this whole note",
+      ].join("\n"),
+      [
+        "Sender (untrusted metadata):",
+        "```json",
+        JSON.stringify("Syu"),
+        "```",
+        "",
+        "please keep this whole note",
+      ].join("\n"),
+    ];
+
+    for (const content of contents) {
+      expect(
+        canonicalizeOpenClawInboundMetadataIdentityContent("user", content),
+      ).toBe(content);
+    }
+  });
+
+  it("does not strip metadata-only content without real user text", () => {
+    const metadataOnly = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({
+        chat_id: "telegram:chat-1",
+        message_id: "telegram-1",
+        timestamp: "2026-06-16T00:00:00.000Z",
+      }),
+      "```",
+      "",
+    ].join("\n");
+
+    expect(
+      canonicalizeOpenClawInboundMetadataIdentityContent("user", metadataOnly),
+    ).toBe(metadataOnly);
+  });
+
+  it("stores the raw OpenClaw metadata-prefixed content while hashing canonical identity", async () => {
+    const { db, store } = createStoreFixture();
+    const rawContent = openClawInboundMetadataContent({
+      messageId: "telegram-raw",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+    const sameCanonicalContent = openClawInboundMetadataContent({
+      messageId: "telegram-other",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+
+    try {
+      const conversation = await store.createConversation({ sessionId: "identity-raw-content" });
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: rawContent,
+        tokenCount: 1,
+      });
+
+      const stored = await store.getMessages(conversation.conversationId);
+      expect(stored[0]?.content).toBe(rawContent);
+      await expect(
+        store.countMessagesByIdentityHash(
+          conversation.conversationId,
+          "user",
+          buildMessageIdentityHash("user", sameCanonicalContent),
+        ),
+      ).resolves.toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
   it("finds an exact match even when many rows share the same identity hash", async () => {
     const { db, store } = createStoreFixture();
 
@@ -58,3 +200,27 @@ describe("ConversationStore message identity lookups", () => {
     }
   });
 });
+
+function openClawInboundMetadataContent(params: {
+  messageId: string;
+  senderName: string;
+  text: string;
+}): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:chat-1",
+      message_id: params.messageId,
+      timestamp: "2026-06-16T00:00:00.000Z",
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({ name: params.senderName }),
+    "```",
+    "",
+    params.text,
+  ].join("\n");
+}

--- a/test/message-signatures.test.ts
+++ b/test/message-signatures.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createBootstrapEntryHash } from "../src/message-signatures.js";
+
+describe("message bootstrap signatures", () => {
+  it("canonicalizes OpenClaw inbound metadata for user bootstrap hashes", () => {
+    const first = openClawInboundMetadataContent("telegram-1", "please keep this context");
+    const second = openClawInboundMetadataContent("telegram-2", "please keep this context");
+
+    expect(createBootstrapEntryHash({ role: "user", content: first, tokenCount: 1 })).toBe(
+      createBootstrapEntryHash({ role: "user", content: second, tokenCount: 1 }),
+    );
+    expect(createBootstrapEntryHash({ role: "assistant", content: first, tokenCount: 1 })).not.toBe(
+      createBootstrapEntryHash({ role: "assistant", content: second, tokenCount: 1 }),
+    );
+  });
+});
+
+function openClawInboundMetadataContent(messageId: string, text: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:chat-1",
+      message_id: messageId,
+      timestamp: "2026-06-16T00:00:00.000Z",
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({ name: "Syu" }),
+    "```",
+    "",
+    text,
+  ].join("\n");
+}

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -1,10 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeLcmConnection, getLcmConnection } from "../src/db/connection.js";
 import * as features from "../src/db/features.js";
 import { runLcmMigrations } from "../src/db/migration.js";
+import { canonicalizeOpenClawInboundMetadataIdentityContent } from "../src/openclaw-inbound-metadata.js";
 import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 
 const tempDirs: string[] = [];
@@ -23,6 +25,44 @@ function createTestDb(fileName: string) {
   tempDirs.push(tempDir);
   const dbPath = join(tempDir, fileName);
   return getLcmConnection(dbPath);
+}
+
+function legacyRawMessageIdentityHash(role: string, content: string): string {
+  return createHash("sha256")
+    .update(role)
+    .update("\u0000")
+    .update(content)
+    .digest("hex");
+}
+
+function legacyRawBootstrapEntryHash(role: string, content: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ role, content }))
+    .digest("hex");
+}
+
+function openClawInboundMetadataContent(params: {
+  messageId: string;
+  senderName: string;
+  text: string;
+}): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:chat-1",
+      message_id: params.messageId,
+      timestamp: "2026-06-16T00:00:00.000Z",
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({ name: params.senderName }),
+    "```",
+    "",
+    params.text,
+  ].join("\n");
 }
 
 /**
@@ -315,6 +355,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       { step_name: "backfillSummaryDepths", algorithm_version: 1 },
       { step_name: "backfillSummaryMetadata", algorithm_version: 1 },
       { step_name: "backfillToolCallColumns", algorithm_version: 1 },
+      { step_name: "repairOpenClawMetadataIdentityState", algorithm_version: 1 },
     ]);
 
     const depthRows = db
@@ -650,6 +691,98 @@ describe("runLcmMigrations summary depth backfill", () => {
       .prepare(`SELECT identity_hash FROM messages WHERE conversation_id = ? AND seq = ?`)
       .get(1, 1_204) as { identity_hash: string | null };
     expect(sampledRow.identity_hash).toBe(buildMessageIdentityHash("assistant", "batch message 1204"));
+  });
+
+  it("repairs legacy OpenClaw metadata identity hashes and bootstrap checkpoints", () => {
+    const db = createTestDb("openclaw-metadata-identity-repair.db");
+    const rawMetadataContent = openClawInboundMetadataContent({
+      messageId: "telegram-legacy",
+      senderName: "Syu",
+      text: "please keep this context",
+    });
+
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE messages (
+        message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        token_count INTEGER NOT NULL,
+        identity_hash TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (conversation_id, seq)
+      );
+
+      CREATE TABLE conversation_bootstrap_state (
+        conversation_id INTEGER PRIMARY KEY REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        session_file_path TEXT NOT NULL,
+        last_seen_size INTEGER NOT NULL,
+        last_seen_mtime_ms INTEGER NOT NULL,
+        last_processed_offset INTEGER NOT NULL,
+        last_processed_entry_hash TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+      1,
+      "legacy-openclaw-metadata-session",
+    );
+    db.prepare(
+      `INSERT INTO messages (
+         message_id, conversation_id, seq, role, content, token_count, identity_hash
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      1,
+      1,
+      1,
+      "user",
+      rawMetadataContent,
+      1,
+      legacyRawMessageIdentityHash("user", rawMetadataContent),
+    );
+    db.prepare(
+      `INSERT INTO conversation_bootstrap_state (
+         conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
+         last_processed_offset, last_processed_entry_hash
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      1,
+      "/tmp/openclaw-session.jsonl",
+      128,
+      1000,
+      128,
+      legacyRawBootstrapEntryHash("user", rawMetadataContent),
+    );
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const messageRow = db
+      .prepare(`SELECT identity_hash FROM messages WHERE message_id = ?`)
+      .get(1) as { identity_hash: string | null };
+    const checkpointRow = db
+      .prepare(
+        `SELECT last_processed_entry_hash AS lastProcessedEntryHash
+         FROM conversation_bootstrap_state
+         WHERE conversation_id = ?`,
+      )
+      .get(1) as { lastProcessedEntryHash: string | null };
+
+    expect(messageRow.identity_hash).toBe(buildMessageIdentityHash("user", rawMetadataContent));
+    expect(checkpointRow.lastProcessedEntryHash).toBe(
+      legacyRawBootstrapEntryHash(
+        "user",
+        canonicalizeOpenClawInboundMetadataIdentityContent("user", rawMetadataContent),
+      ),
+    );
   });
 
   it("skips FTS tables when fts5 is unavailable", () => {
@@ -1245,6 +1378,7 @@ describe("runLcmMigrations summary depth backfill", () => {
     });
 
     expect(logMessages.filter((message) => message.includes("migration step skipped"))).toEqual([
+      "[lcm] migration step skipped: step=repairOpenClawMetadataIdentityState algorithmVersion=1 reason=already-complete",
       "[lcm] migration step skipped: step=backfillSummaryDepths algorithmVersion=1 reason=already-complete",
       "[lcm] migration step skipped: step=backfillSummaryMetadata algorithmVersion=1 reason=already-complete",
       "[lcm] migration step skipped: step=backfillToolCallColumns algorithmVersion=1 reason=already-complete",
@@ -1343,6 +1477,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       { step_name: "backfillSummaryDepths", algorithm_version: 1 },
       { step_name: "backfillSummaryMetadata", algorithm_version: 1 },
       { step_name: "backfillToolCallColumns", algorithm_version: 1 },
+      { step_name: "repairOpenClawMetadataIdentityState", algorithm_version: 1 },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

This fixes an LCM context-continuity failure when OpenClaw user messages include injected inbound metadata blocks such as `Conversation info (untrusted metadata)` and `Sender (untrusted metadata)`.

LCM previously used raw message content for message identity and bootstrap checkpoint hashes. OpenClaw metadata can contain volatile fields such as message IDs and timestamps, so the same logical user text could hash differently between the persisted DB frontier and the session JSONL frontier. That could make append-only bootstrap/reconcile miss the frontier and leave a conversation stuck or force slower reconciliation.

## Concrete impact

In real OpenClaw + LCM sessions, this can show up as apparent context loss after resuming a conversation. The same logical user turn can carry different injected OpenClaw message IDs or timestamps, so LCM may fail to recognize the persisted conversation frontier. In the observed failure mode, the context from the last conversation was not carried forward even though the raw transcript content still existed.

Depending on the import path, this can leave `last_processed_offset` stuck, make append-only bootstrap miss the checkpoint, or force slower reconciliation/re-import behavior.

This patch canonicalizes only the identity/bootstrap hash input for recognized OpenClaw user-role metadata preambles. Stored message content remains raw and lossless. The canonicalizer also requires OpenClaw-shaped JSON object keys before stripping, so user-authored fenced JSON after similar headings remains part of identity.

## Related reports

I did not find an exact existing issue for this metadata-hash failure mode.

Related context:
- Martian-Engineering/lossless-claw#489: bootstrap/reconcile identity drift and duplicate historical imports.
- Martian-Engineering/lossless-claw#556: broader conversation identity integrity.
- openclaw/openclaw#93553: prior OpenClaw-side attempt closed because it stripped canonical persisted user messages. This PR uses the LCM-side boundary instead.

## Changes

- Add `canonicalizeOpenClawInboundMetadataIdentityContent(...)`.
- Require recognized OpenClaw metadata object keys before canonicalizing a preamble.
- Use it for:
  - message identity keys/hashes
  - bootstrap entry hashes
- Preserve raw `messages.content` exactly.
- Add regression coverage for:
  - volatile OpenClaw metadata hashing to the same identity
  - ordinary user-authored similar text not being stripped
  - raw stored content remaining lossless
  - append-only bootstrap advancing when only the metadata envelope changes

## Verification

- `npm test -- message-identity.test.ts message-signatures.test.ts engine-bootstrap.test.ts`
- `npm run typecheck`
- `npm run build`
