### PR TITLE
fix: preserve conversation id during transcript rollover

### DIFF
--- a/.changeset/transcript-rollover-rebind.md
+++ b/.changeset/transcript-rollover-rebind.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve conversation ids during fresh transcript rollover by rebinding the existing LCM conversation to the new runtime session instead of archiving it and creating an empty replacement.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1795,9 +1795,9 @@ export class LcmContextEngine implements ContextEngine {
               });
             if (!hasFrontierAnchor) {
               // Tier-2 resolution: a provably fresh new transcript means
-              // this is a legitimate reset; archive the old conversation
-              // and fall through so getOrCreateConversation below binds the
-              // new session and the initial import ingests its transcript.
+              // this is a legitimate reset. Rebind the existing conversation
+              // and import the new transcript immediately while the freshness
+              // proof is still in hand.
               const rotatedForFreshTranscript =
                 await this.sessionRolloverDetector.rotateAmbiguousRolloverForProvablyFreshTranscript({
                   phase: "bootstrap",
@@ -1819,6 +1819,35 @@ export class LcmContextEngine implements ContextEngine {
                   reason: AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON,
                 };
               }
+              const reconcile =
+                await this.transcriptReconciler.importFreshAmbiguousRolloverTranscript({
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                  sessionFile: params.sessionFile,
+                  conversationId: ambiguousRollover.conversationId,
+                  historicalMessages: preloadedHistoricalMessages,
+                });
+              if (reconcile.blockedByImportCap) {
+                return {
+                  bootstrapped: false,
+                  importedMessages: reconcile.importedMessages,
+                  reason: "reconcile import capped",
+                };
+              }
+              if (reconcile.importedMessages > 0) {
+                return {
+                  bootstrapped: true,
+                  importedMessages: reconcile.importedMessages,
+                  reason: "reconciled missing session messages",
+                };
+              }
+              return {
+                bootstrapped: false,
+                importedMessages: 0,
+                reason: reconcile.hasOverlap
+                  ? "conversation already up to date"
+                  : "conversation already has messages",
+              };
             }
           }
 
@@ -2820,9 +2849,8 @@ export class LcmContextEngine implements ContextEngine {
       (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);
     const transcriptReconcileBlockedByAmbiguousRollover =
       transcriptReconcileResult.blockedReason === "ambiguous-session-key-runtime-rollover" ||
-      // Rotated-fresh skips this turn the same way: the replacement
-      // conversation is empty, so telemetry/compaction work below would run
-      // against it for nothing; the next turn binds and reconciles normally.
+      // Fresh-rebind should import immediately; if it cannot, skip this turn
+      // rather than advancing past an unreconciled transcript frontier.
       transcriptReconcileResult.blockedReason === "ambiguous-rollover-rotated-fresh-transcript";
     let dedupedNewMessages: AgentMessage[] = [];
     if (transcriptReconcileUnsafeToAdvance) {

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -401,11 +401,12 @@ export class SessionRolloverDetector {
   /**
    * Tier-2 resolution for ambiguous session-key runtime rollovers
    * (lossless-claw-30b.8): a provably fresh new transcript means the
-   * rollover is a legitimate reset, not a foreign transcript sharing the
-   * key. Archive the old conversation (fully preserved and queryable) so
-   * the new session can bind and bootstrap normally instead of leaving the
-   * lane frozen outside LCM indefinitely. Returns true when rotated;
-   * false leaves the existing freeze-and-preserve behavior in place.
+   * rollover is a legitimate runtime session-file reset, not a foreign
+   * transcript sharing the key. Rebind the existing conversation row so all
+   * summaries, messages, frontier rows, and metadata keep the same
+   * conversation id while the new session can bootstrap normally. Returns
+   * true when rebound; false leaves the existing freeze-and-preserve
+   * behavior in place.
    */
   async rotateAmbiguousRolloverForProvablyFreshTranscript(params: {
     phase: "bootstrap" | "assemble" | "afterTurn";
@@ -433,34 +434,20 @@ export class SessionRolloverDetector {
       return false;
     }
 
-    await this.applySessionReplacement({
-      reason: `${params.phase} ambiguous rollover fresh-transcript rotation`,
-      sessionId: params.rollover.activeSessionId,
-      sessionKey: params.rollover.sessionKey,
-      nextSessionId: params.sessionId,
-      nextSessionKey: params.rollover.sessionKey,
-      createReplacement: params.createReplacement,
-    });
-    // Postcondition: applySessionReplacement has internal no-op paths (e.g.
-    // a fresh lifecycle row is left in place). Claiming "resolved" while the
-    // key is still bound to the old session would hide a live freeze behind
-    // healed-looking logs, so verify the binding actually moved.
-    const bindingAfter = await this.conversationStore.getConversationBySessionKey(
+    const rebound = await this.conversationStore.rebindConversationSession(
+      params.rollover.conversationId,
+      params.sessionId,
       params.rollover.sessionKey,
     );
-    if (
-      bindingAfter &&
-      bindingAfter.conversationId === params.rollover.conversationId &&
-      bindingAfter.sessionId === params.rollover.activeSessionId
-    ) {
+    if (!rebound || rebound.sessionId !== params.sessionId || !rebound.active) {
       this.deps.log.warn(
-        `[lcm] ${params.phase}: ambiguous rollover rotation had no effect (lifecycle no-op) conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId}; leaving lane frozen`,
+        `[lcm] ${params.phase}: ambiguous rollover rebind failed conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId}; leaving lane frozen`,
       );
       return false;
     }
 
     this.deps.log.warn(
-      `[lcm] ${params.phase}: ambiguous rollover resolved by fresh-transcript rotation conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId} candidateMessages=${params.candidateMessages.length} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
+      `[lcm] ${params.phase}: ambiguous rollover resolved by fresh-transcript rebind conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId} candidateMessages=${params.candidateMessages.length} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
     );
     return true;
   }

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -621,6 +621,30 @@ export class ConversationStore {
       .run(conversationId);
   }
 
+  async rebindConversationSession(
+    conversationId: ConversationId,
+    sessionId: string,
+    sessionKey?: string | null,
+  ): Promise<ConversationRecord | null> {
+    const normalizedSessionId = sessionId.trim();
+    const normalizedSessionKey = sessionKey?.trim() || null;
+    if (!normalizedSessionId) {
+      return this.getConversation(conversationId);
+    }
+    this.db
+      .prepare(
+        `UPDATE conversations
+         SET session_id = ?,
+             session_key = COALESCE(?, session_key),
+             active = 1,
+             archived_at = NULL,
+             updated_at = datetime('now')
+         WHERE conversation_id = ?`,
+      )
+      .run(normalizedSessionId, normalizedSessionKey, conversationId);
+    return this.getConversation(conversationId);
+  }
+
   // ── Message operations ────────────────────────────────────────────────────
 
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -537,10 +537,15 @@ export class TranscriptReconciler {
     lastProcessedEntryId?: string | null;
     skipContentAnchorScan?: boolean;
     allowNoAnchorImport?: boolean;
-    // Lift the no-anchor import cap because the persisted frontier was proven to
-    // hold no real conversation content (#822). Bounded by the transcript length,
-    // never unbounded — set ONLY together with a proven non-anchoring frontier.
+    // Lift the no-anchor import cap because the caller proved a full new-epoch
+    // import is safe. Bounded by the transcript length, never unbounded.
     allowFullNonAnchoringFrontierImport?: boolean;
+    // Fresh rollover proof establishes timestamped non-overlap already; generic
+    // replay-prefix dropping would discard valid repeated template turns.
+    skipNoAnchorReplayGuard?: boolean;
+    // Fresh rollover entry ids are new epoch rows, not restamped identities from
+    // the preserved pre-rebind history.
+    skipNoAnchorEntryIdAdoption?: boolean;
     noAnchorImportReason?: string;
   }): Promise<TranscriptReconcileResult> {
     const { sessionId, conversationId, historicalMessages } = params;
@@ -685,6 +690,8 @@ export class TranscriptReconciler {
             historicalMessages,
             noAnchorImportReason: params.noAnchorImportReason,
             allowFullNonAnchoringFrontierImport: params.allowFullNonAnchoringFrontierImport,
+            skipNoAnchorReplayGuard: params.skipNoAnchorReplayGuard,
+            skipNoAnchorEntryIdAdoption: params.skipNoAnchorEntryIdAdoption,
             existingDbCount,
             sessionContext,
             startedAt,
@@ -759,6 +766,75 @@ export class TranscriptReconciler {
   }
 
   /**
+   * Import a transcript after the ambiguous-rollover freshness proof has already
+   * shown it is a new runtime epoch for the same session key. That proof replaces
+   * content anchoring here: recurring template text from the old lane must not
+   * make us skip the beginning of the fresh transcript.
+   */
+  async importFreshAmbiguousRolloverTranscript(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+  }): Promise<TranscriptReconcileResult> {
+    const existingCount = await this.host.conversationStore.getMessageCount(params.conversationId);
+    if (existingCount === 0) {
+      let importedMessages = 0;
+      for (const message of params.historicalMessages) {
+        const result = await this.host.ingestSingle({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          message,
+          createdAt: resolveTranscriptMessageCreatedAt(message),
+          skipReplayTimestampFloodGuard: true,
+        });
+        if (result.ingested) {
+          importedMessages += 1;
+        }
+      }
+      await this.host.conversationStore.markConversationBootstrapped(params.conversationId);
+      await this.recordImportAndRefreshCheckpoint({
+        conversationId: params.conversationId,
+        sessionFile: params.sessionFile,
+        importedMessages,
+      });
+      return {
+        importedMessages,
+        blockedByImportCap: false,
+        hasOverlap: true,
+        transcriptCovered: importedMessages > 0,
+      };
+    }
+
+    const reconcile = await this.reconcileSessionTail({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      conversationId: params.conversationId,
+      historicalMessages: params.historicalMessages,
+      skipContentAnchorScan: true,
+      allowNoAnchorImport: true,
+      allowFullNonAnchoringFrontierImport: true,
+      skipNoAnchorReplayGuard: true,
+      skipNoAnchorEntryIdAdoption: true,
+      noAnchorImportReason: "fresh-ambiguous-rollover-rebind",
+    });
+    if (!reconcile.blockedByImportCap && reconcile.importedMessages > 0) {
+      await this.host.conversationStore.markConversationBootstrapped(params.conversationId);
+      await this.recordImportAndRefreshCheckpoint({
+        conversationId: params.conversationId,
+        sessionFile: params.sessionFile,
+        importedMessages: reconcile.importedMessages,
+      });
+      return { ...reconcile, transcriptCovered: true };
+    }
+    return {
+      ...reconcile,
+      transcriptCovered: reconcile.hasOverlap || reconcile.importedMessages > 0,
+    };
+  }
+
+  /**
    * No-anchor recovery: the transcript shares no anchor with persisted
    * history, but the caller has lineage evidence (path mismatch, declared
    * epoch rollover, same-path shrink, checkpoint recovery) that this file is
@@ -775,6 +851,8 @@ export class TranscriptReconciler {
     historicalMessages: AgentMessage[];
     noAnchorImportReason?: string;
     allowFullNonAnchoringFrontierImport?: boolean;
+    skipNoAnchorReplayGuard?: boolean;
+    skipNoAnchorEntryIdAdoption?: boolean;
     existingDbCount: number;
     sessionContext: string;
     startedAt: number;
@@ -818,7 +896,11 @@ export class TranscriptReconciler {
       noAnchorImportMessages.length > 0 &&
       noAnchorImportMessages.every((message) => getTranscriptEntryId(message) !== null);
     const replayThreshold = Math.max(3, Math.ceil(historicalMessages.length * 0.5));
-    if (!allEntryIdBearing && persistedIdentityOverlaps >= replayThreshold) {
+    if (
+      !params.skipNoAnchorReplayGuard &&
+      !allEntryIdBearing &&
+      persistedIdentityOverlaps >= replayThreshold
+    ) {
       if (replayAnalysis.firstNonOverlappingIndex < 0) {
         this.host.deps.log.warn(
           `[lcm] reconcileSessionTail: duplicate transcript replay blocked for ${sessionContext} - ${persistedIdentityOverlaps}/${historicalMessages.length} candidate messages already exist (reason: ${params.noAnchorImportReason ?? "unspecified"}). Aborting to prevent replay flood.`,
@@ -927,24 +1009,26 @@ export class TranscriptReconciler {
         if (alreadyPersisted) {
           continue;
         }
-        const stored = toStoredMessage(message);
-        const adopted =
-          (await this.host.conversationStore.adoptTranscriptEntryId(
-            conversationId,
-            stored.role,
-            stored.content,
-            entryId,
-          )) ||
-          (await this.adoptStaleTranscriptEntryId({
-            conversationId,
-            leafEntryIds: noAnchorLeafEntryIds,
-            role: stored.role,
-            content: stored.content,
-            entryId,
-          }));
-        if (adopted) {
-          adoptedMessages += 1;
-          continue;
+        if (!params.skipNoAnchorEntryIdAdoption) {
+          const stored = toStoredMessage(message);
+          const adopted =
+            (await this.host.conversationStore.adoptTranscriptEntryId(
+              conversationId,
+              stored.role,
+              stored.content,
+              entryId,
+            )) ||
+            (await this.adoptStaleTranscriptEntryId({
+              conversationId,
+              leafEntryIds: noAnchorLeafEntryIds,
+              role: stored.role,
+              content: stored.content,
+              entryId,
+            }));
+          if (adopted) {
+            adoptedMessages += 1;
+            continue;
+          }
         }
       }
       const result = await this.host.ingestSingle({
@@ -1891,10 +1975,9 @@ export class TranscriptReconciler {
             checkpointEntryHash: activeBootstrapState?.lastProcessedEntryHash,
           });
         if (!hasFrontierAnchor) {
-          // Tier-2 resolution: archive the frozen conversation and
-          // create the replacement now. This turn's persistence is
-          // skipped (unsafe-to-advance), and the next turn reconciles
-          // the full transcript into the fresh conversation.
+          // Tier-2 resolution: rebind the frozen conversation and import the
+          // fresh transcript now. The freshness proof is the extra safety signal
+          // that lets the no-anchor path ingest the full id-less transcript.
           const rotatedForFreshTranscript =
             await this.rolloverDetector.rotateAmbiguousRolloverForProvablyFreshTranscript({
               phase: "afterTurn",
@@ -1904,12 +1987,19 @@ export class TranscriptReconciler {
               createReplacement: true,
             });
           if (rotatedForFreshTranscript) {
-            return {
-              importedMessages: 0,
-              blockedByImportCap: false,
-              blockedReason: "ambiguous-rollover-rotated-fresh-transcript",
-              hasOverlap: false,
-            };
+            const reconcile = await this.importFreshAmbiguousRolloverTranscript({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              sessionFile: params.sessionFile,
+              conversationId: ambiguousRollover.conversationId,
+              historicalMessages,
+            });
+            return reconcile.blockedByImportCap
+              ? {
+                  ...reconcile,
+                  blockedReason: "ambiguous-rollover-rotated-fresh-transcript",
+                }
+              : reconcile;
           }
           this.rolloverDetector.logAmbiguousSessionKeyRuntimeRollover({
             phase: "afterTurn",

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -185,6 +185,33 @@ function writeRolledTranscript(params: {
   return file;
 }
 
+/**
+ * Write timestamped envelope messages without entry ids. These are legacy-ish
+ * but still supported by the transcript parser and freshness checker; lacking
+ * ids forces reconciliation through the no-anchor identity path.
+ */
+function writeIdlessEnvelopeTranscript(params: {
+  name: string;
+  entries: Array<{ role: string; text: string; timestamp: number }>;
+}): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-rollover-file-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, `${params.name}.jsonl`);
+  const lines = params.entries.map((entry) =>
+    JSON.stringify({
+      type: "message",
+      timestamp: new Date(entry.timestamp).toISOString(),
+      message: {
+        role: entry.role,
+        content: [{ type: "text", text: entry.text }],
+        timestamp: entry.timestamp,
+      },
+    }),
+  );
+  writeFileSync(file, `${lines.join("\n")}\n`);
+  return file;
+}
+
 function freshEntries(count = 6): Array<{ role: string; text: string; timestamp: number }> {
   const base = Date.now() + 60_000;
   return Array.from({ length: count }, (_, index) => ({
@@ -254,7 +281,136 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     expect(imported.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
   });
 
-  it("afterTurn rebinds the lane; the host's next bootstrap imports the transcript", async () => {
+  it("imports a fresh id-less rollover transcript even when it exceeds the no-anchor cap", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+    const entries = freshEntries(60);
+    const newSessionFile = writeIdlessEnvelopeTranscript({
+      name: `${NEW_SESSION_ID}-idless-over-cap`,
+      entries,
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(entries.length);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("no anchor import cap exceeded"),
+    );
+
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.conversationId).toBe(lane.conversationId);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    const persisted = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(persisted.slice(0, lane.persistedContents.length).map((m) => m.content)).toEqual(
+      lane.persistedContents,
+    );
+    expect(persisted.slice(-entries.length).map((m) => m.content)).toEqual(
+      entries.map((entry) => entry.text),
+    );
+  });
+
+  it("keeps repeated id-less prefix messages in a proven-fresh rollover transcript", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+    const repeatedTemplate = "Daily status template line";
+    const oldBase = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    for (let index = 0; index < 3; index += 1) {
+      await seedHistoricalMessage(engine, {
+        sessionId: OLD_SESSION_ID,
+        sessionKey: SESSION_KEY,
+        message: makeMessage("user", repeatedTemplate, oldBase + index),
+      });
+    }
+    db.prepare(
+      "UPDATE messages SET created_at = datetime('now', '-6 days') WHERE conversation_id = ?",
+    ).run(lane.conversationId);
+    const freshBase = Date.now() + 60_000;
+    const entries = [
+      { role: "user", text: repeatedTemplate, timestamp: freshBase },
+      { role: "user", text: repeatedTemplate, timestamp: freshBase + 1 },
+      { role: "user", text: repeatedTemplate, timestamp: freshBase + 2 },
+      { role: "assistant", text: "fresh answer after repeated prefix", timestamp: freshBase + 3 },
+    ];
+    const newSessionFile = writeIdlessEnvelopeTranscript({
+      name: `${NEW_SESSION_ID}-idless-repeated-prefix`,
+      entries,
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(entries.length);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("duplicate transcript replay guard dropped"),
+    );
+    const persisted = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(persisted.slice(-entries.length).map((m) => m.content)).toEqual(
+      entries.map((entry) => entry.text),
+    );
+  });
+
+  it("inserts fresh entry-id rollover messages instead of adopting old repeated rows", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+    const repeatedTemplate = "Daily status template line";
+    const oldBase = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    for (let index = 0; index < 3; index += 1) {
+      await seedHistoricalMessage(engine, {
+        sessionId: OLD_SESSION_ID,
+        sessionKey: SESSION_KEY,
+        message: makeMessage("user", repeatedTemplate, oldBase + index),
+      });
+    }
+    db.prepare(
+      "UPDATE messages SET created_at = datetime('now', '-6 days') WHERE conversation_id = ?",
+    ).run(lane.conversationId);
+    const freshBase = Date.now() + 60_000;
+    const entries = [
+      { role: "user", text: repeatedTemplate, timestamp: freshBase },
+      { role: "user", text: repeatedTemplate, timestamp: freshBase + 1 },
+      { role: "user", text: repeatedTemplate, timestamp: freshBase + 2 },
+      { role: "assistant", text: "fresh entry-id answer after repeated prefix", timestamp: freshBase + 3 },
+    ];
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-entry-id-repeated-prefix`,
+      entries,
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(entries.length);
+    const persisted = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(persisted.slice(-entries.length).map((m) => m.content)).toEqual(
+      entries.map((entry) => entry.text),
+    );
+  });
+
+  it("afterTurn rebinds the lane and imports the fresh transcript immediately", async () => {
     const { engine, log, db } = createEngine();
     const lane = await seedFrozenLane(engine, db);
 
@@ -286,14 +442,22 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       .getConversationBySessionKey(SESSION_KEY);
     expect(reboundAfterFirst?.sessionId).toBe(NEW_SESSION_ID);
 
-    // Production sequence: the host calls bootstrap before each run; with
-    // the rollover resolved it imports the rolled transcript.
+    const persistedAfterTurn = await engine
+      .getConversationStore()
+      .getMessages(reboundAfterFirst!.conversationId);
+    expect(persistedAfterTurn.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(
+      true,
+    );
+
+    // Production sequence: the host calls bootstrap before each run; after the
+    // immediate afterTurn import, bootstrap sees the checkpoint is already current.
     const boot = await engine.bootstrap({
       sessionId: NEW_SESSION_ID,
       sessionKey: SESSION_KEY,
       sessionFile: newSessionFile,
     });
-    expect(boot.importedMessages).toBeGreaterThan(0);
+    expect(boot.importedMessages).toBe(0);
+    expect(boot.reason).toBe("already bootstrapped");
     const persisted = await engine
       .getConversationStore()
       .getMessages(reboundAfterFirst!.conversationId);
@@ -515,7 +679,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
   });
 
   it("rebinds even an empty lifecycle row instead of creating a replacement", async () => {
-    const { engine, log } = createEngine();
+    const { engine, log } = createEngine({ bootstrapMaxTokens: 1 });
     // Empty conversation pinned to the old session: rebind it in-place so
     // even lifecycle edge cases preserve the conversation id.
     const conversation = await engine
@@ -557,6 +721,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       .getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.conversationId).toBe(conversation.conversationId);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    const imported = await engine
+      .getConversationStore()
+      .getMessages(conversation.conversationId);
+    expect(imported.map((m) => m.content)).toEqual(entries.map((entry) => entry.text));
   });
   it("heals a heartbeat-idle lane on time evidence alone (live conv-1 shape)", async () => {
     const { engine, log, db } = createEngine();

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -10,7 +10,7 @@
  * Policy under test: when the new transcript is PROVABLY FRESH — zero
  * identity overlap with the frozen conversation's recent persisted history
  * and every timestamped entry postdating its last persisted message — the
- * rollover resolves by archive-and-rotate. Freshness is content+time
+ * rollover resolves by rebind-in-place. Freshness is content+time
  * evidence, never transcript size, so lanes frozen for days (aged, with
  * accumulated history) still heal. Anything short of proof stays frozen.
  */
@@ -218,7 +218,7 @@ async function seedHistoricalMessage(
 }
 
 describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
-  it("bootstrap heals an aged frozen lane: archives it and imports the rolled transcript", async () => {
+  it("bootstrap heals an aged frozen lane: rebinds it and imports the rolled transcript", async () => {
     const { engine, log, db } = createEngine();
     const lane = await seedFrozenLane(engine, db);
 
@@ -233,30 +233,28 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
     expect(result.importedMessages).toBeGreaterThan(0);
 
-    // Old conversation archived, fully preserved.
-    const oldConversation = await engine
-      .getConversationStore()
-      .getConversationBySessionId(OLD_SESSION_ID);
-    expect(oldConversation?.active).toBe(false);
+    // Existing conversation id is rebound to the new session, fully preserving history.
     const preserved = await engine.getConversationStore().getMessages(lane.conversationId);
-    expect(preserved.map((m) => m.content)).toEqual(lane.persistedContents);
+    expect(preserved.slice(0, lane.persistedContents.length).map((m) => m.content)).toEqual(
+      lane.persistedContents,
+    );
 
-    // The key now binds the new session, with the transcript imported.
+    // The key now binds the new session on the same conversation id, with the transcript imported.
     const rebound = await engine
       .getConversationStore()
       .getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
-    expect(rebound?.conversationId).not.toBe(lane.conversationId);
-    const imported = await engine.getConversationStore().getMessages(rebound!.conversationId);
+    expect(rebound?.conversationId).toBe(lane.conversationId);
+    const imported = await engine.getConversationStore().getMessages(lane.conversationId);
     expect(imported.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
   });
 
-  it("afterTurn rotates the lane; the host's next bootstrap imports the transcript", async () => {
+  it("afterTurn rebinds the lane; the host's next bootstrap imports the transcript", async () => {
     const { engine, log, db } = createEngine();
     const lane = await seedFrozenLane(engine, db);
 
@@ -281,7 +279,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const reboundAfterFirst = await engine
       .getConversationStore()
@@ -302,7 +300,9 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     expect(persisted.some((m) => m.content.includes("fresh rolled-session turn"))).toBe(true);
 
     const preserved = await engine.getConversationStore().getMessages(lane.conversationId);
-    expect(preserved.map((m) => m.content)).toEqual(lane.persistedContents);
+    expect(preserved.slice(0, lane.persistedContents.length).map((m) => m.content)).toEqual(
+      lane.persistedContents,
+    );
   });
 
   it("stays frozen when the rolled transcript overlaps the lane's persisted history", async () => {
@@ -410,7 +410,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       expect.stringContaining("freshness=delivery-only-synthetic-transcript"),
     );
     expect(log.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
       .getConversationStore()
@@ -451,7 +451,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       expect.stringContaining("freshness=no-comparable-candidate-content"),
     );
     expect(log.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
       .getConversationStore()
@@ -502,7 +502,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
     );
     expect(log.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
       .getConversationStore()
@@ -514,10 +514,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     ).resolves.toEqual([]);
   });
 
-  it("reports a lifecycle no-op honestly instead of claiming the lane healed", async () => {
+  it("rebinds even an empty lifecycle row instead of creating a replacement", async () => {
     const { engine, log } = createEngine();
-    // Empty conversation pinned to the old session: applySessionReplacement
-    // treats a fresh lifecycle row as a no-op, so rotation cannot land.
+    // Empty conversation pinned to the old session: rebind it in-place so
+    // even lifecycle edge cases preserve the conversation id.
     const conversation = await engine
       .getConversationStore()
       .getOrCreateConversation(OLD_SESSION_ID, { sessionKey: SESSION_KEY });
@@ -550,11 +550,13 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("rotation had no effect"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
-    expect(log.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
-    );
+    const rebound = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.conversationId).toBe(conversation.conversationId);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
   });
   it("heals a heartbeat-idle lane on time evidence alone (live conv-1 shape)", async () => {
     const { engine, log, db } = createEngine();
@@ -611,18 +613,20 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
     const rebound = await engine
       .getConversationStore()
       .getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
-    // The heartbeat history is archived intact, not deleted.
+    // The heartbeat history remains intact on the same conversation id.
     const preserved = await engine
       .getConversationStore()
       .getMessages(conversation!.conversationId);
-    expect(preserved).toHaveLength(60);
+    expect(preserved.slice(0, 60).map((m) => m.content)).toEqual(
+      heartbeatContents.map((entry) => entry.content),
+    );
   });
 
   it("heartbeat polls and recurring template content never block the heal", async () => {
@@ -668,12 +672,13 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rotation"),
+      expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
     const rebound = await engine
       .getConversationStore()
       .getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    expect(rebound?.conversationId).toBe(lane.conversationId);
   });
 });


### PR DESCRIPTION
$## What\n- Rebind provably fresh transcript rollovers onto the existing LCM conversation instead of archiving and creating a replacement\n- Preserve messages, summaries, context frontier, parents, bootstrap state, and conversation id across runtime session-file changes\n- Update rollover regressions so fresh rollovers must keep the original conversation id\n\n## Why\nPR #864 fixed frozen ambiguous rollover lanes, but used archive-and-create as the recovery primitive. That preserved old rows in the database, but split stable sessionKey continuity across conversation ids, making active conversation views lose access to prior summaries and messages. Transcript rotation should preserve LCM identity.\n\n## Verification\n- npx vitest run test/ambiguous-rollover-rotation.test.ts test/engine-lifecycle.test.ts\n- npm run build\n- env -u OPENCLAW_STATE_DIR npm test\n\nFull suite: 72 files / 1313 tests passed.