### PR TITLE
feat: add rollover split doctor repair

### DIFF
--- a/.changeset/rollover-split-doctor.md
+++ b/.changeset/rollover-split-doctor.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add `/lossless doctor` detection and confirmed repair for safe whole-DB fresh-transcript rollover split memory.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -28,6 +28,12 @@ import {
   type DoctorSummaryStats,
 } from "./lcm-doctor-shared.js";
 import {
+  applyRolloverSplitRepair,
+  scanRolloverSplits,
+  type RolloverSplitCounts,
+  type RolloverSplitExample,
+} from "./lcm-doctor-rollover-splits.js";
+import {
   CompactionMaintenanceStore,
   type ConversationCompactionMaintenanceRecord,
 } from "../store/compaction-maintenance-store.js";
@@ -77,6 +83,9 @@ type CurrentConversationResolution =
 type DoctorApplyOptions = {
   confirmOffline: boolean;
 };
+type RolloverSplitApplyOptions = {
+  confirm: boolean;
+};
 
 type ParsedLcmCommand =
   | { kind: "status" }
@@ -87,6 +96,7 @@ type ParsedLcmCommand =
   | { kind: "refocus" }
   | { kind: "unfocus" }
   | { kind: "doctor"; apply: boolean; applyOptions?: DoctorApplyOptions }
+  | { kind: "doctor_rollover_splits"; apply: boolean; applyOptions?: RolloverSplitApplyOptions }
   | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
   | { kind: "help"; error?: string };
 
@@ -267,6 +277,21 @@ function parseDoctorApplyArgs(tokens: string[]):
   return { ok: true, options: { confirmOffline } };
 }
 
+function parseRolloverSplitApplyArgs(tokens: string[]):
+  | { ok: true; options: RolloverSplitApplyOptions }
+  | { ok: false; error: string } {
+  if (tokens.length === 0) {
+    return { ok: true, options: { confirm: false } };
+  }
+  if (tokens.length === 1 && tokens[0]?.toLowerCase() === "confirm") {
+    return { ok: true, options: { confirm: true } };
+  }
+  return {
+    ok: false,
+    error: `\`${VISIBLE_COMMAND} doctor apply rollover-splits\` accepts optional \`confirm\`.`,
+  };
+}
+
 function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
   const raw = (rawArgs ?? "").trim();
   if (raw === "") {
@@ -310,6 +335,9 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       if (rest.length === 1 && rest[0]?.toLowerCase() === "clean") {
         return { kind: "doctor_cleaners", apply: false, vacuum: false };
       }
+      if (rest.length === 1 && rest[0]?.toLowerCase() === "rollover-splits") {
+        return { kind: "doctor_rollover_splits", apply: false };
+      }
       if (rest[0]?.toLowerCase() === "clean" && rest[1]?.toLowerCase() === "apply") {
         const parsedApply = parseDoctorCleanerApplyArgs(rest.slice(2));
         return parsedApply.ok
@@ -318,6 +346,16 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
               apply: true,
               filterId: parsedApply.filterId,
               vacuum: parsedApply.vacuum,
+            }
+          : { kind: "help", error: parsedApply.error };
+      }
+      if (rest[0]?.toLowerCase() === "apply" && rest[1]?.toLowerCase() === "rollover-splits") {
+        const parsedApply = parseRolloverSplitApplyArgs(rest.slice(2));
+        return parsedApply.ok
+          ? {
+              kind: "doctor_rollover_splits",
+              apply: true,
+              applyOptions: parsedApply.options,
             }
           : { kind: "help", error: parsedApply.error };
       }
@@ -330,7 +368,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [confirm-offline]\` for the scoped summary repair path.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [confirm-offline]\` for the scoped summary repair path.`,
       };
     case "help":
       return { kind: "help" };
@@ -862,6 +900,14 @@ function buildHelpText(error?: string): string {
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor rollover-splits`),
+        "Report whole-DB fresh-transcript rollover split memory.",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor apply rollover-splits confirm`),
+        "Repair all safe rollover split memory groups after creating a DB backup.",
+      ),
+      buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor clean`),
         "Report global high-confidence junk candidates without deleting anything.",
       ),
@@ -1052,6 +1098,7 @@ async function buildDoctorText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
 }): Promise<string> {
+  const rolloverSplits = scanRolloverSplits(params.db);
   const current = await resolveCurrentConversation(params);
 
   if (current.kind === "unavailable") {
@@ -1063,8 +1110,10 @@ async function buildDoctorText(params: {
       buildSection("📍 Current conversation", [
         buildStatLine("status", "unavailable"),
         buildStatLine("reason", current.reason),
-        buildStatLine("fallback", "Doctor is conversation-scoped, so no global scan ran."),
+        buildStatLine("fallback", "Summary doctor is conversation-scoped."),
       ]),
+      "",
+      buildRolloverSplitScanSection(rolloverSplits),
     ].join("\n");
   }
 
@@ -1091,6 +1140,8 @@ async function buildDoctorText(params: {
       buildStatLine("emergency-fallback summaries", formatNumber(stats.emergency)),
       buildStatLine("result", stats.total === 0 ? "clean" : "issues found"),
     ]),
+    "",
+    buildRolloverSplitScanSection(rolloverSplits),
   ];
 
   if (stats.total > 0) {
@@ -1110,6 +1161,60 @@ async function buildDoctorText(params: {
   }
 
   return lines.join("\n");
+}
+
+function formatRolloverCounts(counts: RolloverSplitCounts): string {
+  const parts = [
+    `${formatNumber(counts.messages)} messages`,
+    `${formatNumber(counts.summaries)} summaries`,
+    `${formatNumber(counts.contextItems)} context items`,
+    `${formatNumber(counts.largeFiles)} large files`,
+    `${formatNumber(counts.focusBriefs)} focus briefs`,
+  ];
+  return parts.join(" · ");
+}
+
+function formatRolloverExample(example: RolloverSplitExample): string {
+  const sources = example.sourceConversationIds.map((id) => formatNumber(id)).join(",");
+  return [
+    `${truncateMiddle(example.sessionKey, 44)}: conv ${sources} -> ${formatNumber(example.targetConversationId)}`,
+    formatRolloverCounts(example),
+  ].join(", ");
+}
+
+function buildRolloverSplitScanSection(scan: ReturnType<typeof scanRolloverSplits>): string {
+  if (scan.safe.length === 0 && scan.needsReview.length === 0) {
+    return buildSection("✅ Rollover split memory", [
+      buildStatLine("result", "clean"),
+      buildStatLine("safe lanes", "0"),
+      buildStatLine("needs review", "0"),
+    ]);
+  }
+
+  const lines = [
+    buildStatLine("result", scan.safe.length > 0 ? "safe repairs available" : "review needed"),
+    buildStatLine("affected safe lanes", formatNumber(scan.totals.safeLanes)),
+    buildStatLine("stranded", formatRolloverCounts(scan.totals)),
+    buildStatLine("needs review", formatNumber(scan.totals.needsReviewLanes)),
+    buildStatLine("repair", formatCommand(`${VISIBLE_COMMAND} doctor apply rollover-splits confirm`)),
+  ];
+
+  for (const example of scan.safe.slice(0, 3)) {
+    lines.push(`- ${formatRolloverExample(example)}`);
+  }
+  if (scan.safe.length > 3) {
+    lines.push(`- ... ${formatNumber(scan.safe.length - 3)} more safe lane(s)`);
+  }
+  if (scan.needsReview.length > 0) {
+    lines.push(
+      buildStatLine(
+        "skipped",
+        `${formatNumber(scan.needsReview.length)} lane(s) require manual review before repair`,
+      ),
+    );
+  }
+
+  return buildSection("⚠️ Rollover split memory", lines);
 }
 
 async function buildDoctorCleanersText(params: {
@@ -2262,6 +2367,86 @@ async function buildDoctorCleanersApplyText(params: {
   return lines.join("\n");
 }
 
+async function buildRolloverSplitApplyText(params: {
+  db: DatabaseSync;
+  config: LcmConfig;
+  options?: RolloverSplitApplyOptions;
+}): Promise<string> {
+  const scan = scanRolloverSplits(params.db);
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🩺 Lossless Claw Rollover Split Repair",
+    "",
+    buildSection("🌐 Repair scope", [
+      buildStatLine("safe lanes", formatNumber(scan.totals.safeLanes)),
+      buildStatLine("needs review", formatNumber(scan.totals.needsReviewLanes)),
+      buildStatLine("stranded", formatRolloverCounts(scan.totals)),
+    ]),
+    "",
+  ];
+
+  if (scan.safe.length > 0 && params.options?.confirm !== true) {
+    lines.push(
+      buildSection("🧯 Safety preflight", [
+        buildStatLine("status", "blocked"),
+        buildStatLine("mode", "read-only; no rollover split repair ran"),
+        buildStatLine("reason", "confirmation word required"),
+      ]),
+      "",
+      buildSection("🛠️ Next step", [
+        `Run ${formatCommand(`${VISIBLE_COMMAND} doctor apply rollover-splits confirm`)} to create a backup and repair all safe rollover split groups.`,
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  let result: Awaited<ReturnType<typeof applyRolloverSplitRepair>>;
+  try {
+    result = await applyRolloverSplitRepair({
+      db: params.db,
+      databasePath: params.config.databasePath,
+    });
+  } catch (error) {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "failed"),
+        buildStatLine("reason", error instanceof Error ? error.message : "unknown rollover split repair failure"),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  if (result.kind === "unavailable") {
+    lines.push(
+      buildSection("🛠️ Apply", [
+        buildStatLine("status", "unavailable"),
+        buildStatLine("reason", result.reason),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("🛠️ Apply", [
+      buildStatLine("status", "completed"),
+      buildStatLine("backup path", result.backupPath),
+      buildStatLine("repaired lanes", formatNumber(result.repairedLanes)),
+      buildStatLine("skipped for review", formatNumber(result.skippedReviewLanes)),
+      buildStatLine("merged", formatRolloverCounts(result.totals)),
+      buildStatLine("integrity", result.verification.integrity),
+      buildStatLine("foreign keys", result.verification.foreignKeys),
+      buildStatLine(
+        "result",
+        result.repairedLanes > 0
+          ? `repaired ${formatNumber(result.repairedLanes)} rollover split lane(s)`
+          : "clean; no writes ran",
+      ),
+    ]),
+  );
+  return lines.join("\n");
+}
+
 async function buildDoctorApplyText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
@@ -2523,6 +2708,24 @@ export function createLcmCommand(params: {
                 }),
               }
             : { text: await buildDoctorText({ ctx, db: await getDb() }) };
+        case "doctor_rollover_splits":
+          return parsed.apply
+            ? {
+                text: await buildRolloverSplitApplyText({
+                  db: await getDb(),
+                  config: params.config,
+                  options: parsed.applyOptions,
+                }),
+              }
+            : {
+                text: [
+                  ...buildHeaderLines(),
+                  "",
+                  "🩺 Lossless Claw Rollover Splits",
+                  "",
+                  buildRolloverSplitScanSection(scanRolloverSplits(await getDb())),
+                ].join("\n"),
+              };
         case "doctor_cleaners":
           return parsed.apply
             ? {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -951,6 +951,7 @@ async function buildStatusText(params: {
 }): Promise<string> {
   const status = getLcmStatusStats(params.db);
   const doctor = getDoctorSummaryStats(params.db);
+  const rolloverSplits = scanRolloverSplits(params.db);
   const enabled = resolvePluginEnabled(params.ctx.config);
   const selected = resolvePluginSelected(params.ctx.config);
   const slot = resolveContextEngineSlot(params.ctx.config);
@@ -981,6 +982,10 @@ async function buildStatusText(params: {
     ]),
     "",
   ];
+
+  if (rolloverSplits.safe.length > 0 || rolloverSplits.needsReview.length > 0) {
+    lines.push(buildRolloverSplitScanSection(rolloverSplits), "");
+  }
 
   if (current.kind === "resolved") {
     const conversationDoctor =

--- a/src/plugin/lcm-doctor-rollover-splits.ts
+++ b/src/plugin/lcm-doctor-rollover-splits.ts
@@ -76,6 +76,13 @@ type DuplicateRow = {
   count: number;
 };
 
+type ForeignKeyViolationRow = {
+  table?: string;
+  rowid?: number | null;
+  parent?: string;
+  fkid?: number;
+};
+
 const HANDLED_CONVERSATION_ID_TABLES = new Set([
   "conversations",
   "messages",
@@ -536,9 +543,41 @@ function rebuildFtsTables(db: DatabaseSync): void {
   }
 }
 
-function verifyForeignKeys(db: DatabaseSync): string {
-  const rows = db.prepare(`PRAGMA foreign_key_check`).all();
-  return rows.length === 0 ? "clean" : `${rows.length} foreign key issue(s)`;
+function formatForeignKeyIssueCount(count: number): string {
+  return `${count} foreign key issue(s)`;
+}
+
+function loadForeignKeyViolationKeys(db: DatabaseSync): string[] {
+  const rows = db.prepare(`PRAGMA foreign_key_check`).all() as ForeignKeyViolationRow[];
+  return rows
+    .map((row) => [row.table ?? "", row.rowid ?? "", row.parent ?? "", row.fkid ?? ""].join("\u0000"))
+    .sort();
+}
+
+function verifyForeignKeys(db: DatabaseSync, baselineViolations: string[]): string {
+  const currentViolations = loadForeignKeyViolationKeys(db);
+  if (currentViolations.length === 0) {
+    return "clean";
+  }
+
+  const baseline = new Set(baselineViolations);
+  const newViolations = currentViolations.filter((violation) => !baseline.has(violation));
+  if (newViolations.length > 0) {
+    return formatForeignKeyIssueCount(currentViolations.length);
+  }
+
+  if (currentViolations.length === baselineViolations.length) {
+    return `unchanged (${formatForeignKeyIssueCount(currentViolations.length)} pre-existing)`;
+  }
+  return `improved (${formatForeignKeyIssueCount(currentViolations.length)} remain; no new issues)`;
+}
+
+function hasNewForeignKeyViolations(status: string): boolean {
+  return (
+    status !== "clean" &&
+    !status.startsWith("unchanged (") &&
+    !status.endsWith("no new issues)")
+  );
 }
 
 function verifyIntegrity(db: DatabaseSync): string {
@@ -656,6 +695,7 @@ export async function applyRolloverSplitRepair(params: {
     };
   }
 
+  const baselineForeignKeyViolations = loadForeignKeyViolationKeys(params.db);
   let verification = { integrity: "unknown", foreignKeys: "unknown" };
   await withDatabaseTransaction(params.db, "BEGIN IMMEDIATE", () => {
     const safeGroups = loadSafeGroups(params.db);
@@ -666,12 +706,12 @@ export async function applyRolloverSplitRepair(params: {
 
     verification = {
       integrity: verifyIntegrity(params.db),
-      foreignKeys: verifyForeignKeys(params.db),
+      foreignKeys: verifyForeignKeys(params.db, baselineForeignKeyViolations),
     };
     if (verification.integrity !== "ok") {
       throw new Error(`SQLite integrity_check failed: ${verification.integrity}`);
     }
-    if (verification.foreignKeys !== "clean") {
+    if (hasNewForeignKeyViolations(verification.foreignKeys)) {
       throw new Error(`SQLite foreign_key_check failed: ${verification.foreignKeys}`);
     }
     verifyRepairedTargets(

--- a/src/plugin/lcm-doctor-rollover-splits.ts
+++ b/src/plugin/lcm-doctor-rollover-splits.ts
@@ -1,0 +1,694 @@
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import { getFileBackedDatabasePath } from "../db/connection.js";
+import { normalizeMessageContentForFullTextIndex } from "../store/conversation-store.js";
+import { withDatabaseTransaction } from "../transaction-mutex.js";
+import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
+
+export const ROLLOVER_SPLIT_MAINTENANCE_REASON = "doctor-rollover-split-repair";
+
+export type RolloverSplitCounts = {
+  messages: number;
+  summaries: number;
+  contextItems: number;
+  largeFiles: number;
+  focusBriefs: number;
+};
+
+export type RolloverSplitExample = RolloverSplitCounts & {
+  sessionKey: string;
+  sourceConversationIds: number[];
+  targetConversationId: number;
+};
+
+export type RolloverSplitReviewGroup = RolloverSplitCounts & {
+  sessionKey: string;
+  conversationIds: number[];
+  reasons: string[];
+};
+
+export type RolloverSplitScan = {
+  safe: RolloverSplitExample[];
+  needsReview: RolloverSplitReviewGroup[];
+  totals: RolloverSplitCounts & {
+    safeLanes: number;
+    needsReviewLanes: number;
+  };
+};
+
+export type RolloverSplitApplyResult =
+  | {
+      kind: "applied";
+      backupPath: string;
+      repairedLanes: number;
+      skippedReviewLanes: number;
+      totals: RolloverSplitCounts;
+      verification: {
+        integrity: string;
+        foreignKeys: string;
+      };
+    }
+  | {
+      kind: "unavailable";
+      reason: string;
+    };
+
+type ConversationRow = {
+  conversation_id: number;
+  session_key: string;
+  active: number;
+  archived_at: string | null;
+  created_at: string;
+  messages: number;
+  summaries: number;
+  context_items: number;
+  large_files: number;
+  focus_briefs: number;
+};
+
+type SafeGroup = RolloverSplitExample & {
+  sourceConversationIds: number[];
+  targetConversationId: number;
+  orderedConversationIds: number[];
+};
+
+type DuplicateRow = {
+  value: string | number | null;
+  count: number;
+};
+
+const HANDLED_CONVERSATION_ID_TABLES = new Set([
+  "conversations",
+  "messages",
+  "summaries",
+  "context_items",
+  "large_files",
+  "conversation_bootstrap_state",
+  "conversation_compaction_telemetry",
+  "conversation_compaction_maintenance",
+  "focus_briefs",
+]);
+
+const EMPTY_COUNTS: RolloverSplitCounts = {
+  messages: 0,
+  summaries: 0,
+  contextItems: 0,
+  largeFiles: 0,
+  focusBriefs: 0,
+};
+
+function quoteSqlIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function placeholders(values: readonly unknown[]): string {
+  return values.map(() => "?").join(", ");
+}
+
+function addCounts(left: RolloverSplitCounts, right: RolloverSplitCounts): RolloverSplitCounts {
+  return {
+    messages: left.messages + right.messages,
+    summaries: left.summaries + right.summaries,
+    contextItems: left.contextItems + right.contextItems,
+    largeFiles: left.largeFiles + right.largeFiles,
+    focusBriefs: left.focusBriefs + right.focusBriefs,
+  };
+}
+
+function countsFromRows(rows: ConversationRow[]): RolloverSplitCounts {
+  return rows.reduce<RolloverSplitCounts>(
+    (counts, row) =>
+      addCounts(counts, {
+        messages: row.messages,
+        summaries: row.summaries,
+        contextItems: row.context_items,
+        largeFiles: row.large_files,
+        focusBriefs: row.focus_briefs,
+      }),
+    { ...EMPTY_COUNTS },
+  );
+}
+
+function hasStrandedData(row: ConversationRow): boolean {
+  return (
+    row.messages > 0 ||
+    row.summaries > 0 ||
+    row.context_items > 0 ||
+    row.large_files > 0 ||
+    row.focus_briefs > 0
+  );
+}
+
+function isIsolatedCronSessionKey(sessionKey: string): boolean {
+  const parts = sessionKey.split(":");
+  return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
+}
+
+function compareConversationChronology(left: ConversationRow, right: ConversationRow): number {
+  const created = left.created_at.localeCompare(right.created_at);
+  if (created !== 0) return created;
+  const archived = (left.archived_at ?? "").localeCompare(right.archived_at ?? "");
+  if (archived !== 0) return archived;
+  return left.conversation_id - right.conversation_id;
+}
+
+function loadSessionKeysWithMultipleConversations(db: DatabaseSync): string[] {
+  const rows = db
+    .prepare(
+      `SELECT session_key
+       FROM conversations
+       WHERE session_key IS NOT NULL
+       GROUP BY session_key
+       HAVING COUNT(*) > 1
+       ORDER BY session_key ASC`,
+    )
+    .all() as Array<{ session_key: string }>;
+  return rows.map((row) => row.session_key);
+}
+
+function loadConversationRows(db: DatabaseSync, sessionKey: string): ConversationRow[] {
+  return db
+    .prepare(
+      `SELECT
+         c.conversation_id,
+         c.session_key,
+         c.active,
+         c.archived_at,
+         c.created_at,
+         COALESCE((SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.conversation_id), 0) AS messages,
+         COALESCE((SELECT COUNT(*) FROM summaries s WHERE s.conversation_id = c.conversation_id), 0) AS summaries,
+         COALESCE((SELECT COUNT(*) FROM context_items ci WHERE ci.conversation_id = c.conversation_id), 0) AS context_items,
+         COALESCE((SELECT COUNT(*) FROM large_files lf WHERE lf.conversation_id = c.conversation_id), 0) AS large_files,
+         COALESCE((SELECT COUNT(*) FROM focus_briefs fb WHERE fb.conversation_id = c.conversation_id), 0) AS focus_briefs
+       FROM conversations c
+       WHERE c.session_key = ?
+       ORDER BY c.created_at ASC, c.archived_at ASC, c.conversation_id ASC`,
+    )
+    .all(sessionKey) as ConversationRow[];
+}
+
+function loadUnhandledConversationIdTables(db: DatabaseSync): string[] {
+  const tables = db
+    .prepare(
+      `SELECT name
+       FROM sqlite_master
+       WHERE type = 'table'
+         AND name NOT LIKE 'sqlite_%'
+       ORDER BY name ASC`,
+    )
+    .all() as Array<{ name: string }>;
+  const unhandled: string[] = [];
+  for (const table of tables) {
+    const columns = db
+      .prepare(`PRAGMA table_info(${quoteSqlIdentifier(table.name)})`)
+      .all() as Array<{ name?: string }>;
+    if (
+      columns.some((column) => column.name === "conversation_id") &&
+      !HANDLED_CONVERSATION_ID_TABLES.has(table.name)
+    ) {
+      unhandled.push(table.name);
+    }
+  }
+  return unhandled;
+}
+
+function loadDuplicateRows(
+  db: DatabaseSync,
+  sql: string,
+  conversationIds: number[],
+): DuplicateRow[] {
+  if (conversationIds.length === 0) return [];
+  return db.prepare(sql.replace("__IDS__", placeholders(conversationIds))).all(...conversationIds) as DuplicateRow[];
+}
+
+function loadCollisionReasons(db: DatabaseSync, conversationIds: number[]): string[] {
+  const duplicateTranscriptEntries = loadDuplicateRows(
+    db,
+    `SELECT transcript_entry_id AS value, COUNT(*) AS count
+     FROM messages
+     WHERE conversation_id IN (__IDS__)
+       AND transcript_entry_id IS NOT NULL
+     GROUP BY transcript_entry_id
+     HAVING COUNT(*) > 1`,
+    conversationIds,
+  );
+  const duplicateSummaries = loadDuplicateRows(
+    db,
+    `SELECT summary_id AS value, COUNT(*) AS count
+     FROM summaries
+     WHERE conversation_id IN (__IDS__)
+     GROUP BY summary_id
+     HAVING COUNT(*) > 1`,
+    conversationIds,
+  );
+  const duplicateFiles = loadDuplicateRows(
+    db,
+    `SELECT file_id AS value, COUNT(*) AS count
+     FROM large_files
+     WHERE conversation_id IN (__IDS__)
+     GROUP BY file_id
+     HAVING COUNT(*) > 1`,
+    conversationIds,
+  );
+  const reasons: string[] = [];
+  if (duplicateTranscriptEntries.length > 0) {
+    reasons.push("duplicate transcript_entry_id");
+  }
+  if (duplicateSummaries.length > 0) {
+    reasons.push("duplicate summary_id");
+  }
+  if (duplicateFiles.length > 0) {
+    reasons.push("duplicate file_id");
+  }
+  return reasons;
+}
+
+function classifySessionKeyGroup(params: {
+  db: DatabaseSync;
+  sessionKey: string;
+  unhandledTables: string[];
+}): { safe?: SafeGroup; needsReview?: RolloverSplitReviewGroup } | null {
+  if (isIsolatedCronSessionKey(params.sessionKey)) {
+    return null;
+  }
+
+  const rows = loadConversationRows(params.db, params.sessionKey);
+  const sources = rows.filter((row) => row.active === 0 && hasStrandedData(row));
+  if (sources.length === 0) {
+    return null;
+  }
+
+  const activeRows = rows.filter((row) => row.active === 1);
+  const reasons: string[] = [];
+  if (activeRows.length !== 1) {
+    reasons.push(`expected exactly one active conversation, found ${activeRows.length}`);
+  }
+  if (params.unhandledTables.length > 0) {
+    reasons.push(`unhandled conversation tables: ${params.unhandledTables.join(", ")}`);
+  }
+
+  const target = activeRows[0];
+  if (target) {
+    for (const source of sources) {
+      if (!source.archived_at) {
+        reasons.push(`source conversation ${source.conversation_id} is archived without archived_at`);
+      }
+      if (compareConversationChronology(source, target) >= 0) {
+        reasons.push(`source conversation ${source.conversation_id} is not earlier than active target`);
+      }
+    }
+  }
+
+  const candidateConversationIds = target
+    ? [...sources.map((row) => row.conversation_id), target.conversation_id]
+    : rows.map((row) => row.conversation_id);
+  reasons.push(...loadCollisionReasons(params.db, candidateConversationIds));
+  if (reasons.length > 0 || !target) {
+    return {
+      needsReview: {
+        sessionKey: params.sessionKey,
+        conversationIds: rows.map((row) => row.conversation_id),
+        reasons: [...new Set(reasons)],
+        ...countsFromRows(sources),
+      },
+    };
+  }
+
+  const orderedSources = sources.slice().sort(compareConversationChronology);
+  const counts = countsFromRows(orderedSources);
+  return {
+    safe: {
+      sessionKey: params.sessionKey,
+      sourceConversationIds: orderedSources.map((row) => row.conversation_id),
+      targetConversationId: target.conversation_id,
+      orderedConversationIds: [
+        ...orderedSources.map((row) => row.conversation_id),
+        target.conversation_id,
+      ],
+      ...counts,
+    },
+  };
+}
+
+/**
+ * Scan the entire database for rollover-split memory groups.
+ */
+export function scanRolloverSplits(db: DatabaseSync): RolloverSplitScan {
+  const unhandledTables = loadUnhandledConversationIdTables(db);
+  const safe: RolloverSplitExample[] = [];
+  const needsReview: RolloverSplitReviewGroup[] = [];
+  let totals: RolloverSplitCounts = { ...EMPTY_COUNTS };
+
+  for (const sessionKey of loadSessionKeysWithMultipleConversations(db)) {
+    const classified = classifySessionKeyGroup({ db, sessionKey, unhandledTables });
+    if (!classified) {
+      continue;
+    }
+    if (classified.safe) {
+      safe.push(classified.safe);
+      totals = addCounts(totals, classified.safe);
+    }
+    if (classified.needsReview) {
+      needsReview.push(classified.needsReview);
+    }
+  }
+
+  return {
+    safe,
+    needsReview,
+    totals: {
+      ...totals,
+      safeLanes: safe.length,
+      needsReviewLanes: needsReview.length,
+    },
+  };
+}
+
+function hasTable(db: DatabaseSync, tableName: string): boolean {
+  const row = db
+    .prepare(`SELECT 1 AS found FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1`)
+    .get(tableName) as { found?: number } | undefined;
+  return row?.found === 1;
+}
+
+function loadSafeGroups(db: DatabaseSync): SafeGroup[] {
+  const unhandledTables = loadUnhandledConversationIdTables(db);
+  const groups: SafeGroup[] = [];
+  for (const sessionKey of loadSessionKeysWithMultipleConversations(db)) {
+    const classified = classifySessionKeyGroup({ db, sessionKey, unhandledTables });
+    if (classified?.safe) {
+      groups.push(classified.safe);
+    }
+  }
+  return groups;
+}
+
+function loadOrderedMessageIds(
+  db: DatabaseSync,
+  group: Pick<SafeGroup, "orderedConversationIds">,
+): number[] {
+  const conversationRankSql = group.orderedConversationIds
+    .map((conversationId, index) => `WHEN ${conversationId} THEN ${index}`)
+    .join(" ");
+  const rows = db
+    .prepare(
+      `SELECT message_id
+       FROM messages
+       WHERE conversation_id IN (${placeholders(group.orderedConversationIds)})
+       ORDER BY CASE conversation_id ${conversationRankSql} ELSE 999999 END,
+                seq ASC,
+                message_id ASC`,
+    )
+    .all(...group.orderedConversationIds) as Array<{ message_id: number }>;
+  return rows.map((row) => row.message_id);
+}
+
+function loadOrderedContextRowIds(
+  db: DatabaseSync,
+  group: Pick<SafeGroup, "orderedConversationIds">,
+): number[] {
+  const conversationRankSql = group.orderedConversationIds
+    .map((conversationId, index) => `WHEN ${conversationId} THEN ${index}`)
+    .join(" ");
+  const rows = db
+    .prepare(
+      `SELECT rowid AS row_id
+       FROM context_items
+       WHERE conversation_id IN (${placeholders(group.orderedConversationIds)})
+       ORDER BY CASE conversation_id ${conversationRankSql} ELSE 999999 END,
+                ordinal ASC,
+                rowid ASC`,
+    )
+    .all(...group.orderedConversationIds) as Array<{ row_id: number }>;
+  return rows.map((row) => row.row_id);
+}
+
+function reparentMessages(db: DatabaseSync, group: SafeGroup): void {
+  const messageIds = loadOrderedMessageIds(db, group);
+  const stage = db.prepare(
+    `UPDATE messages
+     SET conversation_id = ?, seq = ?
+     WHERE message_id = ?`,
+  );
+  const finalize = db.prepare(`UPDATE messages SET seq = ? WHERE message_id = ?`);
+
+  messageIds.forEach((messageId, index) => {
+    stage.run(group.targetConversationId, -(index + 1), messageId);
+  });
+  messageIds.forEach((messageId, index) => {
+    finalize.run(index + 1, messageId);
+  });
+}
+
+function reparentContextItems(db: DatabaseSync, group: SafeGroup): void {
+  const rowIds = loadOrderedContextRowIds(db, group);
+  const stage = db.prepare(
+    `UPDATE context_items
+     SET conversation_id = ?, ordinal = ?
+     WHERE rowid = ?`,
+  );
+  const finalize = db.prepare(`UPDATE context_items SET ordinal = ? WHERE rowid = ?`);
+
+  rowIds.forEach((rowId, index) => {
+    stage.run(group.targetConversationId, -(index + 1), rowId);
+  });
+  rowIds.forEach((rowId, index) => {
+    finalize.run(index, rowId);
+  });
+}
+
+function reparentSimpleConversationTables(db: DatabaseSync, group: SafeGroup): void {
+  if (group.sourceConversationIds.length === 0) {
+    return;
+  }
+  const sourcePlaceholders = placeholders(group.sourceConversationIds);
+  for (const table of ["summaries", "large_files", "focus_briefs"]) {
+    db.prepare(
+      `UPDATE ${quoteSqlIdentifier(table)}
+       SET conversation_id = ?
+       WHERE conversation_id IN (${sourcePlaceholders})`,
+    ).run(group.targetConversationId, ...group.sourceConversationIds);
+  }
+}
+
+function clearSourceStateAndMarkTarget(db: DatabaseSync, group: SafeGroup): void {
+  const sourcePlaceholders = placeholders(group.sourceConversationIds);
+  for (const table of [
+    "conversation_bootstrap_state",
+    "conversation_compaction_maintenance",
+    "conversation_compaction_telemetry",
+  ]) {
+    db.prepare(
+      `DELETE FROM ${quoteSqlIdentifier(table)}
+       WHERE conversation_id IN (${sourcePlaceholders})`,
+    ).run(...group.sourceConversationIds);
+  }
+
+  db.prepare(
+    `UPDATE conversations
+     SET created_at = (
+           SELECT MIN(created_at)
+           FROM conversations
+           WHERE conversation_id IN (${placeholders(group.orderedConversationIds)})
+         ),
+         updated_at = datetime('now')
+     WHERE conversation_id = ?`,
+  ).run(...group.orderedConversationIds, group.targetConversationId);
+
+  db.prepare(
+    `INSERT INTO conversation_compaction_maintenance (
+       conversation_id,
+       pending,
+       requested_at,
+       reason,
+       running,
+       updated_at
+     ) VALUES (?, 1, datetime('now'), ?, 0, datetime('now'))
+     ON CONFLICT(conversation_id) DO UPDATE SET
+       pending = 1,
+       requested_at = datetime('now'),
+       reason = excluded.reason,
+       running = 0,
+       updated_at = datetime('now')`,
+  ).run(group.targetConversationId, ROLLOVER_SPLIT_MAINTENANCE_REASON);
+}
+
+function rebuildFtsTables(db: DatabaseSync): void {
+  if (hasTable(db, "messages_fts")) {
+    db.exec(`DELETE FROM messages_fts`);
+    const rows = db
+      .prepare(`SELECT message_id, content FROM messages ORDER BY message_id ASC`)
+      .all() as Array<{ message_id: number; content: string }>;
+    const insertMessageFts = db.prepare(`INSERT INTO messages_fts(rowid, content) VALUES (?, ?)`);
+    for (const row of rows) {
+      const normalizedContent = normalizeMessageContentForFullTextIndex(row.content);
+      if (normalizedContent) {
+        insertMessageFts.run(row.message_id, normalizedContent);
+      }
+    }
+  }
+  if (hasTable(db, "summaries_fts")) {
+    db.exec(`DELETE FROM summaries_fts`);
+    db.exec(`INSERT INTO summaries_fts(summary_id, content) SELECT summary_id, content FROM summaries`);
+  }
+  if (hasTable(db, "summaries_fts_cjk")) {
+    db.exec(`DELETE FROM summaries_fts_cjk`);
+    db.exec(`INSERT INTO summaries_fts_cjk(summary_id, content) SELECT summary_id, content FROM summaries`);
+  }
+}
+
+function verifyForeignKeys(db: DatabaseSync): string {
+  const rows = db.prepare(`PRAGMA foreign_key_check`).all();
+  return rows.length === 0 ? "clean" : `${rows.length} foreign key issue(s)`;
+}
+
+function verifyIntegrity(db: DatabaseSync): string {
+  const rows = db.prepare(`PRAGMA integrity_check`).all() as Array<{ integrity_check?: string }>;
+  const results = rows.map((row) => row.integrity_check).filter(Boolean);
+  return results.length === 1 && results[0] === "ok" ? "ok" : results.join("; ") || "unknown";
+}
+
+function assertNoRows(db: DatabaseSync, sql: string, params: SQLInputValue[], message: string): void {
+  const rows = db.prepare(sql).all(...params);
+  if (rows.length > 0) {
+    throw new Error(message);
+  }
+}
+
+function verifyRepairedTargets(db: DatabaseSync, targetConversationIds: number[]): void {
+  if (targetConversationIds.length === 0) {
+    return;
+  }
+  const ids = placeholders(targetConversationIds);
+  assertNoRows(
+    db,
+    `SELECT conversation_id
+     FROM messages
+     WHERE conversation_id IN (${ids})
+     GROUP BY conversation_id
+     HAVING COUNT(*) > 0
+        AND (MIN(seq) != 1 OR MAX(seq) != COUNT(*) OR COUNT(DISTINCT seq) != COUNT(*))`,
+    targetConversationIds,
+    "message seq verification failed",
+  );
+  assertNoRows(
+    db,
+    `SELECT conversation_id
+     FROM context_items
+     WHERE conversation_id IN (${ids})
+     GROUP BY conversation_id
+     HAVING COUNT(*) > 0
+        AND (MIN(ordinal) != 0 OR MAX(ordinal) != COUNT(*) - 1 OR COUNT(DISTINCT ordinal) != COUNT(*))`,
+    targetConversationIds,
+    "context ordinal verification failed",
+  );
+  assertNoRows(
+    db,
+    `SELECT ci.conversation_id
+     FROM context_items ci
+     JOIN messages m ON m.message_id = ci.message_id
+     WHERE ci.conversation_id IN (${ids})
+       AND ci.item_type = 'message'
+       AND m.conversation_id != ci.conversation_id`,
+    targetConversationIds,
+    "context message reference verification failed",
+  );
+  assertNoRows(
+    db,
+    `SELECT ci.conversation_id
+     FROM context_items ci
+     JOIN summaries s ON s.summary_id = ci.summary_id
+     WHERE ci.conversation_id IN (${ids})
+       AND ci.item_type = 'summary'
+       AND s.conversation_id != ci.conversation_id`,
+    targetConversationIds,
+    "context summary reference verification failed",
+  );
+}
+
+function repairSafeGroup(db: DatabaseSync, group: SafeGroup): void {
+  reparentMessages(db, group);
+  reparentContextItems(db, group);
+  reparentSimpleConversationTables(db, group);
+  clearSourceStateAndMarkTarget(db, group);
+}
+
+export function getRolloverSplitApplyUnavailableReason(databasePath: string): string | null {
+  return getFileBackedDatabasePath(databasePath)
+    ? null
+    : "Rollover split repair requires a file-backed SQLite database so Lossless Claw can create a backup first.";
+}
+
+/**
+ * Repair every safe rollover split in the database.
+ */
+export async function applyRolloverSplitRepair(params: {
+  db: DatabaseSync;
+  databasePath: string;
+}): Promise<RolloverSplitApplyResult> {
+  const unavailableReason = getRolloverSplitApplyUnavailableReason(params.databasePath);
+  if (unavailableReason) {
+    return { kind: "unavailable", reason: unavailableReason };
+  }
+
+  const before = scanRolloverSplits(params.db);
+  if (before.safe.length === 0) {
+    return {
+      kind: "applied",
+      backupPath: "skipped (no safe rollover splits)",
+      repairedLanes: 0,
+      skippedReviewLanes: before.needsReview.length,
+      totals: { ...EMPTY_COUNTS },
+      verification: {
+        integrity: "not run (no writes)",
+        foreignKeys: "not run (no writes)",
+      },
+    };
+  }
+
+  const backupPath = createLcmDatabaseBackup(params.db, {
+    databasePath: params.databasePath,
+    label: "rollover-split-repair",
+  });
+  if (!backupPath) {
+    return {
+      kind: "unavailable",
+      reason: "Lossless Claw could not determine a rollover split backup path.",
+    };
+  }
+
+  let verification = { integrity: "unknown", foreignKeys: "unknown" };
+  await withDatabaseTransaction(params.db, "BEGIN IMMEDIATE", () => {
+    const safeGroups = loadSafeGroups(params.db);
+    for (const group of safeGroups) {
+      repairSafeGroup(params.db, group);
+    }
+    rebuildFtsTables(params.db);
+
+    verification = {
+      integrity: verifyIntegrity(params.db),
+      foreignKeys: verifyForeignKeys(params.db),
+    };
+    if (verification.integrity !== "ok") {
+      throw new Error(`SQLite integrity_check failed: ${verification.integrity}`);
+    }
+    if (verification.foreignKeys !== "clean") {
+      throw new Error(`SQLite foreign_key_check failed: ${verification.foreignKeys}`);
+    }
+    verifyRepairedTargets(
+      params.db,
+      safeGroups.map((group) => group.targetConversationId),
+    );
+    if (loadSafeGroups(params.db).length > 0) {
+      throw new Error("safe rollover split verification failed: unrepaired safe groups remain");
+    }
+  });
+
+  return {
+    kind: "applied",
+    backupPath,
+    repairedLanes: before.safe.length,
+    skippedReviewLanes: before.needsReview.length,
+    totals: before.totals,
+    verification,
+  };
+}

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -296,7 +296,8 @@ function toMessagePartRecord(row: MessagePartRow): MessagePartRecord {
   };
 }
 
-function normalizeMessageContentForFullTextIndex(content: string): string | null {
+/** Normalize persisted message text before indexing it in the message FTS table. */
+export function normalizeMessageContentForFullTextIndex(content: string): string | null {
   if (typeof content !== "string") return null;
   const trimmed = content.trim();
   if (!trimmed) {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1600,6 +1600,74 @@ describe("lcm command", () => {
     expect(helperFtsRows).toEqual([]);
   });
 
+  it("repairs rollover splits when unrelated foreign key issues already exist", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:test:rollover-preexisting-fk";
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-preexisting-fk-old",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: archived.conversationId,
+      label: "oldfk",
+      includeSummary: true,
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-preexisting-fk-new",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: active.conversationId,
+      label: "activefk",
+      includeSummary: true,
+    });
+    setConversationTimes(fixture, archived.conversationId, "2026-06-17 02:00:00", "2026-06-17 02:05:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 02:10:00");
+
+    // Simulate an unrelated live-DB orphan that predates rollover repair.
+    fixture.db.exec(`PRAGMA foreign_keys = OFF`);
+    fixture.db
+      .prepare(
+        `INSERT INTO message_parts (
+           part_id,
+           message_id,
+           session_id,
+           part_type,
+           ordinal,
+           text_content
+         ) VALUES ('orphan-preexisting-part', 9999999, 'orphan-session', 'text', 0, 'orphaned')`,
+      )
+      .run();
+    fixture.db.exec(`PRAGMA foreign_keys = ON`);
+
+    const beforeIssues = fixture.db.prepare(`PRAGMA foreign_key_check`).all();
+    expect(beforeIssues).toHaveLength(1);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply rollover-splits confirm"),
+    );
+
+    expect(result.text).toContain("status: completed");
+    expect(result.text).toContain("repaired lanes: 1");
+    expect(result.text).toContain("foreign keys: unchanged (1 foreign key issue(s) pre-existing)");
+
+    const targetMessages = fixture.db
+      .prepare(
+        `SELECT content
+         FROM messages
+         WHERE conversation_id = ?
+         ORDER BY seq ASC`,
+      )
+      .all(active.conversationId) as Array<{ content: string }>;
+    expect(targetMessages.map((row) => row.content)).toEqual(["oldfk message", "activefk message"]);
+    expect(fixture.db.prepare(`PRAGMA foreign_key_check`).all()).toEqual(beforeIssues);
+  });
+
   it("skips rollover split repair when transcript entry ids collide", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -66,6 +66,137 @@ function createCommandContext(
   };
 }
 
+type CommandFixture = ReturnType<typeof createCommandFixture>;
+
+async function createRolloverConversationData(
+  fixture: CommandFixture,
+  input: {
+    conversationId: number;
+    label: string;
+    transcriptEntryId?: string;
+    includeSummary?: boolean;
+    includeLargeFile?: boolean;
+    includeFocusBrief?: boolean;
+  },
+): Promise<void> {
+  const [message] = await fixture.conversationStore.createMessagesBulk([
+    {
+      conversationId: input.conversationId,
+      seq: 0,
+      role: "user",
+      content: `${input.label} message`,
+      tokenCount: 5,
+      ...(input.transcriptEntryId ? { transcriptEntryId: input.transcriptEntryId } : {}),
+    },
+  ]);
+  await fixture.summaryStore.appendContextMessage(input.conversationId, message.messageId);
+
+  if (input.includeSummary) {
+    const summaryId = `${input.label}_summary`;
+    await fixture.summaryStore.insertSummary({
+      summaryId,
+      conversationId: input.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `${input.label} summary`,
+      tokenCount: 3,
+      sourceMessageTokenCount: 5,
+    });
+    await fixture.summaryStore.linkSummaryToMessages(summaryId, [message.messageId]);
+    await fixture.summaryStore.appendContextSummary(input.conversationId, summaryId);
+  }
+
+  if (input.includeLargeFile) {
+    await fixture.summaryStore.insertLargeFile({
+      fileId: `${input.label}_file`,
+      conversationId: input.conversationId,
+      fileName: `${input.label}.txt`,
+      mimeType: "text/plain",
+      byteSize: 64,
+      storageUri: `file:///tmp/${input.label}.txt`,
+      explorationSummary: `${input.label} file summary`,
+    });
+  }
+
+  if (input.includeFocusBrief) {
+    fixture.db
+      .prepare(
+        `INSERT INTO focus_briefs (
+           brief_id,
+           conversation_id,
+           session_key,
+           prompt,
+           content,
+           status
+         ) VALUES (?, ?, ?, ?, ?, 'active')`,
+      )
+      .run(
+        `${input.label}_brief`,
+        input.conversationId,
+        `agent:main:test:${input.label}`,
+        `${input.label} focus prompt`,
+        `${input.label} focus content`,
+      );
+  }
+}
+
+function setConversationTimes(
+  fixture: CommandFixture,
+  conversationId: number,
+  createdAt: string,
+  archivedAt?: string,
+): void {
+  fixture.db
+    .prepare(
+      `UPDATE conversations
+       SET created_at = ?,
+           archived_at = COALESCE(?, archived_at),
+           updated_at = ?
+       WHERE conversation_id = ?`,
+    )
+    .run(createdAt, archivedAt ?? null, archivedAt ?? createdAt, conversationId);
+}
+
+function insertRolloverStateRows(fixture: CommandFixture, sourceId: number, targetId: number): void {
+  fixture.db
+    .prepare(
+      `INSERT INTO conversation_bootstrap_state (
+         conversation_id,
+         session_file_path,
+         last_seen_size,
+         last_seen_mtime_ms,
+         last_processed_offset
+       ) VALUES (?, ?, 10, 20, 30)`,
+    )
+    .run(sourceId, `/tmp/source-${sourceId}.jsonl`);
+  fixture.db
+    .prepare(
+      `INSERT INTO conversation_compaction_telemetry (
+         conversation_id,
+         cache_state
+       ) VALUES (?, 'cold')`,
+    )
+    .run(sourceId);
+  fixture.db
+    .prepare(
+      `INSERT INTO conversation_compaction_maintenance (
+         conversation_id,
+         pending,
+         reason
+       ) VALUES (?, 1, 'old-source-maintenance')`,
+    )
+    .run(sourceId);
+  fixture.db
+    .prepare(
+      `INSERT INTO conversation_compaction_maintenance (
+         conversation_id,
+         pending,
+         reason
+       ) VALUES (?, 0, 'target-maintenance')`,
+    )
+    .run(targetId);
+}
+
 describe("lcm command", () => {
   const tempDirs = new Set<string>();
   const dbPaths = new Set<string>();
@@ -1261,6 +1392,304 @@ describe("lcm command", () => {
     expect(result.text).not.toContain("sum_unknown_clean");
   });
 
+  it("reports whole-DB rollover split memory even when no current conversation is resolved", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:test:rollover-detect";
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-detect-old",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: archived.conversationId,
+      label: "detect_old",
+      includeSummary: true,
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-detect-new",
+      sessionKey,
+    });
+    setConversationTimes(fixture, archived.conversationId, "2026-06-17 01:00:00", "2026-06-17 01:05:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 01:06:00");
+
+    const result = await fixture.command.handler(createCommandContext("doctor"));
+
+    expect(result.text).toContain("Summary doctor is conversation-scoped.");
+    expect(result.text).toContain("**⚠️ Rollover split memory**");
+    expect(result.text).toContain("affected safe lanes: 1");
+    expect(result.text).toContain("stranded: 1 messages · 1 summaries · 2 context items");
+    expect(result.text).toContain("repair: `/lossless doctor apply rollover-splits confirm`");
+    expect(result.text).toContain("rollover-detect");
+  });
+
+  it("repairs safe whole-DB rollover splits after confirmation", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:test:rollover-apply";
+    const firstArchived = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-apply-old-1",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: firstArchived.conversationId,
+      label: "oldone",
+      includeSummary: true,
+      includeLargeFile: true,
+      includeFocusBrief: true,
+    });
+    await fixture.conversationStore.archiveConversation(firstArchived.conversationId);
+
+    const secondArchived = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-apply-old-2",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: secondArchived.conversationId,
+      label: "oldtwo",
+      includeSummary: true,
+    });
+    await fixture.conversationStore.archiveConversation(secondArchived.conversationId);
+
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-apply-new",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: active.conversationId,
+      label: "active",
+      includeSummary: true,
+    });
+    const unrelated = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-apply-unrelated",
+      sessionKey: "agent:main:test:rollover-apply-unrelated",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: unrelated.conversationId,
+        seq: 0,
+        role: "tool",
+        content:
+          "[LCM Tool Output: tool_1]\nCall lcm_describe(id=\"tool_1\") to inspect the full payload.\nExploration Summary:\npayloaddelta retained content",
+        tokenCount: 9,
+      },
+    ]);
+    setConversationTimes(fixture, firstArchived.conversationId, "2026-06-17 01:00:00", "2026-06-17 01:05:00");
+    setConversationTimes(fixture, secondArchived.conversationId, "2026-06-17 01:06:00", "2026-06-17 01:10:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 01:11:00");
+    insertRolloverStateRows(fixture, firstArchived.conversationId, active.conversationId);
+
+    const blocked = await fixture.command.handler(
+      createCommandContext("doctor apply rollover-splits"),
+    );
+    expect(blocked.text).toContain("status: blocked");
+    expect(blocked.text).toContain("read-only; no rollover split repair ran");
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply rollover-splits confirm"),
+    );
+
+    expect(result.text).toContain("status: completed");
+    expect(result.text).toContain("repaired lanes: 1");
+    expect(result.text).toContain("merged: 2 messages · 2 summaries · 4 context items · 1 large files · 1 focus briefs");
+    expect(result.text).toContain("integrity: ok");
+    expect(result.text).toContain("foreign keys: clean");
+    expect(result.text).toContain("backup path:");
+    expect(result.text).not.toContain("backup path: skipped");
+
+    const targetMessages = fixture.db
+      .prepare(
+        `SELECT seq, content
+         FROM messages
+         WHERE conversation_id = ?
+         ORDER BY seq ASC`,
+      )
+      .all(active.conversationId) as Array<{ seq: number; content: string }>;
+    expect(targetMessages).toEqual([
+      { seq: 1, content: "oldone message" },
+      { seq: 2, content: "oldtwo message" },
+      { seq: 3, content: "active message" },
+    ]);
+
+    const targetContext = fixture.db
+      .prepare(
+        `SELECT ordinal, item_type
+         FROM context_items
+         WHERE conversation_id = ?
+         ORDER BY ordinal ASC`,
+      )
+      .all(active.conversationId) as Array<{ ordinal: number; item_type: string }>;
+    expect(targetContext.map((row) => row.ordinal)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(targetContext.map((row) => row.item_type)).toEqual([
+      "message",
+      "summary",
+      "message",
+      "summary",
+      "message",
+      "summary",
+    ]);
+
+    const counts = fixture.db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM summaries WHERE conversation_id = ?) AS summaries,
+           (SELECT COUNT(*) FROM large_files WHERE conversation_id = ?) AS large_files,
+           (SELECT COUNT(*) FROM focus_briefs WHERE conversation_id = ?) AS focus_briefs,
+           (SELECT COUNT(*) FROM messages WHERE conversation_id IN (?, ?)) AS source_messages,
+           (SELECT COUNT(*) FROM context_items WHERE conversation_id IN (?, ?)) AS source_context,
+           (SELECT COUNT(*) FROM conversation_bootstrap_state WHERE conversation_id = ?) AS source_bootstrap,
+           (SELECT COUNT(*) FROM conversation_compaction_telemetry WHERE conversation_id = ?) AS source_telemetry`,
+      )
+      .get(
+        active.conversationId,
+        active.conversationId,
+        active.conversationId,
+        firstArchived.conversationId,
+        secondArchived.conversationId,
+        firstArchived.conversationId,
+        secondArchived.conversationId,
+        firstArchived.conversationId,
+        firstArchived.conversationId,
+      ) as {
+      summaries: number;
+      large_files: number;
+      focus_briefs: number;
+      source_messages: number;
+      source_context: number;
+      source_bootstrap: number;
+      source_telemetry: number;
+    };
+    expect(counts).toEqual({
+      summaries: 3,
+      large_files: 1,
+      focus_briefs: 1,
+      source_messages: 0,
+      source_context: 0,
+      source_bootstrap: 0,
+      source_telemetry: 0,
+    });
+
+    const maintenance = fixture.db
+      .prepare(
+        `SELECT pending, reason, running
+         FROM conversation_compaction_maintenance
+         WHERE conversation_id = ?`,
+      )
+      .get(active.conversationId) as { pending: number; reason: string; running: number };
+    expect(maintenance).toEqual({
+      pending: 1,
+      reason: "doctor-rollover-split-repair",
+      running: 0,
+    });
+
+    const ftsRows = fixture.db
+      .prepare(`SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'oldone'`)
+      .all();
+    expect(ftsRows.length).toBeGreaterThan(0);
+    const retainedFtsRows = fixture.db
+      .prepare(`SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'payloaddelta'`)
+      .all();
+    expect(retainedFtsRows.length).toBeGreaterThan(0);
+    const helperFtsRows = fixture.db
+      .prepare(`SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'lcm_describe'`)
+      .all();
+    expect(helperFtsRows).toEqual([]);
+  });
+
+  it("skips rollover split repair when transcript entry ids collide", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:test:rollover-collision";
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-collision-old",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: archived.conversationId,
+      label: "collision_old",
+      transcriptEntryId: "duplicate-entry-id",
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "rollover-collision-new",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: active.conversationId,
+      label: "collision_active",
+      transcriptEntryId: "duplicate-entry-id",
+    });
+    setConversationTimes(fixture, archived.conversationId, "2026-06-17 02:00:00", "2026-06-17 02:05:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 02:06:00");
+
+    const scan = await fixture.command.handler(createCommandContext("doctor rollover-splits"));
+    expect(scan.text).toContain("affected safe lanes: 0");
+    expect(scan.text).toContain("needs review: 1");
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply rollover-splits confirm"),
+    );
+    expect(result.text).toContain("repaired lanes: 0");
+    expect(result.text).toContain("skipped for review: 1");
+    expect(result.text).toContain("backup path: skipped (no safe rollover splits)");
+
+    const archivedMessageCount = fixture.db
+      .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
+      .get(archived.conversationId) as { count: number };
+    expect(archivedMessageCount.count).toBe(1);
+  });
+
+  it("ignores isolated cron session-key rollovers", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:cron:rollover-nightly";
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "cron-rollover-old",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: archived.conversationId,
+      label: "cron_old",
+      includeSummary: true,
+      includeFocusBrief: true,
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "cron-rollover-new",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: active.conversationId,
+      label: "cron_active",
+    });
+    setConversationTimes(fixture, archived.conversationId, "2026-06-17 03:00:00", "2026-06-17 03:05:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 03:06:00");
+
+    const scan = await fixture.command.handler(createCommandContext("doctor rollover-splits"));
+    expect(scan.text).toContain("result: clean");
+    expect(scan.text).toContain("safe lanes: 0");
+    expect(scan.text).toContain("needs review: 0");
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply rollover-splits confirm"),
+    );
+    expect(result.text).toContain("repaired lanes: 0");
+    expect(result.text).toContain("backup path: skipped (no safe rollover splits)");
+
+    const archivedMessageCount = fixture.db
+      .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
+      .get(archived.conversationId) as { count: number };
+    expect(archivedMessageCount.count).toBe(1);
+  });
+
   it("reports doctor as unavailable when the current conversation cannot be resolved", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
@@ -1292,7 +1721,8 @@ describe("lcm command", () => {
     expect(result.text).toContain(
       "No LCM conversation is stored yet for active session key `agent:main:telegram:direct:not-stored` or active session id `doctor-unresolved-missing`.",
     );
-    expect(result.text).toContain("fallback: Doctor is conversation-scoped, so no global scan ran.");
+    expect(result.text).toContain("fallback: Summary doctor is conversation-scoped.");
+    expect(result.text).toContain("**✅ Rollover split memory**");
     expect(result.text).not.toContain("detected summaries:");
     expect(result.text).not.toContain("sum_unresolved_other");
   });
@@ -2864,6 +3294,15 @@ describe("lcm command helpers", () => {
       kind: "doctor",
       apply: true,
       applyOptions: { confirmOffline: true },
+    });
+    expect(__testing.parseLcmCommand("doctor rollover-splits")).toEqual({
+      kind: "doctor_rollover_splits",
+      apply: false,
+    });
+    expect(__testing.parseLcmCommand("doctor apply rollover-splits confirm")).toEqual({
+      kind: "doctor_rollover_splits",
+      apply: true,
+      applyOptions: { confirm: true },
     });
   });
 

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -282,6 +282,42 @@ describe("lcm command", () => {
     expect(result.text).toContain("OpenClaw did not expose an active session key or session id here");
   });
 
+  it("surfaces rollover split memory from the default status command", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const sessionKey = "agent:main:test:status-rollover-detect";
+    const archived = await fixture.conversationStore.createConversation({
+      sessionId: "status-rollover-old",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: archived.conversationId,
+      label: "statusold",
+      includeSummary: true,
+    });
+    await fixture.conversationStore.archiveConversation(archived.conversationId);
+
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "status-rollover-new",
+      sessionKey,
+    });
+    await createRolloverConversationData(fixture, {
+      conversationId: active.conversationId,
+      label: "statusactive",
+    });
+    setConversationTimes(fixture, archived.conversationId, "2026-06-17 03:00:00", "2026-06-17 03:05:00");
+    setConversationTimes(fixture, active.conversationId, "2026-06-17 03:10:00");
+
+    const result = await fixture.command.handler(createCommandContext());
+
+    expect(result.text).toContain("**⚠️ Rollover split memory**");
+    expect(result.text).toContain("result: safe repairs available");
+    expect(result.text).toContain("affected safe lanes: 1");
+    expect(result.text).toContain("repair: `/lossless doctor apply rollover-splits confirm`");
+  });
+
   it("resolves current conversation stats when the host provides a session key", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);


### PR DESCRIPTION
## What

Adds whole-DB `/lossless doctor` detection and confirmed repair for safe fresh-transcript rollover split memory from issue #904.

## Why

Lossless Claw 0.13.0 could split one stable `session_key` across archived predecessor conversations and a new active conversation after runtime transcript rollover. The active lane then lost access to prior persisted messages, summaries, context items, large files, and focus briefs even though that data still existed in archived rows.

## Changes

- Adds rollover split scanner
- Adds confirmed repair command
- Reparents safe archived data
- Rebuilds FTS indexes safely
- Skips cron isolated rollovers
- Adds command regressions
- Adds patch changeset

## Testing

- `npm test -- --run test/lcm-command.test.ts`
- `npm run typecheck`
- `npm test`
- `autoreview --mode local --parallel-tests "npm test -- --run test/lcm-command.test.ts && npm run typecheck"`
