### PR TITLE
fix: pass runtime session id to recall tools

### DIFF
--- a/.changeset/scoped-recall-runtime-session.md
+++ b/.changeset/scoped-recall-runtime-session.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix default-scoped recall tools so they receive the active OpenClaw runtime session id when resolving the current LCM conversation.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1651,15 +1651,33 @@ function wirePluginHandlers(
   });
 
   api.registerTool(
-    (ctx) => createLcmGrepTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    (ctx) =>
+      createLcmGrepTool({
+        deps,
+        getLcm: shared.waitForEngine,
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey,
+      }),
     { name: "lcm_grep" },
   );
   api.registerTool(
-    (ctx) => createLcmDescribeTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    (ctx) =>
+      createLcmDescribeTool({
+        deps,
+        getLcm: shared.waitForEngine,
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey,
+      }),
     { name: "lcm_describe" },
   );
   api.registerTool(
-    (ctx) => createLcmExpandTool({ deps, getLcm: shared.waitForEngine, sessionKey: ctx.sessionKey }),
+    (ctx) =>
+      createLcmExpandTool({
+        deps,
+        getLcm: shared.waitForEngine,
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey,
+      }),
     { name: "lcm_expand" },
   );
   api.registerTool(
@@ -1667,6 +1685,7 @@ function wirePluginHandlers(
       createLcmExpandQueryTool({
         deps,
         getLcm: shared.waitForEngine,
+        sessionId: ctx.sessionId,
         sessionKey: ctx.sessionKey,
         requesterSessionKey: ctx.sessionKey,
       }),

--- a/test/plugin-tool-session-scope.test.ts
+++ b/test/plugin-tool-session-scope.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
+import { clearAllSharedInit } from "../src/plugin/shared-init.js";
+
+const toolFactoryMocks = vi.hoisted(() => ({
+  grep: vi.fn((input: unknown) => ({ name: "lcm_grep", input })),
+  describe: vi.fn((input: unknown) => ({ name: "lcm_describe", input })),
+  expand: vi.fn((input: unknown) => ({ name: "lcm_expand", input })),
+  expandQuery: vi.fn((input: unknown) => ({ name: "lcm_expand_query", input })),
+}));
+
+vi.mock("openclaw/plugin-sdk/core", () => ({
+  buildMemorySystemPromptAddition: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/logging-core", () => ({
+  redactSensitiveText: (text: string) => text,
+}));
+
+vi.mock("../src/tools/lcm-grep-tool.js", () => ({
+  createLcmGrepTool: toolFactoryMocks.grep,
+}));
+
+vi.mock("../src/tools/lcm-describe-tool.js", () => ({
+  createLcmDescribeTool: toolFactoryMocks.describe,
+}));
+
+vi.mock("../src/tools/lcm-expand-tool.js", () => ({
+  createLcmExpandTool: toolFactoryMocks.expand,
+}));
+
+vi.mock("../src/tools/lcm-expand-query-tool.js", () => ({
+  createLcmExpandQueryTool: toolFactoryMocks.expandQuery,
+}));
+
+const lcmPluginPromise = import("../index.js");
+
+function buildToolDiscoveryApi(): OpenClawPluginApi {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  return {
+    id: "lossless-claw",
+    name: "Lossless Context Management",
+    source: "/tmp/lossless-claw",
+    registrationMode: "tool-discovery",
+    pluginConfig: { enabled: true },
+    config: {},
+    runtime: {
+      llm: {
+        complete: vi.fn(),
+      },
+      modelAuth: {
+        getApiKeyForModel: vi.fn(),
+        resolveApiKeyForProvider: vi.fn(),
+      },
+      config: {
+        current: vi.fn(() => ({})),
+        loadConfig: vi.fn(() => ({})),
+      },
+      logging: {
+        shouldLogVerbose: vi.fn(() => false),
+        getChildLogger: vi.fn(() => log),
+      },
+      channel: {
+        session: {
+          resolveStorePath: vi.fn(() => "/tmp/nonexistent-session-store.json"),
+        },
+      },
+    },
+    logger: log,
+    registerContextEngine: vi.fn(),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+    on: vi.fn(),
+    resolvePath: vi.fn(() => "/tmp/fake-agent"),
+  } as unknown as OpenClawPluginApi;
+}
+
+describe("plugin recall tool session scope", () => {
+  afterEach(() => {
+    clearAllSharedInit();
+    vi.clearAllMocks();
+  });
+
+  it("passes both runtime session id and stable session key to recall tools", async () => {
+    const lcmPlugin = (await lcmPluginPromise).default;
+    const api = buildToolDiscoveryApi();
+
+    lcmPlugin.register(api);
+
+    const toolFactories = new Map(
+      (api.registerTool as ReturnType<typeof vi.fn>).mock.calls.map(([factory, options]) => [
+        options.name,
+        factory,
+      ]),
+    );
+    const context = {
+      sessionId: "runtime-session-104",
+      sessionKey: "agent:main:main",
+    };
+
+    for (const name of ["lcm_grep", "lcm_describe", "lcm_expand", "lcm_expand_query"]) {
+      const factory = toolFactories.get(name);
+      expect(factory).toBeTypeOf("function");
+      factory(context);
+    }
+
+    const expectedScope = expect.objectContaining({
+      sessionId: context.sessionId,
+      sessionKey: context.sessionKey,
+    });
+    expect(toolFactoryMocks.grep).toHaveBeenCalledWith(expectedScope);
+    expect(toolFactoryMocks.describe).toHaveBeenCalledWith(expectedScope);
+    expect(toolFactoryMocks.expand).toHaveBeenCalledWith(expectedScope);
+    expect(toolFactoryMocks.expandQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: context.sessionId,
+        sessionKey: context.sessionKey,
+        requesterSessionKey: context.sessionKey,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Pass the active OpenClaw runtime `sessionId` into lossless-claw recall tool factories alongside the stable `sessionKey`, so default-scoped recall can resolve the current LCM conversation with the same runtime identity available to lifecycle and context-engine paths.

## Why

Fixes #897. Default-scoped recall could fail or resolve stale scope when the tool registration only supplied `sessionKey`, especially after reset/replacement state where the active runtime session id was the authoritative handle.

## Changes

- Forward `ctx.sessionId` to recall tools
- Cover tool registration scope contract
- Add patch changeset

## Testing

- `npm test -- --run test/plugin-tool-session-scope.test.ts`
- `npm test -- --run test/plugin-tool-session-scope.test.ts test/lcm-tools.test.ts`
- `npm run typecheck`
- `npm test`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`