### PR TITLE
fix: prefer message timestamps during transcript import

### DIFF
--- a/.changeset/message-timestamp-import.md
+++ b/.changeset/message-timestamp-import.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prefer transcript message timestamps during import so replayed history preserves message ordering when envelope timestamps are coarse.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -45,11 +45,6 @@ export function getTranscriptEntryId(message: AgentMessage): string | null {
 }
 
 export function resolveTranscriptMessageCreatedAt(message: AgentMessage): Date | string | undefined {
-  const envelopeTimestamp = getTranscriptEntryMeta(message)?.timestamp;
-  if (envelopeTimestamp) {
-    return envelopeTimestamp;
-  }
-
   const raw = message as unknown as Record<string, unknown>;
   const value = raw.timestamp ?? raw.createdAt ?? raw.created_at;
   if (typeof value === "number") {
@@ -62,7 +57,7 @@ export function resolveTranscriptMessageCreatedAt(message: AgentMessage): Date |
   if (typeof value === "string" && value.trim()) {
     return value;
   }
-  return undefined;
+  return getTranscriptEntryMeta(message)?.timestamp ?? undefined;
 }
 
 function normalizeEnvelopeString(value: unknown): string | null {

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -12,6 +12,7 @@ import {
   getTranscriptEntryMeta,
   parseBootstrapJsonl,
   readLeafPathMessages,
+  resolveTranscriptMessageCreatedAt,
 } from "../src/transcript.js";
 import type { LcmDependencies } from "../src/types.js";
 import { createTestConfig, createTestDeps as createSharedTestDeps } from "./helpers.js";
@@ -144,6 +145,39 @@ describe("transcript entry metadata parsing", () => {
     expect(getTranscriptEntryId(messages[0]!)).toBeTruthy();
     expect(getTranscriptEntryId(messages[1]!)).toBeTruthy();
     expect(getTranscriptEntryId(messages[0]!)).not.toBe(getTranscriptEntryId(messages[1]!));
+  });
+
+  it("prefers message timestamps over replay envelope timestamps", () => {
+    const raw = JSON.stringify({
+      type: "message",
+      id: "entry-replayed",
+      timestamp: "2026-06-17T02:26:07.589Z",
+      message: {
+        role: "user",
+        timestamp: Date.parse("2026-06-05T20:16:17.367Z"),
+        content: [{ type: "text", text: "historical user message" }],
+      },
+    });
+
+    const message = parseBootstrapJsonl(raw).messages[0]!;
+    const createdAt = resolveTranscriptMessageCreatedAt(message);
+    expect(createdAt).toBeInstanceOf(Date);
+    expect((createdAt as Date).toISOString()).toBe("2026-06-05T20:16:17.367Z");
+  });
+
+  it("falls back to envelope timestamps for envelope-only transcript entries", () => {
+    const raw = JSON.stringify({
+      type: "message",
+      id: "entry-envelope-only",
+      timestamp: "2026-06-10T18:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "recovered assistant message" }],
+      },
+    });
+
+    const message = parseBootstrapJsonl(raw).messages[0]!;
+    expect(resolveTranscriptMessageCreatedAt(message)).toBe("2026-06-10T18:00:00.000Z");
   });
 });
 


### PR DESCRIPTION
## What
Prefer transcript message timestamps when importing replayed messages, while keeping envelope timestamps as the fallback for envelope-only entries.

## Why
Envelope timestamps can be coarse across imported batches, which can collapse distinct messages onto the same timestamp and break replay ordering. Message-level timestamps preserve the ordering captured by the source transcript.

## Changes
- Prefer message timestamp during import
- Preserve envelope timestamp fallback
- Cover replay ordering regression
- Add patch changeset

## Testing
- `npm test -- test/transcript-entry-id.test.ts`
- `npm run typecheck`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`