### PR TITLE
fix: clean up lossless status and doctor apply output

### DIFF
--- a/.changeset/quiet-status-health.md
+++ b/.changeset/quiet-status-health.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Clean up `/lossless` status health output by using the last runtime maintenance budget when no explicit assembly cap is configured, renaming the frontier token metric, and removing repair-source pressure from default status reasons.
+Clean up `/lossless` status output by using the last runtime maintenance budget when no explicit assembly cap is configured, renaming the frontier token metric, removing repair-source pressure from default status reasons, and shortening maintenance details to actionable state.

--- a/.changeset/quiet-status-health.md
+++ b/.changeset/quiet-status-health.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Clean up `/lossless` status output by using the last runtime maintenance budget when no explicit assembly cap is configured, renaming the frontier token metric, removing repair-source pressure from default status reasons, and shortening maintenance details to actionable state.
+Clean up `/lossless` status output by using the last runtime maintenance budget when no explicit assembly cap is configured, renaming the frontier token metric, removing repair-source pressure from default status reasons, and shortening maintenance details to actionable state. Also tighten `/lossless doctor apply` safety output to show scoped repair targets, repair input tokens, and deduplicated repair target source tokens instead of whole-conversation message-count or compressed-source proxies.

--- a/.changeset/quiet-status-health.md
+++ b/.changeset/quiet-status-health.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Clean up `/lossless` status health output by using the last runtime maintenance budget when no explicit assembly cap is configured, renaming the frontier token metric, and removing repair-source pressure from default status reasons.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,25 @@ jobs:
         run: npm run typecheck
 
       - name: Run tests
-        run: npm test
+        run: |
+          set +e
+          npx vitest run --dir test --reporter=json --outputFile=vitest-results.json
+          test_status=$?
+          node --input-type=module <<'EOF'
+          import fs from "node:fs";
+          const clean = (value) => String(value ?? "").replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "?");
+          const report = JSON.parse(fs.readFileSync("vitest-results.json", "utf8"));
+          console.log(`tests: ${report.numPassedTests}/${report.numTotalTests} passed; files: ${report.numPassedTestSuites}/${report.numTotalTestSuites} passed`);
+          for (const suite of report.testResults ?? []) {
+            for (const assertion of suite.assertionResults ?? []) {
+              if (assertion.status === "failed") {
+                console.log(`failed: ${clean(assertion.fullName)}`);
+                for (const message of assertion.failureMessages ?? []) console.log(clean(message));
+              }
+            }
+          }
+          EOF
+          exit $test_status
 
   plugin-inspector:
     runs-on: ubuntu-latest

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -788,7 +788,7 @@ Design note: stripping happens at compaction time, not at message ingestion.  Th
 
 Useful interpretation notes:
 
-- `tokens in context` is the current LCM frontier token count in the live LCM state.
+- `LCM frontier tokens` is the current LCM frontier token count in the live LCM state.
 - `compression ratio` is shown as a rounded `1:N`, which is easier to read than a tiny percentage for heavily compacted conversations.
 - `/status` may still show a different context number because it reflects the runtime prompt that was actually assembled and sent on the last turn.
 

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -42,7 +42,6 @@ import { FocusBriefStore, hashFocusSourceContext } from "../store/focus-brief-st
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
 const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
-const DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD = 1_000;
 const DOCTOR_APPLY_LARGE_TARGET_THRESHOLD = 25;
 const DOCTOR_APPLY_BUDGET_PRESSURE_RATIO = 0.75;
 
@@ -81,6 +80,10 @@ type CurrentConversationResolution =
     };
 type DoctorApplyOptions = {
   confirmOffline: boolean;
+};
+type DoctorApplyRepairMetrics = {
+  repairInputTokenCount: number;
+  repairTargetSourceTokenCount: number;
 };
 type RolloverSplitApplyOptions = {
   confirm: boolean;
@@ -646,39 +649,98 @@ function resolveStatusAssemblyTokenBudget(
   );
 }
 
+function buildTargetSummaryValuesSql(summaryIds: string[]): string {
+  return summaryIds.map(() => "(?)").join(", ");
+}
+
+function loadDoctorApplyRepairMetrics(
+  db: DatabaseSync,
+  doctor: DoctorSummaryStats,
+): DoctorApplyRepairMetrics {
+  const summaryIds = [...new Set(doctor.candidates.map((candidate) => candidate.summaryId))];
+  if (summaryIds.length === 0) {
+    return {
+      repairInputTokenCount: 0,
+      repairTargetSourceTokenCount: 0,
+    };
+  }
+
+  const targetValuesSql = buildTargetSummaryValuesSql(summaryIds);
+
+  // Repair input mirrors lcm-doctor-apply: leaf targets read linked messages,
+  // while condensed targets read their immediate child summaries.
+  const repairInputRow = db
+    .prepare(
+      `WITH target_summaries(summary_id) AS (VALUES ${targetValuesSql})
+       SELECT COALESCE(SUM(input_tokens), 0) AS token_count
+       FROM (
+         SELECT t.summary_id, COALESCE(SUM(m.token_count), 0) AS input_tokens
+         FROM target_summaries t
+         JOIN summaries target ON target.summary_id = t.summary_id
+         JOIN summary_messages sm ON sm.summary_id = t.summary_id
+         JOIN messages m ON m.message_id = sm.message_id
+         WHERE target.kind = 'leaf' OR COALESCE(target.depth, 0) = 0
+         GROUP BY t.summary_id
+         UNION ALL
+         SELECT t.summary_id, COALESCE(SUM(child.token_count), 0) AS input_tokens
+         FROM target_summaries t
+         JOIN summaries target ON target.summary_id = t.summary_id
+         JOIN summary_parents sp ON sp.summary_id = t.summary_id
+         JOIN summaries child ON child.summary_id = sp.parent_summary_id
+         WHERE NOT (target.kind = 'leaf' OR COALESCE(target.depth, 0) = 0)
+         GROUP BY t.summary_id
+       ) repair_inputs`,
+    )
+    .get(...summaryIds) as { token_count: number | null } | undefined;
+
+  // Source coverage expands each target's summary tree to linked raw messages
+  // and deduplicates messages shared by multiple target roots.
+  const sourceCoverageRow = db
+    .prepare(
+      `WITH RECURSIVE
+       target_summaries(summary_id) AS (VALUES ${targetValuesSql}),
+       target_tree(summary_id) AS (
+         SELECT summary_id FROM target_summaries
+         UNION
+         SELECT sp.parent_summary_id
+         FROM target_tree tree
+         JOIN summary_parents sp ON sp.summary_id = tree.summary_id
+       ),
+       covered_messages AS (
+         SELECT DISTINCT sm.message_id
+         FROM target_tree tree
+         JOIN summary_messages sm ON sm.summary_id = tree.summary_id
+       )
+       SELECT COALESCE(SUM(m.token_count), 0) AS token_count
+       FROM covered_messages covered
+       JOIN messages m ON m.message_id = covered.message_id`,
+    )
+    .get(...summaryIds) as { token_count: number | null } | undefined;
+
+  return {
+    repairInputTokenCount: Math.max(0, Math.floor(repairInputRow?.token_count ?? 0)),
+    repairTargetSourceTokenCount: Math.max(0, Math.floor(sourceCoverageRow?.token_count ?? 0)),
+  };
+}
+
 function buildDoctorApplySafetyPreflight(params: {
   config: LcmConfig;
-  stats: LcmConversationStatusStats;
   doctor: DoctorSummaryStats;
+  repairMetrics: DoctorApplyRepairMetrics;
   maintenance: ConversationCompactionMaintenanceRecord | null;
 }): { blocked: boolean; reasons: string[]; tokenBudget: number; tokenThreshold: number } {
   const tokenBudget = resolveLifecycleCompactionTokenBudget(params.config);
   const tokenThreshold = Math.floor(tokenBudget * DOCTOR_APPLY_BUDGET_PRESSURE_RATIO);
   const reasons: string[] = [];
-  const maintenanceObservedTokens = Math.max(
-    params.maintenance?.currentTokenCount ?? 0,
-    params.maintenance?.projectedTokenCount ?? 0,
-  );
-  const observedTokens = Math.max(
-    params.stats.contextTokenCount,
-    params.stats.summarizedSourceTokens,
-    params.stats.compressedTokenCount,
-    maintenanceObservedTokens,
-  );
 
   if (params.doctor.total > DOCTOR_APPLY_LARGE_TARGET_THRESHOLD) {
     reasons.push(
       `doctor target count ${formatNumber(params.doctor.total)} exceeds safe inline limit ${formatNumber(DOCTOR_APPLY_LARGE_TARGET_THRESHOLD)}`,
     );
   }
-  if (params.stats.messageCount > DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD) {
+  if (params.repairMetrics.repairInputTokenCount > tokenThreshold) {
     reasons.push(
-      `message count ${formatNumber(params.stats.messageCount)} exceeds safe inline limit ${formatNumber(DOCTOR_APPLY_LARGE_MESSAGE_THRESHOLD)}`,
-    );
-  }
-  if (observedTokens > tokenThreshold) {
-    reasons.push(
-      `observed token count ${formatNumber(observedTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of repair budget ${formatNumber(tokenBudget)}`,
+      `repair input token count ${formatNumber(params.repairMetrics.repairInputTokenCount)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of repair budget ${formatNumber(tokenBudget)}`,
     );
   }
   if (params.maintenance?.pending) {
@@ -2497,10 +2559,11 @@ async function buildDoctorApplyText(params: {
     params.db,
     current.stats.conversationId,
   );
+  const repairMetrics = loadDoctorApplyRepairMetrics(params.db, stats);
   const preflight = buildDoctorApplySafetyPreflight({
     config: params.config,
-    stats: current.stats,
     doctor: stats,
+    repairMetrics,
     maintenance,
   });
   if (preflight.blocked && params.options?.confirmOffline !== true) {
@@ -2521,9 +2584,10 @@ async function buildDoctorApplyText(params: {
       buildSection("🧯 Safety preflight", [
         buildStatLine("status", "blocked"),
         buildStatLine("mode", "read-only; no summary rewrites ran"),
-        buildStatLine("messages", formatNumber(current.stats.messageCount)),
         buildStatLine("LCM frontier tokens", formatNumber(current.stats.contextTokenCount)),
-        buildStatLine("detected summaries", formatNumber(stats.total)),
+        buildStatLine("repair targets", formatNumber(stats.total)),
+        buildStatLine("repair input tokens", formatNumber(repairMetrics.repairInputTokenCount)),
+        buildStatLine("repair target source tokens", formatNumber(repairMetrics.repairTargetSourceTokenCount)),
         buildStatLine("token threshold", formatNumber(preflight.tokenThreshold)),
         ...preflight.reasons.map((reason) => buildStatLine("reason", reason)),
       ]),
@@ -2601,7 +2665,7 @@ async function buildDoctorApplyText(params: {
       ...(params.options?.confirmOffline === true
         ? [buildStatLine("safety override", "confirm-offline")]
         : []),
-      buildStatLine("detected summaries", formatNumber(stats.total)),
+      buildStatLine("repair targets", formatNumber(stats.total)),
       buildStatLine("old-marker summaries", formatNumber(stats.old)),
       buildStatLine("truncated-marker summaries", formatNumber(stats.truncated)),
       buildStatLine("fallback-marker summaries", formatNumber(stats.fallback)),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -37,7 +37,6 @@ import {
   CompactionMaintenanceStore,
   type ConversationCompactionMaintenanceRecord,
 } from "../store/compaction-maintenance-store.js";
-import { CompactionTelemetryStore } from "../store/compaction-telemetry-store.js";
 import { FocusBriefStore, hashFocusSourceContext } from "../store/focus-brief-store.js";
 
 const VISIBLE_COMMAND = "/lossless";
@@ -546,13 +545,6 @@ async function getConversationCompactionMaintenanceByConversationId(
   );
 }
 
-async function getConversationCompactionTelemetryByConversationId(
-  db: DatabaseSync,
-  conversationId: number,
-) {
-  return await new CompactionTelemetryStore(db).getConversationCompactionTelemetry(conversationId);
-}
-
 async function resolveCurrentConversation(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
@@ -753,6 +745,57 @@ function buildLcmHealthSummary(params: {
     return { state: "warning", reasons: warningReasons };
   }
   return { state: "healthy", reasons: [] };
+}
+
+function getMaintenanceState(
+  maintenance: ConversationCompactionMaintenanceRecord | null,
+): "pending" | "running" | "idle" {
+  if (maintenance?.pending) return "pending";
+  if (maintenance?.running) return "running";
+  return "idle";
+}
+
+// Keep default status focused on operator action: active work, failure state, or
+// the last successful budget. Detailed token-pressure and cache telemetry stay in
+// logs and maintenance internals instead of the chat command surface.
+function buildMaintenanceSummaryLines(params: {
+  maintenance: ConversationCompactionMaintenanceRecord | null;
+  formatTime: (value: Date | null) => string;
+}): string[] {
+  const maintenance = params.maintenance;
+  const state = getMaintenanceState(maintenance);
+  const lines = [buildStatLine("state", state)];
+  if (!maintenance) {
+    return lines;
+  }
+
+  const active = state === "pending" || state === "running";
+  const failed = Boolean(maintenance.lastFailureSummary);
+  if (active || failed) {
+    if (maintenance.reason) lines.push(buildStatLine("reason", maintenance.reason));
+    if (active && maintenance.requestedAt) {
+      lines.push(buildStatLine("requested at", params.formatTime(maintenance.requestedAt)));
+    }
+    if (maintenance.lastStartedAt) {
+      lines.push(buildStatLine("last started", params.formatTime(maintenance.lastStartedAt)));
+    }
+    if (maintenance.lastFinishedAt && state !== "running") {
+      lines.push(buildStatLine("last finished", params.formatTime(maintenance.lastFinishedAt)));
+    }
+    if (maintenance.lastFailureSummary) {
+      lines.push(buildStatLine("last failure", maintenance.lastFailureSummary));
+    }
+    if (maintenance.nextAttemptAfter) {
+      lines.push(buildStatLine("next retry", params.formatTime(maintenance.nextAttemptAfter)));
+    }
+  } else if (maintenance.lastFinishedAt) {
+    lines.push(buildStatLine("last finished", params.formatTime(maintenance.lastFinishedAt)));
+  }
+
+  if (maintenance.tokenBudget != null) {
+    lines.push(buildStatLine("budget", formatNumber(maintenance.tokenBudget)));
+  }
+  return lines;
 }
 
 // Run the cache-aware focus lifecycle sweep. Focus and unfocus both mutate the
@@ -1009,10 +1052,6 @@ async function buildStatusText(params: {
       params.db,
       current.stats.conversationId,
     );
-    const telemetry = await getConversationCompactionTelemetryByConversationId(
-      params.db,
-      current.stats.conversationId,
-    );
     const lcmHealth = buildLcmHealthSummary({
       config: params.config,
       stats: current.stats,
@@ -1058,42 +1097,10 @@ async function buildStatusText(params: {
     lines.push("", buildSection("🎯 Focus", focusLines));
     lines.push(
       "",
-      buildSection("🛠️ Maintenance", [
-        buildStatLine(
-          "state",
-          maintenance?.pending
-            ? "pending"
-            : maintenance?.running
-              ? "running"
-              : "idle",
-        ),
-        buildStatLine("requested at", formatMaintenanceTime(maintenance?.requestedAt ?? null)),
-        buildStatLine("reason", maintenance?.reason ?? "none"),
-        buildStatLine("last started", formatMaintenanceTime(maintenance?.lastStartedAt ?? null)),
-        buildStatLine("last finished", formatMaintenanceTime(maintenance?.lastFinishedAt ?? null)),
-        buildStatLine("last failure", maintenance?.lastFailureSummary ?? "none"),
-        buildStatLine(
-          "requested token budget",
-          maintenance?.tokenBudget != null ? formatNumber(maintenance.tokenBudget) : "unknown",
-        ),
-        buildStatLine(
-          "observed token count",
-          maintenance?.currentTokenCount != null ? formatNumber(maintenance.currentTokenCount) : "unknown",
-        ),
-        buildStatLine(
-          "projected token count",
-          maintenance?.projectedTokenCount != null ? formatNumber(maintenance.projectedTokenCount) : "unknown",
-        ),
-        buildStatLine(
-          "raw tokens outside tail",
-          maintenance?.rawTokensOutsideTail != null ? formatNumber(maintenance.rawTokensOutsideTail) : "unknown",
-        ),
-        buildStatLine("last api call", formatMaintenanceTime(telemetry?.lastApiCallAt ?? null)),
-        buildStatLine("last cache touch", formatMaintenanceTime(telemetry?.lastCacheTouchAt ?? null)),
-        buildStatLine("cache retention", telemetry?.retention ?? "unknown"),
-        buildStatLine("cache state", telemetry?.cacheState ?? "unknown"),
-        buildStatLine("provider/model", [telemetry?.provider, telemetry?.model].filter(Boolean).join(" / ") || "unknown"),
-      ]),
+      buildSection(
+        "🛠️ Maintenance",
+        buildMaintenanceSummaryLines({ maintenance, formatTime: formatMaintenanceTime }),
+      ),
     );
   } else {
     lines.push(

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -633,10 +633,25 @@ async function resolveRuntimeSessionId(params: {
   return normalizeIdentity(params.current.stats.sessionId);
 }
 
+function normalizePositiveInteger(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : null;
+}
+
 function resolveLifecycleCompactionTokenBudget(config: LcmConfig): number {
-  return config.maxAssemblyTokenBudget && config.maxAssemblyTokenBudget > 0
-    ? Math.floor(config.maxAssemblyTokenBudget)
-    : 128_000;
+  return normalizePositiveInteger(config.maxAssemblyTokenBudget) ?? 128_000;
+}
+
+function resolveStatusAssemblyTokenBudget(
+  config: LcmConfig,
+  maintenance: ConversationCompactionMaintenanceRecord | null,
+): number {
+  return (
+    normalizePositiveInteger(config.maxAssemblyTokenBudget)
+    ?? normalizePositiveInteger(maintenance?.tokenBudget)
+    ?? 128_000
+  );
 }
 
 function buildDoctorApplySafetyPreflight(params: {
@@ -696,17 +711,16 @@ function buildLcmHealthSummary(params: {
   stats: LcmConversationStatusStats;
   maintenance: ConversationCompactionMaintenanceRecord | null;
 }): { state: "healthy" | "warning" | "degraded"; reasons: string[] } {
-  const tokenBudget = resolveLifecycleCompactionTokenBudget(params.config);
+  const tokenBudget = resolveStatusAssemblyTokenBudget(
+    params.config,
+    params.maintenance,
+  );
   const warningThreshold = Math.floor(tokenBudget * DOCTOR_APPLY_BUDGET_PRESSURE_RATIO);
   const activeMaintenance = params.maintenance?.pending || params.maintenance?.running;
   const assemblyObservedTokens = Math.max(
     params.stats.contextTokenCount,
     activeMaintenance ? params.maintenance?.currentTokenCount ?? 0 : 0,
     activeMaintenance ? params.maintenance?.projectedTokenCount ?? 0 : 0,
-  );
-  const repairSurfaceTokens = Math.max(
-    params.stats.summarizedSourceTokens,
-    params.stats.compressedTokenCount,
   );
   const degradedReasons: string[] = [];
   const warningReasons: string[] = [];
@@ -726,11 +740,6 @@ function buildLcmHealthSummary(params: {
   } else if (assemblyObservedTokens > warningThreshold) {
     warningReasons.push(
       `observed token count ${formatNumber(assemblyObservedTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of assembly budget ${formatNumber(tokenBudget)}`,
-    );
-  }
-  if (repairSurfaceTokens > warningThreshold) {
-    warningReasons.push(
-      `repair source token count ${formatNumber(repairSurfaceTokens)} exceeds ${formatNumber(Math.round(DOCTOR_APPLY_BUDGET_PRESSURE_RATIO * 100))}% of assembly budget ${formatNumber(tokenBudget)}`,
     );
   }
   if (params.maintenance?.lastFailureSummary) {
@@ -1030,7 +1039,7 @@ async function buildStatusText(params: {
         ),
         buildStatLine("stored summary tokens", formatNumber(current.stats.storedSummaryTokens)),
         buildStatLine("summarized source tokens", formatNumber(current.stats.summarizedSourceTokens)),
-        buildStatLine("tokens in context", formatNumber(current.stats.contextTokenCount)),
+        buildStatLine("LCM frontier tokens", formatNumber(current.stats.contextTokenCount)),
         buildStatLine(
           "compression ratio",
           formatCompressionRatio(current.stats.contextTokenCount, current.stats.compressedTokenCount),
@@ -2506,7 +2515,7 @@ async function buildDoctorApplyText(params: {
         buildStatLine("status", "blocked"),
         buildStatLine("mode", "read-only; no summary rewrites ran"),
         buildStatLine("messages", formatNumber(current.stats.messageCount)),
-        buildStatLine("tokens in context", formatNumber(current.stats.contextTokenCount)),
+        buildStatLine("LCM frontier tokens", formatNumber(current.stats.contextTokenCount)),
         buildStatLine("detected summaries", formatNumber(stats.total)),
         buildStatLine("token threshold", formatNumber(preflight.tokenThreshold)),
         ...preflight.reasons.map((reason) => buildStatLine("reason", reason)),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -2559,11 +2559,18 @@ async function buildDoctorApplyText(params: {
     params.db,
     current.stats.conversationId,
   );
-  const repairMetrics = loadDoctorApplyRepairMetrics(params.db, stats);
+  const skipRepairMetrics =
+    params.options?.confirmOffline !== true && stats.total > DOCTOR_APPLY_LARGE_TARGET_THRESHOLD;
+  const repairMetrics = skipRepairMetrics
+    ? null
+    : loadDoctorApplyRepairMetrics(params.db, stats);
   const preflight = buildDoctorApplySafetyPreflight({
     config: params.config,
     doctor: stats,
-    repairMetrics,
+    repairMetrics: repairMetrics ?? {
+      repairInputTokenCount: 0,
+      repairTargetSourceTokenCount: 0,
+    },
     maintenance,
   });
   if (preflight.blocked && params.options?.confirmOffline !== true) {
@@ -2586,8 +2593,15 @@ async function buildDoctorApplyText(params: {
         buildStatLine("mode", "read-only; no summary rewrites ran"),
         buildStatLine("LCM frontier tokens", formatNumber(current.stats.contextTokenCount)),
         buildStatLine("repair targets", formatNumber(stats.total)),
-        buildStatLine("repair input tokens", formatNumber(repairMetrics.repairInputTokenCount)),
-        buildStatLine("repair target source tokens", formatNumber(repairMetrics.repairTargetSourceTokenCount)),
+        ...(repairMetrics
+          ? [
+              buildStatLine("repair input tokens", formatNumber(repairMetrics.repairInputTokenCount)),
+              buildStatLine(
+                "repair target source tokens",
+                formatNumber(repairMetrics.repairTargetSourceTokenCount),
+              ),
+            ]
+          : []),
         buildStatLine("token threshold", formatNumber(preflight.tokenThreshold)),
         ...preflight.reasons.map((reason) => buildStatLine("reason", reason)),
       ]),

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1061,8 +1061,12 @@ describe("lcm command", () => {
     expect(result.text).toContain("state: pending");
     expect(result.text).toContain("reason: budget-trigger");
     expect(result.text).toContain("last failure: provider timeout");
-    expect(result.text).toContain("requested token budget: 128,000");
-    expect(result.text).toContain("observed token count: 96,000");
+    expect(result.text).toContain("budget: 128,000");
+    expect(result.text).not.toContain("observed token count: 96,000");
+    expect(result.text).not.toContain("projected token count");
+    expect(result.text).not.toContain("raw tokens outside tail");
+    expect(result.text).not.toContain("cache state");
+    expect(result.text).not.toContain("provider/model");
   });
 
   it("reports LCM token pressure separately from transport health in status output", async () => {
@@ -1171,10 +1175,19 @@ describe("lcm command", () => {
     );
 
     expect(result.text).toContain("LCM frontier tokens: 144,291");
-    expect(result.text).toContain("requested token budget: 258,000");
+    expect(result.text).toContain("budget: 258,000");
+    expect(result.text).toContain("last finished: 2026-06-17 11:52 PDT");
     expect(result.text).toContain("lcm health: healthy");
     expect(result.text).not.toContain("assembly budget 128,000");
     expect(result.text).not.toContain("lcm reason: observed token count 144,291");
+    expect(result.text).not.toContain("requested at");
+    expect(result.text).not.toContain("reason: threshold");
+    expect(result.text).not.toContain("observed token count");
+    expect(result.text).not.toContain("projected token count");
+    expect(result.text).not.toContain("raw tokens outside tail");
+    expect(result.text).not.toContain("last api call");
+    expect(result.text).not.toContain("cache state");
+    expect(result.text).not.toContain("provider/model");
   });
 
   it("does not surface repair-source pressure in default status output", async () => {
@@ -1283,7 +1296,10 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("LCM frontier tokens: 8");
     expect(result.text).toContain("state: idle");
-    expect(result.text).toContain("observed token count: 150");
+    expect(result.text).toContain("last finished: 2026-04-11 17:07 PDT");
+    expect(result.text).toContain("budget: 100");
+    expect(result.text).not.toContain("observed token count: 150");
+    expect(result.text).not.toContain("projected token count: 150");
     expect(result.text).toContain("lcm health: healthy");
     expect(result.text).not.toContain("lcm reason: observed token count 150");
   });

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -391,7 +391,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("summaries: 2 (1 leaf, 1 condensed)");
     expect(result.text).toContain("stored summary tokens: 12");
     expect(result.text).toContain("summarized source tokens: 21");
-    expect(result.text).toContain("tokens in context: 5");
+    expect(result.text).toContain("LCM frontier tokens: 5");
     expect(result.text).toContain("compression ratio: 1:6");
     expect(result.text).toContain("lcm health: healthy");
     expect(result.text).toContain("transport health: not assessed by Lossless Claw");
@@ -1116,7 +1116,68 @@ describe("lcm command", () => {
     );
   });
 
-  it("warns when repair-source pressure would block doctor apply even if active context is small", async () => {
+  it("uses the last runtime maintenance budget for status health when no cap is configured", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "status-runtime-budget-session",
+      sessionKey: "agent:main:telegram:runtime-budget:1",
+      title: "Runtime budget fixture",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "frontier above fallback but below runtime threshold",
+        tokenCount: 144_291,
+      },
+    ]);
+    await fixture.summaryStore.appendContextMessages(conversation.conversationId, [message.messageId]);
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           last_started_at,
+           last_finished_at,
+           token_budget,
+           current_token_count,
+           projected_token_count,
+           updated_at
+         ) VALUES (?, 0, ?, ?, 0, ?, ?, ?, ?, ?, datetime('now'))`,
+      )
+      .run(
+        conversation.conversationId,
+        "2026-06-17T18:22:15.729Z",
+        "threshold",
+        "2026-06-17T18:52:47.111Z",
+        "2026-06-17T18:52:47.113Z",
+        258_000,
+        75_448,
+        228_874,
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        sessionKey: "agent:main:telegram:runtime-budget:1",
+        sessionId: "status-runtime-budget-session",
+      }),
+    );
+
+    expect(result.text).toContain("LCM frontier tokens: 144,291");
+    expect(result.text).toContain("requested token budget: 258,000");
+    expect(result.text).toContain("lcm health: healthy");
+    expect(result.text).not.toContain("assembly budget 128,000");
+    expect(result.text).not.toContain("lcm reason: observed token count 144,291");
+  });
+
+  it("does not surface repair-source pressure in default status output", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
@@ -1160,11 +1221,9 @@ describe("lcm command", () => {
       }),
     );
 
-    expect(result.text).toContain("tokens in context: 8");
-    expect(result.text).toContain("lcm health: warning");
-    expect(result.text).toContain(
-      "lcm reason: repair source token count 120,000 exceeds 75% of assembly budget 128,000",
-    );
+    expect(result.text).toContain("LCM frontier tokens: 8");
+    expect(result.text).toContain("lcm health: healthy");
+    expect(result.text).not.toContain("repair source token count");
   });
 
   it("does not treat stale idle maintenance token counts as degraded status", async () => {
@@ -1222,7 +1281,7 @@ describe("lcm command", () => {
       }),
     );
 
-    expect(result.text).toContain("tokens in context: 8");
+    expect(result.text).toContain("LCM frontier tokens: 8");
     expect(result.text).toContain("state: idle");
     expect(result.text).toContain("observed token count: 150");
     expect(result.text).toContain("lcm health: healthy");
@@ -1263,7 +1322,7 @@ describe("lcm command", () => {
     expect(result.text).not.toContain("session id:");
     expect(result.text).toContain("session key: missing");
     expect(result.text).toContain("messages: 1");
-    expect(result.text).toContain("tokens in context: 0");
+    expect(result.text).toContain("LCM frontier tokens: 0");
     expect(result.text).toContain("compression ratio: n/a");
   });
 

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { getLcmDbFeatures } from "../src/db/features.js";
+import { formatTimestamp } from "../src/compaction.js";
 import { createLcmDatabaseConnection, closeLcmConnection } from "../src/db/connection.js";
 import { resolveLcmConfig } from "../src/db/config.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
@@ -1176,7 +1177,9 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("LCM frontier tokens: 144,291");
     expect(result.text).toContain("budget: 258,000");
-    expect(result.text).toContain("last finished: 2026-06-17 11:52 PDT");
+    expect(result.text).toContain(
+      `last finished: ${formatTimestamp(new Date("2026-06-17T18:52:47.113Z"), fixture.config.timezone)}`,
+    );
     expect(result.text).toContain("lcm health: healthy");
     expect(result.text).not.toContain("assembly budget 128,000");
     expect(result.text).not.toContain("lcm reason: observed token count 144,291");
@@ -1296,7 +1299,9 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("LCM frontier tokens: 8");
     expect(result.text).toContain("state: idle");
-    expect(result.text).toContain("last finished: 2026-04-11 17:07 PDT");
+    expect(result.text).toContain(
+      `last finished: ${formatTimestamp(new Date("2026-04-12T00:07:00.000Z"), fixture.config.timezone)}`,
+    );
     expect(result.text).toContain("budget: 100");
     expect(result.text).not.toContain("observed token count: 150");
     expect(result.text).not.toContain("projected token count: 150");
@@ -2403,8 +2408,8 @@ describe("lcm command", () => {
     expect(result.text).toContain("status: blocked");
     expect(result.text).toContain("mode: read-only; no summary rewrites ran");
     expect(result.text).toContain("repair targets: 26");
-    expect(result.text).toContain("repair input tokens: 0");
-    expect(result.text).toContain("repair target source tokens: 0");
+    expect(result.text).not.toContain("repair input tokens");
+    expect(result.text).not.toContain("repair target source tokens");
     expect(result.text).toContain("doctor target count 26 exceeds safe inline limit 25");
     expect(result.text).toContain("`/lossless doctor apply confirm-offline`");
     expect(summarize).not.toHaveBeenCalled();

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -2316,10 +2316,57 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
     expect(result.text).toContain("scope: this conversation only");
-    expect(result.text).toContain("detected summaries: 0");
+    expect(result.text).toContain("repair targets: 0");
     expect(result.text).toContain("repaired summaries: 0");
     expect(result.text).toContain("result: clean; no writes ran");
     expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it("does not block doctor apply solely because the conversation has many unrelated messages", async () => {
+    const summarize = vi.fn(async () => "small scoped repair");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-large-message-count",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-large-message-count",
+    });
+    const messages = await fixture.conversationStore.createMessagesBulk(
+      Array.from({ length: 1_001 }, (_, index) => ({
+        conversationId: currentConversation.conversationId,
+        seq: index,
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `unrelated message ${index}`,
+        tokenCount: 1,
+      })),
+    );
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_large_message_count",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `broken leaf\n${"[Truncated from 512 tokens]"}`,
+      tokenCount: 11,
+      sourceMessageTokenCount: 1,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_large_message_count", [
+      messages[0].messageId,
+    ]);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-large-message-count",
+      }),
+    );
+
+    const repaired = await fixture.summaryStore.getSummary("sum_large_message_count");
+    expect(result.text).toContain("repair targets: 1");
+    expect(result.text).toContain("repaired summaries: 1");
+    expect(result.text).not.toContain("Safety preflight");
+    expect(result.text).not.toContain("message count");
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(repaired?.content).toBe("small scoped repair");
   });
 
   it("blocks doctor apply for large scoped repairs before summarizer or writes run", async () => {
@@ -2355,7 +2402,9 @@ describe("lcm command", () => {
     expect(result.text).toContain("**🧯 Safety preflight**");
     expect(result.text).toContain("status: blocked");
     expect(result.text).toContain("mode: read-only; no summary rewrites ran");
-    expect(result.text).toContain("detected summaries: 26");
+    expect(result.text).toContain("repair targets: 26");
+    expect(result.text).toContain("repair input tokens: 0");
+    expect(result.text).toContain("repair target source tokens: 0");
     expect(result.text).toContain("doctor target count 26 exceeds safe inline limit 25");
     expect(result.text).toContain("`/lossless doctor apply confirm-offline`");
     expect(summarize).not.toHaveBeenCalled();
@@ -2422,10 +2471,98 @@ describe("lcm command", () => {
 
     const unchanged = await fixture.summaryStore.getSummary("sum_pending_maintenance");
     expect(result.text).toContain("status: blocked");
+    expect(result.text).toContain("repair targets: 1");
+    expect(result.text).toContain("repair input tokens: 7");
+    expect(result.text).toContain("repair target source tokens: 7");
     expect(result.text).toContain("compaction maintenance is pending (budget-trigger)");
-    expect(result.text).toContain("observed token count 96,001 exceeds 75% of repair budget 128,000");
+    expect(result.text).not.toContain("observed token count");
+    expect(result.text).not.toContain("message count");
     expect(summarize).not.toHaveBeenCalled();
     expect(unchanged?.content).toContain("[Truncated from 512 tokens]");
+  });
+
+  it("reports condensed doctor repair input separately from target source coverage", async () => {
+    const summarize = vi.fn(async () => "should not run");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-condensed-metrics",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-condensed-metrics",
+    });
+    const messages = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first condensed source",
+        tokenCount: 100,
+      },
+      {
+        conversationId: currentConversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "second condensed source",
+        tokenCount: 200,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_condensed_metrics_child",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "healthy child summary",
+      tokenCount: 12,
+      sourceMessageTokenCount: 300,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_condensed_metrics_child", [
+      messages[0].messageId,
+      messages[1].messageId,
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_condensed_metrics_parent",
+      conversationId: currentConversation.conversationId,
+      kind: "condensed",
+      depth: 1,
+      content: FALLBACK_DIRECTIVE_SUMMARY_MARKER,
+      tokenCount: 8,
+      sourceMessageTokenCount: 300,
+      descendantTokenCount: 12,
+    });
+    await fixture.summaryStore.linkSummaryToParents("sum_condensed_metrics_parent", [
+      "sum_condensed_metrics_child",
+    ]);
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           updated_at
+         ) VALUES (?, 1, ?, ?, 0, datetime('now'))`,
+      )
+      .run(
+        currentConversation.conversationId,
+        "2026-04-12T00:00:00.000Z",
+        "budget-trigger",
+      );
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-condensed-metrics",
+      }),
+    );
+
+    expect(result.text).toContain("status: blocked");
+    expect(result.text).toContain("repair targets: 1");
+    expect(result.text).toContain("repair input tokens: 12");
+    expect(result.text).toContain("repair target source tokens: 300");
+    expect(result.text).toContain("compaction maintenance is pending (budget-trigger)");
+    expect(result.text).not.toContain("observed token count");
+    expect(summarize).not.toHaveBeenCalled();
   });
 
   it("blocks doctor apply when a broken leaf summary points at oversized raw source tokens", async () => {
@@ -2466,8 +2603,11 @@ describe("lcm command", () => {
 
     const unchanged = await fixture.summaryStore.getSummary("sum_raw_source_tokens");
     expect(result.text).toContain("status: blocked");
-    expect(result.text).toContain("detected summaries: 1");
-    expect(result.text).toContain("observed token count 120,000 exceeds 75% of repair budget 128,000");
+    expect(result.text).toContain("repair targets: 1");
+    expect(result.text).toContain("repair input tokens: 120,000");
+    expect(result.text).toContain("repair target source tokens: 120,000");
+    expect(result.text).toContain("repair input token count 120,000 exceeds 75% of repair budget 128,000");
+    expect(result.text).not.toContain("observed token count");
     expect(summarize).not.toHaveBeenCalled();
     expect(unchanged?.content).toContain("[Truncated from 512 tokens]");
   });
@@ -2621,7 +2761,7 @@ describe("lcm command", () => {
     const repairedEmergency = await fixture.summaryStore.getSummary("sum_emergency_fix");
     const repairedParent = await fixture.summaryStore.getSummary("sum_parent_fix");
 
-    expect(result.text).toContain("detected summaries: 3");
+    expect(result.text).toContain("repair targets: 3");
     expect(result.text).toContain("emergency-fallback summaries: 1");
     expect(result.text).toContain("repaired summaries: 3");
     expect(result.text).toContain("result: repaired 3 summary(s) in place");


### PR DESCRIPTION
## What
Clean up the default /lossless status surface and make /lossless doctor apply report scoped repair safety metrics instead of broad conversation proxies.

## Why
The old output mixed internal maintenance details with user-facing health, and doctor apply often required confirm-offline because it treated total message count and summary-tree metadata as repair risk even when the actual repair target set was small.

## Changes
- Rename frontier token status
- Use real assembly budget
- Shorten maintenance output
- Remove repair-source status noise
- Scope doctor apply metrics
- Drop message-count repair block

## Testing
- /Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "npx vitest run test/lcm-command.test.ts"
- npx vitest run test/lcm-command.test.ts
- npm run typecheck
- npm test
- npm run build