### PR TITLE
Warn when LCM installs are pinned to exact versions

### DIFF
--- a/.changeset/tall-update-track-warning.md
+++ b/.changeset/tall-update-track-warning.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Warn from `/lossless` status and doctor when OpenClaw metadata shows lossless-claw installed from an exact npm version, and document `@latest` as the routine install/update track.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,19 @@ The bundled skill focuses on configuration, diagnostics, architecture, and recal
 Use OpenClaw's plugin installer (recommended):
 
 ```bash
-openclaw plugins install @martian-engineering/lossless-claw
+openclaw plugins install @martian-engineering/lossless-claw@latest
 ```
 
 If you're running from a local OpenClaw checkout, use:
 
 ```bash
-pnpm openclaw plugins install @martian-engineering/lossless-claw
+pnpm openclaw plugins install @martian-engineering/lossless-claw@latest
+```
+
+Use exact versions only for rollback or reproducible canary testing. OpenClaw records an exact install spec such as `@martian-engineering/lossless-claw@0.12.0` as a pinned update track, so OpenClaw plugin update sync will keep that version until you move back to the stable track:
+
+```bash
+openclaw plugins update @martian-engineering/lossless-claw@latest
 ```
 
 For local plugin development, build your working copy first, then link it instead of copying files:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,13 +141,19 @@ Notes on the example:
 Install with OpenClaw's plugin installer:
 
 ```bash
-openclaw plugins install @martian-engineering/lossless-claw
+openclaw plugins install @martian-engineering/lossless-claw@latest
 ```
 
 If you are running from a local OpenClaw checkout:
 
 ```bash
-pnpm openclaw plugins install @martian-engineering/lossless-claw
+pnpm openclaw plugins install @martian-engineering/lossless-claw@latest
+```
+
+Use exact versions only for rollback or reproducible canary testing. OpenClaw treats an exact install spec such as `@martian-engineering/lossless-claw@0.12.0` as pinned, so plugin update sync will not follow newer LCM releases until you return to the moving track:
+
+```bash
+openclaw plugins update @martian-engineering/lossless-claw@latest
 ```
 
 For local plugin development, link a working copy:

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1621,6 +1621,7 @@ function wirePluginHandlers(
   api: ContextEngineCapableOpenClawPluginApi,
   deps: LcmDependencies,
   shared: SharedLcmInit,
+  openClawConfig?: unknown,
 ): void {
   api.on("before_reset", async (event, ctx) => {
     await (await shared.waitForEngine()).handleBeforeReset({
@@ -1696,6 +1697,7 @@ function wirePluginHandlers(
     createLcmCommand({
       db: shared.waitForDatabase,
       config: deps.config,
+      openClawConfig,
       deps,
       getLcm: shared.waitForEngine,
     }),
@@ -1906,7 +1908,7 @@ const lcmPlugin = {
           logStartupMaintenanceSchedulingError,
         );
       }
-      wirePluginHandlers(api, deps, existingInit);
+      wirePluginHandlers(api, deps, existingInit, registrationConfig.openClawConfig);
       return;
     }
 
@@ -2109,7 +2111,7 @@ const lcmPlugin = {
       removeSharedInit(normalizedDbPath);
     });
 
-    wirePluginHandlers(api, deps, nextShared);
+    wirePluginHandlers(api, deps, nextShared, registrationConfig.openClawConfig);
 
     logStartupBannerOnce({
       key: "plugin-loaded",

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -41,6 +41,8 @@ import { FocusBriefStore, hashFocusSourceContext } from "../store/focus-brief-st
 
 const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
+const LOSSLESS_PLUGIN_ID = "lossless-claw";
+const LOSSLESS_NPM_PACKAGE = "@martian-engineering/lossless-claw";
 const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
 const DOCTOR_APPLY_LARGE_TARGET_THRESHOLD = 25;
 const DOCTOR_APPLY_BUDGET_PRESSURE_RATIO = 0.75;
@@ -87,6 +89,11 @@ type DoctorApplyRepairMetrics = {
 };
 type RolloverSplitApplyOptions = {
   confirm: boolean;
+};
+type LcmInstallTrackWarning = {
+  kind: "exact-pinned";
+  spec: string;
+  version: string;
 };
 
 type ParsedLcmCommand =
@@ -187,6 +194,147 @@ function buildStatLine(label: string, value: string): string {
 function formatFailureReason(error: unknown): string {
   const message = describeLogError(error).trim();
   return message || "Unknown error";
+}
+
+function readStringField(record: Record<string, unknown> | undefined, key: string): string {
+  const value = record?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function listConfigCandidates(ctx: PluginCommandContext, fallbackConfig?: unknown): unknown[] {
+  const candidates: unknown[] = [];
+  if (ctx.config !== undefined) {
+    candidates.push(ctx.config);
+  }
+  if (fallbackConfig !== undefined && fallbackConfig !== ctx.config) {
+    candidates.push(fallbackConfig);
+  }
+  return candidates;
+}
+
+function readEffectiveSelectionConfig(
+  ctx: PluginCommandContext,
+  fallbackConfig?: unknown,
+): unknown {
+  return ctx.config ?? fallbackConfig;
+}
+
+function normalizeLosslessInstallRecord(value: unknown): Record<string, unknown> | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const id = readStringField(record, "id") || readStringField(record, "pluginId");
+  const name = readStringField(record, "name") || readStringField(record, "packageName");
+  const spec =
+    readStringField(record, "spec")
+    || readStringField(record, "installSpec")
+    || readStringField(record, "packageSpec")
+    || readStringField(record, "resolvedSpec");
+  if (
+    (id && id !== LOSSLESS_PLUGIN_ID)
+    || (name && name !== LOSSLESS_PLUGIN_ID && name !== LOSSLESS_NPM_PACKAGE)
+  ) {
+    return undefined;
+  }
+  if (!id && !name && spec && !spec.includes(LOSSLESS_NPM_PACKAGE)) {
+    return undefined;
+  }
+  return record;
+}
+
+function collectLosslessInstallRecords(config: unknown): Record<string, unknown>[] {
+  const root = asRecord(config);
+  const plugins = asRecord(root?.plugins);
+  const entries = asRecord(plugins?.entries);
+  const entry = asRecord(entries?.[LOSSLESS_PLUGIN_ID]);
+  const records: Record<string, unknown>[] = [];
+
+  const pushRecord = (value: unknown): void => {
+    const record = normalizeLosslessInstallRecord(value);
+    if (record) {
+      records.push(record);
+    }
+  };
+
+  pushRecord(entry);
+
+  for (const container of [
+    asRecord(plugins?.installs),
+    asRecord(plugins?.installed),
+    asRecord(plugins?.registry),
+    asRecord(root?.pluginInstalls),
+  ]) {
+    pushRecord(container?.[LOSSLESS_PLUGIN_ID]);
+    pushRecord(container?.[LOSSLESS_NPM_PACKAGE]);
+  }
+
+  for (const list of [plugins?.installs, plugins?.installed, root?.pluginInstalls]) {
+    if (Array.isArray(list)) {
+      for (const item of list) {
+        pushRecord(item);
+      }
+    }
+  }
+
+  return records;
+}
+
+function parseExactLosslessPackageVersion(spec: string): string | null {
+  const trimmed = spec.trim();
+  if (!trimmed.startsWith(`${LOSSLESS_NPM_PACKAGE}@`)) {
+    return null;
+  }
+  const version = trimmed.slice(LOSSLESS_NPM_PACKAGE.length + 1).trim();
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)
+    ? version
+    : null;
+}
+
+function detectLcmInstallTrackWarning(params: {
+  ctx: PluginCommandContext;
+  fallbackConfig?: unknown;
+}): LcmInstallTrackWarning | null {
+  const selectionConfig = readEffectiveSelectionConfig(params.ctx, params.fallbackConfig);
+  if (!resolvePluginEnabled(selectionConfig) || !resolvePluginSelected(selectionConfig)) {
+    return null;
+  }
+
+  for (const config of listConfigCandidates(params.ctx, params.fallbackConfig)) {
+    for (const record of collectLosslessInstallRecords(config)) {
+      const source = readStringField(record, "source") || readStringField(record, "type");
+      if (source && source !== "npm") {
+        continue;
+      }
+      const spec =
+        readStringField(record, "spec")
+        || readStringField(record, "installSpec")
+        || readStringField(record, "packageSpec")
+        || readStringField(record, "resolvedSpec");
+      const version = parseExactLosslessPackageVersion(spec);
+      if (version) {
+        return { kind: "exact-pinned", spec, version };
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildInstallTrackWarningSection(warning: LcmInstallTrackWarning): string {
+  return buildSection("⚠️ Update track", [
+    buildStatLine("status", warning.kind),
+    buildStatLine("installed spec", formatCommand(warning.spec)),
+    buildStatLine(
+      "impact",
+      "OpenClaw plugin update sync will keep this exact version and will not follow new LCM releases.",
+    ),
+    buildStatLine(
+      "repair",
+      formatCommand(`openclaw plugins update ${LOSSLESS_NPM_PACKAGE}@latest`),
+    ),
+  ]);
 }
 
 function formatCompressionRatio(contextTokens: number, compressedTokens: number): string {
@@ -1062,6 +1210,7 @@ async function buildStatusText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
   config: LcmConfig;
+  openClawConfig?: unknown;
 }): Promise<string> {
   const status = getLcmStatusStats(params.db);
   const doctor = getDoctorSummaryStats(params.db);
@@ -1070,6 +1219,10 @@ async function buildStatusText(params: {
   const selected = resolvePluginSelected(params.ctx.config);
   const slot = resolveContextEngineSlot(params.ctx.config);
   const dbSize = resolveDbSizeLabel(params.config.databasePath);
+  const installTrackWarning = detectLcmInstallTrackWarning({
+    ctx: params.ctx,
+    fallbackConfig: params.openClawConfig,
+  });
   const current = await resolveCurrentConversation({
     ctx: params.ctx,
     db: params.db,
@@ -1085,6 +1238,13 @@ async function buildStatusText(params: {
       buildStatLine("db size", dbSize),
     ]),
     "",
+  ];
+
+  if (installTrackWarning) {
+    lines.push(buildInstallTrackWarningSection(installTrackWarning), "");
+  }
+
+  lines.push(
     buildSection("🌐 Global", [
       buildStatLine("conversations", formatNumber(status.conversationCount)),
       buildStatLine(
@@ -1095,7 +1255,7 @@ async function buildStatusText(params: {
       buildStatLine("summarized source tokens", formatNumber(status.summarizedSourceTokens)),
     ]),
     "",
-  ];
+  );
 
   if (rolloverSplits.safe.length > 0 || rolloverSplits.needsReview.length > 0) {
     lines.push(buildRolloverSplitScanSection(rolloverSplits), "");
@@ -1180,16 +1340,26 @@ async function buildStatusText(params: {
 async function buildDoctorText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
+  openClawConfig?: unknown;
 }): Promise<string> {
   const rolloverSplits = scanRolloverSplits(params.db);
+  const installTrackWarning = detectLcmInstallTrackWarning({
+    ctx: params.ctx,
+    fallbackConfig: params.openClawConfig,
+  });
   const current = await resolveCurrentConversation(params);
 
   if (current.kind === "unavailable") {
-    return [
+    const lines = [
       ...buildHeaderLines(),
       "",
       "🩺 Lossless Claw Doctor",
       "",
+    ];
+    if (installTrackWarning) {
+      lines.push(buildInstallTrackWarningSection(installTrackWarning), "");
+    }
+    lines.push(
       buildSection("📍 Current conversation", [
         buildStatLine("status", "unavailable"),
         buildStatLine("reason", current.reason),
@@ -1197,7 +1367,8 @@ async function buildDoctorText(params: {
       ]),
       "",
       buildRolloverSplitScanSection(rolloverSplits),
-    ].join("\n");
+    );
+    return lines.join("\n");
   }
 
   const stats = getDoctorSummaryStats(params.db, current.stats.conversationId);
@@ -1206,6 +1377,11 @@ async function buildDoctorText(params: {
     "",
     "🩺 Lossless Claw Doctor",
     "",
+  ];
+  if (installTrackWarning) {
+    lines.push(buildInstallTrackWarningSection(installTrackWarning), "");
+  }
+  lines.push(
     buildSection("📍 Current conversation", [
       buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
       buildStatLine(
@@ -1225,7 +1401,7 @@ async function buildDoctorText(params: {
     ]),
     "",
     buildRolloverSplitScanSection(rolloverSplits),
-  ];
+  );
 
   if (stats.total > 0) {
     const summaryList = stats.candidates
@@ -2721,6 +2897,7 @@ async function buildDoctorApplyText(params: {
 export function createLcmCommand(params: {
   db: DatabaseSync | (() => DatabaseSync | Promise<DatabaseSync>);
   config: LcmConfig;
+  openClawConfig?: unknown;
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
   getLcm?: () => Promise<RuntimeCommandEngine>;
@@ -2743,7 +2920,14 @@ export function createLcmCommand(params: {
       const parsed = parseLcmCommand(ctx.args);
       switch (parsed.kind) {
         case "status":
-          return { text: await buildStatusText({ ctx, db: await getDb(), config: params.config }) };
+          return {
+            text: await buildStatusText({
+              ctx,
+              db: await getDb(),
+              config: params.config,
+              openClawConfig: params.openClawConfig,
+            }),
+          };
         case "backup":
           return {
             text: await buildBackupText({
@@ -2806,7 +2990,13 @@ export function createLcmCommand(params: {
                   options: parsed.applyOptions,
                 }),
               }
-            : { text: await buildDoctorText({ ctx, db: await getDb() }) };
+            : {
+                text: await buildDoctorText({
+                  ctx,
+                  db: await getDb(),
+                  openClawConfig: params.openClawConfig,
+                }),
+              };
         case "doctor_rollover_splits":
           return parsed.apply
             ? {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1,8 +1,9 @@
 import { existsSync, statSync } from "node:fs";
-import type { DatabaseSync } from "node:sqlite";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import packageJson from "../../package.json" with { type: "json" };
 import { formatTimestamp } from "../compaction.js";
-import type { LcmConfig } from "../db/config.js";
+import { resolveOpenclawStateDir, type LcmConfig } from "../db/config.js";
 import type { RotateSessionStorageWithBackupResult } from "../engine.js";
 import { runDelegatedFocusBrief, runDelegatedRefocusBrief } from "../focus-briefs.js";
 import type { LcmSummarizeFn } from "../summarize.js";
@@ -43,6 +44,7 @@ const VISIBLE_COMMAND = "/lossless";
 const HIDDEN_ALIAS = "/lcm";
 const LOSSLESS_PLUGIN_ID = "lossless-claw";
 const LOSSLESS_NPM_PACKAGE = "@martian-engineering/lossless-claw";
+const INSTALLED_PLUGIN_INDEX_KEY = "installed-plugin-index";
 const ROTATE_DATABASE_LOCK_TIMEOUT_MS = 30_000;
 const DOCTOR_APPLY_LARGE_TARGET_THRESHOLD = 25;
 const DOCTOR_APPLY_BUDGET_PRESSURE_RATIO = 0.75;
@@ -219,6 +221,52 @@ function readEffectiveSelectionConfig(
   return ctx.config ?? fallbackConfig;
 }
 
+function parseJsonRecord(value: string | null | undefined): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return asRecord(JSON.parse(value) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveOpenClawStateSqlitePath(): string | undefined {
+  if (process.env.VITEST && !process.env.OPENCLAW_STATE_DIR?.trim()) {
+    return undefined;
+  }
+  return join(resolveOpenclawStateDir(), "state", "openclaw.sqlite");
+}
+
+/** Read the host's durable install metadata when OpenClaw has not exposed it on command config. */
+function readPersistedOpenClawInstallRecords(): Record<string, unknown> | undefined {
+  const dbPath = resolveOpenClawStateSqlitePath();
+  if (!dbPath || !existsSync(dbPath)) {
+    return undefined;
+  }
+
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const row = db.prepare(
+      `SELECT install_records_json
+         FROM installed_plugin_index
+        WHERE index_key = ?`,
+    ).get(INSTALLED_PLUGIN_INDEX_KEY) as { install_records_json?: string | null } | undefined;
+    return parseJsonRecord(row?.install_records_json);
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}
+
+function readPersistedOpenClawInstallRecordsConfig(): unknown {
+  const installRecords = readPersistedOpenClawInstallRecords();
+  return installRecords ? { plugins: { installs: installRecords } } : undefined;
+}
+
 function normalizeLosslessInstallRecord(value: unknown): Record<string, unknown> | undefined {
   const record = asRecord(value);
   if (!record) {
@@ -301,7 +349,10 @@ function detectLcmInstallTrackWarning(params: {
     return null;
   }
 
-  for (const config of listConfigCandidates(params.ctx, params.fallbackConfig)) {
+  for (const config of [
+    ...listConfigCandidates(params.ctx, params.fallbackConfig),
+    readPersistedOpenClawInstallRecordsConfig(),
+  ]) {
     for (const record of collectLosslessInstallRecords(config)) {
       const source = readStringField(record, "source") || readStringField(record, "type");
       if (source && source !== "npm") {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { DatabaseSync } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { getLcmDbFeatures } from "../src/db/features.js";
@@ -68,6 +68,38 @@ function createCommandContext(
 }
 
 type CommandFixture = ReturnType<typeof createCommandFixture>;
+
+function writeOpenClawInstallRecord(params: {
+  stateDir: string;
+  pluginId: string;
+  record: Record<string, unknown>;
+}): void {
+  const stateDbDir = join(params.stateDir, "state");
+  mkdirSync(stateDbDir, { recursive: true });
+  const db = new DatabaseSync(join(stateDbDir, "openclaw.sqlite"));
+  try {
+    db.exec(`
+      CREATE TABLE installed_plugin_index (
+        index_key TEXT PRIMARY KEY,
+        install_records_json TEXT NOT NULL,
+        plugins_json TEXT NOT NULL
+      )
+    `);
+    db.prepare(
+      `INSERT INTO installed_plugin_index (
+         index_key,
+         install_records_json,
+         plugins_json
+       ) VALUES (?, ?, ?)`,
+    ).run(
+      "installed-plugin-index",
+      JSON.stringify({ [params.pluginId]: params.record }),
+      "[]",
+    );
+  } finally {
+    db.close();
+  }
+}
 
 async function createRolloverConversationData(
   fixture: CommandFixture,
@@ -204,6 +236,7 @@ describe("lcm command", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     for (const dbPath of dbPaths) {
       closeLcmConnection(dbPath);
     }
@@ -317,6 +350,28 @@ describe("lcm command", () => {
     expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
     expect(result.text).toContain("impact: OpenClaw plugin update sync will keep this exact version");
     expect(result.text).toContain("repair: `openclaw plugins update @martian-engineering/lossless-claw@latest`");
+  });
+
+  it("warns when status sees an exact npm install spec in OpenClaw's installed plugin index", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const stateDir = join(fixture.tempDir, "openclaw-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    writeOpenClawInstallRecord({
+      stateDir,
+      pluginId: "lossless-claw",
+      record: {
+        source: "npm",
+        spec: "@martian-engineering/lossless-claw@0.12.0",
+        version: "0.12.0",
+      },
+    });
+
+    const result = await fixture.command.handler(createCommandContext());
+
+    expect(result.text).toContain("**⚠️ Update track**");
+    expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
   });
 
   it("does not warn when status sees a moving npm install spec", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -283,6 +283,125 @@ describe("lcm command", () => {
     expect(result.text).toContain("OpenClaw did not expose an active session key or session id here");
   });
 
+  it("warns when status sees an exact npm install spec for the selected LCM engine", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+              },
+            },
+            slots: {
+              contextEngine: "lossless-claw",
+            },
+            installs: {
+              "lossless-claw": {
+                source: "npm",
+                spec: "@martian-engineering/lossless-claw@0.12.0",
+                version: "0.12.0",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.text).toContain("**⚠️ Update track**");
+    expect(result.text).toContain("status: exact-pinned");
+    expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
+    expect(result.text).toContain("impact: OpenClaw plugin update sync will keep this exact version");
+    expect(result.text).toContain("repair: `openclaw plugins update @martian-engineering/lossless-claw@latest`");
+  });
+
+  it("does not warn when status sees a moving npm install spec", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+              },
+            },
+            slots: {
+              contextEngine: "lossless-claw",
+            },
+            installs: {
+              "lossless-claw": {
+                source: "npm",
+                spec: "@martian-engineering/lossless-claw@latest",
+                version: "0.13.1",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.text).not.toContain("**⚠️ Update track**");
+    expect(result.text).not.toContain("status: exact-pinned");
+  });
+
+  it("warns from doctor when the fallback OpenClaw config has an exact npm install spec", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const command = createLcmCommand({
+      db: fixture.db,
+      config: fixture.config,
+      openClawConfig: {
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+            },
+          },
+          slots: {
+            contextEngine: "lossless-claw",
+          },
+          installs: {
+            "lossless-claw": {
+              source: "npm",
+              spec: "@martian-engineering/lossless-claw@0.12.0",
+              version: "0.12.0",
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(
+      createCommandContext("doctor", {
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+              },
+            },
+            slots: {
+              contextEngine: "lossless-claw",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.text).toContain("🩺 Lossless Claw Doctor");
+    expect(result.text).toContain("**⚠️ Update track**");
+    expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
+  });
+
   it("surfaces rollover split memory from the default status command", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);


### PR DESCRIPTION
## Summary

This PR adds an LCM-side guardrail for the update-track failure described in #910.

Historically, LCM followed OpenClaw plugin update sync during `openclaw update`. After an exact-version install or force reinstall such as:

```bash
openclaw plugins install @martian-engineering/lossless-claw@0.12.0 --force
```

OpenClaw records the exact package spec. From that point forward, plugin update sync can correctly-but-surprisingly keep resolving the same exact version, so `openclaw plugins update lossless-claw --dry-run` can report “up to date” even when npm has a newer LCM release. Explicitly moving the install track back to the npm dist-tag works:

```bash
openclaw plugins update @martian-engineering/lossless-claw@latest
```

## Long-Term Shape

The intended long-term default for routine LCM installs should be the moving stable track:

```bash
openclaw plugins install @martian-engineering/lossless-claw@latest
```

Exact versions are still useful, but they should mean “pin this version for rollback, reproducible canary testing, or incident containment.” They should not be the documented steady-state install shape for users who expect `openclaw update` to keep LCM current.

This PR treats `@latest` as the correct durable LCM-side answer and makes exact pins visible when they are likely to surprise users.

## What Changed

- `/lossless` status now warns when OpenClaw metadata shows `lossless-claw` installed from an exact npm package spec such as `@martian-engineering/lossless-claw@0.12.0`.
- `/lossless doctor` shows the same warning, including the repair command:

```bash
openclaw plugins update @martian-engineering/lossless-claw@latest
```

- Command handling now receives the plugin registration OpenClaw config snapshot as a fallback metadata source, so the warning can still fire when the command context itself does not include install metadata.
- README and configuration docs now document `@latest` as the routine install/update track and frame exact versions as rollback/canary pins.
- Regression tests cover exact-version warnings, moving `@latest` silence, and fallback config detection.

## Correctness Boundary

This is the right LCM-side fix if OpenClaw’s current behavior is intentional: exact npm specs are pins, and moving specs/dist-tags are update tracks.

The deeper platform-level fix, if desired, belongs in OpenClaw: make plugin update track state first-class, separate “desired spec” from “resolved installed version,” or have OpenClaw warn/repair exact official-plugin specs during `openclaw update` / `openclaw doctor`. LCM should not silently rewrite its own plugin install record from inside the plugin runtime.

## User Impact

- Existing users pinned to an exact LCM version get a visible warning instead of silently missing future LCM releases.
- New installs following the docs land on the moving stable track.
- Users who intentionally pin for rollback or canary testing can keep doing that; the warning is informational and includes the command to return to the stable track.

## Test Plan

- `npm exec vitest -- run test/lcm-command.test.ts`
- `npm run typecheck`
- `npm run build`
- GitHub CI: `test`, `plugin-inspector`, `smoke-latest-openclaw`

Fixes #910
