### PR TITLE
[codex] Fix lossless slash command alias drift

### DIFF
--- a/.changeset/lucky-command-aliases.md
+++ b/.changeset/lucky-command-aliases.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare the `/lossless` and `/lcm` runtime slash commands in plugin metadata and align command docs around `/lossless` as the primary command.

--- a/README.md
+++ b/README.md
@@ -33,27 +33,28 @@ Nothing is lost. Raw messages stay in the database. Summaries link back to their
 
 The plugin now ships a bundled `lossless-claw` skill plus a small plugin command surface for supported OpenClaw chat/native command providers:
 
-- `/lcm` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
-- `/lcm backup` creates a timestamped backup of the current LCM SQLite database
-- `/lcm rotate` rewrites the active session transcript into a compact tail-preserving form without changing the live OpenClaw session identity or current LCM conversation
-- `/lcm doctor` scans for broken or truncated summaries
-- `/lcm doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
-- `/lcm status` shows plugin, conversation, and maintenance state including deferred compaction debt
-- `/lossless` is an alias for `/lcm` on supported native command surfaces
+- `/lossless` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
+- `/lossless backup` creates a timestamped backup of the current LCM SQLite database
+- `/lossless rotate` rewrites the active session transcript into a compact tail-preserving form without changing the live OpenClaw session identity or current LCM conversation
+- `/lossless doctor` scans for broken or truncated summaries
+- `/lossless doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
+- `/lossless status` shows plugin, conversation, and maintenance state including deferred compaction debt
+- `/lcm` is the shorter alias for `/lossless`
 
 These are plugin slash/native commands, not root shell CLI subcommands. Supported examples:
 
-- `/lcm`
-- `/lcm backup`
-- `/lcm rotate`
-- `/lcm doctor`
-- `/lcm doctor clean`
 - `/lossless`
+- `/lossless backup`
+- `/lossless rotate`
+- `/lossless doctor`
+- `/lossless doctor clean`
+- `/lcm`
 
 Not currently supported as root CLI commands:
 
-- `openclaw lcm`
 - `openclaw lossless`
+- `openclaw lcm`
+- `openclaw /lossless`
 - `openclaw /lcm`
 
 The bundled skill focuses on configuration, diagnostics, architecture, and recall-tool usage. Its reference set lives under `skills/lossless-claw/references/`.
@@ -313,7 +314,7 @@ For large sessions, neither command is a perfect “keep my live agent context, 
 - `/new` keeps writing into the same active LCM conversation row.
 - `/reset` changes OpenClaw session flow, which is heavier than users often want when their real problem is just LCM row size.
 
-`/lcm rotate` fills that gap. Before trimming the transcript, it forces leaf-only compaction for raw context outside the preserved live tail so older transcript messages are represented by LCM summaries. It then replaces one rolling `rotate-latest` SQLite backup, rewrites the current session transcript down to the preserved live tail plus current session settings, and refreshes the bootstrap frontier on the same active LCM conversation so dropped transcript history is not replayed. Existing durable messages, summaries, context items, and conversation identity stay in place; only the transcript backing is compacted. If you want additional timestamped snapshots instead, run `/lcm backup`.
+`/lossless rotate` fills that gap. Before trimming the transcript, it forces leaf-only compaction for raw context outside the preserved live tail so older transcript messages are represented by LCM summaries. It then replaces one rolling `rotate-latest` SQLite backup, rewrites the current session transcript down to the preserved live tail plus current session settings, and refreshes the bootstrap frontier on the same active LCM conversation so dropped transcript history is not replayed. Existing durable messages, summaries, context items, and conversation identity stay in place; only the transcript backing is compacted. If you want additional timestamped snapshots instead, run `/lossless backup`.
 
 `newSessionRetainDepth` (or `LCM_NEW_SESSION_RETAIN_DEPTH`) controls how much summary structure survives `/new`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,17 +176,17 @@ openclaw plugins install --link /path/to/lossless-claw
 | `enableSummaryThinking` | `boolean` | `true` | `LCM_ENABLE_SUMMARY_THINKING` | When true, requests low reasoning budget from the model during summarization calls. Set to false to disable reasoning and keep summarization output concise. |
 | `proactiveThresholdCompactionMode` | `"deferred" \| "inline"` | `"deferred"` | `LCM_PROACTIVE_THRESHOLD_COMPACTION_MODE` | Controls whether proactive threshold compaction is deferred into maintenance debt by default or run inline for legacy behavior. |
 | `autoRotateSessionFiles.enabled` | `boolean` | `true` | `LCM_AUTO_ROTATE_SESSION_FILES_ENABLED` | Enables automatic rotation for oversized LCM-managed session JSONL files. |
-| `autoRotateSessionFiles.createBackups` | `boolean` | `false` | `LCM_AUTO_ROTATE_SESSION_FILES_CREATE_BACKUPS` | Creates or replaces the rolling `rotate-latest` SQLite backup before automatic session-file rotation. Manual `/lcm rotate` backups are always created. |
+| `autoRotateSessionFiles.createBackups` | `boolean` | `false` | `LCM_AUTO_ROTATE_SESSION_FILES_CREATE_BACKUPS` | Creates or replaces the rolling `rotate-latest` SQLite backup before automatic session-file rotation. Manual `/lossless rotate` backups are always created. |
 | `autoRotateSessionFiles.sizeBytes` | `integer` | `2097152` | `LCM_AUTO_ROTATE_SESSION_FILES_SIZE_BYTES` | Byte threshold that triggers automatic session-file rotation. |
 | `autoRotateSessionFiles.startup` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_STARTUP` | Startup behavior for oversized indexed OpenClaw session transcripts that also have active LCM bootstrap state. |
-| `autoRotateSessionFiles.runtime` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME` | Runtime behavior after post-turn checks. Runtime `rotate` logs deferral for active session JSONL rewrites and leaves direct rotation to startup or manual `/lcm rotate`. |
+| `autoRotateSessionFiles.runtime` | `"rotate" \| "warn" \| "off"` | `"rotate"` | `LCM_AUTO_ROTATE_SESSION_FILES_RUNTIME` | Runtime behavior after post-turn checks. Runtime `rotate` logs deferral for active session JSONL rewrites and leaves direct rotation to startup or manual `/lossless rotate`. |
 | `independentLogFile.enabled` | `boolean` | `true` | `LCM_LOG_FILE_ENABLED` | Writes lossless-claw JSONL logs to an independent plugin-owned file in addition to OpenClaw's runtime logger. |
 | `independentLogFile.file` | `string` | `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log` | `LCM_LOG_FILE` | Optional log path. A dated `lossless-claw-YYYY-MM-DD.log` path rolls over daily. |
 | `independentLogFile.maxFileBytes` | `integer` | `104857600` | `LCM_LOG_MAX_FILE_BYTES` | Size threshold for rotating the active lossless-claw log file to `.1.log` through `.5.log`. |
 
 > **Multi-profile note:** `OPENCLAW_STATE_DIR` (set by the host OpenClaw gateway) controls where state is stored. When two gateways run on the same host (e.g. separate bot personas), each gateway sets its own `OPENCLAW_STATE_DIR` and lossless-claw automatically uses that directory for the database, large-file payloads, auth-profile lookups, and legacy secrets — no per-profile plugin config is needed.
 
-Automatic session-file rotation rewrites only the live session transcript, keeps the active LCM conversation and durable history intact, and refreshes the bootstrap checkpoint. Before manual or startup rewrites, rotation forces leaf-only compaction for raw context outside the preserved tail so trimmed transcript messages are covered by LCM summaries without running unrelated summary-condensation passes. Startup rotation first scans OpenClaw's current indexed session stores for configured agents, then intersects those candidates with active LCM conversations and matching bootstrap file mappings. Runtime rotation checks from `afterTurn()` and `maintain()` intentionally do not directly rewrite active session JSONL because embedded prompt-lock fences can still be open while tool-call loops and host background maintenance overlap; runtime `rotate` logs a deferral until startup, manual `/lcm rotate`, or a future host-owned full-transcript rewrite primitive is available. Automatic rotation does not create a SQLite backup by default; set `autoRotateSessionFiles.createBackups` to `true` to make startup rotation create one pre-rotation LCM database backup for the batch before any transcript is rewritten. Manual `/lcm rotate` always keeps its backup-backed behavior regardless of this flag. Rotation never runs for ignored sessions, stateless sessions, or sessions without active LCM state. The preserved JSONL tail follows the existing rotate behavior, which is controlled by `freshTailCount`. Transcript GC uses the host-provided `rewriteTranscriptEntries` primitive and defers until host-approved background maintenance when `transcriptGcEnabled` is enabled.
+Automatic session-file rotation rewrites only the live session transcript, keeps the active LCM conversation and durable history intact, and refreshes the bootstrap checkpoint. Before manual or startup rewrites, rotation forces leaf-only compaction for raw context outside the preserved tail so trimmed transcript messages are covered by LCM summaries without running unrelated summary-condensation passes. Startup rotation first scans OpenClaw's current indexed session stores for configured agents, then intersects those candidates with active LCM conversations and matching bootstrap file mappings. Runtime rotation checks from `afterTurn()` and `maintain()` intentionally do not directly rewrite active session JSONL because embedded prompt-lock fences can still be open while tool-call loops and host background maintenance overlap; runtime `rotate` logs a deferral until startup, manual `/lossless rotate`, or a future host-owned full-transcript rewrite primitive is available. Automatic rotation does not create a SQLite backup by default; set `autoRotateSessionFiles.createBackups` to `true` to make startup rotation create one pre-rotation LCM database backup for the batch before any transcript is rewritten. Manual `/lossless rotate` always keeps its backup-backed behavior regardless of this flag. Rotation never runs for ignored sessions, stateless sessions, or sessions without active LCM state. The preserved JSONL tail follows the existing rotate behavior, which is controlled by `freshTailCount`. Transcript GC uses the host-provided `rewriteTranscriptEntries` primitive and defers until host-approved background maintenance when `transcriptGcEnabled` is enabled.
 
 Lossless-claw writes routine operational JSONL logs by default at `/tmp/openclaw/lossless-claw-YYYY-MM-DD.log`, beside OpenClaw's `/tmp/openclaw/openclaw-YYYY-MM-DD.log`. Routine info and debug lines go to the independent file instead of the shared OpenClaw log. Startup banners and warning/error lines still go through OpenClaw's runtime logger so gateway-level startup and failure diagnostics remain visible. The independent file follows the same practical rotation model as OpenClaw: a dated filename rolls over when the local date changes, stale dated files are pruned after 3 days, and an oversized active file is rotated through `.1.log` to `.5.log`.
 
@@ -380,19 +380,19 @@ Lossless-claw now defaults `proactiveThresholdCompactionMode` to `deferred`.
 - `assemble()` leaves pending threshold debt for after-turn background drain or host-approved `maintain()` while the live prompt is still within budget
 - `assemble()` only consumes pending threshold debt synchronously as an emergency safeguard when the live prompt estimate is already over the active token budget
 - old non-threshold debt from earlier builds is revalidated; if the conversation is no longer over threshold, it is cleared as a no-op
-- `/lcm status` / `/lossless status` shows the current maintenance state, including pending/running/last-failure details
+- `/lossless status` (`/lcm status` alias) shows the current maintenance state, including pending/running/last-failure details
 - status output also surfaces the latest API/cache telemetry as diagnostics, not as a deferral gate
 - set `proactiveThresholdCompactionMode` to `inline` only if you need the legacy inline proactive compaction behavior for compatibility
 
-### `/lcm rotate`
+### `/lossless rotate`
 
-`/lcm rotate` exists for a different use case than `/new` or `/reset`:
+`/lossless rotate` exists for a different use case than `/new` or `/reset`:
 
 - `/new` keeps the same active LCM conversation row and only prunes context.
 - `/reset` changes OpenClaw session flow, which is sometimes more disruptive than users want.
-- `/lcm rotate` keeps the live OpenClaw session identity and the same active LCM conversation row, but rewrites the backing transcript into a compact preserved-tail form.
+- `/lossless rotate` keeps the live OpenClaw session identity and the same active LCM conversation row, but rewrites the backing transcript into a compact preserved-tail form.
 
-Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. It then rewrites the current session transcript and checkpoints the same conversation at the new transcript frontier so bootstrap does not replay the dropped transcript history. Existing summaries, context items, and conversation identity stay in place. If you want additional timestamped snapshots, run `/lcm backup` explicitly before `/lcm rotate`.
+Before rotating, Lossless-claw replaces one rolling `rotate-latest` SQLite backup. It then rewrites the current session transcript and checkpoints the same conversation at the new transcript frontier so bootstrap does not replay the dropped transcript history. Existing summaries, context items, and conversation identity stay in place. If you want additional timestamped snapshots, run `/lossless backup` explicitly before `/lossless rotate`.
 
 ## Environment-only knobs outside plugin config
 
@@ -428,7 +428,7 @@ sqlite3 "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/lcm.db" ".backup ${OPENCLAW_STAT
 Or from a supported OpenClaw chat/native command surface:
 
 ```text
-/lcm backup
+/lossless backup
 ```
 
 ## Disabling lossless-claw

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5,6 +5,16 @@
   "activation": {
     "onStartup": true
   },
+  "commandAliases": [
+    {
+      "name": "lossless",
+      "kind": "runtime-slash"
+    },
+    {
+      "name": "lcm",
+      "kind": "runtime-slash"
+    }
+  ],
   "skills": [
     "skills/lossless-claw"
   ],

--- a/skills/lossless-claw/references/architecture.md
+++ b/skills/lossless-claw/references/architecture.md
@@ -29,7 +29,7 @@ Bad summaries do not stay local:
 
 That is why configuration choices around compaction thresholds and summary model quality matter operationally.
 
-## What `/lcm` tells you
+## What `/lossless` tells you
 
 The MVP command surface focuses on operational facts:
 
@@ -40,7 +40,7 @@ The MVP command surface focuses on operational facts:
 - total summarized source-token coverage when available
 - broken or truncated summary presence
 
-## What `/lcm doctor` tells you
+## What `/lossless doctor` tells you
 
 The MVP doctor flow is diagnostic only.
 
@@ -51,7 +51,7 @@ It looks for known summary-health markers that indicate:
 
 This gives users one place to answer the question “is my summary graph healthy?” without introducing a broader mutation surface.
 
-## What `/lcm doctor clean` tells you
+## What `/lossless doctor clean` tells you
 
 The cleaners flow is also diagnostic first.
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -347,7 +347,7 @@ Why it matters:
 - `deferred` is the default and avoids foreground turn stalls by recording one coalesced maintenance row per conversation
 - `deferred` also stores provider/model/cache telemetry so Anthropic-family sessions can avoid rewriting a still-hot prompt cache
 - `inline` preserves the legacy foreground compaction path for hosts that do not yet support deferred execution
-- `/lossless status` and `/lcm status` surface pending/running/last-failure maintenance state so operators can see when compaction is queued
+- `/lossless status` (`/lcm status` alias) surfaces pending/running/last-failure maintenance state so operators can see when compaction is queued
 - after-turn background drain and host-approved `maintain()` consume routine threshold debt; `assemble()` only drains pending threshold debt synchronously as an emergency safeguard when the live prompt estimate is already over budget
 
 ### `autoRotateSessionFiles`
@@ -365,7 +365,7 @@ Defaults:
 Why it matters:
 
 - prevents very large OpenClaw session JSONL files from choking fallback/gateway startup while LCM owns the durable context
-- runtime rotation only creates or replaces the rolling `rotate-latest` DB backup when `createBackups` is `true`; manual `/lossless rotate` / `/lcm rotate` always keeps its backup-backed behavior
+- runtime rotation only creates or replaces the rolling `rotate-latest` DB backup when `createBackups` is `true`; manual `/lossless rotate` always keeps its backup-backed behavior
 - runtime JSONL rewrites run from `afterTurn()` after the host turn completes; `maintain()` skips rotation and leaves it to `afterTurn()` or startup because background maintenance can overlap an embedded model call
 - startup scans OpenClaw's current indexed session stores for configured agents, intersects those candidates with active LCM bootstrap state, and creates one pre-rotation DB backup for the startup batch only when `createBackups` is `true`
 - only runs for active, writable LCM conversations; ignored sessions, stateless sessions, sessions outside the indexed startup candidate set, and sessions without active LCM state are skipped

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -321,15 +321,24 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
     case "status":
       return rest.length === 0
         ? { kind: "status" }
-        : { kind: "help", error: "`/lcm status` does not accept extra arguments." };
+        : {
+            kind: "help",
+            error: `\`${VISIBLE_COMMAND} status\` does not accept extra arguments.`,
+          };
     case "backup":
       return rest.length === 0
         ? { kind: "backup" }
-        : { kind: "help", error: "`/lcm backup` does not accept extra arguments." };
+        : {
+            kind: "help",
+            error: `\`${VISIBLE_COMMAND} backup\` does not accept extra arguments.`,
+          };
     case "rotate":
       return rest.length === 0
         ? { kind: "rotate" }
-        : { kind: "help", error: "`/lcm rotate` does not accept extra arguments." };
+        : {
+            kind: "help",
+            error: `\`${VISIBLE_COMMAND} rotate\` does not accept extra arguments.`,
+          };
     case "doctor":
       if (rest.length === 0) {
         return { kind: "doctor", apply: false };

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -3549,6 +3549,23 @@ describe("lcm command", () => {
     expect(result.text).toContain("`/lcm` is accepted as a shorter alias.");
   });
 
+  it("uses the visible /lossless command in subcommand argument errors", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const status = await fixture.command.handler(createCommandContext("status extra"));
+    const backup = await fixture.command.handler(createCommandContext("backup extra"));
+    const rotate = await fixture.command.handler(createCommandContext("rotate extra"));
+
+    expect(status.text).toContain("`/lossless status` does not accept extra arguments.");
+    expect(backup.text).toContain("`/lossless backup` does not accept extra arguments.");
+    expect(rotate.text).toContain("`/lossless rotate` does not accept extra arguments.");
+    expect(status.text).not.toContain("`/lcm status` does not accept extra arguments.");
+    expect(backup.text).not.toContain("`/lcm backup` does not accept extra arguments.");
+    expect(rotate.text).not.toContain("`/lcm rotate` does not accept extra arguments.");
+  });
+
   it("accepts db as a lazy function and does not invoke it for help", async () => {
     const dbFn = vi.fn((): never => {
       throw new Error("should not be called for help");

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -135,4 +135,11 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
     expect(manifest.kind).toBe("context-engine");
     expect(manifest.activation?.onStartup).toBe(true);
   });
+
+  it("declares both supported runtime slash commands for lazy activation", () => {
+    expect(manifest.commandAliases).toEqual([
+      { name: "lossless", kind: "runtime-slash" },
+      { name: "lcm", kind: "runtime-slash" },
+    ]);
+  });
 });


### PR DESCRIPTION
## TL;DR

Users currently see a confusing slash-command story:

- `/lossless doctor` works and is the visible/native command path.
- `/lcm` is advertised as the shorter alias, but in a restored live session it returned `Command failed. Please try again later.`
- The installed plugin code says both names exist in different layers: `name: "lcm"`, `nativeNames.default: "lossless"`, `VISIBLE_COMMAND = "/lossless"`, `HIDDEN_ALIAS = "/lcm"`.
- The manifest declares no command ownership for either `lossless` or `lcm`, so OpenClaw's static command owner / lazy activation layer has no durable source of truth for those tokens.
- README/config docs still treated `/lcm` as primary in several places, while runtime help points users to `/lossless help` and says `/lcm` is an alias.

This PR makes `/lossless` the canonical user-facing command, keeps `/lcm` as the short runtime alias, and declares both command tokens in manifest metadata.

Fixes #520.

## User-visible command matrix

| User action | Before this PR | After this PR |
| --- | --- | --- |
| Type `/` in a native/chat command surface | The plugin exposes `nativeNames.default: "lossless"`, but docs still describe `/lcm` as primary. | `/lossless` is documented as the primary visible/native command. |
| Run `/lossless` | Works as the visible Lossless Claw command. | Still works and remains the primary command. |
| Run `/lossless doctor` | Works; this was the command used successfully in the restored-session evidence. | Still works. |
| Run `/lcm` | Advertised as a short alias, but not declared in `openclaw.plugin.json#commandAliases`; on the restored live session it returned `Command failed. Please try again later.` | Declared as a `runtime-slash` command alias so OpenClaw can attribute/activate it consistently. |
| Run `/lcm status`, `/lcm backup`, `/lcm rotate` | Handler intent exists, but user-facing error/help text and docs drift between `/lcm` and `/lossless`. | `/lcm` remains the short alias; canonical guidance and errors point back to `/lossless`. |
| Add `lcm` or `lossless` to `plugins.allow` | Confusing, because neither is a plugin id. | Docs continue to say `plugins.allow` should use `lossless-claw`, not slash command names. |
| Run `openclaw lcm`, `openclaw lossless`, or `openclaw /lcm` as root CLI commands | Not supported root CLI commands. | Still not supported; README now states that clearly with `/lossless` and `/lcm` examples. |

## Root cause

The runtime command registration and the docs were describing different layers:

```ts
return {
  name: "lcm",
  nativeNames: { default: "lossless" },
  acceptsArgs: true,
}
```

The same command module also renders:

```ts
const VISIBLE_COMMAND = "/lossless";
const HIDDEN_ALIAS = "/lcm";
```

That means there are two valid command tokens in practice, but the manifest had no static command metadata:

```json
// before
{
  "activation": { "onStartup": true },
  "skills": ["skills/lossless-claw"]
}
```

OpenClaw uses manifest command aliases for command ownership, diagnostics, and lazy activation planning. Without `commandAliases`, `/lossless` and `/lcm` depend on whether the plugin is already loaded and which command surface is routing the message.

## What changed

- Added manifest command ownership:

```json
"commandAliases": [
  { "name": "lossless", "kind": "runtime-slash" },
  { "name": "lcm", "kind": "runtime-slash" }
]
```

- Kept `/lossless` as the visible/canonical command in docs and help text.
- Kept `/lcm` as the shorter alias.
- Replaced hardcoded `/lcm ...` parser errors for `status`, `backup`, and `rotate` with the shared visible command constant.
- Updated README/config/skill references so `/lossless` is primary and `/lcm` is alias-only.
- Added regression coverage for manifest command alias metadata and canonical error text.
- Added a patch changeset.

## Out of scope

This PR does not try to make every native provider command menu display both `/lossless` and `/lcm`. OpenClaw's plugin command API exposes a single provider-native name through `nativeNames.default`, and this plugin already uses `lossless` for that visible/native name.

The goal here is to remove the inconsistent ownership/docs state: `/lossless` is the visible command, `/lcm` is a declared runtime alias, and `lossless-claw` remains the only plugin id.

## Verification

Local verification from the Lexar worktree:

```text
npm test -- lcm-command.test.ts manifest.test.ts
# 64 passed

npm run build
# passed

git diff --check
# passed
```

GitHub CI on this PR:

```text
test: pass x2
plugin-inspector: pass x2
smoke-latest-openclaw: pass x2
```

Local note: full `npm run typecheck` is blocked in this checkout by missing private `@earendil-works/*` test dependencies, so I did not use it as a local gate.
