### PR TITLE
fix(dedup): align OpenClaw decorated and bare inbound copies by body

### DIFF
--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -5,7 +5,10 @@
  */
 import { buildMessageParts, toStoredMessage, type StoredMessage } from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
-import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
+import {
+  canonicalizeOpenClawInboundMetadataIdentityContent,
+  extractOpenClawInboundBody,
+} from "./openclaw-inbound-metadata.js";
 import type { CreateMessagePartInput } from "./store/conversation-store.js";
 import { extractToolResultIdForPairing } from "./tool-pairing.js";
 import { extractBootstrapMessageCandidate } from "./transcript.js";
@@ -36,7 +39,18 @@ export function readBootstrapMessageFromJsonLine(line: string | null): AgentMess
 }
 
 export function messageIdentity(role: string, content: string): string {
-  return `${role}\u0000${content}`;
+  // In-memory identity for dedup / replay detection / after-turn alignment.
+  // OpenClaw delivers each channel turn in two forms - the live model-facing
+  // copy decorated with injected untrusted-metadata blocks, and the bare
+  // transcript copy - which are the SAME logical message and must align so the
+  // covered-frontier dedup does not persist a duplicate row (issue #912).
+  // Strip the inbound decoration for user content before forming the identity.
+  // This is NOT the persisted identity hash (buildMessageIdentityHash /
+  // canonicalizeOpenClawInboundMetadataIdentityContent / #901); the chat-aware
+  // persisted identity is unchanged, so #901 cross-chat distinction holds.
+  // extractOpenClawInboundBody is a no-op for already-bare content and for
+  // non-user roles, so only the decorated user copy is affected.
+  return `${role}\u0000${extractOpenClawInboundBody(role, content)}`;
 }
 
 export function isBootstrapReplayCandidateMessage(message: AgentMessage): boolean {

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -194,3 +194,43 @@ function getKnownKeysForHeading(heading: string): Set<string> | undefined {
   }
   return undefined;
 }
+
+const OPENCLAW_INBOUND_TIMESTAMP_PREFIX_RE =
+  /^\s*\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}[^\]]*GMT[^\]]*\]\s*/;
+
+const OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE = /^.{1,80}\(untrusted[^)]*\):\s*$/;
+
+/**
+ * Extract the raw user body from an OpenClaw inbound message by dropping every
+ * injected untrusted-metadata block (Conversation info, Sender, Conversation
+ * context, Reply chain/target, Forwarded message context, Thread starter,
+ * Location, ... — the whole family) plus any leading channel timestamp.
+ *
+ * Unlike `canonicalizeOpenClawInboundMetadataIdentityContent` (which preserves
+ * stable metadata so two genuinely different messages keep distinct identity
+ * hashes), this reduces an inbound turn to its body alone. It is used ONLY to
+ * recognize that the bare transcript copy and the decorated model-facing copy
+ * are the same logical turn during flush-lag adoption — it never feeds the
+ * message identity hash, so the chat-aware identity design is unaffected.
+ *
+ * Generic by construction: the builder emits each block as a
+ * "<Label> (untrusted...):" header followed by a fenced JSON body or a list,
+ * with blocks and the body separated by blank lines. Dropping the
+ * header-led segments survives new block types. The one edge is a list entry
+ * that itself contains a blank line; that is safe-by-default (the bodies
+ * simply will not match, so adoption does not fire and nothing is mis-merged).
+ */
+export function extractOpenClawInboundBody(role: string, content: string): string {
+  if (role !== "user" || typeof content !== "string") {
+    return typeof content === "string" ? content : "";
+  }
+  const withoutTimestamp = content.replace(OPENCLAW_INBOUND_TIMESTAMP_PREFIX_RE, "");
+  return withoutTimestamp
+    .split(/\n{2,}/)
+    .filter((segment) => {
+      const firstLine = segment.split("\n", 1)[0] ?? "";
+      return !OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE.test(firstLine);
+    })
+    .join("\n\n")
+    .trim();
+}

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -199,12 +199,14 @@ const OPENCLAW_INBOUND_TIMESTAMP_PREFIX_RE =
   /^\s*\[[A-Za-z]{3}\s+\d{4}-\d{2}-\d{2}[^\]]*GMT[^\]]*\]\s*/;
 
 const OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE = /^.{1,80}\(untrusted[^)]*\):\s*$/;
+const OPENCLAW_GENERATED_CONTEXT_LINE_RE = /^#\d+\s+\S+/;
 
 /**
- * Extract the raw user body from an OpenClaw inbound message by dropping every
- * injected untrusted-metadata block (Conversation info, Sender, Conversation
- * context, Reply chain/target, Forwarded message context, Thread starter,
- * Location, ... — the whole family) plus any leading channel timestamp.
+ * Extract the raw user body from an OpenClaw inbound message by first proving
+ * there is a valid injected metadata preamble, then dropping each leading
+ * untrusted-metadata block (Conversation info, Sender, Conversation context,
+ * Reply chain/target, Forwarded message context, Thread starter, Location, ...
+ * — the whole family) plus any leading channel timestamp before that preamble.
  *
  * Unlike `canonicalizeOpenClawInboundMetadataIdentityContent` (which preserves
  * stable metadata so two genuinely different messages keep distinct identity
@@ -213,24 +215,91 @@ const OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE = /^.{1,80}\(untrusted[^)]*\):\s*$/;
  * are the same logical turn during flush-lag adoption — it never feeds the
  * message identity hash, so the chat-aware identity design is unaffected.
  *
- * Generic by construction: the builder emits each block as a
- * "<Label> (untrusted...):" header followed by a fenced JSON body or a list,
- * with blocks and the body separated by blank lines. Dropping the
- * header-led segments survives new block types. The one edge is a list entry
- * that itself contains a blank line; that is safe-by-default (the bodies
- * simply will not match, so adoption does not fire and nothing is mis-merged).
+ * After the validated Conversation info block, strip only metadata shapes we
+ * can recognize: the optional Sender JSON block and the generated chronological
+ * context list. Bare user text that merely resembles a timestamp or metadata
+ * block is returned exactly unchanged, so adoption fails closed instead of
+ * collapsing distinct messages.
  */
 export function extractOpenClawInboundBody(role: string, content: string): string {
   if (role !== "user" || typeof content !== "string") {
     return typeof content === "string" ? content : "";
   }
-  const withoutTimestamp = content.replace(OPENCLAW_INBOUND_TIMESTAMP_PREFIX_RE, "");
-  return withoutTimestamp
-    .split(/\n{2,}/)
-    .filter((segment) => {
-      const firstLine = segment.split("\n", 1)[0] ?? "";
-      return !OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE.test(firstLine);
-    })
-    .join("\n\n")
-    .trim();
+  const timestampMatch = OPENCLAW_INBOUND_TIMESTAMP_PREFIX_RE.exec(content);
+  const withoutTimestamp = timestampMatch ? content.slice(timestampMatch[0].length) : content;
+  return (
+    extractBodyAfterValidatedOpenClawPreamble(withoutTimestamp) ??
+    extractBodyAfterValidatedOpenClawPreamble(content) ??
+    content
+  );
+}
+
+function extractBodyAfterValidatedOpenClawPreamble(content: string): string | null {
+  const { metadataCandidate } = splitOpenClawInboundMetadataPrelude(content);
+  const conversationCandidate = metadataCandidate.trimStart();
+  const conversationMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(conversationCandidate);
+  const conversationHeading = conversationMatch?.[1] ?? "";
+  const conversationRecord = conversationMatch
+    ? parseOpenClawInboundMetadataRecord(conversationHeading, conversationMatch[2] ?? "")
+    : null;
+  if (
+    !conversationMatch ||
+    conversationHeading !== "Conversation info (untrusted metadata)" ||
+    !conversationRecord
+  ) {
+    return null;
+  }
+
+  let remaining = stripMetadataSeparator(
+    conversationCandidate.slice(conversationMatch[0].length),
+  );
+  remaining = stripOptionalSenderBlock(remaining);
+  remaining = stripOptionalGeneratedContextBlock(remaining);
+  return remaining;
+}
+
+function stripOptionalSenderBlock(content: string): string {
+  const senderCandidate = content.trimStart();
+  const senderMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(senderCandidate);
+  const senderHeading = senderMatch?.[1] ?? "";
+  const senderRecord = senderMatch
+    ? parseOpenClawInboundMetadataRecord(senderHeading, senderMatch[2] ?? "")
+    : null;
+  if (
+    !senderMatch ||
+    senderHeading !== "Sender (untrusted metadata)" ||
+    !senderRecord
+  ) {
+    return content;
+  }
+  return stripMetadataSeparator(senderCandidate.slice(senderMatch[0].length));
+}
+
+function stripOptionalGeneratedContextBlock(content: string): string {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? "";
+  if (!OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE.test(firstLine)) {
+    return content;
+  }
+  const nextSegmentMatch = /\r?\n\r?\n/.exec(content);
+  const segment = nextSegmentMatch ? content.slice(0, nextSegmentMatch.index) : content;
+  if (!isGeneratedOpenClawContextSegment(segment)) {
+    return content;
+  }
+  if (!nextSegmentMatch) {
+    return "";
+  }
+  return stripMetadataSeparator(content.slice(nextSegmentMatch.index + nextSegmentMatch[0].length));
+}
+
+function isGeneratedOpenClawContextSegment(segment: string): boolean {
+  const lines = segment.split(/\r?\n/);
+  const firstLine = lines[0] ?? "";
+  if (!OPENCLAW_UNTRUSTED_BLOCK_HEADER_RE.test(firstLine)) {
+    return false;
+  }
+  const bodyLines = lines.slice(1).filter((line) => line.trim().length > 0);
+  return (
+    bodyLines.length > 0 &&
+    bodyLines.every((line) => OPENCLAW_GENERATED_CONTEXT_LINE_RE.test(line))
+  );
 }

--- a/test/openclaw-inbound-dedup.test.ts
+++ b/test/openclaw-inbound-dedup.test.ts
@@ -1,0 +1,180 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { BatchDeduplicator } from "../src/batch-dedup.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { messageIdentity } from "../src/message-signatures.js";
+import { extractOpenClawInboundBody } from "../src/openclaw-inbound-metadata.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+
+function createStoreFixture() {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+  return { db, store: new ConversationStore(db, { fts5Available }) };
+}
+
+// Deps stub for BatchDeduplicator — only log is needed and align only calls warn.
+const noopDeps = {
+  log: { debug() {}, info() {}, warn() {}, error() {} },
+} as unknown as ConstructorParameters<typeof BatchDeduplicator>[1];
+
+const BODY = "back to Telegram. How is it looking now?";
+
+// The decorated, model-facing copy OpenClaw delivers live: a run of untrusted
+// metadata blocks (Conversation info / Sender / Conversation context) followed
+// by the raw body. The transcript copy is just the raw body.
+function decorated(body: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:527476217",
+      message_id: "1625",
+      sender_id: "527476217",
+      sender: "Gorkem",
+      timestamp: "Thu 2026-06-18 14:24:56 GMT+3",
+      inbound_event_kind: "user_request",
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({ label: "Gorkem (527476217)", id: "527476217", name: "Gorkem" }),
+    "```",
+    "",
+    "Conversation context (untrusted, chronological, selected for current message):",
+    "#1601 Wed 2026-06-17 23:50:44 GMT+3 Gorkem: an earlier message",
+    "#1604 Wed 2026-06-17 23:51:21 GMT+3 Jennifer: an earlier reply",
+    "",
+    body,
+  ].join("\n");
+}
+
+// The decorated form a DIFFERENT chat would deliver for the SAME body — used to
+// pin down that the in-memory dedup identity is body-only (chat distinction is
+// a concern of the persisted identity hash / #901, not this primitive).
+function decoratedFromOtherChat(body: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({ chat_id: "telegram:999999999", sender: "Someone" }),
+    "```",
+    "",
+    body,
+  ].join("\n");
+}
+
+describe("messageIdentity OpenClaw inbound normalization (issue #912)", () => {
+  it("gives a decorated user turn the same in-memory identity as its bare body", () => {
+    expect(messageIdentity("user", decorated(BODY))).toBe(messageIdentity("user", BODY));
+  });
+
+  it("keeps distinct user bodies distinct", () => {
+    expect(messageIdentity("user", decorated(BODY))).not.toBe(
+      messageIdentity("user", "an entirely different request"),
+    );
+  });
+
+  it("does not collapse decorated vs bare for non-user roles", () => {
+    // The inbound normalization is user-only; assistant/tool content is never
+    // decorated, so these forms must remain distinct identities.
+    expect(messageIdentity("assistant", decorated(BODY))).not.toBe(
+      messageIdentity("assistant", BODY),
+    );
+  });
+
+  it("treats same-body decorations from different chats as the same in-memory identity", () => {
+    // messageIdentity is the per-conversation alignment primitive; conversations
+    // are never cross-compared here, so body-only collapse is correct. The
+    // chat-aware persisted hash (buildMessageIdentityHash / #901) is unaffected.
+    expect(messageIdentity("user", decorated(BODY))).toBe(
+      messageIdentity("user", decoratedFromOtherChat(BODY)),
+    );
+  });
+});
+
+describe("alignRuntimeBatchAgainstCoveredFrontier bare-vs-decorated (issue #912)", () => {
+  it("drops the decorated runtime copy when the bare body is the covered-frontier tail", async () => {
+    const { db, store } = createStoreFixture();
+    try {
+      const conversation = await store.createConversation({ sessionId: "tg-align" });
+      // Transcript reconcile flushed the BARE body as the covered-frontier tail.
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BODY,
+        tokenCount: 1,
+      });
+      const dedup = new BatchDeduplicator(store, noopDeps);
+      // The runtime turn delta delivers the SAME message decorated (live copy).
+      const aligned = await dedup.alignRuntimeBatchAgainstCoveredFrontier("tg-align", undefined, [
+        { role: "user", content: decorated(BODY) } as any,
+      ]);
+      // Recognized as already-flushed → nothing left to ingest → no duplicate row.
+      expect(aligned).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps a genuinely new turn whose body differs from the covered-frontier tail", async () => {
+    const { db, store } = createStoreFixture();
+    try {
+      const conversation = await store.createConversation({ sessionId: "tg-align-new" });
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BODY,
+        tokenCount: 1,
+      });
+      const dedup = new BatchDeduplicator(store, noopDeps);
+      const aligned = await dedup.alignRuntimeBatchAgainstCoveredFrontier("tg-align-new", undefined, [
+        { role: "user", content: decorated("a brand new unrelated question") } as any,
+      ]);
+      expect(aligned).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("extractOpenClawInboundBody", () => {
+  it("reduces a decorated telegram message (incl. Conversation context) to its body", () => {
+    expect(extractOpenClawInboundBody("user", decorated(BODY))).toBe(BODY);
+  });
+
+  it("strips a leading channel timestamp (webchat flavor)", () => {
+    expect(
+      extractOpenClawInboundBody("user", "[Thu 2026-06-18 14:23 GMT+3] I've updated the plugins"),
+    ).toBe("I've updated the plugins");
+  });
+
+  it("strips Conversation info + Sender blocks (slack flavor)", () => {
+    const slack = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      JSON.stringify({ chat_id: "user:U1", sender: "g" }),
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      JSON.stringify({ id: "U1", name: "g" }),
+      "```",
+      "",
+      "now we are on Slack",
+    ].join("\n");
+    expect(extractOpenClawInboundBody("user", slack)).toBe("now we are on Slack");
+  });
+
+  it("leaves a bare body unchanged", () => {
+    expect(extractOpenClawInboundBody("user", "just a plain message")).toBe("just a plain message");
+  });
+
+  it("does not strip metadata-looking blocks from non-user roles", () => {
+    expect(extractOpenClawInboundBody("assistant", decorated(BODY))).toBe(decorated(BODY));
+  });
+});

--- a/test/openclaw-inbound-dedup.test.ts
+++ b/test/openclaw-inbound-dedup.test.ts
@@ -66,6 +66,17 @@ function decoratedFromOtherChat(body: string): string {
   ].join("\n");
 }
 
+function userAuthoredMetadataLookingText(body = "please keep this whole note"): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```text",
+    "this is quoted prompt text, not an OpenClaw JSON metadata block",
+    "```",
+    "",
+    body,
+  ].join("\n");
+}
+
 describe("messageIdentity OpenClaw inbound normalization (issue #912)", () => {
   it("gives a decorated user turn the same in-memory identity as its bare body", () => {
     expect(messageIdentity("user", decorated(BODY))).toBe(messageIdentity("user", BODY));
@@ -74,6 +85,35 @@ describe("messageIdentity OpenClaw inbound normalization (issue #912)", () => {
   it("keeps distinct user bodies distinct", () => {
     expect(messageIdentity("user", decorated(BODY))).not.toBe(
       messageIdentity("user", "an entirely different request"),
+    );
+  });
+
+  it("keeps user-authored metadata-looking text distinct from its trailing body", () => {
+    const ordinaryText = userAuthoredMetadataLookingText();
+    expect(messageIdentity("user", ordinaryText)).not.toBe(
+      messageIdentity("user", "please keep this whole note"),
+    );
+  });
+
+  it("keeps decorated user-authored metadata-looking body distinct from its trailing body", () => {
+    const ordinaryText = userAuthoredMetadataLookingText();
+    expect(messageIdentity("user", decorated(ordinaryText))).not.toBe(
+      messageIdentity("user", "please keep this whole note"),
+    );
+    expect(messageIdentity("user", decorated(ordinaryText))).toBe(
+      messageIdentity("user", ordinaryText),
+    );
+  });
+
+  it("keeps user-authored leading whitespace distinct", () => {
+    expect(messageIdentity("user", "  indented code")).not.toBe(
+      messageIdentity("user", "indented code"),
+    );
+  });
+
+  it("keeps timestamp-looking bare user text distinct from the unprefixed body", () => {
+    expect(messageIdentity("user", "[Thu 2026-06-18 14:23 GMT+3] I've updated")).not.toBe(
+      messageIdentity("user", "I've updated"),
     );
   });
 
@@ -140,6 +180,52 @@ describe("alignRuntimeBatchAgainstCoveredFrontier bare-vs-decorated (issue #912)
       db.close();
     }
   });
+
+  it("keeps a new user-authored metadata-looking turn instead of aligning it to the body", async () => {
+    const { db, store } = createStoreFixture();
+    try {
+      const conversation = await store.createConversation({ sessionId: "tg-align-ordinary" });
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "please keep this whole note",
+        tokenCount: 1,
+      });
+      const dedup = new BatchDeduplicator(store, noopDeps);
+      const aligned = await dedup.alignRuntimeBatchAgainstCoveredFrontier(
+        "tg-align-ordinary",
+        undefined,
+        [{ role: "user", content: userAuthoredMetadataLookingText() } as any],
+      );
+      expect(aligned).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps a decorated user-authored metadata-looking body instead of aligning it to the suffix", async () => {
+    const { db, store } = createStoreFixture();
+    try {
+      const conversation = await store.createConversation({ sessionId: "tg-align-decorated-body" });
+      await store.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "please keep this whole note",
+        tokenCount: 1,
+      });
+      const dedup = new BatchDeduplicator(store, noopDeps);
+      const aligned = await dedup.alignRuntimeBatchAgainstCoveredFrontier(
+        "tg-align-decorated-body",
+        undefined,
+        [{ role: "user", content: decorated(userAuthoredMetadataLookingText()) } as any],
+      );
+      expect(aligned).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
 });
 
 describe("extractOpenClawInboundBody", () => {
@@ -147,9 +233,10 @@ describe("extractOpenClawInboundBody", () => {
     expect(extractOpenClawInboundBody("user", decorated(BODY))).toBe(BODY);
   });
 
-  it("strips a leading channel timestamp (webchat flavor)", () => {
+  it("strips a leading channel timestamp only when validated OpenClaw metadata follows", () => {
+    const withTimestamp = `[Thu 2026-06-18 14:23 GMT+3] ${decorated("I've updated the plugins")}`;
     expect(
-      extractOpenClawInboundBody("user", "[Thu 2026-06-18 14:23 GMT+3] I've updated the plugins"),
+      extractOpenClawInboundBody("user", withTimestamp),
     ).toBe("I've updated the plugins");
   });
 
@@ -172,6 +259,21 @@ describe("extractOpenClawInboundBody", () => {
 
   it("leaves a bare body unchanged", () => {
     expect(extractOpenClawInboundBody("user", "just a plain message")).toBe("just a plain message");
+  });
+
+  it("leaves timestamp-looking bare user text unchanged", () => {
+    const body = "[Thu 2026-06-18 14:23 GMT+3] I've updated the plugins";
+    expect(extractOpenClawInboundBody("user", body)).toBe(body);
+  });
+
+  it("leaves user-authored metadata-looking bare text unchanged", () => {
+    const body = userAuthoredMetadataLookingText();
+    expect(extractOpenClawInboundBody("user", body)).toBe(body);
+  });
+
+  it("preserves user-authored metadata-looking body after real OpenClaw metadata", () => {
+    const body = userAuthoredMetadataLookingText();
+    expect(extractOpenClawInboundBody("user", decorated(body))).toBe(body);
   });
 
   it("does not strip metadata-looking blocks from non-user roles", () => {


### PR DESCRIPTION
Fixes #912.

OpenClaw delivers each channel turn in two forms: a live model-facing copy decorated with injected untrusted-metadata blocks (Conversation info, Sender, Conversation context, and the rest of the family) and the bare transcript copy. After-turn dedup decides whether to persist the live runtime copy by aligning it against the persisted transcript tail with the in-memory signature `messageIdentity(role, content)`, which compared the raw content. The decorated copy's raw content never matched the bare transcript row, so the alignment treated it as unflushed and ingested it as a second row (`transcript_entry_id` NULL). Because the assembler replays stored rows verbatim, every channel turn rendered to the model twice across Slack, Telegram, and webchat.

This makes `messageIdentity` strip the inbound decoration for user content via `extractOpenClawInboundBody` before forming the in-memory signature, so the decorated and bare forms align and only one row persists.

Key points:

- In-memory dedup signature only. The persisted identity hash (`buildMessageIdentityHash`, and `canonicalizeOpenClawInboundMetadataIdentityContent` from #901) is unchanged, so #901's cross-chat distinction is preserved and its identity tests still pass.
- `extractOpenClawInboundBody` is structural: strip a leading channel timestamp, then drop untrusted-metadata-header segments. It is robust to the full block family and to new block types, and it is a no-op for already-bare content and for non-user roles, so only the decorated user copy is affected.
- Tests: `messageIdentity` normalization units, an `alignRuntimeBatchAgainstCoveredFrontier` integration test, and `extractOpenClawInboundBody` units. Full suite green.

Verified against real stored rows from a live deployment: the change collapses Slack, Telegram (including the `Conversation context` block), and webchat decorated copies onto their bare counterparts, and post-deploy channel turns persist a single row per turn.

Supersedes #890, which normalized only the bare-brace `Conversation info` form in the persisted normalizer and predated #901.
