### PR TITLE
fix: clear summary spend backoff on force compaction

### DIFF
--- a/.changeset/force-compaction-backoff.md
+++ b/.changeset/force-compaction-backoff.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Allow forced compaction recovery to clear summary spend backoff so overflow repair is not blocked by an earlier failed summary attempt.

--- a/src/compaction-guards.ts
+++ b/src/compaction-guards.ts
@@ -145,9 +145,9 @@ export class CompactionGuards {
 
   /**
    * Clear an open spend backoff for a scope, returning the prior expiry if
-   * one was open. Used by user-initiated compaction: an explicit repair
-   * request is informed consent to spend, so it must not silently no-op
-   * behind a backoff opened by an earlier automatic attempt.
+   * one was open. Used by manual compaction and force-driven recovery:
+   * manual repair is informed consent to spend, and force-driven repair must
+   * not silently no-op behind a backoff opened by an earlier automatic attempt.
    */
   clearSummarySpendBackoff(scopeKey: string): Date | null {
     const state = this.summarySpendGuardStates.get(scopeKey);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1027,11 +1027,16 @@ export class LcmContextEngine implements ContextEngine {
       kind: "compaction",
       scope: compactionScope,
     });
-    if (manualCompactionRequested) {
+    // Clear summary spend backoff on manual compaction or force compaction.
+    // force:true is used by overflow recovery and other internal paths that
+    // should not be blocked by an active spend backoff.  Without this, a
+    // previous backoff can prevent overflow recovery from compacting, causing
+    // a context-overflow crash loop.
+    if (manualCompactionRequested || force) {
       const clearedBackoffUntil = this.compactionGuards.clearSummarySpendBackoff(summarySpendScopeKey);
       if (clearedBackoffUntil) {
         this.deps.log.info(
-          `[lcm] compact: manual request cleared summary spend backoff conversation=${params.conversationId} ${sessionLabel} scope=${summarySpendScopeKey} previousBackoffUntil=${clearedBackoffUntil.toISOString()}`,
+          `[lcm] compact: ${manualCompactionRequested ? "manual request" : "force compaction"} cleared summary spend backoff conversation=${params.conversationId} ${sessionLabel} scope=${summarySpendScopeKey} previousBackoffUntil=${clearedBackoffUntil.toISOString()}`,
         );
       }
     }

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -2230,7 +2230,7 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(executeSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("poor-reduction spend backoff blocks custom summarizers in the same compaction scope", async () => {
+  it("force compaction clears poor-reduction spend backoff for custom summarizers in the same scope", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-31T12:35:00.000Z"));
     try {

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -2270,6 +2270,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
       expect(first.reason).toBe("could not reach target");
       expect(summarize).toHaveBeenCalledTimes(1);
 
+      // force:true clears the spend backoff before compaction, so a
+      // second force-driven call proceeds instead of being blocked.
+      // The backoff is still set by the first call's failure, but force
+      // overrides it (overflow recovery and other forced paths must not
+      // be blocked by a spend backoff).
       const second = await engine.compact({
         sessionId,
         sessionFile: createSessionFilePath("custom-summarizer-poor-reduction-backoff-retry"),
@@ -2278,8 +2283,8 @@ describe("LcmContextEngine fidelity and token budget", () => {
         force: true,
         legacyParams: { summarize },
       });
-      expect(second.reason).toBe("summary spend backoff open");
-      expect(summarize).toHaveBeenCalledTimes(1);
+      expect(second.reason).toBe("could not reach target");
+      expect(summarize).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

Addresses #902.

Overflow recovery calls `compact({ force: true })`, but the existing summary-spend backoff clearing only recognized `legacyParams.manualCompaction === true`. OpenClaw's overflow-recovery runtime context does not set that manual flag, so a stale `summary spend backoff open` state could block forced recovery and leave the conversation in a context-overflow crash loop.

## What changed

- Clear the summary-spend backoff when compaction is explicitly forced (`manualCompactionRequested || force`).
- Keep ordinary/non-force compaction behavior unchanged, so regular deferred maintenance still respects spend backoff.
- Improve the log message to distinguish `manual request` from `force compaction` when a backoff is cleared.

## Validation

- Updated the existing poor-reduction spend-backoff regression so the first forced compaction opens the backoff and a second `force: true` compaction proceeds instead of returning `summary spend backoff open`.
- GitHub Actions on head `7448e6f8dafc275263479eefee71854ade9c1e28` are green: `test`, `plugin-inspector`, and `smoke-latest-openclaw`.

## Notes

This intentionally does not clear auth circuit breakers or change the non-force spend guard. Forced compaction remains bounded by the existing compaction round/deadline limits.
