### PR TITLE
fix: recover afterTurn from transient transcript ENOENT

### DIFF
--- a/.changeset/soft-owls-reload.md
+++ b/.changeset/soft-owls-reload.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Retry transient ENOENT while reconciling afterTurn transcripts so plugin reload races do not preserve offset-0 checkpoints and skip durable catchup for active session files.

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -68,6 +68,16 @@ const FLUSH_LAG_ADOPTION_TAIL_WINDOW = 16;
 // rather than scan an arbitrarily large real DB tail (#649 no-proof-no-advance).
 const NON_ANCHORING_FRONTIER_SCAN_LIMIT = 32;
 
+// A hot plugin/runtime reload can race the host session registry and produce a
+// transient ENOENT for a transcript that is still being written. Retry once
+// before taking the sticky missing-file branch so active sessions do not spend a
+// turn preserving an offset-0 checkpoint and skipping durable transcript catchup.
+const TRANSIENT_SESSION_FILE_MISSING_RETRY_MS = 25;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // No-anchor recovery reasons that can proceed from checkpoint/frontier metadata
 // instead of a content anchor. Block them if raw IDs are already owned by another
 // active conversation.
@@ -2072,6 +2082,7 @@ export class TranscriptReconciler {
         await this.refreshBootstrapState({
           conversationId: conversation.conversationId,
           sessionFile: params.sessionFile,
+          fileStats: sessionFileState,
         });
         rememberSlowReadState();
       } else {
@@ -2189,6 +2200,7 @@ export class TranscriptReconciler {
     await this.refreshBootstrapState({
       conversationId: conversation.conversationId,
       sessionFile: params.sessionFile,
+      fileStats: sessionFileState,
     });
     rememberSlowReadState();
     this.host.deps.log.warn(
@@ -2247,14 +2259,30 @@ export class TranscriptReconciler {
     );
     let sessionFileState: { size: number; mtimeMs: number } | undefined;
     let sessionFileStatError: unknown;
-    try {
+    const captureSessionFileState = async (): Promise<void> => {
       const sessionFileStats = await stat(params.sessionFile);
       sessionFileState = {
         size: sessionFileStats.size,
         mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
       };
+      sessionFileStatError = undefined;
+    };
+    try {
+      await captureSessionFileState();
     } catch (error) {
       sessionFileStatError = error;
+      // A just-reloaded plugin can observe a transient ENOENT while the host is
+      // republishing the active session file path. Retry once before treating an
+      // existing checkpoint as missing/stale; this keeps long-lived writers from
+      // falling into the sticky "preserve offset=0" recovery lane (#916).
+      if (isMissingFileError(error)) {
+        await delay(TRANSIENT_SESSION_FILE_MISSING_RETRY_MS);
+        try {
+          await captureSessionFileState();
+        } catch (retryError) {
+          sessionFileStatError = retryError;
+        }
+      }
       // Leave undefined: without stat proof, do not use append-only guards or slow-read caps.
     }
     const transcriptEpochShrank = checkpointIsPastTranscriptEof(

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -1725,6 +1725,78 @@ describe("LcmContextEngine fidelity and token budget", () => {
     expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
   });
 
+  it("retries transient ENOENT before preserving an offset-0 afterTurn checkpoint (#916)", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      {
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+      },
+    );
+    const sessionId = "after-turn-transient-enoent-retry";
+    const sessionKey = "agent:main:test:after-turn-transient-enoent-retry";
+    const sessionFile = createSessionFilePath("after-turn-transient-enoent-retry");
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: "first user turn" }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: "first assistant turn" }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    setTimeout(() => {
+      writeLeafTranscript(sessionFile, [
+        { role: "user", content: "first user turn" },
+        { role: "assistant", content: "first assistant turn" },
+        { role: "user", content: "second user turn after reload" },
+        { role: "assistant", content: "second assistant turn after reload" },
+      ]);
+    }, 5);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "second assistant turn after reload" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    expect(
+      warnLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("session file missing; skipping transcript reconcile")),
+    ).toBe(false);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "first user turn",
+      "first assistant turn",
+      "second user turn after reload",
+      "second assistant turn after reload",
+    ]);
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint?.lastProcessedOffset).toBe(statSync(sessionFile).size);
+  });
+
   it("bootstrap imports a bounded path-mismatched transcript with no old anchor as a new epoch", async () => {
     const engine = createEngine();
     const sessionId = "bootstrap-transcript-epoch-no-anchor";


### PR DESCRIPTION
Fixes #916

## Summary
- Retry a transient ENOENT once before afterTurn treats an active transcript as missing.
- Reuse the successful stat result when refreshing slow-path checkpoints to avoid a second stat race.
- Add a regression test covering a plugin reload/session registry race where the transcript appears during the retry window.

## Verification
- `npm test -- --run test/engine-fidelity.test.ts -t "transient ENOENT"`
- `npm run typecheck`
- `npm run build`
