### PR TITLE
fix(reconcile): recover offset-0 placeholder sessions with un-addressed or room-event frontiers

### DIFF
--- a/.changeset/lucky-frontiers-recover.md
+++ b/.changeset/lucky-frontiers-recover.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Recover stuck afterTurn reconciliation for OpenClaw room-event and unaddressed Delivery frontiers so compaction can resume from placeholder or checkpoint-missing sessions.

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -122,16 +122,17 @@ export function canonicalizeOpenClawInboundMetadataIdentityContent(
  * (untrusted metadata)" block is present (located through the same optional
  * "[OpenClaw room event]" header and "Delivery:" prelude the rest of this
  * module handles) AND the parsed metadata is either an explicit room event, or
- * a clearly un-addressed delivery (explicitly_mentioned_bot === false AND
- * mention_source === "none").
+ * a clearly un-addressed group delivery (is_group_chat === true AND
+ * explicitly_mentioned_bot === false AND mention_source === "none").
  *
  * SAFETY (#824 contamination zone): under-match is the safe direction. Any
  * parse failure, a missing/unexpected flag, an addressed turn
  * (explicitly_mentioned_bot === true or mention_source !== "none"), or a
- * non-user role returns false. The un-addressed case requires BOTH fields; if
- * mention_source is absent we do NOT treat the row as ambient unless the event
- * is an explicit room_event. A real directed turn is never misclassified as
- * ambient regardless of its trailing body.
+ * non-user role returns false. The un-addressed case requires the explicit
+ * group-chat flag plus BOTH mention fields; if any are absent we do NOT treat
+ * the row as ambient unless the event is an explicit room_event. A real
+ * directed turn is never misclassified as ambient regardless of its trailing
+ * body.
  */
 export function isOpenClawAmbientInboundRecord(role: string, content: string): boolean {
   if (role !== "user") {
@@ -161,6 +162,10 @@ export function isOpenClawAmbientInboundRecord(role: string, content: string): b
 
   if (record.inbound_event_kind === "room_event") {
     return true;
+  }
+
+  if (record.is_group_chat !== true) {
+    return false;
   }
 
   const mentioned = record.explicitly_mentioned_bot;

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -1,6 +1,14 @@
 const OPENCLAW_INBOUND_METADATA_BLOCK_RE =
   /^(Conversation info \(untrusted metadata\)|Sender \(untrusted metadata\)):\r?\n```json\r?\n([\s\S]*?)\r?\n```/;
 
+// OpenClaw-version-coupled inbound decoration string: the header an OpenClaw
+// runtime prepends to a user turn that carries an ambient room event (channel
+// chatter the agent was not directly addressed by). Treated like the Delivery
+// prelude, a non-anchoring wrapper (not real user content).
+const OPENCLAW_ROOM_EVENT_HEADER = "[OpenClaw room event]";
+
+const CONVERSATION_INFO_HEADING = "Conversation info (untrusted metadata):";
+
 const CONVERSATION_INFO_KEYS = new Set([
   "chat_id",
   "message_id",
@@ -101,6 +109,69 @@ export function canonicalizeOpenClawInboundMetadataIdentityContent(
   return remaining.trim().length > 0
     ? `${prelude}${canonicalBlocks.join("\n\n")}\n\n${remaining}`
     : content;
+}
+
+/**
+ * True only when a user row is an OpenClaw AMBIENT (non-anchoring) inbound
+ * delivery, decided by the injected inbound metadata rather than the trailing
+ * body. Such a row anchors no directed conversation, so a stuck offset-0
+ * placeholder / checkpoint-missing frontier built only from these rows can
+ * recover instead of freezing.
+ *
+ * Returns true ONLY when role === "user" AND a parseable "Conversation info
+ * (untrusted metadata)" block is present (located through the same optional
+ * "[OpenClaw room event]" header and "Delivery:" prelude the rest of this
+ * module handles) AND the parsed metadata is either an explicit room event, or
+ * a clearly un-addressed delivery (explicitly_mentioned_bot === false AND
+ * mention_source === "none").
+ *
+ * SAFETY (#824 contamination zone): under-match is the safe direction. Any
+ * parse failure, a missing/unexpected flag, an addressed turn
+ * (explicitly_mentioned_bot === true or mention_source !== "none"), or a
+ * non-user role returns false. The un-addressed case requires BOTH fields; if
+ * mention_source is absent we do NOT treat the row as ambient unless the event
+ * is an explicit room_event. A real directed turn is never misclassified as
+ * ambient regardless of its trailing body.
+ */
+export function isOpenClawAmbientInboundRecord(role: string, content: string): boolean {
+  if (role !== "user") {
+    return false;
+  }
+
+  let metadataBearing = content.trimStart();
+  if (metadataBearing.startsWith(OPENCLAW_ROOM_EVENT_HEADER)) {
+    const headingIndex = metadataBearing.indexOf(CONVERSATION_INFO_HEADING);
+    if (headingIndex === -1) {
+      return false;
+    }
+    metadataBearing = metadataBearing.slice(headingIndex);
+  }
+
+  const { metadataCandidate } = splitOpenClawInboundMetadataPrelude(metadataBearing);
+  const conversationCandidate = metadataCandidate.trimStart();
+  const conversationMatch = OPENCLAW_INBOUND_METADATA_BLOCK_RE.exec(conversationCandidate);
+  if (!conversationMatch || conversationMatch[1] !== "Conversation info (untrusted metadata)") {
+    return false;
+  }
+
+  const record = parseOpenClawInboundMetadataRecord(conversationMatch[1], conversationMatch[2] ?? "");
+  if (!record) {
+    return false;
+  }
+
+  if (record.inbound_event_kind === "room_event") {
+    return true;
+  }
+
+  const mentioned = record.explicitly_mentioned_bot;
+  const mentionSource = record.mention_source;
+  if (mentioned === true) {
+    return false;
+  }
+  if (mentionSource !== undefined && mentionSource !== "none") {
+    return false;
+  }
+  return mentioned === false && mentionSource === "none";
 }
 
 function splitOpenClawInboundMetadataPrelude(content: string): {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -28,6 +28,7 @@ import {
   toStoredMessage,
   type StoredMessage,
 } from "./message-content.js";
+import { isOpenClawAmbientInboundRecord } from "./openclaw-inbound-metadata.js";
 import {
   createBootstrapEntryHash,
   createLosslessMessageSignature,
@@ -523,7 +524,11 @@ export class TranscriptReconciler {
     });
     return (
       frontier.length === existingMessageCount &&
-      frontier.every((message) => isLikelyInjectedMetadataPreambleRecord(message))
+      frontier.every(
+        (message) =>
+          isLikelyInjectedMetadataPreambleRecord(message) ||
+          isOpenClawAmbientInboundRecord(message.role, message.content),
+      )
     );
   }
 
@@ -2102,9 +2107,22 @@ export class TranscriptReconciler {
     // bootstrapped_at alone as lineage proof. The downstream no-anchor
     // import path is itself guarded (replay-overlap detection, import cap,
     // delivery-only block).
+    // An idle-created channel session carries an ALL-ZERO placeholder
+    // bootstrap_state row, so a row EXISTS and reason resolves to
+    // "append-only-ineligible", never "checkpoint-missing". Both lanes were
+    // never ingested, so the slow path treats the placeholder like a missing
+    // checkpoint and recovers via the same non-anchoring-frontier guard the
+    // checkpoint-missing lane uses; otherwise the frontier freezes forever.
+    const placeholderCheckpoint =
+      !!checkpoint &&
+      checkpoint.lastSeenSize === 0 &&
+      checkpoint.lastSeenMtimeMs === 0 &&
+      checkpoint.lastProcessedOffset === 0 &&
+      checkpoint.lastProcessedEntryHash === null;
+    const neverIngestedCheckpoint = reason === "checkpoint-missing" || placeholderCheckpoint;
     let checkpointMissingMetadataFrontier = false;
     if (
-      reason === "checkpoint-missing" &&
+      neverIngestedCheckpoint &&
       conversation.sessionId === params.sessionId &&
       conversation.bootstrappedAt !== null
     ) {
@@ -2112,7 +2130,7 @@ export class TranscriptReconciler {
         await this.conversationFrontierIsEntirelyNonAnchoring(conversation.conversationId);
     }
     const recoverCheckpointMissingNoAnchor =
-      reason === "checkpoint-missing" &&
+      neverIngestedCheckpoint &&
       (params.allowNoAnchorImportOnCheckpointMissing === true ||
         checkpointMissingMetadataFrontier);
     // A transcript whose session header id differs from the checkpoint's
@@ -2155,7 +2173,9 @@ export class TranscriptReconciler {
       noAnchorImportReason: recoverCheckpointMissingNoAnchor
         ? params.allowNoAnchorImportOnCheckpointMissing === true
           ? "rotate-checkpoint-missing"
-          : "checkpoint-missing-recovery"
+          : reason === "checkpoint-missing"
+            ? "checkpoint-missing-recovery"
+            : "placeholder-checkpoint-recovery"
         : declaredEpochRollover && reason === "append-only-ineligible"
           ? "declared-epoch-rollover"
           : reason,

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -2186,6 +2186,25 @@ describe("LcmContextEngine afterTurn", () => {
     '[{"sender":"sam.rivera","body":"/new"}]\n' +
     "```\n\n" +
     ":white_check_mark: New session started.";
+  // A 1:1/direct delivery can be real user content even when no explicit bot
+  // mention is needed. The un-addressed relaxation is channel/group-only.
+  const UNADDRESSED_DIRECT_FRONTIER_ROW =
+    "Delivery: Final assistant text is not automatically delivered in this run. " +
+    "Use the `message` tool to send user-visible output.\n\n" +
+    "Conversation info (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "chat_id": "dm:D0CHANNEL1",\n' +
+    '  "conversation_label": "sam.rivera",\n' +
+    '  "sender": "sam.rivera",\n' +
+    '  "inbound_event_kind": "user_request",\n' +
+    '  "is_group_chat": false,\n' +
+    '  "explicitly_mentioned_bot": false,\n' +
+    '  "mention_source": "none",\n' +
+    '  "history_count": 0\n' +
+    "}\n" +
+    "```\n\n" +
+    "Please summarize the deploy status.";
   // An ADDRESSED user turn: same Delivery shape, but the metadata says the bot
   // was directly addressed (explicitly_mentioned_bot:true / mention_source:reply)
   // and a real user question trails the metadata. MUST classify as anchoring.
@@ -2502,6 +2521,71 @@ describe("LcmContextEngine afterTurn", () => {
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((m) => m.content)).toEqual([ADDRESSED_FRONTIER_ROW]);
+    const state = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(state?.lastProcessedOffset).toBe(0);
+  });
+
+  it("afterTurn STILL freezes an unaddressed direct-message frontier without group-channel proof", async () => {
+    // In a direct chat, "not explicitly mentioned" does not prove ambient
+    // channel chatter. The no-anchor relaxation must remain group-only so a DM
+    // frontier with real user content cannot unlock divergent transcript import.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "session-unaddressed-direct-still-freezes";
+    const sessionKey = "agent:agent-two:dm:direct-frontier";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: UNADDRESSED_DIRECT_FRONTIER_ROW }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+
+    const sessionFile = createSessionFilePath("session-unaddressed-direct-still-freezes");
+    const txLine = (role: AgentMessage["role"], text: string) =>
+      `${JSON.stringify({ message: { role, content: [{ type: "text", text }] } })}\n`;
+    writeFileSync(
+      sessionFile,
+      `not-json\n${txLine("user", "divergent direct question")}${txLine(
+        "assistant",
+        "divergent direct answer",
+      )}`,
+      "utf8",
+    );
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "divergent direct answer" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([UNADDRESSED_DIRECT_FRONTIER_ROW]);
     const state = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -191,7 +191,7 @@ describe("LcmContextEngine afterTurn", () => {
   it("afterTurn keeps a 24+ char user message that only collides as a substring of the summary narrative (F6)", async () => {
     // PR-6 #566 / F6: bare summary.includes(content) was too loose. A medium-
     // length user instruction that coincidentally appears inside a long
-    // narrative summary must NOT be silently dropped — only anchored or
+    // narrative summary must NOT be silently dropped; only anchored or
     // quoted matches count as covered.
     const engine = createEngine();
     const sessionId = "after-turn-summary-substring-collision";
@@ -228,7 +228,7 @@ describe("LcmContextEngine afterTurn", () => {
 
   it("afterTurn drops a user message when the summary ends with that exact content (F6 anchored)", async () => {
     // Anchored truth case: content appears at the end of the summary's
-    // normalized text — that's a real coverage signal, drop the dup.
+    // normalized text, that's a real coverage signal, drop the dup.
     const engine = createEngine();
     const sessionId = "after-turn-summary-suffix-anchored";
     const repeatedInstruction = "kick off the workers and check back in an hour";
@@ -1435,7 +1435,7 @@ describe("LcmContextEngine afterTurn", () => {
   it("afterTurn fails closed when the transcript reconcile throws: no batch persistence, no checkpoint advance", async () => {
     // The catch handler used to leave the initialized in-sync default in place,
     // so a thrown reconcile persisted the live batch AND refreshed the
-    // checkpoint to EOF — silently advancing past transcript history that was
+    // checkpoint to EOF, silently advancing past transcript history that was
     // never reconciled.
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(
@@ -1561,7 +1561,7 @@ describe("LcmContextEngine afterTurn", () => {
       .getConversationStore()
       .getMessages(conversation!.conversationId);
     const contents = messages.map((m) => m.content);
-    // Full transcript imported, including content PAST the cap of 50 — proving
+    // Full transcript imported, including content PAST the cap of 50, proving
     // the cap bypass for the proven-non-anchoring frontier.
     expect(contents).toContain("general recovery transcript turn 0");
     expect(contents).toContain("general recovery transcript turn 59");
@@ -1750,7 +1750,7 @@ describe("LcmContextEngine afterTurn", () => {
     const sessionId = "placeholder-real-frontier-no-contaminate";
     const sessionKey = "agent:main:placeholder-real-frontier-no-contaminate";
 
-    // Real (anchoring) conversation rows — NOT injected metadata.
+    // Real (anchoring) conversation rows, NOT injected metadata.
     await engine.ingest({
       sessionId,
       sessionKey,
@@ -1876,7 +1876,7 @@ describe("LcmContextEngine afterTurn", () => {
     // no-anchor cap (50) would otherwise import 0 (cap-blocked), so the host keeps
     // sending the raw transcript every turn until the provider context window
     // overflows. The proven non-anchoring metadata frontier lifts the cap so the
-    // full real history recovers and becomes compactable — without losing it.
+    // full real history recovers and becomes compactable, without losing it.
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
@@ -2111,6 +2111,401 @@ describe("LcmContextEngine afterTurn", () => {
       await engine.getConversationStore().getMessages(conversation!.conversationId)
     ).map((m) => m.content);
     expect(finalContents).toContain("third turn assistant");
+  });
+
+  // Production frontier shapes on a group channel. These rows are PURE
+  // OpenClaw-injected inbound decoration (a room-event header and/or a Delivery
+  // prelude wrapping a Conversation-info metadata block) with no real user body,
+  // so they are non-anchoring, but they do NOT start with the bare
+  // "Conversation info (untrusted metadata)" prefix that the #837/#822
+  // classifier matched, so the frontier froze forever.
+  // These shapes mirror real frozen-frontier rows seen on disk: every real
+  // frozen row carries a non-empty trailing body (a Chat-history block, a
+  // Current-event block, or a system line) AND classification now keys off the
+  // inbound metadata, not the body. One reproduces a room_event frontier and one
+  // an un-addressed user_request frontier.
+  const ROOM_EVENT_FRONTIER_ROW =
+    "[OpenClaw room event]\n\n" +
+    "inbound_event_kind: room_event\n\n" +
+    "visible_reply_contract: message_tool_only\n\n" +
+    "Room context:\n" +
+    "Delivery: Final assistant text is not automatically delivered in this run. " +
+    "Use the `message` tool to send user-visible output.\n\n" +
+    "Conversation info (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "chat_id": "channel:C0CHANNEL1",\n' +
+    '  "conversation_label": "#general",\n' +
+    '  "sender": "sam.rivera",\n' +
+    '  "inbound_event_kind": "room_event",\n' +
+    '  "is_group_chat": true,\n' +
+    '  "explicitly_mentioned_bot": false,\n' +
+    '  "mention_source": "none",\n' +
+    '  "history_count": 11\n' +
+    "}\n" +
+    "```\n\n" +
+    "Sender (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "label": "sam.rivera (U0EXAMPLE01)",\n' +
+    '  "id": "U0EXAMPLE01",\n' +
+    '  "name": "sam.rivera"\n' +
+    "}\n" +
+    "```\n\n" +
+    "Chat history since last reply (untrusted, for context):\n" +
+    "```json\n" +
+    '[{"sender":"sam.rivera","body":"/lcm status"}]\n' +
+    "```\n\n" +
+    "Current event:\nSlack message in #general from sam.rivera";
+  const UNADDRESSED_DELIVERY_FRONTIER_ROW =
+    "Delivery: Final assistant text is not automatically delivered in this run. " +
+    "Use the `message` tool to send user-visible output.\n\n" +
+    "Conversation info (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "chat_id": "channel:C0CHANNEL1",\n' +
+    '  "conversation_label": "#general",\n' +
+    '  "sender": "lee.chen",\n' +
+    '  "inbound_event_kind": "user_request",\n' +
+    '  "is_group_chat": true,\n' +
+    '  "explicitly_mentioned_bot": false,\n' +
+    '  "mention_source": "none",\n' +
+    '  "history_count": 2\n' +
+    "}\n" +
+    "```\n\n" +
+    "Sender (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "label": "lee.chen (U0EXAMPLE02)",\n' +
+    '  "id": "U0EXAMPLE02",\n' +
+    '  "name": "lee.chen"\n' +
+    "}\n" +
+    "```\n\n" +
+    "Chat history since last reply (untrusted, for context):\n" +
+    "```json\n" +
+    '[{"sender":"sam.rivera","body":"/new"}]\n' +
+    "```\n\n" +
+    ":white_check_mark: New session started.";
+  // An ADDRESSED user turn: same Delivery shape, but the metadata says the bot
+  // was directly addressed (explicitly_mentioned_bot:true / mention_source:reply)
+  // and a real user question trails the metadata. MUST classify as anchoring.
+  const ADDRESSED_FRONTIER_ROW =
+    "Delivery: Final assistant text is not automatically delivered in this run. " +
+    "Use the `message` tool to send user-visible output.\n\n" +
+    "Conversation info (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "chat_id": "channel:C0CHANNEL1",\n' +
+    '  "conversation_label": "#general",\n' +
+    '  "sender": "sam.rivera",\n' +
+    '  "inbound_event_kind": "user_request",\n' +
+    '  "is_group_chat": true,\n' +
+    '  "explicitly_mentioned_bot": true,\n' +
+    '  "mention_source": "reply",\n' +
+    '  "history_count": 2\n' +
+    "}\n" +
+    "```\n\n" +
+    "Sender (untrusted metadata):\n" +
+    "```json\n" +
+    "{\n" +
+    '  "label": "sam.rivera (U0EXAMPLE01)",\n' +
+    '  "id": "U0EXAMPLE01",\n' +
+    '  "name": "sam.rivera"\n' +
+    "}\n" +
+    "```\n\n" +
+    "<@U0EXAMPLE03> can you summarize the deploy status?";
+
+  it("afterTurn recovers a checkpoint-missing conversation whose frontier is OpenClaw room-event/Delivery decoration", async () => {
+    // A checkpoint-missing conversation (NO bootstrap_state row, so
+    // reason="checkpoint-missing") already passes GATE 1, but the frontier rows
+    // are room-event/Delivery-prefixed injected decoration, not the bare
+    // "Conversation info" preamble, so conversationFrontierIsEntirelyNonAnchoring
+    // returned false (GATE 2) and the conversation froze. The widened classifier
+    // recognizes these as non-anchoring so recovery fires.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "session-room-event-checkpoint-missing";
+    const sessionKey = "agent:agent-one:slack:channel:room-event-cm";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: UNADDRESSED_DELIVERY_FRONTIER_ROW }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+    expect(
+      await engine.getSummaryStore().getConversationBootstrapState(conversation!.conversationId),
+    ).toBeNull();
+
+    const sessionFile = createSessionFilePath("session-room-event-checkpoint-missing");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "RECALL_FACT_ALPHA is teal-lantern-3." },
+      { role: "assistant", content: "noted the fact" },
+      { role: "user", content: "follow-up question" },
+      { role: "assistant", content: "follow-up answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "follow-up question" }),
+        makeMessage({ role: "assistant", content: "follow-up answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // RED-before-fix: this is the freeze, not a setup error.
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(false);
+
+    const contents = (await engine.getConversationStore().getMessages(conversation!.conversationId))
+      .map((m) => m.content);
+    expect(contents).toContain("RECALL_FACT_ALPHA is teal-lantern-3.");
+    expect(contents).toContain("follow-up answer");
+
+    const advancedState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advancedState).not.toBeNull();
+    expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
+  });
+
+  it("afterTurn recovers an all-zero placeholder conversation on the slow (append-only-ineligible) path with an OpenClaw room-event frontier", async () => {
+    // An idle-created channel session carries an ALL-ZERO placeholder
+    // bootstrap_state row, so a row EXISTS and reason resolves to
+    // "append-only-ineligible" (NOT "checkpoint-missing"), GATE 1 kept the
+    // slow-path no-anchor recovery off. Its frontier rows are room-event/Delivery
+    // decoration, GATE 2 kept the frontier classified as anchoring. Both gates
+    // compounded into a permanent "did not cover the transcript frontier" freeze.
+    // The placeholder-lane recovery opens GATE 1 and the widened classifier
+    // resolves the frontier as non-anchoring.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "session-placeholder-room-event-slow-path";
+    const sessionKey = "agent:agent-two:slack:channel:placeholder-room-event";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: ROOM_EVENT_FRONTIER_ROW }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: UNADDRESSED_DELIVERY_FRONTIER_ROW }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+
+    // Leading malformed line at offset 0 forces the appended-bytes strict parse
+    // to fail (canUseAppendOnly=false) so the SLOW path runs with
+    // reason="append-only-ineligible", while the lenient full re-read still
+    // yields the valid rows that follow.
+    const sessionFile = createSessionFilePath("session-placeholder-room-event-slow-path");
+    const txLine = (role: AgentMessage["role"], text: string) =>
+      `${JSON.stringify({ message: { role, content: [{ type: "text", text }] } })}\n`;
+    writeFileSync(
+      sessionFile,
+      `not-json\n${txLine("user", "RECALL_FACT_BETA is rust-anchor-9.")}${txLine(
+        "assistant",
+        "noted the placeholder fact",
+      )}${txLine("user", "placeholder follow-up question")}${txLine(
+        "assistant",
+        "placeholder follow-up answer",
+      )}`,
+      "utf8",
+    );
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "placeholder follow-up question" }),
+        makeMessage({ role: "assistant", content: "placeholder follow-up answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // RED-before-fix: this is the freeze, not a setup error.
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(false);
+
+    const contents = (await engine.getConversationStore().getMessages(conversation!.conversationId))
+      .map((m) => m.content);
+    expect(contents).toContain("RECALL_FACT_BETA is rust-anchor-9.");
+    expect(contents).toContain("placeholder follow-up answer");
+
+    const advancedState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advancedState?.lastProcessedOffset).toBeGreaterThan(0);
+  });
+
+  it("afterTurn STILL freezes an append-only-ineligible conversation whose checkpoint already advanced past offset 0 (#649 bound: non-placeholder)", async () => {
+    // The placeholder-lane relaxation is bounded to the never-ingested placeholder lane. A
+    // checkpoint that already advanced (lastProcessedOffset > 0) is NOT a
+    // placeholder, so neverIngestedCheckpoint stays false and the conversation
+    // must freeze per #649 rather than blindly import an unanchored transcript.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "session-nonplaceholder-still-freezes";
+    const sessionKey = "agent:agent-two:slack:channel:nonplaceholder";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: ROOM_EVENT_FRONTIER_ROW }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+
+    const sessionFile = createSessionFilePath("session-nonplaceholder-still-freezes");
+    const txLine = (role: AgentMessage["role"], text: string) =>
+      `${JSON.stringify({ message: { role, content: [{ type: "text", text }] } })}\n`;
+    writeFileSync(
+      sessionFile,
+      `not-json\n${txLine("user", "unrelated rewritten question")}${txLine(
+        "assistant",
+        "unrelated rewritten answer",
+      )}`,
+      "utf8",
+    );
+
+    // A NON-placeholder checkpoint: offset already advanced. Same-path,
+    // non-shrunk => reason="append-only-ineligible", placeholderCheckpoint=false.
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 5,
+      lastSeenMtimeMs: 1,
+      lastProcessedOffset: 5,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "unrelated rewritten answer" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([ROOM_EVENT_FRONTIER_ROW]);
+    const state = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(state?.lastProcessedOffset).toBe(5);
+  });
+
+  it("afterTurn STILL freezes a placeholder conversation whose frontier holds an ADDRESSED turn (#649/#824 bound: directed frontier)", async () => {
+    // The classifier keys off the inbound metadata, not the trailing body: a frontier
+    // row whose metadata says the bot WAS addressed (explicitly_mentioned_bot:true
+    // / mention_source:"reply") is a real directed turn and MUST NOT be treated as
+    // ambient decoration, so the conversation freezes per #649/#824 instead of
+    // importing a divergent transcript over real history. This is the #824
+    // contamination guard for the un-addressed relaxation.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "session-addressed-frontier-still-freezes";
+    const sessionKey = "agent:agent-two:slack:channel:addressed-frontier";
+
+    // A Delivery row whose metadata marks the bot as directly addressed. Despite
+    // the same wrapper shape as the recoverable rows, this is anchoring.
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: ADDRESSED_FRONTIER_ROW }),
+    });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    await engine.getConversationStore().markConversationBootstrapped(conversation!.conversationId);
+
+    const sessionFile = createSessionFilePath("session-addressed-frontier-still-freezes");
+    const txLine = (role: AgentMessage["role"], text: string) =>
+      `${JSON.stringify({ message: { role, content: [{ type: "text", text }] } })}\n`;
+    writeFileSync(
+      sessionFile,
+      `not-json\n${txLine("user", "divergent rewritten question")}${txLine(
+        "assistant",
+        "divergent rewritten answer",
+      )}`,
+      "utf8",
+    );
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "assistant", content: "divergent rewritten answer" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const warns = warnLog.mock.calls.map((c) => String(c[0]));
+    expect(warns.some((m) => m.includes("did not cover the transcript frontier"))).toBe(true);
+
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([ADDRESSED_FRONTIER_ROW]);
+    const state = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(state?.lastProcessedOffset).toBe(0);
   });
 
   it("afterTurn does not recover checkpoint-missing delivery-only transcript traffic", async () => {


### PR DESCRIPTION
## Problem

A conversation that is created (a `conversation_bootstrap_state` row written at offset 0 / size 0) but never written to until later gets permanently stuck in the afterTurn `transcript reconcile did not cover the transcript frontier` loop the first time it is activated, when its first persisted frontier is composed entirely of OpenClaw ambient inbound rows (room-event deliveries and un-addressed channel messages). The checkpoint never advances, so the context engine goes inert for that conversation (no compaction) and emits the warning on every subsequent turn. No data is lost and the agent still answers, but the conversation is frozen and the warning multiplies per active session. A manual rotate clears it, which confirms the no-anchor import path is the right recovery lever.

## Root cause

Two compounding gates in `src/transcript-reconciler.ts`:

1. The slow-path no-anchor recovery is gated on `reason === "checkpoint-missing"`. An idle-created session carries an all-zero placeholder `conversation_bootstrap_state` row, so a row exists and the reconcile reason is `append-only-ineligible`, never `checkpoint-missing`. The recovery gate stays closed, `allowNoAnchorImport` is false, no content anchor is found against the empty offset-0 tail, and the engine treats it as unsafe to advance and skips persistence on every turn.

2. Even with gate 1 relaxed, recovery is conditioned on `conversationFrontierIsEntirelyNonAnchoring()`, which only recognized a user row whose content starts with `Conversation info (untrusted metadata)`. Real ambient frontiers do not match that prefix: they are room-event deliveries (`[OpenClaw room event]` with `inbound_event_kind: room_event`) or un-addressed channel deliveries (a `Delivery:` prelude wrapping the metadata, `explicitly_mentioned_bot: false`, `mention_source: "none"`), where the metadata block is embedded after a prelude and is followed by a real-looking trailing body (chat-history context, a current-event line, or a system notification). So the predicate returned false for the production rows.

## Fix

- Extend the no-anchor recovery to also fire when the checkpoint is the all-zero placeholder (offset 0, nothing processed, nothing to lose), treating it like a missing checkpoint for recovery purposes. The existing `placeholder-checkpoint-recovery` reason is already on the guarded-import allowlists.
- Add `isOpenClawAmbientInboundRecord` in `src/openclaw-inbound-metadata.ts`, which decides a user row is ambient/non-anchoring from the injected inbound metadata rather than from its body: true only for `inbound_event_kind === "room_event"`, or a clearly un-addressed delivery (`explicitly_mentioned_bot === false` and `mention_source === "none"`). It reuses the existing prelude split, metadata-block regex, and record parser. `conversationFrontierIsEntirelyNonAnchoring` now accepts a row that is either the existing metadata-preamble shape or this ambient shape.

## Safety

Under-match is the safe direction. Any parse failure, a missing or unexpected flag, an addressed turn (`explicitly_mentioned_bot === true` or `mention_source !== "none"`), or a non-user role returns false, so a real directed turn is never reclassified as ambient regardless of its trailing body. Recovery stays bounded to offset 0 plus a frontier proven entirely non-anchoring (and the existing 32-row scan limit), so a genuinely divergent history with real content still fail-closes per [#649](https://github.com/Martian-Engineering/lossless-claw/issues/649). This preserves the contamination boundary that closed [#824](https://github.com/Martian-Engineering/lossless-claw/issues/824).

## Tests

`test/engine-after-turn.test.ts` adds coverage built from the real frontier shapes (a room-event delivery row, an un-addressed `Delivery:` user-request row, and an addressed control row). It asserts that both an offset-0 placeholder session and a checkpoint-missing session whose frontier is entirely ambient recover (rows imported, no frontier-not-covered warning, checkpoint advances), and that two negative bounds still freeze: a non-placeholder checkpoint (offset advanced past 0), and a frontier containing an addressed turn. Full suite green.

## Relationship to prior work

Sibling of the no-anchor recovery shipped in [#837](https://github.com/Martian-Engineering/lossless-claw/issues/837) and [#822](https://github.com/Martian-Engineering/lossless-claw/issues/822); this extends it to the all-zero placeholder checkpoint and to the room-event / un-addressed-delivery frontier shapes that the original `Conversation info` prefix check did not recognize.
