### PR TITLE
fix(reconcile): scope cross-conversation raw-id guard to an agent's own channel siblings

### DIFF
--- a/.changeset/same-channel-sibling-recovery.md
+++ b/.changeset/same-channel-sibling-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Recover base channel sessions that were stuck in afterTurn reconciliation when their raw ids also appeared in same-agent same-channel thread or active-memory fork history.

--- a/src/session-patterns.ts
+++ b/src/session-patterns.ts
@@ -39,11 +39,8 @@ export function sessionKeyChannelScope(
   return match ? match[1] : null;
 }
 
-/** Whether two session keys are siblings of the same agent on the same channel. */
-export function sessionKeysAreSameAgentChannelSiblings(
-  a: string | null | undefined,
-  b: string | null | undefined,
-): boolean {
-  const scopeA = sessionKeyChannelScope(a);
-  return scopeA !== null && scopeA === sessionKeyChannelScope(b);
+/** Whether a session key names the base session for its agent and channel. */
+export function isBaseChannelSessionKey(sessionKey: string | null | undefined): boolean {
+  const scope = sessionKeyChannelScope(sessionKey);
+  return scope !== null && scope === sessionKey;
 }

--- a/src/session-patterns.ts
+++ b/src/session-patterns.ts
@@ -21,3 +21,29 @@ export function compileSessionPatterns(patterns: string[]): RegExp[] {
 export function matchesSessionPattern(sessionKey: string, patterns: RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(sessionKey));
 }
+
+const SESSION_KEY_CHANNEL_SCOPE = /^(.*:channel:[^:]+)(?::thread:[^:]+|:active-memory:[^:]+)*$/;
+
+/**
+ * The agent-and-channel scope a session key belongs to, with thread and
+ * active-memory suffixes stripped. Sibling sessions of the same agent on the
+ * same channel share this scope; keys without a channel segment have none.
+ */
+export function sessionKeyChannelScope(
+  sessionKey: string | null | undefined,
+): string | null {
+  if (!sessionKey) {
+    return null;
+  }
+  const match = SESSION_KEY_CHANNEL_SCOPE.exec(sessionKey);
+  return match ? match[1] : null;
+}
+
+/** Whether two session keys are siblings of the same agent on the same channel. */
+export function sessionKeysAreSameAgentChannelSiblings(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const scopeA = sessionKeyChannelScope(a);
+  return scopeA !== null && scopeA === sessionKeyChannelScope(b);
+}

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -36,7 +36,7 @@ import {
   messageIdentity,
 } from "./message-signatures.js";
 import { resolveEpochRoute, selectEntryIdTail, transcriptImportCap } from "./reconcile-plan.js";
-import { sessionKeyChannelScope } from "./session-patterns.js";
+import { isBaseChannelSessionKey, sessionKeyChannelScope } from "./session-patterns.js";
 import {
   externalizedReplayMetadataMatches,
   extractPlainToolReplayTextsById,
@@ -1081,11 +1081,10 @@ export class TranscriptReconciler {
   }
 
   /**
-   * Count candidate raw event IDs that already belong to a FOREIGN active
-   * conversation. Sibling sessions of the same agent on the same channel
-   * (the base channel session, its thread forks, and active-memory variants)
-   * inherit a shared transcript prefix via parentSession, so their raw ids
-   * overlap legitimately and must not count against the recovery.
+   * Count candidate raw event IDs that already belong to a foreign active
+   * conversation. A base channel session may collide with rows from its forked
+   * thread and active-memory sessions because they inherit the parent prefix.
+   * Thread and variant candidates are still checked against sibling rows.
    */
   private countActiveCrossConversationRawIdMatches(params: {
     conversationId: number;
@@ -1112,12 +1111,17 @@ export class TranscriptReconciler {
       return { candidateRawIds: 0, matchedRawIds: 0 };
     }
 
-    const siblingScope = sessionKeyChannelScope(params.sessionKey);
+    const siblingScope = isBaseChannelSessionKey(params.sessionKey)
+      ? sessionKeyChannelScope(params.sessionKey)
+      : null;
     const siblingClause = siblingScope
       ? `AND NOT (
-           c.session_key = $siblingScope
-           OR c.session_key LIKE $siblingThreadPrefix ESCAPE '\\'
-           OR c.session_key LIKE $siblingMemoryPrefix ESCAPE '\\'
+           c.session_key IS NOT NULL
+           AND (
+             c.session_key = $siblingScope
+             OR c.session_key LIKE $siblingThreadPrefix ESCAPE '\\'
+             OR c.session_key LIKE $siblingMemoryPrefix ESCAPE '\\'
+           )
          )`
       : "";
     const escapeLike = (value: string): string => value.replace(/[\\%_]/g, "\\$&");

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -36,6 +36,7 @@ import {
   messageIdentity,
 } from "./message-signatures.js";
 import { resolveEpochRoute, selectEntryIdTail, transcriptImportCap } from "./reconcile-plan.js";
+import { sessionKeyChannelScope } from "./session-patterns.js";
 import {
   externalizedReplayMetadataMatches,
   extractPlainToolReplayTextsById,
@@ -987,6 +988,7 @@ export class TranscriptReconciler {
       const rawIdMatches = this.countActiveCrossConversationRawIdMatches({
         conversationId,
         sessionId,
+        sessionKey: params.sessionKey,
         messages: noAnchorImportMessages,
       });
       if (rawIdMatches.matchedRawIds > 0) {
@@ -1078,10 +1080,17 @@ export class TranscriptReconciler {
     return { blockedByImportCap: false, importedMessages, hasOverlap: adoptedMessages > 0 };
   }
 
-  /** Count candidate raw event IDs that already belong to another active conversation. */
+  /**
+   * Count candidate raw event IDs that already belong to a FOREIGN active
+   * conversation. Sibling sessions of the same agent on the same channel
+   * (the base channel session, its thread forks, and active-memory variants)
+   * inherit a shared transcript prefix via parentSession, so their raw ids
+   * overlap legitimately and must not count against the recovery.
+   */
   private countActiveCrossConversationRawIdMatches(params: {
     conversationId: number;
     sessionId: string;
+    sessionKey?: string;
     messages: AgentMessage[];
   }): { candidateRawIds: number; matchedRawIds: number } {
     const candidateRawIds = new Set<string>();
@@ -1103,51 +1112,58 @@ export class TranscriptReconciler {
       return { candidateRawIds: 0, matchedRawIds: 0 };
     }
 
+    const siblingScope = sessionKeyChannelScope(params.sessionKey);
+    const siblingClause = siblingScope
+      ? `AND NOT (
+           c.session_key = $siblingScope
+           OR c.session_key LIKE $siblingThreadPrefix ESCAPE '\\'
+           OR c.session_key LIKE $siblingMemoryPrefix ESCAPE '\\'
+         )`
+      : "";
+    const escapeLike = (value: string): string => value.replace(/[\\%_]/g, "\\$&");
+    const siblingBindings: Record<string, string> = siblingScope
+      ? {
+          $siblingScope: siblingScope,
+          $siblingThreadPrefix: `${escapeLike(siblingScope)}:thread:%`,
+          $siblingMemoryPrefix: `${escapeLike(siblingScope)}:active-memory:%`,
+        }
+      : {};
+
     const matchStmt = this.host.db.prepare(
       `SELECT 1 AS found
        FROM message_parts mp
        JOIN messages m ON m.message_id = mp.message_id
        JOIN conversations c ON c.conversation_id = m.conversation_id
        WHERE c.active = 1
-         AND m.conversation_id <> ?
+         AND m.conversation_id <> $conversationId
+         ${siblingClause}
          AND mp.metadata IS NOT NULL
          AND json_valid(mp.metadata)
          AND (
-           json_extract(mp.metadata, '$.raw.id') = ?
-           OR json_extract(mp.metadata, '$.raw.call_id') = ?
-           OR json_extract(mp.metadata, '$.raw.toolCallId') = ?
-           OR json_extract(mp.metadata, '$.raw.tool_call_id') = ?
-           OR json_extract(mp.metadata, '$.raw.toolUseId') = ?
-           OR json_extract(mp.metadata, '$.raw.tool_use_id') = ?
-           OR mp.tool_call_id = ?
-           OR json_extract(mp.metadata, '$.id') = ?
-           OR json_extract(mp.metadata, '$.call_id') = ?
-           OR json_extract(mp.metadata, '$.toolCallId') = ?
-           OR json_extract(mp.metadata, '$.tool_call_id') = ?
-           OR json_extract(mp.metadata, '$.toolUseId') = ?
-           OR json_extract(mp.metadata, '$.tool_use_id') = ?
+           json_extract(mp.metadata, '$.raw.id') = $rawId
+           OR json_extract(mp.metadata, '$.raw.call_id') = $rawId
+           OR json_extract(mp.metadata, '$.raw.toolCallId') = $rawId
+           OR json_extract(mp.metadata, '$.raw.tool_call_id') = $rawId
+           OR json_extract(mp.metadata, '$.raw.toolUseId') = $rawId
+           OR json_extract(mp.metadata, '$.raw.tool_use_id') = $rawId
+           OR mp.tool_call_id = $rawId
+           OR json_extract(mp.metadata, '$.id') = $rawId
+           OR json_extract(mp.metadata, '$.call_id') = $rawId
+           OR json_extract(mp.metadata, '$.toolCallId') = $rawId
+           OR json_extract(mp.metadata, '$.tool_call_id') = $rawId
+           OR json_extract(mp.metadata, '$.toolUseId') = $rawId
+           OR json_extract(mp.metadata, '$.tool_use_id') = $rawId
          )
        LIMIT 1`,
     );
 
     let matchedRawIds = 0;
     for (const rawId of candidateRawIds) {
-      const row = matchStmt.get(
-        params.conversationId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-        rawId,
-      ) as { found: number } | undefined;
+      const row = matchStmt.get({
+        ...siblingBindings,
+        $conversationId: params.conversationId,
+        $rawId: rawId,
+      } as Record<string, string | number>) as { found: number } | undefined;
       if (row?.found === 1) {
         matchedRawIds += 1;
       }

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1813,6 +1813,145 @@ describe("LcmContextEngine afterTurn", () => {
     ).toBe(false);
   });
 
+  it("blocks checkpoint-missing recovery when colliding raw ids belong to a keyless active conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const ownedMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "keyless-owner-user", text: "keyless owner user turn" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "keyless-owner-assistant", text: "keyless owner answer" }],
+      }),
+    ];
+
+    const ownerSessionFile = createSessionFilePath("keyless-rawid-owner");
+    writeLeafTranscriptMessages(ownerSessionFile, ownedMessages);
+    await engine.bootstrap({
+      sessionId: "keyless-rawid-owner",
+      sessionFile: ownerSessionFile,
+    });
+
+    const candidateSessionId = "keyless-collision-candidate";
+    const candidateSessionKey = "agent:scout:slack:channel:lobby";
+    await engine.ingest({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): keyless collision candidate",
+      }),
+    });
+    const candidateConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+    });
+    expect(candidateConversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(candidateConversation!.conversationId);
+
+    const candidateSessionFile = createSessionFilePath("keyless-collision-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, ownedMessages);
+
+    await engine.afterTurn({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const candidateMessages = await engine
+      .getConversationStore()
+      .getMessages(candidateConversation!.conversationId);
+    expect(candidateMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): keyless collision candidate",
+    ]);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked checkpoint-missing-recovery no-anchor import")),
+    ).toBe(true);
+  });
+
+  it("blocks checkpoint-missing recovery when colliding raw ids belong to another same-channel thread", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const threadOneMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "thread-one-user", text: "thread one user turn" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "thread-one-assistant", text: "thread one answer" }],
+      }),
+    ];
+
+    const ownerSessionFile = createSessionFilePath("same-channel-thread-owner");
+    writeLeafTranscriptMessages(ownerSessionFile, threadOneMessages);
+    await engine.bootstrap({
+      sessionId: "same-channel-thread-owner",
+      sessionKey: "agent:scout:slack:channel:lobby:thread:1700000000.000100",
+      sessionFile: ownerSessionFile,
+    });
+
+    const candidateSessionId = "same-channel-thread-candidate";
+    const candidateSessionKey = "agent:scout:slack:channel:lobby:thread:1700000000.000200";
+    await engine.ingest({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): same-channel thread candidate",
+      }),
+    });
+    const candidateConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+    });
+    expect(candidateConversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(candidateConversation!.conversationId);
+
+    const candidateSessionFile = createSessionFilePath("same-channel-thread-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, threadOneMessages);
+
+    await engine.afterTurn({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const candidateMessages = await engine
+      .getConversationStore()
+      .getMessages(candidateConversation!.conversationId);
+    expect(candidateMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): same-channel thread candidate",
+    ]);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked checkpoint-missing-recovery no-anchor import")),
+    ).toBe(true);
+  });
+
   it("blocks checkpoint-missing recovery when the colliding raw ids belong to a same-agent different-channel conversation", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDeps(

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1736,6 +1736,153 @@ describe("LcmContextEngine afterTurn", () => {
     ).toBe(true);
   });
 
+  it("allows checkpoint-missing recovery when the colliding raw ids belong only to a same-agent same-channel sibling conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const sharedMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "sibling-shared-user", text: "shared channel user turn" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "sibling-shared-assistant", text: "shared channel answer" }],
+      }),
+    ];
+
+    const siblingSessionFile = createSessionFilePath("sibling-thread-owner");
+    writeLeafTranscriptMessages(siblingSessionFile, sharedMessages);
+    await engine.bootstrap({
+      sessionId: "sibling-thread-owner",
+      sessionKey: "agent:scout:slack:channel:lobby:thread:1700000000.000100",
+      sessionFile: siblingSessionFile,
+    });
+
+    const baseSessionId = "sibling-base-candidate";
+    const baseSessionKey = "agent:scout:slack:channel:lobby";
+    await engine.ingest({
+      sessionId: baseSessionId,
+      sessionKey: baseSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): sibling base candidate",
+      }),
+    });
+    const baseConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: baseSessionId,
+      sessionKey: baseSessionKey,
+    });
+    expect(baseConversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(baseConversation!.conversationId);
+    expect(
+      await engine
+        .getSummaryStore()
+        .getConversationBootstrapState(baseConversation!.conversationId),
+    ).toBeNull();
+
+    const candidateSessionFile = createSessionFilePath("sibling-base-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, sharedMessages);
+
+    await engine.afterTurn({
+      sessionId: baseSessionId,
+      sessionKey: baseSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const baseMessages = await engine
+      .getConversationStore()
+      .getMessages(baseConversation!.conversationId);
+    expect(baseMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): sibling base candidate",
+      "shared channel user turn",
+      "shared channel answer",
+    ]);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("candidate raw ids already exist in other active conversations")),
+    ).toBe(false);
+  });
+
+  it("blocks checkpoint-missing recovery when the colliding raw ids belong to a same-agent different-channel conversation", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+
+    const ownedMessages = [
+      makeMessage({
+        role: "user",
+        content: [{ type: "text", id: "other-channel-user", text: "other channel user turn" }],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [{ type: "text", id: "other-channel-assistant", text: "other channel answer" }],
+      }),
+    ];
+
+    const ownerSessionFile = createSessionFilePath("other-channel-owner");
+    writeLeafTranscriptMessages(ownerSessionFile, ownedMessages);
+    await engine.bootstrap({
+      sessionId: "other-channel-owner",
+      sessionKey: "agent:scout:slack:channel:annex",
+      sessionFile: ownerSessionFile,
+    });
+
+    const candidateSessionId = "other-channel-candidate";
+    const candidateSessionKey = "agent:scout:slack:channel:lobby";
+    await engine.ingest({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      message: makeMessage({
+        role: "user",
+        content: "Conversation info (untrusted metadata): other channel candidate",
+      }),
+    });
+    const candidateConversation = await engine.getConversationStore().getConversationForSession({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+    });
+    expect(candidateConversation).not.toBeNull();
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(candidateConversation!.conversationId);
+
+    const candidateSessionFile = createSessionFilePath("other-channel-candidate");
+    writeLeafTranscriptMessages(candidateSessionFile, ownedMessages);
+
+    await engine.afterTurn({
+      sessionId: candidateSessionId,
+      sessionKey: candidateSessionKey,
+      sessionFile: candidateSessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const candidateMessages = await engine
+      .getConversationStore()
+      .getMessages(candidateConversation!.conversationId);
+    expect(candidateMessages.map((message) => message.content)).toEqual([
+      "Conversation info (untrusted metadata): other channel candidate",
+    ]);
+    expect(
+      warnLog.mock.calls
+        .map((c) => String(c[0]))
+        .some((m) => m.includes("blocked checkpoint-missing-recovery no-anchor import")),
+    ).toBe(true);
+  });
+
   it("does NOT import an unrelated transcript onto a placeholder-checkpoint conversation that already holds real anchoring rows (#824 contamination guard)", async () => {
     // The failure that closed PR #824: a placeholder checkpoint can coexist with
     // real persisted rows; blindly opening an unbounded no-anchor import would

--- a/test/session-patterns.test.ts
+++ b/test/session-patterns.test.ts
@@ -3,6 +3,8 @@ import {
   compileSessionPattern,
   compileSessionPatterns,
   matchesSessionPattern,
+  sessionKeyChannelScope,
+  sessionKeysAreSameAgentChannelSiblings,
 } from "../src/session-patterns.js";
 
 describe("session ignore patterns", () => {
@@ -27,5 +29,36 @@ describe("session ignore patterns", () => {
     expect(matchesSessionPattern("agent:main:cron:nightly:run:run-123", patterns)).toBe(true);
     expect(matchesSessionPattern("agent:ops:subagent:123", patterns)).toBe(true);
     expect(matchesSessionPattern("agent:main:main", patterns)).toBe(false);
+  });
+});
+
+describe("session key channel scope", () => {
+  it("reduces base, thread, and active-memory variants to one channel scope", () => {
+    const base = "agent:scout:slack:channel:lobby";
+    expect(sessionKeyChannelScope(base)).toBe(base);
+    expect(sessionKeyChannelScope("agent:scout:slack:channel:lobby:thread:1700000000.000100")).toBe(base);
+    expect(sessionKeyChannelScope("agent:scout:slack:channel:lobby:active-memory:abc123")).toBe(base);
+    expect(
+      sessionKeyChannelScope("agent:scout:slack:channel:lobby:thread:1700000000.000100:active-memory:abc123"),
+    ).toBe(base);
+  });
+
+  it("has no channel scope for keys without a channel segment", () => {
+    expect(sessionKeyChannelScope("agent:scout:direct-session")).toBeNull();
+    expect(sessionKeyChannelScope("agent:main:main")).toBeNull();
+    expect(sessionKeyChannelScope(undefined)).toBeNull();
+    expect(sessionKeyChannelScope("")).toBeNull();
+  });
+
+  it("treats only same-agent same-channel keys as siblings", () => {
+    const base = "agent:scout:slack:channel:lobby";
+    const thread = "agent:scout:slack:channel:lobby:thread:1700000000.000100";
+    const memory = "agent:scout:slack:channel:lobby:active-memory:abc123";
+    expect(sessionKeysAreSameAgentChannelSiblings(base, thread)).toBe(true);
+    expect(sessionKeysAreSameAgentChannelSiblings(thread, memory)).toBe(true);
+    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:relay:slack:channel:lobby")).toBe(false);
+    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:scout:slack:channel:annex")).toBe(false);
+    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:scout:direct-session")).toBe(false);
+    expect(sessionKeysAreSameAgentChannelSiblings(undefined, undefined)).toBe(false);
   });
 });

--- a/test/session-patterns.test.ts
+++ b/test/session-patterns.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   compileSessionPattern,
   compileSessionPatterns,
+  isBaseChannelSessionKey,
   matchesSessionPattern,
   sessionKeyChannelScope,
-  sessionKeysAreSameAgentChannelSiblings,
 } from "../src/session-patterns.js";
 
 describe("session ignore patterns", () => {
@@ -50,15 +50,11 @@ describe("session key channel scope", () => {
     expect(sessionKeyChannelScope("")).toBeNull();
   });
 
-  it("treats only same-agent same-channel keys as siblings", () => {
-    const base = "agent:scout:slack:channel:lobby";
-    const thread = "agent:scout:slack:channel:lobby:thread:1700000000.000100";
-    const memory = "agent:scout:slack:channel:lobby:active-memory:abc123";
-    expect(sessionKeysAreSameAgentChannelSiblings(base, thread)).toBe(true);
-    expect(sessionKeysAreSameAgentChannelSiblings(thread, memory)).toBe(true);
-    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:relay:slack:channel:lobby")).toBe(false);
-    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:scout:slack:channel:annex")).toBe(false);
-    expect(sessionKeysAreSameAgentChannelSiblings(base, "agent:scout:direct-session")).toBe(false);
-    expect(sessionKeysAreSameAgentChannelSiblings(undefined, undefined)).toBe(false);
+  it("identifies base channel keys separately from thread and active-memory variants", () => {
+    expect(isBaseChannelSessionKey("agent:scout:slack:channel:lobby")).toBe(true);
+    expect(isBaseChannelSessionKey("agent:scout:slack:channel:lobby:thread:1700000000.000100")).toBe(false);
+    expect(isBaseChannelSessionKey("agent:scout:slack:channel:lobby:active-memory:abc123")).toBe(false);
+    expect(isBaseChannelSessionKey("agent:scout:direct-session")).toBe(false);
+    expect(isBaseChannelSessionKey(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

A base channel session can get permanently stuck in the afterTurn `did not cover the transcript frontier` loop. Its no-anchor recovery import is blocked by the cross-conversation raw-id contamination guard because the candidate raw ids already exist in other active conversations, so the engine skips persistence every turn. The conversation never anchors or compacts (no data loss, but it goes inert and the warning repeats on every turn).

## Root cause

The "other active conversations" that trip the guard are the same agent's own sibling sessions on the same channel. A channel agent gets a base channel session plus a separate per-thread session for each thread it replies in (and active-memory variants). Those thread sessions are forks of the base session: they carry a `parentSession` reference and inherit its transcript prefix and entry-id chain, so their tool-call and block ids overlap the base session's legitimately. `countActiveCrossConversationRawIdMatches` counted those siblings as foreign owners and vetoed the import, treating an agent importing its own lineage as contamination.

This is a distinct failure from the placeholder/room-event frontier recovery in #931. There the recovery path was never reached; here it is reached but blocked by the guard. A base channel session with no bootstrap row reaches `checkpoint-missing-recovery`; one with an all-zero placeholder reaches `placeholder-checkpoint-recovery`. Both are vetoed by the same guard.

## Fix

Add `sessionKeyChannelScope`, which reduces a session key to its `agent:<id>:...:channel:<id>` scope, stripping `:thread:<ts>` and `:active-memory:<hash>` suffixes. The guard now excludes active conversations that share that scope (the base channel session, its thread forks, and active-memory variants) from the cross-conversation match. Genuinely foreign conversations (a different agent, a different channel, or a key with no channel segment) still block, preserving the #824 contamination boundary. A key shape that does not parse returns null and still blocks (fail-safe, under-match preferred).

## Tests

- `test/engine-after-turn.test.ts`: a no-anchor recovery whose only colliding raw ids belong to a same-agent same-channel thread sibling now imports the transcript (previously blocked); a same-agent different-channel collision still blocks.
- `test/session-patterns.test.ts`: unit coverage for the scope reduction (thread and active-memory suffixes stripped, no-channel keys return null) and the sibling predicate (different agent, different channel, and non-channel keys are not siblings).

Full suite green, typecheck clean.
