### PR TITLE
fix(reconcile): dedup the decorated runtime row on never-ingested recovery

### DIFF
--- a/.changeset/never-ingested-decorated-recovery.md
+++ b/.changeset/never-ingested-decorated-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve conversation continuity when never-ingested recovery encounters an exact metadata-decorated runtime copy of a bare transcript row.

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -1092,9 +1092,8 @@ export class ConversationStore {
    * entry id — the flush-lagged runtime rows a transcript catch-up may adopt.
    * Returns id + content so the caller can apply a decoration-invariant match
    * before stamping, rather than the exact identity_hash + content match the SQL
-   * adopters use. Ordered OLDEST-first so a multi-turn recovery pairs each bare
-   * row with its own decorated twin chronologically, instead of letting a short
-   * earlier turn adopt a later, longer row that merely shares a trailing line.
+   * adopters use. Ordered OLDEST-first so a multi-turn recovery consumes
+   * repeated equal bodies in transcript order.
    */
   async listRecentUnstampedMessagesByRole(
     conversationId: ConversationId,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -1088,6 +1088,40 @@ export class ConversationStore {
   }
 
   /**
+   * Tail rows (within the window) of the given role that carry no transcript
+   * entry id — the flush-lagged runtime rows a transcript catch-up may adopt.
+   * Returns id + content so the caller can apply a decoration-invariant match
+   * before stamping, rather than the exact identity_hash + content match the SQL
+   * adopters use. Ordered OLDEST-first so a multi-turn recovery pairs each bare
+   * row with its own decorated twin chronologically, instead of letting a short
+   * earlier turn adopt a later, longer row that merely shares a trailing line.
+   */
+  async listRecentUnstampedMessagesByRole(
+    conversationId: ConversationId,
+    role: MessageRole,
+    tailWindow: number,
+  ): Promise<Array<{ messageId: MessageId; content: string }>> {
+    const rows = this.db
+      .prepare(
+        `SELECT message_id, content
+       FROM (
+         SELECT message_id, content, transcript_entry_id, role, seq
+         FROM messages
+         WHERE conversation_id = ?
+         ORDER BY seq DESC
+         LIMIT ?
+       )
+       WHERE transcript_entry_id IS NULL AND role = ?
+       ORDER BY seq ASC`,
+      )
+      .all(conversationId, Math.max(1, Math.floor(tailWindow)), role) as unknown as Array<{
+      message_id: number;
+      content: string;
+    }>;
+    return rows.map((row) => ({ messageId: row.message_id, content: row.content }));
+  }
+
+  /**
    * Whether the newest persisted row has the same identity hash and preserved
    * reasoning content. Used to dedup adjacent delivery-mirror messages whose
    * text content is already covered by the immediately preceding response entry.

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -14,7 +14,7 @@ import type { LcmConfig } from "./db/config.js";
 import type { AgentMessage, IngestResult } from "./openclaw-bridge.js";
 import type { TranscriptReconcileResult } from "./reconcile-plan.js";
 import { SessionRolloverDetector } from "./session-rollover.js";
-import type { ConversationRecord, ConversationStore } from "./store/conversation-store.js";
+import type { ConversationRecord, ConversationStore, MessageRole } from "./store/conversation-store.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { LcmDependencies } from "./types.js";
 import { readFileSync } from "node:fs";
@@ -29,6 +29,7 @@ import {
   type StoredMessage,
 } from "./message-content.js";
 import { isOpenClawAmbientInboundRecord } from "./openclaw-inbound-metadata.js";
+import { liveContentIsRecognizedDecoratedBareBody } from "./live-coverage.js";
 import {
   createBootstrapEntryHash,
   createLosslessMessageSignature,
@@ -79,6 +80,16 @@ const CROSS_CONVERSATION_RAW_ID_GUARDED_NO_ANCHOR_REASONS = new Set([
   "checkpoint-missing-recovery",
   "rotate-checkpoint-missing",
   "placeholder-checkpoint-recovery",
+]);
+
+// No-anchor recovery reasons where the runtime may have already persisted the
+// turn as a decorated, still-unstamped row before the transcript caught up. Both
+// "never ingested" recovery lanes (an all-zero placeholder checkpoint, or no
+// checkpoint row at all) reach the same import path, so the bare transcript row
+// is adopted onto that decorated row on either, instead of imported as a duplicate.
+const DECORATION_INVARIANT_ADOPTION_NO_ANCHOR_REASONS = new Set([
+  "placeholder-checkpoint-recovery",
+  "checkpoint-missing-recovery",
 ]);
 
 export type BootstrapCheckpointFileState = {
@@ -1142,6 +1153,26 @@ export class TranscriptReconciler {
             adoptedMessages += 1;
             continue;
           }
+          // A placeholder/checkpoint recovery on a brand-new
+          // conversation re-imports the bare transcript row of a turn the live
+          // afterTurn ingest already persisted as a decorated, still-unstamped
+          // row. The two faces differ on both identity_hash and content, so the
+          // adopters above miss them; stamp the decorated row's id via the
+          // structural decorated-face match instead of importing a duplicate.
+          if (
+            DECORATION_INVARIANT_ADOPTION_NO_ANCHOR_REASONS.has(
+              params.noAnchorImportReason ?? "",
+            ) &&
+            (await this.adoptDecorationInvariantEntryId({
+              conversationId,
+              role: stored.role,
+              bareContent: stored.content,
+              entryId,
+            }))
+          ) {
+            adoptedMessages += 1;
+            continue;
+          }
         }
       }
       const result = await this.host.ingestSingle({
@@ -1180,6 +1211,42 @@ export class TranscriptReconciler {
     // overlap — the caller then refreshes the checkpoint instead of
     // re-entering this path every turn.
     return { blockedByImportCap: false, importedMessages, hasOverlap: adoptedMessages > 0 };
+  }
+
+  /**
+   * Stamp a brand-new transcript entry id onto a recently-persisted,
+   * still-unstamped runtime row that is the DECORATED face of the same turn
+   * (the bare body is its line-aligned trailing segment under recognized
+   * decoration). Keeps the single decorated row and anchors it, instead of
+   * importing the bare transcript copy as a duplicate. Bounded to the flush-lag
+   * tail window so legacy unstamped history is never mis-adopted.
+   */
+  private async adoptDecorationInvariantEntryId(params: {
+    conversationId: number;
+    role: MessageRole;
+    bareContent: string;
+    entryId: string;
+  }): Promise<boolean> {
+    const candidates = await this.host.conversationStore.listRecentUnstampedMessagesByRole(
+      params.conversationId,
+      params.role,
+      FLUSH_LAG_ADOPTION_TAIL_WINDOW,
+    );
+    for (const candidate of candidates) {
+      if (
+        liveContentIsRecognizedDecoratedBareBody({
+          liveContent: candidate.content,
+          bareContent: params.bareContent,
+        }) &&
+        (await this.host.conversationStore.restampTranscriptEntryId(
+          candidate.messageId,
+          params.entryId,
+        ))
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1219,9 +1219,10 @@ export class TranscriptReconciler {
    * Stamp a brand-new transcript entry id onto a recently-persisted,
    * still-unstamped user runtime row that is the DECORATED face of the same
    * turn (its recognized metadata wrapper reduces to the exact bare
-   * model-facing body). Keeps the single decorated row and anchors it, instead
-   * of importing the bare transcript copy as a duplicate. Bounded to the
-   * flush-lag tail window so legacy unstamped history is never mis-adopted.
+   * model-facing body). When that body matches exactly one candidate, keeps the
+   * decorated row and anchors it instead of importing the bare transcript copy
+   * as a duplicate. Bounded to the flush-lag tail window and fails closed on
+   * ambiguous repeated bodies so legacy or unrelated rows are never mis-adopted.
    */
   private async adoptDecorationInvariantEntryId(params: {
     conversationId: number;
@@ -1233,18 +1234,16 @@ export class TranscriptReconciler {
       "user",
       FLUSH_LAG_ADOPTION_TAIL_WINDOW,
     );
-    for (const candidate of candidates) {
-      if (
-        openClawInboundBodiesMatch(candidate.content, params.bareContent) &&
-        (await this.host.conversationStore.restampTranscriptEntryId(
-          candidate.messageId,
-          params.entryId,
-        ))
-      ) {
-        return true;
-      }
+    const matches = candidates.filter((candidate) =>
+      openClawInboundBodiesMatch(candidate.content, params.bareContent),
+    );
+    if (matches.length !== 1) {
+      return false;
     }
-    return false;
+    return this.host.conversationStore.restampTranscriptEntryId(
+      matches[0].messageId,
+      params.entryId,
+    );
   }
 
   /**

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -14,7 +14,7 @@ import type { LcmConfig } from "./db/config.js";
 import type { AgentMessage, IngestResult } from "./openclaw-bridge.js";
 import type { TranscriptReconcileResult } from "./reconcile-plan.js";
 import { SessionRolloverDetector } from "./session-rollover.js";
-import type { ConversationRecord, ConversationStore, MessageRole } from "./store/conversation-store.js";
+import type { ConversationRecord, ConversationStore } from "./store/conversation-store.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { LcmDependencies } from "./types.js";
 import { readFileSync } from "node:fs";
@@ -28,8 +28,10 @@ import {
   toStoredMessage,
   type StoredMessage,
 } from "./message-content.js";
-import { isOpenClawAmbientInboundRecord } from "./openclaw-inbound-metadata.js";
-import { liveContentIsRecognizedDecoratedBareBody } from "./live-coverage.js";
+import {
+  isOpenClawAmbientInboundRecord,
+  openClawInboundBodiesMatch,
+} from "./openclaw-inbound-metadata.js";
 import {
   createBootstrapEntryHash,
   createLosslessMessageSignature,
@@ -1157,15 +1159,15 @@ export class TranscriptReconciler {
           // conversation re-imports the bare transcript row of a turn the live
           // afterTurn ingest already persisted as a decorated, still-unstamped
           // row. The two faces differ on both identity_hash and content, so the
-          // adopters above miss them; stamp the decorated row's id via the
-          // structural decorated-face match instead of importing a duplicate.
+          // adopters above miss them; stamp the decorated row's id only when its
+          // recognized metadata wrapper reduces to the exact transcript body.
           if (
+            stored.role === "user" &&
             DECORATION_INVARIANT_ADOPTION_NO_ANCHOR_REASONS.has(
               params.noAnchorImportReason ?? "",
             ) &&
             (await this.adoptDecorationInvariantEntryId({
               conversationId,
-              role: stored.role,
               bareContent: stored.content,
               entryId,
             }))
@@ -1215,29 +1217,25 @@ export class TranscriptReconciler {
 
   /**
    * Stamp a brand-new transcript entry id onto a recently-persisted,
-   * still-unstamped runtime row that is the DECORATED face of the same turn
-   * (the bare body is its line-aligned trailing segment under recognized
-   * decoration). Keeps the single decorated row and anchors it, instead of
-   * importing the bare transcript copy as a duplicate. Bounded to the flush-lag
-   * tail window so legacy unstamped history is never mis-adopted.
+   * still-unstamped user runtime row that is the DECORATED face of the same
+   * turn (its recognized metadata wrapper reduces to the exact bare
+   * model-facing body). Keeps the single decorated row and anchors it, instead
+   * of importing the bare transcript copy as a duplicate. Bounded to the
+   * flush-lag tail window so legacy unstamped history is never mis-adopted.
    */
   private async adoptDecorationInvariantEntryId(params: {
     conversationId: number;
-    role: MessageRole;
     bareContent: string;
     entryId: string;
   }): Promise<boolean> {
     const candidates = await this.host.conversationStore.listRecentUnstampedMessagesByRole(
       params.conversationId,
-      params.role,
+      "user",
       FLUSH_LAG_ADOPTION_TAIL_WINDOW,
     );
     for (const candidate of candidates) {
       if (
-        liveContentIsRecognizedDecoratedBareBody({
-          liveContent: candidate.content,
-          bareContent: params.bareContent,
-        }) &&
+        openClawInboundBodiesMatch(candidate.content, params.bareContent) &&
         (await this.host.conversationStore.restampTranscriptEntryId(
           candidate.messageId,
           params.entryId,

--- a/test/placeholder-recovery-double-write.test.ts
+++ b/test/placeholder-recovery-double-write.test.ts
@@ -253,6 +253,61 @@ describe("placeholder-checkpoint recovery double-write", () => {
     expect(userRows.map((message) => message.content)).toEqual([differentDecoratedBody, "ok"]);
   });
 
+  it("does not adopt when multiple decorated rows reduce to the same bare body", async () => {
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "ambiguous-identical-bodies";
+    const sessionKey = "agent:agent-one:telegram:ambiguous-identical-bodies";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("ok") }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("ok") }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("ambiguous-identical-bodies");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "ok" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "assistant", content: "reply" }));
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const userRows = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).filter((message) => message.role === "user");
+    expect(userRows.map((message) => message.content)).toEqual([
+      decoratedRoomEvent("ok"),
+      decoratedRoomEvent("ok"),
+      "ok",
+    ]);
+  });
+
   it("does not apply inbound-decoration adoption to assistant rows", async () => {
     const engine = createEngineWithDeps(
       {},

--- a/test/placeholder-recovery-double-write.test.ts
+++ b/test/placeholder-recovery-double-write.test.ts
@@ -1,0 +1,251 @@
+// On a brand-new conversation whose first turn was persisted by the live
+// afterTurn ingest (a decorated, id-less row) BEFORE the session jsonl was
+// flushed, the placeholder-checkpoint recovery later re-imports the same turn's
+// bare, id-bearing transcript row. The bare and decorated faces differ on both
+// identity_hash and content, so the existing entry-id / exact-content adoption
+// misses them and the bare row is imported as a duplicate (and the spurious new
+// epoch strips the agent's continuity). Recovery must dedup the bare row against
+// the already-persisted decorated runtime row instead of importing it.
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendSessionMessage,
+  cleanupEngineTestState,
+  createEngineWithDeps,
+  createSessionFilePath,
+  makeMessage,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+const BODY = "what did we decide about the deploy window?";
+
+// The live afterTurn ingest persists the DECORATED, id-less face of a turn: an
+// OpenClaw room-event inbound (non-anchoring frontier) whose trailing line is
+// the real user body.
+function decoratedRoomEvent(body: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "telegram:10000000x",
+      inbound_event_kind: "room_event",
+      sender: "sam.rivera",
+    }),
+    "```",
+    "",
+    `[Sun 2026-06-21 13:19 GMT+3] ${body}`,
+  ].join("\n");
+}
+
+const DECORATED_FIRST_TURN = decoratedRoomEvent(BODY);
+
+describe("placeholder-checkpoint recovery double-write", () => {
+  it("dedups the bare transcript row of a turn already persisted decorated instead of double-writing it", async () => {
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "new-conv-double-write";
+    const sessionKey = "agent:agent-one:telegram:new-conv";
+
+    // Live afterTurn ingest of the first turn (decorated, transcript_entry_id NULL).
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: DECORATED_FIRST_TURN }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    // The session jsonl now holds the BARE, id-bearing face of that SAME turn,
+    // plus the assistant reply (what OpenClaw flushes once the turn completes).
+    // Built through the SessionManager so each entry carries a real JSONL
+    // envelope id, exactly as production transcripts do (a bare {role, content}
+    // file would be id-less and take a different reconcile path).
+    const sessionFile = createSessionFilePath("new-conv");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: BODY }));
+    appendSessionMessage(
+      sessionManager,
+      makeMessage({ role: "assistant", content: "we decided on 9pm" }),
+    );
+
+    // The all-zero placeholder checkpoint the missing-jsonl afterTurn left behind.
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    // Prove we actually exercised the placeholder-checkpoint-recovery path.
+    const warns = warnLog.mock.calls.map((call) => String(call[0]));
+    expect(
+      warns.some((message) => message.includes("reason=placeholder-checkpoint-recovery")),
+    ).toBe(true);
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+
+    // The first turn must survive EXACTLY ONCE. Before the fix the bare transcript
+    // row imports alongside the decorated runtime row (the double-write bug).
+    const firstTurnFaces = messages.filter(
+      (message) => message.role === "user" && message.content.includes(BODY),
+    );
+    expect(firstTurnFaces).toHaveLength(1);
+    // The survivor is the decorated runtime row (recovery adopted onto it rather
+    // than dropping it for the bare copy).
+    expect(firstTurnFaces[0].content).toContain("inbound_event_kind");
+    // The genuinely-new assistant reply is still imported (no over-suppression).
+    expect(
+      messages.some(
+        (message) => message.role === "assistant" && message.content.includes("we decided on 9pm"),
+      ),
+    ).toBe(true);
+
+    // Continuity: adoption reported overlap, so the checkpoint advanced off the
+    // all-zero placeholder instead of re-importing a fresh epoch every turn (the
+    // mechanism behind the "newborn" continuity strip).
+    const advancedState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(advancedState?.lastProcessedOffset ?? 0).toBeGreaterThan(0);
+  });
+
+  it("does not mis-adopt across turns or re-import a duplicate when recovery covers multiple turns", async () => {
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "multi-turn-recovery";
+    const sessionKey = "agent:agent-one:telegram:multi-turn";
+
+    // Turn 1's body ("ok") is the trailing line of turn 2's body ("sounds good\nok").
+    // Both are persisted decorated + unstamped by the live ingest. A newest-first
+    // candidate scan adopts turn 2's row for turn 1's bare face, then re-imports
+    // turn 2 as a duplicate; oldest-first chronological pairing keeps each once.
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("ok") }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("sounds good\nok") }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    // Transcript alternates user/assistant (real transcripts never have two
+    // consecutive same-role entries) and carries both turns' bare faces.
+    const sessionFile = createSessionFilePath("multi-turn");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "ok" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "assistant", content: "first reply" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "sounds good\nok" }));
+    appendSessionMessage(
+      sessionManager,
+      makeMessage({ role: "assistant", content: "second reply" }),
+    );
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const userRows = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).filter((message) => message.role === "user");
+    // Exactly the two decorated rows survive — neither turn re-imported as a duplicate.
+    expect(userRows).toHaveLength(2);
+    expect(userRows.filter((message) => message.content.includes("sounds good"))).toHaveLength(1);
+  });
+
+  it("dedups the bare transcript row on checkpoint-missing recovery too", async () => {
+    // The sibling never-ingested recovery reason: no bootstrap_state row at all
+    // (vs an all-zero placeholder). The same decorated-then-bare double-write
+    // applies, so the gate must cover this reason as well.
+    const warnLog = vi.fn();
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "checkpoint-missing-double-write";
+    const sessionKey = "agent:agent-one:slack:channel:c0example";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: DECORATED_FIRST_TURN }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+    // checkpoint-missing recovery requires the conversation be marked bootstrapped
+    // with NO bootstrap_state row (the #837 shape).
+    await engine
+      .getConversationStore()
+      .markConversationBootstrapped(conversation!.conversationId);
+
+    const sessionFile = createSessionFilePath("checkpoint-missing");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: BODY }));
+    appendSessionMessage(
+      sessionManager,
+      makeMessage({ role: "assistant", content: "we decided on 9pm" }),
+    );
+
+    // No bootstrap_state seeded — recovery resolves to checkpoint-missing.
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const warns = warnLog.mock.calls.map((call) => String(call[0]));
+    expect(
+      warns.some((message) => message.includes("reason=checkpoint-missing-recovery")),
+    ).toBe(true);
+
+    const firstTurnFaces = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).filter((message) => message.role === "user" && message.content.includes(BODY));
+    expect(firstTurnFaces).toHaveLength(1);
+  });
+});

--- a/test/placeholder-recovery-double-write.test.ts
+++ b/test/placeholder-recovery-double-write.test.ts
@@ -8,6 +8,7 @@
 // the already-persisted decorated runtime row instead of importing it.
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLeafPathMessages } from "../src/transcript.js";
 import {
   appendSessionMessage,
   cleanupEngineTestState,
@@ -137,9 +138,8 @@ describe("placeholder-checkpoint recovery double-write", () => {
     const sessionKey = "agent:agent-one:telegram:multi-turn";
 
     // Turn 1's body ("ok") is the trailing line of turn 2's body ("sounds good\nok").
-    // Both are persisted decorated + unstamped by the live ingest. A newest-first
-    // candidate scan adopts turn 2's row for turn 1's bare face, then re-imports
-    // turn 2 as a duplicate; oldest-first chronological pairing keeps each once.
+    // Both are persisted decorated + unstamped by the live ingest. Recovery must
+    // inspect them chronologically and require exact reduced-body equality.
     await engine.ingest({
       sessionId,
       sessionKey,
@@ -154,6 +154,14 @@ describe("placeholder-checkpoint recovery double-write", () => {
       .getConversationStore()
       .getConversationForSession({ sessionId, sessionKey });
     expect(conversation).not.toBeNull();
+
+    const unstamped = await engine
+      .getConversationStore()
+      .listRecentUnstampedMessagesByRole(conversation!.conversationId, "user", 8);
+    expect(unstamped.map((message) => message.content)).toEqual([
+      decoratedRoomEvent("ok"),
+      decoratedRoomEvent("sounds good\nok"),
+    ]);
 
     // Transcript alternates user/assistant (real transcripts never have two
     // consecutive same-role entries) and carries both turns' bare faces.
@@ -191,6 +199,102 @@ describe("placeholder-checkpoint recovery double-write", () => {
     // Exactly the two decorated rows survive — neither turn re-imported as a duplicate.
     expect(userRows).toHaveLength(2);
     expect(userRows.filter((message) => message.content.includes("sounds good"))).toHaveLength(1);
+  });
+
+  it("does not adopt a decorated row whose different body only ends in the same timestamped text", async () => {
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "different-body-suffix";
+    const sessionKey = "agent:agent-one:telegram:different-body-suffix";
+
+    // The stored row is a different turn. Its user-authored body merely ends
+    // with a timestamped copy of the incoming transcript's short body.
+    const differentDecoratedBody = decoratedRoomEvent(
+      "context from a different turn\n[Sun 2026-06-21 13:19 GMT+3] ok",
+    );
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: differentDecoratedBody }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("different-body-suffix");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "ok" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "assistant", content: "new reply" }));
+
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const userRows = (
+      await engine.getConversationStore().getMessages(conversation!.conversationId)
+    ).filter((message) => message.role === "user");
+    expect(userRows.map((message) => message.content)).toEqual([differentDecoratedBody, "ok"]);
+  });
+
+  it("does not apply inbound-decoration adoption to assistant rows", async () => {
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "assistant-decoration-shaped-content";
+    const sessionKey = "agent:agent-one:telegram:assistant-decoration-shaped-content";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "assistant", content: DECORATED_FIRST_TURN }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("assistant-decoration-shaped-content");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "new user turn" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "assistant", content: BODY }));
+
+    const reconcile = await engine.getTranscriptReconciler().reconcileSessionTail({
+      sessionId,
+      sessionKey,
+      conversationId: conversation!.conversationId,
+      historicalMessages: await readLeafPathMessages(sessionFile),
+      skipContentAnchorScan: true,
+      allowNoAnchorImport: true,
+      noAnchorImportReason: "placeholder-checkpoint-recovery",
+    });
+    expect(reconcile).toMatchObject({ importedMessages: 2, hasOverlap: false });
+
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages.map((message) => [message.role, message.content])).toEqual([
+      ["assistant", DECORATED_FIRST_TURN],
+      ["user", "new user turn"],
+      ["assistant", BODY],
+    ]);
   });
 
   it("dedups the bare transcript row on checkpoint-missing recovery too", async () => {


### PR DESCRIPTION
> Rebased onto `main` now that [#927](https://github.com/Martian-Engineering/lossless-claw/pull/927) has merged (it reuses `liveContentIsRecognizedDecoratedBareBody` from that change). This PR is now the single fix commit on top of `main`.

## Problem

On a brand-new conversation, the live `afterTurn` ingest can persist a turn as a decorated, still-unstamped row before the session jsonl is flushed. The subsequent never-ingested recovery (an all-zero placeholder checkpoint, or no checkpoint row at all) then re-imports the same turn's bare, id-bearing transcript row through `importNoAnchorEpoch`.

The bare and decorated faces of that turn differ on both `identity_hash` and `content` (the decorated face carries the injected inbound-metadata block and the channel timestamp), so the existing adopters all miss the pair:

- `hasMessageByTranscriptEntryId` and `adoptTranscriptEntryId` key on the entry id or an exact `identity_hash` + `content` match, which the decorated row does not satisfy.
- the replay-overlap analyzer keys on the raw message identity, which also differs.

The bare row therefore imports as a duplicate. And because the import is treated as a fresh, non-overlapping epoch, the checkpoint never advances off the placeholder, so the conversation re-enters recovery every turn and loses continuity.

### Where it bites

The trigger is host plus classification level, not channel specific. When an inbound is classified as a room event (ambient group or unaddressed), `suppressNextUserMessagePersistence` is set, so the user message is placed in the model prompt but never written to the jsonl as a runtime event. On the embedded context-engine host, which does not pre-flush the transcript before `afterTurn` (unlike the codex app-server host, which awaits a mirror first), the file `afterTurn` stats is then missing or empty for that turn, which seeds the placeholder and drives the re-import. Any deployment on the embedded host that starts new conversations from ambient or room-event inbounds is exposed.

## Change

Before importing a bare row on a never-ingested recovery, adopt a recent same-role unstamped row that is the recognized decorated face of the same turn, stamping it with the bare row's entry id instead of importing a duplicate.

- New `ConversationStore.listRecentUnstampedMessagesByRole`: returns the windowed (flush-lag tail) unstamped rows of a role, oldest-first, so a multi-turn recovery pairs each bare row with its own decorated twin chronologically rather than letting a short earlier turn adopt a later, longer row that merely shares a trailing line.
- New `TranscriptReconciler.adoptDecorationInvariantEntryId`: matches a candidate via the existing structural primitive `liveContentIsRecognizedDecoratedBareBody` (line-aligned containment plus recognized-decoration evidence, fail-closed) and restamps on a hit.
- Gated on the two never-ingested recovery reasons (`placeholder-checkpoint-recovery` and `checkpoint-missing-recovery`). On any other reason, or with no decorated twin in the window, behaviour is unchanged.

Adopting rather than skipping makes the import report overlap, so the caller advances the checkpoint and the conversation stops re-entering recovery, which also resolves the continuity loss.

It is complementary to the existing recovery guards ([#822](https://github.com/Martian-Engineering/lossless-claw/issues/822), [#824](https://github.com/Martian-Engineering/lossless-claw/issues/824), [#649](https://github.com/Martian-Engineering/lossless-claw/issues/649)) and to the afterTurn `identity_hash` dedup, none of which catch the decorated-versus-bare pair.

## Testing

- `npm run typecheck` clean.
- Full suite green (`npm test`).
- New `test/placeholder-recovery-double-write.test.ts` drives the real `afterTurn` recovery path with id-bearing transcripts (built through `SessionManager`, so entries carry genuine envelope ids) and a non-anchoring room-event frontier:
  - single-turn: the turn survives once as the decorated row, the assistant reply still imports, and the checkpoint advances off the placeholder (continuity).
  - multi-turn: two turns where the earlier body is the trailing line of the later one both survive exactly once (the oldest-first ordering regression).
  - checkpoint-missing: the same dedup on the `checkpoint-missing` recovery lane.
