### PR TITLE
feat(engine): report deferred maintenance debt

### DIFF
--- a/.changeset/deferred-maintenance-hint.md
+++ b/.changeset/deferred-maintenance-hint.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Expose `hasDeferredMaintenance` from the OpenClaw context-engine metadata so hosts can skip background turn maintenance when no compaction debt is pending.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -340,6 +340,7 @@ export class LcmContextEngine implements ContextEngine {
       version: "0.1.0",
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
+      hasDeferredMaintenance: (params) => this.hasDeferredMaintenance(params),
       hostRequirements: {
         "agent-run": {
           requiredCapabilities: LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
@@ -4346,6 +4347,29 @@ export class LcmContextEngine implements ContextEngine {
 
   getCompactionMaintenanceStore(): CompactionMaintenanceStore {
     return this.compactionMaintenanceStore;
+  }
+
+  private async hasDeferredMaintenance(params: {
+    sessionId: string;
+    sessionKey?: string;
+  }): Promise<boolean> {
+    if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      return false;
+    }
+    if (this.isStatelessSession(params.sessionKey)) {
+      return false;
+    }
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    if (!conversation) {
+      return false;
+    }
+    const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
+      conversation.conversationId,
+    );
+    return maintenance?.pending === true || maintenance?.running === true;
   }
 
 }

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -98,7 +98,17 @@ export type ContextEngineInfo = {
   version: string;
   ownsCompaction?: boolean;
   turnMaintenanceMode?: "background" | "inline" | string;
+  hasDeferredMaintenance?: (
+    params: ContextEngineMaintenanceHintParams,
+  ) => boolean | Promise<boolean>;
   hostRequirements?: Partial<Record<ContextEngineOperation, ContextEngineHostRequirements>>;
+};
+
+export type ContextEngineMaintenanceHintParams = {
+  sessionId: string;
+  sessionKey?: string;
+  reason: "turn";
+  runtimeContext?: Record<string, unknown>;
 };
 
 export type ContextEngineOperation = "agent-run" | "manual-compact" | "subagent-spawn";

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -37,6 +37,44 @@ describe("LcmContextEngine metadata", () => {
     expect(engine.info.ownsCompaction).toBe(true);
   });
 
+  it("reports deferred maintenance only when compaction debt is pending", async () => {
+    const engine = createEngine();
+    const sessionId = "session-maintenance-hint";
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "user",
+        content: "hello",
+        timestamp: Date.now(),
+      },
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    await expect(
+      engine.info.hasDeferredMaintenance?.({
+        sessionId,
+        reason: "turn",
+      }),
+    ).resolves.toBe(false);
+
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation!.conversationId,
+      reason: "threshold",
+      tokenBudget: 1000,
+      currentTokenCount: 1200,
+    });
+
+    await expect(
+      engine.info.hasDeferredMaintenance?.({
+        sessionId,
+        reason: "turn",
+      }),
+    ).resolves.toBe(true);
+  });
+
   it("requires the full native host lifecycle for agent runs", () => {
     const engine = createEngine();
     expect(engine.info.hostRequirements?.["agent-run"]).toEqual({
@@ -1350,4 +1388,3 @@ describe("LcmContextEngine connection lifecycle", () => {
 });
 
 // ── Bootstrap ───────────────────────────────────────────────────────────────
-


### PR DESCRIPTION
## Summary

- expose `info.hasDeferredMaintenance(...)` from the Lossless Claw context engine
- report deferred maintenance only when conversation compaction maintenance is pending or running
- return false for ignored, stateless, and no-conversation sessions
- add lifecycle coverage for the no-debt and pending-debt states
- add a patch changeset

## What Problem This Solves

OpenClaw can now ask context engines whether a turn-triggered background maintenance pass has actual durable work to do. Lossless Claw already tracks that state in `CompactionMaintenanceStore`; this PR wires that existing debt state into the optional host hint.

`turnMaintenanceMode: "background"` remains the capability signal. `hasDeferredMaintenance(...)` is the debt signal.

## Behavior

The hint returns:

- `false` for ignored sessions
- `false` for stateless sessions
- `false` when no conversation exists for the session
- `true` only when the conversation maintenance record is `pending` or `running`

## Companion

OpenClaw host API/support: https://github.com/openclaw/openclaw/pull/97284

## Evidence

- `npx vitest run test/engine-lifecycle.test.ts`
- `npm run typecheck`
- `npm run build`
- Regression coverage verifies the hint resolves `false` before compaction debt is requested and `true` after `requestProactiveCompactionDebt(...)`.

## Proof (real run)

Captured from a live gateway running a companion OpenClaw host with this engine hint implementation, before and after deploying the host/plugin pair.

**Before** — on turns with no durable maintenance debt, the host queued a no-op deferred maintenance task on essentially every successful turn:

```
[context-engine] deferred turn maintenance queued taskId=<redacted> sessionKey=<redacted> lane=context-engine-turn-maintenance:<redacted>
```

These fired continuously throughout the day (peaking at ~21 in a single hour; last occurrence immediately before the deploy).

**After** — with this engine hint live (no compaction debt -> `hasDeferredMaintenance(...)` resolves `false` -> the companion host skips scheduling):

- **0** `deferred turn maintenance queued` lines across the **1,172** turn-level context-engine events logged since the deploy.
- The active conversation had no maintenance-debt row, so this implementation returned `false` from existing `CompactionMaintenanceStore` state rather than creating new bookkeeping.

Real pending/running maintenance debt still reports `true` and remains eligible for background scheduling.
