### PR TITLE
[codex] Repair unsafe conversation ids during migration

### DIFF
--- a/.changeset/safe-conversation-id-repair.md
+++ b/.changeset/safe-conversation-id-repair.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Repair legacy SQLite databases whose `conversation_id` values exceed JavaScript's safe integer range before migration, startup recovery, or recall tools read those rows.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -263,6 +263,195 @@ function ensureFocusBriefTables(db: DatabaseSync): void {
   `);
 }
 
+function repairUnsafeConversationIdentifiers(db: DatabaseSync): void {
+  const maxSafeInteger = Number.MAX_SAFE_INTEGER;
+
+  db.exec(`
+    PRAGMA defer_foreign_keys = ON;
+
+    DROP TABLE IF EXISTS temp.lcm_unsafe_conversation_id_map;
+    CREATE TEMP TABLE lcm_unsafe_conversation_id_map (
+      old_id INTEGER PRIMARY KEY,
+      new_id INTEGER NOT NULL UNIQUE
+    ) WITHOUT ROWID;
+
+    WITH
+      unsafe_conversations AS (
+        SELECT
+          conversation_id AS old_id,
+          ROW_NUMBER() OVER (ORDER BY conversation_id) AS ordinal
+        FROM conversations
+        WHERE conversation_id > ${maxSafeInteger}
+      ),
+      safe_conversation_bounds AS (
+        SELECT COALESCE(MAX(conversation_id), 0) AS max_safe_id
+        FROM conversations
+        WHERE conversation_id <= ${maxSafeInteger}
+      ),
+      unsafe_conversation_count AS (
+        SELECT COUNT(*) AS unsafe_count
+        FROM unsafe_conversations
+      )
+    INSERT INTO temp.lcm_unsafe_conversation_id_map (old_id, new_id)
+    SELECT
+      unsafe_conversations.old_id,
+      safe_conversation_bounds.max_safe_id + unsafe_conversations.ordinal
+    FROM unsafe_conversations
+    CROSS JOIN safe_conversation_bounds
+    CROSS JOIN unsafe_conversation_count
+    WHERE safe_conversation_bounds.max_safe_id + unsafe_conversation_count.unsafe_count <= ${maxSafeInteger};
+
+    DROP TABLE IF EXISTS temp.lcm_unsafe_conversation_id_repair_guard;
+    CREATE TEMP TABLE lcm_unsafe_conversation_id_repair_guard (
+      can_repair INTEGER NOT NULL CHECK (can_repair = 1)
+    );
+    INSERT INTO temp.lcm_unsafe_conversation_id_repair_guard (can_repair)
+    SELECT CASE
+      WHEN (
+        SELECT COUNT(*)
+        FROM temp.lcm_unsafe_conversation_id_map
+      ) = (
+        SELECT COUNT(*)
+        FROM conversations
+        WHERE conversation_id > ${maxSafeInteger}
+      )
+      THEN 1
+      ELSE 0
+    END;
+    DROP TABLE IF EXISTS temp.lcm_unsafe_conversation_id_repair_guard;
+
+    UPDATE messages
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = messages.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE summaries
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = summaries.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE context_items
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = context_items.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE large_files
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = large_files.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE conversation_bootstrap_state
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = conversation_bootstrap_state.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE conversation_compaction_telemetry
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = conversation_compaction_telemetry.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE conversation_compaction_maintenance
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = conversation_compaction_maintenance.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE focus_briefs
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = focus_briefs.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE conversations
+    SET conversation_id = (
+      SELECT new_id
+      FROM temp.lcm_unsafe_conversation_id_map
+      WHERE old_id = conversations.conversation_id
+    )
+    WHERE conversation_id IN (
+      SELECT old_id
+      FROM temp.lcm_unsafe_conversation_id_map
+    );
+
+    UPDATE sqlite_sequence
+    SET seq = (
+      SELECT COALESCE(MAX(conversation_id), 0)
+      FROM conversations
+    )
+    WHERE name = 'conversations'
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM temp.lcm_unsafe_conversation_id_map
+        )
+        OR seq > ${maxSafeInteger}
+      );
+
+    INSERT INTO sqlite_sequence (name, seq)
+    SELECT
+      'conversations',
+      COALESCE(MAX(conversation_id), 0)
+    FROM conversations
+    WHERE EXISTS (
+        SELECT 1
+        FROM temp.lcm_unsafe_conversation_id_map
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM sqlite_sequence
+        WHERE name = 'conversations'
+      );
+
+    DROP TABLE IF EXISTS temp.lcm_unsafe_conversation_id_map;
+  `);
+}
+
 /**
  * Belt-and-suspenders guard: create `message_parts` if it does not yet exist.
  *
@@ -1334,6 +1523,9 @@ export function runLcmMigrations(
       ON conversations (session_id, active, created_at)
     `);
     db.exec(`DROP INDEX IF EXISTS conversations_session_key_idx`);
+    runMigrationStep("repairUnsafeConversationIdentifiers", log, () =>
+      repairUnsafeConversationIdentifiers(db),
+    );
     runMigrationStep("ensureSummaryDepthColumn", log, () => ensureSummaryDepthColumn(db));
     runMigrationStep("ensureSummaryMetadataColumns", log, () =>
       ensureSummaryMetadataColumns(db),

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -1480,4 +1480,207 @@ describe("runLcmMigrations summary depth backfill", () => {
       { step_name: "repairOpenClawMetadataIdentityState", algorithm_version: 1 },
     ]);
   });
+
+  it("remaps unsafe conversation identifiers before later migrations read them", () => {
+    const db = createTestDb("unsafe-conversation-id.db");
+    const unsafeConversationId = "11536543435202597";
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    db.exec(`
+      INSERT INTO conversations (
+        conversation_id,
+        session_id,
+        session_key,
+        active,
+        created_at,
+        updated_at
+      ) VALUES (
+        ${unsafeConversationId},
+        'unsafe-session',
+        'agent:main:faye',
+        1,
+        '2026-06-26 16:41:04',
+        '2026-06-26 16:41:04'
+      );
+
+      INSERT INTO messages (
+        message_id,
+        conversation_id,
+        seq,
+        role,
+        content,
+        token_count,
+        identity_hash,
+        created_at
+      ) VALUES (
+        1,
+        ${unsafeConversationId},
+        1,
+        'user',
+        'Conversation info that should stay queryable',
+        8,
+        'legacy-hash',
+        '2026-06-26 16:41:05'
+      );
+
+      INSERT INTO summaries (
+        summary_id,
+        conversation_id,
+        kind,
+        depth,
+        content,
+        token_count,
+        file_ids
+      ) VALUES (
+        'sum-unsafe',
+        ${unsafeConversationId},
+        'leaf',
+        0,
+        'unsafe summary',
+        4,
+        '[]'
+      );
+
+      INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+      VALUES (${unsafeConversationId}, 0, 'message', 1);
+
+      INSERT INTO large_files (
+        file_id,
+        conversation_id,
+        storage_uri
+      ) VALUES (
+        'file-unsafe',
+        ${unsafeConversationId},
+        'file:///tmp/unsafe'
+      );
+
+      INSERT INTO conversation_bootstrap_state (
+        conversation_id,
+        session_file_path,
+        last_seen_size,
+        last_seen_mtime_ms,
+        last_processed_offset
+      ) VALUES (
+        ${unsafeConversationId},
+        '/tmp/unsafe-session.jsonl',
+        42,
+        1000,
+        42
+      );
+
+      INSERT INTO conversation_compaction_telemetry (conversation_id)
+      VALUES (${unsafeConversationId});
+
+      INSERT INTO conversation_compaction_maintenance (conversation_id, pending)
+      VALUES (${unsafeConversationId}, 1);
+
+      INSERT INTO focus_briefs (
+        brief_id,
+        conversation_id,
+        prompt,
+        content,
+        status
+      ) VALUES (
+        'focus-unsafe',
+        ${unsafeConversationId},
+        'prompt',
+        'content',
+        'draft'
+      );
+    `);
+
+    expect(() =>
+      db.prepare(`SELECT conversation_id FROM conversations ORDER BY conversation_id DESC LIMIT 1`).all(),
+    ).toThrow(/Value is too large/);
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const conversationRow = db
+      .prepare(
+        `SELECT conversation_id, session_id, session_key
+         FROM conversations
+         WHERE session_id = 'unsafe-session'`,
+      )
+      .get() as { conversation_id: number; session_id: string; session_key: string };
+    expect(conversationRow.conversation_id).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+    expect(conversationRow.session_key).toBe("agent:main:faye");
+
+    const unsafeCounts = db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM conversations WHERE conversation_id > ?) AS conversations,
+           (SELECT COUNT(*) FROM messages WHERE conversation_id > ?) AS messages,
+           (SELECT COUNT(*) FROM summaries WHERE conversation_id > ?) AS summaries,
+           (SELECT COUNT(*) FROM context_items WHERE conversation_id > ?) AS context_items,
+           (SELECT COUNT(*) FROM large_files WHERE conversation_id > ?) AS large_files,
+           (SELECT COUNT(*) FROM conversation_bootstrap_state WHERE conversation_id > ?) AS bootstrap_state,
+           (SELECT COUNT(*) FROM conversation_compaction_telemetry WHERE conversation_id > ?) AS telemetry,
+           (SELECT COUNT(*) FROM conversation_compaction_maintenance WHERE conversation_id > ?) AS maintenance,
+           (SELECT COUNT(*) FROM focus_briefs WHERE conversation_id > ?) AS focus_briefs`,
+      )
+      .get(
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ) as Record<string, number>;
+
+    expect(unsafeCounts).toMatchObject({
+      conversations: 0,
+      messages: 0,
+      summaries: 0,
+      context_items: 0,
+      large_files: 0,
+      bootstrap_state: 0,
+      telemetry: 0,
+      maintenance: 0,
+      focus_briefs: 0,
+    });
+
+    const remappedCounts = db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM messages WHERE conversation_id = ?) AS messages,
+           (SELECT COUNT(*) FROM summaries WHERE conversation_id = ?) AS summaries,
+           (SELECT COUNT(*) FROM context_items WHERE conversation_id = ?) AS context_items,
+           (SELECT COUNT(*) FROM large_files WHERE conversation_id = ?) AS large_files,
+           (SELECT COUNT(*) FROM conversation_bootstrap_state WHERE conversation_id = ?) AS bootstrap_state,
+           (SELECT COUNT(*) FROM conversation_compaction_telemetry WHERE conversation_id = ?) AS telemetry,
+           (SELECT COUNT(*) FROM conversation_compaction_maintenance WHERE conversation_id = ?) AS maintenance,
+           (SELECT COUNT(*) FROM focus_briefs WHERE conversation_id = ?) AS focus_briefs`,
+      )
+      .get(
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+        conversationRow.conversation_id,
+      ) as Record<string, number>;
+
+    expect(remappedCounts).toMatchObject({
+      messages: 1,
+      summaries: 1,
+      context_items: 1,
+      large_files: 1,
+      bootstrap_state: 1,
+      telemetry: 1,
+      maintenance: 1,
+      focus_briefs: 1,
+    });
+
+    const sequenceRow = db
+      .prepare(`SELECT seq FROM sqlite_sequence WHERE name = 'conversations'`)
+      .get() as { seq: number };
+    expect(sequenceRow.seq).toBe(conversationRow.conversation_id);
+    expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Repair legacy LCM SQLite databases where `conversations.conversation_id` can exceed JavaScript's safe integer range before migration, startup recovery, or recall tools read those rows.

The migration now builds a SQLite-side remap table, updates all known `conversation_id` references, resets the `conversations` sqlite sequence, and avoids reading unsafe integer values into JS while repairing.

## Root Cause

`node:sqlite` throws when reading integer values larger than `Number.MAX_SAFE_INTEGER`. Existing safe-ID repair covered oversized `message_id` rows, but not oversized `conversation_id` rows, so startup/session hooks and `lcm_grep` could fail before Lossless could repair or use the DB.

## Validation

- `npm test -- test/migration.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run plugin-inspector:ci -- --openclaw /tmp/lossless-openclaw-contract`