### PR TITLE
Add JSONL session migration CLI

### DIFF
--- a/.changeset/jsonl-session-migrate-cli.md
+++ b/.changeset/jsonl-session-migrate-cli.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add a packaged `lossless-claw-migrate-sessions` CLI for dry-run-by-default OpenClaw JSONL session backfills into `lcm.db`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lossless Context Management plugin for [OpenClaw](https://github.com/openclaw/op
 - [Quick start](#quick-start)
 - [Configuration](#configuration)
 - [Commands And Skill](#commands-and-skill)
+- [Session Migration CLI](#session-migration-cli)
 - [Documentation](#documentation)
 - [Development](#development)
 - [Security](#security)
@@ -58,6 +59,24 @@ Not currently supported as root CLI commands:
 - `openclaw /lcm`
 
 The bundled skill focuses on configuration, diagnostics, architecture, and recall-tool usage. Its reference set lives under `skills/lossless-claw/references/`.
+
+## Session Migration CLI
+
+`lossless-claw-migrate-sessions` is a one-time shell CLI for backfilling OpenClaw JSONL session files into `lcm.db` after lossless-claw was disabled, missing, or installed after sessions already existed. It is not a background replay loop and it does not run summarization.
+
+Run it in dry-run mode first:
+
+```bash
+npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw
+```
+
+Apply the import only after reviewing the dry-run output:
+
+```bash
+npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
+```
+
+The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`. `--apply` creates a timestamped SQLite backup before writing when the database already exists. Use `--file <path>` or repeatable `--sessions-dir <path>` for targeted imports, `--since <iso-date>` or `--limit <n>` to narrow a batch, and `--json` for machine-readable output.
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "lossless-claw-migrate-sessions": "dist/migrate-sessions.js"
+  },
   "license": "MIT",
   "author": "Josh Lehman <josh@martian.engineering>",
   "keywords": [
@@ -16,7 +19,7 @@
     "dag"
   ],
   "scripts": {
-    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
+    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace && esbuild src/cli/migrate-sessions.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/migrate-sessions.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
     "changeset": "changeset",
     "plugin-inspector:ci": "npm exec --yes --package @openclaw/plugin-inspector@0.3.11 -- plugin-inspector ci --plugin-root . --out plugin-inspector-reports",
     "release:verify": "npm run typecheck && npm run build && npm test && npm pack --dry-run",

--- a/skills/lossless-claw/SKILL.md
+++ b/skills/lossless-claw/SKILL.md
@@ -15,7 +15,8 @@ Start here:
 4. If they suspect summary corruption or truncation, use `/lossless doctor`.
 5. If they want high-confidence junk/session cleanup guidance, use `/lossless doctor clean` before recommending any deletes.
 6. If they ask how `/new`, `/reset`, or `/lossless rotate` interacts with LCM, read the session-lifecycle reference before answering.
-7. Load the relevant reference file instead of improvising details from memory.
+7. If they ask how to import old or past OpenClaw conversation data into Lossless, read the session-lifecycle reference before answering.
+8. Load the relevant reference file instead of improvising details from memory.
 
 Reference map:
 
@@ -23,13 +24,13 @@ Reference map:
 - Internal model and data flow: `references/architecture.md`
 - Diagnostics and summary-health workflow: `references/diagnostics.md`
 - Recall tools and when to use them: `references/recall-tools.md`
-- `/new`, `/reset`, and `/lossless rotate` behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
+- `/new`, `/reset`, `/lossless rotate`, and past-session import behavior with current lossless-claw session mapping: `references/session-lifecycle.md`
 
 Working rules:
 
 - Prioritize explaining why a setting matters, not just what it does.
 - Prefer the native plugin command surface for MVP workflows (`/lossless`, with `/lcm` as alias).
 - Do not assume the Go TUI is installed.
-- Do not recommend advanced rewrite/backfill/transplant/dissolve flows unless the user explicitly asks for non-MVP internals.
+- Do not recommend advanced rewrite/backfill/transplant/dissolve flows unless the user explicitly asks for non-MVP internals. If the user specifically asks to import old or past OpenClaw conversation data into Lossless, recommend the packaged session migration CLI instead of TUI backfill/surgery flows.
 - For exact evidence retrieval from compacted history, guide the user toward recall tools instead of guessing from summaries.
 - When users compare `/lossless` to `/status`, explain that they report different layers: `/lossless` shows LCM-side frontier/summary metrics, while `/status` shows the last assembled runtime prompt snapshot.

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -73,6 +73,40 @@ When answering users:
 - explain that cron scheduler session keys are isolated per runtime run while preserving archived prior runs
 - if they need a truly separate LCM history, use a different session key context (for example a different chat/thread/binding) or explicit non-MVP migration/surgery tools
 
+## Importing past conversation data
+
+If a user explicitly asks how to import old or past OpenClaw conversation data into Lossless, recommend the packaged session migration CLI:
+
+```bash
+npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw
+```
+
+That command name, `lossless-claw-migrate-sessions`, is the npm package executable declared by lossless-claw. It backfills OpenClaw JSONL session files into `lcm.db`.
+
+Use it when:
+
+- lossless-claw was installed after useful OpenClaw sessions already existed
+- lossless-claw was disabled or missing for a period
+- the user wants historical JSONL sessions imported into Lossless storage
+
+Do not present it as:
+
+- a background replay loop
+- a summarization or embedding migration
+- a replacement for normal startup bootstrap/crash recovery
+- a general rewrite/transplant/surgery tool
+
+Safe recommendation pattern:
+
+1. Run the dry-run command first and inspect the output.
+2. Apply only after the user confirms the target state directory and import set:
+
+```bash
+npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
+```
+
+The CLI defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`. On `--apply`, it creates a timestamped SQLite backup before writing when the database already exists. For narrow imports, suggest `--file <path>`, repeatable `--sessions-dir <path>`, `--since <iso-date>`, or `--limit <n>`.
+
 ## Relation to `/status`
 
 This session behavior is separate from `/status` metrics.

--- a/src/cli/migrate-sessions.ts
+++ b/src/cli/migrate-sessions.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import { defaultDbPath, defaultStateDir, runSessionMigration, type SessionMigrationOptions } from "../migrate-sessions.js";
+
+type CliOptions = SessionMigrationOptions & {
+  json?: boolean;
+  help?: boolean;
+};
+
+function usage(): string {
+  return [
+    "Usage: lossless-claw-migrate-sessions [options]",
+    "",
+    "Backfill OpenClaw JSONL session files into lcm.db. Dry-run by default.",
+    "",
+    "Options:",
+    "  --db <path>             Database path (default: ${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db)",
+    "  --state-dir <path>      OpenClaw state dir (default: ${OPENCLAW_STATE_DIR:-~/.openclaw})",
+    "  --sessions-dir <path>   Directory containing *.jsonl sessions; repeatable",
+    "  --file <path>           Import one JSONL file; repeatable",
+    "  --apply                 Write changes after creating a database backup",
+    "  --limit <n>             Limit scanned files",
+    "  --since <iso-date>      Include files modified at/after the date",
+    "  --json                  Print machine-readable JSON",
+    "  --verbose               Print per-file warnings",
+    "  -h, --help              Show this help",
+  ].join("\n");
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    sessionDirs: [],
+    files: [],
+  };
+  for (let idx = 0; idx < argv.length; idx++) {
+    const arg = argv[idx];
+    switch (arg) {
+      case "--db":
+        options.dbPath = requireValue(argv, idx, arg);
+        idx += 1;
+        break;
+      case "--state-dir":
+        options.stateDir = requireValue(argv, idx, arg);
+        idx += 1;
+        break;
+      case "--sessions-dir":
+        options.sessionDirs!.push(requireValue(argv, idx, arg));
+        idx += 1;
+        break;
+      case "--file":
+        options.files!.push(requireValue(argv, idx, arg));
+        idx += 1;
+        break;
+      case "--apply":
+        options.apply = true;
+        break;
+      case "--limit": {
+        const value = Number(requireValue(argv, idx, arg));
+        if (!Number.isInteger(value) || value < 0) {
+          throw new Error("--limit must be a non-negative integer.");
+        }
+        options.limit = value;
+        idx += 1;
+        break;
+      }
+      case "--since":
+        options.since = requireValue(argv, idx, arg);
+        idx += 1;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "--verbose":
+        options.verbose = true;
+        break;
+      case "-h":
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  if (options.sessionDirs?.length === 0) {
+    delete options.sessionDirs;
+  }
+  if (options.files?.length === 0) {
+    delete options.files;
+  }
+  return options;
+}
+
+function formatHumanSummary(result: Awaited<ReturnType<typeof runSessionMigration>>, verbose = false): string {
+  const mode = result.apply ? "apply" : "dry-run";
+  const lines = [
+    `lossless-claw-migrate-sessions ${mode}`,
+    `state dir: ${result.stateDir}`,
+    `database: ${result.dbPath}`,
+  ];
+  if (result.backupPath) {
+    lines.push(`backup: ${result.backupPath}`);
+  } else if (result.apply) {
+    lines.push("backup: skipped (database did not exist yet)");
+  }
+  lines.push(
+    `files: ${result.scannedFiles} scanned, ${result.importedFiles} imported, ${result.skippedFiles} skipped, ${result.errorFiles} errors`,
+    `messages: ${result.importedMessages} imported`,
+  );
+  if (!result.apply) {
+    lines.push("dry-run only; rerun with --apply to write changes");
+  }
+
+  const notableFiles = verbose
+    ? result.files
+    : result.files.filter((file) => file.status === "error" || file.status === "skipped");
+  for (const file of notableFiles) {
+    const reason = file.reason ? ` (${file.reason})` : "";
+    lines.push(`- ${file.status}${reason}: ${file.file}`);
+    for (const warning of file.warnings) {
+      lines.push(`  warning: ${warning}`);
+    }
+    if (file.error) {
+      lines.push(`  error: ${file.error}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const stateDir = options.stateDir ?? defaultStateDir();
+  const dbPath = options.dbPath ?? defaultDbPath(stateDir);
+  const result = await runSessionMigration({ ...options, stateDir, dbPath });
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatHumanSummary(result, options.verbose));
+  }
+  if (result.errorFiles > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/migrate-sessions.ts
+++ b/src/migrate-sessions.ts
@@ -355,6 +355,19 @@ async function importPreparedFile(
           continue;
         }
         seenEntryIds.add(entry.transcriptEntryId);
+        if (existingCount > 0) {
+          const adopted = await conversationStore.adoptTranscriptEntryId(
+            conversation.conversationId,
+            entry.stored.role,
+            entry.stored.content,
+            entry.transcriptEntryId,
+          );
+          if (adopted) {
+            existingEntryIds.add(entry.transcriptEntryId);
+            skippedMessages += 1;
+            continue;
+          }
+        }
       }
       toImport.push(entry);
     }

--- a/src/migrate-sessions.ts
+++ b/src/migrate-sessions.ts
@@ -1,0 +1,504 @@
+import { constants, type Dirent } from "node:fs";
+import { access, mkdir, readdir, stat } from "node:fs/promises";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { closeLcmConnection, createLcmDatabaseConnection } from "./db/connection.js";
+import { runLcmMigrations } from "./db/migration.js";
+import { buildMessageParts, filterPersistableMessages, toStoredMessage, type StoredMessage } from "./message-content.js";
+import { createBootstrapEntryHash } from "./message-signatures.js";
+import type { AgentMessage } from "./openclaw-bridge.js";
+import { ConversationStore, type MessageRecord } from "./store/conversation-store.js";
+import { SummaryStore } from "./store/summary-store.js";
+import { withDatabaseTransaction } from "./transaction-mutex.js";
+import {
+  getTranscriptEntryId,
+  readLeafPathMessages,
+  readTranscriptHeader,
+  resolveTranscriptMessageCreatedAt,
+} from "./transcript.js";
+
+export type MigrationFileStatus = "would-import" | "imported" | "up-to-date" | "skipped" | "error";
+
+export type MigrationFileResult = {
+  file: string;
+  status: MigrationFileStatus;
+  sessionId: string | null;
+  candidateMessages: number;
+  importedMessages: number;
+  skippedMessages: number;
+  reason?: string;
+  warnings: string[];
+  error?: string;
+};
+
+export type SessionMigrationOptions = {
+  dbPath?: string;
+  stateDir?: string;
+  sessionDirs?: string[];
+  files?: string[];
+  apply?: boolean;
+  limit?: number;
+  since?: string | Date;
+  verbose?: boolean;
+};
+
+export type SessionMigrationResult = {
+  apply: boolean;
+  dbPath: string;
+  stateDir: string;
+  backupPath: string | null;
+  scannedFiles: number;
+  importedFiles: number;
+  skippedFiles: number;
+  errorFiles: number;
+  importedMessages: number;
+  files: MigrationFileResult[];
+};
+
+type PreparedSessionFile = {
+  file: string;
+  sessionId: string;
+  sessionHeaderId: string | null;
+  messages: AgentMessage[];
+  stat: {
+    size: number;
+    mtimeMs: number;
+  };
+};
+
+type ImportableMessage = {
+  message: AgentMessage;
+  stored: StoredMessage;
+  transcriptEntryId: string | null;
+};
+
+export function defaultStateDir(): string {
+  return process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), ".openclaw");
+}
+
+export function defaultDbPath(stateDir = defaultStateDir()): string {
+  return join(stateDir, "lcm.db");
+}
+
+export function expandHomePath(pathValue: string): string {
+  if (pathValue === "~") {
+    return homedir();
+  }
+  if (pathValue.startsWith("~/")) {
+    return join(homedir(), pathValue.slice(2));
+  }
+  return pathValue;
+}
+
+function normalizePathInput(pathValue: string): string {
+  return resolve(expandHomePath(pathValue));
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isFinite(limit) || limit < 0) {
+    throw new Error(`Invalid --limit value: ${limit}`);
+  }
+  return Math.floor(limit);
+}
+
+function normalizeSince(since: string | Date | undefined): Date | undefined {
+  if (since === undefined) {
+    return undefined;
+  }
+  const value = since instanceof Date ? since : new Date(since);
+  if (!Number.isFinite(value.getTime())) {
+    throw new Error(`Invalid --since value: ${String(since)}`);
+  }
+  return value;
+}
+
+async function safeStat(file: string): Promise<{ size: number; mtimeMs: number } | null> {
+  try {
+    const fileStat = await stat(file);
+    if (!fileStat.isFile()) {
+      return null;
+    }
+    await access(file, constants.R_OK);
+    return { size: fileStat.size, mtimeMs: fileStat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+async function listJsonlFilesInDirectory(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true, encoding: "utf8" });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+      .map((entry) => join(dir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+async function listDefaultSessionFiles(stateDir: string): Promise<string[]> {
+  const agentsDir = join(stateDir, "agents");
+  let agents: Dirent<string>[];
+  try {
+    agents = await readdir(agentsDir, { withFileTypes: true, encoding: "utf8" });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const agent of agents) {
+    if (!agent.isDirectory()) {
+      continue;
+    }
+    files.push(...await listJsonlFilesInDirectory(join(agentsDir, agent.name, "sessions")));
+  }
+  return files;
+}
+
+export async function discoverSessionFiles(options: SessionMigrationOptions = {}): Promise<string[]> {
+  const stateDir = normalizePathInput(options.stateDir ?? defaultStateDir());
+  const since = normalizeSince(options.since);
+  const limit = normalizeLimit(options.limit);
+  if (limit === 0) {
+    return [];
+  }
+  const discovered = new Set<string>();
+
+  for (const file of options.files ?? []) {
+    discovered.add(normalizePathInput(file));
+  }
+
+  for (const sessionDir of options.sessionDirs ?? []) {
+    for (const file of await listJsonlFilesInDirectory(normalizePathInput(sessionDir))) {
+      discovered.add(resolve(file));
+    }
+  }
+
+  if ((options.files?.length ?? 0) === 0 && (options.sessionDirs?.length ?? 0) === 0) {
+    for (const file of await listDefaultSessionFiles(stateDir)) {
+      discovered.add(resolve(file));
+    }
+  }
+
+  const files = [...discovered].sort((left, right) => left.localeCompare(right));
+  const filtered: string[] = [];
+  for (const file of files) {
+    const fileStat = await safeStat(file);
+    if (!fileStat) {
+      filtered.push(file);
+      continue;
+    }
+    if (since && fileStat.mtimeMs < since.getTime()) {
+      continue;
+    }
+    filtered.push(file);
+    if (limit !== undefined && filtered.length >= limit) {
+      break;
+    }
+  }
+  return filtered;
+}
+
+async function prepareSessionFile(file: string): Promise<PreparedSessionFile | MigrationFileResult> {
+  const fileStat = await safeStat(file);
+  if (!fileStat) {
+    return {
+      file,
+      status: "error",
+      sessionId: null,
+      candidateMessages: 0,
+      importedMessages: 0,
+      skippedMessages: 0,
+      reason: "unreadable-file",
+      warnings: [],
+      error: "File does not exist, is not readable, or is not a regular file.",
+    };
+  }
+
+  const [header, rawMessages] = await Promise.all([
+    readTranscriptHeader(file),
+    readLeafPathMessages(file),
+  ]);
+  const messages = filterPersistableMessages(rawMessages);
+  const sessionId = header.sessionHeaderId ?? basename(file, extname(file));
+
+  if (messages.length === 0) {
+    return {
+      file,
+      status: "skipped",
+      sessionId,
+      candidateMessages: 0,
+      importedMessages: 0,
+      skippedMessages: 0,
+      reason: "no-persistable-messages",
+      warnings: [`No persistable messages were found in ${file}.`],
+    };
+  }
+
+  return {
+    file,
+    sessionId,
+    sessionHeaderId: header.sessionHeaderId,
+    messages,
+    stat: fileStat,
+  };
+}
+
+function isPreparedSessionFile(
+  value: PreparedSessionFile | MigrationFileResult,
+): value is PreparedSessionFile {
+  return "messages" in value;
+}
+
+async function createDatabaseBackup(dbPath: string): Promise<string | null> {
+  try {
+    await access(dbPath, constants.R_OK);
+  } catch {
+    return null;
+  }
+
+  const timestamp = new Date().toISOString().replace(/[-:.]/g, "");
+  const backupPath = `${dbPath}.migrate-sessions-${timestamp}.bak`;
+  await mkdir(dirname(backupPath), { recursive: true });
+  const source = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    source.exec("PRAGMA busy_timeout = 30000");
+    source.exec(`VACUUM INTO ${sqliteStringLiteral(backupPath)}`);
+  } finally {
+    source.close();
+  }
+  return backupPath;
+}
+
+function sqliteStringLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function toImportableMessages(messages: AgentMessage[]): ImportableMessage[] {
+  return messages.map((message) => ({
+    message,
+    stored: toStoredMessage(message),
+    transcriptEntryId: getTranscriptEntryId(message),
+  }));
+}
+
+function buildDryRunResult(prepared: PreparedSessionFile | MigrationFileResult): MigrationFileResult {
+  if (!isPreparedSessionFile(prepared)) {
+    return prepared;
+  }
+  return {
+    file: prepared.file,
+    status: "would-import",
+    sessionId: prepared.sessionId,
+    candidateMessages: prepared.messages.length,
+    importedMessages: 0,
+    skippedMessages: 0,
+    warnings: [],
+  };
+}
+
+async function importPreparedFile(
+  db: DatabaseSync,
+  conversationStore: ConversationStore,
+  summaryStore: SummaryStore,
+  prepared: PreparedSessionFile,
+): Promise<MigrationFileResult> {
+  const importable = toImportableMessages(prepared.messages);
+  const warnings: string[] = [];
+  return withDatabaseTransaction(db, "BEGIN IMMEDIATE", async () => {
+    const conversation = await conversationStore.getOrCreateConversation(prepared.sessionId, {
+      title: `Imported OpenClaw session ${prepared.sessionId}`,
+    });
+    const existingCount = await conversationStore.getMessageCount(conversation.conversationId);
+    const hasMissingTranscriptEntryIds = importable.some((entry) => !entry.transcriptEntryId);
+    if (existingCount > 0 && hasMissingTranscriptEntryIds) {
+      warnings.push(
+        `Conversation ${prepared.sessionId} already has messages but the transcript lacks stable entry ids; skipping to avoid duplicates.`,
+      );
+      return {
+        file: prepared.file,
+        status: "skipped",
+        sessionId: prepared.sessionId,
+        candidateMessages: importable.length,
+        importedMessages: 0,
+        skippedMessages: importable.length,
+        reason: "existing-conversation-without-transcript-entry-ids",
+        warnings,
+      };
+    }
+
+    const existingEntryIds =
+      existingCount > 0
+        ? await conversationStore.filterExistingTranscriptEntryIds(
+            conversation.conversationId,
+            importable
+              .map((entry) => entry.transcriptEntryId)
+              .filter((entryId): entryId is string => entryId !== null),
+          )
+        : new Set<string>();
+    const seenEntryIds = new Set<string>();
+    const toImport: ImportableMessage[] = [];
+    let skippedMessages = 0;
+    for (const entry of importable) {
+      if (entry.transcriptEntryId) {
+        if (existingEntryIds.has(entry.transcriptEntryId)) {
+          skippedMessages += 1;
+          continue;
+        }
+        if (seenEntryIds.has(entry.transcriptEntryId)) {
+          skippedMessages += 1;
+          warnings.push(`Duplicate transcript entry id ${entry.transcriptEntryId} was skipped within ${prepared.file}.`);
+          continue;
+        }
+        seenEntryIds.add(entry.transcriptEntryId);
+      }
+      toImport.push(entry);
+    }
+
+    const createdMessages: MessageRecord[] = [];
+    let nextSeq = (await conversationStore.getMaxSeq(conversation.conversationId)) + 1;
+    for (const entry of toImport) {
+      const message = await conversationStore.createMessage({
+        conversationId: conversation.conversationId,
+        seq: nextSeq,
+        role: entry.stored.role,
+        content: entry.stored.content,
+        tokenCount: entry.stored.tokenCount,
+        transcriptEntryId: entry.transcriptEntryId,
+        createdAt: resolveTranscriptMessageCreatedAt(entry.message),
+        skipReplayTimestampFloodGuard: true,
+      });
+      nextSeq += 1;
+      await conversationStore.createMessageParts(
+        message.messageId,
+        buildMessageParts({
+          sessionId: prepared.sessionId,
+          message: entry.message,
+          fallbackContent: entry.stored.content,
+        }),
+      );
+      createdMessages.push(message);
+    }
+
+    await summaryStore.appendContextMessages(
+      conversation.conversationId,
+      createdMessages.map((message) => message.messageId),
+    );
+    await conversationStore.markConversationBootstrapped(conversation.conversationId);
+
+    const lastImportable = importable[importable.length - 1] ?? null;
+    await summaryStore.upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: prepared.file,
+      lastSeenSize: prepared.stat.size,
+      lastSeenMtimeMs: prepared.stat.mtimeMs,
+      lastProcessedOffset: prepared.stat.size,
+      lastProcessedEntryHash: createBootstrapEntryHash(lastImportable?.stored ?? null),
+      sessionHeaderId: prepared.sessionHeaderId,
+      lastProcessedEntryId: lastImportable?.transcriptEntryId ?? null,
+      forkBounded: false,
+      forkSourceMessageCount: importable.length,
+    });
+
+    if (createdMessages.length === 0) {
+      return {
+        file: prepared.file,
+        status: "up-to-date",
+        sessionId: prepared.sessionId,
+        candidateMessages: importable.length,
+        importedMessages: 0,
+        skippedMessages,
+        warnings,
+      };
+    }
+
+    return {
+      file: prepared.file,
+      status: "imported",
+      sessionId: prepared.sessionId,
+      candidateMessages: importable.length,
+      importedMessages: createdMessages.length,
+      skippedMessages,
+      warnings,
+    };
+  });
+}
+
+function summarizeResult(params: {
+  apply: boolean;
+  dbPath: string;
+  stateDir: string;
+  backupPath: string | null;
+  files: MigrationFileResult[];
+}): SessionMigrationResult {
+  const files = params.files;
+  return {
+    apply: params.apply,
+    dbPath: params.dbPath,
+    stateDir: params.stateDir,
+    backupPath: params.backupPath,
+    scannedFiles: files.length,
+    importedFiles: files.filter((file) => file.status === "imported").length,
+    skippedFiles: files.filter((file) => file.status === "skipped" || file.status === "up-to-date").length,
+    errorFiles: files.filter((file) => file.status === "error").length,
+    importedMessages: files.reduce((total, file) => total + file.importedMessages, 0),
+    files,
+  };
+}
+
+export async function runSessionMigration(
+  options: SessionMigrationOptions = {},
+): Promise<SessionMigrationResult> {
+  const stateDir = normalizePathInput(options.stateDir ?? defaultStateDir());
+  const dbPath = normalizePathInput(options.dbPath ?? defaultDbPath(stateDir));
+  const apply = options.apply === true;
+  const files = await discoverSessionFiles({ ...options, stateDir });
+  const prepared = await Promise.all(files.map((file) => prepareSessionFile(file)));
+
+  if (!apply) {
+    return summarizeResult({
+      apply,
+      dbPath,
+      stateDir,
+      backupPath: null,
+      files: prepared.map(buildDryRunResult),
+    });
+  }
+
+  const backupPath = await createDatabaseBackup(dbPath);
+  const db = createLcmDatabaseConnection(dbPath);
+  try {
+    runLcmMigrations(db);
+    const conversationStore = new ConversationStore(db);
+    const summaryStore = new SummaryStore(db);
+    const results: MigrationFileResult[] = [];
+    for (const file of prepared) {
+      if (!isPreparedSessionFile(file)) {
+        results.push(file);
+        continue;
+      }
+      try {
+        results.push(await importPreparedFile(db, conversationStore, summaryStore, file));
+      } catch (error) {
+        results.push({
+          file: file.file,
+          status: "error",
+          sessionId: file.sessionId,
+          candidateMessages: file.messages.length,
+          importedMessages: 0,
+          skippedMessages: 0,
+          reason: "import-failed",
+          warnings: [],
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return summarizeResult({ apply, dbPath, stateDir, backupPath, files: results });
+  } finally {
+    closeLcmConnection(db);
+  }
+}

--- a/test/migrate-sessions.test.ts
+++ b/test/migrate-sessions.test.ts
@@ -230,6 +230,64 @@ describe("runSessionMigration", () => {
     }
   });
 
+  it("adopts transcript entry ids onto existing identity-matching rows instead of duplicating them", async () => {
+    const root = tempRoot();
+    writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "already persisted"),
+      messageEntry("m2", "m1", "assistant", "existing reply"),
+    ]);
+    const dbPath = migratedDb(root);
+    const { db, conversationStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getOrCreateConversation("session-a");
+      await conversationStore.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "user",
+        content: "already persisted",
+        tokenCount: 2,
+      });
+      await conversationStore.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 2,
+        role: "assistant",
+        content: "existing reply",
+        tokenCount: 2,
+      });
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    const result = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(result.importedMessages).toBe(0);
+    expect(result.files[0]).toMatchObject({
+      status: "up-to-date",
+      skippedMessages: 2,
+    });
+
+    const reopened = openMigratedDb(dbPath);
+    try {
+      const conversation = await reopened.conversationStore.getConversationForSession({ sessionId: "session-a" });
+      expect(await reopened.conversationStore.getMessageCount(conversation!.conversationId)).toBe(2);
+      const rows = reopened.db
+        .prepare(
+          `SELECT content, transcript_entry_id
+           FROM messages
+           WHERE conversation_id = ?
+           ORDER BY seq`,
+        )
+        .all(conversation!.conversationId) as Array<{ content: string; transcript_entry_id: string | null }>;
+      expect(rows).toEqual([
+        { content: "already persisted", transcript_entry_id: "m1" },
+        { content: "existing reply", transcript_entry_id: "m2" },
+      ]);
+    } finally {
+      closeLcmConnection(reopened.db);
+    }
+  });
+
   it("imports only the active leaf path from branched JSONL", async () => {
     const root = tempRoot();
     writeAgentSession(root, "session-a.jsonl", [

--- a/test/migrate-sessions.test.ts
+++ b/test/migrate-sessions.test.ts
@@ -1,0 +1,321 @@
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { SummaryStore } from "../src/store/summary-store.js";
+import { runSessionMigration } from "../src/migrate-sessions.js";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "lcm-migrate-sessions-"));
+  roots.push(root);
+  return root;
+}
+
+function writeAgentSession(root: string, fileName: string, entries: unknown[]): string {
+  const sessionsDir = join(root, "agents", "main", "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, fileName);
+  writeFileSync(filePath, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+  return filePath;
+}
+
+function writeRawAgentSession(root: string, fileName: string, content: string): string {
+  const sessionsDir = join(root, "agents", "main", "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  const filePath = join(sessionsDir, fileName);
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+function sessionHeader(id: string): Record<string, unknown> {
+  return {
+    type: "session",
+    version: 3,
+    id,
+    timestamp: "2026-06-10T00:00:00.000Z",
+  };
+}
+
+function messageEntry(
+  id: string,
+  parentId: string | null,
+  role: "user" | "assistant" | "system" | "tool",
+  content: string,
+): Record<string, unknown> {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp: "2026-06-10T00:00:00.000Z",
+    message: { role, content },
+  };
+}
+
+function bareMessage(role: "user" | "assistant", content: string): Record<string, unknown> {
+  return { role, content };
+}
+
+function migratedDb(root: string): string {
+  return join(root, "lcm.db");
+}
+
+function openMigratedDb(dbPath: string): {
+  db: ReturnType<typeof createLcmDatabaseConnection>;
+  conversationStore: ConversationStore;
+  summaryStore: SummaryStore;
+} {
+  const db = createLcmDatabaseConnection(dbPath);
+  runLcmMigrations(db);
+  return {
+    db,
+    conversationStore: new ConversationStore(db),
+    summaryStore: new SummaryStore(db),
+  };
+}
+
+afterEach(() => {
+  closeLcmConnection();
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("runSessionMigration", () => {
+  it("dry-runs by default and leaves the database untouched", async () => {
+    const root = tempRoot();
+    writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "hello from history"),
+      messageEntry("m2", "m1", "assistant", "saved reply"),
+    ]);
+    const dbPath = migratedDb(root);
+
+    const result = await runSessionMigration({ dbPath, stateDir: root });
+
+    expect(result.apply).toBe(false);
+    expect(result.scannedFiles).toBe(1);
+    expect(result.importedMessages).toBe(0);
+    expect(result.files[0]).toMatchObject({
+      status: "would-import",
+      candidateMessages: 2,
+      sessionId: "session-a",
+    });
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it("imports a fresh session into conversations, messages, parts, context, FTS, and checkpoint state", async () => {
+    const root = tempRoot();
+    const sessionFile = writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "hello searchable history"),
+      messageEntry("m2", "m1", "assistant", "saved reply"),
+    ]);
+    const dbPath = migratedDb(root);
+
+    const result = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(result).toMatchObject({
+      apply: true,
+      scannedFiles: 1,
+      importedFiles: 1,
+      importedMessages: 2,
+    });
+    expect(result.files[0]).toMatchObject({
+      status: "imported",
+      importedMessages: 2,
+      skippedMessages: 0,
+    });
+
+    const { db, conversationStore, summaryStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getConversationForSession({ sessionId: "session-a" });
+      expect(conversation).not.toBeNull();
+      expect(await conversationStore.getMessageCount(conversation!.conversationId)).toBe(2);
+      const messages = await conversationStore.getMessages(conversation!.conversationId);
+      expect(messages.map((message) => message.content)).toEqual([
+        "hello searchable history",
+        "saved reply",
+      ]);
+      const firstParts = await conversationStore.getMessageParts(messages[0]!.messageId);
+      expect(firstParts).toMatchObject([{ partType: "text", textContent: "hello searchable history" }]);
+      const contextRows = db
+        .prepare(
+          `SELECT item_type, message_id
+           FROM context_items
+           WHERE conversation_id = ?
+           ORDER BY ordinal`,
+        )
+        .all(conversation!.conversationId);
+      expect(contextRows).toHaveLength(2);
+      const search = await conversationStore.searchMessages({
+        conversationId: conversation!.conversationId,
+        query: "searchable",
+        mode: "full_text",
+      });
+      expect(search).toHaveLength(1);
+      const checkpoint = await summaryStore.getConversationBootstrapState(conversation!.conversationId);
+      expect(checkpoint).toMatchObject({
+        sessionFilePath: sessionFile,
+        lastSeenSize: expect.any(Number),
+        lastProcessedOffset: expect.any(Number),
+        sessionHeaderId: "session-a",
+        lastProcessedEntryId: "m2",
+      });
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("is idempotent on rerun and imports no duplicate rows", async () => {
+    const root = tempRoot();
+    writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "hello"),
+      messageEntry("m2", "m1", "assistant", "reply"),
+    ]);
+    const dbPath = migratedDb(root);
+
+    await runSessionMigration({ dbPath, stateDir: root, apply: true });
+    const rerun = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(rerun.importedMessages).toBe(0);
+    expect(rerun.backupPath).not.toBeNull();
+    expect(existsSync(rerun.backupPath!)).toBe(true);
+    expect(rerun.files[0]).toMatchObject({
+      status: "up-to-date",
+      skippedMessages: 2,
+    });
+
+    const { db, conversationStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getConversationForSession({ sessionId: "session-a" });
+      expect(await conversationStore.getMessageCount(conversation!.conversationId)).toBe(2);
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("catches up a plugin-off session by importing only missing transcript entry ids", async () => {
+    const root = tempRoot();
+    const sessionFile = writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "first"),
+      messageEntry("m2", "m1", "assistant", "second"),
+    ]);
+    const dbPath = migratedDb(root);
+    await runSessionMigration({ dbPath, stateDir: root, apply: true });
+    appendFileSync(sessionFile, `${JSON.stringify(messageEntry("m3", "m2", "user", "third"))}\n`);
+
+    const catchup = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(catchup.importedMessages).toBe(1);
+    expect(catchup.files[0]).toMatchObject({
+      status: "imported",
+      importedMessages: 1,
+      skippedMessages: 2,
+    });
+
+    const { db, conversationStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getConversationForSession({ sessionId: "session-a" });
+      const messages = await conversationStore.getMessages(conversation!.conversationId);
+      expect(messages.map((message) => message.content)).toEqual(["first", "second", "third"]);
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("imports only the active leaf path from branched JSONL", async () => {
+    const root = tempRoot();
+    writeAgentSession(root, "session-a.jsonl", [
+      sessionHeader("session-a"),
+      messageEntry("m1", null, "user", "root"),
+      messageEntry("abandoned", "m1", "assistant", "abandoned branch"),
+      messageEntry("m2", "m1", "assistant", "active branch"),
+      messageEntry("m3", "m2", "user", "active leaf"),
+    ]);
+    const dbPath = migratedDb(root);
+
+    await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    const { db, conversationStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getConversationForSession({ sessionId: "session-a" });
+      const messages = await conversationStore.getMessages(conversation!.conversationId);
+      expect(messages.map((message) => message.content)).toEqual([
+        "root",
+        "active branch",
+        "active leaf",
+      ]);
+    } finally {
+      closeLcmConnection(db);
+    }
+  });
+
+  it("skips non-empty legacy/idless conversations instead of duplicating them", async () => {
+    const root = tempRoot();
+    writeAgentSession(root, "legacy.jsonl", [
+      bareMessage("user", "legacy first"),
+      bareMessage("assistant", "legacy reply"),
+    ]);
+    const dbPath = migratedDb(root);
+    const { db, conversationStore } = openMigratedDb(dbPath);
+    try {
+      const conversation = await conversationStore.getOrCreateConversation("legacy");
+      await conversationStore.createMessage({
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "user",
+        content: "already imported",
+        tokenCount: 2,
+      });
+    } finally {
+      closeLcmConnection(db);
+    }
+
+    const result = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(result.importedMessages).toBe(0);
+    expect(result.files[0]).toMatchObject({
+      status: "skipped",
+      reason: "existing-conversation-without-transcript-entry-ids",
+      warnings: expect.arrayContaining([
+        expect.stringContaining("already has messages but the transcript lacks stable entry ids"),
+      ]),
+    });
+
+    const reopened = openMigratedDb(dbPath);
+    try {
+      const conversation = await reopened.conversationStore.getConversationForSession({ sessionId: "legacy" });
+      expect(await reopened.conversationStore.getMessageCount(conversation!.conversationId)).toBe(1);
+    } finally {
+      closeLcmConnection(reopened.db);
+    }
+  });
+
+  it("reports malformed or empty files and continues the batch", async () => {
+    const root = tempRoot();
+    writeRawAgentSession(root, "bad.jsonl", "{not json}\n");
+    writeAgentSession(root, "good.jsonl", [
+      sessionHeader("good"),
+      messageEntry("g1", null, "user", "good"),
+    ]);
+    const dbPath = migratedDb(root);
+
+    const result = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(result.scannedFiles).toBe(2);
+    expect(result.importedMessages).toBe(1);
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ file: expect.stringContaining("bad.jsonl"), status: "skipped" }),
+        expect.objectContaining({ file: expect.stringContaining("good.jsonl"), status: "imported" }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5.
Refs #18.

Adds a first-party packaged `lossless-claw-migrate-sessions` CLI for safe OpenClaw JSONL session backfill into `lcm.db`, intended for fresh installs and plugin-off catch-up.

The CLI is dry-run by default and only writes with `--apply`. Apply mode creates a SQLite `VACUUM INTO` backup before opening the DB for writes, imports each file in its own transaction, and updates `conversation_bootstrap_state` only after a successful per-file transaction.

## Behavior

- Adds package bin `lossless-claw-migrate-sessions` -> `dist/migrate-sessions.js`.
- Supports `--db`, `--state-dir`, repeatable `--sessions-dir`, repeatable `--file`, `--apply`, `--limit`, `--since`, `--json`, and `--verbose`.
- Defaults to scanning `${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl`.
- Uses existing transcript helpers to import only active leaf-path messages.
- Uses existing store/helper APIs for conversations, messages, message parts, context rows, FTS indexing, and bootstrap state.
- Derives `sessionId` from transcript header id, falling back to the JSONL filename stem.
- Imports all messages for empty conversations.
- For existing conversations, imports only missing transcript-entry-id-backed messages.
- Skips existing non-empty legacy/idless conversations instead of duplicating them.
- Reports malformed/empty/unreadable files without aborting the batch.

## Out of scope

This does not implement Markdown import (#149), SQLite-vNext replay, background auto-backfill, embeddings backfill, or summarization/compaction changes.

## Validation

All commands ran from `/Volumes/LEXAR/repos/worktrees/lossless-claw-jsonl-session-migrate`.

- `npm test -- test/migrate-sessions.test.ts`
- `npm run typecheck`
- `npm run build`
- `node dist/migrate-sessions.js --state-dir /Volumes/LEXAR/Codex/reports/lossless-claw-jsonl-session-migrate/2026-06-28/nonexistent-state --json`
- `npm pack --dry-run`

Evidence note: `/Volumes/LEXAR/Codex/reports/lossless-claw-jsonl-session-migrate/2026-06-28/evidence.md`

## Proof boundary

The focused tests cover deterministic local DB import behavior: dry-run, fresh import, idempotent rerun, plugin-off catch-up, active leaf-path filtering, legacy/idless safety skip, and malformed-file continuation. They do not prove SQLite-vNext replay or runtime summarization quality.
