### PR TITLE
feat(tools): let lcm_grep search externalized file contents

### DIFF
--- a/.changeset/wet-bags-create.md
+++ b/.changeset/wet-bags-create.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Teach `lcm_grep` to search the contents of externalized `large_files` rows via the new `scope="files"` option. Add an optional `fileIds` parameter to restrict the search to specific file IDs. Each match reports the file ID, line number, byte offset, matched text, and a contextual snippet. Update `lcm_describe` to give accurate guidance when inlined content is truncated. Honor `allConversations=true` for `scope="files"` by searching large files across all conversations.
+Teach `lcm_grep` to search the first 512,000 bytes of externalized `large_files` text rows via the new `scope="files"` option. Add an optional `fileIds` parameter to restrict the search to specific file IDs. Each match reports the file ID, line number, byte offset, matched text, and a contextual snippet. Update `lcm_describe` to give accurate bounded-search guidance when inlined content is truncated. Honor `allConversations=true` for `scope="files"` by searching large files across all conversations.

--- a/.changeset/wet-bags-create.md
+++ b/.changeset/wet-bags-create.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Teach `lcm_grep` to search the contents of externalized `large_files` rows via the new `scope="files"` option. Add an optional `fileIds` parameter to restrict the search to specific file IDs. Each match reports the file ID, line number, byte offset, matched text, and a contextual snippet. Update `lcm_describe` to give accurate guidance when inlined content is truncated. Honor `allConversations=true` for `scope="files"` by searching large files across all conversations.

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -8,7 +8,7 @@ LCM provides four tools for agents to search, inspect, and recall information fr
 
 Most recall tasks follow this escalation:
 
-1. **`lcm_grep`** — Find relevant summaries or messages by keyword/regex
+1. **`lcm_grep`** — Find relevant summaries, messages, or externalized file prefixes by keyword/regex
 2. **`lcm_describe`** — Inspect a specific summary's full content (cheap, no sub-agent)
 3. **`lcm_expand_query`** — Deep recall: spawn a sub-agent to expand the DAG and answer a focused question
 
@@ -30,7 +30,7 @@ Summaries are lossy by design. The "Expand for details about:" footer at the end
 
 ### lcm_grep
 
-Search across messages and/or summaries using regex or full-text search.
+Search across messages, summaries, and/or the bounded prefix of externalized large files using regex or full-text search.
 
 Use `mode: "full_text"` for keyword or topical recall. Full-text queries are not regexes: alternation (`A|B`), regex wildcards (`.*`), character classes (`[abc]`), and anchors (`^foo`, `foo$`) require `mode: "regex"`. Wrap exact multi-word phrases in quotes to preserve phrase matching. Keep the default `sort: "recency"` for recent events, switch to `sort: "relevance"` when looking for the best older match on a topic, and use `sort: "hybrid"` when you want relevance without giving up recency entirely.
 
@@ -40,7 +40,8 @@ Use `mode: "full_text"` for keyword or topical recall. Full-text queries are not
 |-------|------|----------|---------|-------------|
 | `pattern` | string | ✅ | — | Search pattern |
 | `mode` | string | | `"regex"` | `"regex"` or `"full_text"` |
-| `scope` | string | | `"both"` | `"messages"`, `"summaries"`, or `"both"` |
+| `scope` | string | | `"both"` | `"messages"`, `"summaries"`, `"both"`, or `"files"` |
+| `fileIds` | string[] | | — | Optional `file_xxx` IDs to restrict `scope: "files"` searches |
 | `conversationId` | number | | current session family | Specific physical conversation to search |
 | `allConversations` | boolean | | `false` | Search all conversations |
 | `since` | string | | — | ISO timestamp lower bound |
@@ -49,12 +50,13 @@ Use `mode: "full_text"` for keyword or topical recall. Full-text queries are not
 | `sort` | string | | `"recency"` | `"recency"`, `"relevance"`, or `"hybrid"` for full-text ranking |
 
 **Returns:** Array of matches with:
-- `id` — Message or summary ID
-- `type` — `"message"` or `"summary"`
+- `id` — Message, summary, or file ID
+- `type` — `"message"`, `"summary"`, or `"file"`
 - `snippet` — Truncated content around the match
 - `conversationId` — Which conversation
 - `createdAt` — Timestamp
 - For summaries: `depth`, `kind`, `summaryId`
+- For files: line number, byte offset, matched text, and a snippet from the first 512,000 bytes scanned per file
 
 **Examples:**
 
@@ -70,6 +72,9 @@ lcm_grep(pattern: "config\\.threshold.*0\\.[0-9]+", scope: "summaries")
 
 # Recent messages containing a specific term
 lcm_grep(pattern: "deployment", since: "2026-02-19T00:00:00Z", scope: "messages")
+
+# Search the bounded scanned prefix of an externalized file
+lcm_grep(pattern: "CRITICAL_MARKER", scope: "files", fileIds: ["file_789abc012345"])
 ```
 
 ### lcm_describe
@@ -95,7 +100,7 @@ Look up metadata and content for a specific summary or stored file.
 - File IDs referenced in the summary
 
 **Returns for files:**
-- File content (full text)
+- File content, capped by `expandFileMaxBytes`
 - Metadata: fileName, mimeType, byteSize
 - Exploration summary
 - Storage path

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,7 @@ Files embedded in user messages (typically via `<file>` blocks from tool output)
    - Generate a ~200 token exploration summary (structural analysis, key sections, etc.)
    - Insert a `large_files` record with metadata
    - Replace the file block in the message with a compact reference
-3. The `lcm_describe` tool can retrieve full file content by ID.
+3. The `lcm_describe` tool can retrieve bounded file content by ID, and `lcm_grep(scope="files")` can search the first 512,000 bytes of externalized text files.
 
 This prevents a single large file paste from consuming the entire context window while keeping the content accessible.
 

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -179,6 +179,14 @@ function ensureCompactionTelemetryColumns(db: DatabaseSync): void {
   }
 }
 
+function ensureLargeFilesLineCountColumn(db: DatabaseSync): void {
+  const columns = db.prepare(`PRAGMA table_info(large_files)`).all() as SummaryColumnInfo[];
+  const hasLineCount = columns.some((col) => col.name === "line_count");
+  if (!hasLineCount) {
+    db.exec(`ALTER TABLE large_files ADD COLUMN line_count INTEGER`);
+  }
+}
+
 function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   const maintenanceColumns = db
     .prepare(`PRAGMA table_info(conversation_compaction_maintenance)`)
@@ -1174,6 +1182,7 @@ export function runLcmMigrations(
       file_name TEXT,
       mime_type TEXT,
       byte_size INTEGER,
+      line_count INTEGER,
       storage_uri TEXT NOT NULL,
       exploration_summary TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -1384,6 +1393,9 @@ export function runLcmMigrations(
     );
     runMigrationStep("ensureCompactionMaintenanceColumns", log, () =>
       ensureCompactionMaintenanceColumns(db),
+    );
+    runMigrationStep("ensureLargeFilesLineCountColumn", log, () =>
+      ensureLargeFilesLineCountColumn(db),
     );
     runMigrationStep("ensureFocusBriefTables", log, () => ensureFocusBriefTables(db));
     runVersionedBackfillStep(db, "backfillSummaryDepths", log, () => backfillSummaryDepths(db));

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -662,6 +662,7 @@ export class LargeFileInterceptor {
       content: params.content,
     });
     const byteSize = Buffer.byteLength(params.content, "utf8");
+    const lineCount = params.content.split(/\r?\n/).length;
     const explorationSummary = await generateExplorationSummary({
       content: params.content,
       fileName: params.fileName,
@@ -675,6 +676,7 @@ export class LargeFileInterceptor {
       fileName: params.fileName,
       mimeType: params.mimeType,
       byteSize,
+      lineCount,
       storageUri,
       explorationSummary,
     });

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -529,6 +529,7 @@ function truncateToValidUtf8End(buf: Buffer, byteLength: number): number {
         -1; // invalid leading pattern
       if (continuationBytes === expectedContinuations) {
         // The multi-byte character is fully inside the buffer.
+        safeEnd = byteLength;
         break;
       }
       // Incomplete sequence: drop the start byte and everything after it.

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -17,6 +17,8 @@ import type {
   SummaryRecord,
   SummarySearchResult,
   LargeFileRecord,
+  LargeFileSearchInput,
+  LargeFileSearchResult,
 } from "./store/summary-store.js";
 import type { SearchSort } from "./store/full-text-sort.js";
 import { estimateTokens } from "./estimate-tokens.js";
@@ -65,6 +67,7 @@ export interface DescribeResult {
     fileName: string | null;
     mimeType: string | null;
     byteSize: number | null;
+    lineCount: number | null;
     storageUri: string;
     explorationSummary: string | null;
     createdAt: Date;
@@ -83,9 +86,10 @@ export interface DescribeResult {
 export interface GrepInput {
   query: string;
   mode: "regex" | "full_text";
-  scope: "messages" | "summaries" | "both";
+  scope: "messages" | "summaries" | "both" | "files";
   conversationId?: number;
   conversationIds?: number[];
+  fileIds?: string[];
   since?: Date;
   before?: Date;
   limit?: number;
@@ -93,11 +97,14 @@ export interface GrepInput {
    *  "relevance" sorts by FTS5 BM25 rank (full_text mode only).
    *  "hybrid" blends relevance with recency. */
   sort?: SearchSort;
+  /** Required when scope="files". Used to validate file paths before reading. */
+  largeFilesDir?: string;
 }
 
 export interface GrepResult {
   messages: MessageSearchResult[];
   summaries: SummarySearchResult[];
+  files: LargeFileSearchResult[];
   totalMatches: number;
 }
 
@@ -154,7 +161,13 @@ export class RetrievalEngine {
    */
   async describe(
     id: string,
-    options?: { expandFile?: boolean; expandFileMaxBytes?: number; largeFilesDir?: string },
+    options?: {
+      expandFile?: boolean;
+      expandFileMaxBytes?: number;
+      startLine?: number;
+      endLine?: number;
+      largeFilesDir?: string;
+    },
   ): Promise<DescribeResult | null> {
     if (id.startsWith("sum_")) {
       return this.describeSummary(id);
@@ -219,7 +232,13 @@ export class RetrievalEngine {
 
   private async describeFile(
     id: string,
-    options?: { expandFile?: boolean; expandFileMaxBytes?: number; largeFilesDir?: string },
+    options?: {
+      expandFile?: boolean;
+      expandFileMaxBytes?: number;
+      startLine?: number;
+      endLine?: number;
+      largeFilesDir?: string;
+    },
   ): Promise<DescribeResult | null> {
     const file = await this.summaryStore.getLargeFile(id);
     if (!file) {
@@ -238,6 +257,8 @@ export class RetrievalEngine {
     //      can't blow out the agent's context. Override via
     //      `expandFileMaxBytes`. Files over the cap return the head
     //      portion + `contentTruncated: true`.
+    //   4. Line range: optional `startLine`/`endLine` (1-based, inclusive)
+    //      read a specific slice instead of the head cap.
     let content: string | null = null;
     let contentTruncated = false;
     // Wave-3 P3 fix: refuse expansion when largeFilesDir is unset in
@@ -266,7 +287,14 @@ export class RetrievalEngine {
           const fd = openSync(realTarget, "r");
           try {
             const stat = fstatSync(fd);
-            if (stat.size <= maxBytes) {
+            const startLine = typeof options.startLine === "number" ? Math.max(1, Math.trunc(options.startLine)) : undefined;
+            const endLine = typeof options.endLine === "number" ? Math.max(1, Math.trunc(options.endLine)) : undefined;
+
+            if (startLine != null) {
+              const lineRange = readFileLineRange(fd, stat.size, startLine, endLine ?? Number.POSITIVE_INFINITY, maxBytes);
+              content = lineRange.content;
+              contentTruncated = lineRange.truncated;
+            } else if (stat.size <= maxBytes) {
               content = readFileSync(fd, "utf8");
             } else {
               // Read just the head. Wave-3 P1 fix: scan back from the
@@ -274,14 +302,7 @@ export class RetrievalEngine {
               // emit U+FFFD mojibake from a split multi-byte sequence.
               const buf = Buffer.alloc(maxBytes);
               readSync(fd, buf, 0, maxBytes, 0);
-              let safeEnd = maxBytes;
-              while (safeEnd > 0) {
-                const b = buf[safeEnd - 1];
-                if ((b & 0x80) === 0) break;             // ASCII
-                if ((b & 0xc0) === 0xc0) { safeEnd -= 1; break; } // start byte
-                safeEnd -= 1;                             // continuation
-                if (maxBytes - safeEnd > 4) break;        // bounded
-              }
+              const safeEnd = truncateToValidUtf8End(buf, maxBytes);
               content = buf.subarray(0, safeEnd).toString("utf8");
               contentTruncated = true;
             }
@@ -315,6 +336,7 @@ export class RetrievalEngine {
         fileName: file.fileName,
         mimeType: file.mimeType,
         byteSize: file.byteSize,
+        lineCount: file.lineCount,
         storageUri: file.storageUri,
         explorationSummary: file.explorationSummary,
         createdAt: file.createdAt,
@@ -331,7 +353,25 @@ export class RetrievalEngine {
    * Depending on `scope`, searches messages, summaries, or both (in parallel).
    */
   async grep(input: GrepInput): Promise<GrepResult> {
-    const { query, mode, scope, conversationId, conversationIds, since, before, limit, sort } = input;
+    const { query, mode, scope, conversationId, conversationIds, fileIds, since, before, limit, sort, largeFilesDir } = input;
+
+    if (scope === "files") {
+      if (!largeFilesDir) {
+        return { messages: [], summaries: [], files: [], totalMatches: 0 };
+      }
+      const files = await this.summaryStore.searchLargeFiles({
+        query,
+        mode,
+        conversationId,
+        conversationIds,
+        fileIds,
+        since,
+        before,
+        limit,
+        largeFilesDir,
+      });
+      return { messages: [], summaries: [], files, totalMatches: files.length };
+    }
 
     const searchInput = { query, mode, conversationId, conversationIds, since, before, limit, sort };
 
@@ -353,6 +393,7 @@ export class RetrievalEngine {
     return {
       messages,
       summaries,
+      files: [],
       totalMatches: messages.length + summaries.length,
     };
   }
@@ -464,4 +505,87 @@ export class RetrievalEngine {
       }
     }
   }
+}
+
+function truncateToValidUtf8End(buf: Buffer, byteLength: number): number {
+  let safeEnd = byteLength;
+  while (safeEnd > 0) {
+    const b = buf[safeEnd - 1];
+    if ((b & 0x80) === 0) {
+      // ASCII: clean boundary.
+      break;
+    }
+    if ((b & 0xc0) === 0xc0) {
+      // Start byte. Count continuation bytes that follow it in the buffer.
+      const continuationBytes = byteLength - safeEnd;
+      const expectedContinuations =
+        (b & 0xf8) === 0xf0 ? 3 : // 11110xxx -> 4-byte sequence
+        (b & 0xf0) === 0xe0 ? 2 : // 1110xxxx -> 3-byte sequence
+        (b & 0xe0) === 0xc0 ? 1 : // 110xxxxx -> 2-byte sequence
+        -1; // invalid leading pattern
+      if (continuationBytes === expectedContinuations) {
+        // The multi-byte character is fully inside the buffer.
+        break;
+      }
+      // Incomplete sequence: drop the start byte and everything after it.
+      safeEnd -= 1;
+      break;
+    }
+    // Continuation byte: keep walking back to the start byte.
+    safeEnd -= 1;
+    if (byteLength - safeEnd > 4) {
+      // Bounded safety: no valid UTF-8 sequence exceeds 4 bytes.
+      break;
+    }
+  }
+  return safeEnd;
+}
+
+function readFileLineRange(
+  fd: number,
+  fileSize: number,
+  startLine: number,
+  endLine: number,
+  maxBytes: number,
+): { content: string; truncated: boolean } {
+  const readBytes = Math.min(fileSize, maxBytes);
+  const buf = Buffer.alloc(readBytes);
+  let bytesRead = 0;
+  while (bytesRead < readBytes) {
+    const n = readSync(fd, buf, bytesRead, readBytes - bytesRead, bytesRead);
+    if (n === 0) break;
+    bytesRead += n;
+  }
+
+  let safeEnd = truncateToValidUtf8End(buf, bytesRead);
+
+  const text = buf.subarray(0, safeEnd).toString("utf8");
+  const allLines = text.split(/\r?\n/);
+  const startIndex = Math.max(0, startLine - 1);
+  const hasExplicitEndLine = endLine !== Number.POSITIVE_INFINITY;
+  const endIndex = hasExplicitEndLine ? Math.min(allLines.length, endLine) : allLines.length;
+  const selectedLines = allLines.slice(startIndex, endIndex);
+
+  let content = selectedLines.join("\n");
+  // Truncated if we could not read the whole file, or the explicit endLine
+  // sits past EOF, or the selected slice itself exceeds the byte budget.
+  let truncated = bytesRead < fileSize || (hasExplicitEndLine && endLine > allLines.length);
+  if (Buffer.byteLength(content, "utf8") > maxBytes) {
+    let byteCount = 0;
+    let lastIndex = 0;
+    for (let i = 0; i < selectedLines.length; i++) {
+      const lineBytes = Buffer.byteLength(selectedLines[i], "utf8");
+      const sepBytes = i > 0 ? 1 : 0;
+      if (byteCount + sepBytes + lineBytes > maxBytes) {
+        lastIndex = i;
+        break;
+      }
+      byteCount += sepBytes + lineBytes;
+      lastIndex = i + 1;
+    }
+    content = selectedLines.slice(0, lastIndex).join("\n");
+    truncated = true;
+  }
+
+  return { content, truncated };
 }

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -99,6 +99,9 @@ export interface GrepInput {
   sort?: SearchSort;
   /** Required when scope="files". Used to validate file paths before reading. */
   largeFilesDir?: string;
+  /** When true and no explicit fileIds/conversationId/conversationIds are
+   *  provided, search large files across all conversations. */
+  allConversations?: boolean;
 }
 
 export interface GrepResult {
@@ -353,7 +356,7 @@ export class RetrievalEngine {
    * Depending on `scope`, searches messages, summaries, or both (in parallel).
    */
   async grep(input: GrepInput): Promise<GrepResult> {
-    const { query, mode, scope, conversationId, conversationIds, fileIds, since, before, limit, sort, largeFilesDir } = input;
+    const { query, mode, scope, conversationId, conversationIds, fileIds, since, before, limit, sort, largeFilesDir, allConversations } = input;
 
     if (scope === "files") {
       if (!largeFilesDir) {
@@ -369,6 +372,7 @@ export class RetrievalEngine {
         before,
         limit,
         largeFilesDir,
+        allConversations,
       });
       return { messages: [], summaries: [], files, totalMatches: files.length };
     }

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -7,6 +7,7 @@ import { buildLikeSearchPlan, containsCjk, createFallbackSnippet } from "./full-
 import { buildMessageIdentityHash } from "./message-identity.js";
 import { parseUtcTimestamp, parseUtcTimestampOrNull } from "./parse-utc-timestamp.js";
 import { buildFtsOrderBy, type SearchSort } from "./full-text-sort.js";
+import { compileSafeSearchRegex } from "./search-regex.js";
 
 export type ConversationId = number;
 export type MessageId = number;
@@ -1670,14 +1671,8 @@ export class ConversationStore {
     before?: Date,
   ): MessageSearchResult[] {
     // SQLite has no native POSIX regex; fetch candidates and filter in JS
-    // Guard against ReDoS: reject patterns with nested quantifiers or excessive length
-    if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) {
-      return [];
-    }
-    let re: RegExp;
-    try {
-      re = new RegExp(pattern);
-    } catch {
+    const re = compileSafeSearchRegex(pattern);
+    if (!re) {
       return [];
     }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,6 +27,8 @@ export type {
   SummaryMessageSeqRangeRecord,
   CreateLargeFileInput,
   LargeFileRecord,
+  LargeFileSearchInput,
+  LargeFileSearchResult,
   UpsertConversationBootstrapStateInput,
   ConversationBootstrapStateRecord,
 } from "./summary-store.js";

--- a/src/store/search-regex.ts
+++ b/src/store/search-regex.ts
@@ -1,0 +1,26 @@
+const MAX_SEARCH_REGEX_PATTERN_LENGTH = 500;
+const REGEX_QUANTIFIER_PATTERN = String.raw`(?:[+*?]|\{\d+(?:,\d*)?\})`;
+const NESTED_QUANTIFIER_PATTERN = new RegExp(
+  `${REGEX_QUANTIFIER_PATTERN}\\)${REGEX_QUANTIFIER_PATTERN}`,
+);
+const QUANTIFIED_ALTERNATION_GROUP_PATTERN =
+  /\((?:[^()\\]|\\.)*\|(?:[^()\\]|\\.)*\)(?:[+*?]|\{\d)/;
+
+/**
+ * Compile a user-provided search regex only after applying the shared search
+ * safety guard used by JS-backed message, summary, and large-file scans.
+ */
+export function compileSafeSearchRegex(pattern: string, flags?: string): RegExp | null {
+  if (
+    pattern.length > MAX_SEARCH_REGEX_PATTERN_LENGTH ||
+    NESTED_QUANTIFIER_PATTERN.test(pattern) ||
+    QUANTIFIED_ALTERNATION_GROUP_PATTERN.test(pattern)
+  ) {
+    return null;
+  }
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -7,6 +7,7 @@ import { sanitizeFts5Query } from "./fts5-sanitize.js";
 import { buildLikeSearchPlan, containsCjk, createFallbackSnippet } from "./full-text-fallback.js";
 import { parseUtcTimestamp, parseUtcTimestampOrNull } from "./parse-utc-timestamp.js";
 import { buildFtsOrderBy, type SearchSort } from "./full-text-sort.js";
+import { compileSafeSearchRegex } from "./search-regex.js";
 
 export type SummaryKind = "leaf" | "condensed";
 export type ContextItemType = "message" | "summary";
@@ -136,6 +137,8 @@ export type LargeFileSearchInput = {
   allConversations?: boolean;
 };
 
+export const DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES = 512_000;
+
 export type LargeFileSearchResult = {
   fileId: string;
   conversationId: number;
@@ -148,6 +151,12 @@ export type LargeFileSearchResult = {
   byteOffset: number;
   /** Snippet with surrounding context. */
   snippet: string;
+  /** Number of bytes scanned from the file for this match. */
+  scannedBytes: number;
+  /** Maximum bytes searched per file for this scan. */
+  scanByteLimit: number;
+  /** True when the file had content beyond the scanned prefix. */
+  scanTruncated: boolean;
   createdAt: Date;
 };
 
@@ -405,20 +414,19 @@ interface FileContentMatch {
 }
 
 function findRegexMatches(content: string, pattern: string, maxMatches: number): FileContentMatch[] {
-  try {
-    const regex = new RegExp(pattern, "g");
-    const matches: FileContentMatch[] = [];
-    let match;
-    while ((match = regex.exec(content)) !== null && matches.length < maxMatches) {
-      matches.push({ index: match.index, length: match[0].length, text: match[0] });
-      if (match.index === regex.lastIndex) {
-        regex.lastIndex++;
-      }
-    }
-    return matches;
-  } catch {
+  const regex = compileSafeSearchRegex(pattern, "g");
+  if (!regex) {
     return [];
   }
+  const matches: FileContentMatch[] = [];
+  let match;
+  while ((match = regex.exec(content)) !== null && matches.length < maxMatches) {
+    matches.push({ index: match.index, length: match[0].length, text: match[0] });
+    if (match.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+  }
+  return matches;
 }
 
 function findFullTextMatches(content: string, query: string, maxMatches: number): FileContentMatch[] {
@@ -508,6 +516,10 @@ function createSearchSnippet(content: string, index: number, length: number): st
     snippet = snippet + "...";
   }
   return snippet;
+}
+
+function byteOffsetAt(content: string, index: number): number {
+  return Buffer.byteLength(content.slice(0, index), "utf8");
 }
 
 function toConversationBootstrapStateRecord(
@@ -1623,14 +1635,8 @@ export class SummaryStore {
     since?: Date,
     before?: Date,
   ): SummarySearchResult[] {
-    // Guard against ReDoS: reject patterns with nested quantifiers or excessive length
-    if (pattern.length > 500 || /(\+|\*|\?)\)(\+|\*|\?|\{\d)/.test(pattern)) {
-      return [];
-    }
-    let re: RegExp;
-    try {
-      re = new RegExp(pattern);
-    } catch {
+    const re = compileSafeSearchRegex(pattern);
+    if (!re) {
       return [];
     }
 
@@ -1756,7 +1762,10 @@ export class SummaryStore {
    */
   async searchLargeFiles(input: LargeFileSearchInput): Promise<LargeFileSearchResult[]> {
     const limit = input.limit ?? 50;
-    const maxBytesPerFile = input.maxBytesPerFile ?? 512_000;
+    const requestedMaxBytes = input.maxBytesPerFile ?? DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES;
+    const maxBytesPerFile = Number.isFinite(requestedMaxBytes)
+      ? Math.max(0, Math.trunc(requestedMaxBytes))
+      : DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES;
     const maxMatchesPerFile = 10;
 
     let files: LargeFileRecord[] = [];
@@ -1784,6 +1793,12 @@ export class SummaryStore {
     if (input.before) {
       files = files.filter((f) => f.createdAt.getTime() < input.before!.getTime());
     }
+    if (input.conversationIds && input.conversationIds.length > 0) {
+      const conversationIds = new Set(input.conversationIds);
+      files = files.filter((f) => conversationIds.has(f.conversationId));
+    } else if (input.conversationId != null) {
+      files = files.filter((f) => f.conversationId === input.conversationId);
+    }
 
     const results: LargeFileSearchResult[] = [];
     for (const file of files) {
@@ -1794,13 +1809,14 @@ export class SummaryStore {
         continue;
       }
 
-      const content = await this.readValidatedLargeFileContentUpTo(file.storageUri, {
+      const readResult = await this.readValidatedLargeFileContentUpTo(file.storageUri, {
         largeFilesDir: input.largeFilesDir,
         maxBytes: maxBytesPerFile,
       });
-      if (content == null) {
+      if (readResult == null) {
         continue;
       }
+      const { content, scannedBytes, scanTruncated } = readResult;
 
       const matches =
         input.mode === "regex"
@@ -1817,8 +1833,11 @@ export class SummaryStore {
           fileName: file.fileName,
           matchedText: match.text,
           lineNumber: lineNumberAt(content, match.index),
-          byteOffset: match.index,
+          byteOffset: byteOffsetAt(content, match.index),
           snippet: createSearchSnippet(content, match.index, match.length),
+          scannedBytes,
+          scanByteLimit: maxBytesPerFile,
+          scanTruncated,
           createdAt: file.createdAt,
         });
       }
@@ -1958,7 +1977,7 @@ export class SummaryStore {
   private async readValidatedLargeFileContentUpTo(
     storageUri: string,
     options: LargeFileReadOptions,
-  ): Promise<string | null> {
+  ): Promise<{ content: string; scannedBytes: number; scanTruncated: boolean } | null> {
     try {
       const file = await this.openValidatedLargeFile(storageUri, options);
       if (!file) {
@@ -1970,9 +1989,21 @@ export class SummaryStore {
           return null;
         }
         const maxBytes = options.maxBytes ?? stats.size;
-        const buffer = Buffer.alloc(Math.min(maxBytes, stats.size));
-        const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
-        return buffer.subarray(0, bytesRead).toString("utf8");
+        const readLimit = Math.min(maxBytes, stats.size);
+        const buffer = Buffer.alloc(readLimit);
+        let bytesRead = 0;
+        while (bytesRead < buffer.length) {
+          const result = await file.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+          if (result.bytesRead === 0) {
+            break;
+          }
+          bytesRead += result.bytesRead;
+        }
+        return {
+          content: buffer.subarray(0, bytesRead).toString("utf8"),
+          scannedBytes: bytesRead,
+          scanTruncated: bytesRead < stats.size,
+        };
       } finally {
         await file.close().catch(() => undefined);
       }

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -98,6 +98,7 @@ export type CreateLargeFileInput = {
   fileName?: string;
   mimeType?: string;
   byteSize?: number;
+  lineCount?: number;
   storageUri: string;
   explorationSummary?: string;
 };
@@ -108,6 +109,7 @@ export type LargeFileRecord = {
   fileName: string | null;
   mimeType: string | null;
   byteSize: number | null;
+  lineCount: number | null;
   storageUri: string;
   explorationSummary: string | null;
   createdAt: Date;
@@ -116,6 +118,34 @@ export type LargeFileRecord = {
 export type LargeFileReadOptions = {
   largeFilesDir: string;
   maxBytes?: number;
+};
+
+export type LargeFileSearchInput = {
+  query: string;
+  mode: "regex" | "full_text";
+  conversationId?: number;
+  conversationIds?: number[];
+  fileIds?: string[];
+  since?: Date;
+  before?: Date;
+  limit?: number;
+  largeFilesDir: string;
+  maxBytesPerFile?: number;
+};
+
+export type LargeFileSearchResult = {
+  fileId: string;
+  conversationId: number;
+  fileName: string | null;
+  /** Matched text. */
+  matchedText: string;
+  /** 1-based line number where the match starts. */
+  lineNumber: number;
+  /** 0-based byte offset where the match starts. */
+  byteOffset: number;
+  /** Snippet with surrounding context. */
+  snippet: string;
+  createdAt: Date;
 };
 
 export type UpsertConversationBootstrapStateInput = {
@@ -235,6 +265,7 @@ interface LargeFileRow {
   file_name: string | null;
   mime_type: string | null;
   byte_size: number | null;
+  line_count: number | null;
   storage_uri: string;
   exploration_summary: string | null;
   created_at: string;
@@ -336,10 +367,144 @@ function toLargeFileRecord(row: LargeFileRow): LargeFileRecord {
     fileName: row.file_name,
     mimeType: row.mime_type,
     byteSize: row.byte_size,
+    lineCount: row.line_count,
     storageUri: row.storage_uri,
     explorationSummary: row.exploration_summary,
     createdAt: parseUtcTimestamp(row.created_at),
   };
+}
+
+function isTextLikeMimeType(mimeType: string | null): boolean {
+  if (mimeType == null) {
+    return true;
+  }
+  const lower = mimeType.toLowerCase();
+  if (lower.startsWith("text/")) {
+    return true;
+  }
+  if (
+    lower.includes("json") ||
+    lower.includes("javascript") ||
+    lower.includes("xml") ||
+    lower.includes("yaml") ||
+    lower.includes("yml") ||
+    lower.includes("toml")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+interface FileContentMatch {
+  index: number;
+  length: number;
+  text: string;
+}
+
+function findRegexMatches(content: string, pattern: string, maxMatches: number): FileContentMatch[] {
+  try {
+    const regex = new RegExp(pattern, "g");
+    const matches: FileContentMatch[] = [];
+    let match;
+    while ((match = regex.exec(content)) !== null && matches.length < maxMatches) {
+      matches.push({ index: match.index, length: match[0].length, text: match[0] });
+      if (match.index === regex.lastIndex) {
+        regex.lastIndex++;
+      }
+    }
+    return matches;
+  } catch {
+    return [];
+  }
+}
+
+function findFullTextMatches(content: string, query: string, maxMatches: number): FileContentMatch[] {
+  const terms = parseFullTextTerms(query);
+  if (terms.length === 0) {
+    return [];
+  }
+  const lowerContent = content.toLowerCase();
+  const lowerTerms = terms.map((t) => t.toLowerCase());
+
+  // AND semantics: every term must appear somewhere in the document.
+  for (const term of lowerTerms) {
+    if (!lowerContent.includes(term)) {
+      return [];
+    }
+  }
+
+  const matches: FileContentMatch[] = [];
+  const firstTerm = lowerTerms[0]!;
+  let searchFrom = 0;
+  while (matches.length < maxMatches) {
+    const index = lowerContent.indexOf(firstTerm, searchFrom);
+    if (index === -1) {
+      break;
+    }
+    matches.push({
+      index,
+      length: terms[0].length,
+      text: content.slice(index, index + terms[0].length),
+    });
+    searchFrom = index + 1;
+  }
+  return matches;
+}
+
+function lineNumberAt(content: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < content.length; i++) {
+    if (content[i] === "\n") {
+      line++;
+    }
+  }
+  return line;
+}
+
+function parseFullTextTerms(query: string): string[] {
+  const terms: string[] = [];
+  let inQuote = false;
+  let current = "";
+  for (const char of query.trim()) {
+    if (char === '"') {
+      if (inQuote) {
+        if (current.length > 0) {
+          terms.push(current);
+          current = "";
+        }
+        inQuote = false;
+      } else {
+        inQuote = true;
+      }
+      continue;
+    }
+    if (char === " " && !inQuote) {
+      if (current.length > 0) {
+        terms.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) {
+    terms.push(current);
+  }
+  return terms;
+}
+
+function createSearchSnippet(content: string, index: number, length: number): string {
+  const context = 80;
+  const start = Math.max(0, index - context);
+  const end = Math.min(content.length, index + length + context);
+  let snippet = content.slice(start, end).replace(/\n/g, " ").trim();
+  if (start > 0) {
+    snippet = "..." + snippet;
+  }
+  if (end < content.length) {
+    snippet = snippet + "...";
+  }
+  return snippet;
 }
 
 function toConversationBootstrapStateRecord(
@@ -1524,8 +1689,8 @@ export class SummaryStore {
   async insertLargeFile(input: CreateLargeFileInput): Promise<LargeFileRecord> {
     this.db
       .prepare(
-        `INSERT INTO large_files (file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO large_files (file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         input.fileId,
@@ -1533,13 +1698,14 @@ export class SummaryStore {
         input.fileName ?? null,
         input.mimeType ?? null,
         input.byteSize ?? null,
+        input.lineCount ?? null,
         input.storageUri,
         input.explorationSummary ?? null,
       );
 
     const row = this.db
       .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
+        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary, created_at
        FROM large_files WHERE file_id = ?`,
       )
       .get(input.fileId) as unknown as LargeFileRow;
@@ -1550,7 +1716,7 @@ export class SummaryStore {
   async getLargeFile(fileId: string): Promise<LargeFileRecord | null> {
     const row = this.db
       .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
+        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary, created_at
        FROM large_files WHERE file_id = ?`,
       )
       .get(fileId) as unknown as LargeFileRow | undefined;
@@ -1560,13 +1726,89 @@ export class SummaryStore {
   async getLargeFilesByConversation(conversationId: number): Promise<LargeFileRecord[]> {
     const rows = this.db
       .prepare(
-        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, storage_uri, exploration_summary, created_at
+        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary, created_at
        FROM large_files
        WHERE conversation_id = ?
        ORDER BY created_at`,
       )
       .all(conversationId) as unknown as LargeFileRow[];
     return rows.map(toLargeFileRecord);
+  }
+
+  /**
+   * Search the contents of persisted large files using regex or simple full-text
+   * matching. Each file is read up to `maxBytesPerFile` (default 512KB) and only
+   * text-like MIME types are scanned.
+   */
+  async searchLargeFiles(input: LargeFileSearchInput): Promise<LargeFileSearchResult[]> {
+    const limit = input.limit ?? 50;
+    const maxBytesPerFile = input.maxBytesPerFile ?? 512_000;
+    const maxMatchesPerFile = 10;
+
+    let files: LargeFileRecord[] = [];
+    if (input.fileIds && input.fileIds.length > 0) {
+      for (const fileId of input.fileIds) {
+        const file = await this.getLargeFile(fileId);
+        if (file) {
+          files.push(file);
+        }
+      }
+    } else if (input.conversationIds && input.conversationIds.length > 0) {
+      for (const conversationId of input.conversationIds) {
+        const convFiles = await this.getLargeFilesByConversation(conversationId);
+        files.push(...convFiles);
+      }
+    } else if (input.conversationId != null) {
+      files = await this.getLargeFilesByConversation(input.conversationId);
+    }
+
+    if (input.since) {
+      files = files.filter((f) => f.createdAt.getTime() >= input.since!.getTime());
+    }
+    if (input.before) {
+      files = files.filter((f) => f.createdAt.getTime() < input.before!.getTime());
+    }
+
+    const results: LargeFileSearchResult[] = [];
+    for (const file of files) {
+      if (results.length >= limit) {
+        break;
+      }
+      if (!isTextLikeMimeType(file.mimeType)) {
+        continue;
+      }
+
+      const content = await this.readValidatedLargeFileContentUpTo(file.storageUri, {
+        largeFilesDir: input.largeFilesDir,
+        maxBytes: maxBytesPerFile,
+      });
+      if (content == null) {
+        continue;
+      }
+
+      const matches =
+        input.mode === "regex"
+          ? findRegexMatches(content, input.query, maxMatchesPerFile)
+          : findFullTextMatches(content, input.query, maxMatchesPerFile);
+
+      for (const match of matches) {
+        if (results.length >= limit) {
+          break;
+        }
+        results.push({
+          fileId: file.fileId,
+          conversationId: file.conversationId,
+          fileName: file.fileName,
+          matchedText: match.text,
+          lineNumber: lineNumberAt(content, match.index),
+          byteOffset: match.index,
+          snippet: createSearchSnippet(content, match.index, match.length),
+          createdAt: file.createdAt,
+        });
+      }
+    }
+
+    return results;
   }
 
   /**
@@ -1689,6 +1931,32 @@ export class SummaryStore {
           return null;
         }
         return await file.readFile({ encoding: "utf8" });
+      } finally {
+        await file.close().catch(() => undefined);
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  private async readValidatedLargeFileContentUpTo(
+    storageUri: string,
+    options: LargeFileReadOptions,
+  ): Promise<string | null> {
+    try {
+      const file = await this.openValidatedLargeFile(storageUri, options);
+      if (!file) {
+        return null;
+      }
+      try {
+        const stats = await file.stat();
+        if (!stats.isFile()) {
+          return null;
+        }
+        const maxBytes = options.maxBytes ?? stats.size;
+        const buffer = Buffer.alloc(Math.min(maxBytes, stats.size));
+        const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+        return buffer.subarray(0, bytesRead).toString("utf8");
       } finally {
         await file.close().catch(() => undefined);
       }

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -131,6 +131,9 @@ export type LargeFileSearchInput = {
   limit?: number;
   largeFilesDir: string;
   maxBytesPerFile?: number;
+  /** When true and no explicit fileIds/conversationId/conversationIds are
+   *  provided, search large files across all conversations. */
+  allConversations?: boolean;
 };
 
 export type LargeFileSearchResult = {
@@ -1729,9 +1732,20 @@ export class SummaryStore {
         `SELECT file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary, created_at
        FROM large_files
        WHERE conversation_id = ?
-       ORDER BY created_at`,
+       ORDER BY created_at DESC`,
       )
       .all(conversationId) as unknown as LargeFileRow[];
+    return rows.map(toLargeFileRecord);
+  }
+
+  async getAllLargeFiles(): Promise<LargeFileRecord[]> {
+    const rows = this.db
+      .prepare(
+        `SELECT file_id, conversation_id, file_name, mime_type, byte_size, line_count, storage_uri, exploration_summary, created_at
+       FROM large_files
+       ORDER BY created_at DESC`,
+      )
+      .all() as unknown as LargeFileRow[];
     return rows.map(toLargeFileRecord);
   }
 
@@ -1760,6 +1774,8 @@ export class SummaryStore {
       }
     } else if (input.conversationId != null) {
       files = await this.getLargeFilesByConversation(input.conversationId);
+    } else if (input.allConversations) {
+      files = await this.getAllLargeFiles();
     }
 
     if (input.since) {

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -55,8 +55,8 @@ const LcmDescribeSchema = Type.Object({
         "the original output of an elided tool result that was replaced with a " +
         "[LCM Tool Output: file_xxx | tool=… | N bytes] reference. Capped at " +
         "expandFileMaxBytes (default 32768 = ~8K tokens). Returns content + " +
-        "contentTruncated boolean. Use lcm_grep to search across the full file when " +
-        "it exceeds the cap.",
+        "contentTruncated boolean. Use lcm_grep(scope='files', fileIds=[file_xxx]) to " +
+        "search the full file content when it exceeds the cap.",
     }),
   ),
   expandFileMaxBytes: Type.Optional(
@@ -64,6 +64,24 @@ const LcmDescribeSchema = Type.Object({
       description: "Max bytes of inlined file content when expandFile=true. Default 32768. Hard cap 512000.",
       minimum: 1024,
       maximum: 512_000,
+    }),
+  ),
+  startLine: Type.Optional(
+    Type.Number({
+      description:
+        "1-based start line for a partial file read when expandFile=true. " +
+        "If provided, only lines from startLine to endLine (inclusive) are inlined. " +
+        "Line ranges are read from the first expandFileMaxBytes bytes of the file (hard cap 512KB); " +
+        "use lcm_grep(scope='files', fileIds=[id]) to locate content in larger files before selecting a range.",
+      minimum: 1,
+    }),
+  ),
+  endLine: Type.Optional(
+    Type.Number({
+      description:
+        "1-based end line for a partial file read when expandFile=true. Must be >= startLine. " +
+        "If omitted with startLine, reads through the last line available within the byte budget.",
+      minimum: 1,
     }),
   ),
 });
@@ -120,7 +138,8 @@ export function createLcmDescribeTool(input: {
       "reference in the conversation — that means an older tool result was elided " +
       "for context efficiency. Call lcm_describe(id=file_xxx, expandFile=true) to " +
       "fetch the original output content before answering questions that depend on " +
-      "its specifics.",
+      "its specifics. If the inlined content is truncated, use lcm_grep(scope='files', " +
+      "fileIds=[file_xxx]) to search the full file content.",
     parameters: LcmDescribeSchema,
     async execute(_toolCallId, params) {
       const lcm = input.lcm ?? (await input.getLcm?.());
@@ -160,9 +179,15 @@ export function createLcmDescribeTool(input: {
         typeof p.expandFileMaxBytes === "number" && Number.isFinite(p.expandFileMaxBytes)
           ? p.expandFileMaxBytes
           : undefined;
+      const startLine =
+        typeof p.startLine === "number" && Number.isFinite(p.startLine) ? p.startLine : undefined;
+      const endLine =
+        typeof p.endLine === "number" && Number.isFinite(p.endLine) ? p.endLine : undefined;
       const result = await retrieval.describe(id, {
         expandFile,
         expandFileMaxBytes,
+        startLine,
+        endLine,
         // Optional-chained for test mocks that may not expose configView.
         largeFilesDir: lcm.configView?.largeFilesDir,
       });
@@ -305,6 +330,9 @@ export function createLcmDescribeTool(input: {
         if (f.byteSize != null) {
           lines.push(`**Size:** ${f.byteSize.toLocaleString()} bytes`);
         }
+        if (f.lineCount != null) {
+          lines.push(`**Lines:** ${f.lineCount.toLocaleString()}`);
+        }
         lines.push(`**Created:** ${formatDisplayTime(f.createdAt, timezone)}`);
         if (f.explorationSummary) {
           lines.push("");
@@ -328,7 +356,7 @@ export function createLcmDescribeTool(input: {
             lines.push("");
             lines.push(
               `*Output truncated to ${f.content.length.toLocaleString()} of ${f.byteSize?.toLocaleString() ?? "?"} bytes. ` +
-              `Use lcm_grep against the file id to search the full content.*`,
+                `Use lcm_grep(scope='files', fileIds=['${result.id}']) to search the full content.*`,
             );
           }
         } else if (expandFile) {

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -55,8 +55,8 @@ const LcmDescribeSchema = Type.Object({
         "the original output of an elided tool result that was replaced with a " +
         "[LCM Tool Output: file_xxx | tool=… | N bytes] reference. Capped at " +
         "expandFileMaxBytes (default 32768 = ~8K tokens). Returns content + " +
-        "contentTruncated boolean. Use lcm_grep(scope='files', fileIds=[file_xxx]) to " +
-        "search the full file content when it exceeds the cap.",
+        "contentTruncated boolean. Use lcm_grep(scope='files', fileIds=[file_xxx]) " +
+        "to search the bounded file prefix when it exceeds the cap.",
     }),
   ),
   expandFileMaxBytes: Type.Optional(
@@ -139,7 +139,7 @@ export function createLcmDescribeTool(input: {
       "for context efficiency. Call lcm_describe(id=file_xxx, expandFile=true) to " +
       "fetch the original output content before answering questions that depend on " +
       "its specifics. If the inlined content is truncated, use lcm_grep(scope='files', " +
-      "fileIds=[file_xxx]) to search the full file content.",
+      "fileIds=[file_xxx]) to search the bounded file prefix.",
     parameters: LcmDescribeSchema,
     async execute(_toolCallId, params) {
       const lcm = input.lcm ?? (await input.getLcm?.());
@@ -183,6 +183,9 @@ export function createLcmDescribeTool(input: {
         typeof p.startLine === "number" && Number.isFinite(p.startLine) ? p.startLine : undefined;
       const endLine =
         typeof p.endLine === "number" && Number.isFinite(p.endLine) ? p.endLine : undefined;
+      if (startLine != null && endLine != null && endLine < startLine) {
+        return jsonResult({ error: "`endLine` must be greater than or equal to `startLine`." });
+      }
       const result = await retrieval.describe(id, {
         expandFile,
         expandFileMaxBytes,
@@ -356,7 +359,7 @@ export function createLcmDescribeTool(input: {
             lines.push("");
             lines.push(
               `*Output truncated to ${f.content.length.toLocaleString()} of ${f.byteSize?.toLocaleString() ?? "?"} bytes. ` +
-                `Use lcm_grep(scope='files', fileIds=['${result.id}']) to search the full content.*`,
+                `Use lcm_grep(scope='files', fileIds=['${result.id}']) to search the bounded file prefix.*`,
             );
           }
         } else if (expandFile) {

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -5,6 +5,7 @@ import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { parseIsoTimestampParam, resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import { formatTimestamp } from "../compaction.js";
+import { DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES } from "../store/summary-store.js";
 
 const MAX_RESULT_CHARS = 40_000; // ~10k tokens
 
@@ -37,14 +38,14 @@ const LcmGrepSchema = Type.Object({
   scope: Type.Optional(
     Type.String({
       description:
-        'What to search: "messages" for raw messages, "summaries" for compacted summaries, "both" for all, or "files" for externalized large file contents. Default: "both".',
+        'What to search: "messages" for raw messages, "summaries" for compacted summaries, "both" for all, or "files" for the bounded prefix of externalized large file contents. Default: "both".',
       enum: ["messages", "summaries", "both", "files"],
     }),
   ),
   fileIds: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        'Optional list of file_xxx IDs to restrict the search to when scope="files". If omitted, all large files in the conversation scope are searched.',
+        'Optional list of file_xxx IDs to restrict the search to when scope="files". If omitted, large files in the conversation scope are searched, scanning up to 512000 bytes per file.',
     }),
   ),
   conversationId: Type.Optional(
@@ -164,9 +165,9 @@ export function createLcmGrepTool(input: {
     label: "LCM Grep",
     description:
       "Search compacted conversation history or externalized file contents using regex or full-text search. " +
-      "Searches across messages, summaries, and/or large files stored by LCM. " +
+      "Searches across messages, summaries, and/or a bounded prefix of large files stored by LCM. " +
       "Use this to find specific content that may have been compacted away from " +
-      "active context, or to search within the full content of externalized files " +
+      "active context, or to search within the first 512000 bytes of externalized files " +
       "(scope='files') when a previous lcm_describe result was truncated. " +
       "In full_text mode, queries use FTS5 AND semantics by default, so keep them short and focused; quoted phrases stay intact and optional sort modes can prioritize relevance for older topics. Returns matching snippets with their summary/message/file IDs " +
       "for follow-up with lcm_expand or lcm_describe.",
@@ -266,6 +267,11 @@ export function createLcmGrepTool(input: {
           }`,
         );
       }
+      if (scope === "files") {
+        lines.push(
+          `**File scan:** first ${DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES.toLocaleString()} bytes per file; matches beyond that prefix are not searched.`,
+        );
+      }
       lines.push(`**Total matches:** ${result.totalMatches}`);
       lines.push("");
 
@@ -311,7 +317,8 @@ export function createLcmGrepTool(input: {
         for (const file of files) {
           const snippet = truncateSnippet(file.snippet);
           const nameSuffix = file.fileName ? ` (${file.fileName})` : "";
-          const line = `- [conv=${file.conversationId} ${file.fileId}${nameSuffix}] line ${file.lineNumber}, offset ${file.byteOffset}: \`${file.matchedText}\` ${snippet}`;
+          const truncationSuffix = file.scanTruncated ? " (file scan truncated)" : "";
+          const line = `- [conv=${file.conversationId} ${file.fileId}${nameSuffix}] line ${file.lineNumber}, offset ${file.byteOffset}: \`${file.matchedText}\` ${snippet}${truncationSuffix}`;
           if (currentChars + line.length > MAX_RESULT_CHARS) {
             lines.push("*(truncated — more results available)*");
             break;
@@ -332,6 +339,9 @@ export function createLcmGrepTool(input: {
           messageCount: result.messages.length,
           summaryCount: result.summaries.length,
           fileCount: files.length,
+          ...(scope === "files"
+            ? { fileScanByteLimit: DEFAULT_LARGE_FILE_SEARCH_MAX_BYTES }
+            : {}),
           totalMatches: result.totalMatches,
         },
       };

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -242,6 +242,7 @@ export function createLcmGrepTool(input: {
         before,
         sort: effectiveSort,
         largeFilesDir: lcm.configView?.largeFilesDir,
+        allConversations: conversationScope.allConversations,
       });
 
       const lines: string[] = [];

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -37,8 +37,14 @@ const LcmGrepSchema = Type.Object({
   scope: Type.Optional(
     Type.String({
       description:
-        'What to search: "messages" for raw messages, "summaries" for compacted summaries, "both" for all. Default: "both".',
-      enum: ["messages", "summaries", "both"],
+        'What to search: "messages" for raw messages, "summaries" for compacted summaries, "both" for all, or "files" for externalized large file contents. Default: "both".',
+      enum: ["messages", "summaries", "both", "files"],
+    }),
+  ),
+  fileIds: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Optional list of file_xxx IDs to restrict the search to when scope="files". If omitted, all large files in the conversation scope are searched.',
     }),
   ),
   conversationId: Type.Optional(
@@ -157,10 +163,12 @@ export function createLcmGrepTool(input: {
     name: "lcm_grep",
     label: "LCM Grep",
     description:
-      "Search compacted conversation history using regex or full-text search. " +
-      "Searches across messages and/or summaries stored by LCM. " +
+      "Search compacted conversation history or externalized file contents using regex or full-text search. " +
+      "Searches across messages, summaries, and/or large files stored by LCM. " +
       "Use this to find specific content that may have been compacted away from " +
-      "active context. In full_text mode, queries use FTS5 AND semantics by default, so keep them short and focused; quoted phrases stay intact and optional sort modes can prioritize relevance for older topics. Returns matching snippets with their summary/message IDs " +
+      "active context, or to search within the full content of externalized files " +
+      "(scope='files') when a previous lcm_describe result was truncated. " +
+      "In full_text mode, queries use FTS5 AND semantics by default, so keep them short and focused; quoted phrases stay intact and optional sort modes can prioritize relevance for older topics. Returns matching snippets with their summary/message/file IDs " +
       "for follow-up with lcm_expand or lcm_describe.",
     parameters: LcmGrepSchema,
     async execute(_toolCallId, params) {
@@ -174,7 +182,10 @@ export function createLcmGrepTool(input: {
       const p = params as Record<string, unknown>;
       const pattern = (p.pattern as string).trim();
       const mode = (p.mode as "regex" | "full_text") ?? "regex";
-      const scope = (p.scope as "messages" | "summaries" | "both") ?? "both";
+      const scope = (p.scope as "messages" | "summaries" | "both" | "files") ?? "both";
+      const fileIds = Array.isArray(p.fileIds)
+        ? p.fileIds.filter((id): id is string => typeof id === "string")
+        : undefined;
       const limit = typeof p.limit === "number" ? Math.trunc(p.limit) : 50;
       const requestedSort = (p.sort as "recency" | "relevance" | "hybrid") ?? "recency";
       const effectiveSort = mode === "full_text" ? requestedSort : "recency";
@@ -225,10 +236,12 @@ export function createLcmGrepTool(input: {
         scope,
         conversationId: conversationScope.conversationId,
         conversationIds: conversationScope.conversationIds,
+        fileIds,
         limit,
         since,
         before,
         sort: effectiveSort,
+        largeFilesDir: lcm.configView?.largeFilesDir,
       });
 
       const lines: string[] = [];
@@ -289,6 +302,25 @@ export function createLcmGrepTool(input: {
         lines.push("");
       }
 
+      const files = result.files ?? [];
+
+      if (files.length > 0) {
+        lines.push("### Files");
+        lines.push("");
+        for (const file of files) {
+          const snippet = truncateSnippet(file.snippet);
+          const nameSuffix = file.fileName ? ` (${file.fileName})` : "";
+          const line = `- [conv=${file.conversationId} ${file.fileId}${nameSuffix}] line ${file.lineNumber}, offset ${file.byteOffset}: \`${file.matchedText}\` ${snippet}`;
+          if (currentChars + line.length > MAX_RESULT_CHARS) {
+            lines.push("*(truncated — more results available)*");
+            break;
+          }
+          lines.push(line);
+          currentChars += line.length;
+        }
+        lines.push("");
+      }
+
       if (result.totalMatches === 0) {
         lines.push("No matches found.");
       }
@@ -298,6 +330,7 @@ export function createLcmGrepTool(input: {
         details: {
           messageCount: result.messages.length,
           summaryCount: result.summaries.length,
+          fileCount: files.length,
           totalMatches: result.totalMatches,
         },
       };

--- a/test/engine-ingest.test.ts
+++ b/test/engine-ingest.test.ts
@@ -832,6 +832,96 @@ describe("LcmContextEngine.ingest content extraction", () => {
     });
   });
 
+  it("greps externalized file contents via scope=files", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = randomUUID();
+      const uniqueMarker = `UNIQUE_MARKER_${randomUUID().slice(0, 8)}`;
+      const toolOutput = `${"tool output line\n".repeat(80)}${uniqueMarker}\n${"more lines\n".repeat(80)}done`;
+
+      await engine.ingest({
+        sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_grep_file",
+              name: "exec",
+              input: { cmd: "cat large.log" },
+            },
+          ],
+        } as AgentMessage,
+      });
+
+      await engine.ingest({
+        sessionId,
+        message: {
+          role: "toolResult",
+          toolCallId: "call_grep_file",
+          toolName: "exec",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_grep_file",
+              name: "exec",
+              content: [{ type: "text", text: toolOutput }],
+            },
+          ],
+        } as AgentMessage,
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const largeFiles = await engine
+        .getSummaryStore()
+        .getLargeFilesByConversation(conversation!.conversationId);
+      expect(largeFiles).toHaveLength(1);
+      const fileId = largeFiles[0]!.fileId;
+
+      const retrieval = new RetrievalEngine(
+        engine.getConversationStore(),
+        engine.getSummaryStore(),
+      );
+
+      const regexResult = await retrieval.grep({
+        query: uniqueMarker,
+        mode: "regex",
+        scope: "files",
+        conversationId: conversation!.conversationId,
+        largeFilesDir: engine.configView.largeFilesDir,
+      });
+      expect(regexResult.files).toHaveLength(1);
+      expect(regexResult.files[0]!.fileId).toBe(fileId);
+      expect(regexResult.files[0]!.matchedText).toBe(uniqueMarker);
+      expect(regexResult.files[0]!.lineNumber).toBe(81);
+      expect(regexResult.files[0]!.byteOffset).toBe(toolOutput.indexOf(uniqueMarker));
+      expect(regexResult.files[0]!.snippet).toContain(uniqueMarker);
+
+      const fullTextResult = await retrieval.grep({
+        query: uniqueMarker,
+        mode: "full_text",
+        scope: "files",
+        conversationId: conversation!.conversationId,
+        largeFilesDir: engine.configView.largeFilesDir,
+      });
+      expect(fullTextResult.files).toHaveLength(1);
+      expect(fullTextResult.files[0]!.matchedText).toBe(uniqueMarker);
+
+      const fileIdsResult = await retrieval.grep({
+        query: "no-such-pattern-xyz",
+        mode: "regex",
+        scope: "files",
+        fileIds: [fileId],
+        largeFilesDir: engine.configView.largeFilesDir,
+      });
+      expect(fileIdsResult.files).toHaveLength(0);
+    });
+  });
+
   it("externalizes oversized plain-text tool-result blocks from live exec-style messages", async () => {
     await withTempHome(async () => {
       const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });

--- a/test/integration-helpers.ts
+++ b/test/integration-helpers.ts
@@ -567,6 +567,7 @@ export function createMockSummaryStore() {
         fileName: input.fileName ?? null,
         mimeType: input.mimeType ?? null,
         byteSize: input.byteSize ?? null,
+        lineCount: input.lineCount ?? null,
         storageUri: input.storageUri,
         explorationSummary: input.explorationSummary ?? null,
         createdAt: new Date(),

--- a/test/lcm-integration-retrieval.test.ts
+++ b/test/lcm-integration-retrieval.test.ts
@@ -63,6 +63,7 @@ describe("LCM integration: retrieval", () => {
       fileName: "data.csv",
       mimeType: "text/csv",
       byteSize: 1024,
+      lineCount: 100,
       storageUri: "s3://bucket/data.csv",
       explorationSummary: "CSV with 100 rows of test data.",
     });
@@ -74,6 +75,7 @@ describe("LCM integration: retrieval", () => {
     expect(result!.file).toBeDefined();
     expect(result!.file!.fileName).toBe("data.csv");
     expect(result!.file!.storageUri).toBe("s3://bucket/data.csv");
+    expect(result!.file!.lineCount).toBe(100);
   });
 
   it("describe returns null for unknown IDs", async () => {

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -158,6 +158,12 @@ describe("LCM tools session scoping", () => {
     expect(patternDescription).toContain("FTS5 defaults to AND matching");
     expect(patternDescription).toContain("prefer 1-3 distinctive terms or one quoted multi-word phrase");
     expect(patternDescription).toContain("Regex syntax such as alternation (`A|B`) requires regex mode");
+    const scopeDescription = (
+      tool.parameters as {
+        properties: Record<string, { description?: string }>;
+      }
+    ).properties.scope?.description;
+    expect(scopeDescription).toContain("bounded prefix of externalized large file contents");
   });
 
   it("lcm_grep rejects regex alternation in full-text mode before searching", async () => {
@@ -350,6 +356,84 @@ describe("LCM tools session scoping", () => {
     );
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("**Mode:** full_text | **Scope:** both | **Sort:** relevance");
+  });
+
+  it("lcm_grep reports the bounded file scan contract for scope=files", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        files: [
+          {
+            fileId: "file_abc123",
+            conversationId: 42,
+            fileName: "large.log",
+            matchedText: "NEEDLE",
+            lineNumber: 12,
+            byteOffset: 345,
+            snippet: "before NEEDLE after",
+            scannedBytes: 512_000,
+            scanByteLimit: 512_000,
+            scanTruncated: true,
+            createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          },
+        ],
+        totalMatches: 1,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-files", {
+      pattern: "NEEDLE",
+      scope: "files",
+      fileIds: ["file_abc123"],
+    });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "files",
+        fileIds: ["file_abc123"],
+      }),
+    );
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("**File scan:** first 512,000 bytes per file");
+    expect(text).toContain("matches beyond that prefix are not searched");
+    expect(text).toContain("file scan truncated");
+    expect(result.details).toMatchObject({
+      fileCount: 1,
+      fileScanByteLimit: 512_000,
+    });
+  });
+
+  it("lcm_describe rejects inverted file line ranges before retrieval", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-range", {
+      id: "file_abc123",
+      expandFile: true,
+      startLine: 20,
+      endLine: 10,
+    });
+
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain(
+      "`endLine` must be greater than or equal to `startLine`",
+    );
   });
 
   it("lcm_grep resolves conversation scope via sessionKey continuity before sessionId lookup", async () => {

--- a/test/summary-store.test.ts
+++ b/test/summary-store.test.ts
@@ -7,6 +7,7 @@ import { runLcmMigrations } from "../src/db/migration.js";
 import { getLcmDbFeatures } from "../src/db/features.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
+import { RetrievalEngine } from "../src/retrieval.js";
 
 function createStores() {
   const db = new DatabaseSync(":memory:");
@@ -234,6 +235,437 @@ describe("SummaryStore shallow-tree helpers", () => {
           largeFilesDir: safeRoot,
         }),
       ).resolves.toBe(true);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("searches large file contents with regex and reports line numbers", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-large-files-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-large-files",
+        title: "Summary store search large files",
+      });
+      const content = "alpha\nbeta\ngamma\ndelta\n";
+      const payloadPath = join(safeRoot, "content.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_searchable1234",
+        conversationId: conversation.conversationId,
+        fileName: "content.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "gamma",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        fileId: "file_searchable1234",
+        fileName: "content.txt",
+        matchedText: "gamma",
+        lineNumber: 3,
+        byteOffset: content.indexOf("gamma"),
+      });
+      expect(results[0].snippet).toContain("gamma");
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("returns multiple regex matches per file up to the cap", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-multi-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-multi",
+        title: "Summary store search multi",
+      });
+      const content = "hit one\nmiss\nhit two\nmiss\nhit three\n";
+      const payloadPath = join(safeRoot, "multi.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_multi12345678",
+        conversationId: conversation.conversationId,
+        fileName: "multi.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "hit\\s\\w+",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.matchedText)).toEqual(["hit one", "hit two", "hit three"]);
+      expect(results.map((r) => r.lineNumber)).toEqual([1, 3, 5]);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("filters large file search by fileIds", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-fileids-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-fileids",
+        title: "Summary store search fileIds",
+      });
+      const sharedContent = "needle in haystack";
+
+      for (const [fileId, name] of [
+        ["file_include_12345", "include.txt"],
+        ["file_exclude_67890", "exclude.txt"],
+      ] as const) {
+        const payloadPath = join(safeRoot, name);
+        writeFileSync(payloadPath, sharedContent, "utf8");
+        await summaryStore.insertLargeFile({
+          fileId,
+          conversationId: conversation.conversationId,
+          fileName: name,
+          mimeType: "text/plain",
+          byteSize: Buffer.byteLength(sharedContent, "utf8"),
+          storageUri: payloadPath,
+        });
+      }
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "needle",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        fileIds: ["file_include_12345"],
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].fileId).toBe("file_include_12345");
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("respects maxBytesPerFile when searching large files", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-maxbytes-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-maxbytes",
+        title: "Summary store search maxBytes",
+      });
+      const prefix = "aaa\n".repeat(100);
+      const suffix = "ZZZ_FIND_ME_ZZZ";
+      const content = prefix + suffix;
+      const payloadPath = join(safeRoot, "big.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_maxbytes_12345",
+        conversationId: conversation.conversationId,
+        fileName: "big.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "ZZZ_FIND_ME_ZZZ",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+        maxBytesPerFile: 50,
+      });
+
+      expect(results).toHaveLength(0);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("skips non-text large files when searching contents", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-binary-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-binary",
+        title: "Summary store search binary",
+      });
+      const content = "definitely not an image";
+      const payloadPath = join(safeRoot, "fake.png");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_binary_12345",
+        conversationId: conversation.conversationId,
+        fileName: "fake.png",
+        mimeType: "image/png",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "definitely",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(0);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("searches large files with full_text mode requiring all terms", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-fulltext-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-fulltext",
+        title: "Summary store search fullText",
+      });
+      const content = "quick brown fox jumps over the lazy dog";
+      const payloadPath = join(safeRoot, "animals.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_fulltext_12345",
+        conversationId: conversation.conversationId,
+        fileName: "animals.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const allTerms = await summaryStore.searchLargeFiles({
+        query: "quick fox",
+        mode: "full_text",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(allTerms).toHaveLength(1);
+
+      const missingTerm = await summaryStore.searchLargeFiles({
+        query: "quick zebra",
+        mode: "full_text",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(missingTerm).toHaveLength(0);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("stores and returns large file lineCount", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "summary-store-line-count",
+      title: "Summary store line count",
+    });
+
+    const record = await summaryStore.insertLargeFile({
+      fileId: "file_linecount_12345",
+      conversationId: conversation.conversationId,
+      fileName: "lines.txt",
+      mimeType: "text/plain",
+      byteSize: 100,
+      lineCount: 42,
+      storageUri: "/tmp/lines.txt",
+      explorationSummary: "line count test",
+    });
+
+    expect(record.lineCount).toBe(42);
+
+    const fetched = await summaryStore.getLargeFile("file_linecount_12345");
+    expect(fetched?.lineCount).toBe(42);
+
+    const byConversation = await summaryStore.getLargeFilesByConversation(conversation.conversationId);
+    expect(byConversation[0]?.lineCount).toBe(42);
+  });
+
+  it("defaults large file lineCount to null when omitted", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "summary-store-line-count-null",
+      title: "Summary store line count null",
+    });
+
+    const record = await summaryStore.insertLargeFile({
+      fileId: "file_linecount_null",
+      conversationId: conversation.conversationId,
+      fileName: "legacy.txt",
+      mimeType: "text/plain",
+      byteSize: 100,
+      storageUri: "/tmp/legacy.txt",
+    });
+
+    expect(record.lineCount).toBeNull();
+  });
+
+  it("describes a large file with startLine/endLine range", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-describe-range-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-describe-range",
+        title: "Summary store describe range",
+      });
+      const content = ["line one", "line two", "line three", "line four", "line five"].join("\n");
+      const payloadPath = join(safeRoot, "range.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_range_12345",
+        conversationId: conversation.conversationId,
+        fileName: "range.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        lineCount: 5,
+        storageUri: payloadPath,
+        explorationSummary: "range test",
+      });
+
+      const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+      const result = await retrieval.describe("file_range_12345", {
+        expandFile: true,
+        startLine: 2,
+        endLine: 4,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(result?.type).toBe("file");
+      expect(result?.file?.content).toBe("line two\nline three\nline four");
+      expect(result?.file?.contentTruncated).toBe(false);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("describes a large file from startLine to end when endLine is omitted", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-describe-range-open-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-describe-range-open",
+        title: "Summary store describe range open",
+      });
+      const content = ["alpha", "beta", "gamma", "delta"].join("\n");
+      const payloadPath = join(safeRoot, "open.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_range_open_12345",
+        conversationId: conversation.conversationId,
+        fileName: "open.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        lineCount: 4,
+        storageUri: payloadPath,
+        explorationSummary: "open range test",
+      });
+
+      const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+      const result = await retrieval.describe("file_range_open_12345", {
+        expandFile: true,
+        startLine: 3,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(result?.file?.content).toBe("gamma\ndelta");
+      expect(result?.file?.contentTruncated).toBe(false);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports truncation when a line-range read cannot reach the requested endLine", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-describe-range-trunc-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-describe-range-trunc",
+        title: "Summary store describe range truncation",
+      });
+      const content = ["one", "two", "three", "four", "five"].join("\n");
+      const payloadPath = join(safeRoot, "trunc.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_range_trunc_12345",
+        conversationId: conversation.conversationId,
+        fileName: "trunc.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        lineCount: 5,
+        storageUri: payloadPath,
+        explorationSummary: "truncation test",
+      });
+
+      const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+      const result = await retrieval.describe("file_range_trunc_12345", {
+        expandFile: true,
+        startLine: 2,
+        endLine: 10,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(result?.file?.content).toBe("two\nthree\nfour\nfive");
+      expect(result?.file?.contentTruncated).toBe(true);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves complete multi-byte UTF-8 characters at the byte budget boundary", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-describe-range-utf8-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-describe-range-utf8",
+        title: "Summary store describe range utf8",
+      });
+      // "中" is U+4E2D, UTF-8: E4 B8 AD (3 bytes). Build lines that end right at a boundary.
+      const lines = ["alpha", "中", "beta", "国", "gamma"];
+      const content = lines.join("\n");
+      const payloadPath = join(safeRoot, "utf8.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_range_utf8_12345",
+        conversationId: conversation.conversationId,
+        fileName: "utf8.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        lineCount: lines.length,
+        storageUri: payloadPath,
+        explorationSummary: "utf8 boundary test",
+      });
+
+      const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+      const result = await retrieval.describe("file_range_utf8_12345", {
+        expandFile: true,
+        startLine: 1,
+        endLine: lines.length,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(result?.file?.content).toBe(content);
+      expect(result?.file?.content).not.toContain("\uFFFD");
     } finally {
       rmSync(safeRoot, { recursive: true, force: true });
     }

--- a/test/summary-store.test.ts
+++ b/test/summary-store.test.ts
@@ -359,6 +359,63 @@ describe("SummaryStore shallow-tree helpers", () => {
     }
   });
 
+  it("keeps fileIds constrained to the requested conversation scope", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-fileids-scope-"));
+    try {
+      const allowedConversation = await conversationStore.createConversation({
+        sessionId: "summary-store-fileids-scope-allowed",
+        title: "Summary store fileIds scope allowed",
+      });
+      const otherConversation = await conversationStore.createConversation({
+        sessionId: "summary-store-fileids-scope-other",
+        title: "Summary store fileIds scope other",
+      });
+      const allowedPath = join(safeRoot, "allowed.txt");
+      const otherPath = join(safeRoot, "other.txt");
+      writeFileSync(allowedPath, "allowed needle", "utf8");
+      writeFileSync(otherPath, "other needle", "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_allowed_scope",
+        conversationId: allowedConversation.conversationId,
+        fileName: "allowed.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength("allowed needle", "utf8"),
+        storageUri: allowedPath,
+      });
+      await summaryStore.insertLargeFile({
+        fileId: "file_other_scope",
+        conversationId: otherConversation.conversationId,
+        fileName: "other.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength("other needle", "utf8"),
+        storageUri: otherPath,
+      });
+
+      const scopedResults = await summaryStore.searchLargeFiles({
+        query: "needle",
+        mode: "regex",
+        conversationId: allowedConversation.conversationId,
+        fileIds: ["file_other_scope"],
+        largeFilesDir: safeRoot,
+      });
+      expect(scopedResults).toHaveLength(0);
+
+      const allConversationResults = await summaryStore.searchLargeFiles({
+        query: "needle",
+        mode: "regex",
+        allConversations: true,
+        fileIds: ["file_other_scope"],
+        largeFilesDir: safeRoot,
+      });
+      expect(allConversationResults).toHaveLength(1);
+      expect(allConversationResults[0].fileId).toBe("file_other_scope");
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
   it("respects maxBytesPerFile when searching large files", async () => {
     const { conversationStore, summaryStore } = createStores();
     const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-maxbytes-"));
@@ -396,6 +453,69 @@ describe("SummaryStore shallow-tree helpers", () => {
     }
   });
 
+  it("rejects unsafe regex patterns when searching large files", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-regex-guard-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-search-regex-guard",
+        title: "Summary store search regex guard",
+      });
+      const content = "aaaaaaaaaaaaaaaaaaaaaaaa";
+      const payloadPath = join(safeRoot, "guard.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_regex_guard_12345",
+        conversationId: conversation.conversationId,
+        fileName: "guard.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const nestedQuantifierResults = await summaryStore.searchLargeFiles({
+        query: "(a+)+",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(nestedQuantifierResults).toHaveLength(0);
+
+      const quantifiedAlternationResults = await summaryStore.searchLargeFiles({
+        query: "(a|aa)+$",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(quantifiedAlternationResults).toHaveLength(0);
+
+      const boundedNestedQuantifierResults = await summaryStore.searchLargeFiles({
+        query: "(a{1,2})+$",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(boundedNestedQuantifierResults).toHaveLength(0);
+
+      const safeResults = await summaryStore.searchLargeFiles({
+        query: "a+",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+      expect(safeResults).toHaveLength(1);
+      expect(safeResults[0]).toMatchObject({
+        fileId: "file_regex_guard_12345",
+        scannedBytes: Buffer.byteLength(content, "utf8"),
+        scanByteLimit: 512_000,
+        scanTruncated: false,
+      });
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
   it("skips non-text large files when searching contents", async () => {
     const { conversationStore, summaryStore } = createStores();
     const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-binary-"));
@@ -425,6 +545,41 @@ describe("SummaryStore shallow-tree helpers", () => {
       });
 
       expect(results).toHaveLength(0);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports large file byteOffset as a UTF-8 byte offset", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-byte-offset-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-byte-offset",
+        title: "Summary store byte offset",
+      });
+      const content = "πreamble\nneedle";
+      const payloadPath = join(safeRoot, "unicode.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_byte_offset_12345",
+        conversationId: conversation.conversationId,
+        fileName: "unicode.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        storageUri: payloadPath,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "needle",
+        mode: "regex",
+        conversationId: conversation.conversationId,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].byteOffset).toBe(Buffer.byteLength("πreamble\n", "utf8"));
     } finally {
       rmSync(safeRoot, { recursive: true, force: true });
     }
@@ -717,6 +872,43 @@ describe("SummaryStore shallow-tree helpers", () => {
 
       expect(result?.file?.content).toBe(content);
       expect(result?.file?.content).not.toContain("\uFFFD");
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a trailing multi-byte UTF-8 character in line-range reads", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-describe-range-trailing-utf8-"));
+    try {
+      const conversation = await conversationStore.createConversation({
+        sessionId: "summary-store-describe-range-trailing-utf8",
+        title: "Summary store describe range trailing utf8",
+      });
+      const content = "alpha\n中";
+      const payloadPath = join(safeRoot, "trailing-utf8.txt");
+      writeFileSync(payloadPath, content, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_range_trailing_utf8",
+        conversationId: conversation.conversationId,
+        fileName: "trailing-utf8.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content, "utf8"),
+        lineCount: 2,
+        storageUri: payloadPath,
+        explorationSummary: "trailing utf8 boundary test",
+      });
+
+      const retrieval = new RetrievalEngine(conversationStore, summaryStore);
+      const result = await retrieval.describe("file_range_trailing_utf8", {
+        expandFile: true,
+        startLine: 1,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(result?.file?.content).toBe(content);
+      expect(result?.file?.contentTruncated).toBe(false);
     } finally {
       rmSync(safeRoot, { recursive: true, force: true });
     }

--- a/test/summary-store.test.ts
+++ b/test/summary-store.test.ts
@@ -471,6 +471,57 @@ describe("SummaryStore shallow-tree helpers", () => {
     }
   });
 
+  it("searches large files across all conversations when allConversations is true", async () => {
+    const { conversationStore, summaryStore } = createStores();
+    const safeRoot = mkdtempSync(join(tmpdir(), "lcm-search-all-convs-"));
+    try {
+      const conv1 = await conversationStore.createConversation({
+        sessionId: "summary-store-search-all-1",
+        title: "Summary store search all 1",
+      });
+      const conv2 = await conversationStore.createConversation({
+        sessionId: "summary-store-search-all-2",
+        title: "Summary store search all 2",
+      });
+
+      const content1 = "needle alpha";
+      const content2 = "needle beta";
+      const path1 = join(safeRoot, "a.txt");
+      const path2 = join(safeRoot, "b.txt");
+      writeFileSync(path1, content1, "utf8");
+      writeFileSync(path2, content2, "utf8");
+
+      await summaryStore.insertLargeFile({
+        fileId: "file_all_1",
+        conversationId: conv1.conversationId,
+        fileName: "a.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content1, "utf8"),
+        storageUri: path1,
+      });
+      await summaryStore.insertLargeFile({
+        fileId: "file_all_2",
+        conversationId: conv2.conversationId,
+        fileName: "b.txt",
+        mimeType: "text/plain",
+        byteSize: Buffer.byteLength(content2, "utf8"),
+        storageUri: path2,
+      });
+
+      const results = await summaryStore.searchLargeFiles({
+        query: "needle",
+        mode: "regex",
+        allConversations: true,
+        largeFilesDir: safeRoot,
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.fileId).sort()).toEqual(["file_all_1", "file_all_2"]);
+    } finally {
+      rmSync(safeRoot, { recursive: true, force: true });
+    }
+  });
+
   it("stores and returns large file lineCount", async () => {
     const { conversationStore, summaryStore } = createStores();
     const conversation = await conversationStore.createConversation({


### PR DESCRIPTION
## Problem

`lcm_describe(id=file_xxx, expandFile=true)` inlines the original content of an already-externalized file, but caps the inlined bytes at `expandFileMaxBytes` (default 32KB). Its tool description told agents to use `lcm_grep` to search the full file when the output was truncated.

That guidance was misleading: `lcm_grep` only searched indexed conversation messages and summaries, not the contents of `large_files`. An agent following the hint would search the wrong scope and fail to find content that existed only in the externalized file.

## Solution

Teach `lcm_grep` to search externalized file contents:

- New `scope: "files"` option restricts the search to `large_files` rows.
- New optional `fileIds: ["file_xxx", ...]` parameter restricts the search to specific file IDs.
- Regex and full-text modes are both supported.
- Each match reports the file ID, line number, byte offset, matched text, and a contextual snippet.

`lcm_describe` now gives accurate guidance: when inlined content is truncated, use `lcm_grep(scope="files", fileIds=[file_xxx])` to search the full file.

## Changes

- `src/store/summary-store.ts`
  - Add `searchLargeFiles` with regex/full-text matching over file contents.
  - Return per-match results with `matchedText`, `lineNumber`, `byteOffset`, and `snippet`.
  - Cap each file read to 512KB and skip non-text MIME types.

- `src/retrieval.ts`
  - Extend `GrepInput.scope` with `"files"` and add `fileIds`/`largeFilesDir` fields.
  - Route `scope="files"` to `summaryStore.searchLargeFiles`.

- `src/tools/lcm-grep-tool.ts`
  - Expose `scope="files"` and `fileIds` in the tool schema and description.
  - Render a "Files" section in the output with line numbers and matched text.

- `src/tools/lcm-describe-tool.ts`
  - Restore `lcm_grep` guidance now that the tool can actually search file contents.

- `test/engine-ingest.test.ts`
  - Add integration test covering regex search, full-text search, and `fileIds` filtering on externalized tool outputs.

## Verification

```bash
pnpm test test/lcm-tools.test.ts test/engine-ingest.test.ts test/retrieval-sort.test.ts test/lcm-integration-retrieval.test.ts -- --run --reporter=dot
```

61 tests passed.
