### PR TITLE
fix(interceptor): do not re-externalize oversized lcm_describe tool results

### DIFF
--- a/.changeset/lcm-describe-inline-results.md
+++ b/.changeset/lcm-describe-inline-results.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep oversized `lcm_describe` tool results inline instead of wrapping them in another externalized tool-output stub, so drilldown responses return the requested content directly.

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -850,10 +850,7 @@ export class LargeFileInterceptor {
         safeString(record.id) ??
         topLevelToolCallId;
 
-      // The lcm_describe tool returns the original content of an already-
-      // externalized file. Wrapping that output in another externalized stub
-      // makes the drilldown useless and forces the agent to call lcm_describe
-      // again just to read what it just asked for.
+      // lcm_describe is already a drilldown response; re-stubbing adds another hop.
       if (toolName === "lcm_describe") {
         rewrittenContent.push(item);
         continue;

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -837,7 +837,6 @@ export class LargeFileInterceptor {
         continue;
       }
 
-      interceptedAny = true;
       const toolName =
         safeString(record.name) ??
         topLevelToolName ??
@@ -850,6 +849,17 @@ export class LargeFileInterceptor {
         safeString(record.call_id) ??
         safeString(record.id) ??
         topLevelToolCallId;
+
+      // The lcm_describe tool returns the original content of an already-
+      // externalized file. Wrapping that output in another externalized stub
+      // makes the drilldown useless and forces the agent to call lcm_describe
+      // again just to read what it just asked for.
+      if (toolName === "lcm_describe") {
+        rewrittenContent.push(item);
+        continue;
+      }
+
+      interceptedAny = true;
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,
         content: extractedText,

--- a/test/engine-ingest.test.ts
+++ b/test/engine-ingest.test.ts
@@ -929,6 +929,77 @@ describe("LcmContextEngine.ingest content extraction", () => {
     });
   });
 
+  it("keeps oversized lcm_describe tool results inline instead of re-externalizing", async () => {
+    await withTempHome(async () => {
+      const engine = createEngineWithConfig({ largeFileTokenThreshold: 20 });
+      const sessionId = randomUUID();
+      const describedOutput = `${"described line\n".repeat(160)}done`;
+
+      await engine.ingest({
+        sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_describe",
+              name: "lcm_describe",
+              input: { id: "file_abc37559665143d0", expandFile: true },
+            },
+          ],
+        } as AgentMessage,
+      });
+
+      await engine.ingest({
+        sessionId,
+        message: {
+          role: "toolResult",
+          toolCallId: "call_describe",
+          toolName: "lcm_describe",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_describe",
+              name: "lcm_describe",
+              content: [{ type: "text", text: describedOutput }],
+            },
+          ],
+        } as AgentMessage,
+      });
+
+      const conversation = await engine
+        .getConversationStore()
+        .getConversationBySessionId(sessionId);
+      expect(conversation).not.toBeNull();
+
+      const storedMessages = await engine
+        .getConversationStore()
+        .getMessages(conversation!.conversationId);
+      expect(storedMessages).toHaveLength(2);
+
+      // Tool-result content is intentionally stored as empty string; the real
+      // payload lives in message_parts.
+      expect(storedMessages[1].content).toBe("");
+
+      const largeFiles = await engine
+        .getSummaryStore()
+        .getLargeFilesByConversation(conversation!.conversationId);
+      expect(largeFiles).toHaveLength(0);
+
+      const parts = await engine
+        .getConversationStore()
+        .getMessageParts(storedMessages[1].messageId);
+      expect(parts).toHaveLength(1);
+      expect(parts[0].partType).toBe("tool");
+      expect(parts[0].toolName).toBe("lcm_describe");
+      const metadata = JSON.parse(parts[0].metadata ?? "{}") as Record<string, unknown>;
+      expect(metadata).not.toHaveProperty("toolOutputExternalized");
+      expect(metadata).not.toHaveProperty("externalizedFileId");
+      const raw = metadata.raw as { content?: Array<{ text?: string }> };
+      expect(raw.content?.[0]?.text).toBe(describedOutput);
+    });
+  });
+
   it("externalizes structured tool-result image payloads before text externalization", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);


### PR DESCRIPTION
## Problem

`lcm_describe` is the drill-down tool an agent uses when it sees a compact `[LCM Tool Output: file_xxx | tool=… | N bytes]` reference in the conversation. Its whole purpose is to return the original, full content of that externalized file.

Because that content can be large, the large-file interceptor was treating the `lcm_describe` result itself as a new oversized tool output and wrapping it in a second `[LCM Tool Output: file_yyy]` stub. This defeated the tool:

- The agent calls `lcm_describe(id=file_xxx, expandFile=true)` expecting the original file content.
- It receives a stub pointing at `file_yyy` instead.
- It must then call `lcm_describe(id=file_yyy)` to read what it just asked for, wasting a turn and a model context window.

This is especially wasteful because `lcm_describe` output is already the answer to a previous externalization; re-externalizing it adds no new information and only creates indirection.

## Fix

In `interceptLargeToolResults`, detect `toolName === "lcm_describe"` before the threshold/externalization step and keep the original block inline. The content still flows through normal message-part storage, so it is not lost; it is simply not turned into another stub.

## Files Changed

- `src/large-file-interceptor.ts`  
  Skip externalization for blocks whose tool name is `lcm_describe`.

- `test/engine-ingest.test.ts`  
  Add regression test: ingesting an oversized `lcm_describe` tool result with `largeFileTokenThreshold=20` produces no `large_files` rows and no `toolOutputExternalized` / `externalizedFileId` metadata.

## Verification

```bash
pnpm test test/engine-ingest.test.ts -- --run --reporter=dot -t "keeps oversized lcm_describe tool results inline"
```

All 28 tests in `test/engine-ingest.test.ts` pass.
