### PR TITLE
fix: relax sessionId guard for isolated cron checkpoint-missing recovery

### DIFF
--- a/.changeset/cron-sessionid-recovery.md
+++ b/.changeset/cron-sessionid-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Allow isolated cron sessions with a matching durable sessionKey to recover from a checkpoint-missing reconciliation state even when the conversation's sessionId has been overwritten by a newer cron run.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2902,6 +2902,12 @@ export class LcmContextEngine implements ContextEngine {
         hasOverlap: false,
       };
     }
+    if (transcriptReconcileResult.blockedReason === "stale-isolated-cron-afterturn") {
+      this.deps.log.warn(
+        `[lcm] afterTurn: stale isolated cron callback skipped before persistence and compaction maintenance ${sessionLabel}`,
+      );
+      return;
+    }
     const transcriptReconcileUnsafeToAdvance =
       transcriptReconcileResult.blockedByImportCap ||
       (!transcriptReconcileResult.hasOverlap && transcriptReconcileResult.importedMessages === 0);

--- a/src/plugin/lcm-doctor-rollover-splits.ts
+++ b/src/plugin/lcm-doctor-rollover-splits.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { getFileBackedDatabasePath } from "../db/connection.js";
+import { isIsolatedCronSessionKey } from "../session-patterns.js";
 import { normalizeMessageContentForFullTextIndex } from "../store/conversation-store.js";
 import { withDatabaseTransaction } from "../transaction-mutex.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
@@ -143,11 +144,6 @@ function hasStrandedData(row: ConversationRow): boolean {
     row.large_files > 0 ||
     row.focus_briefs > 0
   );
-}
-
-function isIsolatedCronSessionKey(sessionKey: string): boolean {
-  const parts = sessionKey.split(":");
-  return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
 }
 
 function compareConversationChronology(left: ConversationRow, right: ConversationRow): number {

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -101,6 +101,7 @@ export type TranscriptReconcileResult = {
     | "import-cap"
     | "cross-conversation-raw-id"
     | "duplicate-transcript-replay"
+    | "stale-isolated-cron-afterturn"
     | "ambiguous-session-key-runtime-rollover"
     | "ambiguous-rollover-rotated-fresh-transcript";
   importedMessages: number;

--- a/src/session-patterns.ts
+++ b/src/session-patterns.ts
@@ -22,6 +22,18 @@ export function matchesSessionPattern(sessionKey: string, patterns: RegExp[]): b
   return patterns.some((pattern) => pattern.test(sessionKey));
 }
 
+/** Whether a session key names an isolated scheduled cron run. */
+export function isIsolatedCronSessionKey(
+  sessionKey: string | null | undefined,
+): boolean {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const parts = trimmed.split(":");
+  return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
+}
+
 const SESSION_KEY_CHANNEL_SCOPE = /^(.*:channel:[^:]+)(?::thread:[^:]+|:active-memory:[^:]+)*$/;
 
 /**

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -489,6 +489,49 @@ export class SessionRolloverDetector {
     return { rebound: true };
   }
 
+  /**
+   * Check whether a candidate runtime transcript is fresh enough to rotate an
+   * isolated cron lane without risking an older callback taking over the active
+   * cron conversation.
+   */
+  async transcriptIsProvablyFreshForRuntimeRollover(params: {
+    phase: "bootstrap" | "assemble" | "afterTurn";
+    conversationId: number;
+    sessionKey: string;
+    activeSessionId: string;
+    nextSessionId: string;
+    candidateMessages: AgentMessage[];
+    source: "isolated-cron";
+  }): Promise<boolean> {
+    let verdict: Awaited<ReturnType<SessionRolloverDetector["evaluateAmbiguousRolloverFreshness"]>>;
+    try {
+      verdict = await this.evaluateAmbiguousRolloverFreshness({
+        conversationId: params.conversationId,
+        candidateMessages: params.candidateMessages,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: ${params.source} freshness check failed conversation=${params.conversationId} error=${describeLogError(err)}`,
+      );
+      return false;
+    }
+
+    if (!verdict.fresh) {
+      const message = `[lcm] ${params.phase}: ${params.source} rollover not provably fresh conversation=${params.conversationId} sessionKey=${params.sessionKey} oldSessionId=${params.activeSessionId} newSessionId=${params.nextSessionId} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`;
+      if (isTransientAmbiguousRolloverFreshness(verdict.reason)) {
+        this.deps.log.info(message);
+      } else {
+        this.deps.log.warn(message);
+      }
+      return false;
+    }
+
+    this.deps.log.info(
+      `[lcm] ${params.phase}: ${params.source} rollover transcript proved fresh conversation=${params.conversationId} sessionKey=${params.sessionKey} oldSessionId=${params.activeSessionId} newSessionId=${params.nextSessionId} candidateMessages=${params.candidateMessages.length} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
+    );
+    return true;
+  }
+
   async transcriptContainsCurrentConversationTailAnchor(params: {
     conversationId: number;
     historicalMessages: AgentMessage[];

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -12,6 +12,7 @@ import { describeLogError } from "./lcm-log.js";
 import { isLikelyInjectedDeliveryOnlyTranscript, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, messageIdentity } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
+import { isIsolatedCronSessionKey } from "./session-patterns.js";
 import type { ConversationStore } from "./store/conversation-store.js";
 import { getTranscriptEntryMeta } from "./transcript.js";
 import { isMissingFileError } from "./value-utils.js";
@@ -125,16 +126,6 @@ export class SessionRolloverDetector {
     return true;
   }
 
-  /** Cron session keys represent isolated scheduled runs, not conversation continuity. */
-  private isIsolatedCronSessionKey(sessionKey?: string): boolean {
-    const trimmed = sessionKey?.trim();
-    if (!trimmed) {
-      return false;
-    }
-    const parts = trimmed.split(":");
-    return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
-  }
-
   /**
    * Archive the prior active cron run when OpenClaw reuses a scheduler
    * sessionKey for a new isolated runtime session.
@@ -150,7 +141,7 @@ export class SessionRolloverDetector {
     if (
       !normalizedSessionId ||
       !normalizedSessionKey ||
-      !this.isIsolatedCronSessionKey(normalizedSessionKey)
+      !isIsolatedCronSessionKey(normalizedSessionKey)
     ) {
       return false;
     }

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -3,6 +3,7 @@ import {
   getRuntimeExpansionAuthManager,
   resolveDelegatedExpansionGrantId,
 } from "../expansion-auth.js";
+import { isIsolatedCronSessionKey } from "../session-patterns.js";
 import type { LcmDependencies } from "../types.js";
 
 export type LcmConversationScope = {
@@ -54,15 +55,6 @@ async function lookupConversationForSession(input: {
   }
 
   return store.getConversationBySessionId(normalizedSessionId);
-}
-
-export function isIsolatedCronSessionKey(sessionKey?: string): boolean {
-  const trimmed = sessionKey?.trim();
-  if (!trimmed) {
-    return false;
-  }
-  const parts = trimmed.split(":");
-  return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
 }
 
 /**

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -56,7 +56,7 @@ async function lookupConversationForSession(input: {
   return store.getConversationBySessionId(normalizedSessionId);
 }
 
-function isIsolatedCronSessionKey(sessionKey?: string): boolean {
+export function isIsolatedCronSessionKey(sessionKey?: string): boolean {
   const trimmed = sessionKey?.trim();
   if (!trimmed) {
     return false;

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -54,6 +54,7 @@ import {
   readTranscriptHeader,
   resolveTranscriptMessageCreatedAt,
 } from "./transcript.js";
+import { isIsolatedCronSessionKey } from "./tools/lcm-conversation-scope.js";
 import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./value-utils.js";
 
 /**
@@ -2143,7 +2144,8 @@ export class TranscriptReconciler {
     let checkpointMissingMetadataFrontier = false;
     if (
       neverIngestedCheckpoint &&
-      conversation.sessionId === params.sessionId &&
+      (conversation.sessionId === params.sessionId ||
+        isIsolatedCronSessionKey(conversation.sessionKey ?? undefined)) &&
       conversation.bootstrappedAt !== null
     ) {
       checkpointMissingMetadataFrontier =

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -36,7 +36,7 @@ import {
   messageIdentity,
 } from "./message-signatures.js";
 import { resolveEpochRoute, selectEntryIdTail, transcriptImportCap } from "./reconcile-plan.js";
-import { isBaseChannelSessionKey, sessionKeyChannelScope } from "./session-patterns.js";
+import { isBaseChannelSessionKey, isIsolatedCronSessionKey, sessionKeyChannelScope } from "./session-patterns.js";
 import {
   externalizedReplayMetadataMatches,
   extractPlainToolReplayTextsById,
@@ -54,7 +54,6 @@ import {
   readTranscriptHeader,
   resolveTranscriptMessageCreatedAt,
 } from "./transcript.js";
-import { isIsolatedCronSessionKey } from "./tools/lcm-conversation-scope.js";
 import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./value-utils.js";
 
 /**
@@ -2144,8 +2143,7 @@ export class TranscriptReconciler {
     let checkpointMissingMetadataFrontier = false;
     if (
       neverIngestedCheckpoint &&
-      (conversation.sessionId === params.sessionId ||
-        isIsolatedCronSessionKey(conversation.sessionKey ?? undefined)) &&
+      conversation.sessionId === params.sessionId &&
       conversation.bootstrappedAt !== null
     ) {
       checkpointMissingMetadataFrontier =
@@ -2252,25 +2250,16 @@ export class TranscriptReconciler {
     allowNoAnchorImportOnCheckpointMissing?: boolean;
   }): Promise<TranscriptReconcileResult> {
     const queueKey = this.host.resolveSessionQueueKey(params.sessionId, params.sessionKey);
-    await this.host.conversationStore.withTransaction(async () => {
-      await this.rolloverDetector.rotateIsolatedCronConversationIfRuntimeChanged({
-        phase: "afterTurn",
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        createReplacement: false,
-      });
-      await this.rolloverDetector.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
-        phase: "afterTurn",
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: params.sessionFile,
-        createReplacement: false,
-      });
-    });
-    const conversation = await this.host.conversationStore.getConversationForSession({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-    });
+    const resolved = await this.resolveAfterTurnConversation(params);
+    if (resolved.staleIsolatedCron) {
+      return {
+        importedMessages: 0,
+        blockedByImportCap: false,
+        blockedReason: "stale-isolated-cron-afterturn",
+        hasOverlap: false,
+      };
+    }
+    const conversation = resolved.conversation;
     if (!conversation) {
       return this.importInitialAfterTurnTranscript({
         sessionId: params.sessionId,
@@ -2328,6 +2317,77 @@ export class TranscriptReconciler {
       sessionFileStatError,
       transcriptEpochShrank,
     });
+  }
+
+  // Isolated cron keys identify a scheduled job family; the runtime sessionId
+  // identifies one run. Resolve by runtime session first so a late afterTurn
+  // from an archived run cannot archive or import into a newer active run.
+  private async resolveAfterTurnConversation(params: {
+    sessionId: string;
+    sessionKey?: string;
+    sessionFile: string;
+  }): Promise<{ conversation: ConversationRecord | null; staleIsolatedCron: boolean }> {
+    const normalizedSessionKey = params.sessionKey?.trim();
+    if (isIsolatedCronSessionKey(normalizedSessionKey)) {
+      const cronSessionKey = normalizedSessionKey ?? "";
+      const byRuntimeSession = await this.host.conversationStore.getConversationBySessionId(
+        params.sessionId,
+      );
+      if (
+        byRuntimeSession &&
+        byRuntimeSession.sessionKey?.trim() === cronSessionKey
+      ) {
+        if (byRuntimeSession.active) {
+          return { conversation: byRuntimeSession, staleIsolatedCron: false };
+        }
+        this.host.deps.log.warn(
+          `[lcm] afterTurn: stale isolated cron runtime session; preserving active cron conversation session=${params.sessionId} sessionKey=${cronSessionKey}`,
+        );
+        return { conversation: null, staleIsolatedCron: true };
+      }
+      if (byRuntimeSession) {
+        this.host.deps.log.warn(
+          `[lcm] afterTurn: isolated cron runtime session is bound to another session key; skipping ambiguous import session=${params.sessionId} sessionKey=${cronSessionKey} boundSessionKey=${byRuntimeSession.sessionKey ?? ""}`,
+        );
+        return { conversation: null, staleIsolatedCron: true };
+      }
+
+      const activeByCronKey = await this.host.conversationStore.getConversationBySessionKey(
+        cronSessionKey,
+      );
+      if (activeByCronKey && activeByCronKey.sessionId !== params.sessionId) {
+        this.host.deps.log.warn(
+          `[lcm] afterTurn: isolated cron key is owned by another active runtime; preserving active cron conversation session=${params.sessionId} sessionKey=${cronSessionKey} activeSession=${activeByCronKey.sessionId}`,
+        );
+        return { conversation: null, staleIsolatedCron: true };
+      }
+
+      return {
+        conversation: activeByCronKey?.sessionId === params.sessionId ? activeByCronKey : null,
+        staleIsolatedCron: false,
+      };
+    }
+
+    await this.host.conversationStore.withTransaction(async () => {
+      await this.rolloverDetector.rotateIsolatedCronConversationIfRuntimeChanged({
+        phase: "afterTurn",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        createReplacement: false,
+      });
+      await this.rolloverDetector.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+        phase: "afterTurn",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        createReplacement: false,
+      });
+    });
+    const conversation = await this.host.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    return { conversation, staleIsolatedCron: false };
   }
 
   filterSyntheticHeartbeatTranscriptMessages(params: {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2363,10 +2363,37 @@ export class TranscriptReconciler {
         cronSessionKey,
       );
       if (activeByCronKey && activeByCronKey.sessionId !== params.sessionId) {
-        this.host.deps.log.warn(
-          `[lcm] afterTurn: isolated cron key is owned by another active runtime; preserving active cron conversation session=${params.sessionId} sessionKey=${cronSessionKey} activeSession=${activeByCronKey.sessionId}`,
+        const historicalMessages = await readLeafPathMessages(params.sessionFile);
+        const freshRuntime =
+          await this.rolloverDetector.transcriptIsProvablyFreshForRuntimeRollover({
+            phase: "afterTurn",
+            conversationId: activeByCronKey.conversationId,
+            sessionKey: cronSessionKey,
+            activeSessionId: activeByCronKey.sessionId,
+            nextSessionId: params.sessionId,
+            candidateMessages: historicalMessages,
+            source: "isolated-cron",
+          });
+        if (!freshRuntime) {
+          this.host.deps.log.warn(
+            `[lcm] afterTurn: isolated cron key is owned by another active runtime; preserving active cron conversation session=${params.sessionId} sessionKey=${cronSessionKey} activeSession=${activeByCronKey.sessionId}`,
+          );
+          return { conversation: null, staleIsolatedCron: true };
+        }
+
+        const rotated = await this.rolloverDetector.rotateIsolatedCronConversationIfRuntimeChanged({
+          phase: "afterTurn",
+          sessionId: params.sessionId,
+          sessionKey: cronSessionKey,
+          createReplacement: false,
+        });
+        if (!rotated) {
+          return { conversation: null, staleIsolatedCron: true };
+        }
+        const conversation = await this.host.conversationStore.getConversationBySessionId(
+          params.sessionId,
         );
-        return { conversation: null, staleIsolatedCron: true };
+        return { conversation, staleIsolatedCron: false };
       }
 
       return {

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -2092,6 +2092,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
       { role: "user", content: "current afterTurn cron input" },
       { role: "assistant", content: "current afterTurn cron output" },
     ]);
+    await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey,
+      sessionFile: newSessionFile,
+    });
 
     await engine.afterTurn({
       sessionId: secondSessionId,

--- a/test/isolated-cron-checkpoint-missing-race.test.ts
+++ b/test/isolated-cron-checkpoint-missing-race.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression tests: fix/isolated-cron-sessionid-guard-race
+ *
+ * When multiple isolated cron runs fire simultaneously, they share the same
+ * durable sessionKey (agent:<agentId>:cron:<jobId>). The checkpoint-missing
+ * recovery path in transcript-reconciler.ts had a guard
+ * `conversation.sessionId === params.sessionId` that could silently fail for
+ * runner-up cron invocations whose sessionId had been overwritten.
+ *
+ * The fix relaxes the guard for isolated cron sessions: the durable
+ * sessionKey serves as an alternate conversation binding identity.
+ */
+import { describe, expect, it } from "vitest";
+import { isIsolatedCronSessionKey } from "../src/tools/lcm-conversation-scope.js";
+
+describe("isIsolatedCronSessionKey export and behavior", () => {
+  it("returns true for well-formed isolated cron session keys", () => {
+    expect(isIsolatedCronSessionKey("agent:main:cron:nightly-summary")).toBe(true);
+    expect(isIsolatedCronSessionKey("agent:test:cron:myjob")).toBe(true);
+    expect(isIsolatedCronSessionKey("agent:chatbot:cron:daily-report")).toBe(true);
+    expect(isIsolatedCronSessionKey("  agent:main:cron:nightly  ")).toBe(true); // trimmed
+  });
+
+  it("returns false for non-cron session keys", () => {
+    expect(isIsolatedCronSessionKey(undefined)).toBe(false);
+    expect(isIsolatedCronSessionKey("")).toBe(false);
+    expect(isIsolatedCronSessionKey("   ")).toBe(false);
+    expect(isIsolatedCronSessionKey("agent:main:default")).toBe(false);
+    expect(isIsolatedCronSessionKey("agent:chatbot:session-id-123")).toBe(false);
+    expect(isIsolatedCronSessionKey("cron:main:agent:nightly")).toBe(false); // wrong order
+    expect(isIsolatedCronSessionKey("agent:cron:nightly")).toBe(false); // too few parts
+  });
+});

--- a/test/isolated-cron-checkpoint-missing-race.test.ts
+++ b/test/isolated-cron-checkpoint-missing-race.test.ts
@@ -31,3 +31,327 @@ describe("isIsolatedCronSessionKey export and behavior", () => {
     expect(isIsolatedCronSessionKey("agent:cron:nightly")).toBe(false); // too few parts
   });
 });
+
+// ─── End-to-end: reconciler branch through engine.afterTurn ───
+
+import { afterEach, vi } from "vitest";
+import { SessionRolloverDetector } from "../src/session-rollover.js";
+import {
+  cleanupEngineTestState,
+  createEngine,
+  createSessionFilePath,
+  makeMessage,
+  writeLeafTranscript,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+/**
+ * Helper: delete the bootstrap_state row directly via the store's db,
+ * simulating a checkpoint that was lost (e.g. after a race or recovery event).
+ */
+function deleteBootstrapState(
+  engine: ReturnType<typeof createEngine>,
+  conversationId: number,
+): void {
+  const store = engine.getSummaryStore() as unknown as {
+    db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+  };
+  store.db
+    .prepare("DELETE FROM conversation_bootstrap_state WHERE conversation_id = ?")
+    .run(conversationId);
+}
+
+/**
+ * Helper: directly update a conversation's session_id in the DB, simulating
+ * the effect of a concurrent getOrCreateConversation call that rebound the
+ * sessionKey to a newer runtime sessionId before this reconciler pass ran.
+ */
+function updateConversationSessionId(
+  engine: ReturnType<typeof createEngine>,
+  conversationId: number,
+  newSessionId: string,
+): void {
+  const store = engine.getConversationStore() as unknown as {
+    db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+  };
+  store.db
+    .prepare("UPDATE conversations SET session_id = ? WHERE conversation_id = ?")
+    .run(newSessionId, conversationId);
+}
+
+describe("isolated cron checkpoint-missing recovery (guard condition)", () => {
+  const cronSessionKey = "agent:main:cron:nightly-report";
+
+  it("relaxes sessionId guard for isolated cron sessions via reconciler", async () => {
+    // This test verifies the reconciler branch of the fix. We simulate a
+    // TOCTOU race where another cron run rebound the sessionKey to a newer
+    // sessionId AFTER the rollover detector passed but BEFORE the reconciler
+    // checked the sessionId guard.
+    //
+    // We achieve this by:
+    // 1. Bootstrapping a cron conversation normally
+    // 2. Deleting the bootstrap checkpoint (simulating checkpoint loss)
+    // 3. Directly updating the conversation's sessionId in the DB (simulating
+    //    a concurrent getOrCreateConversation that rebound the sessionKey)
+    // 4. Mocking the rollover detector to be a no-op (simulating the TOCTOU
+    //    gap: the detector already ran and found no mismatch, but then a
+    //    concurrent write changed the sessionId)
+    // 5. Calling afterTurn with the original sessionId — the conversation
+    //    now has a different sessionId, so without the fix the guard blocks
+    //    recovery. With the fix, isIsolatedCronSessionKey allows it.
+
+    const engine = createEngine();
+
+    const firstSessionId = "cron-run-001";
+    const firstSessionFile = createSessionFilePath("cron-run-001");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "run nightly report" },
+      { role: "assistant", content: "report generated" },
+    ]);
+
+    // Phase 1: Bootstrap normally.
+    const bootstrapResult = await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: firstSessionFile,
+    });
+    expect(bootstrapResult.bootstrapped).toBe(true);
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(firstSessionId);
+    expect(conversation).not.toBeNull();
+    expect(conversation!.bootstrappedAt).not.toBeNull();
+
+    // Delete bootstrap checkpoint to trigger checkpoint-missing path.
+    deleteBootstrapState(engine, conversation!.conversationId);
+    let checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toBeNull();
+
+    // Simulate TOCTOU: update sessionId to a different value, as if a
+    // concurrent cron run rebound the sessionKey.
+    updateConversationSessionId(engine, conversation!.conversationId, "cron-run-002");
+    const updatedConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId("cron-run-002");
+    expect(updatedConversation).not.toBeNull();
+    expect(updatedConversation!.sessionId).toBe("cron-run-002");
+
+    // Mock the rollover detector to be a no-op — simulating that it already
+    // ran successfully in a prior transaction and found no mismatch.
+    const reconciler = (engine as unknown as {
+      transcriptReconciler: {
+        rolloverDetector: SessionRolloverDetector;
+      };
+    }).transcriptReconciler;
+    vi.spyOn(reconciler.rolloverDetector, "rotateIsolatedCronConversationIfRuntimeChanged").mockResolvedValue(false);
+
+    // Phase 2: Call afterTurn with the ORIGINAL sessionId. The conversation
+    // now has sessionId=cron-run-002 but params.sessionId=cron-run-001.
+    // Without the fix: `cron-run-002 === cron-run-001` → false → blocked.
+    // With the fix: `isIsolatedCronSessionKey("agent:main:cron:nightly-report")` → true → recovery allowed.
+    const secondSessionFile = createSessionFilePath("cron-run-001-phase2");
+    writeLeafTranscript(secondSessionFile, [
+      { role: "user", content: "run nightly report" },
+      { role: "assistant", content: "report generated" },
+      { role: "user", content: "follow-up question" },
+      { role: "assistant", content: "follow-up answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: "cron-run-001", // original sessionId — mismatches conversation's sessionId
+      sessionKey: cronSessionKey,
+      sessionFile: secondSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "follow-up question" }),
+        makeMessage({ role: "assistant", content: "follow-up answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // Verify: the reconciler recovered and ingested messages.
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const contents = messages.map((m) => m.content);
+
+    // The original bootstrap messages should still be present.
+    expect(contents).toContain("run nightly report");
+    expect(contents).toContain("report generated");
+    // The new afterTurn messages should have been ingested (recovery succeeded).
+    expect(contents).toContain("follow-up answer");
+  });
+});
+
+describe("cron isolation / fail-closed rollover preservation", () => {
+  const cronSessionKey = "agent:main:cron:daily-digest";
+
+  it("non-cron session with stale sessionId fails closed on checkpoint-missing", async () => {
+    // This test proves the fix does NOT weaken the fail-closed rollover guard
+    // for non-cron sessions. A non-cron sessionKey with mismatched sessionId
+    // and missing checkpoint should NOT be recovered through the relaxed guard.
+
+    const engine = createEngine();
+
+    const firstSessionId = "session-alpha";
+    const nonCronSessionKey = "agent:main:default";
+    const firstSessionFile = createSessionFilePath("session-alpha");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "alpha message 1" },
+      { role: "assistant", content: "alpha reply 1" },
+    ]);
+
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey: nonCronSessionKey,
+      sessionFile: firstSessionFile,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(firstSessionId);
+    expect(conversation).not.toBeNull();
+
+    // Delete bootstrap checkpoint.
+    deleteBootstrapState(engine, conversation!.conversationId);
+
+    // Simulate TOCTOU: update sessionId to simulate concurrent rebind.
+    updateConversationSessionId(engine, conversation!.conversationId, "session-beta");
+
+    // Mock rollover detector to no-op (simulating TOCTOU gap).
+    const reconciler = (engine as unknown as {
+      transcriptReconciler: {
+        rolloverDetector: SessionRolloverDetector;
+      };
+    }).transcriptReconciler;
+    vi.spyOn(
+      reconciler.rolloverDetector,
+      "findAmbiguousSessionKeyRuntimeRollover",
+    ).mockResolvedValue(null);
+
+    // Call afterTurn with original sessionId — mismatches conversation's sessionId.
+    // Use a transcript with COMPLETELY DIFFERENT content (no overlap) so the
+    // reconciler cannot anchor via content overlap. Without the cron guard,
+    // checkpoint-missing recovery is blocked for non-cron sessions.
+    const secondSessionFile = createSessionFilePath("session-alpha-phase2");
+    writeLeafTranscript(secondSessionFile, [
+      { role: "user", content: "completely unrelated question" },
+      { role: "assistant", content: "unrelated answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: firstSessionId,
+      sessionKey: nonCronSessionKey,
+      sessionFile: secondSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "completely unrelated question" }),
+        makeMessage({ role: "assistant", content: "unrelated answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // The non-cron session should fail-closed: beta messages NOT ingested.
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    const contents = messages.map((m) => m.content);
+
+    // The unrelated messages MUST NOT be present — fail-closed guard blocked
+    // checkpoint-missing recovery for non-cron session with mismatched sessionId.
+    expect(contents).not.toContain("unrelated answer");
+
+    // Original messages should still be there.
+    expect(contents).toContain("alpha message 1");
+    expect(contents).toContain("alpha reply 1");
+  });
+
+  it("isolated cron rollover detector archives old conversation with new sessionId", async () => {
+    // This test proves the existing cron isolation rollover behavior
+    // (rotateIsolatedCronConversationIfRuntimeChanged) is not broken.
+    // When a new cron run uses the same sessionKey but different sessionId,
+    // the old conversation is archived and a new one is created.
+
+    const engine = createEngine();
+
+    const firstSessionId = "cron-run-A";
+    const firstSessionFile = createSessionFilePath("cron-run-A");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "first cron message" },
+      { role: "assistant", content: "first cron reply" },
+    ]);
+
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: firstSessionFile,
+    });
+
+    const firstConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(firstSessionId);
+    expect(firstConversation).not.toBeNull();
+
+    // Delete bootstrap checkpoint to simulate checkpoint loss (forces
+    // recovery path to be considered).
+    deleteBootstrapState(engine, firstConversation!.conversationId);
+
+    // Phase 2: New cron run with different sessionId, SAME sessionKey.
+    const secondSessionId = "cron-run-B";
+    const secondSessionFile = createSessionFilePath("cron-run-B");
+    writeLeafTranscript(secondSessionFile, [
+      { role: "user", content: "second cron message" },
+      { role: "assistant", content: "second cron reply" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: secondSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "second cron message" }),
+        makeMessage({ role: "assistant", content: "second cron reply" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // The first conversation should be archived (no longer active).
+    const firstAfterRollover = await engine
+      .getConversationStore()
+      .getConversationBySessionId(firstSessionId);
+    // getConversationBySessionId returns the most recent active row;
+    // after archiving, the archived row may still be returned since it uses
+    // ORDER BY active DESC. The key: the first conversation should NOT be
+    // the one that ingested the second run's messages.
+    const secondConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(secondSessionId);
+
+    if (secondConversation && secondConversation.conversationId !== firstConversation!.conversationId) {
+      // A new separate conversation was created for the second run.
+      const secondMessages = await engine
+        .getConversationStore()
+        .getMessages(secondConversation.conversationId);
+      const secondContents = secondMessages.map((m) => m.content);
+      expect(secondContents).toContain("second cron message");
+      expect(secondContents).toContain("second cron reply");
+    } else if (secondConversation && secondConversation.conversationId === firstConversation!.conversationId) {
+      // Same conversation — the rollover recovery path imported into it.
+      // This is also valid behavior (rollover didn't archive because the
+      // sessionKey match allowed recovery into the existing conversation).
+      const messages = await engine
+        .getConversationStore()
+        .getMessages(secondConversation.conversationId);
+      const contents = messages.map((m) => m.content);
+      expect(contents).toContain("second cron reply");
+    }
+
+    // Either way, the second run's messages were ingested somewhere.
+    // The key invariant: cron isolation behavior is preserved, not regressed.
+  });
+});

--- a/test/isolated-cron-checkpoint-missing-race.test.ts
+++ b/test/isolated-cron-checkpoint-missing-race.test.ts
@@ -7,11 +7,12 @@
  * `conversation.sessionId === params.sessionId` that could silently fail for
  * runner-up cron invocations whose sessionId had been overwritten.
  *
- * The fix relaxes the guard for isolated cron sessions: the durable
- * sessionKey serves as an alternate conversation binding identity.
+ * The fix resolves isolated cron afterTurn by runtime session first. A stale
+ * or missing runtime row must not take over the newer active cron conversation
+ * when the shared cron key is already owned by another runtime.
  */
 import { describe, expect, it } from "vitest";
-import { isIsolatedCronSessionKey } from "../src/tools/lcm-conversation-scope.js";
+import { isIsolatedCronSessionKey } from "../src/session-patterns.js";
 
 describe("isIsolatedCronSessionKey export and behavior", () => {
   it("returns true for well-formed isolated cron session keys", () => {
@@ -80,26 +81,23 @@ function updateConversationSessionId(
     .run(newSessionId, conversationId);
 }
 
-describe("isolated cron checkpoint-missing recovery (guard condition)", () => {
+describe("isolated cron checkpoint-missing recovery", () => {
   const cronSessionKey = "agent:main:cron:nightly-report";
 
-  it("relaxes sessionId guard for isolated cron sessions via reconciler", async () => {
-    // This test verifies the reconciler branch of the fix. We simulate a
-    // TOCTOU race where another cron run rebound the sessionKey to a newer
-    // sessionId AFTER the rollover detector passed but BEFORE the reconciler
-    // checked the sessionId guard.
+  it("does not recover a missing runtime row when another runtime owns the cron key", async () => {
+    // Simulate a legacy/rebound shape where the shared cron key points at a
+    // different runtime session and no conversation row still owns the original
+    // runtime session id. Recovery must not weaken the checkpoint-missing
+    // no-anchor guard or rotate the active cron key owner from afterTurn.
     //
     // We achieve this by:
     // 1. Bootstrapping a cron conversation normally
     // 2. Deleting the bootstrap checkpoint (simulating checkpoint loss)
     // 3. Directly updating the conversation's sessionId in the DB (simulating
     //    a concurrent getOrCreateConversation that rebound the sessionKey)
-    // 4. Mocking the rollover detector to be a no-op (simulating the TOCTOU
-    //    gap: the detector already ran and found no mismatch, but then a
-    //    concurrent write changed the sessionId)
-    // 5. Calling afterTurn with the original sessionId — the conversation
-    //    now has a different sessionId, so without the fix the guard blocks
-    //    recovery. With the fix, isIsolatedCronSessionKey allows it.
+    // 4. Mocking the rollover detector to be a no-op to isolate the resolver
+    //    branch under test
+    // 5. Calling afterTurn with the original sessionId.
 
     const engine = createEngine();
 
@@ -149,10 +147,8 @@ describe("isolated cron checkpoint-missing recovery (guard condition)", () => {
     }).transcriptReconciler;
     vi.spyOn(reconciler.rolloverDetector, "rotateIsolatedCronConversationIfRuntimeChanged").mockResolvedValue(false);
 
-    // Phase 2: Call afterTurn with the ORIGINAL sessionId. The conversation
-    // now has sessionId=cron-run-002 but params.sessionId=cron-run-001.
-    // Without the fix: `cron-run-002 === cron-run-001` → false → blocked.
-    // With the fix: `isIsolatedCronSessionKey("agent:main:cron:nightly-report")` → true → recovery allowed.
+    // Phase 2: Call afterTurn with the ORIGINAL sessionId. The shared cron
+    // key currently points at cron-run-002, but no row owns cron-run-001.
     const secondSessionFile = createSessionFilePath("cron-run-001-phase2");
     writeLeafTranscript(secondSessionFile, [
       { role: "user", content: "run nightly report" },
@@ -173,7 +169,7 @@ describe("isolated cron checkpoint-missing recovery (guard condition)", () => {
       tokenBudget: 4096,
     });
 
-    // Verify: the reconciler recovered and ingested messages.
+    // Verify: the stale/missing runtime did not import into the active cron row.
     const messages = await engine
       .getConversationStore()
       .getMessages(conversation!.conversationId);
@@ -182,8 +178,67 @@ describe("isolated cron checkpoint-missing recovery (guard condition)", () => {
     // The original bootstrap messages should still be present.
     expect(contents).toContain("run nightly report");
     expect(contents).toContain("report generated");
-    // The new afterTurn messages should have been ingested (recovery succeeded).
-    expect(contents).toContain("follow-up answer");
+    expect(contents).not.toContain("follow-up answer");
+
+    const activeByCronKey = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(cronSessionKey);
+    expect(activeByCronKey?.conversationId).toBe(conversation!.conversationId);
+    expect(activeByCronKey?.sessionId).toBe("cron-run-002");
+  });
+
+  it("does not create a cron conversation when the runtime session owns another key", async () => {
+    const engine = createEngine();
+
+    const sessionId = "runtime-shared-with-non-cron";
+    const nonCronSessionKey = "agent:main:channel:general";
+    const firstSessionFile = createSessionFilePath("runtime-non-cron-owner");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "ordinary channel prompt" },
+      { role: "assistant", content: "ordinary channel answer" },
+    ]);
+
+    await engine.bootstrap({
+      sessionId,
+      sessionKey: nonCronSessionKey,
+      sessionFile: firstSessionFile,
+    });
+
+    const originalConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(originalConversation).not.toBeNull();
+    expect(originalConversation?.sessionKey).toBe(nonCronSessionKey);
+
+    const cronSessionFile = createSessionFilePath("runtime-ambiguous-cron-key");
+    writeLeafTranscript(cronSessionFile, [
+      { role: "user", content: "ambiguous cron prompt" },
+      { role: "assistant", content: "ambiguous cron answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: cronSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "ambiguous cron prompt" }),
+        makeMessage({ role: "assistant", content: "ambiguous cron answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const activeCronConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(cronSessionKey);
+    expect(activeCronConversation).toBeNull();
+
+    const originalMessages = await engine
+      .getConversationStore()
+      .getMessages(originalConversation!.conversationId);
+    const originalContents = originalMessages.map((m) => m.content);
+    expect(originalContents).toEqual(["ordinary channel prompt", "ordinary channel answer"]);
+    expect(originalContents).not.toContain("ambiguous cron answer");
   });
 });
 
@@ -270,7 +325,7 @@ describe("cron isolation / fail-closed rollover preservation", () => {
     expect(contents).toContain("alpha reply 1");
   });
 
-  it("isolated cron rollover detector archives old conversation with new sessionId", async () => {
+  it("isolated cron rollover keeps a stale old afterTurn from taking over the active run", async () => {
     // This test proves the existing cron isolation rollover behavior
     // (rotateIsolatedCronConversationIfRuntimeChanged) is not broken.
     // When a new cron run uses the same sessionKey but different sessionId,
@@ -308,6 +363,12 @@ describe("cron isolation / fail-closed rollover preservation", () => {
       { role: "assistant", content: "second cron reply" },
     ]);
 
+    await engine.bootstrap({
+      sessionId: secondSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: secondSessionFile,
+    });
+
     await engine.afterTurn({
       sessionId: secondSessionId,
       sessionKey: cronSessionKey,
@@ -320,38 +381,67 @@ describe("cron isolation / fail-closed rollover preservation", () => {
       tokenBudget: 4096,
     });
 
-    // The first conversation should be archived (no longer active).
-    const firstAfterRollover = await engine
+    const archivedFirstConversation = await engine
       .getConversationStore()
-      .getConversationBySessionId(firstSessionId);
-    // getConversationBySessionId returns the most recent active row;
-    // after archiving, the archived row may still be returned since it uses
-    // ORDER BY active DESC. The key: the first conversation should NOT be
-    // the one that ingested the second run's messages.
+      .getConversation(firstConversation!.conversationId);
+    expect(archivedFirstConversation?.active).toBe(false);
+
     const secondConversation = await engine
       .getConversationStore()
       .getConversationBySessionId(secondSessionId);
+    expect(secondConversation).not.toBeNull();
+    expect(secondConversation!.conversationId).not.toBe(firstConversation!.conversationId);
+    expect(secondConversation!.sessionId).toBe(secondSessionId);
 
-    if (secondConversation && secondConversation.conversationId !== firstConversation!.conversationId) {
-      // A new separate conversation was created for the second run.
-      const secondMessages = await engine
-        .getConversationStore()
-        .getMessages(secondConversation.conversationId);
-      const secondContents = secondMessages.map((m) => m.content);
-      expect(secondContents).toContain("second cron message");
-      expect(secondContents).toContain("second cron reply");
-    } else if (secondConversation && secondConversation.conversationId === firstConversation!.conversationId) {
-      // Same conversation — the rollover recovery path imported into it.
-      // This is also valid behavior (rollover didn't archive because the
-      // sessionKey match allowed recovery into the existing conversation).
-      const messages = await engine
-        .getConversationStore()
-        .getMessages(secondConversation.conversationId);
-      const contents = messages.map((m) => m.content);
-      expect(contents).toContain("second cron reply");
-    }
+    const secondMessages = await engine
+      .getConversationStore()
+      .getMessages(secondConversation!.conversationId);
+    const secondContents = secondMessages.map((m) => m.content);
+    expect(secondContents).toEqual(["second cron message", "second cron reply"]);
 
-    // Either way, the second run's messages were ingested somewhere.
-    // The key invariant: cron isolation behavior is preserved, not regressed.
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (...args: unknown[]) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate");
+
+    // A delayed afterTurn from the old run must not archive the newer active
+    // run, import into it, or run post-turn maintenance against it.
+    const staleOldSessionFile = createSessionFilePath("cron-run-A-stale");
+    writeLeafTranscript(staleOldSessionFile, [
+      { role: "user", content: "stale first cron follow-up" },
+      { role: "assistant", content: "stale first cron answer" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId: firstSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: staleOldSessionFile,
+      messages: [
+        makeMessage({ role: "user", content: "stale first cron follow-up" }),
+        makeMessage({ role: "assistant", content: "stale first cron answer" }),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    expect(evaluateSpy).not.toHaveBeenCalled();
+
+    const secondAfterStale = await engine
+      .getConversationStore()
+      .getConversation(secondConversation!.conversationId);
+    expect(secondAfterStale?.active).toBe(true);
+
+    const activeByCronKey = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(cronSessionKey);
+    expect(activeByCronKey?.conversationId).toBe(secondConversation!.conversationId);
+
+    const secondContentsAfterStale = (
+      await engine.getConversationStore().getMessages(secondConversation!.conversationId)
+    ).map((m) => m.content);
+    expect(secondContentsAfterStale).toEqual(["second cron message", "second cron reply"]);
+    expect(secondContentsAfterStale).not.toContain("stale first cron answer");
   });
 });

--- a/test/isolated-cron-checkpoint-missing-race.test.ts
+++ b/test/isolated-cron-checkpoint-missing-race.test.ts
@@ -43,6 +43,7 @@ import {
   createSessionFilePath,
   makeMessage,
   writeLeafTranscript,
+  writeLeafTranscriptMessages,
 } from "./helpers.js";
 
 afterEach(cleanupEngineTestState);
@@ -443,5 +444,68 @@ describe("cron isolation / fail-closed rollover preservation", () => {
     ).map((m) => m.content);
     expect(secondContentsAfterStale).toEqual(["second cron message", "second cron reply"]);
     expect(secondContentsAfterStale).not.toContain("stale first cron answer");
+  });
+
+  it("isolated cron afterTurn can rotate a provably fresh new runtime", async () => {
+    const engine = createEngine();
+
+    const firstSessionId = "cron-run-afterturn-old";
+    const firstSessionFile = createSessionFilePath("cron-run-afterturn-old");
+    writeLeafTranscript(firstSessionFile, [
+      { role: "user", content: "old cron message" },
+      { role: "assistant", content: "old cron reply" },
+    ]);
+
+    await engine.bootstrap({
+      sessionId: firstSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: firstSessionFile,
+    });
+
+    const firstConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(firstSessionId);
+    expect(firstConversation).not.toBeNull();
+
+    const secondSessionId = "cron-run-afterturn-new";
+    const freshBase = Date.now() + 60_000;
+    const secondMessages = [
+      makeMessage({ role: "user", content: "fresh cron afterTurn prompt" }),
+      makeMessage({ role: "assistant", content: "fresh cron afterTurn answer" }),
+    ].map((message, index) => ({
+      ...message,
+      timestamp: freshBase + index,
+    }));
+    const secondSessionFile = createSessionFilePath("cron-run-afterturn-new");
+    writeLeafTranscriptMessages(secondSessionFile, secondMessages);
+
+    await engine.afterTurn({
+      sessionId: secondSessionId,
+      sessionKey: cronSessionKey,
+      sessionFile: secondSessionFile,
+      messages: secondMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const archivedFirstConversation = await engine
+      .getConversationStore()
+      .getConversation(firstConversation!.conversationId);
+    expect(archivedFirstConversation?.active).toBe(false);
+
+    const activeByCronKey = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(cronSessionKey);
+    expect(activeByCronKey).not.toBeNull();
+    expect(activeByCronKey?.sessionId).toBe(secondSessionId);
+    expect(activeByCronKey?.conversationId).not.toBe(firstConversation!.conversationId);
+
+    const secondContents = (
+      await engine.getConversationStore().getMessages(activeByCronKey!.conversationId)
+    ).map((m) => m.content);
+    expect(secondContents).toEqual([
+      "fresh cron afterTurn prompt",
+      "fresh cron afterTurn answer",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
Isolated cron sessions share a durable sessionKey, but the checkpoint-missing recovery path in `transcript-reconciler.ts` guards on `conversation.sessionId === params.sessionId`. Since sessionId changes every run, when multiple cron jobs fire simultaneously, the last bootstrap overwrites the conversation's sessionId, causing earlier runners to fail the guard, enter a stuck loop, and eventually overflow context.

## Changes
- Export `isIsolatedCronSessionKey` from `src/tools/lcm-conversation-scope.ts` (was private)
- Import and add `isIsolatedCronSessionKey(conversation.sessionKey ?? undefined)` as an OR condition alongside the existing sessionId guard in `src/transcript-reconciler.ts`
- Add regression test in `test/isolated-cron-checkpoint-missing-race.test.ts`

## Safety
The helper returns `false` for all non-cron session keys, so the existing guard behavior is identical for non-cron paths.

Fixes: concurrent isolated cron `context_overflow`