### PR TITLE
chore: codify LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+# Normalize text files to LF in the repository.
+# Git will store these files with LF line endings.
+* text=auto eol=lf
+
+# Source files
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.go text eol=lf
+
+# Documentation and structured data
+*.md text eol=lf
+*.json text eol=lf
+*.jsonl text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+
+# Shell and config files
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf
+Makefile text eol=lf
+*.tmpl text eol=lf
+*.sql text eol=lf
+
+# Package manager lockfiles
+pnpm-lock.yaml text eol=lf
+package-lock.json text eol=lf
+yarn.lock text eol=lf
+
+# Preserve binary files without line-ending conversion.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lossless Context Management plugin for [OpenClaw](https://github.com/openclaw/op
 - [Session Migration CLI](#session-migration-cli)
 - [Documentation](#documentation)
 - [Development](#development)
+  - [Line endings](#line-endings)
 - [Security](#security)
 - [License](#license)
 
@@ -544,6 +545,22 @@ tui/                        # Interactive terminal UI (Go)
   prompts/                  # Depth-aware prompt templates
 .goreleaser.yml             # GoReleaser config for TUI binary releases
 ```
+
+### Line endings
+
+This repository codifies LF line endings through `.gitattributes` so diffs stay
+stable across macOS, Linux, and Windows development environments.
+
+- Git should store text files with LF endings in the repository.
+- The root `* text=auto eol=lf` rule normalizes newly added text files.
+- Common source, documentation, lockfile, template, and config extensions are
+  listed explicitly so contributors and tooling see the expected policy.
+- Binary assets and SQLite/database files are marked `binary` to avoid unsafe
+  newline conversion.
+- If your editor or operating system prefers CRLF locally, keep the repository
+  rules authoritative and avoid committing CRLF-only rewrites.
+- After changing line-ending rules, prefer a focused normalization commit so
+  future functional changes remain easy to review.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- add `.gitattributes` rules to normalize text files to LF
- explicitly cover common source, docs, config, template, lockfile, and binary file types
- document the repository line-ending policy in the README development section

Fixes #933

## Test plan
- `git diff --check`
