### PR TITLE
fix(interceptor): recover full file content when read tool truncates output

### DIFF
--- a/.changeset/read-truncation-recovery.md
+++ b/.changeset/read-truncation-recovery.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-When OpenClaw's built-in `read` tool returns truncated output, recover the full file content before externalizing the oversized tool result — but only for the live `assemble()` current turn. The truncated text is preserved on ingest, bootstrap, and replay paths so transcript fidelity is not compromised by current disk state. Fallback to the truncated fragment when the original path is missing, relative, or unreadable.
+When OpenClaw's built-in `read` tool returns truncated output, recover the full file content before externalizing the oversized tool result — but only for the live `assemble()` current turn. The truncated text is preserved on ingest, bootstrap, and replay paths so transcript fidelity is not compromised by current disk state. Fallback to the truncated fragment when the original path is missing, relative, unreadable, non-regular, or too large for bounded live recovery.

--- a/.changeset/read-truncation-recovery.md
+++ b/.changeset/read-truncation-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+When OpenClaw's built-in `read` tool returns truncated output, recover the full file content before externalizing the oversized tool result — but only for the live `assemble()` current turn. The truncated text is preserved on ingest, bootstrap, and replay paths so transcript fidelity is not compromised by current disk state. Fallback to the truncated fragment when the original path is missing, relative, or unreadable.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2545,12 +2545,11 @@ export class LcmContextEngine implements ContextEngine {
     sessionId: string;
     sessionKey?: string;
     message: AgentMessage;
-    toolCallInputMap?: ReadonlyMap<string, Record<string, unknown>>;
     isHeartbeat?: boolean;
     createdAt?: Date | string;
     skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult> {
-    const { sessionId, sessionKey, message, toolCallInputMap, isHeartbeat, createdAt, skipReplayTimestampFloodGuard } = params;
+    const { sessionId, sessionKey, message, isHeartbeat, createdAt, skipReplayTimestampFloodGuard } = params;
     if (isHeartbeat) {
       return { ingested: false };
     }
@@ -2696,7 +2695,6 @@ export class LcmContextEngine implements ContextEngine {
       const intercepted = await this.largeFileInterceptor.interceptLargeToolResults({
         conversationId,
         message: messageForParts,
-        toolCallInputMap,
       });
       if (intercepted) {
         messageForParts = intercepted.rewrittenMessage;
@@ -2808,13 +2806,11 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
           let ingestedCount = 0;
-          const toolCallInputMap = buildToolCallInputMap(messages);
           for (const message of messages) {
             const result = await this.ingestSingle({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               message,
-              toolCallInputMap,
               isHeartbeat: params.isHeartbeat,
               createdAt: resolveTranscriptMessageCreatedAt(message),
             });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -46,6 +46,7 @@ import { CompactionTelemetryStore } from "./store/compaction-telemetry-store.js"
 import { CompactionMaintenanceStore } from "./store/compaction-maintenance-store.js";
 import { ConversationStore, type ConversationRecord } from "./store/conversation-store.js";
 import { FocusBriefStore, type FocusBriefRecord } from "./store/focus-brief-store.js";
+import { buildToolCallInputMap } from "./tool-pairing.js";
 import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, FALLBACK_SUMMARY_MARKER, LcmProviderAuthError, LcmSummarySpendLimitError, type LcmSummarizeFn } from "./summarize.js";
 import type { LcmDependencies } from "./types.js";
@@ -2544,11 +2545,12 @@ export class LcmContextEngine implements ContextEngine {
     sessionId: string;
     sessionKey?: string;
     message: AgentMessage;
+    toolCallInputMap?: ReadonlyMap<string, Record<string, unknown>>;
     isHeartbeat?: boolean;
     createdAt?: Date | string;
     skipReplayTimestampFloodGuard?: boolean;
   }): Promise<IngestResult> {
-    const { sessionId, sessionKey, message, isHeartbeat, createdAt, skipReplayTimestampFloodGuard } = params;
+    const { sessionId, sessionKey, message, toolCallInputMap, isHeartbeat, createdAt, skipReplayTimestampFloodGuard } = params;
     if (isHeartbeat) {
       return { ingested: false };
     }
@@ -2694,6 +2696,7 @@ export class LcmContextEngine implements ContextEngine {
       const intercepted = await this.largeFileInterceptor.interceptLargeToolResults({
         conversationId,
         message: messageForParts,
+        toolCallInputMap,
       });
       if (intercepted) {
         messageForParts = intercepted.rewrittenMessage;
@@ -2805,11 +2808,13 @@ export class LcmContextEngine implements ContextEngine {
             }
           }
           let ingestedCount = 0;
+          const toolCallInputMap = buildToolCallInputMap(messages);
           for (const message of messages) {
             const result = await this.ingestSingle({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               message,
+              toolCallInputMap,
               isHeartbeat: params.isHeartbeat,
               createdAt: resolveTranscriptMessageCreatedAt(message),
             });
@@ -3428,11 +3433,13 @@ export class LcmContextEngine implements ContextEngine {
         // Keep the rewritten view local; OpenClaw owns the live message array.
         const rewrittenMessages = liveMessages.slice();
         let interceptedAny = false;
+        const toolCallInputMap = buildToolCallInputMap(liveMessages);
         for (let i = 0; i < liveMessages.length; i++) {
           const message = liveMessages[i]!;
           const intercepted = await this.largeFileInterceptor.interceptLargeToolResults({
             conversationId: conversation.conversationId,
             message,
+            toolCallInputMap,
             getFileId: ({ content, toolName, callId }) =>
               buildLiveToolOutputFileId({
                 conversationId: conversation.conversationId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3429,13 +3429,24 @@ export class LcmContextEngine implements ContextEngine {
         // Keep the rewritten view local; OpenClaw owns the live message array.
         const rewrittenMessages = liveMessages.slice();
         let interceptedAny = false;
-        const toolCallInputMap = buildToolCallInputMap(liveMessages);
+        const lastLiveUserIndex = (() => {
+          for (let index = liveMessages.length - 1; index >= 0; index--) {
+            if (liveMessages[index]?.role === "user") {
+              return index;
+            }
+          }
+          return -1;
+        })();
+        const currentTurnToolCallInputMap =
+          lastLiveUserIndex >= 0
+            ? buildToolCallInputMap(liveMessages.slice(lastLiveUserIndex + 1))
+            : undefined;
         for (let i = 0; i < liveMessages.length; i++) {
           const message = liveMessages[i]!;
           const intercepted = await this.largeFileInterceptor.interceptLargeToolResults({
             conversationId: conversation.conversationId,
             message,
-            toolCallInputMap,
+            toolCallInputMap: i > lastLiveUserIndex ? currentTurnToolCallInputMap : undefined,
             getFileId: ({ content, toolName, callId }) =>
               buildLiveToolOutputFileId({
                 conversationId: conversation.conversationId,

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -7,8 +7,9 @@
  * Extracted from engine.ts (Phase 2 of the engine decomposition).
  */
 import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { LcmConfig } from "./db/config.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
@@ -753,6 +754,7 @@ export class LargeFileInterceptor {
   async interceptLargeToolResults(params: {
     conversationId: number;
     message: AgentMessage;
+    toolCallInputMap?: ReadonlyMap<string, Record<string, unknown>>;
     getFileId?: (input: { content: string; toolName: string; callId?: string }) => string;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
     if (
@@ -857,9 +859,32 @@ export class LargeFileInterceptor {
       }
 
       interceptedAny = true;
+
+      // If the read tool output was truncated, recover the full content from disk.
+      // The tool call input carries the original file path; without this recovery
+      // the truncated output gets externalized and the agent can never retrieve
+      // the complete file via lcm_describe.
+      let contentToExternalize = extractedText;
+      if (
+        toolName === "read" &&
+        callId &&
+        params.toolCallInputMap &&
+        isReadToolTruncated(extractedText)
+      ) {
+        const toolInput = params.toolCallInputMap.get(callId);
+        const readPath = toolInput && safeString(toolInput.path);
+        if (readPath && isAbsolute(readPath) && existsSync(readPath)) {
+          try {
+            contentToExternalize = readFileSync(readPath, "utf8");
+          } catch {
+            // Fall back to the truncated text if the file can't be read.
+          }
+        }
+      }
+
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,
-        content: extractedText,
+        content: contentToExternalize,
         fileId: params.getFileId?.({ content: extractedText, toolName, callId }),
         fileName: `${toolName}.txt`,
         mimeType: "text/plain",
@@ -996,4 +1021,11 @@ export class LargeFileInterceptor {
       },
     };
   }
+}
+
+const READ_CAPPED_RE = /\[Read output capped at/i;
+const READ_TRUNCATED_RE = /\[Truncated:/;
+
+function isReadToolTruncated(text: string): boolean {
+  return READ_CAPPED_RE.test(text) || READ_TRUNCATED_RE.test(text);
 }

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -835,7 +835,7 @@ export class LargeFileInterceptor {
         rewrittenContent.push(item);
         continue;
       }
-      if (typeof extractedText !== "string" || estimateTokens(extractedText) < threshold) {
+      if (typeof extractedText !== "string") {
         rewrittenContent.push(item);
         continue;
       }
@@ -859,14 +859,31 @@ export class LargeFileInterceptor {
         continue;
       }
 
-      interceptedAny = true;
-
       const externalizedPayload = resolveLiveToolResultExternalization({
         toolName,
         callId,
         extractedText,
         toolCallInputMap: params.toolCallInputMap,
       });
+      if (estimateTokens(externalizedPayload.content) < threshold) {
+        if (externalizedPayload.content !== extractedText) {
+          const recoveredBlock = { ...record };
+          if (isPlainTextToolResult) {
+            recoveredBlock.text = externalizedPayload.content;
+          } else if ("output" in recoveredBlock || !("content" in recoveredBlock)) {
+            recoveredBlock.output = externalizedPayload.content;
+          } else {
+            recoveredBlock.content = externalizedPayload.content;
+          }
+          interceptedAny = true;
+          rewrittenContent.push(recoveredBlock);
+        } else {
+          rewrittenContent.push(item);
+        }
+        continue;
+      }
+
+      interceptedAny = true;
 
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -754,7 +754,7 @@ export class LargeFileInterceptor {
   async interceptLargeToolResults(params: {
     conversationId: number;
     message: AgentMessage;
-    toolCallInputMap?: ReadonlyMap<string, Record<string, unknown>>;
+    toolCallInputMap?: ReadonlyMap<string, { name?: string; input?: Record<string, unknown> }>;
     getFileId?: (input: { content: string; toolName: string; callId?: string }) => string;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
     if (
@@ -861,18 +861,23 @@ export class LargeFileInterceptor {
       interceptedAny = true;
 
       // If the read tool output was truncated, recover the full content from disk.
-      // The tool call input carries the original file path; without this recovery
-      // the truncated output gets externalized and the agent can never retrieve
-      // the complete file via lcm_describe.
+      // The tool call input carries the original file path. Because tool result
+      // blocks often do not repeat the tool name, fall back to the name recorded
+      // in the paired tool_use input (when a live toolCallInputMap is supplied).
+      // The presence of a toolCallInputMap signals a live current-turn context;
+      // historical ingest/replay paths omit it and therefore preserve the
+      // truncated text as recorded.
       let contentToExternalize = extractedText;
+      const effectiveToolName =
+        (callId && params.toolCallInputMap?.get(callId)?.name) || toolName;
       if (
-        toolName === "read" &&
+        effectiveToolName === "read" &&
         callId &&
         params.toolCallInputMap &&
         isReadToolTruncated(extractedText)
       ) {
         const toolInput = params.toolCallInputMap.get(callId);
-        const readPath = toolInput && safeString(toolInput.path);
+        const readPath = toolInput?.input && safeString(toolInput.input.path);
         if (readPath && isAbsolute(readPath) && existsSync(readPath)) {
           try {
             contentToExternalize = readFileSync(readPath, "utf8");
@@ -885,7 +890,7 @@ export class LargeFileInterceptor {
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,
         content: contentToExternalize,
-        fileId: params.getFileId?.({ content: extractedText, toolName, callId }),
+        fileId: params.getFileId?.({ content: contentToExternalize, toolName, callId }),
         fileName: `${toolName}.txt`,
         mimeType: "text/plain",
         formatReference: ({ fileId, byteSize, summary }) =>

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -7,9 +7,8 @@
  * Extracted from engine.ts (Phase 2 of the engine decomposition).
  */
 import { mkdir, writeFile } from "node:fs/promises";
-import { existsSync, readFileSync } from "node:fs";
 import { createHash, randomUUID } from "node:crypto";
-import { isAbsolute, join } from "node:path";
+import { join } from "node:path";
 import type { LcmConfig } from "./db/config.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
@@ -29,6 +28,8 @@ import {
   serializeRawPayloadContent,
   type StoredMessage,
 } from "./message-content.js";
+import { resolveLiveToolResultExternalization } from "./read-tool-recovery.js";
+import { buildExternalizedToolResultBlock } from "./tool-result-blocks.js";
 import { asRecord, safeBoolean, safeString } from "./value-utils.js";
 
 /** Resolves the optional model-backed summarizer used for large-file exploration summaries. */
@@ -860,43 +861,27 @@ export class LargeFileInterceptor {
 
       interceptedAny = true;
 
-      // If the read tool output was truncated, recover the full content from disk.
-      // The tool call input carries the original file path. Because tool result
-      // blocks often do not repeat the tool name, fall back to the name recorded
-      // in the paired tool_use input (when a live toolCallInputMap is supplied).
-      // The presence of a toolCallInputMap signals a live current-turn context;
-      // historical ingest/replay paths omit it and therefore preserve the
-      // truncated text as recorded.
-      let contentToExternalize = extractedText;
-      const effectiveToolName =
-        (callId && params.toolCallInputMap?.get(callId)?.name) || toolName;
-      if (
-        effectiveToolName === "read" &&
-        callId &&
-        params.toolCallInputMap &&
-        isReadToolTruncated(extractedText)
-      ) {
-        const toolInput = params.toolCallInputMap.get(callId);
-        const readPath = toolInput?.input && safeString(toolInput.input.path);
-        if (readPath && isAbsolute(readPath) && existsSync(readPath)) {
-          try {
-            contentToExternalize = readFileSync(readPath, "utf8");
-          } catch {
-            // Fall back to the truncated text if the file can't be read.
-          }
-        }
-      }
+      const externalizedPayload = resolveLiveToolResultExternalization({
+        toolName,
+        callId,
+        extractedText,
+        toolCallInputMap: params.toolCallInputMap,
+      });
 
       const externalized = await this.externalizeLargeTextPayload({
         conversationId: params.conversationId,
-        content: contentToExternalize,
-        fileId: params.getFileId?.({ content: contentToExternalize, toolName, callId }),
-        fileName: `${toolName}.txt`,
+        content: externalizedPayload.content,
+        fileId: params.getFileId?.({
+          content: externalizedPayload.content,
+          toolName: externalizedPayload.toolName,
+          callId,
+        }),
+        fileName: `${externalizedPayload.toolName}.txt`,
         mimeType: "text/plain",
         formatReference: ({ fileId, byteSize, summary }) =>
           formatToolOutputReference({
             fileId,
-            toolName,
+            toolName: externalizedPayload.toolName,
             byteSize,
             summary,
           }),
@@ -904,41 +889,18 @@ export class LargeFileInterceptor {
 
       const normalizedRawType =
         rawType === "function_call_output" ? "function_call_output" : "tool_result";
-      const compactBlock: Record<string, unknown> = isPlainTextToolResult
-        ? {
-            type: "text",
-            text: externalized.reference,
-            rawType: normalizedRawType,
-            externalizedFileId: externalized.fileId,
-            originalByteSize: externalized.byteSize,
-            toolOutputExternalized: true,
-            externalizationReason: "large_tool_result",
-          }
-        : {
-            type: normalizedRawType,
-            output: externalized.reference,
-            externalizedFileId: externalized.fileId,
-            originalByteSize: externalized.byteSize,
-            toolOutputExternalized: true,
-            externalizationReason: "large_tool_result",
-          };
-      if (callId) {
-        if (normalizedRawType === "function_call_output") {
-          compactBlock.call_id = callId;
-        } else {
-          compactBlock.tool_use_id = callId;
-        }
-      }
-      if (typeof record.is_error === "boolean") {
-        compactBlock.is_error = record.is_error;
-      } else if (typeof record.isError === "boolean") {
-        compactBlock.isError = record.isError;
-      } else if (typeof topLevelIsError === "boolean") {
-        compactBlock.isError = topLevelIsError;
-      }
-      if (toolName) {
-        compactBlock.name = toolName;
-      }
+      const compactBlock = buildExternalizedToolResultBlock({
+        isPlainTextToolResult,
+        normalizedRawType,
+        reference: externalized.reference,
+        fileId: externalized.fileId,
+        byteSize: externalized.byteSize,
+        callId,
+        recordIsError: record.is_error,
+        recordIsErrorCamel: record.isError,
+        topLevelIsError,
+        toolName: externalizedPayload.toolName,
+      });
 
       rewrittenContent.push(compactBlock);
       fileIds.push(externalized.fileId);
@@ -1026,11 +988,4 @@ export class LargeFileInterceptor {
       },
     };
   }
-}
-
-const READ_CAPPED_RE = /\[Read output capped at/i;
-const READ_TRUNCATED_RE = /\[Truncated:/;
-
-function isReadToolTruncated(text: string): boolean {
-  return READ_CAPPED_RE.test(text) || READ_TRUNCATED_RE.test(text);
 }

--- a/src/read-tool-recovery.ts
+++ b/src/read-tool-recovery.ts
@@ -1,7 +1,9 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import type { ToolCallInputMap } from "./tool-pairing.js";
 import { safeString } from "./value-utils.js";
+
+export const MAX_LIVE_READ_RECOVERY_BYTES = 8 * 1024 * 1024;
 
 const READ_CAPPED_RE = /\[Read output capped at/i;
 const READ_TRUNCATED_RE = /\[Truncated:/;
@@ -22,10 +24,14 @@ export function recoverLiveReadToolContent(params: {
   }
   const toolInput = params.toolCallInputMap.get(params.callId);
   const readPath = toolInput?.input && safeString(toolInput.input.path);
-  if (!readPath || !isAbsolute(readPath) || !existsSync(readPath)) {
+  if (!readPath || !isAbsolute(readPath)) {
     return params.extractedText;
   }
   try {
+    const stats = statSync(readPath);
+    if (!stats.isFile() || stats.size > MAX_LIVE_READ_RECOVERY_BYTES) {
+      return params.extractedText;
+    }
     return readFileSync(readPath, "utf8");
   } catch {
     return params.extractedText;

--- a/src/read-tool-recovery.ts
+++ b/src/read-tool-recovery.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import type { ToolCallInputMap } from "./tool-pairing.js";
 import { safeString } from "./value-utils.js";
@@ -27,14 +27,20 @@ export function recoverLiveReadToolContent(params: {
   if (!readPath || !isAbsolute(readPath)) {
     return params.extractedText;
   }
+  let fd: number | undefined;
   try {
-    const stats = statSync(readPath);
+    fd = openSync(readPath, "r");
+    const stats = fstatSync(fd);
     if (!stats.isFile() || stats.size > MAX_LIVE_READ_RECOVERY_BYTES) {
       return params.extractedText;
     }
-    return readFileSync(readPath, "utf8");
+    return readFileSync(fd, "utf8");
   } catch {
     return params.extractedText;
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd);
+    }
   }
 }
 

--- a/src/read-tool-recovery.ts
+++ b/src/read-tool-recovery.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import type { ToolCallInputMap } from "./tool-pairing.js";
+import { safeString } from "./value-utils.js";
+
+const READ_CAPPED_RE = /\[Read output capped at/i;
+const READ_TRUNCATED_RE = /\[Truncated:/;
+
+/** Return true when OpenClaw's read tool clearly reported truncated output. */
+export function isReadToolTruncated(text: string): boolean {
+  return READ_CAPPED_RE.test(text) || READ_TRUNCATED_RE.test(text);
+}
+
+/** Best-effort live recovery for current-turn read results that were capped by the host tool. */
+export function recoverLiveReadToolContent(params: {
+  callId?: string;
+  extractedText: string;
+  toolCallInputMap?: ToolCallInputMap;
+}): string {
+  if (!params.callId || !params.toolCallInputMap || !isReadToolTruncated(params.extractedText)) {
+    return params.extractedText;
+  }
+  const toolInput = params.toolCallInputMap.get(params.callId);
+  const readPath = toolInput?.input && safeString(toolInput.input.path);
+  if (!readPath || !isAbsolute(readPath) || !existsSync(readPath)) {
+    return params.extractedText;
+  }
+  try {
+    return readFileSync(readPath, "utf8");
+  } catch {
+    return params.extractedText;
+  }
+}
+
+/** Resolve the live tool label and externalized payload for one oversized tool result. */
+export function resolveLiveToolResultExternalization(params: {
+  toolName: string;
+  callId?: string;
+  extractedText: string;
+  toolCallInputMap?: ToolCallInputMap;
+}): { content: string; toolName: string } {
+  const toolName =
+    (params.callId && params.toolCallInputMap?.get(params.callId)?.name) || params.toolName;
+  const content =
+    toolName === "read"
+      ? recoverLiveReadToolContent({
+          callId: params.callId,
+          extractedText: params.extractedText,
+          toolCallInputMap: params.toolCallInputMap,
+        })
+      : params.extractedText;
+  return { content, toolName };
+}

--- a/src/tool-pairing.ts
+++ b/src/tool-pairing.ts
@@ -63,6 +63,29 @@ export function extractToolResultIdForPairing(message: AgentMessage): string | u
   return undefined;
 }
 
+export function buildToolCallInputMap(
+  messages: AgentMessage[],
+): Map<string, Record<string, unknown>> {
+  const map = new Map<string, Record<string, unknown>>();
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content) {
+      const record = asRecord(block);
+      if (!record || typeof record.type !== "string" || !TOOL_CALL_RAW_TYPES.has(record.type)) {
+        continue;
+      }
+      const id = extractToolPairingIdFromRecord(record);
+      const input = asRecord(record.input) ?? asRecord(record.arguments);
+      if (id && input) {
+        map.set(id, input);
+      }
+    }
+  }
+  return map;
+}
+
 export function expandProtectedToolPairIndexes(params: {
   assembledMessages: AgentMessage[];
   protectedAssembledIndexes: Set<number>;

--- a/src/tool-pairing.ts
+++ b/src/tool-pairing.ts
@@ -63,7 +63,7 @@ export function extractToolResultIdForPairing(message: AgentMessage): string | u
   return undefined;
 }
 
-export type ToolCallInputMap = Map<
+export type ToolCallInputMap = ReadonlyMap<
   string,
   { name?: string; input?: Record<string, unknown> }
 >;
@@ -71,7 +71,7 @@ export type ToolCallInputMap = Map<
 export function buildToolCallInputMap(
   messages: AgentMessage[],
 ): ToolCallInputMap {
-  const map: ToolCallInputMap = new Map();
+  const map = new Map<string, { name?: string; input?: Record<string, unknown> }>();
   for (const message of messages) {
     if (message.role !== "assistant" || !Array.isArray(message.content)) {
       continue;

--- a/src/tool-pairing.ts
+++ b/src/tool-pairing.ts
@@ -68,10 +68,31 @@ export type ToolCallInputMap = ReadonlyMap<
   { name?: string; input?: Record<string, unknown> }
 >;
 
+function parseToolCallInput(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const directInput = asRecord(record.input);
+  if (directInput) {
+    return directInput;
+  }
+  const directArguments = asRecord(record.arguments);
+  if (directArguments) {
+    return directArguments;
+  }
+  if (typeof record.arguments !== "string") {
+    return undefined;
+  }
+  try {
+    return asRecord(JSON.parse(record.arguments));
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildToolCallInputMap(
   messages: AgentMessage[],
 ): ToolCallInputMap {
   const map = new Map<string, { name?: string; input?: Record<string, unknown> }>();
+  const seenIds = new Set<string>();
+  const ambiguousIds = new Set<string>();
   for (const message of messages) {
     if (message.role !== "assistant" || !Array.isArray(message.content)) {
       continue;
@@ -83,8 +104,17 @@ export function buildToolCallInputMap(
       }
       const id = extractToolPairingIdFromRecord(record);
       const name = safeString(record.name);
-      const input = asRecord(record.input) ?? asRecord(record.arguments);
-      if (id && input) {
+      const input = parseToolCallInput(record);
+      if (!id) {
+        continue;
+      }
+      if (seenIds.has(id)) {
+        map.delete(id);
+        ambiguousIds.add(id);
+        continue;
+      }
+      seenIds.add(id);
+      if (input && !ambiguousIds.has(id)) {
         map.set(id, { name, input });
       }
     }

--- a/src/tool-pairing.ts
+++ b/src/tool-pairing.ts
@@ -63,10 +63,15 @@ export function extractToolResultIdForPairing(message: AgentMessage): string | u
   return undefined;
 }
 
+export type ToolCallInputMap = Map<
+  string,
+  { name?: string; input?: Record<string, unknown> }
+>;
+
 export function buildToolCallInputMap(
   messages: AgentMessage[],
-): Map<string, Record<string, unknown>> {
-  const map = new Map<string, Record<string, unknown>>();
+): ToolCallInputMap {
+  const map: ToolCallInputMap = new Map();
   for (const message of messages) {
     if (message.role !== "assistant" || !Array.isArray(message.content)) {
       continue;
@@ -77,9 +82,10 @@ export function buildToolCallInputMap(
         continue;
       }
       const id = extractToolPairingIdFromRecord(record);
+      const name = safeString(record.name);
       const input = asRecord(record.input) ?? asRecord(record.arguments);
       if (id && input) {
-        map.set(id, input);
+        map.set(id, { name, input });
       }
     }
   }

--- a/src/tool-result-blocks.ts
+++ b/src/tool-result-blocks.ts
@@ -1,0 +1,50 @@
+/** Build the compact replacement block for an externalized tool result. */
+export function buildExternalizedToolResultBlock(params: {
+  isPlainTextToolResult: boolean;
+  normalizedRawType: "function_call_output" | "tool_result";
+  reference: string;
+  fileId: string;
+  byteSize: number;
+  callId?: string;
+  recordIsError?: unknown;
+  recordIsErrorCamel?: unknown;
+  topLevelIsError?: boolean;
+  toolName: string;
+}): Record<string, unknown> {
+  const block: Record<string, unknown> = params.isPlainTextToolResult
+    ? {
+        type: "text",
+        text: params.reference,
+        rawType: params.normalizedRawType,
+        externalizedFileId: params.fileId,
+        originalByteSize: params.byteSize,
+        toolOutputExternalized: true,
+        externalizationReason: "large_tool_result",
+      }
+    : {
+        type: params.normalizedRawType,
+        output: params.reference,
+        externalizedFileId: params.fileId,
+        originalByteSize: params.byteSize,
+        toolOutputExternalized: true,
+        externalizationReason: "large_tool_result",
+      };
+  if (params.callId) {
+    if (params.normalizedRawType === "function_call_output") {
+      block.call_id = params.callId;
+    } else {
+      block.tool_use_id = params.callId;
+    }
+  }
+  if (typeof params.recordIsError === "boolean") {
+    block.is_error = params.recordIsError;
+  } else if (typeof params.recordIsErrorCamel === "boolean") {
+    block.isError = params.recordIsErrorCamel;
+  } else if (typeof params.topLevelIsError === "boolean") {
+    block.isError = params.topLevelIsError;
+  }
+  if (params.toolName) {
+    block.name = params.toolName;
+  }
+  return block;
+}

--- a/test/read-tool-truncation-recovery.test.ts
+++ b/test/read-tool-truncation-recovery.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import {
+  cleanupEngineTestState,
+  createEngineWithConfig,
+  createSessionFilePath,
+  makeMessage,
+  tempDirs,
+  writeLeafTranscriptMessages,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+function createEngineForRecovery(overrides?: Partial<{ largeFilesDir: string }>) {
+  const largeFilesDir = overrides?.largeFilesDir ?? mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+  tempDirs.push(largeFilesDir);
+  return createEngineWithConfig({
+    largeFileTokenThreshold: 20,
+    stubLargeToolPayloads: true,
+    largeFilesDir,
+  });
+}
+
+function makeTruncatedOutput(marker: string): string {
+  return `${"truncated fragment ".repeat(25)}\n${marker}`;
+}
+
+function readToolResultMessages(params: {
+  filePath: string;
+  truncatedOutput: string;
+  callId?: string;
+}): AgentMessage[] {
+  const callId = params.callId ?? "call_read_1";
+  return [
+    makeMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: callId,
+          name: "read",
+          input: { path: params.filePath },
+        },
+      ],
+    }),
+    makeMessage({
+      role: "toolResult",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: callId,
+          output: params.truncatedOutput,
+        },
+      ],
+    }),
+  ];
+}
+
+describe("read tool truncation recovery", () => {
+  it("assemble() recovers full file content from a live current-turn read tool result", async () => {
+    const engine = createEngineForRecovery();
+    const sessionId = "assemble-read-truncation-recovery";
+
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const fullContent = ["line 1", "line 2", "line 3", "line 4", "line 5"].join("\n");
+    writeFileSync(filePath, fullContent, "utf8");
+
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 50 bytes]");
+    const liveMessages = [
+      makeMessage({ role: "user", content: "read the file" }),
+      ...readToolResultMessages({ filePath, truncatedOutput }),
+    ];
+
+    await engine.getConversationStore().getOrCreateConversation(sessionId);
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+
+    const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
+    expect(storedContent).toBe(fullContent);
+
+    const stubText = assembleResult.messages
+      .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+      .join("\n");
+    expect(stubText).toContain(`[LCM Tool Output: ${largeFiles[0]!.fileId}`);
+  });
+
+  it("afterTurn() ingest preserves truncated read tool result without recovery", async () => {
+    const engine = createEngineForRecovery();
+    const sessionId = "afterturn-read-truncation-no-recovery";
+    const sessionFile = createSessionFilePath("afterturn-read-truncation-no-recovery");
+
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const fullContent = ["alpha", "beta", "gamma", "delta", "epsilon"].join("\n");
+    writeFileSync(filePath, fullContent, "utf8");
+
+    const truncatedOutput = makeTruncatedOutput("[Truncated: content exceeded limit]");
+    const messages = [
+      makeMessage({ role: "user", content: "read the file" }),
+      ...readToolResultMessages({ filePath, truncatedOutput }),
+    ];
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+
+    const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
+    expect(storedContent).toBe(truncatedOutput);
+    expect(storedContent).not.toBe(fullContent);
+  });
+
+  it("bootstrap import does not rehydrate truncated read tool results from current disk", async () => {
+    const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
+    tempDirs.push(largeFilesDir);
+    const engine = createEngineForRecovery({ largeFilesDir });
+    const sessionId = "bootstrap-read-truncation-no-recovery";
+    const sessionFile = createSessionFilePath("bootstrap-read-truncation-no-recovery");
+
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const currentContent = "completely rewritten content";
+    writeFileSync(filePath, currentContent, "utf8");
+
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+    const transcriptMessages = [
+      makeMessage({ role: "user", content: "read the file" }),
+      ...readToolResultMessages({ filePath, truncatedOutput }),
+    ];
+    writeLeafTranscriptMessages(sessionFile, transcriptMessages);
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionFile,
+    });
+    expect(result.bootstrapped).toBe(true);
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+
+    const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
+    expect(storedContent).toBe(truncatedOutput);
+    expect(storedContent).not.toBe(currentContent);
+  });
+
+  it("falls back to truncated content when the read tool path is relative or missing", async () => {
+    const engine = createEngineForRecovery();
+    const sessionId = "assemble-read-truncation-fallback";
+
+    const relativePath = "./relative-file.txt";
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+    const liveMessages = [
+      makeMessage({ role: "user", content: "read the file" }),
+      makeMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_read_missing",
+            name: "read",
+            input: { path: relativePath },
+          },
+        ],
+      }),
+      makeMessage({
+        role: "toolResult",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_read_missing",
+            output: truncatedOutput,
+          },
+        ],
+      }),
+    ];
+
+    await engine.getConversationStore().getOrCreateConversation(sessionId);
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+
+    const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
+    expect(storedContent).toBe(truncatedOutput);
+
+    const stubText = assembleResult.messages
+      .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+      .join("\n");
+    expect(stubText).toContain(`[LCM Tool Output: ${largeFiles[0]!.fileId}`);
+  });
+});

--- a/test/read-tool-truncation-recovery.test.ts
+++ b/test/read-tool-truncation-recovery.test.ts
@@ -95,10 +95,18 @@ describe("read tool truncation recovery", () => {
     const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
     expect(storedContent).toBe(fullContent);
 
+    const described = await engine.getRetrieval().describe(largeFiles[0]!.fileId, {
+      expandFile: true,
+      largeFilesDir: engine.configView.largeFilesDir,
+    });
+    expect(described?.file?.content).toBe(fullContent);
+    expect(described?.file?.contentTruncated).toBe(false);
+
     const stubText = assembleResult.messages
       .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
       .join("\n");
     expect(stubText).toContain(`[LCM Tool Output: ${largeFiles[0]!.fileId}`);
+    expect(stubText).toContain("tool=read");
   });
 
   it("afterTurn() ingest preserves truncated read tool result without recovery", async () => {

--- a/test/read-tool-truncation-recovery.test.ts
+++ b/test/read-tool-truncation-recovery.test.ts
@@ -300,6 +300,47 @@ describe("read tool truncation recovery", () => {
     expect(storedContent).not.toBe(fullContent);
   });
 
+  it("assemble() does not recover historical live read results before the active user turn", async () => {
+    const engine = createEngineForRecovery();
+    const sessionId = "assemble-read-historical-live-no-recovery";
+
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const currentContent = Array.from(
+      { length: 30 },
+      (_, index) => `line ${index + 1}: current disk content must not replace history`,
+    ).join("\n");
+    writeFileSync(filePath, currentContent, "utf8");
+
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+    const liveMessages = [
+      makeMessage({ role: "user", content: "old request" }),
+      ...readToolResultMessages({ filePath, truncatedOutput, callId: "call_old_read" }),
+      makeMessage({ role: "user", content: "new active request" }),
+    ];
+
+    await engine.getConversationStore().getOrCreateConversation(sessionId);
+
+    await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(1);
+
+    const storedContent = readFileSync(largeFiles[0]!.storageUri, "utf8");
+    expect(storedContent).toBe(truncatedOutput);
+    expect(storedContent).not.toBe(currentContent);
+  });
+
   it("bootstrap import does not rehydrate truncated read tool results from current disk", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);

--- a/test/read-tool-truncation-recovery.test.ts
+++ b/test/read-tool-truncation-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_LIVE_READ_RECOVERY_BYTES,
   recoverLiveReadToolContent,
 } from "../src/read-tool-recovery.js";
+import { buildToolCallInputMap } from "../src/tool-pairing.js";
 import {
   cleanupEngineTestState,
   createEngineWithConfig,
@@ -18,11 +19,13 @@ import {
 
 afterEach(cleanupEngineTestState);
 
-function createEngineForRecovery(overrides?: Partial<{ largeFilesDir: string }>) {
+function createEngineForRecovery(
+  overrides?: Partial<{ largeFilesDir: string; largeFileTokenThreshold: number }>,
+) {
   const largeFilesDir = overrides?.largeFilesDir ?? mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
   tempDirs.push(largeFilesDir);
   return createEngineWithConfig({
-    largeFileTokenThreshold: 20,
+    largeFileTokenThreshold: overrides?.largeFileTokenThreshold ?? 20,
     stubLargeToolPayloads: true,
     largeFilesDir,
   });
@@ -98,6 +101,71 @@ describe("read tool truncation recovery", () => {
     expect(recovered).toBe(truncatedOutput);
   });
 
+  it("does not recover from duplicate tool call ids", () => {
+    const firstDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-first-"));
+    const secondDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-second-"));
+    tempDirs.push(firstDir, secondDir);
+    const firstPath = join(firstDir, "first.txt");
+    const secondPath = join(secondDir, "second.txt");
+    writeFileSync(firstPath, "first file content", "utf8");
+    writeFileSync(secondPath, "second file content", "utf8");
+
+    const toolCallInputMap = buildToolCallInputMap([
+      makeMessage({
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "duplicate_read", name: "read", input: { path: firstPath } },
+        ],
+      }),
+      makeMessage({
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "duplicate_read", name: "read", input: { path: secondPath } },
+        ],
+      }),
+    ]);
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+
+    const recovered = recoverLiveReadToolContent({
+      callId: "duplicate_read",
+      extractedText: truncatedOutput,
+      toolCallInputMap,
+    });
+
+    expect(recovered).toBe(truncatedOutput);
+  });
+
+  it("recovers read paths from JSON-string function_call arguments", () => {
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-function-call-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const fullContent = "function_call JSON arguments should recover this content";
+    writeFileSync(filePath, fullContent, "utf8");
+
+    const toolCallInputMap = buildToolCallInputMap([
+      makeMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "function_call",
+            call_id: "call_function_read",
+            name: "read",
+            arguments: JSON.stringify({ path: filePath }),
+          },
+        ],
+      }),
+    ]);
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+
+    const recovered = recoverLiveReadToolContent({
+      callId: "call_function_read",
+      extractedText: truncatedOutput,
+      toolCallInputMap,
+    });
+
+    expect(recovered).toBe(fullContent);
+  });
+
   it("assemble() recovers full file content from a live current-turn read tool result", async () => {
     const engine = createEngineForRecovery();
     const sessionId = "assemble-read-truncation-recovery";
@@ -105,7 +173,10 @@ describe("read tool truncation recovery", () => {
     const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
     tempDirs.push(fileDir);
     const filePath = join(fileDir, "source.txt");
-    const fullContent = ["line 1", "line 2", "line 3", "line 4", "line 5"].join("\n");
+    const fullContent = Array.from(
+      { length: 30 },
+      (_, index) => `line ${index + 1}: recovered read content should be externalized`,
+    ).join("\n");
     writeFileSync(filePath, fullContent, "utf8");
 
     const truncatedOutput = makeTruncatedOutput("[Read output capped at 50 bytes]");
@@ -145,6 +216,50 @@ describe("read tool truncation recovery", () => {
       .join("\n");
     expect(stubText).toContain(`[LCM Tool Output: ${largeFiles[0]!.fileId}`);
     expect(stubText).toContain("tool=read");
+  });
+
+  it("assemble() recovers capped read output before applying the large-tool threshold", async () => {
+    const engine = createEngineForRecovery({ largeFileTokenThreshold: 25_000 });
+    const sessionId = "assemble-read-recovery-before-threshold";
+
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-source-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "source.txt");
+    const fullContent = [
+      "Recovered content should be visible to the model.",
+      "The capped fragment alone is below the default large-tool threshold.",
+      "Lossless should still use the paired live read path.",
+    ].join("\n");
+    writeFileSync(filePath, fullContent, "utf8");
+
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 32768 bytes]");
+    const liveMessages = [
+      makeMessage({ role: "user", content: "read the file" }),
+      ...readToolResultMessages({ filePath, truncatedOutput }),
+    ];
+
+    await engine.getConversationStore().getOrCreateConversation(sessionId);
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const largeFiles = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(largeFiles).toHaveLength(0);
+
+    const promptText = assembleResult.messages
+      .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+      .join("\n");
+    expect(promptText).toContain("Recovered content should be visible to the model.");
+    expect(promptText).toContain("Lossless should still use the paired live read path.");
+    expect(promptText).not.toContain("[Read output capped at 32768 bytes]");
   });
 
   it("afterTurn() ingest preserves truncated read tool result without recovery", async () => {

--- a/test/read-tool-truncation-recovery.test.ts
+++ b/test/read-tool-truncation-recovery.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import {
+  MAX_LIVE_READ_RECOVERY_BYTES,
+  recoverLiveReadToolContent,
+} from "../src/read-tool-recovery.js";
+import {
   cleanupEngineTestState,
   createEngineWithConfig,
   createSessionFilePath,
@@ -60,6 +64,40 @@ function readToolResultMessages(params: {
 }
 
 describe("read tool truncation recovery", () => {
+  it("rejects non-file read paths during live recovery", () => {
+    const dirPath = mkdtempSync(join(tmpdir(), "lossless-claw-read-dir-"));
+    tempDirs.push(dirPath);
+    const truncatedOutput = makeTruncatedOutput("[Read output capped at 20 bytes]");
+
+    const recovered = recoverLiveReadToolContent({
+      callId: "call_read_dir",
+      extractedText: truncatedOutput,
+      toolCallInputMap: new Map([
+        ["call_read_dir", { name: "read", input: { path: dirPath } }],
+      ]),
+    });
+
+    expect(recovered).toBe(truncatedOutput);
+  });
+
+  it("rejects oversized read paths during live recovery", () => {
+    const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-read-large-"));
+    tempDirs.push(fileDir);
+    const filePath = join(fileDir, "large-source.txt");
+    writeFileSync(filePath, Buffer.alloc(MAX_LIVE_READ_RECOVERY_BYTES + 1, "x"));
+    const truncatedOutput = makeTruncatedOutput("[Truncated: content exceeded limit]");
+
+    const recovered = recoverLiveReadToolContent({
+      callId: "call_read_large",
+      extractedText: truncatedOutput,
+      toolCallInputMap: new Map([
+        ["call_read_large", { name: "read", input: { path: filePath } }],
+      ]),
+    });
+
+    expect(recovered).toBe(truncatedOutput);
+  });
+
   it("assemble() recovers full file content from a live current-turn read tool result", async () => {
     const engine = createEngineForRecovery();
     const sessionId = "assemble-read-truncation-recovery";


### PR DESCRIPTION
## Problem

When OpenClaw's built-in `read` tool reads a file:

1. The base truncation cap (~8KB / 256 lines) cuts the output before it reaches the interceptor.
2. The adaptive paging wrapper (`createOpenClawReadTool`) further caps aggregated text at ~8KB (adjusted by context window).
3. The large-file interceptor externalizes the tool result — the **already-truncated** text is all that gets saved to `large_files`.
4. The agent calls `lcm_describe` to drill down — receives only the truncated fragment. **The full file content is permanently lost.**

## Solution

In `LargeFileInterceptor.interceptLargeToolResults`, when a `read` tool result contains a truncation marker (`[Read output capped at...]` or `[Truncated:...]`):

1. The interceptor looks up the tool call input via a `toolCallInputMap` (built from the ordered message batch) to get the original file path.
2. If the path is absolute and exists on disk, the file is re-read in full via `readFileSync`.
3. The full content replaces the truncated text before externalization.
4. Any subsequent `lcm_describe` read returns the complete file.

### Changes

- `tool-pairing.ts`: new `buildToolCallInputMap(messages)` — maps `toolCallId → input` from assistant `tool_use` blocks.
- `large-file-interceptor.ts`: `interceptLargeToolResults` now accepts optional `toolCallInputMap`; detects read truncation and recovers full content.
- `engine.ts`: both `ingest` and `assemble` paths build and pass the tool call input map to the interceptor.

## Verification

- `pnpm typecheck` passes.
- 186 related tests pass.