### PR TITLE
feat(lcm): add programmatic control handlers

### DIFF
--- a/.changeset/quiet-control-plane.md
+++ b/.changeset/quiet-control-plane.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Document the optional programmatic status/doctor/rotate control surface and keep status free of non-durable rotation timestamps.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Not currently supported as root CLI commands:
 
 The bundled skill focuses on configuration, diagnostics, architecture, and recall-tool usage. Its reference set lives under `skills/lossless-claw/references/`.
 
+### Programmatic control
+
+Lossless-claw also exposes an optional host-facing context-engine control contract for OpenClaw gateways that support context-engine capabilities and control dispatch. The contract is intentionally smaller than the native slash command surface:
+
+- `status` returns whether an LCM conversation is active and the current stored message count.
+- `doctor` returns a bounded, sanitized warning list for summary-health issues.
+- `rotate` runs the same safe transcript rotation path as `/lossless rotate` and returns the post-rotate message count plus the timestamp for that successful rotate operation.
+
+Programmatic control never returns transcript text, local database paths, backup paths, credentials, provider debug, or shell output. `status` does not report `lastRotatedAt`; hosts that need durable rotation timestamps should persist that product state themselves after a successful `rotate` result.
+
+This surface is capability-gated by the OpenClaw host. At the time of this change there is not yet a stable OpenClaw release with the required context-engine control endpoints; downstream users should treat it as unavailable unless their host advertises the matching capability, for example through the pending `openclaw/openclaw#98060` contract or an equivalent downstream gateway.
+
 ## Session Migration CLI
 
 `lossless-claw-migrate-sessions` is a one-time shell CLI for backfilling OpenClaw JSONL session files into `lcm.db` after lossless-claw was disabled, missing, or installed after sessions already existed. It is not a background replay loop and it does not run summarization.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,15 @@ generic CLI harnesses such as `claude-cli` and `codex-cli` do not. If you must
 use a generic CLI harness, set `plugins.slots.contextEngine` to `legacy` for
 that run instead of `lossless-claw`.
 
+The optional programmatic `status` / `doctor` / `rotate` control surface requires
+a host that separately advertises context-engine capabilities/control dispatch.
+That host contract is not covered by the baseline plugin API version above. As
+of this documentation update, no stable OpenClaw release includes those gateway
+endpoints; downstream control planes should probe host capabilities and treat
+control as unavailable until `openclaw/openclaw#98060` or an equivalent stable
+host contract lands. The plugin's normal context-engine behavior and slash
+commands continue to work on the baseline supported OpenClaw versions.
+
 Configuration precedence is:
 
 1. Environment variables
@@ -164,6 +173,21 @@ openclaw plugins install --link /path/to/lossless-claw
 ```
 
 ## Reference
+
+### Programmatic context-engine control
+
+When the OpenClaw host supports context-engine control dispatch, lossless-claw
+advertises three sanitized operations:
+
+| Operation | Result | Notes |
+| --- | --- | --- |
+| `status` | `active`, `messageCount` | Reports current LCM conversation state only. It does not include `lastRotatedAt` because that timestamp is product/runtime state, not durable LCM state. |
+| `doctor` | `ok`, `warnings[]` | Returns a bounded summary-health warning list without transcript text, paths, or raw provider/debug output. |
+| `rotate` | `messageCount`, `lastRotatedAt` | Reuses the `/lossless rotate` implementation and returns the timestamp for the successful rotate operation. Hosts that need durable rotation history should persist this result outside lossless-claw. |
+
+The control surface never accepts arbitrary slash commands and never exposes
+local database paths, transcript paths, backup paths, credentials, or raw shell
+output.
 
 ### Core storage and session behavior
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import type {
   ContextEngine,
+  ContextEngineControlCapabilities,
+  ContextEngineControlRequest,
+  ContextEngineControlResult,
   ContextEngineInfo,
   ContextEngineHostCapability,
   AssembleResult,
@@ -38,6 +41,10 @@ import {
   revokeDelegatedExpansionGrantForSession,
 } from "./expansion-auth.js";
 import { describeLogError, formatSessionLabel } from "./lcm-log.js";
+import {
+  getLcmProgrammaticControlCapabilities,
+  runLcmProgrammaticControl,
+} from "./plugin/lcm-command.js";
 import { describeLcmConfigSource } from "./db/config.js";
 import { RetrievalEngine } from "./retrieval.js";
 import { compileSessionPatterns, matchesSessionPattern } from "./session-patterns.js";
@@ -4295,6 +4302,29 @@ export class LcmContextEngine implements ContextEngine {
     params: Parameters<SessionRotationService["rotateSessionStorageWithBackup"]>[0],
   ): Promise<RotateSessionStorageWithBackupResult> {
     return this.sessionRotation.rotateSessionStorageWithBackup(params);
+  }
+
+  getControlCapabilities(): ContextEngineControlCapabilities {
+    return getLcmProgrammaticControlCapabilities({
+      deps: this.deps,
+      getLcm: async () => this,
+    });
+  }
+
+  async control(params: ContextEngineControlRequest): Promise<ContextEngineControlResult> {
+    return runLcmProgrammaticControl({
+      operation: params.operation,
+      ctx: {
+        agentId: params.agentId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        runtimeContext: params.runtimeContext,
+      },
+      db: this.db,
+      config: this.config,
+      deps: this.deps,
+      getLcm: async () => this,
+    });
   }
 
   /** @internal Test seam: typed access to the compaction engine. */

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -103,6 +103,46 @@ export type ContextEngineInfo = {
 
 export type ContextEngineOperation = "agent-run" | "manual-compact" | "subagent-spawn";
 
+export type ContextEngineControlOperation = "status" | "doctor" | "rotate";
+
+export type ContextEngineControlCapabilities = {
+  status: boolean;
+  doctor: boolean;
+  rotate: boolean;
+};
+
+export type ContextEngineControlStatusResult = {
+  operation: "status";
+  active: boolean;
+  messageCount: number;
+  lastRotatedAt: string | null;
+};
+
+export type ContextEngineControlDoctorResult = {
+  operation: "doctor";
+  ok: boolean;
+  warnings: string[];
+};
+
+export type ContextEngineControlRotateResult = {
+  operation: "rotate";
+  messageCount: number;
+  lastRotatedAt: string;
+};
+
+export type ContextEngineControlResult =
+  | ContextEngineControlStatusResult
+  | ContextEngineControlDoctorResult
+  | ContextEngineControlRotateResult;
+
+export type ContextEngineControlRequest = {
+  agentId?: string;
+  operation: ContextEngineControlOperation;
+  sessionId?: string;
+  sessionKey?: string;
+  runtimeContext?: Record<string, unknown>;
+};
+
 export type ContextEngineHostCapability =
   | "bootstrap"
   | "assemble-before-prompt"
@@ -213,6 +253,8 @@ export type ContextEngine = {
     legacyParams?: Record<string, unknown>;
     force?: boolean;
   }): Promise<CompactResult>;
+  getControlCapabilities?(): ContextEngineControlCapabilities | Promise<ContextEngineControlCapabilities>;
+  control?(params: ContextEngineControlRequest): Promise<ContextEngineControlResult>;
   prepareSubagentSpawn?(params: {
     parentSessionId?: string;
     parentSessionKey?: string;

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -115,7 +115,6 @@ export type ContextEngineControlStatusResult = {
   operation: "status";
   active: boolean;
   messageCount: number;
-  lastRotatedAt: string | null;
 };
 
 export type ContextEngineControlDoctorResult = {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1517,7 +1517,7 @@ function createLcmDependencies(
         const sessionConfig = isRecord(cfg) && isRecord(cfg.session) ? cfg.session : undefined;
         const normalizedSessionKey = sessionKey?.trim();
         const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
-        const agentId = normalizeAgentId(requestedAgentId ?? parsed?.agentId);
+        const agentId = normalizeAgentId(parsed?.agentId ?? requestedAgentId);
         const storePath = sessionApi.resolveStorePath(getStringField(sessionConfig, "store"), {
           agentId,
         });

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -147,6 +147,8 @@ class MemorySupplementContextEngine implements ContextEngine {
   readonly prepareSubagentSpawn: ContextEngine["prepareSubagentSpawn"];
   readonly onSubagentEnded: ContextEngine["onSubagentEnded"];
   readonly maintain: ContextEngine["maintain"];
+  readonly getControlCapabilities: ContextEngine["getControlCapabilities"];
+  readonly control: ContextEngine["control"];
   readonly dispose: ContextEngine["dispose"];
 
   constructor(private readonly inner: ContextEngine) {
@@ -155,6 +157,8 @@ class MemorySupplementContextEngine implements ContextEngine {
     const prepareSubagentSpawn = inner.prepareSubagentSpawn?.bind(inner);
     const onSubagentEnded = inner.onSubagentEnded?.bind(inner);
     const maintain = inner.maintain?.bind(inner);
+    const getControlCapabilities = inner.getControlCapabilities?.bind(inner);
+    const control = inner.control?.bind(inner);
     const dispose = inner.dispose?.bind(inner);
     this.info = inner.info;
     this.ingestBatch = ingestBatch ? (params) => ingestBatch(params) : undefined;
@@ -164,6 +168,10 @@ class MemorySupplementContextEngine implements ContextEngine {
       : undefined;
     this.onSubagentEnded = onSubagentEnded ? (params) => onSubagentEnded(params) : undefined;
     this.maintain = maintain ? (params) => maintain(params) : undefined;
+    this.getControlCapabilities = getControlCapabilities
+      ? () => getControlCapabilities()
+      : undefined;
+    this.control = control ? (params) => control(params) : undefined;
     this.dispose = dispose ? () => dispose() : undefined;
   }
 
@@ -1494,7 +1502,7 @@ function createLcmDependencies(
         return undefined;
       }
     },
-    resolveSessionTranscriptFile: async ({ sessionId, sessionKey }) => {
+    resolveSessionTranscriptFile: async ({ agentId: requestedAgentId, sessionId, sessionKey }) => {
       const normalizedSessionId = sessionId.trim();
       if (!normalizedSessionId) {
         return undefined;
@@ -1509,7 +1517,7 @@ function createLcmDependencies(
         const sessionConfig = isRecord(cfg) && isRecord(cfg.session) ? cfg.session : undefined;
         const normalizedSessionKey = sessionKey?.trim();
         const parsed = normalizedSessionKey ? parseAgentSessionKey(normalizedSessionKey) : null;
-        const agentId = normalizeAgentId(parsed?.agentId);
+        const agentId = normalizeAgentId(requestedAgentId ?? parsed?.agentId);
         const storePath = sessionApi.resolveStorePath(getStringField(sessionConfig, "store"), {
           agentId,
         });

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -10,6 +10,9 @@ import type { LcmSummarizeFn } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
 import type {
   CompactResult,
+  ContextEngineControlCapabilities,
+  ContextEngineControlOperation,
+  ContextEngineControlResult,
   OpenClawPluginCommandDefinition,
   PluginCommandContext,
 } from "../openclaw-bridge.js";
@@ -135,6 +138,28 @@ type FocusCompactionCommandEngine = {
 };
 
 type RuntimeCommandEngine = RotateCommandEngine & Partial<FocusCompactionCommandEngine>;
+
+export class LcmProgrammaticControlUnavailableError extends Error {
+  constructor(
+    readonly operation: ContextEngineControlOperation,
+    readonly reasonCode: string,
+    message = "Lossless Claw control operation is unavailable.",
+  ) {
+    super(message);
+    this.name = "LcmProgrammaticControlUnavailableError";
+  }
+}
+
+export class LcmProgrammaticControlFailedError extends Error {
+  constructor(
+    readonly operation: ContextEngineControlOperation,
+    readonly reasonCode: string,
+    message = "Lossless Claw control operation failed.",
+  ) {
+    super(message);
+    this.name = "LcmProgrammaticControlFailedError";
+  }
+}
 
 const DOCTOR_CLEANER_IDS = new Set<DoctorCleanerId>(getDoctorCleanerFilterIds());
 
@@ -1757,6 +1782,7 @@ async function buildRotateText(params: {
   }
 
   const transcriptPath = await params.deps.resolveSessionTranscriptFile({
+    agentId: normalizeIdentity(params.ctx.agentId),
     sessionId,
     sessionKey,
   });
@@ -1883,6 +1909,186 @@ async function buildRotateText(params: {
     ]),
   );
   return lines.join("\n");
+}
+
+export function getLcmProgrammaticControlCapabilities(params?: {
+  deps?: LcmDependencies;
+  getLcm?: () => Promise<RuntimeCommandEngine>;
+}): ContextEngineControlCapabilities {
+  return {
+    status: true,
+    doctor: true,
+    rotate: Boolean(params?.deps && params.getLcm),
+  };
+}
+
+function buildProgrammaticDoctorWarnings(stats: DoctorSummaryStats): string[] {
+  const warnings: string[] = [];
+  if (stats.total > 0) {
+    warnings.push(`${stats.total} summary issue(s) detected`);
+  }
+  if (stats.old > 0) {
+    warnings.push(`${stats.old} old-marker summary issue(s) detected`);
+  }
+  if (stats.truncated > 0) {
+    warnings.push(`${stats.truncated} truncated-marker summary issue(s) detected`);
+  }
+  if (stats.fallback > 0) {
+    warnings.push(`${stats.fallback} fallback-marker summary issue(s) detected`);
+  }
+  if (stats.emergency > 0) {
+    warnings.push(`${stats.emergency} emergency-fallback summary issue(s) detected`);
+  }
+  return warnings.slice(0, 10);
+}
+
+function throwControlUnavailable(
+  operation: ContextEngineControlOperation,
+  reasonCode: string,
+): never {
+  throw new LcmProgrammaticControlUnavailableError(operation, reasonCode);
+}
+
+const programmaticRotateTimestampByConversationId = new Map<number, string>();
+
+function classifyProgrammaticRotateUnavailableReason(reason: string | undefined): string {
+  const normalized = (reason ?? "").toLowerCase();
+  if (normalized.includes("transcript")) {
+    return "transcript_unavailable";
+  }
+  if (normalized.includes("backup")) {
+    return "backup_unavailable";
+  }
+  if (normalized.includes("transaction") || normalized.includes("database")) {
+    return "database_unavailable";
+  }
+  if (
+    normalized.includes("summar") ||
+    normalized.includes("provider") ||
+    normalized.includes("raw context") ||
+    normalized.includes("circuit breaker")
+  ) {
+    return "summarization_unavailable";
+  }
+  if (normalized.includes("active lossless claw conversation")) {
+    return "conversation_unavailable";
+  }
+  return "unavailable";
+}
+
+export async function runLcmProgrammaticControl(params: {
+  operation: ContextEngineControlOperation;
+  ctx: PluginCommandContext;
+  db: DatabaseSync;
+  config: LcmConfig;
+  deps?: LcmDependencies;
+  getLcm?: () => Promise<RuntimeCommandEngine>;
+}): Promise<ContextEngineControlResult> {
+  const current = await resolveCurrentConversation({
+    ctx: params.ctx,
+    db: params.db,
+  });
+
+  if (params.operation === "status") {
+    const conversationId = current.kind === "resolved" ? current.stats.conversationId : undefined;
+    return {
+      operation: "status",
+      active: current.kind === "resolved",
+      messageCount: current.kind === "resolved" ? current.stats.messageCount : 0,
+      lastRotatedAt: conversationId !== undefined
+        ? programmaticRotateTimestampByConversationId.get(conversationId) ?? null
+        : null,
+    };
+  }
+
+  if (params.operation === "doctor") {
+    if (current.kind === "unavailable") {
+      return {
+        operation: "doctor",
+        ok: false,
+        warnings: ["current conversation unavailable"],
+      };
+    }
+
+    const stats = getDoctorSummaryStats(params.db, current.stats.conversationId);
+    const warnings = buildProgrammaticDoctorWarnings(stats);
+    return {
+      operation: "doctor",
+      ok: warnings.length === 0,
+      warnings,
+    };
+  }
+
+  const sessionKey = normalizeIdentity(params.ctx.sessionKey);
+  if (!sessionKey) {
+    throwControlUnavailable("rotate", "session_key_unavailable");
+  }
+  if (current.kind === "unavailable") {
+    throwControlUnavailable("rotate", "conversation_unavailable");
+  }
+  if (!params.deps || !params.getLcm) {
+    throwControlUnavailable("rotate", "runtime_unavailable");
+  }
+
+  const sessionId = await resolveRuntimeSessionId({
+    ctx: params.ctx,
+    deps: params.deps,
+    current,
+  });
+  if (!sessionId) {
+    throwControlUnavailable("rotate", "session_id_unavailable");
+  }
+
+  const transcriptPath = await params.deps.resolveSessionTranscriptFile({
+    agentId: normalizeIdentity(params.ctx.agentId),
+    sessionId,
+    sessionKey,
+  });
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    throwControlUnavailable("rotate", "transcript_unavailable");
+  }
+
+  if (getLcmBackupUnavailableReason(params.config.databasePath)) {
+    throwControlUnavailable("rotate", "backup_unavailable");
+  }
+
+  let result: RotateSessionStorageWithBackupResult;
+  try {
+    const runtimeContext = readCommandRuntimeContext(params.ctx);
+    result = await (await params.getLcm()).rotateSessionStorageWithBackup({
+      sessionId,
+      sessionKey,
+      sessionFile: transcriptPath,
+      lockTimeoutMs: ROTATE_DATABASE_LOCK_TIMEOUT_MS,
+      ...(runtimeContext ? { runtimeContext } : {}),
+    });
+  } catch {
+    throw new LcmProgrammaticControlFailedError("rotate", "runtime_exception");
+  }
+
+  if (result.kind !== "rotated") {
+    throw new LcmProgrammaticControlUnavailableError(
+      "rotate",
+      result.kind === "unavailable"
+        ? classifyProgrammaticRotateUnavailableReason(result.reason)
+        : result.kind,
+    );
+  }
+
+  const rotatedAt = new Date().toISOString();
+  programmaticRotateTimestampByConversationId.set(current.stats.conversationId, rotatedAt);
+  const refreshed = await resolveCurrentConversation({
+    ctx: params.ctx,
+    db: params.db,
+  });
+
+  return {
+    operation: "rotate",
+    messageCount: refreshed.kind === "resolved"
+      ? refreshed.stats.messageCount
+      : result.currentMessageCount ?? current.stats.messageCount,
+    lastRotatedAt: rotatedAt,
+  };
 }
 
 function formatFocusPreview(content: string, maxChars = 1200): string {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -1949,8 +1949,6 @@ function throwControlUnavailable(
   throw new LcmProgrammaticControlUnavailableError(operation, reasonCode);
 }
 
-const programmaticRotateTimestampByConversationId = new Map<number, string>();
-
 function classifyProgrammaticRotateUnavailableReason(reason: string | undefined): string {
   const normalized = (reason ?? "").toLowerCase();
   if (normalized.includes("transcript")) {
@@ -1990,14 +1988,10 @@ export async function runLcmProgrammaticControl(params: {
   });
 
   if (params.operation === "status") {
-    const conversationId = current.kind === "resolved" ? current.stats.conversationId : undefined;
     return {
       operation: "status",
       active: current.kind === "resolved",
       messageCount: current.kind === "resolved" ? current.stats.messageCount : 0,
-      lastRotatedAt: conversationId !== undefined
-        ? programmaticRotateTimestampByConversationId.get(conversationId) ?? null
-        : null,
     };
   }
 
@@ -2076,7 +2070,6 @@ export async function runLcmProgrammaticControl(params: {
   }
 
   const rotatedAt = new Date().toISOString();
-  programmaticRotateTimestampByConversationId.set(current.stats.conversationId, rotatedAt);
   const refreshed = await resolveCurrentConversation({
     ctx: params.ctx,
     db: params.db,

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -139,9 +139,10 @@ type FocusCompactionCommandEngine = {
 
 type RuntimeCommandEngine = RotateCommandEngine & Partial<FocusCompactionCommandEngine>;
 
+/** Error thrown when a host requests a control operation that cannot run safely. */
 export class LcmProgrammaticControlUnavailableError extends Error {
   constructor(
-    readonly operation: ContextEngineControlOperation,
+    readonly operation: string,
     readonly reasonCode: string,
     message = "Lossless Claw control operation is unavailable.",
   ) {
@@ -150,9 +151,10 @@ export class LcmProgrammaticControlUnavailableError extends Error {
   }
 }
 
+/** Error thrown when a supported control operation fails after starting. */
 export class LcmProgrammaticControlFailedError extends Error {
   constructor(
-    readonly operation: ContextEngineControlOperation,
+    readonly operation: string,
     readonly reasonCode: string,
     message = "Lossless Claw control operation failed.",
   ) {
@@ -843,9 +845,12 @@ async function resolveRuntimeSessionId(params: {
   deps: LcmDependencies;
   current: Extract<CurrentConversationResolution, { kind: "resolved" }>;
 }): Promise<string | undefined> {
+  const currentSessionId = normalizeIdentity(params.current.stats.sessionId);
   const directSessionId = normalizeIdentity(params.ctx.sessionId);
   if (directSessionId) {
-    return directSessionId;
+    return !currentSessionId || directSessionId === currentSessionId
+      ? directSessionId
+      : undefined;
   }
 
   const sessionKey = normalizeIdentity(params.ctx.sessionKey);
@@ -858,7 +863,7 @@ async function resolveRuntimeSessionId(params: {
     }
   }
 
-  return normalizeIdentity(params.current.stats.sessionId);
+  return currentSessionId;
 }
 
 function normalizePositiveInteger(value: number | null | undefined): number | null {
@@ -1922,6 +1927,16 @@ export function getLcmProgrammaticControlCapabilities(params?: {
   };
 }
 
+function normalizeControlOperation(operation: unknown): ContextEngineControlOperation {
+  if (operation === "status" || operation === "doctor" || operation === "rotate") {
+    return operation;
+  }
+  throw new LcmProgrammaticControlUnavailableError(
+    typeof operation === "string" ? operation : "unknown",
+    "unsupported_operation",
+  );
+}
+
 function buildProgrammaticDoctorWarnings(stats: DoctorSummaryStats): string[] {
   const warnings: string[] = [];
   if (stats.total > 0) {
@@ -1982,12 +1997,13 @@ export async function runLcmProgrammaticControl(params: {
   deps?: LcmDependencies;
   getLcm?: () => Promise<RuntimeCommandEngine>;
 }): Promise<ContextEngineControlResult> {
+  const operation = normalizeControlOperation(params.operation);
   const current = await resolveCurrentConversation({
     ctx: params.ctx,
     db: params.db,
   });
 
-  if (params.operation === "status") {
+  if (operation === "status") {
     return {
       operation: "status",
       active: current.kind === "resolved",
@@ -1995,7 +2011,7 @@ export async function runLcmProgrammaticControl(params: {
     };
   }
 
-  if (params.operation === "doctor") {
+  if (operation === "doctor") {
     if (current.kind === "unavailable") {
       return {
         operation: "doctor",

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export interface LcmDependencies {
 
   /** Resolve the current transcript file path for a session identity */
   resolveSessionTranscriptFile: (params: {
+    agentId?: string;
     sessionId: string;
     sessionKey?: string;
   }) => Promise<string | undefined>;

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -3185,7 +3185,6 @@ describe("lcm command", () => {
       operation: "status",
       active: true,
       messageCount: 1,
-      lastRotatedAt: null,
     });
     expect(doctor).toMatchObject({
       operation: "doctor",
@@ -3279,7 +3278,6 @@ describe("lcm command", () => {
       operation: "status",
       active: true,
       messageCount: 2,
-      lastRotatedAt: result.lastRotatedAt,
     });
     expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
       sessionId: "programmatic-rotate-session",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -11,7 +11,12 @@ import { resolveLcmConfig } from "../src/db/config.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { FocusBriefStore } from "../src/store/focus-brief-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
-import { createLcmCommand, __testing } from "../src/plugin/lcm-command.js";
+import {
+  LcmProgrammaticControlUnavailableError,
+  createLcmCommand,
+  runLcmProgrammaticControl,
+  __testing,
+} from "../src/plugin/lcm-command.js";
 import { FALLBACK_DIRECTIVE_SUMMARY_MARKER } from "../src/summary-fallback.js";
 import type { LcmSummarizeFn } from "../src/summarize.js";
 import type { LcmDependencies } from "../src/types.js";
@@ -3129,6 +3134,199 @@ describe("lcm command", () => {
     expect(result.text).toContain("💾 Lossless Claw Backup");
     expect(result.text).toContain("status: failed");
     expect(result.text).toContain("reason: disk full");
+  });
+
+  it("returns sanitized programmatic status and doctor results", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "programmatic-control-session",
+      sessionKey: "user:u1:chat",
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "remember the safe control state",
+        tokenCount: 6,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_programmatic_control",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "broken summary\n[Truncated from 222 tokens]",
+      tokenCount: 8,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_programmatic_control", [message.messageId]);
+
+    const ctx = createCommandContext(undefined, {
+      sessionId: "programmatic-control-session",
+      sessionKey: "user:u1:chat",
+    });
+    const status = await runLcmProgrammaticControl({
+      operation: "status",
+      ctx,
+      db: fixture.db,
+      config: fixture.config,
+    });
+    const doctor = await runLcmProgrammaticControl({
+      operation: "doctor",
+      ctx,
+      db: fixture.db,
+      config: fixture.config,
+    });
+
+    expect(status).toEqual({
+      operation: "status",
+      active: true,
+      messageCount: 1,
+      lastRotatedAt: null,
+    });
+    expect(doctor).toMatchObject({
+      operation: "doctor",
+      ok: false,
+    });
+    expect((doctor as { warnings: string[] }).warnings.join("\n")).toContain("summary issue");
+    expect((doctor as { warnings: string[] }).warnings.join("\n")).not.toContain(fixture.dbPath);
+    expect((doctor as { warnings: string[] }).warnings.join("\n")).not.toContain("programmatic-control-session");
+  });
+
+  it("rotates through the programmatic handler without returning paths", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-programmatic-rotate-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":\"existing\"}}\n");
+    tempDirs.add(transcriptPath);
+
+    let currentConversationId = 0;
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId,
+      currentMessageCount: 2,
+      backupPath: join(tmpdir(), "not-returned.bak"),
+      preservedTailMessageCount: 1,
+      checkpointSize: 11,
+      bytesRemoved: 22,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => undefined),
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const getLcm = async () => ({
+      rotateSessionStorageWithBackup,
+    });
+    const fixture = createCommandFixture({ deps, getLcm });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "programmatic-rotate-session",
+      sessionKey: "user:u1:chat",
+    });
+    currentConversationId = conversation.conversationId;
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "second message",
+        tokenCount: 2,
+      },
+    ]);
+
+    const result = await runLcmProgrammaticControl({
+      operation: "rotate",
+      ctx: createCommandContext(undefined, {
+        agentId: "openmanager-main",
+        sessionId: "programmatic-rotate-session",
+        sessionKey: "user:u1:chat",
+      }),
+      db: fixture.db,
+      config: fixture.config,
+      deps,
+      getLcm,
+    });
+
+    expect(result.operation).toBe("rotate");
+    if (result.operation !== "rotate") {
+      throw new Error("expected rotate result");
+    }
+    expect(result.messageCount).toBe(2);
+    expect(Date.parse(result.lastRotatedAt)).toBeGreaterThan(0);
+    expect(JSON.stringify(result)).not.toContain("not-returned.bak");
+    expect(JSON.stringify(result)).not.toContain(transcriptPath);
+
+    const status = await runLcmProgrammaticControl({
+      operation: "status",
+      ctx: createCommandContext(undefined, {
+        sessionId: "programmatic-rotate-session",
+        sessionKey: "user:u1:chat",
+      }),
+      db: fixture.db,
+      config: fixture.config,
+    });
+    expect(status).toEqual({
+      operation: "status",
+      active: true,
+      messageCount: 2,
+      lastRotatedAt: result.lastRotatedAt,
+    });
+    expect(rotateSessionStorageWithBackup).toHaveBeenCalledWith({
+      sessionId: "programmatic-rotate-session",
+      sessionKey: "user:u1:chat",
+      sessionFile: transcriptPath,
+      lockTimeoutMs: 30_000,
+    });
+    expect(deps.resolveSessionTranscriptFile).toHaveBeenCalledWith({
+      agentId: "openmanager-main",
+      sessionId: "programmatic-rotate-session",
+      sessionKey: "user:u1:chat",
+    });
+  });
+
+  it("reports programmatic rotate unavailable with a stable reason code", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "programmatic-unavailable-session",
+      sessionKey: "user:u1:chat",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    await expect(
+      runLcmProgrammaticControl({
+        operation: "rotate",
+        ctx: createCommandContext(undefined, {
+          sessionId: "programmatic-unavailable-session",
+          sessionKey: "user:u1:chat",
+        }),
+        db: fixture.db,
+        config: fixture.config,
+      }),
+    ).rejects.toMatchObject({
+      name: "LcmProgrammaticControlUnavailableError",
+      reasonCode: "runtime_unavailable",
+    } satisfies Partial<LcmProgrammaticControlUnavailableError>);
   });
 
   it("rotates the current session and replaces the latest rotate backup", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -3327,6 +3327,125 @@ describe("lcm command", () => {
     } satisfies Partial<LcmProgrammaticControlUnavailableError>);
   });
 
+  it("rejects programmatic rotate when the explicit session id conflicts with the resolved conversation", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-programmatic-mismatch-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":\"existing\"}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId: 1,
+      currentMessageCount: 1,
+      backupPath: join(tmpdir(), "not-returned.bak"),
+      preservedTailMessageCount: 1,
+      checkpointSize: 11,
+      bytesRemoved: 22,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => "unrelated-runtime-session"),
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const getLcm = async () => ({
+      rotateSessionStorageWithBackup,
+    });
+    const fixture = createCommandFixture({ deps, getLcm });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "programmatic-mismatch-session",
+      sessionKey: "user:u1:chat",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    await expect(
+      runLcmProgrammaticControl({
+        operation: "rotate",
+        ctx: createCommandContext(undefined, {
+          sessionId: "unrelated-runtime-session",
+          sessionKey: "user:u1:chat",
+        }),
+        db: fixture.db,
+        config: fixture.config,
+        deps,
+        getLcm,
+      }),
+    ).rejects.toMatchObject({
+      name: "LcmProgrammaticControlUnavailableError",
+      reasonCode: "session_id_unavailable",
+    } satisfies Partial<LcmProgrammaticControlUnavailableError>);
+    expect(rotateSessionStorageWithBackup).not.toHaveBeenCalled();
+    expect(deps.resolveSessionTranscriptFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported programmatic operations before rotate can run", async () => {
+    const transcriptPath = join(tmpdir(), `lossless-claw-programmatic-unsupported-${Date.now()}.jsonl`);
+    writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":\"existing\"}}\n");
+    tempDirs.add(transcriptPath);
+
+    const rotateSessionStorageWithBackup = vi.fn(async () => ({
+      kind: "rotated" as const,
+      currentConversationId: 1,
+      currentMessageCount: 1,
+      backupPath: join(tmpdir(), "not-returned.bak"),
+      preservedTailMessageCount: 1,
+      checkpointSize: 11,
+      bytesRemoved: 22,
+    }));
+    const deps = {
+      resolveSessionIdFromSessionKey: vi.fn(async () => "programmatic-unsupported-session"),
+      resolveSessionTranscriptFile: vi.fn(async () => transcriptPath),
+    } as unknown as LcmDependencies;
+    const getLcm = async () => ({
+      rotateSessionStorageWithBackup,
+    });
+    const fixture = createCommandFixture({ deps, getLcm });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "programmatic-unsupported-session",
+      sessionKey: "user:u1:chat",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "first message",
+        tokenCount: 2,
+      },
+    ]);
+
+    await expect(
+      runLcmProgrammaticControl({
+        operation: "backup" as Parameters<typeof runLcmProgrammaticControl>[0]["operation"],
+        ctx: createCommandContext(undefined, {
+          sessionId: "programmatic-unsupported-session",
+          sessionKey: "user:u1:chat",
+        }),
+        db: fixture.db,
+        config: fixture.config,
+        deps,
+        getLcm,
+      }),
+    ).rejects.toMatchObject({
+      name: "LcmProgrammaticControlUnavailableError",
+      operation: "backup",
+      reasonCode: "unsupported_operation",
+    } satisfies Partial<LcmProgrammaticControlUnavailableError>);
+    expect(rotateSessionStorageWithBackup).not.toHaveBeenCalled();
+    expect(deps.resolveSessionTranscriptFile).not.toHaveBeenCalled();
+  });
+
   it("rotates the current session and replaces the latest rotate backup", async () => {
     const transcriptPath = join(tmpdir(), `lossless-claw-rotate-${Date.now()}.jsonl`);
     writeFileSync(transcriptPath, "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"existing\"}]}}\n");

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1090,6 +1090,93 @@ describe("lcm plugin registration", () => {
     rmSync(sessionStorePath, { force: true });
   });
 
+  it("uses the agent encoded in sessionKey when resolving a transcript file", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const alphaStorePath = join(
+      tmpdir(),
+      `lossless-claw-alpha-store-${Date.now()}-${Math.random().toString(16)}.json`,
+    );
+    const betaStorePath = join(
+      tmpdir(),
+      `lossless-claw-beta-store-${Date.now()}-${Math.random().toString(16)}.json`,
+    );
+    const sessionId = `shared-session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sessionKey = `agent:alpha:chat:${Math.random().toString(16).slice(2)}`;
+    const alphaSessionFile = join(tmpdir(), `${sessionId}-alpha.jsonl`);
+    const betaSessionFile = join(tmpdir(), `${sessionId}-beta.jsonl`);
+
+    writeFileSync(
+      alphaStorePath,
+      `${JSON.stringify({
+        [sessionKey]: {
+          sessionId,
+          sessionFile: alphaSessionFile,
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    writeFileSync(
+      betaStorePath,
+      `${JSON.stringify({
+        [`agent:beta:chat:${Math.random().toString(16).slice(2)}`]: {
+          sessionId,
+          sessionFile: betaSessionFile,
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+    const resolveStorePath = vi.fn((_store: string | undefined, options?: { agentId?: string }) =>
+      options?.agentId === "alpha" ? alphaStorePath : betaStorePath,
+    );
+    (api.runtime as unknown as {
+      channel: {
+        session: {
+          resolveStorePath: typeof resolveStorePath;
+          loadSessionStore: (storePath: string) => Record<string, unknown>;
+          resolveSessionFilePath: (
+            runtimeSessionId: string,
+            entry?: { sessionFile?: unknown },
+          ) => string;
+        };
+      };
+    }).channel.session = {
+      resolveStorePath,
+      loadSessionStore: (storePath: string) => JSON.parse(readFileSync(storePath, "utf8")) as Record<string, unknown>,
+      resolveSessionFilePath: (runtimeSessionId: string, entry?: { sessionFile?: unknown }) =>
+        typeof entry?.sessionFile === "string" && entry.sessionFile.trim()
+          ? entry.sessionFile
+          : join(tmpdir(), `${runtimeSessionId}.jsonl`),
+    };
+
+    lcmPlugin.register(api);
+
+    const factory = getFactory();
+    expect(factory).toBeTypeOf("function");
+    const engine = factory!() as {
+      deps?: {
+        resolveSessionTranscriptFile: (params: {
+          agentId?: string;
+          sessionId: string;
+          sessionKey?: string;
+        }) => Promise<string | undefined>;
+      };
+    };
+
+    await expect(
+      engine.deps?.resolveSessionTranscriptFile({
+        agentId: "beta",
+        sessionId,
+        sessionKey,
+      }),
+    ).resolves.toBe(alphaSessionFile);
+    expect(resolveStorePath).toHaveBeenCalledWith(undefined, { agentId: "alpha" });
+    rmSync(alphaStorePath, { force: true });
+    rmSync(betaStorePath, { force: true });
+  });
+
   it("uses runtime OpenClaw defaults when api.pluginConfig is ready before api.config", () => {
     const { api, getFactory, infoLog } = buildApi(
       {


### PR DESCRIPTION
## Summary
- exports programmatic LCM `status`, `doctor`, and `rotate` handlers
- shares the native command implementation instead of shelling out or parsing transcript text
- keeps handler outputs sanitized: no transcript content, database paths, credentials, provider debug, or local filesystem details

## Context
This is a small optional integration surface for developers who want to embed lossless-claw behind another app, gateway, admin tool, CI smoke, or control plane.

The existing native command behavior remains the source of truth. These handlers make the same behavior callable without scraping command text, shelling out, or exposing transcript/local runtime details.

The handlers are intentionally generic and are not tied to any downstream application.

## Validation
- `git fetch upstream main`
- `git diff --check`
- `npm run typecheck`
- `npm run build`
- `npm test -- lcm-command.test.ts`

Additional downstream smoke coverage verified these handlers through gateway control endpoints with status, doctor, rotate, post-rotate state, rate limiting, two-session isolation, and sanitized failure output.