### PR TITLE
fix: skip summary thinking for Ollama

### DIFF
--- a/.changeset/reasoning-block-text-fallback.md
+++ b/.changeset/reasoning-block-text-fallback.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Extract summary content from typed reasoning blocks when a text-type block is also present in the response, so Ollama extended-thinking models that place the entire summary inside a `type:"reasoning"` block produce usable summaries instead of falling through to the truncation fallback. Reasoning-only responses without an accompanying text block remain treated as private diagnostics.
+Avoid requesting summary-thinking controls for Ollama summarizer calls, so extended-thinking models return usable text summaries without promoting typed reasoning blocks into persisted summary content.

--- a/.changeset/reasoning-block-text-fallback.md
+++ b/.changeset/reasoning-block-text-fallback.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Extract summary content from typed reasoning blocks when a text-type block is also present in the response, so Ollama extended-thinking models that place the entire summary inside a `type:"reasoning"` block produce usable summaries instead of falling through to the truncation fallback. Reasoning-only responses without an accompanying text block remain treated as private diagnostics.

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -337,10 +337,14 @@ function shouldAppendDirectTextField(key: string): boolean {
 }
 
 /** Collect text payloads from common provider response shapes. */
-function collectTextLikeFields(value: unknown, out: string[]): void {
+function collectTextLikeFields(
+  value: unknown,
+  out: string[],
+  skipReasoning = true,
+): void {
   if (Array.isArray(value)) {
     for (const entry of value) {
-      collectTextLikeFields(entry, out);
+      collectTextLikeFields(entry, out, skipReasoning);
     }
     return;
   }
@@ -348,7 +352,10 @@ function collectTextLikeFields(value: unknown, out: string[]): void {
     return;
   }
 
-  if (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType)) {
+  if (
+    skipReasoning &&
+    (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType))
+  ) {
     return;
   }
 
@@ -367,7 +374,7 @@ function collectTextLikeFields(value: unknown, out: string[]): void {
         }
         continue;
       }
-      collectTextLikeFields(nested, out);
+      collectTextLikeFields(nested, out, skipReasoning);
     }
   }
 }
@@ -403,6 +410,16 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
 
   collectTextLikeFields(content, chunks);
   collectBlockTypes(content, blockTypeSet);
+
+  // Fallback: when no text was collected from non-reasoning blocks (e.g.
+  // Ollama extended-thinking models that place the entire summary inside a
+  // type:"reasoning" block), re-collect including reasoning blocks so the
+  // model's output is not discarded.  See #944.
+  if (chunks.length === 0) {
+    const reasoningChunks: string[] = [];
+    collectTextLikeFields(content, reasoningChunks, false);
+    chunks.push(...reasoningChunks);
+  }
 
   const blockTypes = [...blockTypeSet].sort((a, b) => a.localeCompare(b));
   return {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -337,14 +337,10 @@ function shouldAppendDirectTextField(key: string): boolean {
 }
 
 /** Collect text payloads from common provider response shapes. */
-function collectTextLikeFields(
-  value: unknown,
-  out: string[],
-  skipReasoning = true,
-): void {
+function collectTextLikeFields(value: unknown, out: string[]): void {
   if (Array.isArray(value)) {
     for (const entry of value) {
-      collectTextLikeFields(entry, out, skipReasoning);
+      collectTextLikeFields(entry, out);
     }
     return;
   }
@@ -352,10 +348,7 @@ function collectTextLikeFields(
     return;
   }
 
-  if (
-    skipReasoning &&
-    (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType))
-  ) {
+  if (isReasoningLikeType(value.type) || isReasoningLikeType(value.rawType)) {
     return;
   }
 
@@ -374,7 +367,7 @@ function collectTextLikeFields(
         }
         continue;
       }
-      collectTextLikeFields(nested, out, skipReasoning);
+      collectTextLikeFields(nested, out);
     }
   }
 }
@@ -410,20 +403,6 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
 
   collectTextLikeFields(content, chunks);
   collectBlockTypes(content, blockTypeSet);
-
-  // Fallback: when no text was collected from non-reasoning blocks but the
-  // content array contains text-type blocks alongside reasoning blocks, the
-  // model intended to produce text output and placed the entire summary
-  // inside the reasoning block (e.g. Ollama extended-thinking models, #944).
-  // Only re-collect from reasoning blocks when a text-type block is present
-  // so truly private reasoning/thinking payloads are never promoted to
-  // summary text.  Empty text blocks produce empty-string chunks, so check
-  // whether every collected chunk is blank rather than relying on length.
-  if (chunks.every((c) => !c.trim()) && blockTypeSet.has("text")) {
-    const reasoningChunks: string[] = [];
-    collectTextLikeFields(content, reasoningChunks, false);
-    chunks.push(...reasoningChunks);
-  }
 
   const blockTypes = [...blockTypeSet].sort((a, b) => a.localeCompare(b));
   return {
@@ -1610,6 +1589,9 @@ export async function createLcmSummarizeFromLegacyParams(params: {
       const model = candidate.model;
       const runtimeModelOverride = buildRuntimeModelOverride(candidate);
       const nextCandidate = index < resolvedCandidates.length - 1 ? resolvedCandidates[index + 1]! : undefined;
+      const shouldRequestSummaryThinking =
+        params.deps.config.enableSummaryThinking !== false &&
+        provider.trim().toLowerCase() !== "ollama";
       const runSummarizerCall = async (
         label: string,
         reasoning?: string,
@@ -1630,7 +1612,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
             },
           ],
           maxTokens: maxTokensOverride ?? initialMaxTokens,
-          ...(params.deps.config.enableSummaryThinking !== false
+          ...(shouldRequestSummaryThinking
             ? ({ reasoningIfSupported: "low" } as const)
             : {}),
           ...(reasoning ? { reasoning } : {}),
@@ -1857,8 +1839,7 @@ export async function createLcmSummarizeFromLegacyParams(params: {
           isCondensed ? condensedTargetTokens : leafTargetTokens,
         );
         try {
-          const retryReasoning =
-            params.deps.config.enableSummaryThinking !== false ? "low" : undefined;
+          const retryReasoning = shouldRequestSummaryThinking ? "low" : undefined;
           const retryResult = await attemptSummarizerCall("retry", retryReasoning, retryMaxTokens);
           const retryNormalized = normalizeCompletionSummary(retryResult.content);
           const retryEnvelopeNormalized = retryNormalized.summary

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -411,11 +411,15 @@ function normalizeCompletionSummary(content: unknown): { summary: string; blockT
   collectTextLikeFields(content, chunks);
   collectBlockTypes(content, blockTypeSet);
 
-  // Fallback: when no text was collected from non-reasoning blocks (e.g.
-  // Ollama extended-thinking models that place the entire summary inside a
-  // type:"reasoning" block), re-collect including reasoning blocks so the
-  // model's output is not discarded.  See #944.
-  if (chunks.length === 0) {
+  // Fallback: when no text was collected from non-reasoning blocks but the
+  // content array contains text-type blocks alongside reasoning blocks, the
+  // model intended to produce text output and placed the entire summary
+  // inside the reasoning block (e.g. Ollama extended-thinking models, #944).
+  // Only re-collect from reasoning blocks when a text-type block is present
+  // so truly private reasoning/thinking payloads are never promoted to
+  // summary text.  Empty text blocks produce empty-string chunks, so check
+  // whether every collected chunk is blank rather than relying on length.
+  if (chunks.every((c) => !c.trim()) && blockTypeSet.has("text")) {
     const reasoningChunks: string[] = [];
     collectTextLikeFields(content, reasoningChunks, false);
     chunks.push(...reasoningChunks);

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -966,10 +966,8 @@ describe("createLcmSummarizeFromLegacyParams", () => {
 
     const summary = await summarize!("H".repeat(8_000), false);
 
-    // Reasoning-only blocks without an accompanying text-type block are
-    // treated as private diagnostics, not summary content. The fallback
-    // only activates when the response contains both reasoning and text
-    // blocks (model intended text output), per #944.
+    // Reasoning-only blocks are treated as private diagnostics, not summary
+    // content, even when a model returns a provider-specific summary wrapper.
     expect(summary).toContain("[LCM fallback summary; truncated for context management]");
 
     const diagnostics = getDepsLogText(deps);
@@ -978,11 +976,43 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     expect(diagnostics).not.toContain("PRIVATE_TYPED_REASONING_TRACE");
   });
 
-  it("recovers summary from reasoning blocks when a text block is also present (#944)", async () => {
-    // Ollama extended-thinking models place the entire summary inside a
-    // type:"reasoning" block while leaving type:"text" empty.  When both
-    // blocks are present (the model intended text output), fall back to
-    // reasoning blocks so the summary is not discarded.
+  it("omits summary thinking for Ollama so summaries stay in text blocks (#944)", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "ollama",
+        model: "qwen3.5:9b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "text",
+            text: "The input describes a text processing pipeline that...",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "ollama",
+        model: "qwen3.5:9b",
+      },
+    });
+
+    const summary = await summarize!("H".repeat(8_000), false);
+
+    expect(summary).toContain("text processing pipeline");
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
+
+    const requestOptions = vi.mocked(deps.complete).mock.calls[0]?.[0] as
+      | { reasoning?: string; reasoningIfSupported?: string }
+      | undefined;
+    expect(requestOptions?.reasoning).toBeUndefined();
+    expect(requestOptions?.reasoningIfSupported).toBeUndefined();
+  });
+
+  it("does not promote Ollama private reasoning text when a text block is also present", async () => {
     const deps = makeDeps({
       resolveModel: vi.fn(() => ({
         provider: "ollama",
@@ -992,7 +1022,7 @@ describe("createLcmSummarizeFromLegacyParams", () => {
         content: [
           {
             type: "reasoning",
-            text: "The input describes a text processing pipeline that...",
+            text: "PRIVATE_MIXED_REASONING_TRACE",
           },
           {
             type: "text",
@@ -1012,9 +1042,17 @@ describe("createLcmSummarizeFromLegacyParams", () => {
 
     const summary = await summarize!("H".repeat(8_000), false);
 
-    expect(summary).toContain("text processing pipeline");
-    // Recovery succeeds on the first attempt — no retry or fallback needed.
-    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
+    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+    expect(summary).not.toContain("PRIVATE_MIXED_REASONING_TRACE");
+
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).not.toContain("PRIVATE_MIXED_REASONING_TRACE");
+
+    for (const call of vi.mocked(deps.complete).mock.calls) {
+      const requestOptions = call[0] as { reasoning?: string; reasoningIfSupported?: string };
+      expect(requestOptions.reasoning).toBeUndefined();
+      expect(requestOptions.reasoningIfSupported).toBeUndefined();
+    }
   });
 
   it("does not treat thinking-only completions as summary content", async () => {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -966,14 +966,54 @@ describe("createLcmSummarizeFromLegacyParams", () => {
 
     const summary = await summarize!("H".repeat(8_000), false);
 
-    // When no non-reasoning text is collected, reasoning blocks are
-    // used as a fallback source so models that place the entire summary
-    // inside a typed reasoning block (e.g. Ollama extended-thinking
-    // models, #944) produce usable summaries instead of falling
-    // through to the truncation fallback.
-    expect(summary).toBe("PRIVATE_TYPED_REASONING_TRACE");
-    // The summary was extracted successfully on the first attempt, so
-    // no empty-summary diagnostics are generated and no retries occur.
+    // Reasoning-only blocks without an accompanying text-type block are
+    // treated as private diagnostics, not summary content. The fallback
+    // only activates when the response contains both reasoning and text
+    // blocks (model intended text output), per #944.
+    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
+
+    const diagnostics = getDepsLogText(deps);
+    expect(diagnostics).toContain("block_types=reasoning");
+    expect(diagnostics).toContain("content_preview=");
+    expect(diagnostics).not.toContain("PRIVATE_TYPED_REASONING_TRACE");
+  });
+
+  it("recovers summary from reasoning blocks when a text block is also present (#944)", async () => {
+    // Ollama extended-thinking models place the entire summary inside a
+    // type:"reasoning" block while leaving type:"text" empty.  When both
+    // blocks are present (the model intended text output), fall back to
+    // reasoning blocks so the summary is not discarded.
+    const deps = makeDeps({
+      resolveModel: vi.fn(() => ({
+        provider: "ollama",
+        model: "qwen3.5:9b",
+      })),
+      complete: vi.fn(async () => ({
+        content: [
+          {
+            type: "reasoning",
+            text: "The input describes a text processing pipeline that...",
+          },
+          {
+            type: "text",
+            text: "",
+          },
+        ],
+      })),
+    });
+
+    const summarize = await createSummarizeFn({
+      deps,
+      legacyParams: {
+        provider: "ollama",
+        model: "qwen3.5:9b",
+      },
+    });
+
+    const summary = await summarize!("H".repeat(8_000), false);
+
+    expect(summary).toContain("text processing pipeline");
+    // Recovery succeeds on the first attempt — no retry or fallback needed.
     expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
   });
 

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -966,12 +966,15 @@ describe("createLcmSummarizeFromLegacyParams", () => {
 
     const summary = await summarize!("H".repeat(8_000), false);
 
-    expect(summary).toContain("[LCM fallback summary; truncated for context management]");
-
-    const diagnostics = getDepsLogText(deps);
-    expect(diagnostics).toContain("block_types=reasoning");
-    expect(diagnostics).toContain("content_preview=");
-    expect(diagnostics).not.toContain("PRIVATE_TYPED_REASONING_TRACE");
+    // When no non-reasoning text is collected, reasoning blocks are
+    // used as a fallback source so models that place the entire summary
+    // inside a typed reasoning block (e.g. Ollama extended-thinking
+    // models, #944) produce usable summaries instead of falling
+    // through to the truncation fallback.
+    expect(summary).toBe("PRIVATE_TYPED_REASONING_TRACE");
+    // The summary was extracted successfully on the first attempt, so
+    // no empty-summary diagnostics are generated and no retries occur.
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledTimes(1);
   });
 
   it("does not treat thinking-only completions as summary content", async () => {


### PR DESCRIPTION
## Problem

When `enableSummaryThinking: true` is used with Ollama extended-thinking models, the summarizer can request low reasoning via `reasoningIfSupported`. Those models may then return the usable summary inside a `type:"reasoning"` block while leaving the `type:"text"` block empty. Lossless intentionally treats typed reasoning/thinking blocks as private diagnostics, so the summary normalizes to empty and falls through to retry/fallback behavior.

Closes #944.

## Fix

Do not request summary-thinking controls for resolved Ollama summarizer candidates. This keeps Ollama summaries on the normal text path without reclassifying typed reasoning blocks as persisted summary content. Reasoning-only and mixed reasoning/empty-text responses remain private and fall back instead of being promoted.

## Testing

- `npm test -- --run test/summarize.test.ts -t "Ollama|reasoning blocks|thinking-only"`
- `npm test -- --run test/summarize.test.ts`
- `npm run typecheck`
- `npm test`
- `autoreview --mode branch --base origin/main` clean