### PR TITLE
fix(rollover): demote happy-path ambiguous-rollover rebind logs from warn

### DIFF
--- a/.changeset/quiet-ambiguous-rollover-rebind-logs.md
+++ b/.changeset/quiet-ambiguous-rollover-rebind-logs.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Demote the happy-path ambiguous session-key rollover recovery logs from warn to info or debug, context-aware. The successful fresh-transcript rebind and the not-provably-fresh decision now log at info; the assemble pass's per-phase preserve restatement logs at debug; the fresh-rebind new-epoch import logs at info, and the afterTurn "frontier not covered" line logs at debug only on the benign ambiguous-rollover path.
+
+The bootstrap and afterTurn preserve log keys off the freshness disposition carried out of the rebind attempt: a transient or unjudgeable verdict (no usable timestamps, delivery-only traffic, nothing comparable) is a pending state the next turn re-evaluates and logs at debug, while a conflicting verdict (identity overlap, or candidate entries predating persistence) is a genuine freeze and stays at warn. The rebind-failed and freshness-check exception paths, the no-anchor import-cap aborts, and every non-rollover unsafe-to-advance frontier skip also stay at warn. The freeze and no-merge protection is unchanged throughout; only log levels move.

--- a/.changeset/quiet-ambiguous-rollover-rebind-logs.md
+++ b/.changeset/quiet-ambiguous-rollover-rebind-logs.md
@@ -2,6 +2,6 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Demote the happy-path ambiguous session-key rollover recovery logs from warn to info or debug, context-aware. The successful fresh-transcript rebind and the not-provably-fresh decision now log at info; the assemble pass's per-phase preserve restatement logs at debug; the fresh-rebind new-epoch import logs at info, and the afterTurn "frontier not covered" line logs at debug only on the benign ambiguous-rollover path.
+Demote the happy-path ambiguous session-key rollover recovery logs from warn to info or debug, context-aware. The successful fresh-transcript rebind and transient not-provably-fresh decisions now log at info; the assemble pass's per-phase preserve restatement logs at debug; the fresh-rebind new-epoch import logs at info, and the afterTurn "frontier not covered" line logs at debug only on the benign ambiguous-rollover path.
 
 The bootstrap and afterTurn preserve log keys off the freshness disposition carried out of the rebind attempt: a transient or unjudgeable verdict (no usable timestamps, delivery-only traffic, nothing comparable) is a pending state the next turn re-evaluates and logs at debug, while a conflicting verdict (identity overlap, or candidate entries predating persistence) is a genuine freeze and stays at warn. The rebind-failed and freshness-check exception paths, the no-anchor import-cap aborts, and every non-rollover unsafe-to-advance frontier skip also stay at warn. The freeze and no-merge protection is unchanged throughout; only log levels move.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1817,7 +1817,7 @@ export class LcmContextEngine implements ContextEngine {
               // this is a legitimate reset. Rebind the existing conversation
               // and import the new transcript immediately while the freshness
               // proof is still in hand.
-              const rotatedForFreshTranscript =
+              const rolloverResolution =
                 await this.sessionRolloverDetector.rotateAmbiguousRolloverForProvablyFreshTranscript({
                   phase: "bootstrap",
                   sessionId: params.sessionId,
@@ -1825,12 +1825,13 @@ export class LcmContextEngine implements ContextEngine {
                   candidateMessages: preloadedHistoricalMessages,
                   createReplacement: false,
                 });
-              if (!rotatedForFreshTranscript) {
+              if (!rolloverResolution.rebound) {
                 this.sessionRolloverDetector.logAmbiguousSessionKeyRuntimeRollover({
                   phase: "bootstrap",
                   rollover: ambiguousRollover,
                   sessionId: params.sessionId,
                   sessionFile: params.sessionFile,
+                  expected: rolloverResolution.preserveExpected,
                 });
                 return {
                   bootstrapped: false,
@@ -2913,9 +2914,16 @@ export class LcmContextEngine implements ContextEngine {
     let dedupedNewMessages: AgentMessage[] = [];
     if (transcriptReconcileUnsafeToAdvance) {
       if (newMessages.length > 0 || params.autoCompactionSummary) {
-        this.deps.log.warn(
-          `[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`,
-        );
+        // The ambiguous-rollover defer is the benign self-heal path; the rotate
+        // below re-runs the rebind that imports the frontier. Any other
+        // unsafe-to-advance result is a genuine "skipping past unreconciled
+        // history" event worth a warn.
+        const frontierNotCovered = `[lcm] afterTurn: transcript reconcile did not cover the transcript frontier; skipping afterTurn persistence to avoid creating a future anchor past unreconciled transcript history ${sessionLabel}`;
+        if (transcriptReconcileBlockedByAmbiguousRollover) {
+          this.deps.log.debug(frontierNotCovered);
+        } else {
+          this.deps.log.warn(frontierNotCovered);
+        }
       }
       if (transcriptReconcileBlockedByAmbiguousRollover) {
         await runRuntimeAutoRotate();
@@ -3412,6 +3420,7 @@ export class LcmContextEngine implements ContextEngine {
           phase: "assemble",
           rollover: ambiguousRollover,
           sessionId: params.sessionId,
+          expected: true,
         });
         return safeFallback();
       }

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -41,6 +41,34 @@ export type AmbiguousSessionKeyRuntimeRollover = {
   trackedSessionFile: string;
 };
 
+/**
+ * Outcome of a tier-2 ambiguous-rollover resolution attempt. `rebound` means
+ * the lane healed in place. When it did not, `preserveExpected` is true only for
+ * a transient freshness failure (the new transcript cannot be judged yet and the
+ * next turn re-evaluates); a conflicting or anomalous failure leaves it false.
+ */
+export type AmbiguousRolloverResolution =
+  | { rebound: true }
+  | { rebound: false; preserveExpected: boolean };
+
+/**
+ * Freshness verdicts where the new transcript simply lacks the evidence to prove
+ * a reset YET (no usable timestamps, delivery-only traffic, nothing comparable):
+ * the preserve is a pending state the next turn re-evaluates, not a stuck freeze.
+ * Every other not-fresh reason (identity overlap, candidate entries predating
+ * persistence) is a genuine conflict that does not heal and stays a warn.
+ */
+const TRANSIENT_AMBIGUOUS_ROLLOVER_FRESHNESS_REASONS = new Set<string>([
+  "no-candidate-timestamps",
+  "candidate-missing-timestamp",
+  "delivery-only-synthetic-transcript",
+  "no-comparable-candidate-content",
+]);
+
+function isTransientAmbiguousRolloverFreshness(reason: string): boolean {
+  return TRANSIENT_AMBIGUOUS_ROLLOVER_FRESHNESS_REASONS.has(reason);
+}
+
 /** Engine callback that closes the old conversation and optionally creates its replacement. */
 export type ApplySessionReplacementFn = (params: {
   reason: string;
@@ -230,10 +258,19 @@ export class SessionRolloverDetector {
     rollover: AmbiguousSessionKeyRuntimeRollover;
     sessionId: string;
     sessionFile?: string;
+    // The assemble pass defers freshness judgment to the next bootstrap/afterTurn,
+    // so its preserve is a transient per-phase restatement that resolves on the
+    // healing pass, not a lane that stayed stuck. Only the genuine freeze (a
+    // bootstrap/afterTurn pass that judged the rollover and could not heal it)
+    // warns.
+    expected?: boolean;
   }): void {
-    this.deps.log.warn(
-      `[lcm] ${params.phase}: ${AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON}; preserving conversation=${params.rollover.conversationId} session=${params.sessionId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} oldFile=${params.rollover.trackedSessionFile}${params.sessionFile ? ` newFile=${params.sessionFile}` : ""}`,
-    );
+    const message = `[lcm] ${params.phase}: ${AMBIGUOUS_SESSION_KEY_RUNTIME_ROLLOVER_REASON}; preserving conversation=${params.rollover.conversationId} session=${params.sessionId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} oldFile=${params.rollover.trackedSessionFile}${params.sessionFile ? ` newFile=${params.sessionFile}` : ""}`;
+    if (params.expected) {
+      this.deps.log.debug(message);
+    } else {
+      this.deps.log.warn(message);
+    }
   }
 
   /**
@@ -414,7 +451,7 @@ export class SessionRolloverDetector {
     rollover: AmbiguousSessionKeyRuntimeRollover;
     candidateMessages: AgentMessage[];
     createReplacement: boolean;
-  }): Promise<boolean> {
+  }): Promise<AmbiguousRolloverResolution> {
     let verdict: Awaited<ReturnType<SessionRolloverDetector["evaluateAmbiguousRolloverFreshness"]>>;
     try {
       verdict = await this.evaluateAmbiguousRolloverFreshness({
@@ -425,13 +462,17 @@ export class SessionRolloverDetector {
       this.deps.log.warn(
         `[lcm] ${params.phase}: ambiguous rollover freshness check failed conversation=${params.rollover.conversationId} error=${describeLogError(err)}`,
       );
-      return false;
+      return { rebound: false, preserveExpected: false };
     }
     if (!verdict.fresh) {
-      this.deps.log.warn(
+      // Not an error: the rollover is a legitimate same-key continuation (or the
+      // evidence is insufficient to prove a reset), so freeze-and-preserve is the
+      // correct, expected outcome. The genuine "could not heal" headline is the
+      // caller's preserve log; this records only the freshness reason.
+      this.deps.log.info(
         `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
       );
-      return false;
+      return { rebound: false, preserveExpected: isTransientAmbiguousRolloverFreshness(verdict.reason) };
     }
 
     const rebound = await this.conversationStore.rebindConversationSession(
@@ -443,13 +484,15 @@ export class SessionRolloverDetector {
       this.deps.log.warn(
         `[lcm] ${params.phase}: ambiguous rollover rebind failed conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId}; leaving lane frozen`,
       );
-      return false;
+      return { rebound: false, preserveExpected: false };
     }
 
-    this.deps.log.warn(
+    // Expected success: the lane healed in place. Logged at info so the
+    // recovery is observable without flagging a routine /new as an anomaly.
+    this.deps.log.info(
       `[lcm] ${params.phase}: ambiguous rollover resolved by fresh-transcript rebind conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} oldSessionId=${params.rollover.activeSessionId} newSessionId=${params.sessionId} candidateMessages=${params.candidateMessages.length} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
     );
-    return true;
+    return { rebound: true };
   }
 
   async transcriptContainsCurrentConversationTailAnchor(params: {

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -441,9 +441,9 @@ export class SessionRolloverDetector {
    * rollover is a legitimate runtime session-file reset, not a foreign
    * transcript sharing the key. Rebind the existing conversation row so all
    * summaries, messages, frontier rows, and metadata keep the same
-   * conversation id while the new session can bootstrap normally. Returns
-   * true when rebound; false leaves the existing freeze-and-preserve
-   * behavior in place.
+   * conversation id while the new session can bootstrap normally. Returns the
+   * rebind outcome plus whether a non-rebound preserve is an expected pending
+   * state rather than a genuine freeze.
    */
   async rotateAmbiguousRolloverForProvablyFreshTranscript(params: {
     phase: "bootstrap" | "assemble" | "afterTurn";
@@ -465,14 +465,14 @@ export class SessionRolloverDetector {
       return { rebound: false, preserveExpected: false };
     }
     if (!verdict.fresh) {
-      // Not an error: the rollover is a legitimate same-key continuation (or the
-      // evidence is insufficient to prove a reset), so freeze-and-preserve is the
-      // correct, expected outcome. The genuine "could not heal" headline is the
-      // caller's preserve log; this records only the freshness reason.
-      this.deps.log.info(
-        `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`,
-      );
-      return { rebound: false, preserveExpected: isTransientAmbiguousRolloverFreshness(verdict.reason) };
+      const preserveExpected = isTransientAmbiguousRolloverFreshness(verdict.reason);
+      const message = `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`;
+      if (preserveExpected) {
+        this.deps.log.info(message);
+      } else {
+        this.deps.log.warn(message);
+      }
+      return { rebound: false, preserveExpected };
     }
 
     const rebound = await this.conversationStore.rebindConversationSession(

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1059,9 +1059,15 @@ export class TranscriptReconciler {
         importedMessages += 1;
       }
     }
-    this.host.deps.log.warn(
-      `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} capped=${noAnchorImportCapped} overlap=${adoptedMessages > 0}`,
-    );
+    // A fresh-ambiguous-rollover rebind imports the rolled transcript as a new
+    // epoch by design (the lane just healed), so record it at info. Every other
+    // no-anchor new-epoch import is an unexpected reconciliation worth a warn.
+    const noAnchorEpochImport = `[lcm] reconcileSessionTail: no anchor for ${sessionContext}; imported transcript as new epoch reason=${params.noAnchorImportReason ?? "unspecified"} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} candidateMessages=${noAnchorImportMessages.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} capped=${noAnchorImportCapped} overlap=${adoptedMessages > 0}`;
+    if (params.noAnchorImportReason === "fresh-ambiguous-rollover-rebind") {
+      this.host.deps.log.info(noAnchorEpochImport);
+    } else {
+      this.host.deps.log.warn(noAnchorEpochImport);
+    }
     if (noAnchorImportCapped) {
       // Partial pass: keep the checkpoint un-advanced so the next pass
       // continues the drain (via the entry-id anchor once this chunk's
@@ -2013,7 +2019,7 @@ export class TranscriptReconciler {
           // Tier-2 resolution: rebind the frozen conversation and import the
           // fresh transcript now. The freshness proof is the extra safety signal
           // that lets the no-anchor path ingest the full id-less transcript.
-          const rotatedForFreshTranscript =
+          const rolloverResolution =
             await this.rolloverDetector.rotateAmbiguousRolloverForProvablyFreshTranscript({
               phase: "afterTurn",
               sessionId: params.sessionId,
@@ -2021,7 +2027,7 @@ export class TranscriptReconciler {
               candidateMessages: historicalMessages,
               createReplacement: true,
             });
-          if (rotatedForFreshTranscript) {
+          if (rolloverResolution.rebound) {
             const reconcile = await this.importFreshAmbiguousRolloverTranscript({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
@@ -2041,6 +2047,7 @@ export class TranscriptReconciler {
             rollover: ambiguousRollover,
             sessionId: params.sessionId,
             sessionFile: params.sessionFile,
+            expected: rolloverResolution.preserveExpected,
           });
           return {
             importedMessages: 0,

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -513,7 +513,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
 
     expect(result.bootstrapped).toBe(false);
     expect(result.reason).toBe("ambiguous session-key runtime rollover");
-    expect(log.info).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
     );
     // A conflicting overlap is a genuine freeze (it never heals), so the
@@ -582,7 +582,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: staleFile,
     });
     expect(staleResult.bootstrapped).toBe(false);
-    expect(log.info).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("freshness=candidate-entries-predate-last-persisted"),
     );
 

--- a/test/ambiguous-rollover-rotation.test.ts
+++ b/test/ambiguous-rollover-rotation.test.ts
@@ -264,9 +264,14 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    // A successful /new heal must be silent: no warn-level noise on the happy path.
+    expect(log.warn).not.toHaveBeenCalled();
     expect(result.bootstrapped).toBe(true);
     expect(result.importedMessages).toBeGreaterThan(0);
 
@@ -301,7 +306,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
@@ -357,7 +365,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
@@ -404,7 +415,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
@@ -439,7 +453,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       tokenBudget: 10_000,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const reboundAfterFirst = await engine
@@ -496,8 +513,51 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
 
     expect(result.bootstrapped).toBe(false);
     expect(result.reason).toBe("ambiguous session-key runtime rollover");
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    // A conflicting overlap is a genuine freeze (it never heals), so the
+    // preserve stays at warn.
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
+    );
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("demotes the preserve to debug when freshness is only transiently unjudgeable (live /new shape)", async () => {
+    const { engine, log, db } = createEngine();
+    const lane = await seedFrozenLane(engine, db);
+
+    // The new session's first event has no usable timestamp (delivery/empty), so
+    // freshness cannot be judged yet: the preserve is a pending state the next
+    // turn re-evaluates. This is the live conv-56 /new shape (freshness=
+    // candidate-missing-timestamp); a pending preserve must NOT warn. If the
+    // transcript later conflicts, that turn's preserve warns on its own.
+    const bareFile = createTempFile(
+      "bare-no-timestamps.jsonl",
+      `${JSON.stringify({ role: "user", content: [{ type: "text", text: "first post-new turn, no timestamp" }] })}\n`,
+    );
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: bareFile,
+    });
+
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=candidate-missing-timestamp"),
+    );
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
     );
     const conversation = await engine
       .getConversationStore()
@@ -522,7 +582,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: staleFile,
     });
     expect(staleResult.bootstrapped).toBe(false);
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("freshness=candidate-entries-predate-last-persisted"),
     );
 
@@ -537,7 +597,7 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: bareFile,
     });
     expect(bareResult.bootstrapped).toBe(false);
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("freshness=candidate-missing-timestamp"),
     );
 
@@ -575,10 +635,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
 
     expect(result.bootstrapped).toBe(false);
     expect(result.reason).toBe("ambiguous session-key runtime rollover");
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("freshness=delivery-only-synthetic-transcript"),
     );
-    expect(log.warn).not.toHaveBeenCalledWith(
+    expect(log.info).not.toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
@@ -616,10 +676,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
 
     expect(result.bootstrapped).toBe(false);
     expect(result.reason).toBe("ambiguous session-key runtime rollover");
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("freshness=no-comparable-candidate-content"),
     );
-    expect(log.warn).not.toHaveBeenCalledWith(
+    expect(log.info).not.toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
@@ -667,10 +727,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
     });
 
     expect(result.messages.length).toBeGreaterThan(0);
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.debug).toHaveBeenCalledWith(
       expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
     );
-    expect(log.warn).not.toHaveBeenCalledWith(
+    expect(log.info).not.toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const conversation = await engine
@@ -718,7 +778,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       tokenBudget: 10_000,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     const rebound = await engine
@@ -785,7 +848,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);
@@ -844,7 +910,10 @@ describe("ambiguous rollover tier-2 fresh-transcript rotation", () => {
       sessionFile: newSessionFile,
     });
 
-    expect(log.warn).toHaveBeenCalledWith(
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
     );
     expect(result.bootstrapped).toBe(true);

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -3094,10 +3094,11 @@ describe("LcmContextEngine afterTurn", () => {
 
   it("afterTurn fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {
     const warnLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
-        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: debugLog },
       },
     );
     const privateEngine = engine as unknown as {
@@ -3163,11 +3164,19 @@ describe("LcmContextEngine afterTurn", () => {
       tokenBudget: 4_096,
     });
 
+    // The new transcript is only transiently unjudgeable (no usable timestamps),
+    // so the preserve is a pending state logged at debug; the freeze/no-merge
+    // guard below is unchanged, and a real conflict would warn on its own turn.
+    expect(
+      debugLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover; preserving")),
+    ).toBe(true);
     expect(
       warnLog.mock.calls
         .map((call) => String(call[0]))
-        .some((message) => message.includes("ambiguous session-key runtime rollover")),
-    ).toBe(true);
+        .some((message) => message.includes("ambiguous session-key runtime rollover; preserving")),
+    ).toBe(false);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual([
       "old afterTurn long-lived question",

--- a/test/engine-fidelity.test.ts
+++ b/test/engine-fidelity.test.ts
@@ -1906,10 +1906,11 @@ describe("LcmContextEngine fidelity and token budget", () => {
 
   it("bootstrap fails closed on ambiguous runtime rollover while the old transcript still exists", async () => {
     const warnLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
-        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: debugLog },
       },
     );
     const firstSessionId = "bootstrap-ambiguous-rollover-old-runtime";
@@ -1954,11 +1955,19 @@ describe("LcmContextEngine fidelity and token budget", () => {
       importedMessages: 0,
       reason: "ambiguous session-key runtime rollover",
     });
+    // Transiently unjudgeable (no usable timestamps): the preserve is a pending
+    // state logged at debug; the freeze/no-merge guard below is unchanged, and a
+    // real conflict would warn on its own turn.
+    expect(
+      debugLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover; preserving")),
+    ).toBe(true);
     expect(
       warnLog.mock.calls
         .map((call) => String(call[0]))
-        .some((message) => message.includes("ambiguous session-key runtime rollover")),
-    ).toBe(true);
+        .some((message) => message.includes("ambiguous session-key runtime rollover; preserving")),
+    ).toBe(false);
 
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual([

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -35,10 +35,11 @@ afterEach(cleanupEngineTestState);
 describe("LcmContextEngine maintain and assemble budget", () => {
   it("assemble falls back to live messages on ambiguous runtime rollover while the old transcript still exists", async () => {
     const warnLog = vi.fn();
+    const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       {},
       {
-        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: vi.fn() },
+        log: { info: vi.fn(), warn: warnLog, error: vi.fn(), debug: debugLog },
       },
     );
     const firstSessionId = "assemble-ambiguous-rollover-old-runtime";
@@ -74,11 +75,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(
       assembled.messages.some((message) => message.content === "openai-codex/gpt-5.5"),
     ).toBe(false);
+    // The assemble pass defers rollover resolution to the next bootstrap/afterTurn,
+    // so its preserve restatement is debug, not an anomaly warn.
+    expect(
+      debugLog.mock.calls
+        .map((call) => String(call[0]))
+        .some((message) => message.includes("ambiguous session-key runtime rollover")),
+    ).toBe(true);
     expect(
       warnLog.mock.calls
         .map((call) => String(call[0]))
         .some((message) => message.includes("ambiguous session-key runtime rollover")),
-    ).toBe(true);
+    ).toBe(false);
     const activeByKey = await engine.getConversationStore().getConversationForSession({
       sessionId: secondSessionId,
       sessionKey,

--- a/test/rebind-loglevel.test.ts
+++ b/test/rebind-loglevel.test.ts
@@ -93,10 +93,10 @@ describe("ambiguous-rollover rebind happy-path log levels", () => {
     );
   });
 
-  it("logs the not-provably-fresh preserve decision at info, not warn", async () => {
+  it("logs the conflicting not-provably-fresh preserve decision at warn", async () => {
     const { detector, log } = makeDetector({
       // Persisted history is newer than the candidate entries: the rollover is
-      // a legitimate same-key continuation, correctly preserved (not an error).
+      // a genuine conflict, so preserve/freeze is correct and actionable.
       getLastMessage: async () => ({ createdAt: new Date(Date.now() + 10 * 60_000) }),
     });
 
@@ -109,8 +109,8 @@ describe("ambiguous-rollover rebind happy-path log levels", () => {
     });
 
     expect(rebound).toEqual({ rebound: false, preserveExpected: false });
-    expect(log.warn).not.toHaveBeenCalled();
-    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("not provably fresh"));
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("not provably fresh"));
   });
 
   it("logs the assemble-phase per-phase preserve restatement at debug, not warn", () => {

--- a/test/rebind-loglevel.test.ts
+++ b/test/rebind-loglevel.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SessionRolloverDetector,
+  type AmbiguousSessionKeyRuntimeRollover,
+} from "../src/session-rollover.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { ConversationStore } from "../src/store/conversation-store.js";
+import type { SummaryStore } from "../src/store/summary-store.js";
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+const ROLLOVER: AmbiguousSessionKeyRuntimeRollover = {
+  conversationId: 1,
+  activeSessionId: "old-session",
+  sessionKey: "agent:main:main",
+  trackedSessionFile: "/tmp/old-transcript.jsonl",
+};
+
+const NEW_SESSION_ID = "new-session";
+
+function freshCandidates(): AgentMessage[] {
+  const base = Date.now() + 60_000;
+  return [
+    { role: "user", content: "real question after the roll", timestamp: base },
+    { role: "assistant", content: "real answer after the roll", timestamp: base + 1 },
+  ] as unknown as AgentMessage[];
+}
+
+function makeDetector(
+  conversationStoreOverrides: Record<string, unknown> = {},
+): { detector: SessionRolloverDetector; log: ReturnType<typeof makeLog> } {
+  const log = makeLog();
+  const conversationStore = {
+    getLastMessage: async () => null,
+    getLastMessages: async () => [],
+    rebindConversationSession: async () => ({ sessionId: NEW_SESSION_ID, active: true }),
+    ...conversationStoreOverrides,
+  } as unknown as ConversationStore;
+  const detector = new SessionRolloverDetector(
+    conversationStore,
+    {} as unknown as SummaryStore,
+    { log },
+    async () => {},
+  );
+  return { detector, log };
+}
+
+describe("ambiguous-rollover rebind happy-path log levels", () => {
+  it("logs the successful fresh-transcript rebind at info, not warn", async () => {
+    const { detector, log } = makeDetector({
+      getLastMessage: async () => null,
+      rebindConversationSession: async () => ({ sessionId: NEW_SESSION_ID, active: true }),
+    });
+
+    const rebound = await detector.rotateAmbiguousRolloverForProvablyFreshTranscript({
+      phase: "bootstrap",
+      sessionId: NEW_SESSION_ID,
+      rollover: ROLLOVER,
+      candidateMessages: freshCandidates(),
+      createReplacement: false,
+    });
+
+    expect(rebound).toEqual({ rebound: true });
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+  });
+
+  it("marks a transient (unjudgeable) freshness failure as an expected preserve", async () => {
+    // The new transcript has no usable timestamps yet (the live conv-56 /new
+    // shape): freshness cannot be judged, so the preserve is a pending state the
+    // next turn re-evaluates. preserveExpected lets the caller demote its log.
+    const { detector, log } = makeDetector({ getLastMessage: async () => null });
+
+    const rebound = await detector.rotateAmbiguousRolloverForProvablyFreshTranscript({
+      phase: "bootstrap",
+      sessionId: NEW_SESSION_ID,
+      rollover: ROLLOVER,
+      candidateMessages: [
+        { role: "user", content: "first turn after the roll, no usable timestamp" },
+      ] as unknown as AgentMessage[],
+      createReplacement: false,
+    });
+
+    expect(rebound).toEqual({ rebound: false, preserveExpected: true });
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=candidate-missing-timestamp"),
+    );
+  });
+
+  it("logs the not-provably-fresh preserve decision at info, not warn", async () => {
+    const { detector, log } = makeDetector({
+      // Persisted history is newer than the candidate entries: the rollover is
+      // a legitimate same-key continuation, correctly preserved (not an error).
+      getLastMessage: async () => ({ createdAt: new Date(Date.now() + 10 * 60_000) }),
+    });
+
+    const rebound = await detector.rotateAmbiguousRolloverForProvablyFreshTranscript({
+      phase: "bootstrap",
+      sessionId: NEW_SESSION_ID,
+      rollover: ROLLOVER,
+      candidateMessages: freshCandidates(),
+      createReplacement: false,
+    });
+
+    expect(rebound).toEqual({ rebound: false, preserveExpected: false });
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("not provably fresh"));
+  });
+
+  it("logs the assemble-phase per-phase preserve restatement at debug, not warn", () => {
+    const { detector, log } = makeDetector({});
+
+    detector.logAmbiguousSessionKeyRuntimeRollover({
+      phase: "assemble",
+      rollover: ROLLOVER,
+      sessionId: NEW_SESSION_ID,
+      expected: true,
+    });
+
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
+    );
+  });
+});
+
+describe("ambiguous-rollover rebind anomaly log levels stay at warn", () => {
+  it("keeps the rebind-failed anomaly at warn", async () => {
+    const { detector, log } = makeDetector({
+      getLastMessage: async () => null,
+      rebindConversationSession: async () => null,
+    });
+
+    const rebound = await detector.rotateAmbiguousRolloverForProvablyFreshTranscript({
+      phase: "bootstrap",
+      sessionId: NEW_SESSION_ID,
+      rollover: ROLLOVER,
+      candidateMessages: freshCandidates(),
+      createReplacement: false,
+    });
+
+    expect(rebound).toEqual({ rebound: false, preserveExpected: false });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("rebind failed"));
+  });
+
+  it("keeps the freshness-check exception at warn", async () => {
+    const { detector, log } = makeDetector({
+      getLastMessage: async () => {
+        throw new Error("store offline");
+      },
+    });
+
+    const rebound = await detector.rotateAmbiguousRolloverForProvablyFreshTranscript({
+      phase: "bootstrap",
+      sessionId: NEW_SESSION_ID,
+      rollover: ROLLOVER,
+      candidateMessages: freshCandidates(),
+      createReplacement: false,
+    });
+
+    expect(rebound).toEqual({ rebound: false, preserveExpected: false });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous rollover freshness check failed"),
+    );
+  });
+
+  it("keeps the genuine freeze preserve (bootstrap/afterTurn, not deferred) at warn", () => {
+    const { detector, log } = makeDetector({});
+
+    detector.logAmbiguousSessionKeyRuntimeRollover({
+      phase: "bootstrap",
+      rollover: ROLLOVER,
+      sessionId: NEW_SESSION_ID,
+    });
+
+    expect(log.debug).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous session-key runtime rollover; preserving"),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The ambiguous session-key rollover recovery path logs its happy path at warn. A routine soft reset (`/new`) that the guard recovers cleanly emits a burst of warn lines (the per-phase preserve restatement, the successful rebind, the not-provably-fresh decision, the new-epoch import, a benign frontier skip), even though nothing went wrong. That noise drowns out the warn level for the cases that actually need attention.

## Fix

Level the recovery logs off the freshness disposition carried out of the rebind attempt:

- The successful fresh-transcript rebind and the not-provably-fresh decision log at info.
- The assemble pass's per-phase preserve restatement logs at debug, since it defers freshness judgment to the next bootstrap or afterTurn pass.
- The bootstrap and afterTurn preserve log keys off the verdict: a transient or unjudgeable freshness state (no usable timestamps, delivery-only traffic, nothing comparable) is a pending state that the next turn re-evaluates and logs at debug, while a conflicting verdict (identity overlap, or candidate entries predating persistence) is a genuine freeze and stays at warn.
- The rebind-failed and freshness-check exception paths, the no-anchor import-cap aborts, and every non-rollover unsafe-to-advance frontier skip stay at warn.

The freeze and no-merge protection is unchanged throughout. Only log levels move.

## Tests

Adds `test/rebind-loglevel.test.ts` and updates the rotation, after-turn, fidelity, and maintenance suites to assert the new levels: debug or info on the benign recovery path, warn retained on conflict, freeze, and rebind failure. Includes a changeset.

## Note

Companion to the conversation-preservation fix #955, which fixes the underlying #754 destruction bug. The two are independent; whichever merges second needs a trivial rebase.
