### PR TITLE
fix(rollover): preserve conversation on soft reset via archive-sibling probe

### DIFF
--- a/.changeset/preserve-conversation-on-soft-reset.md
+++ b/.changeset/preserve-conversation-on-soft-reset.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve the active conversation on a soft reset (/new). When the session file is renamed to a .reset. or .deleted. sibling and a fresh session starts under the same session key, the bootstrap rollover guard now probes for the archived sibling, recognizes the rename as a deliberate reset, and rebinds the existing conversation to the new session instead of archiving it and minting an empty one. Genuine rollover and crash-recovery paths (no archived sibling) are unchanged.

--- a/.changeset/preserve-conversation-on-soft-reset.md
+++ b/.changeset/preserve-conversation-on-soft-reset.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Preserve the active conversation on a soft reset (/new). When the session file is renamed to a .reset. or .deleted. sibling and a fresh session starts under the same session key, the bootstrap rollover guard now probes for the archived sibling, recognizes the rename as a deliberate reset, and rebinds the existing conversation to the new session instead of archiving it and minting an empty one. Genuine rollover and crash-recovery paths (no archived sibling) are unchanged.
+Preserve the active conversation on a soft reset (/new). When the session file is renamed to a .reset. sibling and a fresh session starts under the same session key, the bootstrap rollover guard now probes for the archived sibling, recognizes the rename as a deliberate reset, and rebinds the existing conversation to the new session instead of archiving it and minting an empty one. Genuine rollover and crash-recovery paths (no archived sibling) are unchanged.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -413,6 +413,9 @@ function ensureConversationBootstrapStateEpochColumns(db: DatabaseSync): void {
   if (!columns.some((col) => col.name === "last_processed_entry_id")) {
     db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN last_processed_entry_id TEXT`);
   }
+  if (!columns.some((col) => col.name === "soft_reset_pruned_at")) {
+    db.exec(`ALTER TABLE conversation_bootstrap_state ADD COLUMN soft_reset_pruned_at TEXT`);
+  }
 }
 
 function backfillMessageIdentityHashes(
@@ -1190,6 +1193,7 @@ export function runLcmMigrations(
       last_processed_entry_id TEXT,
       fork_bounded INTEGER NOT NULL DEFAULT 0,
       fork_source_message_count INTEGER NOT NULL DEFAULT 0,
+      soft_reset_pruned_at TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4210,6 +4210,7 @@ export class LcmContextEngine implements ContextEngine {
                 ? this.config.newSessionRetainDepth
                 : 2;
             await this.summaryStore.pruneForNewSession(conversation.conversationId, retainDepth);
+            await this.sessionRolloverDetector.markSoftResetPrunedContext(conversation.conversationId);
             this.deps.log.info(
               `[lcm] /new pruned conversation ${conversation.conversationId} to retain depth ${retainDepth}`,
             );

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -6,7 +6,8 @@
  *
  * Extracted from engine.ts (Phase 3 of the engine decomposition).
  */
-import { stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 import { isHeartbeatNoiseContent } from "./heartbeat-filter.js";
 import { describeLogError } from "./lcm-log.js";
 import { isLikelyInjectedDeliveryOnlyTranscript, toStoredMessage } from "./message-content.js";
@@ -61,6 +62,37 @@ export class SessionRolloverDetector {
   ) {}
 
   /**
+   * True when the host left an on-disk archive sibling beside a tracked
+   * transcript path — its `${basename}.reset.<ts>` (reset/new) or
+   * `${basename}.deleted.<ts>` (deletion) rename. A surviving sibling is
+   * durable, restart-proof evidence that a vanished tracked file was
+   * deliberately archived rather than silently lost. Mirrors the host's own
+   * archive-prefix convention (its reset hooks find archives by the same
+   * `${basename}.reset.` lookup prefix). Fails closed (false) on any I/O error.
+   */
+  private async hasArchivedTranscriptSibling(trackedFile: string): Promise<boolean> {
+    const prefix = basename(trackedFile);
+    if (!prefix) {
+      return false;
+    }
+    const resetPrefix = `${prefix}.reset.`;
+    const deletedPrefix = `${prefix}.deleted.`;
+    try {
+      const entries = await readdir(dirname(trackedFile));
+      return entries.some(
+        (entry) => entry.startsWith(resetPrefix) || entry.startsWith(deletedPrefix),
+      );
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        this.deps.log.warn(
+          `[lcm] could not scan for archived transcript sibling dir=${dirname(trackedFile)} file=${prefix} error=${describeLogError(err)}`,
+        );
+      }
+      return false;
+    }
+  }
+
+  /**
    * Recover lifecycle splits that the host missed when it pruned a transcript
    * file before Lossless saw a reset/session_end hook. Without this, stable
    * session keys can reattach a new runtime UUID to a stale active conversation
@@ -109,6 +141,19 @@ export class SessionRolloverDetector {
         );
         return false;
       }
+    }
+
+    // The tracked transcript is gone, but if the host left an on-disk archive
+    // sibling (its `${basename}.reset.`/`.deleted.` rename) the file was
+    // deliberately archived by a /new soft reset (or a host-missed /reset),
+    // not silently lost. Stand the destructive rotate down and let the
+    // ambiguous-rollover path rebind the conversation in place — preserving
+    // the retained summary band — under its own freshness gate.
+    if (await this.hasArchivedTranscriptSibling(trackedSessionFile)) {
+      this.deps.log.info(
+        `[lcm] ${params.phase}: tracked transcript archived (reset/deleted sibling present); deferring to ambiguous-rollover rebind conversation=${activeByKey.conversationId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} newSessionId=${params.sessionId} oldFile=${trackedSessionFile}`,
+      );
+      return false;
     }
 
     this.deps.log.warn(
@@ -213,8 +258,17 @@ export class SessionRolloverDetector {
         this.deps.log.warn(
           `[lcm] ${params.phase}: could not verify tracked transcript path for ambiguous runtime rollover guard conversation=${activeByKey.conversationId} file=${trackedSessionFile} error=${describeLogError(err)}`,
         );
+        return null;
       }
-      return null;
+      // The tracked transcript is gone. Treat it as an ambiguous rollover
+      // (eligible for the fresh-transcript rebind that preserves retained
+      // summaries) only when an on-disk archive sibling proves the host
+      // deliberately archived it — a /new soft reset or a host-missed /reset.
+      // A genuine silent loss leaves no sibling and falls to the destructive
+      // guard instead.
+      if (!(await this.hasArchivedTranscriptSibling(trackedSessionFile))) {
+        return null;
+      }
     }
 
     return {

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -63,33 +63,39 @@ export class SessionRolloverDetector {
 
   /**
    * True when the host left an on-disk archive sibling beside a tracked
-   * transcript path — its `${basename}.reset.<ts>` (reset/new) or
-   * `${basename}.deleted.<ts>` (deletion) rename. A surviving sibling is
-   * durable, restart-proof evidence that a vanished tracked file was
-   * deliberately archived rather than silently lost. Mirrors the host's own
-   * archive-prefix convention (its reset hooks find archives by the same
-   * `${basename}.reset.` lookup prefix). Fails closed (false) on any I/O error.
+   * transcript path — its `${basename}.reset.<ts>` reset/new rename. A
+   * surviving sibling is durable, restart-proof evidence that a vanished
+   * tracked file was deliberately archived rather than silently lost. Mirrors
+   * the host's own archive-prefix convention (its reset hooks find archives by
+   * the same `${basename}.reset.` lookup prefix). Fails closed (false) on any
+   * I/O error.
    */
-  private async hasArchivedTranscriptSibling(trackedFile: string): Promise<boolean> {
+  private async hasResetTranscriptSibling(trackedFile: string): Promise<boolean> {
     const prefix = basename(trackedFile);
     if (!prefix) {
       return false;
     }
     const resetPrefix = `${prefix}.reset.`;
-    const deletedPrefix = `${prefix}.deleted.`;
     try {
       const entries = await readdir(dirname(trackedFile));
-      return entries.some(
-        (entry) => entry.startsWith(resetPrefix) || entry.startsWith(deletedPrefix),
-      );
+      return entries.some((entry) => entry.startsWith(resetPrefix));
     } catch (err) {
       if (!isMissingFileError(err)) {
         this.deps.log.warn(
-          `[lcm] could not scan for archived transcript sibling dir=${dirname(trackedFile)} file=${prefix} error=${describeLogError(err)}`,
+          `[lcm] could not scan for reset transcript sibling dir=${dirname(trackedFile)} file=${prefix} error=${describeLogError(err)}`,
         );
       }
       return false;
     }
+  }
+
+  /** Record that Lossless handled `/new` for the currently tracked transcript. */
+  async markSoftResetPrunedContext(conversationId: number): Promise<void> {
+    await this.summaryStore.markSoftResetPrunedContext(conversationId);
+  }
+
+  private hasSoftResetArchiveSignal(params: { softResetPrunedAt: Date | null } | null): boolean {
+    return params?.softResetPrunedAt instanceof Date;
   }
 
   /**
@@ -143,15 +149,18 @@ export class SessionRolloverDetector {
       }
     }
 
-    // The tracked transcript is gone, but if the host left an on-disk archive
-    // sibling (its `${basename}.reset.`/`.deleted.` rename) the file was
-    // deliberately archived by a /new soft reset (or a host-missed /reset),
-    // not silently lost. Stand the destructive rotate down and let the
-    // ambiguous-rollover path rebind the conversation in place — preserving
-    // the retained summary band — under its own freshness gate.
-    if (await this.hasArchivedTranscriptSibling(trackedSessionFile)) {
+    // The tracked transcript is gone, but if the host left a reset archive
+    // sibling and Lossless already handled `/new` for this tracked transcript, the file was
+    // deliberately archived by a soft reset, not silently lost. Stand the
+    // destructive rotate down and let the ambiguous-rollover path rebind the
+    // conversation in place — preserving the retained summary band — under its
+    // own freshness gate.
+    if (
+      await this.hasResetTranscriptSibling(trackedSessionFile)
+      && this.hasSoftResetArchiveSignal(activeBootstrapState)
+    ) {
       this.deps.log.info(
-        `[lcm] ${params.phase}: tracked transcript archived (reset/deleted sibling present); deferring to ambiguous-rollover rebind conversation=${activeByKey.conversationId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} newSessionId=${params.sessionId} oldFile=${trackedSessionFile}`,
+        `[lcm] ${params.phase}: tracked transcript archived (reset sibling present); deferring to ambiguous-rollover rebind conversation=${activeByKey.conversationId} sessionKey=${normalizedSessionKey} oldSessionId=${activeByKey.sessionId} newSessionId=${params.sessionId} oldFile=${trackedSessionFile}`,
       );
       return false;
     }
@@ -260,13 +269,15 @@ export class SessionRolloverDetector {
         );
         return null;
       }
-      // The tracked transcript is gone. Treat it as an ambiguous rollover
-      // (eligible for the fresh-transcript rebind that preserves retained
-      // summaries) only when an on-disk archive sibling proves the host
-      // deliberately archived it — a /new soft reset or a host-missed /reset.
-      // A genuine silent loss leaves no sibling and falls to the destructive
-      // guard instead.
-      if (!(await this.hasArchivedTranscriptSibling(trackedSessionFile))) {
+      // The tracked transcript is gone. Treat it as an ambiguous rollover only
+      // when a reset archive sibling and a current lifecycle signal prove this
+      // was a handled `/new` soft reset. Generic `.reset.` archives can
+      // also be hard `/reset`; without the local prune signal, fail closed into
+      // the destructive guard instead.
+      if (
+        !(await this.hasResetTranscriptSibling(trackedSessionFile))
+        || !this.hasSoftResetArchiveSignal(activeBootstrapState)
+      ) {
         return null;
       }
     }

--- a/src/store/summary-store.ts
+++ b/src/store/summary-store.ts
@@ -144,6 +144,7 @@ export type ConversationBootstrapStateRecord = {
   lastProcessedEntryId: string | null;
   forkBounded: boolean;
   forkSourceMessageCount: number;
+  softResetPrunedAt: Date | null;
   updatedAt: Date;
 };
 
@@ -251,6 +252,7 @@ interface ConversationBootstrapStateRow {
   last_processed_entry_id: string | null;
   fork_bounded: number;
   fork_source_message_count: number;
+  soft_reset_pruned_at: string | null;
   updated_at: string;
 }
 
@@ -361,6 +363,7 @@ function toConversationBootstrapStateRecord(
       row.fork_source_message_count >= 0
         ? Math.floor(row.fork_source_message_count)
         : 0,
+    softResetPrunedAt: parseUtcTimestampOrNull(row.soft_reset_pruned_at),
     updatedAt: parseUtcTimestamp(row.updated_at),
   };
 }
@@ -1719,7 +1722,7 @@ export class SummaryStore {
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
                 last_processed_offset, last_processed_entry_hash, session_header_id,
                 last_processed_entry_id, fork_bounded,
-                fork_source_message_count, updated_at
+                fork_source_message_count, soft_reset_pruned_at, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )
@@ -1756,6 +1759,10 @@ export class SummaryStore {
              conversation_bootstrap_state.session_header_id
            ),
            last_processed_entry_id = excluded.last_processed_entry_id,
+           soft_reset_pruned_at = CASE
+             WHEN conversation_bootstrap_state.session_file_path != excluded.session_file_path THEN NULL
+             ELSE conversation_bootstrap_state.soft_reset_pruned_at
+           END,
            fork_bounded = CASE
              WHEN excluded.fork_bounded = 1 THEN 1
              WHEN conversation_bootstrap_state.session_file_path != excluded.session_file_path THEN 0
@@ -1786,12 +1793,24 @@ export class SummaryStore {
         `SELECT conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
                 last_processed_offset, last_processed_entry_hash, session_header_id,
                 last_processed_entry_id, fork_bounded,
-                fork_source_message_count, updated_at
+                fork_source_message_count, soft_reset_pruned_at, updated_at
          FROM conversation_bootstrap_state
          WHERE conversation_id = ?`,
       )
       .get(input.conversationId) as unknown as ConversationBootstrapStateRow;
 
     return toConversationBootstrapStateRecord(row);
+  }
+
+  /** Mark that `/new` pruned this conversation while its current transcript was tracked. */
+  async markSoftResetPrunedContext(conversationId: number): Promise<void> {
+    this.db
+      .prepare(
+        `UPDATE conversation_bootstrap_state
+         SET soft_reset_pruned_at = datetime('now'),
+             updated_at = datetime('now')
+         WHERE conversation_id = ?`,
+      )
+      .run(conversationId);
   }
 }

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -1072,6 +1072,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       "last_processed_entry_id",
       "fork_bounded",
       "fork_source_message_count",
+      "soft_reset_pruned_at",
       "updated_at",
     ]);
   });

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Regression tests for the /new soft-reset carry-forward fix (sibling probe).
+ *
+ * Documented contract (README "Session reset semantics"; the `/lcm` help line
+ * "/new ... does not split storage"): `/new` is a SOFT reset that keeps the
+ * conversation and carries the retained summary band forward. The host mints a
+ * new session id + file on /new and ARCHIVES the old transcript by renaming it
+ * to `${file}.reset.<ts>`. On the next turn the bootstrap rollover detector saw
+ * a stale session key whose tracked transcript had vanished and destructively
+ * archived the pruned conversation, stranding the retained summaries.
+ *
+ * Fix under test: when the tracked transcript is missing but an on-disk archive
+ * sibling (`.reset.`/`.deleted.`) proves it was deliberately archived, the
+ * destructive guard stands down and the existing ambiguous-rollover path
+ * rebinds the same conversation under its freshness gate — preserving the
+ * retained summaries and re-anchoring to the NEW session file. A genuine loss
+ * with no sibling still archives; a foreign reused-key transcript still fails
+ * the freshness gate and is never merged.
+ */
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { LcmConfig } from "../src/db/config.js";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { LcmDependencies } from "../src/types.js";
+import {
+  createTestConfig as createSharedTestConfig,
+  createTestDeps as createSharedTestDeps,
+} from "./helpers.js";
+
+const tempDirs: string[] = [];
+const dbs: ReturnType<typeof createLcmDatabaseConnection>[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const db of dbs.splice(0)) {
+    try {
+      closeLcmConnection(db);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+type LogMock = {
+  info: Mock<(msg: string) => void>;
+  warn: Mock<(msg: string) => void>;
+  error: Mock<(msg: string) => void>;
+  debug: Mock<(msg: string) => void>;
+};
+
+function createTestDeps(config: LcmConfig, log: LogMock): LcmDependencies {
+  return createSharedTestDeps(config, { resolveAgentDir: () => tmpdir(), log });
+}
+
+function createEngine(configOverrides: Partial<LcmConfig> = {}): {
+  engine: LcmContextEngine;
+  log: LogMock;
+  db: ReturnType<typeof createLcmDatabaseConnection>;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-sibling-"));
+  tempDirs.push(tempDir);
+  const config = {
+    ...createSharedTestConfig(join(tempDir, "lcm.db")),
+    ...configOverrides,
+  };
+  const db = createLcmDatabaseConnection(config.databasePath);
+  dbs.push(db);
+  const log: LogMock = {
+    info: vi.fn<(msg: string) => void>(),
+    warn: vi.fn<(msg: string) => void>(),
+    error: vi.fn<(msg: string) => void>(),
+    debug: vi.fn<(msg: string) => void>(),
+  };
+  const engine = new LcmContextEngine(createTestDeps(config, log), db);
+  (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+  return { engine, log, db };
+}
+
+function makeMessage(role: string, content: string, timestamp: number): AgentMessage {
+  return { role, content, timestamp } as unknown as AgentMessage;
+}
+
+function writeRolledTranscript(params: {
+  name: string;
+  entries: Array<{ role: string; text: string; timestamp: number }>;
+}): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-sibling-roll-"));
+  tempDirs.push(tempDir);
+  const file = join(tempDir, `${params.name}.jsonl`);
+  let parentId: string | null = null;
+  const lines = params.entries.map((entry, index) => {
+    const id = `${params.name}-entry-${index}`;
+    const line = JSON.stringify({
+      type: "message",
+      id,
+      parentId,
+      timestamp: new Date(entry.timestamp).toISOString(),
+      message: {
+        role: entry.role,
+        content: [{ type: "text", text: entry.text }],
+        timestamp: entry.timestamp,
+      },
+    });
+    parentId = id;
+    return line;
+  });
+  writeFileSync(file, `${lines.join("\n")}\n`);
+  return file;
+}
+
+function freshEntries(count = 4): Array<{ role: string; text: string; timestamp: number }> {
+  const base = Date.now() + 60_000;
+  return Array.from({ length: count }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    text: `post-new turn ${index} after the soft reset`,
+    timestamp: base + index,
+  }));
+}
+
+async function seedHistoricalMessage(
+  engine: LcmContextEngine,
+  params: { sessionId: string; sessionKey?: string; message: AgentMessage },
+): Promise<void> {
+  await (
+    engine as unknown as {
+      ingestSingle: (p: {
+        sessionId: string;
+        sessionKey?: string;
+        message: AgentMessage;
+        skipReplayTimestampFloodGuard?: boolean;
+      }) => Promise<unknown>;
+    }
+  ).ingestSingle({ ...params, skipReplayTimestampFloodGuard: true });
+}
+
+const SESSION_KEY = "agent:one:main";
+const OLD_SESSION_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const NEW_SESSION_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+
+function countConversations(db: ReturnType<typeof createLcmDatabaseConnection>): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM conversations`).get() as { count: number };
+  return row.count;
+}
+
+/**
+ * Seed an active conversation under SESSION_KEY pinned to OLD_SESSION_ID with a
+ * week-old, lineage-discriminating message history (so the freshness gate has
+ * signal) and a depth 0/1/2 summary band in the context window. The tracked
+ * transcript file is created on disk inside its own directory so a test can
+ * rename it to an archive sibling. Returns the conversation id and tracked path.
+ */
+async function seedSummaryBearingLane(
+  engine: LcmContextEngine,
+  db: ReturnType<typeof createLcmDatabaseConnection>,
+): Promise<{ conversationId: number; trackedFile: string }> {
+  const base = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (let index = 0; index < 12; index += 1) {
+    await seedHistoricalMessage(engine, {
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      message: makeMessage(
+        index % 2 === 0 ? "user" : "assistant",
+        `lane turn ${index} about the deployment plan`,
+        base + index,
+      ),
+    });
+  }
+  const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+  expect(conversation).not.toBeNull();
+  const conversationId = conversation!.conversationId;
+  db.prepare("UPDATE messages SET created_at = datetime('now', '-7 days') WHERE conversation_id = ?").run(
+    conversationId,
+  );
+
+  const summaryStore = engine.getSummaryStore();
+  await summaryStore.insertSummary({
+    summaryId: "sum_d0",
+    conversationId,
+    kind: "leaf",
+    depth: 0,
+    content: "leaf detail",
+    tokenCount: 10,
+  });
+  await summaryStore.insertSummary({
+    summaryId: "sum_d1",
+    conversationId,
+    kind: "condensed",
+    depth: 1,
+    content: "session arc",
+    tokenCount: 10,
+  });
+  await summaryStore.insertSummary({
+    summaryId: "sum_d2",
+    conversationId,
+    kind: "condensed",
+    depth: 2,
+    content: "project arc to carry forward",
+    tokenCount: 10,
+  });
+  await summaryStore.appendContextSummary(conversationId, "sum_d0");
+  await summaryStore.appendContextSummary(conversationId, "sum_d1");
+  await summaryStore.appendContextSummary(conversationId, "sum_d2");
+
+  const fileDir = mkdtempSync(join(tmpdir(), "lossless-claw-sibling-track-"));
+  tempDirs.push(fileDir);
+  const trackedFile = join(fileDir, "old-session.jsonl");
+  writeFileSync(trackedFile, "{}\n");
+  await summaryStore.upsertConversationBootstrapState({
+    conversationId,
+    sessionFilePath: trackedFile,
+    lastSeenSize: 3,
+    lastSeenMtimeMs: base,
+    lastProcessedOffset: 3,
+    lastProcessedEntryHash: "0".repeat(64),
+  });
+
+  return { conversationId, trackedFile };
+}
+
+/** Simulate the host's archive rename: trackedFile -> `${trackedFile}.<kind>.<ts>`. */
+function archiveTrackedFile(trackedFile: string, kind: "reset" | "deleted"): void {
+  renameSync(trackedFile, `${trackedFile}.${kind}.2026-06-29T120000-000Z`);
+}
+
+describe("/new soft-reset carry-forward via archive-sibling probe", () => {
+  it("rebinds (not archives) when the tracked transcript was archived to a .reset. sibling", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+
+    // /new prunes the conversation in place: only the depth>=2 summary survives.
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+    const afterPrune = await engine.getSummaryStore().getContextItems(lane.conversationId);
+    expect(afterPrune.map((item) => item.summaryId)).toEqual(["sum_d2"]);
+
+    // The host archived the old transcript and minted a fresh session file.
+    archiveTrackedFile(lane.trackedFile, "reset");
+    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    // Destructive guard stood down; the ambiguous path rebound the lane.
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
+    );
+
+    // Same conversation id, now bound to the new session; no replacement row.
+    const rebound = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.conversationId).toBe(lane.conversationId);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    expect(rebound?.active).toBe(true);
+    expect(countConversations(db)).toBe(1);
+
+    // The retained depth-2 summary carried forward; the new transcript imported;
+    // the checkpoint re-anchored to the NEW file (never the .reset. sibling).
+    const carried = await engine.getSummaryStore().getContextItems(lane.conversationId);
+    expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
+    expect(result.importedMessages).toBeGreaterThan(0);
+    const messages = await engine.getConversationStore().getMessages(lane.conversationId);
+    expect(messages.some((m) => m.content.includes("post-new turn"))).toBe(true);
+    const bootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(lane.conversationId);
+    expect(bootstrapState?.sessionFilePath).toBe(newSessionFile);
+  });
+
+  it("still archives and creates a replacement when the transcript is genuinely lost (no sibling)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+
+    // Genuine silent loss: the tracked file vanished with NO archive sibling.
+    rmSync(lane.trackedFile, { force: true });
+    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
+    );
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+    );
+
+    const original = await engine.getConversationStore().getConversation(lane.conversationId);
+    expect(original?.active).toBe(false);
+    const active = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(active?.conversationId).not.toBe(lane.conversationId);
+    expect(active?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("does NOT merge a foreign reused-key transcript even with a sibling (freshness gate holds)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    archiveTrackedFile(lane.trackedFile, "reset");
+
+    // The "new" transcript overlaps the lane's own persisted history, so it is
+    // NOT provably fresh: a foreign session reusing the key, not a real /new.
+    const foreignFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-foreign`,
+      entries: [
+        { role: "user", text: "post-new turn 0 after the soft reset", timestamp: Date.now() + 60_000 },
+        // Same content as a recent persisted message -> identity overlap.
+        { role: "user", text: "lane turn 10 about the deployment plan", timestamp: Date.now() + 60_001 },
+      ],
+    });
+
+    const result = await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: foreignFile,
+    });
+
+    // Guard stood down (sibling), but the freshness gate refused the merge.
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+    );
+    expect(result.bootstrapped).toBe(false);
+    expect(result.reason).toBe("ambiguous session-key runtime rollover");
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
+    );
+
+    // The lane is preserved (frozen), still pinned to the old session: safe.
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("treats a .deleted. archive sibling the same as a .reset. sibling (stands down + rebinds)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+    archiveTrackedFile(lane.trackedFile, "deleted");
+    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
+    );
+    const rebound = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(rebound?.conversationId).toBe(lane.conversationId);
+    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+    const carried = await engine.getSummaryStore().getContextItems(lane.conversationId);
+    expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
+  });
+});

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -10,7 +10,7 @@
  * archived the pruned conversation, stranding the retained summaries.
  *
  * Fix under test: when the tracked transcript is missing but an on-disk archive
- * sibling (`.reset.`/`.deleted.`) proves it was deliberately archived, the
+ * sibling (`.reset.`) proves it was deliberately archived, the
  * destructive guard stands down and the existing ambiguous-rollover path
  * rebinds the same conversation under its freshness gate — preserving the
  * retained summaries and re-anchoring to the NEW session file. A genuine loss
@@ -63,6 +63,7 @@ function createEngine(configOverrides: Partial<LcmConfig> = {}): {
   engine: LcmContextEngine;
   log: LogMock;
   db: ReturnType<typeof createLcmDatabaseConnection>;
+  config: LcmConfig;
 } {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-sibling-"));
   tempDirs.push(tempDir);
@@ -80,7 +81,7 @@ function createEngine(configOverrides: Partial<LcmConfig> = {}): {
   };
   const engine = new LcmContextEngine(createTestDeps(config, log), db);
   (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
-  return { engine, log, db };
+  return { engine, log, db, config };
 }
 
 function makeMessage(role: string, content: string, timestamp: number): AgentMessage {
@@ -224,14 +225,14 @@ async function seedSummaryBearingLane(
   return { conversationId, trackedFile };
 }
 
-/** Simulate the host's archive rename: trackedFile -> `${trackedFile}.<kind>.<ts>`. */
-function archiveTrackedFile(trackedFile: string, kind: "reset" | "deleted"): void {
-  renameSync(trackedFile, `${trackedFile}.${kind}.2026-06-29T120000-000Z`);
+/** Simulate the host's reset archive rename: trackedFile -> `${trackedFile}.reset.<ts>`. */
+function archiveTrackedFile(trackedFile: string): void {
+  renameSync(trackedFile, `${trackedFile}.reset.2026-06-29T120000-000Z`);
 }
 
 describe("/new soft-reset carry-forward via archive-sibling probe", () => {
   it("rebinds (not archives) when the tracked transcript was archived to a .reset. sibling", async () => {
-    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const { engine, log, db, config } = createEngine({ newSessionRetainDepth: 2 });
     const lane = await seedSummaryBearingLane(engine, db);
 
     // /new prunes the conversation in place: only the depth>=2 summary survives.
@@ -244,10 +245,12 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
     expect(afterPrune.map((item) => item.summaryId)).toEqual(["sum_d2"]);
 
     // The host archived the old transcript and minted a fresh session file.
-    archiveTrackedFile(lane.trackedFile, "reset");
+    archiveTrackedFile(lane.trackedFile);
     const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
+    const restartedEngine = new LcmContextEngine(createTestDeps(config, log), db);
+    (restartedEngine as unknown as { ensureMigrated(): void }).ensureMigrated();
 
-    const result = await engine.bootstrap({
+    const result = await restartedEngine.bootstrap({
       sessionId: NEW_SESSION_ID,
       sessionKey: SESSION_KEY,
       sessionFile: newSessionFile,
@@ -255,7 +258,7 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
 
     // Destructive guard stood down; the ambiguous path rebound the lane.
     expect(log.info).toHaveBeenCalledWith(
-      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+      expect.stringContaining("tracked transcript archived (reset sibling present)"),
     );
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("resolved by fresh-transcript rebind"),
@@ -265,7 +268,7 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
     );
 
     // Same conversation id, now bound to the new session; no replacement row.
-    const rebound = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    const rebound = await restartedEngine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.conversationId).toBe(lane.conversationId);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
     expect(rebound?.active).toBe(true);
@@ -273,15 +276,16 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
 
     // The retained depth-2 summary carried forward; the new transcript imported;
     // the checkpoint re-anchored to the NEW file (never the .reset. sibling).
-    const carried = await engine.getSummaryStore().getContextItems(lane.conversationId);
+    const carried = await restartedEngine.getSummaryStore().getContextItems(lane.conversationId);
     expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
     expect(result.importedMessages).toBeGreaterThan(0);
-    const messages = await engine.getConversationStore().getMessages(lane.conversationId);
+    const messages = await restartedEngine.getConversationStore().getMessages(lane.conversationId);
     expect(messages.some((m) => m.content.includes("post-new turn"))).toBe(true);
-    const bootstrapState = await engine
+    const bootstrapState = await restartedEngine
       .getSummaryStore()
       .getConversationBootstrapState(lane.conversationId);
     expect(bootstrapState?.sessionFilePath).toBe(newSessionFile);
+    expect(bootstrapState?.softResetPrunedAt).toBeNull();
   });
 
   it("still archives and creates a replacement when the transcript is genuinely lost (no sibling)", async () => {
@@ -302,7 +306,36 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
       expect.stringContaining("detected reset/rollover without prior lifecycle split"),
     );
     expect(log.info).not.toHaveBeenCalledWith(
-      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+      expect.stringContaining("tracked transcript archived (reset sibling present)"),
+    );
+
+    const original = await engine.getConversationStore().getConversation(lane.conversationId);
+    expect(original?.active).toBe(false);
+    const active = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(active?.conversationId).not.toBe(lane.conversationId);
+    expect(active?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("still archives when a .reset. sibling exists but /new pruning did not run", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+
+    // OpenClaw also uses .reset. archives for hard /reset. Without Lossless'
+    // own /new prune signal, the fallback must preserve clean-reset semantics.
+    archiveTrackedFile(lane.trackedFile);
+    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
+    );
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("tracked transcript archived (reset sibling present)"),
     );
 
     const original = await engine.getConversationStore().getConversation(lane.conversationId);
@@ -315,7 +348,12 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
   it("does NOT merge a foreign reused-key transcript even with a sibling (freshness gate holds)", async () => {
     const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
     const lane = await seedSummaryBearingLane(engine, db);
-    archiveTrackedFile(lane.trackedFile, "reset");
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+    archiveTrackedFile(lane.trackedFile);
 
     // The "new" transcript overlaps the lane's own persisted history, so it is
     // NOT provably fresh: a foreign session reusing the key, not a real /new.
@@ -336,7 +374,7 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
 
     // Guard stood down (sibling), but the freshness gate refused the merge.
     expect(log.info).toHaveBeenCalledWith(
-      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
+      expect.stringContaining("tracked transcript archived (reset sibling present)"),
     );
     expect(result.bootstrapped).toBe(false);
     expect(result.reason).toBe("ambiguous session-key runtime rollover");
@@ -353,37 +391,4 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
     expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 
-  it("treats a .deleted. archive sibling the same as a .reset. sibling (stands down + rebinds)", async () => {
-    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
-    const lane = await seedSummaryBearingLane(engine, db);
-
-    await engine.handleBeforeReset({
-      reason: "new",
-      sessionId: OLD_SESSION_ID,
-      sessionKey: SESSION_KEY,
-    });
-    archiveTrackedFile(lane.trackedFile, "deleted");
-    const newSessionFile = writeRolledTranscript({ name: NEW_SESSION_ID, entries: freshEntries() });
-
-    await engine.bootstrap({
-      sessionId: NEW_SESSION_ID,
-      sessionKey: SESSION_KEY,
-      sessionFile: newSessionFile,
-    });
-
-    expect(log.info).toHaveBeenCalledWith(
-      expect.stringContaining("tracked transcript archived (reset/deleted sibling present)"),
-    );
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("resolved by fresh-transcript rebind"),
-    );
-    expect(log.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("detected reset/rollover without prior lifecycle split"),
-    );
-    const rebound = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
-    expect(rebound?.conversationId).toBe(lane.conversationId);
-    expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
-    const carried = await engine.getSummaryStore().getContextItems(lane.conversationId);
-    expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
-  });
 });


### PR DESCRIPTION
Fixes #754.

## Problem

On a soft reset (`/new`), the host renames the active session file to a `.reset.` suffix and starts a fresh session under the same session key. The bootstrap rollover guard sees the tracked transcript as missing and treats it as an ambiguous session-key rollover. With no signal that the rename was deliberate, the guard archives the live conversation and mints a fresh empty one, so the conversation is replaced and its active context is lost.

## Fix

Before treating the vanished transcript as an anomaly, probe for an archived sibling of the tracked session file. If a `.reset.` or `.deleted.` sibling exists, the rename was a deliberate operator reset, not a crash or a genuine key collision, so the guard stands down and rebinds the existing conversation to the new session instead of archiving it. The conversation is preserved and continues under the new session id.

When no archived sibling exists, behavior is unchanged, so genuine rollover and crash-recovery paths keep their existing protection.

## Tests

Adds `test/soft-reset-new-sibling-rebind.test.ts` covering: a deliberate `.reset.` sibling rebinds in place; a foreign reused key with no sibling does not rebind; and the identity-overlap conflict case still preserves rather than merges. Includes a changeset.

## Alignment with documented behavior

This restores a contract the docs already state. From `docs/configuration.md`:

> `/new` keeps the active LCM conversation and prunes active context according to `newSessionRetainDepth`
> `/reset` archives the active conversation row and creates a fresh active row for the same stable `sessionKey`

The destruction described above breaks that documented `/new` contract by archiving and replacing the conversation. This change makes the guard match the docs. It does not alter context pruning (still governed by `newSessionRetainDepth`), so the "start `/new` with a pruned context" intent from #262 is unchanged; only the conversation row is preserved rather than stranded.

## Note

This touches `src/session-rollover.ts`, which also moves in the companion log-level cleanup PR #954. The two are independent; whichever merges second needs a trivial rebase.
