### PR TITLE
fix(doctor): never auto-restore a deliberately archived conversation

### DIFF
--- a/.changeset/doctor-skip-deliberate-reset.md
+++ b/.changeset/doctor-skip-deliberate-reset.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Stop the rollover-split doctor from auto-restoring conversations a user deliberately wiped with `/reset`. A new nullable `archive_cause` column records why each conversation was archived, written at the single archive funnel for both the `before_reset` and `session_end` lifecycle events a `/reset` surfaces. The doctor excludes deliberate causes (`manual-reset`) from its merge sources, so a `/reset` archive is never re-merged into the active conversation. Incidental archives (`rollover-fallback`, `cron-rotation`, `session-end`, idle/daily/compaction) and legacy NULL-cause rows stay merge-eligible, so genuine crash and rollover splits are still recovered.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1067,6 +1067,7 @@ export function runLcmMigrations(
       session_key TEXT,
       active INTEGER NOT NULL DEFAULT 1,
       archived_at TEXT,
+      archive_cause TEXT,
       title TEXT,
       bootstrapped_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -1317,6 +1318,11 @@ export function runLcmMigrations(
     const hasArchivedAt = conversationColumns.some((col) => col.name === "archived_at");
     if (!hasArchivedAt) {
       db.exec(`ALTER TABLE conversations ADD COLUMN archived_at TEXT`);
+    }
+
+    const hasArchiveCause = conversationColumns.some((col) => col.name === "archive_cause");
+    if (!hasArchiveCause) {
+      db.exec(`ALTER TABLE conversations ADD COLUMN archive_cause TEXT`);
     }
 
     db.exec(`UPDATE conversations SET active = 1 WHERE active IS NULL`);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -44,7 +44,11 @@ import { compileSessionPatterns, matchesSessionPattern } from "./session-pattern
 import { logStartupBannerOnce } from "./startup-banner-log.js";
 import { CompactionTelemetryStore } from "./store/compaction-telemetry-store.js";
 import { CompactionMaintenanceStore } from "./store/compaction-maintenance-store.js";
-import { ConversationStore, type ConversationRecord } from "./store/conversation-store.js";
+import {
+  ConversationStore,
+  type ArchiveCause,
+  type ConversationRecord,
+} from "./store/conversation-store.js";
 import { FocusBriefStore, type FocusBriefRecord } from "./store/focus-brief-store.js";
 import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, FALLBACK_SUMMARY_MARKER, LcmProviderAuthError, LcmSummarySpendLimitError, type LcmSummarizeFn } from "./summarize.js";
@@ -94,6 +98,14 @@ const LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapab
 ];
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
+
+// Host-contract dependency: the deliberate-vs-incidental archive distinction
+// relies on OpenClaw emitting these exact reason strings only for genuine
+// operator actions. If the host renames a reason, the archive-cause mapping in
+// the lifecycle handlers changes silently; the producer mapping test guards it.
+const HOST_BEFORE_RESET_REASON_NEW = "new";
+const HOST_BEFORE_RESET_REASON_RESET = "reset";
+const HOST_SESSION_END_REASON_DELETED = "deleted";
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CompactionExecutionParams = {
@@ -4126,6 +4138,7 @@ export class LcmContextEngine implements ContextEngine {
    */
   private async applySessionReplacement(params: {
     reason: string;
+    archiveCause: ArchiveCause;
     sessionId?: string;
     sessionKey?: string;
     nextSessionId?: string;
@@ -4148,7 +4161,7 @@ export class LcmContextEngine implements ContextEngine {
         );
         return;
       }
-      await this.conversationStore.archiveConversation(current.conversationId);
+      await this.conversationStore.archiveConversation(current.conversationId, params.archiveCause);
     }
 
     if (!params.createReplacement) {
@@ -4180,7 +4193,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
   }): Promise<void> {
     const reason = params.reason?.trim();
-    if (reason !== "new" && reason !== "reset") {
+    if (reason !== HOST_BEFORE_RESET_REASON_NEW && reason !== HOST_BEFORE_RESET_REASON_RESET) {
       return;
     }
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
@@ -4195,7 +4208,7 @@ export class LcmContextEngine implements ContextEngine {
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
       async () =>
         this.conversationStore.withTransaction(async () => {
-          if (reason === "new") {
+          if (reason === HOST_BEFORE_RESET_REASON_NEW) {
             const conversation = await this.conversationStore.getConversationForSession({
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
@@ -4217,6 +4230,7 @@ export class LcmContextEngine implements ContextEngine {
           }
           await this.applySessionReplacement({
             reason: "/reset",
+            archiveCause: "manual-reset",
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             createReplacement: true,
@@ -4251,7 +4265,7 @@ export class LcmContextEngine implements ContextEngine {
       return;
     }
 
-    const createReplacement = reason !== "deleted";
+    const createReplacement = reason !== HOST_SESSION_END_REASON_DELETED;
     this.ensureMigrated();
     await this.withSessionQueue(
       this.resolveSessionQueueKey(params.nextSessionId ?? params.sessionId, params.sessionKey ?? params.nextSessionKey),
@@ -4259,6 +4273,8 @@ export class LcmContextEngine implements ContextEngine {
         this.conversationStore.withTransaction(async () => {
           await this.applySessionReplacement({
             reason: `session_end:${reason}`,
+            archiveCause:
+              reason === HOST_SESSION_END_REASON_DELETED ? "session-deleted" : "session-end",
             sessionId: params.sessionId,
             sessionKey: params.sessionKey ?? params.nextSessionKey,
             nextSessionId: params.nextSessionId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -101,11 +101,15 @@ const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
 
 // Host-contract dependency: the deliberate-vs-incidental archive distinction
 // relies on OpenClaw emitting these exact reason strings only for genuine
-// operator actions. If the host renames a reason, the archive-cause mapping in
-// the lifecycle handlers changes silently; the producer mapping test guards it.
+// operator actions. A real /reset surfaces BOTH a before_reset(reason=reset) and
+// a session_end(reason=reset), so both lifecycle handlers must map reset to
+// manual-reset; the COALESCE write makes the order between them irrelevant. If
+// the host renames a reason, the mapping changes silently; the producer mapping
+// test guards it.
 const HOST_BEFORE_RESET_REASON_NEW = "new";
 const HOST_BEFORE_RESET_REASON_RESET = "reset";
 const HOST_SESSION_END_REASON_DELETED = "deleted";
+const HOST_SESSION_END_REASON_RESET = "reset";
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
 type CompactionExecutionParams = {
@@ -4274,7 +4278,11 @@ export class LcmContextEngine implements ContextEngine {
           await this.applySessionReplacement({
             reason: `session_end:${reason}`,
             archiveCause:
-              reason === HOST_SESSION_END_REASON_DELETED ? "session-deleted" : "session-end",
+              reason === HOST_SESSION_END_REASON_DELETED
+                ? "session-deleted"
+                : reason === HOST_SESSION_END_REASON_RESET
+                  ? "manual-reset"
+                  : "session-end",
             sessionId: params.sessionId,
             sessionKey: params.sessionKey ?? params.nextSessionKey,
             nextSessionId: params.nextSessionId,

--- a/src/plugin/lcm-doctor-rollover-splits.ts
+++ b/src/plugin/lcm-doctor-rollover-splits.ts
@@ -1,6 +1,10 @@
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { getFileBackedDatabasePath } from "../db/connection.js";
-import { normalizeMessageContentForFullTextIndex } from "../store/conversation-store.js";
+import {
+  DELIBERATE_ARCHIVE_CAUSES,
+  normalizeMessageContentForFullTextIndex,
+} from "../store/conversation-store.js";
+import type { ArchiveCause } from "../store/conversation-store.js";
 import { withDatabaseTransaction } from "../transaction-mutex.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 
@@ -57,6 +61,7 @@ type ConversationRow = {
   session_key: string;
   active: number;
   archived_at: string | null;
+  archive_cause: string | null;
   created_at: string;
   messages: number;
   summaries: number;
@@ -145,6 +150,15 @@ function hasStrandedData(row: ConversationRow): boolean {
   );
 }
 
+// Deliberate archives (e.g. an operator /reset) are excluded from merge sources:
+// the user wiped that conversation on purpose. A legacy NULL cause stays
+// merge-eligible so a genuine pre-deploy broken split is never withheld.
+function isDeliberateArchive(row: ConversationRow): boolean {
+  return (
+    row.archive_cause !== null && DELIBERATE_ARCHIVE_CAUSES.has(row.archive_cause as ArchiveCause)
+  );
+}
+
 function isIsolatedCronSessionKey(sessionKey: string): boolean {
   const parts = sessionKey.split(":");
   return parts.length >= 4 && parts[0] === "agent" && parts[2] === "cron";
@@ -180,6 +194,7 @@ function loadConversationRows(db: DatabaseSync, sessionKey: string): Conversatio
          c.session_key,
          c.active,
          c.archived_at,
+         c.archive_cause,
          c.created_at,
          COALESCE((SELECT COUNT(*) FROM messages m WHERE m.conversation_id = c.conversation_id), 0) AS messages,
          COALESCE((SELECT COUNT(*) FROM summaries s WHERE s.conversation_id = c.conversation_id), 0) AS summaries,
@@ -279,7 +294,9 @@ function classifySessionKeyGroup(params: {
   }
 
   const rows = loadConversationRows(params.db, params.sessionKey);
-  const sources = rows.filter((row) => row.active === 0 && hasStrandedData(row));
+  const sources = rows.filter(
+    (row) => row.active === 0 && hasStrandedData(row) && !isDeliberateArchive(row),
+  );
   if (sources.length === 0) {
     return null;
   }

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -12,7 +12,7 @@ import { describeLogError } from "./lcm-log.js";
 import { isLikelyInjectedDeliveryOnlyTranscript, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, messageIdentity } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
-import type { ConversationStore } from "./store/conversation-store.js";
+import type { ArchiveCause, ConversationStore } from "./store/conversation-store.js";
 import { getTranscriptEntryMeta } from "./transcript.js";
 import { isMissingFileError } from "./value-utils.js";
 import type { SummaryStore } from "./store/summary-store.js";
@@ -44,6 +44,7 @@ export type AmbiguousSessionKeyRuntimeRollover = {
 /** Engine callback that closes the old conversation and optionally creates its replacement. */
 export type ApplySessionReplacementFn = (params: {
   reason: string;
+  archiveCause: ArchiveCause;
   sessionId?: string;
   sessionKey?: string;
   nextSessionId?: string;
@@ -116,6 +117,7 @@ export class SessionRolloverDetector {
     );
     await this.applySessionReplacement({
       reason: `${params.phase} session-file rollover fallback`,
+      archiveCause: "rollover-fallback",
       sessionId: activeByKey.sessionId,
       sessionKey: normalizedSessionKey,
       nextSessionId: params.sessionId,
@@ -167,6 +169,7 @@ export class SessionRolloverDetector {
     );
     await this.applySessionReplacement({
       reason: `${params.phase} isolated cron session rollover`,
+      archiveCause: "cron-rotation",
       sessionId: activeByKey.sessionId,
       sessionKey: normalizedSessionKey,
       nextSessionId: normalizedSessionId,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -138,6 +138,21 @@ export type ConversationRecord = {
   updatedAt: Date;
 };
 
+/** Normalized provenance for a conversation archive, set at the archive funnel. */
+export type ArchiveCause =
+  | "manual-reset"
+  | "session-deleted"
+  | "session-end"
+  | "rollover-fallback"
+  | "cron-rotation";
+
+// Causes the rollover-split doctor must never auto-restore. Ships with
+// `manual-reset` only: a deliberate operator wipe is rock-solid intent. The other
+// causes are recorded but stay merge-eligible because the safe direction is
+// over-restore (today's behavior); promoting `session-deleted` once the host
+// deletion contract is confirmed is a one-line follow-up.
+export const DELIBERATE_ARCHIVE_CAUSES: ReadonlySet<ArchiveCause> = new Set(["manual-reset"]);
+
 export type MessageSearchInput = {
   conversationId?: ConversationId;
   conversationIds?: ConversationId[];
@@ -610,16 +625,20 @@ export class ConversationStore {
       .run(conversationId);
   }
 
-  async archiveConversation(conversationId: ConversationId): Promise<void> {
+  // Single archive funnel: deliberate archives must flow through here with their
+  // cause. The direct-insert archived-row path (createConversation active:false)
+  // leaves archive_cause NULL = merge-eligible by design.
+  async archiveConversation(conversationId: ConversationId, cause: ArchiveCause): Promise<void> {
     this.db
       .prepare(
         `UPDATE conversations
        SET active = 0,
            archived_at = COALESCE(archived_at, datetime('now')),
+           archive_cause = COALESCE(archive_cause, ?),
            updated_at = datetime('now')
        WHERE conversation_id = ?`,
       )
-      .run(conversationId);
+      .run(cause, conversationId);
   }
 
   async rebindConversationSession(

--- a/test/archive-cause-write.test.ts
+++ b/test/archive-cause-write.test.ts
@@ -90,6 +90,31 @@ describe("archive_cause producers", () => {
     expect(row.archive_cause).toBe("session-deleted");
   });
 
+  it("tags a session_end reset (a real /reset also fires session_end) as manual-reset", async () => {
+    const { engine, db, conversationStore } = setup();
+    const sessionKey = "agent:test:main:session-end-reset";
+    const conversation = await conversationStore.getOrCreateConversation("session-reset-end-old", {
+      sessionKey,
+    });
+    await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "hello",
+      tokenCount: 3,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "reset",
+      sessionId: "session-reset-end-old",
+      sessionKey,
+    });
+
+    const row = readArchiveState(db, conversation.conversationId);
+    expect(row.active).toBe(0);
+    expect(row.archive_cause).toBe("manual-reset");
+  });
+
   it("tags any other session_end reason as session-end", async () => {
     const { engine, db, conversationStore } = setup();
     const sessionKey = "agent:test:main:ended";
@@ -105,7 +130,7 @@ describe("archive_cause producers", () => {
     });
 
     await engine.handleSessionEnd({
-      reason: "expired",
+      reason: "idle",
       sessionId: "session-end-old",
       sessionKey,
       nextSessionId: "session-end-new",

--- a/test/archive-cause-write.test.ts
+++ b/test/archive-cause-write.test.ts
@@ -1,0 +1,183 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLcmDatabaseConnection } from "../src/db/connection.js";
+import { LcmContextEngine } from "../src/engine.js";
+import { SessionRolloverDetector } from "../src/session-rollover.js";
+import type { ApplySessionReplacementFn } from "../src/session-rollover.js";
+import { cleanupEngineTestState, createTestConfig, createTestDeps, tempDirs } from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+function setup() {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-archive-write-"));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, "lcm.db");
+  const config = createTestConfig(dbPath);
+  const deps = createTestDeps(config);
+  const db = createLcmDatabaseConnection(dbPath);
+  const engine = new LcmContextEngine(deps, db);
+  (engine as unknown as { ensureMigrated(): void }).ensureMigrated();
+  return {
+    tempDir,
+    dbPath,
+    db,
+    deps,
+    engine,
+    conversationStore: engine.getConversationStore(),
+    summaryStore: engine.getSummaryStore(),
+  };
+}
+
+function readArchiveState(
+  db: ReturnType<typeof createLcmDatabaseConnection>,
+  conversationId: number,
+): { active: number; archive_cause: string | null } {
+  return db
+    .prepare(`SELECT active, archive_cause FROM conversations WHERE conversation_id = ?`)
+    .get(conversationId) as { active: number; archive_cause: string | null };
+}
+
+describe("archive_cause producers", () => {
+  it("tags a deliberate /reset archive as manual-reset", async () => {
+    const { engine, db, conversationStore } = setup();
+    const sessionKey = "agent:test:main:reset";
+    const conversation = await conversationStore.getOrCreateConversation("session-reset-old", {
+      sessionKey,
+    });
+    await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "hello",
+      tokenCount: 3,
+    });
+
+    await engine.handleBeforeReset({
+      reason: "reset",
+      sessionId: "session-reset-old",
+      sessionKey,
+    });
+
+    const row = readArchiveState(db, conversation.conversationId);
+    expect(row.active).toBe(0);
+    expect(row.archive_cause).toBe("manual-reset");
+  });
+
+  it("tags a host delete (session_end reason=deleted) as session-deleted", async () => {
+    const { engine, db, conversationStore } = setup();
+    const sessionKey = "agent:test:main:deleted";
+    const conversation = await conversationStore.getOrCreateConversation("session-del-old", {
+      sessionKey,
+    });
+    await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "hello",
+      tokenCount: 3,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "deleted",
+      sessionId: "session-del-old",
+      sessionKey,
+    });
+
+    const row = readArchiveState(db, conversation.conversationId);
+    expect(row.active).toBe(0);
+    expect(row.archive_cause).toBe("session-deleted");
+  });
+
+  it("tags any other session_end reason as session-end", async () => {
+    const { engine, db, conversationStore } = setup();
+    const sessionKey = "agent:test:main:ended";
+    const conversation = await conversationStore.getOrCreateConversation("session-end-old", {
+      sessionKey,
+    });
+    await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "hello",
+      tokenCount: 3,
+    });
+
+    await engine.handleSessionEnd({
+      reason: "expired",
+      sessionId: "session-end-old",
+      sessionKey,
+      nextSessionId: "session-end-new",
+      nextSessionKey: sessionKey,
+    });
+
+    const row = readArchiveState(db, conversation.conversationId);
+    expect(row.active).toBe(0);
+    expect(row.archive_cause).toBe("session-end");
+  });
+
+  it("tags a session-file rollover fallback as rollover-fallback", async () => {
+    const { conversationStore, summaryStore, deps, tempDir } = setup();
+    const calls: Parameters<ApplySessionReplacementFn>[0][] = [];
+    const recordReplacement: ApplySessionReplacementFn = async (params) => {
+      calls.push(params);
+    };
+    const detector = new SessionRolloverDetector(
+      conversationStore,
+      summaryStore,
+      deps,
+      recordReplacement,
+    );
+
+    const sessionKey = "agent:test:main:rollover";
+    const conversation = await conversationStore.getOrCreateConversation("session-rollover-old", {
+      sessionKey,
+    });
+    await summaryStore.upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: join(tempDir, "missing-transcript.jsonl"),
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+    });
+
+    const rotated = await detector.rotateStaleSessionKeyConversationIfTrackedTranscriptMissing({
+      phase: "assemble",
+      sessionId: "session-rollover-new",
+      sessionKey,
+    });
+
+    expect(rotated).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.archiveCause).toBe("rollover-fallback");
+  });
+
+  it("tags an isolated cron runtime rollover as cron-rotation", async () => {
+    const { conversationStore, summaryStore, deps } = setup();
+    const calls: Parameters<ApplySessionReplacementFn>[0][] = [];
+    const recordReplacement: ApplySessionReplacementFn = async (params) => {
+      calls.push(params);
+    };
+    const detector = new SessionRolloverDetector(
+      conversationStore,
+      summaryStore,
+      deps,
+      recordReplacement,
+    );
+
+    const sessionKey = "agent:test:cron:nightly";
+    await conversationStore.getOrCreateConversation("cron-old", { sessionKey });
+
+    const rotated = await detector.rotateIsolatedCronConversationIfRuntimeChanged({
+      phase: "assemble",
+      sessionId: "cron-new",
+      sessionKey,
+      createReplacement: true,
+    });
+
+    expect(rotated).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.archiveCause).toBe("cron-rotation");
+  });
+});

--- a/test/doctor-archive-cause-skip.test.ts
+++ b/test/doctor-archive-cause-skip.test.ts
@@ -1,0 +1,274 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import type { ArchiveCause } from "../src/store/conversation-store.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { SummaryStore } from "../src/store/summary-store.js";
+import {
+  applyRolloverSplitRepair,
+  scanRolloverSplits,
+} from "../src/plugin/lcm-doctor-rollover-splits.js";
+
+type Fixture = {
+  tempDir: string;
+  dbPath: string;
+  db: ReturnType<typeof createLcmDatabaseConnection>;
+  conversationStore: ConversationStore;
+  summaryStore: SummaryStore;
+};
+
+const tempDirs = new Set<string>();
+const dbPaths = new Set<string>();
+
+afterEach(() => {
+  for (const dbPath of dbPaths) {
+    closeLcmConnection(dbPath);
+  }
+  dbPaths.clear();
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+function createFixture(): Fixture {
+  const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-archive-cause-"));
+  const dbPath = join(tempDir, "lcm.db");
+  const db = createLcmDatabaseConnection(dbPath);
+  const { fts5Available } = getLcmDbFeatures(db);
+  runLcmMigrations(db, { fts5Available });
+  const conversationStore = new ConversationStore(db, { fts5Available });
+  const summaryStore = new SummaryStore(db, { fts5Available });
+  tempDirs.add(tempDir);
+  dbPaths.add(dbPath);
+  return { tempDir, dbPath, db, conversationStore, summaryStore };
+}
+
+async function seedConversationWithMessage(
+  fixture: Fixture,
+  params: { sessionId: string; sessionKey: string; label: string },
+): Promise<number> {
+  const conversation = await fixture.conversationStore.createConversation({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+  });
+  const message = await fixture.conversationStore.createMessage({
+    conversationId: conversation.conversationId,
+    seq: 0,
+    role: "user",
+    content: `${params.label} message`,
+    tokenCount: 5,
+  });
+  await fixture.summaryStore.appendContextMessage(conversation.conversationId, message.messageId);
+  return conversation.conversationId;
+}
+
+function setConversationTimes(
+  fixture: Fixture,
+  conversationId: number,
+  createdAt: string,
+  archivedAt?: string,
+): void {
+  fixture.db
+    .prepare(
+      `UPDATE conversations
+       SET created_at = ?,
+           archived_at = COALESCE(?, archived_at),
+           updated_at = ?
+       WHERE conversation_id = ?`,
+    )
+    .run(createdAt, archivedAt ?? null, archivedAt ?? createdAt, conversationId);
+}
+
+function setArchiveCause(fixture: Fixture, conversationId: number, cause: string | null): void {
+  fixture.db
+    .prepare(`UPDATE conversations SET archive_cause = ? WHERE conversation_id = ?`)
+    .run(cause, conversationId);
+}
+
+function messageCount(fixture: Fixture, conversationId: number): number {
+  return (
+    fixture.db
+      .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
+      .get(conversationId) as { count: number }
+  ).count;
+}
+
+function activeFlag(fixture: Fixture, conversationId: number): number {
+  return (
+    fixture.db
+      .prepare(`SELECT active FROM conversations WHERE conversation_id = ?`)
+      .get(conversationId) as { active: number }
+  ).active;
+}
+
+async function archiveWithCause(
+  fixture: Fixture,
+  conversationId: number,
+  cause: ArchiveCause,
+  createdAt: string,
+  archivedAt: string,
+): Promise<void> {
+  await fixture.conversationStore.archiveConversation(conversationId, cause);
+  setConversationTimes(fixture, conversationId, createdAt, archivedAt);
+}
+
+describe("doctor rollover-split repair respects archive_cause", () => {
+  it("never restores a deliberate /reset (manual-reset) archive", async () => {
+    const fixture = createFixture();
+    const sessionKey = "agent:test:main:reset-skip";
+
+    const resetId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-reset-old",
+      sessionKey,
+      label: "reset_old",
+    });
+    await archiveWithCause(fixture, resetId, "manual-reset", "2026-06-17 01:00:00", "2026-06-17 01:05:00");
+
+    const activeId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-reset-new",
+      sessionKey,
+      label: "active",
+    });
+    setConversationTimes(fixture, activeId, "2026-06-17 01:10:00");
+
+    const scan = scanRolloverSplits(fixture.db);
+    expect(scan.safe.map((group) => group.sessionKey)).not.toContain(sessionKey);
+    expect(scan.needsReview.map((group) => group.sessionKey)).not.toContain(sessionKey);
+
+    const result = await applyRolloverSplitRepair({ db: fixture.db, databasePath: fixture.dbPath });
+    expect(result.kind).toBe("applied");
+
+    // The deliberately wiped conversation keeps its own messages; the active
+    // successor never inherits them.
+    expect(messageCount(fixture, resetId)).toBe(1);
+    expect(activeFlag(fixture, resetId)).toBe(0);
+    expect(messageCount(fixture, activeId)).toBe(1);
+  });
+
+  it("still repairs a genuine rollover-fallback archive", async () => {
+    const fixture = createFixture();
+    const sessionKey = "agent:test:main:rollover-merge";
+
+    const strandedId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-rollover-old",
+      sessionKey,
+      label: "stranded",
+    });
+    await archiveWithCause(
+      fixture,
+      strandedId,
+      "rollover-fallback",
+      "2026-06-17 02:00:00",
+      "2026-06-17 02:05:00",
+    );
+
+    const activeId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-rollover-new",
+      sessionKey,
+      label: "active",
+    });
+    setConversationTimes(fixture, activeId, "2026-06-17 02:10:00");
+
+    const scan = scanRolloverSplits(fixture.db);
+    const safe = scan.safe.find((group) => group.sessionKey === sessionKey);
+    expect(safe).toBeDefined();
+    expect(safe?.sourceConversationIds).toEqual([strandedId]);
+    expect(safe?.targetConversationId).toBe(activeId);
+
+    const result = await applyRolloverSplitRepair({ db: fixture.db, databasePath: fixture.dbPath });
+    expect(result.kind).toBe("applied");
+
+    expect(messageCount(fixture, strandedId)).toBe(0);
+    expect(messageCount(fixture, activeId)).toBe(2);
+  });
+
+  it("treats a legacy NULL archive_cause as merge-eligible", async () => {
+    const fixture = createFixture();
+    const sessionKey = "agent:test:main:legacy-null";
+
+    const strandedId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-legacy-old",
+      sessionKey,
+      label: "legacy",
+    });
+    await archiveWithCause(
+      fixture,
+      strandedId,
+      "rollover-fallback",
+      "2026-06-17 03:00:00",
+      "2026-06-17 03:05:00",
+    );
+    // Simulate a row archived before the column existed: provenance unknown.
+    setArchiveCause(fixture, strandedId, null);
+
+    const activeId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-legacy-new",
+      sessionKey,
+      label: "active",
+    });
+    setConversationTimes(fixture, activeId, "2026-06-17 03:10:00");
+
+    const scan = scanRolloverSplits(fixture.db);
+    const safe = scan.safe.find((group) => group.sessionKey === sessionKey);
+    expect(safe).toBeDefined();
+    expect(safe?.sourceConversationIds).toEqual([strandedId]);
+
+    const result = await applyRolloverSplitRepair({ db: fixture.db, databasePath: fixture.dbPath });
+    expect(result.kind).toBe("applied");
+
+    expect(messageCount(fixture, strandedId)).toBe(0);
+    expect(messageCount(fixture, activeId)).toBe(2);
+  });
+
+  it("merges only the rollover row in a mixed group, leaving the reset row intact", async () => {
+    const fixture = createFixture();
+    const sessionKey = "agent:test:main:mixed-group";
+
+    const resetId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-mixed-reset",
+      sessionKey,
+      label: "reset",
+    });
+    await archiveWithCause(fixture, resetId, "manual-reset", "2026-06-17 04:00:00", "2026-06-17 04:05:00");
+
+    const rolloverId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-mixed-rollover",
+      sessionKey,
+      label: "rollover",
+    });
+    await archiveWithCause(
+      fixture,
+      rolloverId,
+      "rollover-fallback",
+      "2026-06-17 04:06:00",
+      "2026-06-17 04:10:00",
+    );
+
+    const activeId = await seedConversationWithMessage(fixture, {
+      sessionId: "session-mixed-new",
+      sessionKey,
+      label: "active",
+    });
+    setConversationTimes(fixture, activeId, "2026-06-17 04:11:00");
+
+    const scan = scanRolloverSplits(fixture.db);
+    const safe = scan.safe.find((group) => group.sessionKey === sessionKey);
+    expect(safe).toBeDefined();
+    expect(safe?.sourceConversationIds).toEqual([rolloverId]);
+    expect(safe?.targetConversationId).toBe(activeId);
+
+    const result = await applyRolloverSplitRepair({ db: fixture.db, databasePath: fixture.dbPath });
+    expect(result.kind).toBe("applied");
+
+    // Reset row untouched; only the rollover row is merged into the active row.
+    expect(messageCount(fixture, resetId)).toBe(1);
+    expect(activeFlag(fixture, resetId)).toBe(0);
+    expect(messageCount(fixture, rolloverId)).toBe(0);
+    expect(messageCount(fixture, activeId)).toBe(2);
+  });
+});

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -889,7 +889,7 @@ describe("ConversationStore session reuse", () => {
     const sessionKey = "agent:main:test:archived-lookup";
 
     const archived = await store.getOrCreateConversation(sessionId, { sessionKey });
-    await store.archiveConversation(archived.conversationId);
+    await store.archiveConversation(archived.conversationId, "rollover-fallback");
 
     expect(
       await store.getConversationForSession({

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -472,7 +472,7 @@ describe("lcm command", () => {
       label: "statusold",
       includeSummary: true,
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
 
     const active = await fixture.conversationStore.createConversation({
       sessionId: "status-rollover-new",
@@ -1697,7 +1697,7 @@ describe("lcm command", () => {
       label: "detect_old",
       includeSummary: true,
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
     const active = await fixture.conversationStore.createConversation({
       sessionId: "rollover-detect-new",
       sessionKey,
@@ -1732,7 +1732,7 @@ describe("lcm command", () => {
       includeLargeFile: true,
       includeFocusBrief: true,
     });
-    await fixture.conversationStore.archiveConversation(firstArchived.conversationId);
+    await fixture.conversationStore.archiveConversation(firstArchived.conversationId, "rollover-fallback");
 
     const secondArchived = await fixture.conversationStore.createConversation({
       sessionId: "rollover-apply-old-2",
@@ -1743,7 +1743,7 @@ describe("lcm command", () => {
       label: "oldtwo",
       includeSummary: true,
     });
-    await fixture.conversationStore.archiveConversation(secondArchived.conversationId);
+    await fixture.conversationStore.archiveConversation(secondArchived.conversationId, "rollover-fallback");
 
     const active = await fixture.conversationStore.createConversation({
       sessionId: "rollover-apply-new",
@@ -1905,7 +1905,7 @@ describe("lcm command", () => {
       label: "oldfk",
       includeSummary: true,
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
 
     const active = await fixture.conversationStore.createConversation({
       sessionId: "rollover-preexisting-fk-new",
@@ -1973,7 +1973,7 @@ describe("lcm command", () => {
       label: "collision_old",
       transcriptEntryId: "duplicate-entry-id",
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
     const active = await fixture.conversationStore.createConversation({
       sessionId: "rollover-collision-new",
       sessionKey,
@@ -2019,7 +2019,7 @@ describe("lcm command", () => {
       includeSummary: true,
       includeFocusBrief: true,
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
     const active = await fixture.conversationStore.createConversation({
       sessionId: "cron-rollover-new",
       sessionKey,
@@ -2103,7 +2103,7 @@ describe("lcm command", () => {
         tokenCount: 4,
       },
     ]);
-    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId);
+    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId, "rollover-fallback");
 
     const cronConversation = await fixture.conversationStore.createConversation({
       sessionId: "doctor-cleaner-cron",
@@ -2153,7 +2153,7 @@ describe("lcm command", () => {
       },
     ]);
 
-    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId);
+    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId, "rollover-fallback");
 
     const liveNullSubagent = await fixture.conversationStore.createConversation({
       sessionId: "doctor-cleaner-live-null-subagent",
@@ -2239,7 +2239,7 @@ describe("lcm command", () => {
         tokenCount: 5,
       },
     ]);
-    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId);
+    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId, "rollover-fallback");
 
     const cronConversation = await fixture.conversationStore.createConversation({
       sessionId: "doctor-cleaner-apply-cron",
@@ -2274,7 +2274,7 @@ describe("lcm command", () => {
         tokenCount: 4,
       },
     ]);
-    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId);
+    await fixture.conversationStore.archiveConversation(nullSubagent.conversationId, "rollover-fallback");
 
     const liveNullSubagent = await fixture.conversationStore.createConversation({
       sessionId: "doctor-cleaner-apply-live-null",
@@ -2354,7 +2354,7 @@ describe("lcm command", () => {
         tokenCount: 5,
       },
     ]);
-    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId);
+    await fixture.conversationStore.archiveConversation(archivedSubagent.conversationId, "rollover-fallback");
 
     const cronConversation = await fixture.conversationStore.createConversation({
       sessionId: "doctor-cleaner-single-cron",
@@ -3664,7 +3664,7 @@ describe("lcm command", () => {
       sessionId: "shared-key-old",
       sessionKey: "agent:main:main",
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
     const active = await fixture.conversationStore.createConversation({
       sessionId: "shared-key-new",
       sessionKey: "agent:main:main",
@@ -3689,7 +3689,7 @@ describe("lcm command", () => {
       sessionId: "shared-session-id",
       sessionKey: "agent:main:archived",
     });
-    await fixture.conversationStore.archiveConversation(archived.conversationId);
+    await fixture.conversationStore.archiveConversation(archived.conversationId, "rollover-fallback");
     const active = await fixture.conversationStore.createConversation({
       sessionId: "shared-session-id",
       sessionKey: "agent:main:active",

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -534,6 +534,45 @@ describe("runLcmMigrations summary depth backfill", () => {
     ).toThrow();
   });
 
+  it("adds a nullable archive_cause column to legacy conversations idempotently", () => {
+    const db = createTestDb("archive-cause.db");
+
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        session_key TEXT,
+        active INTEGER NOT NULL DEFAULT 1,
+        archived_at TEXT,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.prepare(`INSERT INTO conversations (session_id, session_key) VALUES (?, ?)`).run(
+      "legacy-session",
+      "agent:test:main:legacy",
+    );
+
+    runLcmMigrations(db, { fts5Available: false });
+
+    const columns = db.prepare(`PRAGMA table_info(conversations)`).all() as Array<{ name: string }>;
+    expect(columns.some((column) => column.name === "archive_cause")).toBe(true);
+
+    const legacyRow = db
+      .prepare(`SELECT archive_cause FROM conversations WHERE session_key = ?`)
+      .get("agent:test:main:legacy") as { archive_cause: string | null };
+    expect(legacyRow.archive_cause).toBeNull();
+
+    // Second run is a no-op: re-adding the column would throw "duplicate column name".
+    expect(() => runLcmMigrations(db, { fts5Available: false })).not.toThrow();
+
+    const archiveCauseColumns = (
+      db.prepare(`PRAGMA table_info(conversations)`).all() as Array<{ name: string }>
+    ).filter((column) => column.name === "archive_cause");
+    expect(archiveCauseColumns).toHaveLength(1);
+  });
+
   it("creates focus brief tables and indexes outside the summary DAG", () => {
     const db = createTestDb("focus-briefs.db");
 


### PR DESCRIPTION
## Problem

The rollover-split doctor (`/lossless doctor apply rollover-splits`) merges archived "stranded" conversation rows back into the active conversation for a session key, recovering conversations that an abrupt crash or session rollover accidentally split off. Its classifier (`classifySessionKeyGroup`) keys only on `active`, `archived_at`, chronology, and stranded-data counts.

But a deliberate operator `/reset` also archives the active conversation (and starts a fresh one), and it archives through the exact same `applySessionReplacement` to `archiveConversation` funnel as a crash rollover. The `reason` is passed in but never persisted, and no column records why a row was archived. So the doctor cannot tell a deliberate `/reset` from a crash, and it resurrects conversations the user intentionally wiped, re-merging their messages back into the active context.

## Fix

Persist the archive provenance. A new nullable column `conversations.archive_cause` is written at the single archive funnel with a normalized cause:

`manual-reset | session-deleted | session-end | rollover-fallback | cron-rotation`

The doctor then excludes deliberately-archived rows from its merge `sources`:

```ts
export const DELIBERATE_ARCHIVE_CAUSES = new Set(["manual-reset"]);
// sources filter:
row.active === 0 && hasStrandedData(row) && !isDeliberateArchive(row)
```

The exclusion is per-row, not per-group: a session key holding both a deliberate `manual-reset` row and a genuine `rollover-fallback` row still merges the rollover row into the active target while leaving the reset row untouched. If the filter empties the source set, the classifier already returns no finding, so the normal "reset then fresh successor" shape produces no doctor noise.

## Conservative scope

Ships with `manual-reset` as the only skipped cause. A `/reset` is unambiguous operator intent. `session-deleted` is recorded but left merge-eligible for now, because it depends on the host emitting its delete reason only for deliberate deletes (not automated tombstone or cleanup pruning); promoting it is a one-line follow-up once that contract is confirmed. Every other cause stays merge-eligible, so the safety-critical direction is preserved: the doctor never withholds recovery of a genuine broken split.

## Backward compatibility

The column is additive and nullable (no default, no index, no backfill). Existing archived rows read NULL, which is treated as unknown provenance and stays merge-eligible (today's behavior). The only behavioral change is the doctor declining to merge rows positively marked as a deliberate reset, which can only be rows archived after this change. A `/reset` archived before deploy can still be over-restored at most once; the gap self-heals forward as new resets carry the marker.

The archive write uses `archive_cause = COALESCE(archive_cause, ?)`, so the first recorded cause is retained if a conversation were ever archived twice. In practice the funnel only re-archives an active conversation and a reset cannot re-touch an already-archived row, so this is the protective direction and does not arise in normal operation.

## Host-contract dependency

The deliberate-vs-incidental distinction relies on the host emitting its lifecycle reason strings (`reset`, `deleted`) only for genuine operator actions. A real `/reset` surfaces as **both** a `before_reset(reason=reset)` and a `session_end(reason=reset)`, so both lifecycle handlers map the reset reason to `manual-reset`; the `COALESCE` write keeps the cause stable whichever event closes the conversation first. Incidental `session_end` reasons (`idle`, `daily`, `compaction`) stay `session-end` and remain merge-eligible, and `new`/`restart`/`shutdown`/`unknown` never archive at all (they hit the handler's early-return guard). Those strings are centralized into named constants at the mapping site with a comment, and producer-mapping tests assert the mapping for both lifecycle events so a host-side rename cannot silently change which archives are skipped.

## Tests

- `test/doctor-archive-cause-skip.test.ts`: a `manual-reset` archive appears in neither the safe nor needs-review scan and is left unmerged after apply; a `rollover-fallback` split still merges; a legacy NULL row still merges; a mixed group merges only the rollover row.
- `test/archive-cause-write.test.ts`: the real `/reset`, `session_end`, and rollover and cron paths persist the expected cause.
- `test/migration.test.ts`: the column is added idempotently to an existing DB; legacy rows read NULL; a second migration run is a no-op.

No public type or API changes. The full suite passes (1468 tests) and the typecheck is clean.
