### PR TITLE
fix(doctor-contract): honor explicit provider in fallbackProviders model refs

### DIFF
--- a/.changeset/blue-signs-swim.md
+++ b/.changeset/blue-signs-swim.md
@@ -1,0 +1,5 @@
+---
+"lossless-claw": patch
+---
+
+Fix `doctor-contract` model reference generation to honor the explicit `provider` field in `fallbackProviders` when the model value also contains a slash, preventing false "Missing allowedModels entries" override-policy warnings.

--- a/doctor-contract-api.js
+++ b/doctor-contract-api.js
@@ -44,14 +44,10 @@ function readSubagentPolicy(cfg) {
   return readModelOverridePolicy(cfg, "subagent");
 }
 
-function toModelRef(provider, model) {
+function toProviderPrefixedModelRef(provider, model) {
   const modelId = readString(model);
   if (!modelId) {
     return undefined;
-  }
-  const providerId = readString(provider);
-  if (providerId) {
-    return `${providerId}/${modelId}`;
   }
   const slash = modelId.indexOf("/");
   if (slash > 0 && slash < modelId.length - 1) {
@@ -59,7 +55,14 @@ function toModelRef(provider, model) {
     const directModel = modelId.slice(slash + 1).trim();
     return directProvider && directModel ? `${directProvider}/${directModel}` : undefined;
   }
-  return undefined;
+  const providerId = readString(provider);
+  return providerId ? `${providerId}/${modelId}` : undefined;
+}
+
+function toFallbackModelRef(provider, model) {
+  const providerId = readString(provider);
+  const modelId = readString(model);
+  return providerId && modelId ? `${providerId}/${modelId}` : undefined;
 }
 
 function uniqueModelRefs(modelRefs) {
@@ -88,7 +91,7 @@ function collectLosslessRuntimeLlmModelRefs(cfg) {
     if (!modelId) {
       return;
     }
-    const modelRef = toModelRef(provider, modelId);
+    const modelRef = toProviderPrefixedModelRef(provider, modelId);
     if (modelRef) {
       modelRefs.push({ field, modelRef, configPath });
       return;
@@ -124,7 +127,7 @@ function collectLosslessRuntimeLlmModelRefs(cfg) {
         });
         continue;
       }
-      const modelRef = toModelRef(fallback.provider, fallback.model);
+      const modelRef = toFallbackModelRef(fallback.provider, fallback.model);
       if (modelRef) {
         modelRefs.push({
           field: "fallbackProviders",
@@ -159,7 +162,7 @@ function collectLosslessSubagentModelRefs(cfg) {
   const skipped = [];
   const modelId = readString(config.expansionModel);
   if (modelId) {
-    const modelRef = toModelRef(config.expansionProvider, modelId);
+    const modelRef = toProviderPrefixedModelRef(config.expansionProvider, modelId);
     if (modelRef) {
       modelRefs.push({
         field: "expansionModel",

--- a/doctor-contract-api.js
+++ b/doctor-contract-api.js
@@ -49,14 +49,17 @@ function toModelRef(provider, model) {
   if (!modelId) {
     return undefined;
   }
+  const providerId = readString(provider);
+  if (providerId) {
+    return `${providerId}/${modelId}`;
+  }
   const slash = modelId.indexOf("/");
   if (slash > 0 && slash < modelId.length - 1) {
     const directProvider = modelId.slice(0, slash).trim();
     const directModel = modelId.slice(slash + 1).trim();
     return directProvider && directModel ? `${directProvider}/${directModel}` : undefined;
   }
-  const providerId = readString(provider);
-  return providerId ? `${providerId}/${modelId}` : undefined;
+  return undefined;
 }
 
 function uniqueModelRefs(modelRefs) {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -980,7 +980,7 @@ function stringifyRuntimeLlmContent(content: unknown): string {
 }
 
 /** Build the optional provider/model override ref accepted by runtime.llm.complete. */
-function buildRuntimeModelRef(provider: string | undefined, model: string): string | undefined {
+function buildProviderPrefixedRuntimeModelRef(provider: string | undefined, model: string): string | undefined {
   const modelId = model.trim();
   if (!modelId) {
     return undefined;
@@ -1065,7 +1065,7 @@ function buildConfiguredModelRequirement(params: {
   if (!modelId) {
     return undefined;
   }
-  const modelRef = buildRuntimeModelRef(
+  const modelRef = buildProviderPrefixedRuntimeModelRef(
     typeof params.provider === "string" ? params.provider.trim() : undefined,
     modelId,
   );
@@ -1082,6 +1082,36 @@ function buildConfiguredModelRequirement(params: {
   }
   return {
     configField: params.configField,
+    configPath: params.configPath,
+    modelRef,
+  };
+}
+
+/** Convert a fallback provider entry to the runtime ref used for policy validation. */
+function buildFallbackModelRequirement(params: {
+  configPath: string;
+  provider?: unknown;
+  model?: unknown;
+}): RuntimeLlmPolicyRequirement | { unresolved: RuntimeLlmPolicyCheck["unresolved"][number] } | undefined {
+  const providerId = typeof params.provider === "string" ? params.provider.trim() : "";
+  const modelId = typeof params.model === "string" ? params.model.trim() : "";
+  if (!providerId && !modelId) {
+    return undefined;
+  }
+  if (!providerId || !modelId) {
+    return {
+      unresolved: {
+        configField: "fallbackProviders",
+        configPath: params.configPath,
+        reason:
+          `${params.configPath} needs both provider and model. ` +
+          `Use provider/model fallback entries so openclaw doctor --fix can update plugins.entries.lossless-claw.llm.allowedModels.`,
+      },
+    };
+  }
+  const modelRef = `${providerId}/${modelId}`;
+  return {
+    configField: "fallbackProviders",
     configPath: params.configPath,
     modelRef,
   };
@@ -1123,8 +1153,7 @@ function collectRuntimeLlmPolicyRequirements(config: LcmDependencies["config"]):
     model: config.largeFileSummaryModel,
   }));
   for (const [index, fallback] of config.fallbackProviders.entries()) {
-    add(buildConfiguredModelRequirement({
-      configField: "fallbackProviders",
+    add(buildFallbackModelRequirement({
       configPath: `plugins.entries.lossless-claw.config.fallbackProviders[${index}]`,
       provider: fallback.provider,
       model: fallback.model,

--- a/test/doctor-contract-api.test.ts
+++ b/test/doctor-contract-api.test.ts
@@ -202,6 +202,30 @@ describe("doctor contract runtime LLM compatibility", () => {
     expect(result.skipped).toEqual([]);
   });
 
+  it("does not combine summaryProvider with provider-prefixed summaryModel", () => {
+    const result = collectLosslessRuntimeLlmModelRefs({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              summaryProvider: "openrouter",
+              summaryModel: "anthropic/claude-sonnet-4-6",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.modelRefs).toEqual([
+      {
+        field: "summaryModel",
+        modelRef: "anthropic/claude-sonnet-4-6",
+        configPath: "plugins.entries.lossless-claw.config.summaryModel",
+      },
+    ]);
+    expect(result.skipped).toEqual([]);
+  });
+
   it("reports bare fallback models as skipped instead of inventing refs", () => {
     const result = collectLosslessRuntimeLlmModelRefs({
       plugins: {

--- a/test/doctor-contract-api.test.ts
+++ b/test/doctor-contract-api.test.ts
@@ -177,6 +177,31 @@ describe("doctor contract runtime LLM compatibility", () => {
     expect(mutation.config.plugins.entries["lossless-claw"].subagent.allowedModels).toEqual(["*"]);
   });
 
+  it("prefers explicit fallback provider over slash-parsed provider in model", () => {
+    const result = collectLosslessRuntimeLlmModelRefs({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              fallbackProviders: [
+                { provider: "openrouter", model: "anthropic/claude-sonnet-4-6" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.modelRefs).toEqual([
+      {
+        field: "fallbackProviders",
+        modelRef: "openrouter/anthropic/claude-sonnet-4-6",
+        configPath: "plugins.entries.lossless-claw.config.fallbackProviders[0]",
+      },
+    ]);
+    expect(result.skipped).toEqual([]);
+  });
+
   it("reports bare fallback models as skipped instead of inventing refs", () => {
     const result = collectLosslessRuntimeLlmModelRefs({
       plugins: {

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -967,6 +967,41 @@ describe("lcm plugin registration", () => {
     );
   });
 
+  it("uses fallbackProviders provider when checking runtime LLM policy", () => {
+    const { api, warnLog } = buildApi({
+      enabled: true,
+      fallbackProviders: [
+        { provider: "openrouter", model: "anthropic/claude-sonnet-4-6" },
+      ],
+    });
+    api.config = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              fallbackProviders: [
+                { provider: "openrouter", model: "anthropic/claude-sonnet-4-6" },
+              ],
+            },
+            llm: {
+              allowModelOverride: true,
+              allowedModels: ["openrouter/anthropic/claude-sonnet-4-6"],
+            },
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"];
+
+    lcmPlugin.register(api);
+
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("fallbackProviders=anthropic/claude-sonnet-4-6"),
+    );
+    expect(warnLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("Runtime LLM model override policy"),
+    );
+  });
+
   it("falls back to runtime plugin config for the startup banner when register runs before api.pluginConfig is populated", () => {
     const { api, infoLog } = buildApi(
       {},


### PR DESCRIPTION
When a `fallbackProviders` entry supplied an explicit `provider` (e.g. `openrouter`) and a `model` containing a slash (e.g. `anthropic/claude-sonnet-4-6`), `toModelRef()` ignored the explicit provider and parsed the provider from the model string. This produced a modelRef that did not match the configured override policy, causing false "Missing allowedModels entries" warnings from `openclaw doctor`.

Now `toModelRef()` prefers the explicit `provider` argument when present and only falls back to parsing provider/model from a slashed model string when no provider is given.

Fixes #853.