### PR TITLE
fix: delegate compact() to runtime for sessions excluded via ignoreSessionPatterns

### DIFF
--- a/.changeset/ignored-session-runtime-compact.md
+++ b/.changeset/ignored-session-runtime-compact.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Delegate ignored-session compaction to OpenClaw's runtime compaction path when the host exposes it, so sessions excluded from LCM can still recover from raw transcript pressure.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,7 +356,7 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 - `*` matches any characters except `:`
 - `**` matches anything, including `:`
 
-Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when a new runtime `sessionId` reuses the same `sessionKey`. Configure `ignoreSessionPatterns` for cron only when the run should bypass LCM entirely; leave cron sessions included when they need in-run compaction.
+Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when a new runtime `sessionId` reuses the same `sessionKey`. Configure `ignoreSessionPatterns` for cron only when the run should bypass LCM entirely; leave cron sessions included when they need in-run compaction. When OpenClaw exposes its runtime compaction delegate, `/compact` and overflow recovery for ignored sessions fall back to OpenClaw's built-in compaction path instead of LCM's summary DAG. Older hosts that do not expose that delegate keep the previous safe skip behavior.
 
 Example:
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -548,6 +548,7 @@ Why it matters:
 - keeps low-value automation or noisy sessions out of the DB
 - useful for excluding certain agent lanes or ephemeral traffic entirely
 - cron scheduler keys are already isolated per runtime run, so ignore them only when they should bypass LCM compaction
+- ignored-session `/compact` calls use OpenClaw's built-in runtime compaction delegate when the host exposes it; older hosts keep the previous safe skip behavior
 
 ### `statelessSessionPatterns`
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,6 @@ import type {
   SubagentEndReason,
   SubagentSpawnPreparation,
 } from "./openclaw-bridge.js";
-import { delegateCompactionToRuntime } from "openclaw/plugin-sdk";
 import { contentFromParts, ContextAssembler, pickToolCallId, pickToolIsError, pickToolName } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import { BatchDeduplicator } from "./batch-dedup.js";
@@ -3996,15 +3995,22 @@ export class LcmContextEngine implements ContextEngine {
     force?: boolean;
   }): Promise<CompactResult> {
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
-      // Excluded sessions get no LCM tracking (no DAG, no summary DB rows), so this
-      // plugin cannot compact them itself. Rather than a bare refusal — which OpenClaw
-      // core's preflight guard treats as a hard failure, not a safe skip — delegate to
-      // the framework's own stock compaction path (the same bridge its default
-      // no-plugin engine uses).
+      if (this.deps.delegateCompactionToRuntime) {
+        // Excluded sessions get no LCM tracking, so delegate to OpenClaw's
+        // runtime compaction when the host exposes that compatibility bridge.
+        this.deps.log.info(
+          `[lcm] compact: delegating to runtime session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded`,
+        );
+        return await this.deps.delegateCompactionToRuntime(params);
+      }
       this.deps.log.info(
-        `[lcm] compact: delegating to runtime session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded`,
+        `[lcm] compact: skipped session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded runtime_delegate=unavailable`,
       );
-      return await delegateCompactionToRuntime(params);
+      return {
+        ok: true,
+        compacted: false,
+        reason: "session excluded",
+      };
     }
     if (this.isStatelessSession(params.sessionKey)) {
       this.deps.log.info(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,6 +14,7 @@ import type {
   SubagentEndReason,
   SubagentSpawnPreparation,
 } from "./openclaw-bridge.js";
+import { delegateCompactionToRuntime } from "openclaw/plugin-sdk";
 import { contentFromParts, ContextAssembler, pickToolCallId, pickToolIsError, pickToolName } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
 import { BatchDeduplicator } from "./batch-dedup.js";
@@ -3995,14 +3996,15 @@ export class LcmContextEngine implements ContextEngine {
     force?: boolean;
   }): Promise<CompactResult> {
     if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+      // Excluded sessions get no LCM tracking (no DAG, no summary DB rows), so this
+      // plugin cannot compact them itself. Rather than a bare refusal — which OpenClaw
+      // core's preflight guard treats as a hard failure, not a safe skip — delegate to
+      // the framework's own stock compaction path (the same bridge its default
+      // no-plugin engine uses).
       this.deps.log.info(
-        `[lcm] compact: skipped session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded`,
+        `[lcm] compact: delegating to runtime session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""} reason=session_excluded`,
       );
-      return {
-        ok: true,
-        compacted: false,
-        reason: "session excluded",
-      };
+      return await delegateCompactionToRuntime(params);
     }
     if (this.isStatelessSession(params.sessionKey)) {
       this.deps.log.info(

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -30,10 +30,17 @@ import type {
   LcmDependencies,
   RuntimeLlmCompleteFn,
   RuntimeLlmModelOverride,
+  RuntimeCompactionDelegateFn,
   StartupSessionFileCandidate,
 } from "../types.js";
 
 const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.28";
+
+type PluginSdkCoreModule = {
+  delegateCompactionToRuntime?: RuntimeCompactionDelegateFn;
+};
+
+let pluginSdkCoreImport: Promise<PluginSdkCoreModule | null> | undefined;
 
 type ContextEngineCapableOpenClawPluginApi = OpenClawPluginApi & {
   registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
@@ -56,6 +63,36 @@ function parseAgentSessionKey(sessionKey: string): { agentId: string; suffix: st
     return null;
   }
   return { agentId, suffix };
+}
+
+/** Lazily load optional OpenClaw SDK helpers without raising the peer floor. */
+function loadPluginSdkCore(log: LcmDependencies["log"]): Promise<PluginSdkCoreModule | null> {
+  pluginSdkCoreImport ??= (Function("specifier", "return import(specifier)") as (
+    specifier: string,
+  ) => Promise<PluginSdkCoreModule>)("openclaw/plugin-sdk/core").catch((error: unknown) => {
+    log.debug(`[lcm] runtime compaction delegate unavailable: ${describeLogError(error)}`);
+    return null;
+  });
+  return pluginSdkCoreImport;
+}
+
+/** Create a late-bound delegate to OpenClaw's stock runtime compaction path. */
+function createRuntimeCompactionDelegate(log: LcmDependencies["log"]): RuntimeCompactionDelegateFn {
+  return async (params) => {
+    const core = await loadPluginSdkCore(log);
+    const delegate = core?.delegateCompactionToRuntime;
+    if (!delegate) {
+      log.debug(
+        `[lcm] runtime compaction delegate unavailable for ignored session=${params.sessionId}${params.sessionKey?.trim() ? ` sessionKey=${params.sessionKey.trim()}` : ""}`,
+      );
+      return {
+        ok: true,
+        compacted: false,
+        reason: "session excluded",
+      };
+    }
+    return await delegate(params);
+  };
 }
 
 /** Return a stable normalized agent id. */
@@ -1311,6 +1348,7 @@ function createLcmDependencies(
   return {
     config,
     configDiagnostics: diagnostics,
+    delegateCompactionToRuntime: createRuntimeCompactionDelegate(log),
     complete: async ({
       provider,
       model,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@
 
 import type { LcmConfig } from "./db/config.js";
 import type { LcmConfigDiagnostics } from "./db/config.js";
+import type { CompactResult } from "./openclaw-bridge.js";
 
 /**
  * Minimal LLM completion interface needed by LCM for summarization.
@@ -75,6 +76,20 @@ export type CompleteFn = (params: {
   reasoningIfSupported?: string;
 }) => Promise<CompletionResult>;
 
+/** Optional bridge to OpenClaw's built-in runtime compaction path. */
+export type RuntimeCompactionDelegateFn = (params: {
+  sessionId: string;
+  sessionKey?: string;
+  sessionFile: string;
+  tokenBudget?: number;
+  currentTokenCount?: number;
+  compactionTarget?: "budget" | "threshold";
+  customInstructions?: string;
+  runtimeContext?: Record<string, unknown>;
+  legacyParams?: Record<string, unknown>;
+  force?: boolean;
+}) => Promise<CompactResult>;
+
 /**
  * Gateway RPC call interface.
  */
@@ -124,6 +139,9 @@ export interface LcmDependencies {
 
   /** LLM completion function for summarization */
   complete: CompleteFn;
+
+  /** Optional OpenClaw runtime compaction delegate for sessions LCM intentionally ignores */
+  delegateCompactionToRuntime?: RuntimeCompactionDelegateFn;
 
   /** Gateway RPC call function (for subagent spawning, session ops) */
   callGateway: CallGatewayFn;

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -254,16 +254,27 @@ describe("LcmContextEngine ignored sessions", () => {
     expect(included.messages[0]?.content).toBe("persisted context");
   });
 
-  it("skips compact for ignored sessions while compact still evaluates included sessions", async () => {
-    const engine = createEngineWithConfig({
-      ignoreSessionPatterns: ["agent:*:cron:**"],
-    });
+  it("delegates compact for ignored sessions while compact still evaluates included sessions", async () => {
+    const delegateCompactionToRuntime = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      reason: "runtime compacted ignored session",
+      result: { summary: "runtime summary" },
+    }));
+    const ignoredSessionFile = createSessionFilePath("ignored-compact");
+    const engine = createEngineWithDeps(
+      { ignoreSessionPatterns: ["agent:*:cron:**"] },
+      { delegateCompactionToRuntime },
+    );
 
     const ignored = await engine.compact({
       sessionId: ignoredSessionId,
       sessionKey: ignoredSessionKey,
-      sessionFile: createSessionFilePath("ignored-compact"),
+      sessionFile: ignoredSessionFile,
       tokenBudget: 1000,
+      currentTokenCount: 2500,
+      compactionTarget: "budget",
+      runtimeContext: { workspaceDir: "/tmp/workspace" },
     });
 
     await engine.ingest({
@@ -278,13 +289,43 @@ describe("LcmContextEngine ignored sessions", () => {
       tokenBudget: 1000,
     });
 
+    expect(delegateCompactionToRuntime).toHaveBeenCalledTimes(1);
+    expect(delegateCompactionToRuntime).toHaveBeenCalledWith({
+      sessionId: ignoredSessionId,
+      sessionKey: ignoredSessionKey,
+      sessionFile: ignoredSessionFile,
+      tokenBudget: 1000,
+      currentTokenCount: 2500,
+      compactionTarget: "budget",
+      runtimeContext: { workspaceDir: "/tmp/workspace" },
+    });
+    expect(ignored).toEqual({
+      ok: true,
+      compacted: true,
+      reason: "runtime compacted ignored session",
+      result: { summary: "runtime summary" },
+    });
+    expect(included.ok).toBe(true);
+    expect(included.reason).not.toBe("runtime compacted ignored session");
+  });
+
+  it("skips compact for ignored sessions when runtime delegation is unavailable", async () => {
+    const engine = createEngineWithConfig({
+      ignoreSessionPatterns: ["agent:*:cron:**"],
+    });
+
+    const ignored = await engine.compact({
+      sessionId: ignoredSessionId,
+      sessionKey: ignoredSessionKey,
+      sessionFile: createSessionFilePath("ignored-compact-no-delegate"),
+      tokenBudget: 1000,
+    });
+
     expect(ignored).toEqual({
       ok: true,
       compacted: false,
       reason: "session excluded",
     });
-    expect(included.ok).toBe(true);
-    expect(included.reason).not.toBe("session excluded");
   });
 
   it("skips prepareSubagentSpawn for ignored sessions while creating grants for included sessions", async () => {
@@ -1350,4 +1391,3 @@ describe("LcmContextEngine connection lifecycle", () => {
 });
 
 // ── Bootstrap ───────────────────────────────────────────────────────────────
-

--- a/test/index-runtime-llm-complete.test.ts
+++ b/test/index-runtime-llm-complete.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
 import lcmPlugin from "../index.js";
 import { closeLcmConnection } from "../src/db/connection.js";
-import type { CompletionResult } from "../src/types.js";
+import type { CompletionResult, RuntimeCompactionDelegateFn } from "../src/types.js";
 
 type RegisteredEngineFactory = (() => unknown) | undefined;
 type RuntimeLlmComplete = ReturnType<typeof vi.fn>;
@@ -88,6 +88,7 @@ function getRegisteredEngine(api: OpenClawPluginApi, getFactory: () => Registere
   }
   return factory() as {
     deps: {
+      delegateCompactionToRuntime?: RuntimeCompactionDelegateFn;
       complete: (input: {
         provider?: string;
         model: string;
@@ -165,6 +166,28 @@ describe("createLcmDependencies.complete runtime.llm bridge", () => {
         model: "gpt-5.4",
         agentId: "research-agent",
         request_api: "runtime.llm",
+      });
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  });
+
+  it("keeps ignored-session compaction safe when the host SDK delegate is unavailable", async () => {
+    const { api, getFactory, dbPath } = buildApi();
+    const engine = getRegisteredEngine(api, getFactory);
+
+    try {
+      const result = await engine.deps.delegateCompactionToRuntime?.({
+        sessionId: "runtime-ignored-session",
+        sessionKey: "agent:main:cron:nightly",
+        sessionFile: "/tmp/ignored.jsonl",
+        tokenBudget: 4096,
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        compacted: false,
+        reason: "session excluded",
       });
     } finally {
       closeLcmConnection(dbPath);


### PR DESCRIPTION
# PR draft (not yet opened — for review)

**Title:** fix: delegate compact() to runtime for sessions excluded via ignoreSessionPatterns

**Body:**

## What

When a session matches `ignoreSessionPatterns`, `compact()`'s exclusion branch currently returns a bare refusal:

```js
return { ok: true, compacted: false, reason: "session excluded" };
```

This PR changes that to delegate to OpenClaw's own runtime compaction bridge instead:

```js
return await delegateCompactionToRuntime(params);
```

## Why

`delegateCompactionToRuntime` (`openclaw/plugin-sdk`) is documented for exactly this case:

> "Delegate a context-engine compaction request to OpenClaw's built-in runtime compaction path. This is the same bridge used by the legacy context engine. Third-party engines can call it from their own `compact()` implementations when they do not own the compaction algorithm but still need `/compact` and overflow recovery to use the stock runtime behavior."

It's the entire implementation of OpenClaw's own default (no-plugin) engine — one line, `return await delegateCompactionToRuntime(params)`.

Without this, OpenClaw core's preflight guard (which checks raw transcript byte size independently of token usage, via `agents.defaults.compaction.maxActiveTranscriptBytes`) hard-fails the turn whenever an excluded session's transcript crosses that threshold, because its reason classifier only treats three specific strings (`below_threshold`, `no_compactable_entries`, `already_compacted_recently`) as safe to skip. `"session excluded"` isn't one of them, so it surfaces to the end user as "Context is too large and auto-compaction could not recover this turn" — even when token usage is a small fraction of the model's actual context window. The manual `/compact` command hits the same result but is handled more leniently on that side (labeled "skipped" rather than erroring), so it doesn't crash, but it also doesn't do anything.

This is a real, reproducible issue for any user who excludes Telegram (or any other) sessions via `ignoreSessionPatterns` for an active, long-running conversation.

## Scope

Limited to the `compact()` method's exclusion branch only. `bootstrap()`, `ingest()`/`ingestBatch()`, and `assemble()` already handle the excluded case correctly:
- `bootstrap()`/`ingest()`: correctly declining to track excluded sessions, no framework bridge exists or is needed there.
- `assemble()`: already a correct pass-through (`{ messages: params.messages, estimatedTokens: 0 }`).

Only `compact()`'s refusal has an externally-visible side effect (blocking overflow recovery).

## Known limitation

Sessions compacted this way get a flat runtime summary instead of the plugin's DAG-based summarization — no `lcm_grep`/`lcm_expand` recall afterward. This is consistent with what "excluded from LCM" already implies, and is strictly better than the current behavior (hard failure / unbounded transcript growth).

## Operational note for anyone using `ignoreSessionPatterns`

If a session is later removed from the exclusion list after having been compacted this way, its transcript will contain a runtime-generated summary block that the plugin's own ingestion has never produced. Depending on how `bootstrap()`/ingestion handles unexpected content at the start of a transcript, this could need a one-time reset (fresh session, or clearing that session's rows) rather than transparent re-adoption. Flagging this as something worth documenting or hardening against, not something this PR attempts to solve.

## Testing

Verified against a real, live, oversized excluded session (Telegram group session, ~7.5MB transcript, `ignoreSessionPatterns`-excluded): before this change, `/compact` returned `Compaction skipped: session excluded` and did nothing; after, it returned a real compacted result (`~190k → ~53k` tokens, transcript rotated with a genuine LLM-generated summary present in the new file), and the preflight hard-fail no longer occurs on subsequent turns.

## Note on the import

This is the first direct runtime import from `openclaw/plugin-sdk` in `engine.ts` — everywhere else in this file goes through the `LcmDependencies` injection pattern (`this.deps.*`) instead of importing directly from `openclaw`. `openclaw` isn't a real devDependency in this repo, so `npm run typecheck` can't resolve `openclaw/plugin-sdk` locally (`Cannot find module`), even though it resolves correctly at runtime inside an actual OpenClaw install (verified — that's how the fix was tested). If the preferred convention here is to route this through `LcmDependencies` instead (e.g. injecting `delegateCompactionToRuntime` alongside `complete`/`callGateway`/etc.), happy to rework it that way — didn't want to guess at the wiring in `src/plugin/index.ts` without more context on the intended pattern.
