### PR TITLE
fix(assemble): demote happy-path fork-suffix append log from warn

### DIFF
--- a/.changeset/demote-fork-suffix-append-log.md
+++ b/.changeset/demote-fork-suffix-append-log.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Demote the per-assemble "appended fork-bounded live suffix" log from warn to debug on the healthy path. Thread-fork sessions append this suffix on essentially every assemble, so the line was warn-level noise in routine operation. The log stays at warn when the append evicted messages or ran over budget, the states that need operator attention. Assembly behavior is unchanged; only the log level moves.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -234,6 +234,7 @@ export function buildForkBoundedLiveFallback(params: {
   };
 }
 
+/** Return the log level for fork-bounded live suffix append pressure. */
 export function forkBoundedLiveSuffixAppendLogLevel(append: {
   evictedMessages: number;
   overBudget: boolean;

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -234,6 +234,13 @@ export function buildForkBoundedLiveFallback(params: {
   };
 }
 
+export function forkBoundedLiveSuffixAppendLogLevel(append: {
+  evictedMessages: number;
+  overBudget: boolean;
+}): "warn" | "debug" {
+  return append.overBudget || append.evictedMessages > 0 ? "warn" : "debug";
+}
+
 export function appendForkBoundedLiveSuffixWithinBudget(params: {
   assembledMessages: AgentMessage[];
   assembledEstimatedTokens: number;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -72,7 +72,7 @@ import {
   type TranscriptRewriteRequest,
 } from "./session-rotation.js";
 import { describeAssembledPrefixChange, formatOverflowDiagnosticsForLog, shouldLogOverflowDiagnostics, type AssemblePrefixSnapshot, type BootstrapImportObservation } from "./assemble-debug.js";
-import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResult, buildForkBoundedLiveFallback, clampMessagesToSerializedBudget, resolveDeferredAssemblyPressure } from "./assemble-fallback.js";
+import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResult, buildForkBoundedLiveFallback, clampMessagesToSerializedBudget, forkBoundedLiveSuffixAppendLogLevel, resolveDeferredAssemblyPressure } from "./assemble-fallback.js";
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
@@ -3703,7 +3703,10 @@ export class LcmContextEngine implements ContextEngine {
       const preRecallEstimatedTokens =
         forkLiveSuffixAppend?.estimatedTokens ?? assembled.estimatedTokens;
       if (forkLiveSuffixAppend && forkLiveSuffixAppend.appendedMessages > 0) {
-        this.deps.log.warn(
+        // Appending the fork-bounded live suffix is routine for thread-fork
+        // sessions; only budget pressure needs operator attention.
+        const forkSuffixLogLevel = forkBoundedLiveSuffixAppendLogLevel(forkLiveSuffixAppend);
+        this.deps.log[forkSuffixLogLevel](
           `[lcm] assemble: appended fork-bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} appendedMessages=${forkLiveSuffixAppend.appendedMessages} appendedTokens=${forkLiveSuffixAppend.appendedTokens} evictedMessages=${forkLiveSuffixAppend.evictedMessages} evictedTokens=${forkLiveSuffixAppend.evictedTokens} overBudget=${forkLiveSuffixAppend.overBudget}`,
         );
       }

--- a/test/fork-suffix-loglevel.test.ts
+++ b/test/fork-suffix-loglevel.test.ts
@@ -3,21 +3,28 @@ import { describe, expect, it } from "vitest";
 import { forkBoundedLiveSuffixAppendLogLevel } from "../src/assemble-fallback.js";
 
 describe("forkBoundedLiveSuffixAppendLogLevel", () => {
-  it("logs the healthy append at debug", () => {
-    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 0, overBudget: false })).toBe(
-      "debug",
-    );
-  });
-
-  it("keeps warn when messages were evicted", () => {
-    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 2, overBudget: false })).toBe(
-      "warn",
-    );
-  });
-
-  it("keeps warn when the append ran over budget", () => {
-    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 0, overBudget: true })).toBe(
-      "warn",
-    );
+  it.each([
+    {
+      append: { evictedMessages: 0, overBudget: false },
+      expectedLevel: "debug",
+      label: "healthy append",
+    },
+    {
+      append: { evictedMessages: 2, overBudget: false },
+      expectedLevel: "warn",
+      label: "evicted messages",
+    },
+    {
+      append: { evictedMessages: 0, overBudget: true },
+      expectedLevel: "warn",
+      label: "over budget",
+    },
+    {
+      append: { evictedMessages: 2, overBudget: true },
+      expectedLevel: "warn",
+      label: "evicted messages and over budget",
+    },
+  ])("logs $label at $expectedLevel", ({ append, expectedLevel }) => {
+    expect(forkBoundedLiveSuffixAppendLogLevel(append)).toBe(expectedLevel);
   });
 });

--- a/test/fork-suffix-loglevel.test.ts
+++ b/test/fork-suffix-loglevel.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { forkBoundedLiveSuffixAppendLogLevel } from "../src/assemble-fallback.js";
+
+describe("forkBoundedLiveSuffixAppendLogLevel", () => {
+  it("logs the healthy append at debug", () => {
+    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 0, overBudget: false })).toBe(
+      "debug",
+    );
+  });
+
+  it("keeps warn when messages were evicted", () => {
+    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 2, overBudget: false })).toBe(
+      "warn",
+    );
+  });
+
+  it("keeps warn when the append ran over budget", () => {
+    expect(forkBoundedLiveSuffixAppendLogLevel({ evictedMessages: 0, overBudget: true })).toBe(
+      "warn",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The per-assemble `[lcm] assemble: appended fork-bounded live suffix ...` line logs at warn unconditionally whenever the append attaches messages. For thread-fork sessions (for example Slack threads, where every thread is a fork of the base conversation) this fires on essentially every assemble, so routine healthy operation produces a steady stream of warns. On a live multi-agent gateway, one afternoon of threaded chatting produced dozens of these, every one of them reporting `evictedMessages=0 evictedTokens=0 overBudget=false`.

This change logs the healthy append at debug and keeps warn for the states that actually need operator attention: the append evicted messages or ran over budget. The level choice lives in a small exported helper (`forkBoundedLiveSuffixAppendLogLevel`) next to `appendForkBoundedLiveSuffixWithinBudget`, and the engine call site uses the existing indexed-log idiom. Assembly behavior is unchanged throughout; only the log level moves.

Same spirit as [#954](https://github.com/Martian-Engineering/lossless-claw/pull/954): happy-path recovery/maintenance chatter should not sit at warn.

## Tests

Adds `test/fork-suffix-loglevel.test.ts` covering the three cases (healthy append at debug; warn retained on eviction; warn retained on over-budget). Full suite green: 1485/1485 (`npx vitest run --dir test`), `tsc --noEmit` clean. Includes a changeset.