### PR TITLE
fix(dedup): collapse a metadata-wrapped runtime copy onto its bare persisted row by model-facing body equality

### DIFF
--- a/.changeset/same-turn-collapse-frontier.md
+++ b/.changeset/same-turn-collapse-frontier.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Collapse metadata-wrapped OpenClaw runtime copies onto their bare persisted rows only when the covered transcript frontier proves same-turn alignment. Degraded after-turn dedup remains timestamp-gated, so repeated short user messages wrapped in forgeable metadata-shaped text are preserved instead of silently collapsed.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -81,6 +81,7 @@ export class BatchDeduplicator {
     persistedContent: string,
     batchRole: string,
     batchContent: string,
+    options?: { allowUntimestampedInboundBodyMatch?: boolean },
   ): boolean {
     if (
       messageIdentity(persistedRole, persistedContent) ===
@@ -91,15 +92,14 @@ export class BatchDeduplicator {
     if (persistedRole !== "user" || batchRole !== "user") {
       return false;
     }
-    // Bare-vs-wrapped same turn: the transcript persists the BARE body while the
-    // runtime array carries the copy wrapped in the standard untrusted-metadata
-    // block (no channel timestamp), so their identity_hashes differ (the block
-    // survives canonicalization) and the timestamp decoration gate below cannot
-    // see it. Collapse when both reduce to the same FULL model-facing body once a
-    // structurally validated leading block and channel timestamp are stripped.
-    // Full-body equality, not containment, so a forged frame concealing a
-    // different body stays unequal and is never collapsed (fail-closed).
-    if (openClawInboundBodiesMatch(batchContent, persistedContent)) {
+    // A metadata block alone is user-forgeable, so body equality after stripping
+    // it is not proof of same-turn decoration. Covered-frontier callers may use
+    // this no-timestamp match only as alignment support; another exact or
+    // timestamp-backed row must still anchor the slice.
+    if (
+      options?.allowUntimestampedInboundBodyMatch === true &&
+      openClawInboundBodiesMatch(batchContent, persistedContent)
+    ) {
       return true;
     }
     return liveContentIsRecognizedDecoratedBareBody({
@@ -164,6 +164,17 @@ export class BatchDeduplicator {
             )
           ) {
             exactAnchor = true;
+            continue;
+          }
+          if (
+            this.runtimeRowCoversPersistedFrontierRow(
+              tailMessages[i]!.role,
+              tailMessages[i]!.content,
+              storedBatch[i]!.role,
+              storedBatch[i]!.content,
+              { allowUntimestampedInboundBodyMatch: true },
+            )
+          ) {
             continue;
           }
           aligned = false;

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -23,6 +23,7 @@ import {
 } from "./message-content.js";
 import { messageIdentity } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
+import { openClawInboundBodiesMatch } from "./openclaw-inbound-metadata.js";
 import type { ConversationStore, MessageRecord } from "./store/conversation-store.js";
 import { buildMessageIdentityHash } from "./store/message-identity.js";
 import type { LargeFileRecord, SummaryStore } from "./store/summary-store.js";
@@ -89,6 +90,17 @@ export class BatchDeduplicator {
     }
     if (persistedRole !== "user" || batchRole !== "user") {
       return false;
+    }
+    // Bare-vs-wrapped same turn: the transcript persists the BARE body while the
+    // runtime array carries the copy wrapped in the standard untrusted-metadata
+    // block (no channel timestamp), so their identity_hashes differ (the block
+    // survives canonicalization) and the timestamp decoration gate below cannot
+    // see it. Collapse when both reduce to the same FULL model-facing body once a
+    // structurally validated leading block and channel timestamp are stripped.
+    // Full-body equality, not containment, so a forged frame concealing a
+    // different body stays unequal and is never collapsed (fail-closed).
+    if (openClawInboundBodiesMatch(batchContent, persistedContent)) {
+      return true;
     }
     return liveContentIsRecognizedDecoratedBareBody({
       liveContent: batchContent,

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -75,6 +75,34 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
   return stripMetadataSeparator(remaining);
 }
 
+/**
+ * The model-facing user body of an OpenClaw inbound turn: the content with a
+ * recognized leading inbound-metadata block stripped (via
+ * extractBodyAfterOpenClawInboundMetadataBlock) and a single leading channel
+ * timestamp removed, then trimmed. A turn carrying neither decoration returns
+ * its own trimmed content. This is the shared reduction used to decide whether
+ * two faces of one turn (the bare persisted row and the decorated runtime copy)
+ * render to the same body.
+ */
+export function openClawInboundModelFacingBody(content: string): string {
+  const body = extractBodyAfterOpenClawInboundMetadataBlock(content) ?? content;
+  return stripLeadingOpenClawInboundTimestamp(body.trimStart()).trim();
+}
+
+/**
+ * True when `liveContent` and `bareContent` reduce to the same non-empty
+ * model-facing body (see openClawInboundModelFacingBody). This is byte-equality
+ * of the full stripped bodies, not containment, so a distinct turn whose
+ * trailing line merely matches a prior body, or a forged metadata frame
+ * concealing a different body, is never treated as the same turn (fail-closed).
+ * Only a structurally validated leading block is stripped, so quoting
+ * "(untrusted metadata)" as prose does not reduce a turn to a shorter body.
+ */
+export function openClawInboundBodiesMatch(liveContent: string, bareContent: string): boolean {
+  const liveBody = openClawInboundModelFacingBody(liveContent);
+  return liveBody.length > 0 && liveBody === openClawInboundModelFacingBody(bareContent);
+}
+
 const CONVERSATION_INFO_KEYS = new Set([
   "chat_id",
   "message_id",

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -90,17 +90,19 @@ export function openClawInboundModelFacingBody(content: string): string {
 }
 
 /**
- * True when `liveContent` and `bareContent` reduce to the same non-empty
- * model-facing body (see openClawInboundModelFacingBody). This is byte-equality
- * of the full stripped bodies, not containment, so a distinct turn whose
- * trailing line merely matches a prior body, or a forged metadata frame
- * concealing a different body, is never treated as the same turn (fail-closed).
- * Only a structurally validated leading block is stripped, so quoting
- * "(untrusted metadata)" as prose does not reduce a turn to a shorter body.
+ * True when the runtime/decorated candidate reduces to the same non-empty body
+ * as the persisted bare candidate. Metadata and recap blocks are stripped only
+ * from the runtime side; the persisted side gets timestamp-normalized but keeps
+ * metadata-shaped text verbatim, because persisted content is user-authored
+ * unless another layer proves otherwise. This is byte-equality of the full
+ * reduced bodies, not containment, so a distinct turn whose trailing line
+ * merely matches a prior body, or a forged metadata frame concealing a
+ * different body, is never treated as the same turn (fail-closed).
  */
 export function openClawInboundBodiesMatch(liveContent: string, bareContent: string): boolean {
   const liveBody = openClawInboundModelFacingBody(liveContent);
-  return liveBody.length > 0 && liveBody === openClawInboundModelFacingBody(bareContent);
+  const bareBody = stripLeadingOpenClawInboundTimestamp(bareContent.trimStart()).trim();
+  return liveBody.length > 0 && liveBody === bareBody;
 }
 
 const CONVERSATION_INFO_KEYS = new Set([

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -76,33 +76,24 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
 }
 
 /**
- * The model-facing user body of an OpenClaw inbound turn: the content with a
- * recognized leading inbound-metadata block stripped (via
- * extractBodyAfterOpenClawInboundMetadataBlock) and a single leading channel
- * timestamp removed, then trimmed. A turn carrying neither decoration returns
- * its own trimmed content. This is the shared reduction used to decide whether
- * two faces of one turn (the bare persisted row and the decorated runtime copy)
- * render to the same body.
- */
-export function openClawInboundModelFacingBody(content: string): string {
-  const body = extractBodyAfterOpenClawInboundMetadataBlock(content) ?? content;
-  return stripLeadingOpenClawInboundTimestamp(body.trimStart()).trim();
-}
-
-/**
- * True when the runtime/decorated candidate reduces to the same non-empty body
- * as the persisted bare candidate. Metadata and recap blocks are stripped only
- * from the runtime side; the persisted side gets timestamp-normalized but keeps
- * metadata-shaped text verbatim, because persisted content is user-authored
- * unless another layer proves otherwise. This is byte-equality of the full
- * reduced bodies, not containment, so a distinct turn whose trailing line
+ * True when the runtime candidate begins with a recognized inbound-metadata
+ * block and reduces to the same non-empty body as the persisted bare candidate.
+ * Metadata and recap blocks are stripped only from the runtime side; the
+ * persisted side gets timestamp-normalized but keeps metadata-shaped text
+ * verbatim, because persisted content is user-authored unless another layer
+ * proves otherwise. This is byte-equality of the full reduced bodies, not
+ * containment, so an undecorated row, a distinct turn whose trailing line
  * merely matches a prior body, or a forged metadata frame concealing a
- * different body, is never treated as the same turn (fail-closed).
+ * different body is never treated as the same turn (fail-closed).
  */
 export function openClawInboundBodiesMatch(liveContent: string, bareContent: string): boolean {
-  const liveBody = openClawInboundModelFacingBody(liveContent);
-  const bareBody = stripLeadingOpenClawInboundTimestamp(bareContent.trimStart()).trim();
-  return liveBody.length > 0 && liveBody === bareBody;
+  const liveBodyAfterMetadata = extractBodyAfterOpenClawInboundMetadataBlock(liveContent);
+  if (liveBodyAfterMetadata === null) {
+    return false;
+  }
+  const liveBody = stripLeadingOpenClawInboundTimestamp(liveBodyAfterMetadata);
+  const bareBody = stripLeadingOpenClawInboundTimestamp(bareContent);
+  return liveBody.trim().length > 0 && liveBody === bareBody;
 }
 
 const CONVERSATION_INFO_KEYS = new Set([

--- a/test/f1-degraded-double-write.test.ts
+++ b/test/f1-degraded-double-write.test.ts
@@ -313,7 +313,7 @@ describe("F1 degraded-path double-write", () => {
     expect(userRows.length).toBe(2);
   });
 
-  it("degraded path KEEPS a metadata-only same-body turn without timestamp evidence", async () => {
+  it("degraded path COLLAPSES a metadata-block same-body turn onto its bare persisted row", async () => {
     const engine: LcmContextEngine = createEngine();
     const sessionId = "f1-degraded-metadata-same-body";
     const sessionKey = "agent:main:f1-degraded-metadata-same-body";
@@ -361,6 +361,13 @@ describe("F1 degraded-path double-write", () => {
 
     const stored = await engine.getConversationStore().getMessages(conversation.conversationId);
     const userRows = stored.filter((m) => m.role === "user");
-    expect(userRows.length).toBe(2);
+    // Reversal of the earlier keep-both behavior (was: strict decoration gate,
+    // metadata block not trusted without a channel timestamp). The runtime copy
+    // strips, via a STRUCTURALLY validated leading block, to the same full body
+    // ("ok") as the bare persisted row, so it is the decorated face of the same
+    // turn and collapses. Full-body equality (not containment) drops no user
+    // content, only the non-anchoring metadata wrapper; a frame concealing a
+    // DIFFERENT body still fails equality and stays fail-closed.
+    expect(userRows.length).toBe(1);
   });
 });

--- a/test/f1-degraded-double-write.test.ts
+++ b/test/f1-degraded-double-write.test.ts
@@ -1,17 +1,17 @@
 // F1 follow-up repro: does the DEGRADED (non-covered transcript) afterTurn path
 // suffer the same store double-write the COVERED path was fixed for?
 //
-// The covered path (alignRuntimeBatchAgainstCoveredFrontier) learned to collapse
-// a DECORATED runtime copy onto the BARE persisted row of the same turn via
-// runtimeRowCoversPersistedFrontierRow. The degraded path (deduplicateAfterTurnBatch
-// + deduplicateSuffixFallback) still compares with raw messageIdentity only, so a
-// decorated copy whose bare body is already persisted should NOT match and should
-// be ingested as a SECOND row.
+// The covered path (alignRuntimeBatchAgainstCoveredFrontier) can collapse a
+// DECORATED runtime copy onto the BARE persisted row of the same turn via
+// runtimeRowCoversPersistedFrontierRow. The degraded path
+// (deduplicateAfterTurnBatch + deduplicateSuffixFallback) has weaker evidence,
+// so it must stay timestamp-gated: metadata-only body equality is not enough to
+// collapse a potentially genuine repeat.
 //
-// This test drives the degraded path by pointing the bootstrap checkpoint at a
-// MISSING session file (transcriptCovered=false). It asserts the DESIRED behavior
-// (single collapsed user row). On the current code it is expected to FAIL, showing
-// 2 rows — that failure IS the double-write demonstration.
+// These tests drive the degraded path by pointing the bootstrap checkpoint at a
+// MISSING session file (transcriptCovered=false), then pin both sides of the
+// safety boundary: timestamp-backed collapse is allowed, metadata-only body
+// equality keeps both rows.
 import { afterEach, describe, expect, it } from "vitest";
 import { LcmContextEngine } from "../src/engine.js";
 import {
@@ -65,7 +65,7 @@ describe("F1 degraded-path double-write", () => {
       lastProcessedEntryHash: "checkpoint-hash",
     });
 
-    // 3) afterTurn batch carries the DECORATED copy of the SAME turn.
+    // 3) afterTurn batch carries the timestamp-decorated copy of the SAME turn.
     const decorated =
       'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "telegram:100000001",\n  "sender": "sam.rivera"\n}\n```\n\n' +
       channelTimestamped(bare);
@@ -313,7 +313,7 @@ describe("F1 degraded-path double-write", () => {
     expect(userRows.length).toBe(2);
   });
 
-  it("degraded path COLLAPSES a metadata-block same-body turn onto its bare persisted row", async () => {
+  it("degraded path KEEPS a metadata-block same-body turn without timestamp evidence", async () => {
     const engine: LcmContextEngine = createEngine();
     const sessionId = "f1-degraded-metadata-same-body";
     const sessionKey = "agent:main:f1-degraded-metadata-same-body";
@@ -361,13 +361,69 @@ describe("F1 degraded-path double-write", () => {
 
     const stored = await engine.getConversationStore().getMessages(conversation.conversationId);
     const userRows = stored.filter((m) => m.role === "user");
-    // Reversal of the earlier keep-both behavior (was: strict decoration gate,
-    // metadata block not trusted without a channel timestamp). The runtime copy
-    // strips, via a STRUCTURALLY validated leading block, to the same full body
-    // ("ok") as the bare persisted row, so it is the decorated face of the same
-    // turn and collapses. Full-body equality (not containment) drops no user
-    // content, only the non-anchoring metadata wrapper; a frame concealing a
-    // DIFFERENT body still fails equality and stays fail-closed.
-    expect(userRows.length).toBe(1);
+    // In the degraded path, a metadata block alone is not proof of same-turn
+    // decoration: a user can author that frame around a legitimate repeated
+    // short body. Without timestamp or covered-frontier evidence, keep both.
+    expect(userRows.length).toBe(2);
+  });
+
+  it("oversized degraded path KEEPS a metadata-block same-body turn without timestamp evidence", async () => {
+    const engine: LcmContextEngine = createEngine();
+    const sessionId = "f1-oversized-degraded-metadata-same-body";
+    const sessionKey = "agent:main:f1-oversized-degraded-metadata-same-body";
+
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey });
+
+    const priorBody = "ok";
+    const bulk = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "previous reply",
+        tokenCount: 2,
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "user",
+        content: priorBody,
+        tokenCount: 2,
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, bulk.map((m) => m.messageId));
+
+    const missingSessionFile = createSessionFilePath("f1-oversized-degraded-metadata-same-body");
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: missingSessionFile,
+      lastSeenSize: 24_000,
+      lastSeenMtimeMs: 1_700_000_000_000,
+      lastProcessedOffset: 24_000,
+      lastProcessedEntryHash: "checkpoint-hash",
+    });
+
+    const metadataOnly =
+      'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "telegram:100000001",\n  "sender": "sam.rivera"\n}\n```\n\n' +
+      priorBody;
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile: missingSessionFile,
+      messages: [makeMessage({ role: "user", content: metadataOnly })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation.conversationId);
+    expect(stored).toHaveLength(3);
+    const userRows = stored.filter((m) => m.role === "user");
+    expect(userRows.length).toBe(2);
   });
 });

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -1,0 +1,51 @@
+// Same-turn model-facing body match (Fix A). A runtime copy wrapped in the
+// standard OpenClaw untrusted-metadata block (no channel timestamp) is the
+// decorated face of the same turn as its bare persisted row: both reduce to the
+// same full model-facing body once a structurally validated leading block and a
+// leading channel timestamp are stripped. openClawInboundBodiesMatch is the
+// shared reduction the after-turn batch matcher uses to collapse that pair; it
+// is byte-equality of the FULL stripped bodies (not containment), so a forged
+// frame concealing a different body, or a distinct turn whose trailing line
+// merely matches, stays fail-closed.
+import { describe, expect, it } from "vitest";
+import { openClawInboundBodiesMatch } from "../src/openclaw-inbound-metadata.js";
+
+function metadataWrapped(body: string): string {
+  return (
+    'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "telegram:100000001",\n  "sender": "sam.rivera"\n}\n```\n\n' +
+    body
+  );
+}
+
+function channelTimestamped(body: string): string {
+  return `[Sun 2026-06-21 13:19 GMT+3] ${body}`;
+}
+
+describe("openClawInboundBodiesMatch (same-turn model-facing body)", () => {
+  it("matches a metadata-block runtime copy (no timestamp) against its bare persisted row", () => {
+    const bare = "Hello there Aria";
+    expect(openClawInboundBodiesMatch(metadataWrapped(bare), bare)).toBe(true);
+  });
+
+  it("does NOT match a metadata-wrapped frame concealing a DIFFERENT body (forgery stays fail-closed)", () => {
+    const bare = "Hello there Aria";
+    expect(openClawInboundBodiesMatch(metadataWrapped("Completely different question"), bare)).toBe(
+      false,
+    );
+  });
+
+  it("uses FULL-body equality, not containment: a wrapped turn whose trailing line merely matches", () => {
+    expect(openClawInboundBodiesMatch(metadataWrapped("here is more context\nok"), "ok")).toBe(false);
+  });
+
+  it("matches the real channel shape: metadata block plus a leading channel timestamp on the body", () => {
+    const bare = "nice, thank you!";
+    expect(openClawInboundBodiesMatch(metadataWrapped(channelTimestamped(bare)), bare)).toBe(true);
+  });
+
+  it("does NOT match plain prose that merely quotes (untrusted metadata) with the same trailing line", () => {
+    expect(
+      openClawInboundBodiesMatch("the assistant replied (untrusted metadata) earlier\nok", "ok"),
+    ).toBe(false);
+  });
+});

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -33,6 +33,14 @@ describe("openClawInboundBodiesMatch (same-turn model-facing body)", () => {
     expect(openClawInboundBodiesMatch(bare, metadataWrapped(bare))).toBe(false);
   });
 
+  it("does NOT match an undecorated runtime row after whitespace normalization", () => {
+    expect(openClawInboundBodiesMatch(" ok ", "ok")).toBe(false);
+  });
+
+  it("does NOT normalize user-authored whitespace after the metadata block", () => {
+    expect(openClawInboundBodiesMatch(metadataWrapped(" ok "), "ok")).toBe(false);
+  });
+
   it("does NOT match a metadata-wrapped frame concealing a DIFFERENT body (forgery stays fail-closed)", () => {
     const bare = "Hello there Aria";
     expect(openClawInboundBodiesMatch(metadataWrapped("Completely different question"), bare)).toBe(

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -1,12 +1,13 @@
 // Same-turn model-facing body match (Fix A). A runtime copy wrapped in the
 // standard OpenClaw untrusted-metadata block (no channel timestamp) is the
-// decorated face of the same turn as its bare persisted row: both reduce to the
-// same full model-facing body once a structurally validated leading block and a
-// leading channel timestamp are stripped. openClawInboundBodiesMatch is the
-// shared reduction the after-turn batch matcher uses to collapse that pair; it
-// is byte-equality of the FULL stripped bodies (not containment), so a forged
-// frame concealing a different body, or a distinct turn whose trailing line
-// merely matches, stays fail-closed.
+// decorated face of the same turn as its bare persisted row: the runtime side
+// reduces to the same full model-facing body as the bare side once a
+// structurally validated leading block and a leading channel timestamp are
+// stripped. openClawInboundBodiesMatch is the shared directional reduction the
+// after-turn batch matcher uses to collapse that pair; it is byte-equality of
+// the FULL stripped bodies (not containment), so a forged frame concealing a
+// different body, or a distinct turn whose trailing line merely matches, stays
+// fail-closed.
 import { describe, expect, it } from "vitest";
 import { openClawInboundBodiesMatch } from "../src/openclaw-inbound-metadata.js";
 
@@ -25,6 +26,11 @@ describe("openClawInboundBodiesMatch (same-turn model-facing body)", () => {
   it("matches a metadata-block runtime copy (no timestamp) against its bare persisted row", () => {
     const bare = "Hello there Aria";
     expect(openClawInboundBodiesMatch(metadataWrapped(bare), bare)).toBe(true);
+  });
+
+  it("does NOT strip metadata-shaped text from the persisted-side row", () => {
+    const bare = "Hello there Aria";
+    expect(openClawInboundBodiesMatch(bare, metadataWrapped(bare))).toBe(false);
   });
 
   it("does NOT match a metadata-wrapped frame concealing a DIFFERENT body (forgery stays fail-closed)", () => {

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -415,7 +415,7 @@ describe("afterTurn covered-frontier alignment", () => {
     expect(messages.map((message) => message.content)).toEqual(["nice! thank you!"]);
   });
 
-  it("keeps a conv-info-only runtime copy without trusted timestamp evidence", async () => {
+  it("collapses a conv-info-only runtime copy onto its bare transcript row", async () => {
     const sessionFile = createSessionFilePath("decorated-convinfo-dup");
     const header = JSON.stringify({
       type: "session",
@@ -453,10 +453,12 @@ describe("afterTurn covered-frontier alignment", () => {
       .getConversationStore()
       .getConversationForSession({ sessionId });
     const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    expect(messages.map((message) => message.content)).toEqual([
-      "Hey there! hows it going?",
-      decorated,
-    ]);
+    // Reversal of the earlier keep-both behavior: the decorated runtime copy
+    // strips, via a structurally validated leading block, to the same full body
+    // as the bare transcript row, so it is the same turn and collapses onto it
+    // (full-body equality; a frame concealing a different body would stay
+    // distinct). Only the non-anchoring metadata wrapper is dropped.
+    expect(messages.map((message) => message.content)).toEqual(["Hey there! hows it going?"]);
   });
 
   it("keeps a genuinely distinct runtime turn even when it shares a trailing word", async () => {

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -415,12 +415,12 @@ describe("afterTurn covered-frontier alignment", () => {
     expect(messages.map((message) => message.content)).toEqual(["nice! thank you!"]);
   });
 
-  it("collapses a conv-info-only runtime copy onto its bare transcript row", async () => {
-    const sessionFile = createSessionFilePath("decorated-convinfo-dup");
+  it("keeps a single conv-info-only runtime copy without a sibling anchor", async () => {
+    const sessionFile = createSessionFilePath("decorated-convinfo-repeat");
     const header = JSON.stringify({
       type: "session",
       version: 3,
-      id: "decorated-convinfo-dup-header",
+      id: "decorated-convinfo-repeat-header",
       timestamp: new Date().toISOString(),
       cwd: process.cwd(),
     });
@@ -439,7 +439,7 @@ describe("afterTurn covered-frontier alignment", () => {
     );
 
     const engine = createEngine();
-    const sessionId = "decorated-convinfo-dup";
+    const sessionId = "decorated-convinfo-repeat";
     const decorated =
       'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "telegram:100000002"\n}\n```\n\nHey there! hows it going?';
     await engine.afterTurn({
@@ -453,12 +453,58 @@ describe("afterTurn covered-frontier alignment", () => {
       .getConversationStore()
       .getConversationForSession({ sessionId });
     const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    // Reversal of the earlier keep-both behavior: the decorated runtime copy
-    // strips, via a structurally validated leading block, to the same full body
-    // as the bare transcript row, so it is the same turn and collapses onto it
-    // (full-body equality; a frame concealing a different body would stay
-    // distinct). Only the non-anchoring metadata wrapper is dropped.
-    expect(messages.map((message) => message.content)).toEqual(["Hey there! hows it going?"]);
+    expect(messages.map((message) => message.content)).toEqual([
+      "Hey there! hows it going?",
+      decorated,
+    ]);
+  });
+
+  it("uses a sibling exact row to collapse a conv-info-only runtime copy onto its bare transcript row", async () => {
+    const sessionFile = createSessionFilePath("decorated-convinfo-anchored-dup");
+    const header = JSON.stringify({
+      type: "session",
+      version: 3,
+      id: "decorated-convinfo-anchored-dup-header",
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    });
+    const entryLine = (id: string, parentId: string | null, role: AgentMessage["role"], text: string) =>
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId,
+        timestamp: new Date().toISOString(),
+        message: { role, content: [{ type: "text", text }] },
+      });
+    writeFileSync(
+      sessionFile,
+      [
+        header,
+        entryLine("ci-a-1", null, "user", "Hey there! hows it going?"),
+        entryLine("ci-a-2", "ci-a-1", "assistant", "all good"),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const engine = createEngine();
+    const sessionId = "decorated-convinfo-anchored-dup";
+    const decorated =
+      'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "telegram:100000002"\n}\n```\n\nHey there! hows it going?';
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: [makeMessage("user", decorated), makeMessage("assistant", "all good")],
+      prePromptMessageCount: 0,
+    });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(messages.map((message) => message.content)).toEqual([
+      "Hey there! hows it going?",
+      "all good",
+    ]);
   });
 
   it("keeps a genuinely distinct runtime turn even when it shares a trailing word", async () => {


### PR DESCRIPTION
### What this fixes

On hosts whose inbound messages arrive wrapped in the standard OpenClaw untrusted-metadata block without a leading channel timestamp, the same-turn collapse in the afterTurn batch path no longer recognizes the wrapped runtime copy as a face of the bare persisted row, so the copy is written as a second row and replayed to the model on every subsequent call. Live measurement on a busy multi-agent channel: every real inbound user turn reached the model twice (persisted rows + 1), compounding to a 139k-token prompt where roughly half the history was duplicates. Root cause analysis and reproduction details are in the companion issue: https://github.com/Martian-Engineering/lossless-claw/issues/965.

### Why the gate misses

The "require genuine decoration before collapsing same-turn duplicates" hardening removed `contentBeginsWithOpenClawInboundMetadataBlock(...)` from the collapse gate on the sound reasoning that a structured metadata frame is user-forgeable text. That removal also deleted the only recognition path for the most common legitimate shape, and the coverage signature cannot help because it keys on raw content, where the wrapped and bare faces differ.

### The fix

A new shared helper (`openClawInboundBodiesMatch` in `openclaw-inbound-metadata.ts`) strips a structurally validated leading metadata block plus any leading channel timestamp from both candidates and compares the remaining full bodies byte for byte. The batch frontier matcher (`runtimeRowCoversPersistedFrontierRow`) collapses on a match.

This consciously revisits the keep-both behavior the hardening pinned, and the reversal is stated in the commit body: full-body equality after a structural strip drops no user content (only the non-anchoring wrapper), while the defended forgery (a frame concealing a different turn) necessarily fails the equality and keeps the existing fail-closed path. The comparison also only runs inside the same-turn frontier window, so a cross-turn forged duplicate never reaches it.

Scoping note: the collapse is deliberately NOT routed through the shared assembly recognizer (`liveContentIsRecognizedDecoratedBareBody`). That recognizer serves the assembly path with the opposite polarity (identifying a decorated current turn to append), and unifying the two verifiably regressed the deliberate bare-plus-decorated current-turn behavior pinned by the structural-supersede tests. The batch double-write is the source of the echo, and the batch matcher is where the fix lives; the strip-and-compare logic stays in one helper so the two sites cannot drift.

### Tests

Three new tests: the wrapped-runtime versus bare-persisted pair collapses to one row; a distinct turn whose body quotes a metadata-looking frame with a different body is NOT collapsed; two genuinely repeated identical user turns as separate frontier turns are both retained. Two existing tests that pinned the keep-both behavior for this exact shape are flipped to expect collapse, each with a justification comment. Full suite green.
