### PR TITLE
fix(reconcile): guard entry-id imports against retry re-appends via source-identity twin detection

### DIFF
--- a/.changeset/replay-twin-entry-id-guard.md
+++ b/.changeset/replay-twin-entry-id-guard.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip replayed transcript entries that OpenClaw re-appends under fresh entry ids when the persisted row and new entry share the same canonical identity and full-precision inner source timestamp.

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -873,6 +873,38 @@ export class ConversationStore {
   }
 
   /**
+   * Tier-1 replay-twin gate for the append-only reconcile path: does this
+   * conversation already hold a row with the same role, identity hash, and
+   * created_at SECOND as the candidate? An indexed point lookup
+   * (messages_conv_identity_hash_idx), no file read. A miss proves the candidate
+   * is genuinely new content, so the append-only fast path proceeds untouched; a
+   * hit is ambiguous (a re-append twin OR a legitimate same-second repeat) and
+   * the caller resolves it at full inner-timestamp precision.
+   */
+  async hasPersistedIdentityAtCreatedAtSecond(
+    conversationId: ConversationId,
+    role: MessageRole,
+    content: string,
+    createdAt: Date | string | undefined,
+  ): Promise<boolean> {
+    const createdAtSecond = formatMessageCreatedAt(createdAt);
+    if (!createdAtSecond) {
+      return false;
+    }
+    const identityHash = buildMessageIdentityHash(role, content);
+    const row = this.db
+      .prepare(
+        `SELECT 1 AS count
+       FROM messages
+       WHERE conversation_id = ? AND identity_hash = ? AND role = ? AND created_at = ?
+       LIMIT 1`,
+      )
+      .get(conversationId, identityHash, role, createdAtSecond) as unknown as CountRow | undefined;
+
+    return row?.count === 1;
+  }
+
+  /**
    * Stamp a transcript entry id onto the earliest identity-matching row that
    * has none. Heals rows persisted from the runtime array (flush lag) or
    * before the entry-id migration when the transcript later delivers the

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -396,12 +396,9 @@ export class TranscriptReconciler {
     const entryIdImportCap = transcriptImportCap(params.existingDbCount);
     const entryIdImportCapped =
       params.existingDbCount > 0 && missingTail.length > entryIdImportCap;
-    const importableTail = entryIdImportCapped
-      ? missingTail.slice(0, entryIdImportCap)
-      : missingTail;
     if (entryIdImportCapped) {
       this.host.deps.log.warn(
-        `[lcm] reconcileSessionTail: entry-id import cap chunking for ${sessionContext} — importing ${importableTail.length}/${missingTail.length} anchored backlog messages this pass (existing: ${params.existingDbCount}, cap: ${entryIdImportCap}); remaining backlog continues next pass`,
+        `[lcm] reconcileSessionTail: entry-id import cap chunking for ${sessionContext} — importing ${entryIdImportCap}/${missingTail.length} anchored backlog messages this pass (existing: ${params.existingDbCount}, cap: ${entryIdImportCap}); remaining backlog continues next pass`,
       );
     }
 
@@ -415,7 +412,9 @@ export class TranscriptReconciler {
     let adoptedMessages = 0;
     let restampedMessages = 0;
     let replayTwinsSkipped = 0;
-    for (const message of importableTail) {
+    let cappedImportProgress = 0;
+    let cappedWithRemaining = false;
+    for (const message of missingTail) {
       const entryId = getTranscriptEntryId(message)!;
       const stored = toStoredMessage(message);
       const adopted = await this.host.conversationStore.adoptTranscriptEntryId(
@@ -426,6 +425,7 @@ export class TranscriptReconciler {
       );
       if (adopted) {
         adoptedMessages += 1;
+        cappedImportProgress += 1;
         continue;
       }
       const restamped = await this.adoptStaleTranscriptEntryId({
@@ -437,6 +437,7 @@ export class TranscriptReconciler {
       });
       if (restamped) {
         restampedMessages += 1;
+        cappedImportProgress += 1;
         continue;
       }
       if (await this.candidateHasPersistedReplayTwin(conversationId, message, replayTwinIndex)) {
@@ -449,6 +450,10 @@ export class TranscriptReconciler {
         );
         continue;
       }
+      if (entryIdImportCapped && cappedImportProgress >= entryIdImportCap) {
+        cappedWithRemaining = true;
+        break;
+      }
       // Entry-id-verified imports are exact (the id is proven absent), so the
       // same-second replay flood heuristic does not apply.
       const result = await this.host.ingestSingle({
@@ -460,13 +465,14 @@ export class TranscriptReconciler {
       });
       if (result.ingested) {
         importedMessages += 1;
+        cappedImportProgress += 1;
       }
     }
 
     this.host.deps.log.debug(
       `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages} replayTwinsSkipped=${replayTwinsSkipped} capped=${entryIdImportCapped}`,
     );
-    if (entryIdImportCapped) {
+    if (entryIdImportCapped && cappedWithRemaining) {
       return {
         blockedByImportCap: true,
         blockedReason: "import-cap",
@@ -528,7 +534,7 @@ export class TranscriptReconciler {
     }
     const stored = toStoredMessage(message);
     const innerTag = typeof inner === "number" ? `n:${inner}` : `s:${inner}`;
-    return `${buildMessageIdentityHash(stored.role, stored.content)} ${innerTag}`;
+    return `${buildMessageIdentityHash(stored.role, stored.content)}\u0000${innerTag}`;
   }
 
   private buildReplayTwinIndex(tail: AgentMessage[]): Map<string, string[]> {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1707,6 +1707,7 @@ export class TranscriptReconciler {
     // persisted twin from a prior pass).
     replayTwinConversationId?: number;
     replayTwinSessionFile?: string;
+    onReplayTwinSkipped?: () => void;
   }): Promise<number> {
     let importedMessages = 0;
     // Tier 2 full-tail index, built lazily at most once per batch: only a Tier-1
@@ -1741,6 +1742,7 @@ export class TranscriptReconciler {
             this.host.deps.log.debug(
               `[lcm] ingestBatch: skipped source-identity replay twin entry=${getTranscriptEntryId(message) ?? "?"} conversation=${replayTwinConversationId}`,
             );
+            params.onReplayTwinSkipped?.();
             continue;
           }
         }
@@ -1996,6 +1998,7 @@ export class TranscriptReconciler {
           source: "afterTurn transcript reconcile append-only",
         });
         if (!appendOnlyOverlapsPersisted) {
+          let replayTwinsSkipped = 0;
           const importedMessages = await this.ingestBatch({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
@@ -2003,12 +2006,22 @@ export class TranscriptReconciler {
             replayGuardExemptPrefixLength: replayFiltered.replayGuardExemptPrefixLength,
             replayTwinConversationId: conversation.conversationId,
             replayTwinSessionFile: params.sessionFile,
+            onReplayTwinSkipped: () => {
+              replayTwinsSkipped += 1;
+            },
           });
-          await this.recordImportAndRefreshCheckpoint({
-            conversationId: conversation.conversationId,
-            sessionFile: params.sessionFile,
-            importedMessages,
-          });
+          if (importedMessages > 0) {
+            await this.recordImportAndRefreshCheckpoint({
+              conversationId: conversation.conversationId,
+              sessionFile: params.sessionFile,
+              importedMessages,
+            });
+          } else if (replayTwinsSkipped > 0) {
+            await this.refreshBootstrapState({
+              conversationId: conversation.conversationId,
+              sessionFile: params.sessionFile,
+            });
+          }
           return {
             importedMessages,
             blockedByImportCap: false,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -53,6 +53,7 @@ import {
   readLeafPathMessages,
   readTranscriptHeader,
   resolveTranscriptMessageCreatedAt,
+  resolveTranscriptMessageInnerTimestamp,
 } from "./transcript.js";
 import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./value-utils.js";
 
@@ -409,9 +410,11 @@ export class TranscriptReconciler {
     // re-appended under new ids) and is eligible for stale-id re-stamping.
     const leafEntryIds = new Set(entryIds);
 
+    const replayTwinIndex = this.buildReplayTwinIndex(historicalMessages);
     let importedMessages = 0;
     let adoptedMessages = 0;
     let restampedMessages = 0;
+    let replayTwinsSkipped = 0;
     for (const message of importableTail) {
       const entryId = getTranscriptEntryId(message)!;
       const stored = toStoredMessage(message);
@@ -436,6 +439,16 @@ export class TranscriptReconciler {
         restampedMessages += 1;
         continue;
       }
+      if (await this.candidateHasPersistedReplayTwin(conversationId, message, replayTwinIndex)) {
+        // Re-appended replay: an already-persisted entry in this tail shares the
+        // role, canonical content, and frozen inner timestamp under a different
+        // id. Skip it rather than insert a duplicate row.
+        replayTwinsSkipped += 1;
+        this.host.deps.log.debug(
+          `[lcm] reconcileSessionTailByEntryIds: skipped source-identity replay twin entry=${entryId} for ${sessionContext}`,
+        );
+        continue;
+      }
       // Entry-id-verified imports are exact (the id is proven absent), so the
       // same-second replay flood heuristic does not apply.
       const result = await this.host.ingestSingle({
@@ -451,7 +464,7 @@ export class TranscriptReconciler {
     }
 
     this.host.deps.log.debug(
-      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages} capped=${entryIdImportCapped}`,
+      `[lcm] reconcileSessionTail: entry-id path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages} adoptedMessages=${adoptedMessages} restampedMessages=${restampedMessages} replayTwinsSkipped=${replayTwinsSkipped} capped=${entryIdImportCapped}`,
     );
     if (entryIdImportCapped) {
       return {
@@ -494,6 +507,83 @@ export class TranscriptReconciler {
         params.entryId,
       );
       if (restamped) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Twin-replay key for a reconcile candidate: the same identity canonicalization
+   * used for identity_hash (role plus canonicalized content) joined to the
+   * full-precision INNER source timestamp. Returns null when the message carries
+   * no inner timestamp, which makes the guard fail open. The per-entry envelope
+   * timestamp is deliberately excluded: OpenClaw re-stamps it fresh on every
+   * re-append, so only the frozen inner timestamp identifies one source event.
+   */
+  private replayTwinKey(message: AgentMessage): string | null {
+    const inner = resolveTranscriptMessageInnerTimestamp(message);
+    if (inner === null) {
+      return null;
+    }
+    const stored = toStoredMessage(message);
+    const innerTag = typeof inner === "number" ? `n:${inner}` : `s:${inner}`;
+    return `${buildMessageIdentityHash(stored.role, stored.content)} ${innerTag}`;
+  }
+
+  private buildReplayTwinIndex(tail: AgentMessage[]): Map<string, string[]> {
+    const index = new Map<string, string[]>();
+    for (const message of tail) {
+      const entryId = getTranscriptEntryId(message);
+      if (!entryId) {
+        continue;
+      }
+      const key = this.replayTwinKey(message);
+      if (key === null) {
+        continue;
+      }
+      const ids = index.get(key);
+      if (ids) {
+        ids.push(entryId);
+      } else {
+        index.set(key, [entryId]);
+      }
+    }
+    return index;
+  }
+
+  /**
+   * True when `candidate` (a proven-absent transcript entry) is a re-appended
+   * replay of a logical source event that is ALREADY persisted under a different
+   * entry id: another entry in the same parsed transcript tail shares its role,
+   * canonical content, and frozen inner millisecond timestamp, and that entry's
+   * id is already in the store. OpenClaw retry/failover storms re-append the same
+   * inbound event under fresh uuids with the same frozen inner timestamp;
+   * genuinely repeated messages are distinct source events with distinct inner
+   * timestamps, so they are never twins. Second-granularity created_at is never
+   * consulted, so same-second legitimate repeats survive.
+   */
+  private async candidateHasPersistedReplayTwin(
+    conversationId: number,
+    candidate: AgentMessage,
+    twinIndex: Map<string, string[]>,
+  ): Promise<boolean> {
+    const key = this.replayTwinKey(candidate);
+    if (key === null) {
+      return false;
+    }
+    const candidateId = getTranscriptEntryId(candidate);
+    const siblingIds = twinIndex.get(key);
+    if (!siblingIds) {
+      return false;
+    }
+    for (const siblingId of siblingIds) {
+      if (siblingId === candidateId) {
+        continue;
+      }
+      if (
+        await this.host.conversationStore.hasMessageByTranscriptEntryId(conversationId, siblingId)
+      ) {
         return true;
       }
     }
@@ -1606,9 +1696,49 @@ export class TranscriptReconciler {
     sessionKey?: string;
     messages: AgentMessage[];
     replayGuardExemptPrefixLength: number;
+    // When both are set, each candidate runs the two-tier replay-twin gate below
+    // (used by the append-only fast path, whose parsed delta cannot see a
+    // persisted twin from a prior pass).
+    replayTwinConversationId?: number;
+    replayTwinSessionFile?: string;
   }): Promise<number> {
     let importedMessages = 0;
+    // Tier 2 full-tail index, built lazily at most once per batch: only a Tier-1
+    // store hit (a persisted same-identity, same-second row) justifies the full
+    // leaf-path re-read.
+    let replayTwinIndex: Map<string, string[]> | null = null;
     for (const [index, message] of params.messages.entries()) {
+      const { replayTwinConversationId, replayTwinSessionFile } = params;
+      if (
+        replayTwinConversationId !== undefined &&
+        replayTwinSessionFile !== undefined &&
+        this.replayTwinKey(message) !== null
+      ) {
+        const stored = toStoredMessage(message);
+        const tier1 = await this.host.conversationStore.hasPersistedIdentityAtCreatedAtSecond(
+          replayTwinConversationId,
+          stored.role,
+          stored.content,
+          resolveTranscriptMessageCreatedAt(message),
+        );
+        if (tier1) {
+          replayTwinIndex ??= this.buildReplayTwinIndex(
+            await readLeafPathMessages(replayTwinSessionFile),
+          );
+          if (
+            await this.candidateHasPersistedReplayTwin(
+              replayTwinConversationId,
+              message,
+              replayTwinIndex,
+            )
+          ) {
+            this.host.deps.log.debug(
+              `[lcm] ingestBatch: skipped source-identity replay twin entry=${getTranscriptEntryId(message) ?? "?"} conversation=${replayTwinConversationId}`,
+            );
+            continue;
+          }
+        }
+      }
       const result = await this.host.ingestSingle({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
@@ -1865,6 +1995,8 @@ export class TranscriptReconciler {
             sessionKey: params.sessionKey,
             messages: replayFilteredMessages,
             replayGuardExemptPrefixLength: replayFiltered.replayGuardExemptPrefixLength,
+            replayTwinConversationId: conversation.conversationId,
+            replayTwinSessionFile: params.sessionFile,
           });
           await this.recordImportAndRefreshCheckpoint({
             conversationId: conversation.conversationId,

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -60,6 +60,31 @@ export function resolveTranscriptMessageCreatedAt(message: AgentMessage): Date |
   return getTranscriptEntryMeta(message)?.timestamp ?? undefined;
 }
 
+/**
+ * The full-precision INNER source timestamp of a transcript message
+ * (message.timestamp / createdAt / created_at) as resolveTranscriptMessageCreatedAt
+ * reads it, BEFORE the store truncates it to a whole second. Returned as a
+ * number of epoch milliseconds when parseable, else the trimmed string, else
+ * null. The per-entry envelope timestamp is intentionally NOT used as a
+ * fallback: OpenClaw re-stamps it fresh on every re-append, so it cannot
+ * identify a frozen source event. Used only for replay-twin detection, which
+ * must fail open when no inner timestamp is present.
+ */
+export function resolveTranscriptMessageInnerTimestamp(message: AgentMessage): number | string | null {
+  const raw = message as unknown as Record<string, unknown>;
+  const value = raw.timestamp ?? raw.createdAt ?? raw.created_at;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  }
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  return null;
+}
+
 function normalizeEnvelopeString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;

--- a/test/ingest-replay-twin-detection.test.ts
+++ b/test/ingest-replay-twin-detection.test.ts
@@ -95,6 +95,35 @@ describe("reconcile ingest replay-twin detection (inner source timestamp)", () =
     expect(await userContents(engine, sessionId)).toEqual([feathers, "they weigh the same"]);
   });
 
+  it("advances the append-only checkpoint when every appended entry is a replay twin", async () => {
+    const sessionFile = createSessionFilePath("replay-twin-checkpoint");
+    const header = headerLine("replay-twin-checkpoint-header");
+    const feathers = "a kilogram of feathers";
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+
+    const engine = createEngine();
+    const sessionId = "replay-twin-checkpoint";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+      entryLine({ id: "e2", parentId: "e1", role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+    await engine.afterTurn({ sessionId, sessionFile, messages: [], prePromptMessageCount: 0 });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+
+    expect(checkpoint?.lastProcessedEntryId).toBe("e2");
+    expect(await userContents(engine, sessionId)).toEqual([feathers]);
+  });
+
   it("keeps a genuine repeat carrying a DISTINCT inner timestamp", async () => {
     const sessionFile = createSessionFilePath("replay-twin-distinct-ts");
     const header = headerLine("replay-twin-distinct-ts-header");

--- a/test/ingest-replay-twin-detection.test.ts
+++ b/test/ingest-replay-twin-detection.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { writeFileSync } from "node:fs";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { readLeafPathMessages } from "../src/transcript.js";
 import { cleanupEngineTestState, createEngine, createSessionFilePath } from "./helpers.js";
 
 afterEach(cleanupEngineTestState);
@@ -151,5 +152,52 @@ describe("reconcile ingest replay-twin detection (inner source timestamp)", () =
     await engine.afterTurn({ sessionId, sessionFile, messages: [], prePromptMessageCount: 0 });
 
     expect(await userContents(engine, sessionId)).toEqual([feathers, "they weigh the same", feathers]);
+  });
+
+  it("continues past capped replay-twin prefixes to import real backlog entries", async () => {
+    const sessionFile = createSessionFilePath("replay-twin-capped-prefix");
+    const header = headerLine("replay-twin-capped-prefix-header");
+    const feathers = "a kilogram of feathers";
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+
+    const engine = createEngine();
+    const sessionId = "replay-twin-capped-prefix";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    const replayTwins = Array.from({ length: 55 }, (_, index) =>
+      entryLine({
+        id: `e-twin-${index}`,
+        parentId: index === 0 ? "e1" : `e-twin-${index - 1}`,
+        role: "user",
+        text: feathers,
+        innerMs: FROZEN_MS,
+      }),
+    );
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+      ...replayTwins,
+      entryLine({
+        id: "e-real",
+        parentId: "e-twin-54",
+        role: "assistant",
+        text: "the scale agrees",
+        innerMs: FROZEN_MS + 1_000,
+      }),
+    ]);
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId });
+    const reconcile = await engine.getTranscriptReconciler().reconcileSessionTail({
+      sessionId,
+      conversationId: conversation!.conversationId,
+      historicalMessages: await readLeafPathMessages(sessionFile),
+      lastProcessedEntryId: "e1",
+    });
+
+    expect(reconcile).toMatchObject({ blockedByImportCap: false, importedMessages: 1 });
+    expect(await userContents(engine, sessionId)).toEqual([feathers, "the scale agrees"]);
   });
 });

--- a/test/ingest-replay-twin-detection.test.ts
+++ b/test/ingest-replay-twin-detection.test.ts
@@ -1,0 +1,155 @@
+// Reconcile ingest replay-twin detection (Fix B). OpenClaw retry/failover storms
+// re-append the same logical inbound event under a FRESH transcript entry id but
+// with the same FROZEN inner source timestamp (message.timestamp), spread across
+// separate reconcile passes. The entry-id idempotency check cannot see a fresh
+// id, so each copy was imported as a new row. A candidate with a proven-absent id
+// is now skipped when the same parsed transcript tail already contains a
+// persisted entry that shares its role, canonical content, and full-precision
+// inner timestamp. Genuine repeats are distinct source events with distinct inner
+// timestamps, so they are never twins; a missing inner timestamp fails open.
+import { afterEach, describe, expect, it } from "vitest";
+import { writeFileSync } from "node:fs";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { cleanupEngineTestState, createEngine, createSessionFilePath } from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+const FROZEN_MS = 1_700_000_000_200;
+
+function headerLine(id: string): string {
+  return JSON.stringify({
+    type: "session",
+    version: 3,
+    id,
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+  });
+}
+
+function entryLine(params: {
+  id: string;
+  parentId: string | null;
+  role: AgentMessage["role"];
+  text: string;
+  innerMs?: number;
+}): string {
+  const message: Record<string, unknown> = {
+    role: params.role,
+    content: [{ type: "text", text: params.text }],
+  };
+  if (params.innerMs !== undefined) {
+    // The frozen inner source-event timestamp, distinct from the per-append
+    // envelope timestamp below.
+    message.timestamp = params.innerMs;
+  }
+  return JSON.stringify({
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: new Date().toISOString(),
+    message,
+  });
+}
+
+function writeTranscript(sessionFile: string, header: string, entries: string[]): void {
+  writeFileSync(sessionFile, [header, ...entries].join("\n") + "\n", "utf8");
+}
+
+async function userContents(engine: ReturnType<typeof createEngine>, sessionId: string): Promise<string[]> {
+  const conversation = await engine
+    .getConversationStore()
+    .getConversationForSession({ sessionId });
+  const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
+  return messages.map((message) => message.content);
+}
+
+describe("reconcile ingest replay-twin detection (inner source timestamp)", () => {
+  it("skips a re-appended twin: fresh id, identical role/content/inner-ms, original already persisted", async () => {
+    const sessionFile = createSessionFilePath("replay-twin-skip");
+    const header = headerLine("replay-twin-skip-header");
+    const feathers = "a kilogram of feathers";
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+
+    const engine = createEngine();
+    const sessionId = "replay-twin-skip";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    // Append an unrelated turn, then a retry re-append of the first turn under a
+    // FRESH id carrying the SAME frozen inner timestamp.
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+      entryLine({
+        id: "e-mid",
+        parentId: "e1",
+        role: "assistant",
+        text: "they weigh the same",
+        innerMs: FROZEN_MS + 5_000,
+      }),
+      entryLine({ id: "e2", parentId: "e-mid", role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+    await engine.afterTurn({ sessionId, sessionFile, messages: [], prePromptMessageCount: 0 });
+
+    expect(await userContents(engine, sessionId)).toEqual([feathers, "they weigh the same"]);
+  });
+
+  it("keeps a genuine repeat carrying a DISTINCT inner timestamp", async () => {
+    const sessionFile = createSessionFilePath("replay-twin-distinct-ts");
+    const header = headerLine("replay-twin-distinct-ts-header");
+    const feathers = "a kilogram of feathers";
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+
+    const engine = createEngine();
+    const sessionId = "replay-twin-distinct-ts";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+      entryLine({
+        id: "e-mid",
+        parentId: "e1",
+        role: "assistant",
+        text: "they weigh the same",
+        innerMs: FROZEN_MS + 5_000,
+      }),
+      // A genuinely repeated question is a distinct source event: distinct inner ms.
+      entryLine({ id: "e2", parentId: "e-mid", role: "user", text: feathers, innerMs: FROZEN_MS + 1 }),
+    ]);
+    await engine.afterTurn({ sessionId, sessionFile, messages: [], prePromptMessageCount: 0 });
+
+    expect(await userContents(engine, sessionId)).toEqual([feathers, "they weigh the same", feathers]);
+  });
+
+  it("imports a candidate with NO inner timestamp (fail-open)", async () => {
+    const sessionFile = createSessionFilePath("replay-twin-no-inner-ts");
+    const header = headerLine("replay-twin-no-inner-ts-header");
+    const feathers = "a kilogram of feathers";
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+    ]);
+
+    const engine = createEngine();
+    const sessionId = "replay-twin-no-inner-ts";
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    writeTranscript(sessionFile, header, [
+      entryLine({ id: "e1", parentId: null, role: "user", text: feathers, innerMs: FROZEN_MS }),
+      entryLine({
+        id: "e-mid",
+        parentId: "e1",
+        role: "assistant",
+        text: "they weigh the same",
+        innerMs: FROZEN_MS + 5_000,
+      }),
+      // No inner timestamp on the candidate: the guard cannot prove a replay, so
+      // it fails open and imports.
+      entryLine({ id: "e2", parentId: "e-mid", role: "user", text: feathers }),
+    ]);
+    await engine.afterTurn({ sessionId, sessionFile, messages: [], prePromptMessageCount: 0 });
+
+    expect(await userContents(engine, sessionId)).toEqual([feathers, "they weigh the same", feathers]);
+  });
+});


### PR DESCRIPTION
### What this fixes

When the host's retry or failover machinery re-appends the same logical inbound event to the transcript under a fresh entry uuid (observed during a provider-stall storm: idle-watchdog retries plus rate-limit retries), the entry-id reconcile path imports one row per re-append. A live deployment accumulated clusters of 2 to 5 rows with byte-identical content, identical identity_hash, identical second-truncated created_at, distinct transcript_entry_id per row, at non-consecutive seq (other traffic landed between passes). Details and the full guard-by-guard analysis are in the companion issue: https://github.com/Martian-Engineering/lossless-claw/issues/966.

### The discriminating signal

Each re-appended copy carries a fresh envelope timestamp but an identical inner millisecond source timestamp (the value later truncated into created_at). Genuine repeats are distinct source events with distinct millisecond stamps. Verified on live data.

### How

Twin detection on the entry-id reconcile path: a candidate entry with a proven-absent id is skipped when an already-persisted entry exists with a different id, the same role, the same canonical content, and an identical inner millisecond timestamp. Full-tail routes (bootstrap and full re-read afterTurn) check the parsed tail directly. The append-only fast path stays fast via a two-tier gate: an indexed store lookup on (conversation_id, role, identity_hash, created_at second) filters normal traffic for free, and only a hit triggers a bounded full leaf-path re-read to compare full millisecond precision. Fail-open when the inner timestamp is missing on either side. No schema migration.

### Tests

New deterministic twin tests: a re-appended twin is skipped (exactly one row persists); an identical message with a 1ms-different source timestamp is imported (both rows kept); a candidate without an inner timestamp imports unchanged (fail-open). The existing keep-repeats invariants (repeated id-less prefix messages, byte-identical tool-loop pairs under fresh ids, repeated content under a fresh id while the original is live) all remain green, since those fixtures carry distinct millisecond stamps. Full suite green.
