### PR TITLE
fix(doctor): back up database before scoped summary-repair apply

### DIFF
--- a/.changeset/scoped-doctor-repair-backup.md
+++ b/.changeset/scoped-doctor-repair-backup.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Create and report a SQLite backup before scoped doctor summary repair writes, matching the backup-first safety behavior used by rollover-split repair.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -2920,6 +2920,7 @@ async function buildDoctorApplyText(params: {
       buildStatLine("truncated-marker summaries", formatNumber(stats.truncated)),
       buildStatLine("fallback-marker summaries", formatNumber(stats.fallback)),
       buildStatLine("emergency-fallback summaries", formatNumber(stats.emergency)),
+      buildStatLine("backup path", result.backupPath ?? "skipped (no writes)"),
       buildStatLine("repaired summaries", formatNumber(result.repaired)),
       buildStatLine("unchanged summaries", formatNumber(result.unchanged)),
       buildStatLine("skipped summaries", formatNumber(result.skipped.length)),

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
-import { withDatabaseTransaction } from "../transaction-mutex.js";
+import { DatabaseTransactionTimeoutError, withExclusiveDatabaseLock } from "../transaction-mutex.js";
 import { formatTimestamp } from "../compaction.js";
 import type { LcmConfig } from "../db/config.js";
 import type { LcmSummarizeFn } from "../summarize.js";
@@ -32,6 +32,7 @@ export type DoctorApplyResult =
       unchanged: number;
       skipped: DoctorApplySkip[];
       repairedSummaryIds: string[];
+      backupPath?: string;
     }
   | {
       kind: "unavailable";
@@ -43,6 +44,8 @@ type DoctorApplyRow = {
   ordinal: number;
   content?: string;
 };
+
+const DOCTOR_APPLY_DATABASE_LOCK_TIMEOUT_MS = 30_000;
 
 /**
  * Repair broken summaries for a single resolved conversation.
@@ -81,6 +84,7 @@ export async function applyScopedDoctorRepair(params: {
   const overrides = new Map<string, SummaryOverride>();
   const skipped: DoctorApplySkip[] = [];
   const repairedSummaryIds: string[] = [];
+  let backupPath: string | undefined;
   let unchanged = 0;
 
   for (const target of ordered) {
@@ -144,33 +148,68 @@ export async function applyScopedDoctorRepair(params: {
   }
 
   if (repairedSummaryIds.length > 0) {
-    const backupPath = createLcmDatabaseBackup(params.db, {
-      databasePath: params.config.databasePath,
-      label: "scoped-doctor-repair",
-    });
-    if (!backupPath) {
-      return {
-        kind: "unavailable",
-        reason: "Lossless Claw could not determine a doctor apply backup path.",
-      };
-    }
-
-    await withDatabaseTransaction(params.db, "BEGIN IMMEDIATE", async () => {
-        for (const summaryId of repairedSummaryIds) {
-          const override = overrides.get(summaryId);
-          if (!override) {
-            continue;
+    try {
+      const unavailable = await withExclusiveDatabaseLock(
+        params.db,
+        { timeoutMs: DOCTOR_APPLY_DATABASE_LOCK_TIMEOUT_MS },
+        () => {
+          if (params.db.isTransaction) {
+            return {
+              kind: "unavailable" as const,
+              reason:
+                "Lossless Claw obtained exclusive doctor apply access, but the shared database connection is still inside another transaction.",
+            };
           }
-          params.db
-            .prepare(
-              `UPDATE summaries
-               SET content = ?, token_count = ?
-               WHERE summary_id = ?`,
-            )
-            .run(override.content, override.tokenCount, summaryId);
-          updateSummaryFts(params.db, summaryId, override.content);
-        }
-    });
+
+          const createdBackupPath = createLcmDatabaseBackup(params.db, {
+            databasePath: params.config.databasePath,
+            label: "scoped-doctor-repair",
+          });
+          if (!createdBackupPath) {
+            return {
+              kind: "unavailable" as const,
+              reason: "Lossless Claw could not determine a doctor apply backup path.",
+            };
+          }
+          backupPath = createdBackupPath;
+
+          params.db.exec("BEGIN IMMEDIATE");
+          try {
+            for (const summaryId of repairedSummaryIds) {
+              const override = overrides.get(summaryId);
+              if (!override) {
+                continue;
+              }
+              params.db
+                .prepare(
+                  `UPDATE summaries
+                   SET content = ?, token_count = ?
+                   WHERE summary_id = ?`,
+                )
+                .run(override.content, override.tokenCount, summaryId);
+              updateSummaryFts(params.db, summaryId, override.content);
+            }
+            params.db.exec("COMMIT");
+          } catch (error) {
+            params.db.exec("ROLLBACK");
+            throw error;
+          }
+
+          return null;
+        },
+      );
+      if (unavailable) {
+        return unavailable;
+      }
+    } catch (error) {
+      if (error instanceof DatabaseTransactionTimeoutError) {
+        return {
+          kind: "unavailable",
+          reason: `Lossless Claw waited ${Math.floor(DOCTOR_APPLY_DATABASE_LOCK_TIMEOUT_MS / 1000)}s for the database to become idle, but another transaction never finished.`,
+        };
+      }
+      throw error;
+    }
   }
 
   return {
@@ -180,6 +219,7 @@ export async function applyScopedDoctorRepair(params: {
     unchanged,
     skipped,
     repairedSummaryIds,
+    ...(backupPath ? { backupPath } : {}),
   };
 }
 

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -5,6 +5,7 @@ import type { LcmConfig } from "../db/config.js";
 import type { LcmSummarizeFn } from "../summarize.js";
 import { createLcmSummarizeFromLegacyParams } from "../summarize.js";
 import type { LcmDependencies } from "../types.js";
+import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import { detectDoctorMarker, loadDoctorTargets, type DoctorTargetRecord } from "./lcm-doctor-shared.js";
 import { estimateTokens } from "../estimate-tokens.js";
 
@@ -143,6 +144,17 @@ export async function applyScopedDoctorRepair(params: {
   }
 
   if (repairedSummaryIds.length > 0) {
+    const backupPath = createLcmDatabaseBackup(params.db, {
+      databasePath: params.config.databasePath,
+      label: "scoped-doctor-repair",
+    });
+    if (!backupPath) {
+      return {
+        kind: "unavailable",
+        reason: "Lossless Claw could not determine a doctor apply backup path.",
+      };
+    }
+
     await withDatabaseTransaction(params.db, "BEGIN IMMEDIATE", async () => {
         for (const summaryId of repairedSummaryIds) {
           const override = overrides.get(summaryId);

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1,18 +1,22 @@
 // Engine maintain() sweeps and assemble() budget/degradation behavior. Split from engine-fidelity.test.ts.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
-import { appendFileSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { ContextAssembler } from "../src/assembler.js";
 import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateSerializedMessageTokens, estimateSerializedMessagesTokens, estimateTokens } from "../src/estimate-tokens.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import { applyScopedDoctorRepair } from "../src/plugin/lcm-doctor-apply.js";
-import { detectDoctorMarker } from "../src/plugin/lcm-doctor-shared.js";
+import { detectDoctorMarker, FALLBACK_SUMMARY_MARKER } from "../src/plugin/lcm-doctor-shared.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { SummaryStore } from "../src/store/summary-store.js";
 import type { LcmDependencies } from "../src/types.js";
 import {
   cleanupEngineTestState,
@@ -25,6 +29,7 @@ import {
   writeLeafTranscriptMessages,
   createEngineWithConfig,
   createEngineWithDeps,
+  createTestConfig,
   makeMessage,
   seedBacklogContext,
   estimateAssembledPayloadTokens,
@@ -1628,5 +1633,58 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         tokenBudget: 2_048,
       }),
     );
+  });
+});
+
+describe("applyScopedDoctorRepair backup safety", () => {
+  it("creates a database backup before mutating summaries", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-doctor-apply-backup-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "lcm.db");
+    const db = createLcmDatabaseConnection(dbPath);
+    const { fts5Available } = getLcmDbFeatures(db);
+    runLcmMigrations(db, { fts5Available });
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const summaryStore = new SummaryStore(db, { fts5Available });
+
+    const conversation = await conversationStore.createConversation({
+      sessionId: "doctor-apply-backup-session",
+      sessionKey: "agent:test:main:doctor-apply-backup",
+    });
+    const message = await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "hello from the backup fixture",
+      tokenCount: 5,
+    });
+
+    const summaryId = "sum_doctor_apply_backup_1";
+    await summaryStore.insertSummary({
+      summaryId,
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: FALLBACK_SUMMARY_MARKER,
+      tokenCount: 10,
+    });
+    await summaryStore.linkSummaryToMessages(summaryId, [message.messageId]);
+
+    const config = createTestConfig(dbPath);
+    const result = await applyScopedDoctorRepair({
+      db,
+      config,
+      conversationId: conversation.conversationId,
+      summarize: async () => "Repaired summary content without any doctor marker.",
+    });
+
+    expect(result.kind).toBe("applied");
+    if (result.kind !== "applied") {
+      throw new Error(`expected doctor repair to apply: ${result.reason}`);
+    }
+    expect(result.repaired).toBe(1);
+
+    const backupFiles = readdirSync(tempDir).filter((name) => name.includes("scoped-doctor-repair"));
+    expect(backupFiles.length).toBeGreaterThan(0);
   });
 });

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1683,8 +1683,22 @@ describe("applyScopedDoctorRepair backup safety", () => {
       throw new Error(`expected doctor repair to apply: ${result.reason}`);
     }
     expect(result.repaired).toBe(1);
+    expect(result.backupPath).toContain("scoped-doctor-repair");
 
     const backupFiles = readdirSync(tempDir).filter((name) => name.includes("scoped-doctor-repair"));
-    expect(backupFiles.length).toBeGreaterThan(0);
+    expect(backupFiles).toHaveLength(1);
+    const repairedSummary = await summaryStore.getSummary(summaryId);
+    expect(repairedSummary?.content).toBe("Repaired summary content without any doctor marker.");
+
+    const backupDb = createLcmDatabaseConnection(join(tempDir, backupFiles[0]!));
+    try {
+      const backedUpSummary = backupDb
+        .prepare("SELECT content FROM summaries WHERE summary_id = ?")
+        .get(summaryId) as { content: string } | undefined;
+      expect(backedUpSummary?.content).toBe(FALLBACK_SUMMARY_MARKER);
+    } finally {
+      closeLcmConnection(backupDb);
+      closeLcmConnection(db);
+    }
   });
 });

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -2942,6 +2942,8 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("repair targets: 3");
     expect(result.text).toContain("emergency-fallback summaries: 1");
+    expect(result.text).toContain("backup path:");
+    expect(result.text).toContain("scoped-doctor-repair");
     expect(result.text).toContain("repaired summaries: 3");
     expect(result.text).toContain("result: repaired 3 summary(s) in place");
     expect(result.text).toContain("sum_emergency_fix, sum_leaf_fix, sum_parent_fix");


### PR DESCRIPTION
## Problem

The scoped summary-repair `doctor apply` path, [`applyScopedDoctorRepair`](https://github.com/gorkem2020/lossless-claw/blob/fix/summary-repair-apply-backup/src/plugin/lcm-doctor-apply.ts#L50-L58), mutates `lcm.db` inside a `withDatabaseTransaction` call with no database backup taken first. The sibling rollover-split repair path, [`applyRolloverSplitRepair`](https://github.com/gorkem2020/lossless-claw/blob/fix/summary-repair-apply-backup/src/plugin/lcm-doctor-rollover-splits.ts#L680-L718), always takes an unconditional backup via [`createLcmDatabaseBackup`](https://github.com/gorkem2020/lossless-claw/blob/fix/summary-repair-apply-backup/src/plugin/lcm-doctor-rollover-splits.ts#L704-L712) before it mutates anything. The two `doctor apply` subcommands ended up with different safety guarantees even though both perform the kind of automatic, in-place repair that [AGENTS.md](https://github.com/Martian-Engineering/lossless-claw/blob/main/AGENTS.md) asks maintenance/repair code to treat carefully ("lossless means lossless").

## Fix

Route `applyScopedDoctorRepair` through the same `createLcmDatabaseBackup` call, in the same spot rollover-splits uses it (right before the mutating transaction, only once at least one summary is queued for rewrite) and with the same failure handling: return `{ kind: "unavailable", reason: ... }` if a backup path can't be resolved, instead of proceeding to mutate. See [lcm-doctor-apply.ts#L147-L157](https://github.com/gorkem2020/lossless-claw/blob/fix/summary-repair-apply-backup/src/plugin/lcm-doctor-apply.ts#L147-L157).

The no-op case is unchanged: when nothing needs repairing (`repairedSummaryIds.length === 0`), the function still returns `applied` with zero counts and never touches the backup helper, the same way rollover-splits skips its own backup when there are no safe lanes to merge.

## Test

Added a focused test asserting a backup file is created before doctor apply mutates any summary: [engine-maintenance.test.ts#L1639-L1690](https://github.com/gorkem2020/lossless-claw/blob/fix/summary-repair-apply-backup/test/engine-maintenance.test.ts#L1639-L1690).

Red/green proof, the test was written and run against the unmodified source first, then again after the fix:

```
# before the fix (source unmodified)
$ npx vitest run test/engine-maintenance.test.ts -t "creates a database backup before mutating summaries"
✗ creates a database backup before mutating summaries
  AssertionError: expected 0 to be greater than 0

# after the fix
$ npx vitest run test/engine-maintenance.test.ts -t "creates a database backup before mutating summaries"
✓ creates a database backup before mutating summaries
```

No regressions in the surrounding suite:

```
$ npx vitest run test/engine-maintenance.test.ts test/engine-fidelity.test.ts test/engine-after-turn.test.ts test/doctor-archive-cause-skip.test.ts
Test Files  4 passed (4)
     Tests  146 passed (146)

$ npx vitest run test/lcm-command.test.ts
Test Files  1 passed (1)
     Tests  63 passed (63)
```

`npm run typecheck` and `npm run build` both pass clean.

## Release note

This changes user-facing behavior: an automatic repair path now backs up the database first, and can newly report `unavailable` if a backup path can't be resolved (for example, a non-file-backed/in-memory database). Per [RELEASING.md](https://github.com/Martian-Engineering/lossless-claw/blob/main/RELEASING.md), that should get a changeset before merge. I have not added one myself since this repo's stated convention is not to expect external contributors to run the Changesets workflow; flagging it here for a maintainer to add (`patch`, matching "fixes, docs-visible behavior changes" in the bump guidance).
