### PR TITLE
docs: add active-memory session ignore patterns

### DIFF
--- a/.changeset/tidy-dreams-rest.md
+++ b/.changeset/tidy-dreams-rest.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Document optional storage exclusions for OpenClaw active-memory and memory-core dreaming narrative sessions, including the breadth and data-retention implications of the recommended patterns.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 }
 ```
 
+The `ignoreSessionPatterns` entries in this example are storage exclusions. Matching cron, active-memory, and dreaming narrative sessions do not create LCM conversation rows or store messages in LCM.
+
 `leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). `summaryMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs` bound repeated non-auth summarization spend per session. When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
 
 ### Environment variables
@@ -379,8 +381,12 @@ Pattern rules:
 Examples:
 
 - `agent:*:cron:**` excludes cron sessions for any agent when you want to bypass LCM entirely
+- `agent:*:**:active-memory:**` excludes active-memory sessions under nested channel or thread keys; the `**` segment is intentionally broad because it spans colon-separated session-key segments
+- `agent:*:dreaming-narrative-**` excludes dreaming narrative sessions for any agent
 - `agent:main:subagent:**` excludes all main-agent subagent sessions
 - `agent:ops:**` excludes every session under the `ops` agent id
+
+Treat these examples as storage exclusions. Matching sessions do not create LCM conversation rows or store messages in LCM, so use them only for lanes whose history can stay outside LCM.
 
 Environment variable example:
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
             "cacheTTLSeconds": 300
           },
           "ignoreSessionPatterns": [
-            "agent:*:cron:**"
+            "agent:*:cron:**",
+            "agent:*:**:active-memory:**",
+            "agent:*:dreaming-narrative-**"
           ],
           "transcriptGcEnabled": false,
           "proactiveThresholdCompactionMode": "deferred",

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Add a `lossless-claw` entry under `plugins.entries` in your OpenClaw config:
 }
 ```
 
-The `ignoreSessionPatterns` entries in this example are storage exclusions. Matching cron, active-memory, and dreaming narrative sessions do not create LCM conversation rows or store messages in LCM.
+The `ignoreSessionPatterns` entries in this example are storage exclusions. Matching cron, active-memory, and OpenClaw memory-core dreaming narrative sessions do not create LCM conversation rows or store messages in LCM.
 
 `leafChunkTokens` controls how many source tokens can accumulate in a leaf compaction chunk before summarization is triggered. The default is `20000`, but quota-limited summary providers may benefit from a larger value to reduce compaction frequency. `summaryModel` and `summaryProvider` let you request a cheaper or faster compaction model through OpenClaw's `api.runtime.llm.complete` capability; OpenClaw still owns provider dispatch and auth. Explicit summary model requests require `llm.allowModelOverride` and matching `llm.allowedModels` policy entries for `lossless-claw`. `expansionModel` does the same for `lcm_expand_query` sub-agent calls (drilling into summaries to recover detail). `delegationTimeoutMs` controls how long `lcm_expand_query` waits for that delegated sub-agent to finish before returning a timeout error; it defaults to `120000` (120s). `summaryTimeoutMs` controls the per-call timeout for model-backed LCM summarization; it defaults to `60000` (60s). `summaryMaxCallsPerWindow`, `summaryCallWindowMs`, and `summarySpendBackoffMs` bound repeated non-auth summarization spend per session. When unset, the model settings still fall back to OpenClaw's configured default model/provider. See [Expansion model override requirements](#expansion-model-override-requirements) for the required `subagent` trust policy when using `expansionModel`.
 
@@ -381,8 +381,8 @@ Pattern rules:
 Examples:
 
 - `agent:*:cron:**` excludes cron sessions for any agent when you want to bypass LCM entirely
-- `agent:*:**:active-memory:**` excludes active-memory sessions under nested channel or thread keys; the `**` segment is intentionally broad because it spans colon-separated session-key segments
-- `agent:*:dreaming-narrative-**` excludes dreaming narrative sessions for any agent
+- `agent:*:**:active-memory:**` excludes active-memory sessions under nested session-key prefixes; the `**` segment is intentionally broad because it spans colon-separated session-key segments
+- `agent:*:dreaming-narrative-**` excludes OpenClaw memory-core dreaming narrative sessions; OpenClaw builds those keys with the `dreaming-narrative-` prefix ([source](https://github.com/openclaw/openclaw/blob/b81666ca6af25c86cc099983a4358cdc5ea9ced8/extensions/memory-core/src/dreaming-narrative.ts))
 - `agent:main:subagent:**` excludes all main-agent subagent sessions
 - `agent:ops:**` excludes every session under the `ops` agent id
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,7 +382,7 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 
 Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when a new runtime `sessionId` reuses the same `sessionKey`. Configure `ignoreSessionPatterns` for cron only when the run should bypass LCM entirely; leave cron sessions included when they need in-run compaction. When OpenClaw exposes its runtime compaction delegate, `/compact` and overflow recovery for ignored sessions fall back to OpenClaw's built-in compaction path instead of LCM's summary DAG. Older hosts that do not expose that delegate keep the previous safe skip behavior.
 
-These examples are storage exclusions, not compaction preferences. Matching sessions do not create LCM conversation rows or store messages in LCM. The `agent:*:**:active-memory:**` pattern is intentionally broad because `**` spans colon-separated session-key segments, including channel or thread prefixes before `active-memory`.
+These examples are storage exclusions, not compaction preferences. Matching sessions do not create LCM conversation rows or store messages in LCM. The `agent:*:**:active-memory:**` pattern is intentionally broad because `**` spans colon-separated session-key segments, including nested prefixes before `active-memory`. The `agent:*:dreaming-narrative-**` example matches OpenClaw memory-core keys built with the `dreaming-narrative-` prefix ([source](https://github.com/openclaw/openclaw/blob/b81666ca6af25c86cc099983a4358cdc5ea9ced8/extensions/memory-core/src/dreaming-narrative.ts)).
 
 Example:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,11 @@ Most installations only need to override a handful of keys. If you want a comple
   "enabled": true,
   "databasePath": "/Users/alice/.openclaw/lcm.db",
   "largeFilesDir": "/Users/alice/.openclaw/lcm-files",
-  "ignoreSessionPatterns": [],
+  "ignoreSessionPatterns": [
+    "agent:*:cron:**",
+    "agent:*:**:active-memory:**",
+    "agent:*:dreaming-narrative-**"
+  ],
   "statelessSessionPatterns": [],
   "skipStatelessSessions": true,
   "contextThreshold": 0.75,
@@ -387,7 +391,9 @@ Example:
 ```json
 {
   "ignoreSessionPatterns": [
-    "agent:*:cron:**"
+    "agent:*:cron:**",
+    "agent:*:**:active-memory:**",
+    "agent:*:dreaming-narrative-**"
   ],
   "statelessSessionPatterns": [
     "agent:*:subagent:**",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,11 +35,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "enabled": true,
   "databasePath": "/Users/alice/.openclaw/lcm.db",
   "largeFilesDir": "/Users/alice/.openclaw/lcm-files",
-  "ignoreSessionPatterns": [
-    "agent:*:cron:**",
-    "agent:*:**:active-memory:**",
-    "agent:*:dreaming-narrative-**"
-  ],
+  "ignoreSessionPatterns": [],
   "statelessSessionPatterns": [],
   "skipStatelessSessions": true,
   "contextThreshold": 0.75,
@@ -385,6 +381,8 @@ LCM_EXPANSION_MODEL=openai/gpt-5.4-mini
 - `**` matches anything, including `:`
 
 Cron scheduler keys (`agent:<agent>:cron:<job>...`) are isolated automatically when a new runtime `sessionId` reuses the same `sessionKey`. Configure `ignoreSessionPatterns` for cron only when the run should bypass LCM entirely; leave cron sessions included when they need in-run compaction. When OpenClaw exposes its runtime compaction delegate, `/compact` and overflow recovery for ignored sessions fall back to OpenClaw's built-in compaction path instead of LCM's summary DAG. Older hosts that do not expose that delegate keep the previous safe skip behavior.
+
+These examples are storage exclusions, not compaction preferences. Matching sessions do not create LCM conversation rows or store messages in LCM. The `agent:*:**:active-memory:**` pattern is intentionally broad because `**` spans colon-separated session-key segments, including channel or thread prefixes before `active-memory`.
 
 Example:
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -548,7 +548,19 @@ Why it matters:
 - keeps low-value automation or noisy sessions out of the DB
 - useful for excluding certain agent lanes or ephemeral traffic entirely
 - cron scheduler keys are already isolated per runtime run, so ignore them only when they should bypass LCM compaction
+- matching sessions do not create LCM conversation rows or store messages in LCM
+- `agent:*:**:active-memory:**` is intentionally broad for active-memory keys because `**` spans colon-separated session-key segments
 - ignored-session `/compact` calls use OpenClaw's built-in runtime compaction delegate when the host exposes it; older hosts keep the previous safe skip behavior
+
+Example:
+
+```json
+[
+  "agent:*:cron:**",
+  "agent:*:**:active-memory:**",
+  "agent:*:dreaming-narrative-**"
+]
+```
 
 ### `statelessSessionPatterns`
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -550,6 +550,7 @@ Why it matters:
 - cron scheduler keys are already isolated per runtime run, so ignore them only when they should bypass LCM compaction
 - matching sessions do not create LCM conversation rows or store messages in LCM
 - `agent:*:**:active-memory:**` is intentionally broad for active-memory keys because `**` spans colon-separated session-key segments
+- `agent:*:dreaming-narrative-**` matches OpenClaw memory-core keys built with the `dreaming-narrative-` prefix ([source](https://github.com/openclaw/openclaw/blob/b81666ca6af25c86cc099983a4358cdc5ea9ced8/extensions/memory-core/src/dreaming-narrative.ts))
 - ignored-session `/compact` calls use OpenClaw's built-in runtime compaction delegate when the host exposes it; older hosts keep the previous safe skip behavior
 
 Example:


### PR DESCRIPTION
Updates the configuration examples so ignored sessions include cron, active-memory, and dreaming narrative session keys. This keeps the docs aligned with #976 without changing runtime behavior.

Verification:
- `npm run typecheck` (passes)
- `npm test` (fails on this Windows environment: 7 existing path/HOME expectation failures in `test/config.test.ts`, `test/db-connection.test.ts`, `test/engine-bootstrap.test.ts`, `test/engine-ingest.test.ts`, and `test/vitest-isolation.test.ts`; no runtime files changed in this docs-only patch)