### PR TITLE
fix(tools): lcm_describe accepts full [LCM Tool Output: ...] reference strings

### DIFF
--- a/.changeset/lcm-describe-reference-string.md
+++ b/.changeset/lcm-describe-reference-string.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+`lcm_describe` now accepts a full `[LCM Tool Output: file_xxx | ...]` reference string as `id`, extracting the embedded `file_xxx` or `sum_xxx` ID automatically. Bare IDs continue to work, and unrecognized inputs return a clearer error hint.

--- a/.changeset/lcm-describe-reference-string.md
+++ b/.changeset/lcm-describe-reference-string.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-`lcm_describe` now accepts a full `[LCM Tool Output: file_xxx | ...]` reference string as `id`, extracting the embedded `file_xxx` or `sum_xxx` ID automatically. Bare IDs continue to work, and unrecognized inputs return a clearer error hint.
+`lcm_describe` now accepts full copied reference strings such as `[LCM Tool Output: file_xxx | ...]` and `[LCM File: file_xxx | ...]` as `id`, extracting the embedded `file_xxx` or `sum_xxx` ID automatically. Bare IDs continue to work; ambiguous input (multiple IDs), zero/empty IDs, and malformed IDs now return clear errors.

--- a/src/tools/lcm-describe-id.ts
+++ b/src/tools/lcm-describe-id.ts
@@ -1,0 +1,76 @@
+const LCM_BARE_ID_RE = /^(?:sum|file)_[a-z0-9_-]+$/;
+const LCM_ID_TOKEN_RE = /\b(?:sum|file)_[a-z0-9_-]+\b/g;
+const LCM_LOOSE_ID_RE = /\b(?:sum|file)_[A-Za-z0-9_-]*\b/i;
+const LCM_REFERENCE_RE =
+  /^\[LCM (?:Tool Output|File|Raw Payload):\s*((?:sum|file)_[a-z0-9_-]+)(?=\s*[|\]])[^\r\n]*\](?:\r?\n[\s\S]*)?$/;
+const LCM_REFERENCE_LINE_RE =
+  /^\[LCM (?:Tool Output|File|Raw Payload):\s*((?:sum|file)_[a-z0-9_-]+)(?=\s*[|\]])/gm;
+
+export type ExtractLcmDescribeIdResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string; hint?: string };
+
+/**
+ * Extract an LCM summary or file ID from either a bare ID or an emitted
+ * Lossless reference block. Free-form text and ambiguous bare input fail
+ * validation instead of selecting an incidental ID.
+ */
+export function extractLcmDescribeId(raw: string): ExtractLcmDescribeIdResult {
+  const trimmed = raw.trim();
+  if (LCM_BARE_ID_RE.test(trimmed)) {
+    return validateLcmId(trimmed);
+  }
+
+  // The leading ID is the only structural ID in references from large-files.ts.
+  // Metadata and summaries may contain ID-like filenames or ordinary prose.
+  const referenceId = trimmed.match(LCM_REFERENCE_RE)?.[1];
+  if (referenceId) {
+    const referenceIds = [
+      ...new Set([...trimmed.matchAll(LCM_REFERENCE_LINE_RE)].map((match) => match[1])),
+    ];
+    if (referenceIds.length > 1) {
+      return {
+        ok: false,
+        error: `Input contains multiple LCM IDs (${referenceIds.join(", ")}). Provide a single reference string.`,
+      };
+    }
+    return validateLcmId(referenceId);
+  }
+
+  const tokens = trimmed.match(LCM_ID_TOKEN_RE) ?? [];
+  if (tokens.length > 1) {
+    return {
+      ok: false,
+      error: `Input contains multiple LCM IDs (${tokens.join(", ")}). Provide a bare ID or a single reference string.`,
+    };
+  }
+
+  const looseId = trimmed.match(LCM_LOOSE_ID_RE)?.[0];
+  if (!looseId) {
+    return { ok: false, error: `Not a recognized LCM ID: ${raw}` };
+  }
+  const validated = validateLcmId(looseId);
+  if (!validated.ok) {
+    return validated;
+  }
+  if (looseId !== looseId.toLowerCase()) {
+    return {
+      ok: false,
+      error: `Malformed LCM ID: ${looseId}. IDs must be lowercase and contain only letters, digits, underscores, and hyphens after the prefix.`,
+    };
+  }
+  return {
+    ok: false,
+    error: `Not a recognized LCM ID format: ${raw}`,
+    hint: "Provide a bare ID or a single copied reference string such as [LCM Tool Output: file_xxx | ...].",
+  };
+}
+
+/** Validate special invalid suffixes after the input grammar has identified an ID. */
+function validateLcmId(id: string): ExtractLcmDescribeIdResult {
+  const suffix = id.slice(id.indexOf("_") + 1);
+  if (suffix.length === 0 || /^0+$/.test(suffix)) {
+    return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
+  }
+  return { ok: true, id };
+}

--- a/src/tools/lcm-describe-id.ts
+++ b/src/tools/lcm-describe-id.ts
@@ -1,10 +1,10 @@
+// Retrieval remains the authority for ID existence; keep this grammar open to
+// future lowercase ID formats instead of duplicating today's 16-hex generator.
 const LCM_BARE_ID_RE = /^(?:sum|file)_[a-z0-9_-]+$/;
 const LCM_ID_TOKEN_RE = /\b(?:sum|file)_[a-z0-9_-]+\b/g;
 const LCM_LOOSE_ID_RE = /\b(?:sum|file)_[A-Za-z0-9_-]*\b/i;
 const LCM_REFERENCE_RE =
   /^\[LCM (?:Tool Output|File|Raw Payload):\s*((?:sum|file)_[a-z0-9_-]+)(?=\s*[|\]])[^\r\n]*\](?:\r?\n[\s\S]*)?$/;
-const LCM_REFERENCE_LINE_RE =
-  /^\[LCM (?:Tool Output|File|Raw Payload):\s*((?:sum|file)_[a-z0-9_-]+)(?=\s*[|\]])/gm;
 
 export type ExtractLcmDescribeIdResult =
   | { ok: true; id: string }
@@ -25,15 +25,6 @@ export function extractLcmDescribeId(raw: string): ExtractLcmDescribeIdResult {
   // Metadata and summaries may contain ID-like filenames or ordinary prose.
   const referenceId = trimmed.match(LCM_REFERENCE_RE)?.[1];
   if (referenceId) {
-    const referenceIds = [
-      ...new Set([...trimmed.matchAll(LCM_REFERENCE_LINE_RE)].map((match) => match[1])),
-    ];
-    if (referenceIds.length > 1) {
-      return {
-        ok: false,
-        error: `Input contains multiple LCM IDs (${referenceIds.join(", ")}). Provide a single reference string.`,
-      };
-    }
     return validateLcmId(referenceId);
   }
 

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -93,19 +93,91 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
   return Math.max(1, Math.trunc(value));
 }
 
+const LCM_BARE_ID_RE = /^(sum|file)_[a-z0-9_-]+$/;
+const LCM_ID_TOKEN_RE = /\b(sum|file)_[a-z0-9_-]+\b/g;
+const LCM_REFERENCE_PREFIX_RE =
+  /^\[LCM (Tool Output|File|Raw Payload):\s*((sum|file)_[a-z0-9_-]+)(?=\s*[|\]])/i;
+
+function isZeroLcmId(id: string): boolean {
+  const suffix = id.slice(id.indexOf("_") + 1);
+  return suffix.length === 0 || /^0+$/.test(suffix);
+}
+
 /**
- * Accept either a bare LCM ID (`sum_xxx`, `file_xxx`) or a reference string
- * such as `[LCM Tool Output: file_xxx | tool=… | N bytes]` and return the
- * first recognizable ID. Returns undefined when no ID can be extracted.
+ * Accept either a bare LCM ID (`sum_xxx`, `file_xxx`) or a single copied
+ * reference string such as `[LCM Tool Output: file_xxx | tool=… | N bytes]`
+ * and return the embedded ID. Rejects ambiguous input (multiple IDs), zero
+ * IDs, malformed IDs, and free-form text that happens to contain an ID.
  */
-function extractLcmDescribeId(raw: string): string | undefined {
+type ExtractLcmDescribeIdResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string; hint?: string };
+
+function extractLcmDescribeId(raw: string): ExtractLcmDescribeIdResult {
   const trimmed = raw.trim();
-  const bare = trimmed.match(/^(?:sum|file)_[A-Za-z0-9_-]+$/);
-  if (bare) {
-    return trimmed;
+
+  // Bare ID: the entire argument must be the ID.
+  if (LCM_BARE_ID_RE.test(trimmed)) {
+    if (isZeroLcmId(trimmed)) {
+      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${trimmed}` };
+    }
+    return { ok: true, id: trimmed };
   }
-  const embedded = trimmed.match(/(?:sum|file)_[A-Za-z0-9_-]+/);
-  return embedded?.[0];
+
+  // Recognized copied reference forms: [LCM Tool Output: id | ...],
+  // [LCM File: id | ...], [LCM Raw Payload: id | ...].
+  const refMatch = trimmed.match(LCM_REFERENCE_PREFIX_RE);
+  if (refMatch && trimmed.endsWith("]")) {
+    const id = refMatch[2] as string;
+    const afterId = trimmed.slice((refMatch.index ?? 0) + refMatch[0].length);
+    const extraIds = [...afterId.matchAll(LCM_ID_TOKEN_RE)].map((m) => m[0] as string);
+    if (extraIds.length > 0) {
+      return {
+        ok: false,
+        error: `Reference string contains multiple LCM IDs (${id}, ${extraIds.join(", ")}). Provide a single reference string.`,
+      };
+    }
+    if (isZeroLcmId(id)) {
+      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
+    }
+    return { ok: true, id };
+  }
+
+  // Not a valid bare ID or reference. Check for ambiguity / malformed input.
+  const tokens = [...trimmed.matchAll(LCM_ID_TOKEN_RE)].map((m) => m[0] as string);
+  if (tokens.length > 1) {
+    return {
+      ok: false,
+      error: `Input contains multiple LCM IDs (${tokens.join(", ")}). Provide a bare ID or a single reference string.`,
+    };
+  }
+
+  const looseTokens = [...trimmed.matchAll(/\b(sum|file)_[A-Za-z0-9_-]*\b/gi)].map(
+    (m) => m[0] as string,
+  );
+  if (looseTokens.length === 1) {
+    const id = looseTokens[0];
+    const suffix = id.slice(id.indexOf("_") + 1);
+    if (suffix.length === 0) {
+      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
+    }
+    if (!/^[a-z0-9_-]+$/.test(suffix)) {
+      return {
+        ok: false,
+        error: `Malformed LCM ID: ${id}. IDs must be lowercase and contain only letters, digits, underscores, and hyphens after the prefix.`,
+      };
+    }
+    if (isZeroLcmId(id)) {
+      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
+    }
+    return {
+      ok: false,
+      error: `Not a recognized LCM ID format: ${raw}`,
+      hint: "Provide a bare ID or a single copied reference string such as [LCM Tool Output: file_xxx | ...].",
+    };
+  }
+
+  return { ok: false, error: `Not a recognized LCM ID: ${raw}` };
 }
 
 function compactDescribeDetails(result: DescribeResult | null) {
@@ -150,10 +222,10 @@ export function createLcmDescribeTool(input: {
       "from compacted conversation history. Returns summary content, lineage, " +
       "token counts, and file exploration results. " +
       "ALSO USE THIS when you see a `[LCM Tool Output: file_xxx | tool=… | N bytes]` " +
-      "reference in the conversation — that means an older tool result was elided " +
-      "for context efficiency. You may pass the full reference string as `id`; " +
-      "Lossless extracts the file_xxx ID automatically. Call " +
-      "lcm_describe(id=file_xxx, expandFile=true) to fetch the original output " +
+      "or `[LCM File: file_xxx | …]` reference in the conversation — that means an " +
+      "older tool result or large file was elided for context efficiency. You may " +
+      "pass the full reference string as `id`; Lossless extracts the file_xxx ID " +
+      "automatically. Call lcm_describe(id=file_xxx, expandFile=true) to fetch the " +
       "content before answering questions that depend on its specifics. " +
       "If the inlined content is truncated, use lcm_grep(scope='files', " +
       "fileIds=[file_xxx]) to search the bounded file prefix.",
@@ -167,13 +239,16 @@ export function createLcmDescribeTool(input: {
       const timezone = lcm.timezone;
       const p = params as Record<string, unknown>;
       const rawId = typeof p.id === "string" ? p.id : "";
-      const id = extractLcmDescribeId(rawId);
-      if (!id) {
+      const extracted = extractLcmDescribeId(rawId);
+      if (!extracted.ok) {
         return jsonResult({
-          error: `Not a recognized LCM ID: ${rawId}`,
-          hint: "Use a bare ID such as sum_xxx or file_xxx, or a reference string such as [LCM Tool Output: file_xxx | ...].",
+          error: extracted.error,
+          hint:
+            extracted.hint ??
+            "Use a bare ID such as sum_xxx or file_xxx, or a single reference string such as [LCM Tool Output: file_xxx | ...].",
         });
       }
+      const id = extracted.id;
       const conversationScope = await resolveLcmConversationScope({
         lcm,
         deps: input.deps,

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -10,6 +10,7 @@ import { jsonResult } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import { formatTimestamp } from "../compaction.js";
 import type { DescribeResult } from "../retrieval.js";
+import { extractLcmDescribeId } from "./lcm-describe-id.js";
 
 function formatDisplayTime(
   value: Date | string | number | null | undefined,
@@ -91,93 +92,6 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
     return undefined;
   }
   return Math.max(1, Math.trunc(value));
-}
-
-const LCM_BARE_ID_RE = /^(sum|file)_[a-z0-9_-]+$/;
-const LCM_ID_TOKEN_RE = /\b(sum|file)_[a-z0-9_-]+\b/g;
-const LCM_REFERENCE_PREFIX_RE =
-  /^\[LCM (Tool Output|File|Raw Payload):\s*((sum|file)_[a-z0-9_-]+)(?=\s*[|\]])/i;
-
-function isZeroLcmId(id: string): boolean {
-  const suffix = id.slice(id.indexOf("_") + 1);
-  return suffix.length === 0 || /^0+$/.test(suffix);
-}
-
-/**
- * Accept either a bare LCM ID (`sum_xxx`, `file_xxx`) or a single copied
- * reference string such as `[LCM Tool Output: file_xxx | tool=… | N bytes]`
- * and return the embedded ID. Rejects ambiguous input (multiple IDs), zero
- * IDs, malformed IDs, and free-form text that happens to contain an ID.
- */
-type ExtractLcmDescribeIdResult =
-  | { ok: true; id: string }
-  | { ok: false; error: string; hint?: string };
-
-function extractLcmDescribeId(raw: string): ExtractLcmDescribeIdResult {
-  const trimmed = raw.trim();
-
-  // Bare ID: the entire argument must be the ID.
-  if (LCM_BARE_ID_RE.test(trimmed)) {
-    if (isZeroLcmId(trimmed)) {
-      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${trimmed}` };
-    }
-    return { ok: true, id: trimmed };
-  }
-
-  // Recognized copied reference forms: [LCM Tool Output: id | ...],
-  // [LCM File: id | ...], [LCM Raw Payload: id | ...].
-  const refMatch = trimmed.match(LCM_REFERENCE_PREFIX_RE);
-  if (refMatch && trimmed.endsWith("]")) {
-    const id = refMatch[2] as string;
-    const afterId = trimmed.slice((refMatch.index ?? 0) + refMatch[0].length);
-    const extraIds = [...afterId.matchAll(LCM_ID_TOKEN_RE)].map((m) => m[0] as string);
-    if (extraIds.length > 0) {
-      return {
-        ok: false,
-        error: `Reference string contains multiple LCM IDs (${id}, ${extraIds.join(", ")}). Provide a single reference string.`,
-      };
-    }
-    if (isZeroLcmId(id)) {
-      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
-    }
-    return { ok: true, id };
-  }
-
-  // Not a valid bare ID or reference. Check for ambiguity / malformed input.
-  const tokens = [...trimmed.matchAll(LCM_ID_TOKEN_RE)].map((m) => m[0] as string);
-  if (tokens.length > 1) {
-    return {
-      ok: false,
-      error: `Input contains multiple LCM IDs (${tokens.join(", ")}). Provide a bare ID or a single reference string.`,
-    };
-  }
-
-  const looseTokens = [...trimmed.matchAll(/\b(sum|file)_[A-Za-z0-9_-]*\b/gi)].map(
-    (m) => m[0] as string,
-  );
-  if (looseTokens.length === 1) {
-    const id = looseTokens[0];
-    const suffix = id.slice(id.indexOf("_") + 1);
-    if (suffix.length === 0) {
-      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
-    }
-    if (!/^[a-z0-9_-]+$/.test(suffix)) {
-      return {
-        ok: false,
-        error: `Malformed LCM ID: ${id}. IDs must be lowercase and contain only letters, digits, underscores, and hyphens after the prefix.`,
-      };
-    }
-    if (isZeroLcmId(id)) {
-      return { ok: false, error: `LCM ID cannot be a zero/empty ID: ${id}` };
-    }
-    return {
-      ok: false,
-      error: `Not a recognized LCM ID format: ${raw}`,
-      hint: "Provide a bare ID or a single copied reference string such as [LCM Tool Output: file_xxx | ...].",
-    };
-  }
-
-  return { ok: false, error: `Not a recognized LCM ID: ${raw}` };
 }
 
 function compactDescribeDetails(result: DescribeResult | null) {

--- a/src/tools/lcm-describe-tool.ts
+++ b/src/tools/lcm-describe-tool.ts
@@ -93,6 +93,21 @@ function normalizeRequestedTokenCap(value: unknown): number | undefined {
   return Math.max(1, Math.trunc(value));
 }
 
+/**
+ * Accept either a bare LCM ID (`sum_xxx`, `file_xxx`) or a reference string
+ * such as `[LCM Tool Output: file_xxx | tool=… | N bytes]` and return the
+ * first recognizable ID. Returns undefined when no ID can be extracted.
+ */
+function extractLcmDescribeId(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  const bare = trimmed.match(/^(?:sum|file)_[A-Za-z0-9_-]+$/);
+  if (bare) {
+    return trimmed;
+  }
+  const embedded = trimmed.match(/(?:sum|file)_[A-Za-z0-9_-]+/);
+  return embedded?.[0];
+}
+
 function compactDescribeDetails(result: DescribeResult | null) {
   if (!result) {
     return result;
@@ -136,9 +151,11 @@ export function createLcmDescribeTool(input: {
       "token counts, and file exploration results. " +
       "ALSO USE THIS when you see a `[LCM Tool Output: file_xxx | tool=… | N bytes]` " +
       "reference in the conversation — that means an older tool result was elided " +
-      "for context efficiency. Call lcm_describe(id=file_xxx, expandFile=true) to " +
-      "fetch the original output content before answering questions that depend on " +
-      "its specifics. If the inlined content is truncated, use lcm_grep(scope='files', " +
+      "for context efficiency. You may pass the full reference string as `id`; " +
+      "Lossless extracts the file_xxx ID automatically. Call " +
+      "lcm_describe(id=file_xxx, expandFile=true) to fetch the original output " +
+      "content before answering questions that depend on its specifics. " +
+      "If the inlined content is truncated, use lcm_grep(scope='files', " +
       "fileIds=[file_xxx]) to search the bounded file prefix.",
     parameters: LcmDescribeSchema,
     async execute(_toolCallId, params) {
@@ -149,7 +166,14 @@ export function createLcmDescribeTool(input: {
       const retrieval = lcm.getRetrieval();
       const timezone = lcm.timezone;
       const p = params as Record<string, unknown>;
-      const id = (p.id as string).trim();
+      const rawId = typeof p.id === "string" ? p.id : "";
+      const id = extractLcmDescribeId(rawId);
+      if (!id) {
+        return jsonResult({
+          error: `Not a recognized LCM ID: ${rawId}`,
+          hint: "Use a bare ID such as sum_xxx or file_xxx, or a reference string such as [LCM Tool Output: file_xxx | ...].",
+        });
+      }
       const conversationScope = await resolveLcmConversationScope({
         lcm,
         deps: input.deps,

--- a/test/lcm-describe-id.test.ts
+++ b/test/lcm-describe-id.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatFileReference,
+  formatRawPayloadReference,
+  formatToolOutputReference,
+} from "../src/large-files.js";
+import { extractLcmDescribeId } from "../src/tools/lcm-describe-id.js";
+
+describe("extractLcmDescribeId", () => {
+  it.each(["file_abc123", "sum_def456"])("accepts the bare ID %s", (id) => {
+    expect(extractLcmDescribeId(`  ${id}  `)).toEqual({ ok: true, id });
+  });
+
+  it.each([
+    formatToolOutputReference({
+      fileId: "file_abc123",
+      toolName: "read_file",
+      byteSize: 1234,
+      summary: "Relevant lines from the requested file.",
+    }),
+    formatFileReference({
+      fileId: "file_abc123",
+      fileName: "file_backup.tar",
+      mimeType: "application/x-tar",
+      byteSize: 1024,
+      summary: "Backup archive contents mention sum_report.csv.",
+    }),
+    formatRawPayloadReference({
+      fileId: "file_abc123",
+      role: "assistant",
+      byteSize: 2048,
+      reason: "large_raw_message",
+      summary: "Structured payload with nested tool results.",
+    }),
+  ])("accepts an emitted multiline reference block", (reference) => {
+    expect(extractLcmDescribeId(reference)).toEqual({
+      ok: true,
+      id: "file_abc123",
+    });
+  });
+
+  it("rejects free-form input containing multiple IDs", () => {
+    const result = extractLcmDescribeId("compare file_abc123 with sum_def456");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("multiple LCM IDs");
+    }
+  });
+
+  it("rejects multiple copied reference blocks", () => {
+    const input = [
+      "[LCM Tool Output: file_abc123 | tool=read_file | 12 bytes]",
+      "[LCM File: file_def456 | report.txt | text/plain | 12 bytes]",
+    ].join("\n");
+    const result = extractLcmDescribeId(input);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("multiple LCM IDs");
+    }
+  });
+
+  it.each(["FILE_ABC123", "[LCM File: FILE_abc123 | spec.md | text/markdown | 12 bytes]"])(
+    "rejects the uppercase ID %s as malformed",
+    (input) => {
+      const result = extractLcmDescribeId(input);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("Malformed LCM ID");
+      }
+    },
+  );
+
+  it.each(["file_0", "file_0000000000000000", "file_"])(
+    "rejects the zero or empty ID %s",
+    (input) => {
+      const result = extractLcmDescribeId(input);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("zero/empty ID");
+      }
+    },
+  );
+
+  it.each(["not-an-id", "file_abc.txt", "use file_abc123"])(
+    "rejects the unrecognized input %s",
+    (input) => {
+      expect(extractLcmDescribeId(input).ok).toBe(false);
+    },
+  );
+});

--- a/test/lcm-describe-id.test.ts
+++ b/test/lcm-describe-id.test.ts
@@ -48,17 +48,19 @@ describe("extractLcmDescribeId", () => {
     }
   });
 
-  it("rejects multiple copied reference blocks", () => {
-    const input = [
-      "[LCM Tool Output: file_abc123 | tool=read_file | 12 bytes]",
-      "[LCM File: file_def456 | report.txt | text/plain | 12 bytes]",
-    ].join("\n");
-    const result = extractLcmDescribeId(input);
+  it("uses the leading reference ID when its summary contains reference-like content", () => {
+    const input = formatToolOutputReference({
+      fileId: "file_abc123",
+      toolName: "read_file",
+      byteSize: 1234,
+      summary: [
+        "Transcript excerpt:",
+        "[LCM File: file_def456 | report.txt | text/plain | 12 bytes]",
+        "Related summary: sum_deadbeef0000000",
+      ].join("\n"),
+    });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain("multiple LCM IDs");
-    }
+    expect(extractLcmDescribeId(input)).toEqual({ ok: true, id: "file_abc123" });
   });
 
   it.each(["FILE_ABC123", "[LCM File: FILE_abc123 | spec.md | text/markdown | 12 bytes]"])(

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -527,6 +527,124 @@ describe("LCM tools session scoping", () => {
     expect((result.details as { error?: string }).error).toContain("Not a recognized LCM ID");
   });
 
+  it("lcm_describe extracts file_xxx from a full [LCM File: ...] reference string", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "file_abc123",
+        type: "file" as const,
+        file: {
+          conversationId: 42,
+          fileName: "spec.md",
+          mimeType: "text/markdown",
+          byteSize: 1024,
+          lineCount: 30,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-file-reference", {
+      id: "[LCM File: file_abc123 | spec.md | text/markdown | 1024 bytes]",
+    });
+
+    expect(retrieval.describe).toHaveBeenCalledWith("file_abc123", expect.any(Object));
+    expect((result.content[0] as { text: string }).text).toContain("LCM File: file_abc123");
+  });
+
+  it("lcm_describe rejects multiple bare IDs as ambiguous", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-multiple-bare", {
+      id: "file_abc123 sum_def456",
+    });
+
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain("multiple LCM IDs");
+  });
+
+  it("lcm_describe rejects a reference string containing multiple IDs", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-multiple-in-reference", {
+      id: "[LCM Tool Output: file_abc123 | tool=read_file | see file_def456]",
+    });
+
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain("multiple LCM IDs");
+  });
+
+  it("lcm_describe rejects malformed bare IDs with disallowed characters", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+
+    const upper = await tool.execute("call-describe-uppercase", { id: "FILE_ABC123" });
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((upper.details as { error?: string }).error).toContain("Malformed LCM ID");
+
+    const spaced = await tool.execute("call-describe-spaced", { id: "file_abc 123" });
+    expect((spaced.details as { error?: string }).error).toMatch(/multiple LCM IDs|Not a recognized LCM ID/);
+  });
+
+  it("lcm_describe rejects zero/empty IDs", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+
+    const zeroSuffix = await tool.execute("call-describe-zero-suffix", { id: "file_0" });
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((zeroSuffix.details as { error?: string }).error).toContain("zero/empty ID");
+
+    const allZeros = await tool.execute("call-describe-all-zeros", {
+      id: "file_0000000000000000",
+    });
+    expect((allZeros.details as { error?: string }).error).toContain("zero/empty ID");
+
+    const emptySuffix = await tool.execute("call-describe-empty-suffix", { id: "file_" });
+    expect((emptySuffix.details as { error?: string }).error).toContain("zero/empty ID");
+  });
+
   it("lcm_grep resolves conversation scope via sessionKey continuity before sessionId lookup", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -436,6 +436,97 @@ describe("LCM tools session scoping", () => {
     );
   });
 
+  it("lcm_describe extracts file_xxx from a full [LCM Tool Output: ...] reference string", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "file_abc123",
+        type: "file" as const,
+        file: {
+          conversationId: 42,
+          fileName: "large.log",
+          mimeType: "text/plain",
+          byteSize: 1234,
+          lineCount: 56,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-reference", {
+      id: "  [LCM Tool Output: file_abc123 | tool=read_file | 1234 bytes]  ",
+    });
+
+    expect(retrieval.describe).toHaveBeenCalledWith(
+      "file_abc123",
+      expect.any(Object),
+    );
+    expect((result.content[0] as { text: string }).text).toContain("LCM File: file_abc123");
+  });
+
+  it("lcm_describe still accepts a bare sum_xxx ID", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(async () => ({
+        id: "sum_abc123",
+        type: "summary" as const,
+        summary: {
+          conversationId: 42,
+          kind: "leaf",
+          content: "summary content",
+          depth: 0,
+          tokenCount: 12,
+          descendantCount: 0,
+          descendantTokenCount: 0,
+          sourceMessageTokenCount: 12,
+          fileIds: [],
+          parentIds: [],
+          childIds: [],
+          messageIds: [],
+          earliestAt: new Date("2026-01-01T00:00:00.000Z"),
+          latestAt: new Date("2026-01-01T00:00:00.000Z"),
+          subtree: [],
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      })),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-bare", { id: "sum_abc123" });
+
+    expect(retrieval.describe).toHaveBeenCalledWith("sum_abc123", expect.any(Object));
+    expect((result.content[0] as { text: string }).text).toContain("LCM_SUMMARY sum_abc123");
+  });
+
+  it("lcm_describe returns a helpful error for an unrecognized id", async () => {
+    const retrieval = {
+      grep: vi.fn(),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmDescribeTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    const result = await tool.execute("call-describe-bad-id", { id: "not-an-id" });
+
+    expect(retrieval.describe).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain("Not a recognized LCM ID");
+  });
+
   it("lcm_grep resolves conversation scope via sessionKey continuity before sessionId lookup", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -4,6 +4,7 @@ import {
   resetDelegatedExpansionGrantsForTests,
 } from "../src/expansion-auth.js";
 import { formatTimestamp } from "../src/compaction.js";
+import { formatToolOutputReference } from "../src/large-files.js";
 import { createLcmDescribeTool } from "../src/tools/lcm-describe-tool.js";
 import { createLcmExpandTool } from "../src/tools/lcm-expand-tool.js";
 import { createLcmGrepTool } from "../src/tools/lcm-grep-tool.js";
@@ -460,7 +461,12 @@ describe("LCM tools session scoping", () => {
       sessionId: "session-1",
     });
     const result = await tool.execute("call-describe-reference", {
-      id: "  [LCM Tool Output: file_abc123 | tool=read_file | 1234 bytes]  ",
+      id: formatToolOutputReference({
+        fileId: "file_abc123",
+        toolName: "read_file",
+        byteSize: 1234,
+        summary: "Relevant lines from the requested file.",
+      }),
     });
 
     expect(retrieval.describe).toHaveBeenCalledWith(
@@ -468,181 +474,6 @@ describe("LCM tools session scoping", () => {
       expect.any(Object),
     );
     expect((result.content[0] as { text: string }).text).toContain("LCM File: file_abc123");
-  });
-
-  it("lcm_describe still accepts a bare sum_xxx ID", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(async () => ({
-        id: "sum_abc123",
-        type: "summary" as const,
-        summary: {
-          conversationId: 42,
-          kind: "leaf",
-          content: "summary content",
-          depth: 0,
-          tokenCount: 12,
-          descendantCount: 0,
-          descendantTokenCount: 0,
-          sourceMessageTokenCount: 12,
-          fileIds: [],
-          parentIds: [],
-          childIds: [],
-          messageIds: [],
-          earliestAt: new Date("2026-01-01T00:00:00.000Z"),
-          latestAt: new Date("2026-01-01T00:00:00.000Z"),
-          subtree: [],
-          createdAt: new Date("2026-01-01T00:00:00.000Z"),
-        },
-      })),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-    const result = await tool.execute("call-describe-bare", { id: "sum_abc123" });
-
-    expect(retrieval.describe).toHaveBeenCalledWith("sum_abc123", expect.any(Object));
-    expect((result.content[0] as { text: string }).text).toContain("LCM_SUMMARY sum_abc123");
-  });
-
-  it("lcm_describe returns a helpful error for an unrecognized id", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-    const result = await tool.execute("call-describe-bad-id", { id: "not-an-id" });
-
-    expect(retrieval.describe).not.toHaveBeenCalled();
-    expect((result.details as { error?: string }).error).toContain("Not a recognized LCM ID");
-  });
-
-  it("lcm_describe extracts file_xxx from a full [LCM File: ...] reference string", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(async () => ({
-        id: "file_abc123",
-        type: "file" as const,
-        file: {
-          conversationId: 42,
-          fileName: "spec.md",
-          mimeType: "text/markdown",
-          byteSize: 1024,
-          lineCount: 30,
-          createdAt: new Date("2026-01-01T00:00:00.000Z"),
-        },
-      })),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-    const result = await tool.execute("call-describe-file-reference", {
-      id: "[LCM File: file_abc123 | spec.md | text/markdown | 1024 bytes]",
-    });
-
-    expect(retrieval.describe).toHaveBeenCalledWith("file_abc123", expect.any(Object));
-    expect((result.content[0] as { text: string }).text).toContain("LCM File: file_abc123");
-  });
-
-  it("lcm_describe rejects multiple bare IDs as ambiguous", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-    const result = await tool.execute("call-describe-multiple-bare", {
-      id: "file_abc123 sum_def456",
-    });
-
-    expect(retrieval.describe).not.toHaveBeenCalled();
-    expect((result.details as { error?: string }).error).toContain("multiple LCM IDs");
-  });
-
-  it("lcm_describe rejects a reference string containing multiple IDs", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-    const result = await tool.execute("call-describe-multiple-in-reference", {
-      id: "[LCM Tool Output: file_abc123 | tool=read_file | see file_def456]",
-    });
-
-    expect(retrieval.describe).not.toHaveBeenCalled();
-    expect((result.details as { error?: string }).error).toContain("multiple LCM IDs");
-  });
-
-  it("lcm_describe rejects malformed bare IDs with disallowed characters", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-
-    const upper = await tool.execute("call-describe-uppercase", { id: "FILE_ABC123" });
-    expect(retrieval.describe).not.toHaveBeenCalled();
-    expect((upper.details as { error?: string }).error).toContain("Malformed LCM ID");
-
-    const spaced = await tool.execute("call-describe-spaced", { id: "file_abc 123" });
-    expect((spaced.details as { error?: string }).error).toMatch(/multiple LCM IDs|Not a recognized LCM ID/);
-  });
-
-  it("lcm_describe rejects zero/empty IDs", async () => {
-    const retrieval = {
-      grep: vi.fn(),
-      expand: vi.fn(),
-      describe: vi.fn(),
-    };
-
-    const tool = createLcmDescribeTool({
-      deps: makeDeps(),
-      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
-      sessionId: "session-1",
-    });
-
-    const zeroSuffix = await tool.execute("call-describe-zero-suffix", { id: "file_0" });
-    expect(retrieval.describe).not.toHaveBeenCalled();
-    expect((zeroSuffix.details as { error?: string }).error).toContain("zero/empty ID");
-
-    const allZeros = await tool.execute("call-describe-all-zeros", {
-      id: "file_0000000000000000",
-    });
-    expect((allZeros.details as { error?: string }).error).toContain("zero/empty ID");
-
-    const emptySuffix = await tool.execute("call-describe-empty-suffix", { id: "file_" });
-    expect((emptySuffix.details as { error?: string }).error).toContain("zero/empty ID");
   });
 
   it("lcm_grep resolves conversation scope via sessionKey continuity before sessionId lookup", async () => {


### PR DESCRIPTION
Closes #895.

 now extracts a bare `file_xxx` or `sum_xxx` ID from a full reference string such as `[LCM Tool Output: file_xxx | tool=... | N bytes]`, so agents can paste the reference directly instead of manually isolating the ID.