### PR TITLE
fix(log): make independent log file redaction tests deterministic

### DIFF
--- a/.changeset/independent-log-redaction-tests.md
+++ b/.changeset/independent-log-redaction-tests.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Make independent log file redaction tests deterministic when the optional OpenClaw host redactor is present in the test environment. The `independentLogFile` config surface is already declared in the manifest and accepted by the runtime; these tests now isolate the fallback redactor path so they do not flake when `openclaw` is installed locally.

--- a/.changeset/independent-log-redaction-tests.md
+++ b/.changeset/independent-log-redaction-tests.md
@@ -1,5 +1,0 @@
----
-"@martian-engineering/lossless-claw": patch
----
-
-Make independent log file redaction tests deterministic when the optional OpenClaw host redactor is present in the test environment. The `independentLogFile` config surface is already declared in the manifest and accepted by the runtime; these tests now isolate the fallback redactor path so they do not flake when `openclaw` is installed locally.

--- a/test/lcm-file-log.test.ts
+++ b/test/lcm-file-log.test.ts
@@ -151,6 +151,7 @@ describe("createIndependentLcmFileLogger", () => {
   });
 
   it("redacts obvious secret-shaped text before writing", () => {
+    __testing.setOpenClawRedactor(undefined);
     const file = path.join(tempDir, "lossless-claw-test.log");
     const logger = createIndependentLcmFileLogger({
       enabled: true,
@@ -165,6 +166,7 @@ describe("createIndependentLcmFileLogger", () => {
   });
 
   it("redacts common host logger secret shapes before writing", () => {
+    __testing.setOpenClawRedactor(undefined);
     const file = path.join(tempDir, "lossless-claw-test.log");
     const githubToken = "ghp_12345678901234567890";
     const githubPat = "github_pat_12345678901234567890";

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -2,22 +2,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing as fileLogTesting } from "../src/lcm-file-log.js";
 import { createLcmLogger } from "../src/lcm-log.js";
 import type { LcmConfig } from "../src/db/config.js";
-
-vi.mock("openclaw/plugin-sdk/logging-core", () => ({
-  redactSensitiveText: (text: string, options?: { patterns?: string[] }) => {
-    let next = text;
-    for (const rawPattern of options?.patterns ?? []) {
-      const match = rawPattern.match(/^\/(.+)\/([gimsuy]*)$/);
-      const pattern = match
-        ? new RegExp(match[1], match[2].includes("g") ? match[2] : `${match[2]}g`)
-        : new RegExp(rawPattern, "gi");
-      next = next.replace(pattern, "[REDACTED]");
-    }
-    return next;
-  },
-}));
 
 let tempDir: string;
 
@@ -27,6 +14,7 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
+  fileLogTesting.resetOpenClawRedactor();
 });
 
 function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
@@ -191,6 +179,18 @@ describe("createLcmLogger", () => {
   });
 
   it("applies OpenClaw custom redaction patterns to independent logs", () => {
+    fileLogTesting.setOpenClawRedactor((text, options) => {
+      let next = text;
+      for (const rawPattern of options?.patterns ?? []) {
+        const match = rawPattern.match(/^\/(.+)\/([gimsuy]*)$/);
+        const pattern = match
+          ? new RegExp(match[1], match[2].includes("g") ? match[2] : `${match[2]}g`)
+          : new RegExp(rawPattern, "gi");
+        next = next.replace(pattern, "[REDACTED]");
+      }
+      return next;
+    });
+
     const file = path.join(tempDir, "lossless-claw-test.log");
     const customSecret = "tenant-secret-12345";
     const { logger } = createRuntimeLogger(file, {


### PR DESCRIPTION
Relates to #883.

The independentLogFile config key is already declared in openclaw.plugin.json and accepted by src/db/config.ts. This change fixes test flakiness: when openclaw is installed in the test environment, createRequire loads the host redactor and the fallback-redaction tests see host-redacted output instead of the expected [REDACTED] markers. The tests now reset or inject the redactor explicitly so the fallback path is deterministic.