### PR TITLE
feat(doctor): allow doctor apply to target a specific conversation id

### DIFF
--- a/.changeset/doctor-apply-conversation-id.md
+++ b/.changeset/doctor-apply-conversation-id.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+`/lossless doctor apply` now accepts an optional conversation id: `doctor apply [<conversation-id>] [confirm-offline]`. This lets operators repair a specific conversation without needing that session to be the current active one. The existing current-conversation behavior is unchanged when no id is provided.

--- a/.changeset/doctor-apply-conversation-id.md
+++ b/.changeset/doctor-apply-conversation-id.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": minor
 ---
 
-`/lossless doctor apply` now accepts an optional conversation id: `doctor apply [<conversation-id>] [confirm-offline]`. This lets operators repair a specific conversation without needing that session to be the current active one. The existing current-conversation behavior is unchanged when no id is provided.
+`/lossless doctor apply` can now repair a specific conversation with `doctor apply <conversation-id> confirm-offline`. Targeted repair is limited to authorized OpenClaw command senders and requires the explicit offline confirmation after the target's active channel path is isolated. The existing current-conversation behavior is unchanged when no id is provided.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 - `/lossless backup` creates a timestamped backup of the current LCM SQLite database
 - `/lossless rotate` rewrites the active session transcript into a compact tail-preserving form without changing the live OpenClaw session identity or current LCM conversation
 - `/lossless doctor` scans for broken or truncated summaries
+- `/lossless doctor apply` repairs broken summaries in the current conversation after the normal safety preflight
+- `/lossless doctor apply <conversation-id> confirm-offline` repairs a specific conversation after its active channel path has been paused or moved away; targeted repair is restricted to authorized OpenClaw command senders and always requires the explicit offline confirmation
 - `/lossless doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
 - `/lossless status` shows plugin, conversation, and maintenance state including deferred compaction debt
 - `/lcm` is the shorter alias for `/lossless`
@@ -49,6 +51,7 @@ These are plugin slash/native commands, not root shell CLI subcommands. Supporte
 - `/lossless backup`
 - `/lossless rotate`
 - `/lossless doctor`
+- `/lossless doctor apply 42 confirm-offline`
 - `/lossless doctor clean`
 - `/lcm`
 

--- a/skills/lossless-claw/references/architecture.md
+++ b/skills/lossless-claw/references/architecture.md
@@ -42,7 +42,7 @@ The MVP command surface focuses on operational facts:
 
 ## What `/lossless doctor` tells you
 
-The MVP doctor flow is diagnostic only.
+The `/lossless doctor` scan is diagnostic only.
 
 It looks for known summary-health markers that indicate:
 
@@ -50,6 +50,8 @@ It looks for known summary-health markers that indicate:
 - truncated summary artifacts near the end of stored content
 
 This gives users one place to answer the question “is my summary graph healthy?” without introducing a broader mutation surface.
+
+`/lossless doctor apply` is the separate backup-first mutation surface for repairing detected summaries. Current-conversation repair keeps the normal large/hot safety preflight. Targeting another conversation by id requires `/lossless doctor apply <conversation-id> confirm-offline` after the target's active channel path has been isolated.
 
 ## What `/lossless doctor clean` tells you
 

--- a/skills/lossless-claw/references/diagnostics.md
+++ b/skills/lossless-claw/references/diagnostics.md
@@ -54,6 +54,16 @@ What it should help confirm:
 - whether truncation markers exist
 - which conversations are affected most
 
+### `/lossless doctor apply`
+
+Use this only after `/lossless doctor` identifies broken summaries. The command rewrites affected summary content in place after creating a database backup.
+
+- `/lossless doctor apply` repairs the current conversation and keeps the normal large/hot safety preflight.
+- `/lossless doctor apply confirm-offline` overrides that preflight for the current conversation after its active channel path has been isolated.
+- `/lossless doctor apply <conversation-id> confirm-offline` targets a specific conversation, including an archived or non-current conversation. Targeted repair always requires the explicit offline confirmation.
+
+Conversation ids are gateway-wide maintenance identifiers rather than sender ownership credentials. Only authorized OpenClaw command senders can invoke the command; before targeting an id, pause or move active delivery away from that conversation and verify the displayed session key is the intended lane.
+
 ### `/lossless doctor clean`
 
 Use this when the user wants read-only diagnostics for high-confidence junk patterns before any cleanup.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -87,6 +87,7 @@ type CurrentConversationResolution =
     };
 type DoctorApplyOptions = {
   confirmOffline: boolean;
+  conversationId?: number;
 };
 type DoctorApplyRepairMetrics = {
   repairInputTokenCount: number;
@@ -482,6 +483,7 @@ function parseDoctorApplyArgs(tokens: string[]):
   }
 
   let confirmOffline = false;
+  let conversationId: number | undefined;
   for (const token of tokens) {
     const normalized = token.toLowerCase();
     if (
@@ -495,14 +497,38 @@ function parseDoctorApplyArgs(tokens: string[]):
       continue;
     }
 
+    const parsedId = Number(token);
+    if (
+      !Number.isNaN(parsedId) &&
+      Number.isInteger(parsedId) &&
+      parsedId > 0 &&
+      String(parsedId) === token
+    ) {
+      if (conversationId !== undefined) {
+        return {
+          ok: false,
+          error:
+            `\`${VISIBLE_COMMAND} doctor apply\` accepts at most one conversation id.`,
+        };
+      }
+      conversationId = parsedId;
+      continue;
+    }
+
     return {
       ok: false,
       error:
-        `\`${VISIBLE_COMMAND} doctor apply\` accepts optional \`confirm-offline\` for large/hot repair overrides.`,
+        `\`${VISIBLE_COMMAND} doctor apply\` accepts an optional conversation id and optional \`confirm-offline\` for large/hot repair overrides.`,
     };
   }
 
-  return { ok: true, options: { confirmOffline } };
+  return {
+    ok: true,
+    options: {
+      confirmOffline,
+      ...(conversationId !== undefined ? { conversationId } : {}),
+    },
+  };
 }
 
 function parseRolloverSplitApplyArgs(tokens: string[]):
@@ -605,7 +631,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [confirm-offline]\` for the scoped summary repair path.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [<conversation-id>] [confirm-offline]\` for the scoped summary repair path.`,
       };
     case "help":
       return { kind: "help" };
@@ -838,6 +864,21 @@ async function resolveCurrentConversation(params: {
     kind: "unavailable",
     reason: "OpenClaw did not expose an active session key or session id here, so only GLOBAL stats are available.",
   };
+}
+
+async function resolveDoctorApplyConversationById(
+  db: DatabaseSync,
+  conversationId: number,
+): Promise<CurrentConversationResolution> {
+  const stats = getConversationStatusStats(db, conversationId);
+  if (!stats) {
+    return {
+      kind: "unavailable",
+      reason: `No LCM conversation found with id ${formatNumber(conversationId)}.`,
+    };
+  }
+
+  return { kind: "resolved", source: "session_id", stats };
 }
 
 async function resolveRuntimeSessionId(params: {
@@ -1269,6 +1310,10 @@ function buildHelpText(error?: string): string {
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor apply`), "Repair broken summaries in the current conversation."),
       buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id>`),
+        "Repair broken summaries in a specific conversation by id.",
+      ),
+      buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor apply confirm-offline`),
         "Override large/hot-session repair preflight after isolating the active channel path.",
       ),
@@ -1504,7 +1549,8 @@ async function buildDoctorText(params: {
       buildSection("🧷 Affected summaries", [summaryList]),
       "",
       buildSection("🛠️ Next step", [
-        `${formatCommand(`${VISIBLE_COMMAND} doctor apply`)} repairs these in place for the current conversation.`,
+        `${formatCommand(`${VISIBLE_COMMAND} doctor apply`)} repairs these in place for the current conversation. ` +
+          `Use ${formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id>`)} to target a different conversation.`,
       ]),
     );
   }
@@ -2989,7 +3035,13 @@ async function buildDoctorApplyText(params: {
   summarize?: LcmSummarizeFn;
   options?: DoctorApplyOptions;
 }): Promise<string> {
-  const current = await resolveCurrentConversation(params);
+  const requestedConversationId = params.options?.conversationId;
+  const targetSectionLabel = requestedConversationId !== undefined
+    ? "📍 Target conversation"
+    : "📍 Current conversation";
+  const current = requestedConversationId !== undefined
+    ? await resolveDoctorApplyConversationById(params.db, requestedConversationId)
+    : await resolveCurrentConversation(params);
 
   if (current.kind === "unavailable") {
     return [
@@ -2997,7 +3049,7 @@ async function buildDoctorApplyText(params: {
       "",
       "🩺 Lossless Claw Doctor Apply",
       "",
-      buildSection("📍 Current conversation", [
+      buildSection("📍 Target conversation", [
         buildStatLine("status", "unavailable"),
         buildStatLine("reason", current.reason),
         buildStatLine("fallback", "Doctor apply is conversation-scoped, so no global repair ran."),
@@ -3030,7 +3082,7 @@ async function buildDoctorApplyText(params: {
       "",
       "🩺 Lossless Claw Doctor Apply",
       "",
-      buildSection("📍 Current conversation", [
+      buildSection(targetSectionLabel, [
         buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
         buildStatLine(
           "session key",
@@ -3080,7 +3132,7 @@ async function buildDoctorApplyText(params: {
       "",
       "🩺 Lossless Claw Doctor Apply",
       "",
-      buildSection("📍 Current conversation", [
+      buildSection(targetSectionLabel, [
         buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
         buildStatLine(
           "session key",
@@ -3102,7 +3154,7 @@ async function buildDoctorApplyText(params: {
     "",
     "🩺 Lossless Claw Doctor Apply",
     "",
-    buildSection("📍 Current conversation", [
+    buildSection(targetSectionLabel, [
       buildStatLine("conversation id", formatNumber(current.stats.conversationId)),
       buildStatLine(
         "session key",

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -78,7 +78,7 @@ type LcmConversationStatusStats = {
 type CurrentConversationResolution =
   | {
       kind: "resolved";
-      source: "session_key" | "session_key_via_session_id" | "session_id";
+      source: "session_key" | "session_key_via_session_id" | "session_id" | "conversation_id";
       stats: LcmConversationStatusStats;
     }
   | {
@@ -878,7 +878,7 @@ async function resolveDoctorApplyConversationById(
     };
   }
 
-  return { kind: "resolved", source: "session_id", stats };
+  return { kind: "resolved", source: "conversation_id", stats };
 }
 
 async function resolveRuntimeSessionId(params: {
@@ -3110,7 +3110,12 @@ async function buildDoctorApplyText(params: {
       ]),
       "",
       buildSection("🛠️ Next step", [
-        `Run ${formatCommand(`${VISIBLE_COMMAND} doctor apply confirm-offline`)} only from an isolated/offline maintenance lane after active channel delivery is paused or moved away from this conversation.`,
+        (() => {
+          const command = requestedConversationId !== undefined
+            ? `${VISIBLE_COMMAND} doctor apply ${formatNumber(requestedConversationId)} confirm-offline`
+            : `${VISIBLE_COMMAND} doctor apply confirm-offline`;
+          return `Run ${formatCommand(command)} only from an isolated/offline maintenance lane after active channel delivery is paused or moved away from this conversation.`;
+        })(),
       ]),
     ].join("\n");
   }

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -483,11 +483,16 @@ function parseDoctorApplyArgs(tokens: string[]):
   }
 
   let confirmOffline = false;
+  let explicitConfirmOffline = false;
   let conversationId: number | undefined;
   for (const token of tokens) {
     const normalized = token.toLowerCase();
+    if (normalized === "confirm-offline") {
+      confirmOffline = true;
+      explicitConfirmOffline = true;
+      continue;
+    }
     if (
-      normalized === "confirm-offline" ||
       normalized === "confirm-large" ||
       normalized === "offline" ||
       normalized === "--offline" ||
@@ -500,7 +505,7 @@ function parseDoctorApplyArgs(tokens: string[]):
     const parsedId = Number(token);
     if (
       !Number.isNaN(parsedId) &&
-      Number.isInteger(parsedId) &&
+      Number.isSafeInteger(parsedId) &&
       parsedId > 0 &&
       String(parsedId) === token
     ) {
@@ -518,7 +523,15 @@ function parseDoctorApplyArgs(tokens: string[]):
     return {
       ok: false,
       error:
-        `\`${VISIBLE_COMMAND} doctor apply\` accepts an optional conversation id and optional \`confirm-offline\` for large/hot repair overrides.`,
+        `\`${VISIBLE_COMMAND} doctor apply\` accepts optional \`confirm-offline\` for the current conversation or \`<conversation-id> confirm-offline\` for targeted repair.`,
+    };
+  }
+
+  if (conversationId !== undefined && confirmOffline && !explicitConfirmOffline) {
+    return {
+      ok: false,
+      error:
+        `\`${VISIBLE_COMMAND} doctor apply <conversation-id>\` requires explicit \`confirm-offline\`; other offline aliases apply only to current-conversation repair.`,
     };
   }
 
@@ -631,7 +644,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, or \`apply [<conversation-id>] [confirm-offline]\` for the scoped summary repair path.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, \`apply [confirm-offline]\` for current-conversation repair, or \`apply <conversation-id> confirm-offline\` for targeted repair.`,
       };
     case "help":
       return { kind: "help" };
@@ -1310,8 +1323,8 @@ function buildHelpText(error?: string): string {
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor apply`), "Repair broken summaries in the current conversation."),
       buildStatLine(
-        formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id>`),
-        "Repair broken summaries in a specific conversation by id.",
+        formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id> confirm-offline`),
+        "Repair a specific conversation by id after isolating its active channel path.",
       ),
       buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor apply confirm-offline`),
@@ -1550,7 +1563,7 @@ async function buildDoctorText(params: {
       "",
       buildSection("🛠️ Next step", [
         `${formatCommand(`${VISIBLE_COMMAND} doctor apply`)} repairs these in place for the current conversation. ` +
-          `Use ${formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id>`)} to target a different conversation.`,
+          `Use ${formatCommand(`${VISIBLE_COMMAND} doctor apply <conversation-id> confirm-offline`)} to target a different conversation after isolating its active channel path.`,
       ]),
     );
   }
@@ -3036,6 +3049,10 @@ async function buildDoctorApplyText(params: {
   options?: DoctorApplyOptions;
 }): Promise<string> {
   const requestedConversationId = params.options?.conversationId;
+  const confirmOffline = params.options?.confirmOffline === true;
+  const nextStepCommand = requestedConversationId !== undefined
+    ? `${VISIBLE_COMMAND} doctor apply ${String(requestedConversationId)} confirm-offline`
+    : `${VISIBLE_COMMAND} doctor apply confirm-offline`;
   const targetSectionLabel = requestedConversationId !== undefined
     ? "📍 Target conversation"
     : "📍 Current conversation";
@@ -3049,7 +3066,7 @@ async function buildDoctorApplyText(params: {
       "",
       "🩺 Lossless Claw Doctor Apply",
       "",
-      buildSection("📍 Target conversation", [
+      buildSection(targetSectionLabel, [
         buildStatLine("status", "unavailable"),
         buildStatLine("reason", current.reason),
         buildStatLine("fallback", "Doctor apply is conversation-scoped, so no global repair ran."),
@@ -3062,8 +3079,7 @@ async function buildDoctorApplyText(params: {
     params.db,
     current.stats.conversationId,
   );
-  const skipRepairMetrics =
-    params.options?.confirmOffline !== true && stats.total > DOCTOR_APPLY_LARGE_TARGET_THRESHOLD;
+  const skipRepairMetrics = !confirmOffline && stats.total > DOCTOR_APPLY_LARGE_TARGET_THRESHOLD;
   const repairMetrics = skipRepairMetrics
     ? null
     : loadDoctorApplyRepairMetrics(params.db, stats);
@@ -3076,7 +3092,10 @@ async function buildDoctorApplyText(params: {
     },
     maintenance,
   });
-  if (preflight.blocked && params.options?.confirmOffline !== true) {
+  const targetedConfirmationReason = requestedConversationId !== undefined && !confirmOffline
+    ? "explicit conversation-id targeting requires `confirm-offline`"
+    : null;
+  if ((preflight.blocked || targetedConfirmationReason !== null) && !confirmOffline) {
     return [
       ...buildHeaderLines(),
       "",
@@ -3106,16 +3125,14 @@ async function buildDoctorApplyText(params: {
             ]
           : []),
         buildStatLine("token threshold", formatNumber(preflight.tokenThreshold)),
+        ...(targetedConfirmationReason
+          ? [buildStatLine("reason", targetedConfirmationReason)]
+          : []),
         ...preflight.reasons.map((reason) => buildStatLine("reason", reason)),
       ]),
       "",
       buildSection("🛠️ Next step", [
-        (() => {
-          const command = requestedConversationId !== undefined
-            ? `${VISIBLE_COMMAND} doctor apply ${formatNumber(requestedConversationId)} confirm-offline`
-            : `${VISIBLE_COMMAND} doctor apply confirm-offline`;
-          return `Run ${formatCommand(command)} only from an isolated/offline maintenance lane after active channel delivery is paused or moved away from this conversation.`;
-        })(),
+        `Run ${formatCommand(nextStepCommand)} only from an isolated/offline maintenance lane after active channel delivery is paused or moved away from this conversation.`,
       ]),
     ].join("\n");
   }
@@ -3184,7 +3201,7 @@ async function buildDoctorApplyText(params: {
   lines.push(
     buildSection("🛠️ Apply", [
       buildStatLine("mode", "in-place summary rewrite"),
-      ...(params.options?.confirmOffline === true
+      ...(confirmOffline
         ? [buildStatLine("safety override", "confirm-offline")]
         : []),
       buildStatLine("repair targets", formatNumber(stats.total)),

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -3067,6 +3067,22 @@ describe("lcm command", () => {
     expect(untouchedCurrent?.content).toBe("healthy current summary");
   });
 
+  it("reports unavailable when targeting a nonexistent conversation id", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext("doctor apply 99999", {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-nonexistent",
+      }),
+    );
+
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
+    expect(result.text).toContain("status: unavailable");
+    expect(result.text).toContain("No LCM conversation found with id 99,999");
+  });
+
   it("uses the normal runtime model chain for doctor apply when no explicit summary model is set", async () => {
     const hostBoundComplete = vi.fn(async () => ({
       text: "HOST BOUND REPAIR",
@@ -4205,6 +4221,10 @@ describe("lcm command helpers", () => {
       kind: "help",
       error:
         "`/lossless doctor apply` accepts an optional conversation id and optional `confirm-offline` for large/hot repair overrides.",
+    });
+    expect(__testing.parseLcmCommand("doctor apply 42 42")).toEqual({
+      kind: "help",
+      error: "`/lossless doctor apply` accepts at most one conversation id.",
     });
     expect(__testing.parseLcmCommand("doctor rollover-splits")).toEqual({
       kind: "doctor_rollover_splits",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1629,7 +1629,9 @@ describe("lcm command", () => {
     expect(result.text).toContain(
       "`/lossless doctor apply` repairs these in place for the current conversation.",
     );
-    expect(result.text).toContain("`/lossless doctor apply <conversation-id>`");
+    expect(result.text).toContain(
+      "`/lossless doctor apply <conversation-id> confirm-offline`",
+    );
     expect(result.text).not.toContain("sum_other_new");
     expect(result.text).not.toContain(`conversation id: ${otherConversation.conversationId}`);
   });
@@ -2996,6 +2998,8 @@ describe("lcm command", () => {
     const untouched = await fixture.summaryStore.getSummary("sum_unresolved_apply_other");
 
     expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
+    expect(result.text).toContain("**📍 Current conversation**");
+    expect(result.text).not.toContain("**📍 Target conversation**");
     expect(result.text).toContain("status: unavailable");
     expect(result.text).toContain(
       "No LCM conversation is stored yet for active session key `agent:main:telegram:direct:not-stored` or active session id `doctor-apply-unresolved-missing`.",
@@ -3006,7 +3010,7 @@ describe("lcm command", () => {
     expect(untouched?.content).toContain("[Truncated from 204 tokens]");
   });
 
-  it("repairs a specific conversation by id regardless of the current session context", async () => {
+  it("requires offline confirmation before repairing a conversation by id", async () => {
     const summarize = vi.fn(async () => "REPAIRED BY ID");
     const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
     tempDirs.add(fixture.tempDir);
@@ -3049,10 +3053,28 @@ describe("lcm command", () => {
     });
     await fixture.summaryStore.linkSummaryToMessages("sum_other_id", [message.messageId]);
 
-    const result = await fixture.command.handler(
+    const blocked = await fixture.command.handler(
       createCommandContext(`doctor apply ${otherConversation.conversationId}`, {
         sessionKey: "agent:main:telegram:direct:doctor-apply-current-id",
       }),
+    );
+
+    const unchangedOther = await fixture.summaryStore.getSummary("sum_other_id");
+    expect(blocked.text).toContain("status: blocked");
+    expect(blocked.text).toContain("explicit conversation-id targeting requires `confirm-offline`");
+    expect(blocked.text).toContain(
+      `/lossless doctor apply ${otherConversation.conversationId} confirm-offline`,
+    );
+    expect(summarize).not.toHaveBeenCalled();
+    expect(unchangedOther?.content).toContain("[Truncated from 123 tokens]");
+
+    const result = await fixture.command.handler(
+      createCommandContext(
+        `doctor apply ${otherConversation.conversationId} confirm-offline`,
+        {
+          sessionKey: "agent:main:telegram:direct:doctor-apply-current-id",
+        },
+      ),
     );
 
     const repairedOther = await fixture.summaryStore.getSummary("sum_other_id");
@@ -3060,11 +3082,92 @@ describe("lcm command", () => {
 
     expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
     expect(result.text).toContain(`conversation id: ${otherConversation.conversationId}`);
+    expect(result.text).toContain("safety override: confirm-offline");
     expect(result.text).toContain("repaired summaries: 1");
     expect(summarize).toHaveBeenCalledTimes(1);
     expect(repairedOther?.content).toContain("REPAIRED BY ID");
     expect(repairedOther?.content).not.toContain("[Truncated from 123 tokens]");
     expect(untouchedCurrent?.content).toBe("healthy current summary");
+  });
+
+  it("preserves a large targeted id through the blocked preflight and offline override", async () => {
+    const summarize = vi.fn(async (_text: string) => "TARGETED OFFLINE REPAIR");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const targetConversationId = 1_234;
+    fixture.db
+      .prepare(
+        `INSERT INTO conversations (conversation_id, session_id, session_key)
+         VALUES (?, ?, ?)`,
+      )
+      .run(
+        targetConversationId,
+        "doctor-apply-large-target-id",
+        "agent:main:telegram:direct:doctor-apply-large-target-id",
+      );
+
+    const messages = await fixture.conversationStore.createMessagesBulk(
+      Array.from({ length: 26 }, (_, index) => ({
+        conversationId: targetConversationId,
+        seq: index,
+        role: "user",
+        content: `targeted repair source ${index}`,
+        tokenCount: 5,
+      })),
+    );
+    for (let index = 0; index < 26; index += 1) {
+      const summaryId = `sum_large_targeted_${index}`;
+      await fixture.summaryStore.insertSummary({
+        summaryId,
+        conversationId: targetConversationId,
+        kind: "leaf",
+        depth: 0,
+        content: `broken targeted leaf ${index}\n${"[Truncated from 512 tokens]"}`,
+        tokenCount: 11,
+        sourceMessageTokenCount: 5,
+      });
+      await fixture.summaryStore.linkSummaryToMessages(summaryId, [messages[index].messageId]);
+    }
+    fixture.db
+      .prepare(
+        `INSERT INTO conversation_compaction_maintenance (
+           conversation_id,
+           pending,
+           requested_at,
+           reason,
+           running,
+           updated_at
+         ) VALUES (?, 1, ?, ?, 0, datetime('now'))`,
+      )
+      .run(targetConversationId, "2026-07-15T00:00:00.000Z", "budget-trigger");
+
+    const blocked = await fixture.command.handler(
+      createCommandContext(`doctor apply ${targetConversationId}`, {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-caller",
+      }),
+    );
+
+    expect(blocked.text).toContain("status: blocked");
+    expect(blocked.text).toContain("repair targets: 26");
+    expect(blocked.text).toContain("explicit conversation-id targeting requires `confirm-offline`");
+    expect(blocked.text).toContain("doctor target count 26 exceeds safe inline limit 25");
+    expect(blocked.text).toContain("compaction maintenance is pending (budget-trigger)");
+    expect(blocked.text).toContain(`/lossless doctor apply ${targetConversationId} confirm-offline`);
+    expect(blocked.text).not.toContain("1,234 confirm-offline");
+    expect(summarize).not.toHaveBeenCalled();
+
+    const result = await fixture.command.handler(
+      createCommandContext(`doctor apply ${targetConversationId} confirm-offline`, {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-caller",
+      }),
+    );
+
+    const repaired = await fixture.summaryStore.getSummary("sum_large_targeted_0");
+    expect(result.text).toContain("safety override: confirm-offline");
+    expect(result.text).toContain("repaired summaries: 26");
+    expect(summarize).toHaveBeenCalledTimes(26);
+    expect(repaired?.content).toBe("TARGETED OFFLINE REPAIR");
   });
 
   it("reports unavailable when targeting a nonexistent conversation id", async () => {
@@ -4207,6 +4310,11 @@ describe("lcm command helpers", () => {
       apply: true,
       applyOptions: { confirmOffline: true },
     });
+    expect(__testing.parseLcmCommand("doctor apply offline")).toEqual({
+      kind: "doctor",
+      apply: true,
+      applyOptions: { confirmOffline: true },
+    });
     expect(__testing.parseLcmCommand("doctor apply 42")).toEqual({
       kind: "doctor",
       apply: true,
@@ -4217,14 +4325,29 @@ describe("lcm command helpers", () => {
       apply: true,
       applyOptions: { confirmOffline: true, conversationId: 42 },
     });
+    expect(__testing.parseLcmCommand("doctor apply 42 offline")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply <conversation-id>` requires explicit `confirm-offline`; other offline aliases apply only to current-conversation repair.",
+    });
+    expect(__testing.parseLcmCommand("doctor apply confirm-large 42")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply <conversation-id>` requires explicit `confirm-offline`; other offline aliases apply only to current-conversation repair.",
+    });
     expect(__testing.parseLcmCommand("doctor apply not-a-number")).toEqual({
       kind: "help",
       error:
-        "`/lossless doctor apply` accepts an optional conversation id and optional `confirm-offline` for large/hot repair overrides.",
+        "`/lossless doctor apply` accepts optional `confirm-offline` for the current conversation or `<conversation-id> confirm-offline` for targeted repair.",
     });
     expect(__testing.parseLcmCommand("doctor apply 42 42")).toEqual({
       kind: "help",
       error: "`/lossless doctor apply` accepts at most one conversation id.",
+    });
+    expect(__testing.parseLcmCommand("doctor apply 9007199254740992")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply` accepts optional `confirm-offline` for the current conversation or `<conversation-id> confirm-offline` for targeted repair.",
     });
     expect(__testing.parseLcmCommand("doctor rollover-splits")).toEqual({
       kind: "doctor_rollover_splits",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1626,7 +1626,10 @@ describe("lcm command", () => {
       "sum_current_directive (fallback), sum_current_emergency (emergency), sum_current_new (new), sum_current_old (old)",
     );
     expect(result.text).toContain("**🛠️ Next step**");
-    expect(result.text).toContain("`/lossless doctor apply` repairs these in place for the current conversation.");
+    expect(result.text).toContain(
+      "`/lossless doctor apply` repairs these in place for the current conversation.",
+    );
+    expect(result.text).toContain("`/lossless doctor apply <conversation-id>`");
     expect(result.text).not.toContain("sum_other_new");
     expect(result.text).not.toContain(`conversation id: ${otherConversation.conversationId}`);
   });
@@ -3003,6 +3006,67 @@ describe("lcm command", () => {
     expect(untouched?.content).toContain("[Truncated from 204 tokens]");
   });
 
+  it("repairs a specific conversation by id regardless of the current session context", async () => {
+    const summarize = vi.fn(async () => "REPAIRED BY ID");
+    const fixture = createCommandFixture({ summarize: summarize as LcmSummarizeFn });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const currentConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-current-id",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-current-id",
+    });
+    const otherConversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-apply-other-id",
+      sessionKey: "agent:main:telegram:direct:doctor-apply-other-id",
+    });
+
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_current_id",
+      conversationId: currentConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "healthy current summary",
+      tokenCount: 9,
+    });
+    const [message] = await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: otherConversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "other repair source",
+        tokenCount: 7,
+      },
+    ]);
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_other_id",
+      conversationId: otherConversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: `broken other summary\n${"[Truncated from 123 tokens]"}`,
+      tokenCount: 11,
+      sourceMessageTokenCount: 7,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_other_id", [message.messageId]);
+
+    const result = await fixture.command.handler(
+      createCommandContext(`doctor apply ${otherConversation.conversationId}`, {
+        sessionKey: "agent:main:telegram:direct:doctor-apply-current-id",
+      }),
+    );
+
+    const repairedOther = await fixture.summaryStore.getSummary("sum_other_id");
+    const untouchedCurrent = await fixture.summaryStore.getSummary("sum_current_id");
+
+    expect(result.text).toContain("🩺 Lossless Claw Doctor Apply");
+    expect(result.text).toContain(`conversation id: ${otherConversation.conversationId}`);
+    expect(result.text).toContain("repaired summaries: 1");
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(repairedOther?.content).toContain("REPAIRED BY ID");
+    expect(repairedOther?.content).not.toContain("[Truncated from 123 tokens]");
+    expect(untouchedCurrent?.content).toBe("healthy current summary");
+  });
+
   it("uses the normal runtime model chain for doctor apply when no explicit summary model is set", async () => {
     const hostBoundComplete = vi.fn(async () => ({
       text: "HOST BOUND REPAIR",
@@ -4126,6 +4190,21 @@ describe("lcm command helpers", () => {
       kind: "doctor",
       apply: true,
       applyOptions: { confirmOffline: true },
+    });
+    expect(__testing.parseLcmCommand("doctor apply 42")).toEqual({
+      kind: "doctor",
+      apply: true,
+      applyOptions: { confirmOffline: false, conversationId: 42 },
+    });
+    expect(__testing.parseLcmCommand("doctor apply 42 confirm-offline")).toEqual({
+      kind: "doctor",
+      apply: true,
+      applyOptions: { confirmOffline: true, conversationId: 42 },
+    });
+    expect(__testing.parseLcmCommand("doctor apply not-a-number")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply` accepts an optional conversation id and optional `confirm-offline` for large/hot repair overrides.",
     });
     expect(__testing.parseLcmCommand("doctor rollover-splits")).toEqual({
       kind: "doctor_rollover_splits",


### PR DESCRIPTION
Closes #917.

## What
Adds native conversation-id targeting for summary repair through `/lossless doctor apply <conversation-id> confirm-offline`.

## Why
The native command repairs only the active conversation, while offline tooling can repair a named conversation. Explicit targeting gives operators the same repair scope without risking a rewrite in the wrong active lane.

## Changes
- Parse one positive conversation id
- Require exact targeted offline confirmation
- Preserve large and hot preflight checks
- Keep current-conversation behavior unchanged
- Document authorization and lane isolation
- Add a minor release changeset

## Testing
- `npm test -- --run test/lcm-command.test.ts`
- `npm run typecheck`
- `npm run build`
- Synthetic current-main merge: 1,821 tests pass
- Hosted test, inspector, and smoke checks pass