### PR TITLE
test(dedup): add focused batch-dedup unit tests

### DIFF
--- a/.changeset/batch-dedup-focused-units.md
+++ b/.changeset/batch-dedup-focused-units.md
@@ -1,5 +1,0 @@
----
-"@martian-engineering/lossless-claw": patch
----
-
-Add focused unit tests for `BatchDeduplicator` in `test/batch-dedup.test.ts`. The new file covers `deduplicateAfterTurnBatch` and `alignRuntimeBatchAgainstCoveredFrontier` directly, including empty batch, empty conversation, full stored-transcript trim, tail-only replay, decorated-face collapse, and fail-closed overlap behavior. This complements the existing integration-level replay proof in `engine-after-turn.test.ts`.

--- a/.changeset/batch-dedup-focused-units.md
+++ b/.changeset/batch-dedup-focused-units.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add focused unit tests for `BatchDeduplicator` in `test/batch-dedup.test.ts`. The new file covers `deduplicateAfterTurnBatch` and `alignRuntimeBatchAgainstCoveredFrontier` directly, including empty batch, empty conversation, full stored-transcript trim, tail-only replay, decorated-face collapse, and fail-closed overlap behavior. This complements the existing integration-level replay proof in `engine-after-turn.test.ts`.

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -25,14 +25,17 @@ function makeConversationStore(initial: FakeConversationStore): ConversationStor
       expect(conversationId).toBe(initial.conversationId);
       return initial.messages.slice(-limit);
     }),
-    getMessages: vi.fn(async (conversationId: number, options?: { limit?: number; offset?: number }) => {
-      expect(conversationId).toBe(initial.conversationId);
-      const limit = options?.limit ?? initial.messages.length;
-      if (options?.offset !== undefined) {
-        return initial.messages.slice(options.offset, options.offset + limit);
-      }
-      return initial.messages.slice(-limit);
-    }),
+    getMessages: vi.fn(
+      async (conversationId: number, options?: { afterSeq?: number; limit?: number }) => {
+        expect(conversationId).toBe(initial.conversationId);
+        const afterSeq = options?.afterSeq ?? -1;
+        const filtered = initial.messages.filter((m) => m.seq > afterSeq).sort((a, b) => a.seq - b.seq);
+        if (options?.limit !== undefined) {
+          return filtered.slice(0, options.limit);
+        }
+        return filtered;
+      },
+    ),
     getLastMessageIdentityHash: vi.fn(async () => {
       const last = initial.messages[initial.messages.length - 1];
       return last ? buildMessageIdentityHash(last.role, last.content) : null;

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -12,11 +12,9 @@ function makeLog() {
 type FakeConversationStore = {
   conversationId: number;
   messages: MessageRecord[];
-  hasMessageAnswers: boolean[];
 };
 
 function makeConversationStore(initial: FakeConversationStore): ConversationStore {
-  const log = makeLog();
   return {
     getConversationForSession: vi.fn(async () => ({ conversationId: initial.conversationId })),
     getMessageCount: vi.fn(async () => initial.messages.length),
@@ -46,7 +44,16 @@ function makeConversationStore(initial: FakeConversationStore): ConversationStor
         .slice(-limit)
         .map((m) => buildMessageIdentityHash(m.role, m.content));
     }),
-    hasMessage: vi.fn(async () => initial.hasMessageAnswers.shift() ?? false),
+    hasMessage: vi.fn(async (conversationId: number, role: string, content: string) => {
+      expect(conversationId).toBe(initial.conversationId);
+      const identityHash = buildMessageIdentityHash(role, content);
+      return initial.messages.some(
+        (message) =>
+          message.role === role &&
+          message.content === content &&
+          buildMessageIdentityHash(message.role, message.content) === identityHash,
+      );
+    }),
     countMessagesByIdentityHash: vi.fn(
       async (_conversationId: number, role: string, identityHash: string) =>
         initial.messages.filter(
@@ -80,7 +87,7 @@ function storedMessage(role: string, content: string): MessageRecord {
 
 describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
   it("returns an empty batch unchanged", async () => {
-    const dedup = makeDedup({ conversationId: 1, messages: [], hasMessageAnswers: [] });
+    const dedup = makeDedup({ conversationId: 1, messages: [] });
     const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, []);
     expect(result).toEqual([]);
   });
@@ -100,7 +107,7 @@ describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
   });
 
   it("returns the batch when the stored conversation is empty", async () => {
-    const dedup = makeDedup({ conversationId: 1, messages: [], hasMessageAnswers: [] });
+    const dedup = makeDedup({ conversationId: 1, messages: [] });
     const batch = [makeMessage({ role: "user", content: "hello" })];
     const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
     expect(result).toEqual(batch);
@@ -110,7 +117,6 @@ describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
-      hasMessageAnswers: [],
     });
     const batch = [
       makeMessage({ role: "user", content: "a" }),
@@ -125,7 +131,6 @@ describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
-      hasMessageAnswers: [],
     });
     const batch = [
       makeMessage({ role: "user", content: "a" }),
@@ -143,7 +148,6 @@ describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
         storedMessage("assistant", "old-2"),
         storedMessage("user", "old-3"),
       ],
-      hasMessageAnswers: [],
     });
     const batch = [
       makeMessage({ role: "user", content: "old-3" }),
@@ -159,7 +163,6 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
-      hasMessageAnswers: [],
     });
     const batch = [
       makeMessage({ role: "user", content: "a" }),
@@ -173,7 +176,6 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
-      hasMessageAnswers: [],
     });
     const batch = [
       makeMessage({ role: "user", content: "a" }),
@@ -188,7 +190,6 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "old")],
-      hasMessageAnswers: [],
     });
     const batch = [makeMessage({ role: "user", content: "new" })];
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
@@ -201,7 +202,6 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", bareContent)],
-      hasMessageAnswers: [],
     });
     const batch = [makeMessage({ role: "user", content: decoratedContent })];
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
@@ -212,7 +212,6 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
-      hasMessageAnswers: [true, false],
     });
     const batch = [
       makeMessage({ role: "user", content: "a" }),

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+import { BatchDeduplicator } from "../src/batch-dedup.js";
+import type { ConversationStore, MessageRecord } from "../src/store/conversation-store.js";
+import { buildMessageIdentityHash } from "../src/store/message-identity.js";
+import type { SummaryStore } from "../src/store/summary-store.js";
+import { makeMessage } from "./helpers.js";
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+type FakeConversationStore = {
+  conversationId: number;
+  messages: MessageRecord[];
+  hasMessageAnswers: boolean[];
+};
+
+function makeConversationStore(initial: FakeConversationStore): ConversationStore {
+  const log = makeLog();
+  return {
+    getConversationForSession: vi.fn(async () => ({ conversationId: initial.conversationId })),
+    getMessageCount: vi.fn(async () => initial.messages.length),
+    getLastMessage: vi.fn(async () => initial.messages[initial.messages.length - 1]),
+    getLastMessages: vi.fn(async (conversationId: number, limit: number) => {
+      expect(conversationId).toBe(initial.conversationId);
+      return initial.messages.slice(-limit);
+    }),
+    getMessages: vi.fn(async (conversationId: number, options?: { limit?: number; offset?: number }) => {
+      expect(conversationId).toBe(initial.conversationId);
+      const limit = options?.limit ?? initial.messages.length;
+      if (options?.offset !== undefined) {
+        return initial.messages.slice(options.offset, options.offset + limit);
+      }
+      return initial.messages.slice(-limit);
+    }),
+    getLastMessageIdentityHash: vi.fn(async () => {
+      const last = initial.messages[initial.messages.length - 1];
+      return last ? buildMessageIdentityHash(last.role, last.content) : null;
+    }),
+    getRecentMessageIdentityHashes: vi.fn(async (conversationId: number, limit: number) => {
+      expect(conversationId).toBe(initial.conversationId);
+      return initial.messages
+        .slice(-limit)
+        .map((m) => buildMessageIdentityHash(m.role, m.content));
+    }),
+    hasMessage: vi.fn(async () => initial.hasMessageAnswers.shift() ?? false),
+    countMessagesByIdentityHash: vi.fn(
+      async (_conversationId: number, role: string, identityHash: string) =>
+        initial.messages.filter(
+          (m) => buildMessageIdentityHash(m.role, m.content) === identityHash && m.role === role,
+        ).length,
+    ),
+  } as unknown as ConversationStore;
+}
+
+function makeDedup(store: FakeConversationStore) {
+  return new BatchDeduplicator(
+    makeConversationStore(store),
+    {} as unknown as SummaryStore,
+    "/tmp/lcm-batch-dedup-test",
+    { log: makeLog() },
+  );
+}
+
+function storedMessage(role: string, content: string): MessageRecord {
+  return {
+    messageId: 0,
+    conversationId: 1,
+    seq: 0,
+    role: role as MessageRecord["role"],
+    content,
+    tokenCount: 1,
+    createdAt: new Date(),
+    largeContent: null,
+  };
+}
+
+describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
+  it("returns an empty batch unchanged", async () => {
+    const dedup = makeDedup({ conversationId: 1, messages: [], hasMessageAnswers: [] });
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns the batch when no conversation is stored yet", async () => {
+    const dedup = new BatchDeduplicator(
+      {
+        getConversationForSession: vi.fn(async () => null),
+      } as unknown as ConversationStore,
+      {} as unknown as SummaryStore,
+      "/tmp/lcm-batch-dedup-test",
+      { log: makeLog() },
+    );
+    const batch = [makeMessage({ role: "user", content: "hello" })];
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+    expect(result).toEqual(batch);
+  });
+
+  it("returns the batch when the stored conversation is empty", async () => {
+    const dedup = makeDedup({ conversationId: 1, messages: [], hasMessageAnswers: [] });
+    const batch = [makeMessage({ role: "user", content: "hello" })];
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+    expect(result).toEqual(batch);
+  });
+
+  it("trims the full stored transcript when the batch begins with it", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
+      hasMessageAnswers: [],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "a" }),
+      makeMessage({ role: "assistant", content: "b" }),
+      makeMessage({ role: "user", content: "c" }),
+    ];
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+    expect(result).toEqual([batch[2]]);
+  });
+
+  it("returns an empty batch when the entire batch is already stored", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
+      hasMessageAnswers: [],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "a" }),
+      makeMessage({ role: "assistant", content: "b" }),
+    ];
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+    expect(result).toEqual([]);
+  });
+
+  it("keeps genuinely new messages after a tail-only replay", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [
+        storedMessage("user", "old-1"),
+        storedMessage("assistant", "old-2"),
+        storedMessage("user", "old-3"),
+      ],
+      hasMessageAnswers: [],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "old-3" }),
+      makeMessage({ role: "assistant", content: "new" }),
+    ];
+    const result = await dedup.deduplicateAfterTurnBatch("s1", undefined, batch);
+    expect(result).toEqual([batch[1]]);
+  });
+});
+
+describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
+  it("returns an empty batch when the runtime batch aligns fully with the covered frontier", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
+      hasMessageAnswers: [],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "a" }),
+      makeMessage({ role: "assistant", content: "b" }),
+    ];
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual([]);
+  });
+
+  it("returns only the new suffix when a prefix aligns with the covered frontier", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
+      hasMessageAnswers: [],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "a" }),
+      makeMessage({ role: "assistant", content: "b" }),
+      makeMessage({ role: "user", content: "c" }),
+    ];
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual([batch[2]]);
+  });
+
+  it("returns the full batch when there is no frontier overlap", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "old")],
+      hasMessageAnswers: [],
+    });
+    const batch = [makeMessage({ role: "user", content: "new" })];
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual(batch);
+  });
+
+  it("collapses a decorated runtime copy of the same user turn instead of persisting it twice", async () => {
+    const bareContent = "please summarize";
+    const decoratedContent = `[Sun 2026-01-01 12:00 GMT+0]\n${bareContent}`;
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", bareContent)],
+      hasMessageAnswers: [],
+    });
+    const batch = [makeMessage({ role: "user", content: decoratedContent })];
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual([]);
+  });
+
+  it("fails closed when persisted identity overlaps without frontier alignment", async () => {
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
+      hasMessageAnswers: [true, false],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: "a" }),
+      makeMessage({ role: "assistant", content: "new" }),
+    ];
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
Refs #934.

Adds test/batch-dedup.test.ts with direct, focused coverage of BatchDeduplicator.deduplicateAfterTurnBatch and BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier. The new tests cover empty batches, empty conversations, full stored-transcript trimming, tail-only replay deduplication, OpenClaw timestamp-decorated face collapse, and fail-closed overlap handling without requiring a full engine fixture.

This complements the existing integration-level replay proof in engine-after-turn.test.ts and makes regressions in the dedup core easier to locate.