### PR TITLE
feat: add agent-oriented lcm CLI

### DIFF
--- a/.changeset/agent-oriented-cli.md
+++ b/.changeset/agent-oriented-cli.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add the TypeScript `lcm` executable for paginated read-only conversation diagnostics, message and fresh-tail inspection, depth- and time-filtered summary inspection, effective config viewing, and manifest-validated targeted config edits.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ Nothing is lost. Raw messages stay in the database. Summaries link back to their
 
 ## Commands And Skill
 
-The plugin now ships a bundled `lossless-claw` skill plus a small plugin command surface for supported OpenClaw chat/native command providers:
+The package installs an agent-oriented `lcm` shell CLI and includes a bundled `lossless-claw` skill plus plugin commands for supported OpenClaw chat/native command providers.
+
+The shell CLI reads `lcm.db` without modifying conversation data. Its only write command sets one validated Lossless config value in `openclaw.json`:
+
+```bash
+lcm status
+lcm conversations show --session-key 'agent:main:example'
+lcm messages tail --conversation-id 42
+lcm summaries list --conversation-id 42 --depth 0 --recency 7d
+lcm config get freshTailCount
+lcm config set freshTailCount 96
+```
+
+JSON is the default output. List commands use bounded keyset pagination. See [Lossless Claw CLI](docs/cli.md) for commands, filters, path precedence, output fields, config-write safety, and exit codes.
+
+The native OpenClaw command surface provides in-session operations:
 
 - `/lossless` shows version, enablement/selection state, DB path and size, summary counts, and summary-health status
 - `/lossless backup` creates a timestamped backup of the current LCM SQLite database
@@ -43,7 +58,7 @@ The plugin now ships a bundled `lossless-claw` skill plus a small plugin command
 - `/lossless status` shows plugin, conversation, and maintenance state including deferred compaction debt
 - `/lcm` is the shorter alias for `/lossless`
 
-These are plugin slash/native commands, not root shell CLI subcommands. Supported examples:
+Supported native command examples:
 
 - `/lossless`
 - `/lossless backup`
@@ -52,7 +67,7 @@ These are plugin slash/native commands, not root shell CLI subcommands. Supporte
 - `/lossless doctor clean`
 - `/lcm`
 
-Not currently supported as root CLI commands:
+The package does not register these OpenClaw root subcommands:
 
 - `openclaw lossless`
 - `openclaw lcm`

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCli } from "./src/cli/main.js";
+
+process.exitCode = runCli(process.argv.slice(2));

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,9 +42,11 @@ The LCM database uses this precedence:
 
 1. `--db`
 2. `LCM_DATABASE_PATH`
-3. `plugins.entries.lossless-claw.config.databasePath`
-4. `plugins.entries.lossless-claw.config.dbPath`
+3. `plugins.entries.lossless-claw.config.dbPath`
+4. `plugins.entries.lossless-claw.config.databasePath`
 5. `<state-directory>/lcm.db`
+
+`databasePath` remains the preferred key for new configuration. The legacy `dbPath` key wins only when both are present, matching the current Lossless Claw runtime resolver.
 
 All response metadata uses absolute paths.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -159,6 +159,7 @@ lcm config get autoRotateSessionFiles.enabled
 
 ```bash
 lcm config set freshTailCount 96
+lcm config set sweepMaxDepth -1
 lcm config set promptAwareEviction true
 lcm config set summaryModel '"openai/gpt-5.4-mini"'
 lcm config set ignoreSessionPatterns '["agent:*:cron:**"]'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,191 @@
+# Lossless Claw CLI
+
+The `lcm` executable provides bounded, structured access to Lossless Claw's persisted conversations, messages, summaries, context state, token counts, maintenance state, and effective configuration. JSON is the default output so agents can consume results without parsing terminal decoration.
+
+The CLI opens `lcm.db` with SQLite's read-only mode and enables `PRAGMA query_only = ON`. Database commands do not run migrations, compaction, cleanup, repair, checkpoint, vacuum, or other write operations. `lcm config set` is the only command that writes state.
+
+## Commands
+
+```text
+lcm status
+lcm conversations list
+lcm conversations show (--conversation-id <id> | --session-key <key>)
+lcm messages list (--conversation-id <id> | --session-key <key>)
+lcm messages tail (--conversation-id <id> | --session-key <key>)
+lcm summaries list [--conversation-id <id> | --session-key <key>]
+lcm summaries show <summary-id>
+lcm config show
+lcm config get <path>
+lcm config set <path> <json-value>
+lcm doctor
+```
+
+Run `lcm --help` for the command and option inventory. Add `--pretty` for indented JSON or `--format table` for compact terminal output.
+
+## Paths
+
+The OpenClaw state directory uses this precedence:
+
+1. `--openclaw-dir`
+2. `LCM_OPENCLAW_DIR`
+3. `OPENCLAW_STATE_DIR`
+4. `${OPENCLAW_HOME}/.openclaw`
+5. `${HOME}/.openclaw`
+
+The OpenClaw config file uses this precedence:
+
+1. `--config`
+2. `OPENCLAW_CONFIG_PATH`
+3. `<state-directory>/openclaw.json`
+
+The LCM database uses this precedence:
+
+1. `--db`
+2. `LCM_DATABASE_PATH`
+3. `plugins.entries.lossless-claw.config.databasePath`
+4. `plugins.entries.lossless-claw.config.dbPath`
+5. `<state-directory>/lcm.db`
+
+All response metadata uses absolute paths.
+
+## Status and conversations
+
+`lcm status` returns database size, conversation/message/summary counts, token totals, coverage timestamps, context totals, summary depth distribution, maintenance state, and the effective fresh-tail limits.
+
+```bash
+lcm status --pretty
+lcm status --db /srv/openclaw/lcm.db
+```
+
+Conversation listing is keyset-paginated and ordered by update time plus conversation ID:
+
+```bash
+lcm conversations list --limit 50
+lcm conversations list --limit 50 --cursor '<nextCursor>'
+```
+
+Conversation detail accepts a numeric conversation ID or stable session key:
+
+```bash
+lcm conversations show --conversation-id 42
+lcm conversations show --session-key 'agent:main:telegram:direct:1234'
+```
+
+The detail response includes aggregate messages, summaries, active context, protected fresh tail, compaction telemetry, deferred maintenance, bootstrap frontier, focus briefs, and large-file storage.
+
+## Messages and fresh tail
+
+Message lists support role filters, time filters, pagination, and full-content opt-in:
+
+```bash
+lcm messages list --conversation-id 42 --limit 100
+lcm messages list --session-key 'agent:main:example' --role user --role assistant
+lcm messages list --conversation-id 42 --after 2026-07-01T00:00:00Z
+lcm messages list --conversation-id 42 --recency 6h --include-content
+```
+
+Without `--include-content`, each row contains a bounded single-line preview. With it, each row also contains the complete stored `content` value.
+
+`lcm messages tail` reads raw messages from the active `context_items` frontier. It applies `freshTailCount` and `freshTailMaxTokens` with the same rules as runtime assembly: the newest message remains protected even when it exceeds the token cap.
+
+```bash
+lcm messages tail --conversation-id 42
+lcm messages tail --conversation-id 42 --count 20
+```
+
+The response reports selected messages/tokens, total persisted messages/tokens, the selected sequence interval, and messages in ascending prompt order.
+
+## Summaries
+
+Summary lists can be global or conversation-scoped:
+
+```bash
+lcm summaries list --limit 50
+lcm summaries list --conversation-id 42 --depth 0 --kind leaf
+lcm summaries list --session-key 'agent:main:example' --recency 7d
+lcm summaries list --between 2026-07-01T00:00:00Z..2026-07-08T00:00:00Z
+```
+
+Summary time filters use `latestAt` when present and `createdAt` as the fallback coverage timestamp.
+
+```bash
+lcm summaries show sum_abc123
+```
+
+Summary detail includes full content, higher-depth `parents` that consume the selected summary, lower-depth source `children`, and ordered raw source messages. Related rows are constrained to the selected summary's conversation.
+
+## Time filters
+
+- `--after <timestamp>` includes records at the timestamp.
+- `--before <timestamp>` excludes records at the timestamp.
+- `--between <start>..<end>` applies an inclusive start and exclusive end.
+- `--recency <duration>` accepts a positive integer followed by `s`, `m`, `h`, `d`, or `w`.
+
+`--between` cannot be combined with another time option. `--recency` cannot be combined with `--after`.
+
+## Pagination
+
+List commands accept `--limit` from 1 through 500 and an opaque `--cursor`. Every list response includes:
+
+```json
+{
+  "pagination": {
+    "limit": 50,
+    "returned": 50,
+    "hasMore": true,
+    "nextCursor": "opaque-value"
+  }
+}
+```
+
+Pass `nextCursor` to the same resource command. A message cursor cannot be used for conversations or summaries.
+
+## Configuration
+
+`lcm config show` returns only the raw Lossless plugin config, effective `LcmConfig`, config diagnostics, and names of active environment overrides. It does not return unrelated OpenClaw config sections or credentials.
+
+```bash
+lcm config show --pretty
+lcm config get freshTailCount
+lcm config get autoRotateSessionFiles.enabled
+```
+
+`lcm config set` accepts a dot path relative to `plugins.entries.lossless-claw.config` and a JSON value:
+
+```bash
+lcm config set freshTailCount 96
+lcm config set promptAwareEviction true
+lcm config set summaryModel '"openai/gpt-5.4-mini"'
+lcm config set ignoreSessionPatterns '["agent:*:cron:**"]'
+lcm config set autoRotateSessionFiles.enabled false
+```
+
+The command checks the path and value against `openclaw.plugin.json`, validates the complete Lossless config, creates an exclusive timestamped sibling backup, preserves the source mode, fsyncs a sibling temporary file, and atomically replaces `openclaw.json`.
+
+Config writes refuse:
+
+- symlink config paths
+- JSON5 syntax or comments
+- malformed JSON
+- `$include` at the root, plugin containers, Lossless entry, or Lossless config
+- paths absent from the Lossless manifest schema
+- values that violate the target or complete config schema
+
+These failures happen before backup creation and leave the config unchanged.
+
+## Output and exit codes
+
+Successful JSON responses contain `ok`, `command`, `data`, optional `pagination`, and `meta`. Expected failures write one JSON object to stderr.
+
+| Exit | Meaning |
+|---:|---|
+| `0` | Success |
+| `1` | Unexpected internal failure |
+| `2` | Invalid command, option, selector, filter, or cursor |
+| `3` | Requested database, config, conversation, summary, or key not found |
+| `4` | Config parse, validation, backup, or write failure |
+| `5` | Database open or query failure |
+
+## Doctor namespace
+
+`lcm doctor` reserves the shell namespace for a separate read-only diagnostics contract. It reports `available: false` and does not open or modify the database. Native `/lcm doctor` behavior remains independent of the shell CLI.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,8 @@ lcm doctor
 
 Run `lcm --help` for the command and option inventory. Add `--pretty` for indented JSON or `--format table` for compact terminal output.
 
+Command-specific options are rejected when their command does not use them. The CLI never reports success after silently ignoring a selector, filter, pagination option, or content flag.
+
 ## Paths
 
 The OpenClaw state directory uses this precedence:
@@ -124,6 +126,7 @@ Summary detail includes full content, higher-depth `parents` that consume the se
 - `--recency <duration>` accepts a positive integer followed by `s`, `m`, `h`, `d`, or `w`.
 
 `--between` cannot be combined with another time option. `--recency` cannot be combined with `--after`.
+Time filters apply only to `messages list` and `summaries list`.
 
 ## Pagination
 
@@ -162,7 +165,7 @@ lcm config set ignoreSessionPatterns '["agent:*:cron:**"]'
 lcm config set autoRotateSessionFiles.enabled false
 ```
 
-The command checks the path and value against `openclaw.plugin.json`, validates the complete Lossless config, creates an exclusive timestamped sibling backup, preserves the source mode, fsyncs a sibling temporary file, and atomically replaces `openclaw.json`.
+The command checks the path and value against `openclaw.plugin.json`, validates the complete Lossless config, creates an exclusive timestamped sibling backup, preserves the source mode, fsyncs a sibling temporary file, atomically replaces `openclaw.json`, and fsyncs the parent directory on POSIX systems.
 
 Config writes refuse:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -437,6 +437,7 @@ These settings are not part of `plugins.entries.lossless-claw.config`, but they 
 | Env var | Default | Purpose |
 | --- | --- | --- |
 | `OPENCLAW_STATE_DIR` | `~/.openclaw` | Active state directory for the OpenClaw gateway. When set, all path defaults (database, large files, auth profiles, secrets) resolve relative to this directory instead of `~/.openclaw`. Set automatically by OpenClaw for non-default profiles. |
+| `LCM_OPENCLAW_DIR` | unset | Lossless shell CLI override for the OpenClaw state directory. Takes precedence over `OPENCLAW_STATE_DIR` for `lcm` commands only. |
 | `LCM_TUI_CONVERSATION_WINDOW_SIZE` | `200` | Number of messages `lcm-tui` loads per keyset-paged conversation window. |
 
 ## Database operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "@sinclair/typebox": "0.34.48"
       },
+      "bin": {
+        "lcm": "dist/cli.js",
+        "lossless-claw-migrate-sessions": "dist/migrate-sessions.js"
+      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
+    "lcm": "dist/cli.js",
     "lossless-claw-migrate-sessions": "dist/migrate-sessions.js"
   },
   "license": "MIT",
@@ -19,7 +20,10 @@
     "dag"
   ],
   "scripts": {
-    "build": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace && esbuild src/cli/migrate-sessions.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/migrate-sessions.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
+    "build": "npm run build:plugin && npm run build:migrate-sessions && npm run build:cli",
+    "build:plugin": "esbuild index.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/index.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
+    "build:migrate-sessions": "esbuild src/cli/migrate-sessions.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/migrate-sessions.js --external:openclaw --external:\"@earendil-works/*\" --minify-whitespace",
+    "build:cli": "esbuild cli.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/cli.js --minify-whitespace",
     "changeset": "changeset",
     "plugin-inspector:ci": "npm exec --yes --package @openclaw/plugin-inspector@0.3.11 -- plugin-inspector ci --plugin-root . --out plugin-inspector-reports",
     "release:verify": "npm run typecheck && npm run build && npm test && npm pack --dry-run",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -292,6 +292,7 @@ Why it matters:
 - useful for custom deployments, testing, or isolating environments
 - wrong path selection is a common reason operators think LCM is empty or not growing
 - the default resolves to `${OPENCLAW_STATE_DIR}/lcm.db` (falls back to `~/.openclaw/lcm.db`)
+- the `lcm` shell CLI also accepts `LCM_OPENCLAW_DIR` as a CLI-only state-directory override before `OPENCLAW_STATE_DIR`
 
 ### `databasePath`
 

--- a/skills/lossless-claw/references/diagnostics.md
+++ b/skills/lossless-claw/references/diagnostics.md
@@ -4,6 +4,21 @@ For the MVP, use the native command surface first. For debugging lossless-claw b
 
 ## Fast path
 
+### `lcm` shell CLI
+
+Use the packaged shell CLI for bounded, structured database inspection outside an OpenClaw conversation:
+
+```bash
+lcm status --pretty
+lcm conversations show --session-key 'agent:main:example'
+lcm messages tail --conversation-id 42
+lcm summaries list --conversation-id 42 --depth 0 --recency 7d
+```
+
+JSON is the default output. List commands return opaque keyset cursors. Database commands open `lcm.db` read-only and do not run migrations, repair, cleanup, compaction, or other write operations. `lcm config set` is the only state-changing shell command and edits one manifest-validated Lossless config path with a timestamped backup.
+
+Path overrides use `--db`, `LCM_DATABASE_PATH`, `--openclaw-dir`, `LCM_OPENCLAW_DIR`, `OPENCLAW_STATE_DIR`, `OPENCLAW_HOME`, `--config`, and `OPENCLAW_CONFIG_PATH`. See `docs/cli.md` in the package for precedence and the complete command contract.
+
 ### Independent Lossless log
 
 Check this first when lossless-claw needs to debug itself, because routine `[lcm]` info and debug lines are written here instead of the shared OpenClaw gateway log.

--- a/specs/agent-oriented-cli.md
+++ b/specs/agent-oriented-cli.md
@@ -50,6 +50,7 @@ lcm doctor
 - `--recency` conflicts with `--after`.
 - Summary lists accept `--depth <integer>` and `--kind <leaf|condensed>`.
 - Message lists accept repeatable `--role <system|user|assistant|tool>` and `--include-content`.
+- Commands reject selection and filtering options that they do not apply.
 
 ### Pagination
 
@@ -202,7 +203,8 @@ It never returns other OpenClaw config sections.
 5. Creates a timestamped sibling backup.
 6. Writes and fsyncs a sibling temporary file.
 7. Atomically renames the temporary file over the config file while preserving its mode.
-8. Returns the old value, new value, config path, and backup path.
+8. Fsyncs the parent directory on POSIX systems so the rename is durable.
+9. Returns the old value, new value, config path, and backup path.
 
 The writer refuses symlinks, non-JSON syntax, malformed files, and `$include` at the root, `plugins`, `plugins.entries`, the Lossless entry, or its `config` object. Refusal leaves the source and backup set unchanged.
 

--- a/specs/agent-oriented-cli.md
+++ b/specs/agent-oriented-cli.md
@@ -1,0 +1,405 @@
+# Agent-Oriented CLI Specification
+
+## Objective
+
+Package a TypeScript executable named `lcm` with Lossless Claw. The executable gives agents a stable, structured interface for inspecting LCM conversations, messages, summaries, context state, token totals, compaction state, and effective configuration. It reads the LCM SQLite database without modifying it. Its only write command sets one validated Lossless plugin configuration value in OpenClaw's config file.
+
+The CLI succeeds when an agent can locate a conversation by numeric ID or session key, page through its records without loading unbounded results, inspect the configured fresh tail and summary DAG, apply exact time filters, and change one supported config key without exposing or rewriting unrelated secrets.
+
+## Public Interface
+
+### Commands
+
+```text
+lcm status
+lcm conversations list
+lcm conversations show (--conversation-id <id> | --session-key <key>)
+lcm messages list (--conversation-id <id> | --session-key <key>)
+lcm messages tail (--conversation-id <id> | --session-key <key>)
+lcm summaries list [--conversation-id <id> | --session-key <key>]
+lcm summaries show <summary-id>
+lcm config show
+lcm config get <path>
+lcm config set <path> <json-value>
+lcm doctor
+```
+
+`lcm doctor` reserves a read-only namespace for later diagnostic checks. It returns a structured unsupported-operation result until doctor subcommands have their own approved specification.
+
+### Global options
+
+```text
+--db <path>                 Explicit LCM database
+--config <path>             Explicit OpenClaw config file
+--openclaw-dir <path>       Explicit OpenClaw state directory
+--format <json|table>       Output format; defaults to json
+--pretty                    Indent JSON output
+--help                      Command help
+--version                   Package version
+```
+
+### Selection and filtering
+
+- Commands that require one conversation accept exactly one of `--conversation-id` and `--session-key`.
+- Session-key resolution prefers an active row and then the newest row.
+- `--after <timestamp>` is inclusive.
+- `--before <timestamp>` is exclusive.
+- `--between <start>..<end>` applies the same inclusive-start, exclusive-end interval.
+- `--recency <duration>` computes an inclusive lower bound once at process start. Durations use an integer followed by `s`, `m`, `h`, `d`, or `w`.
+- `--between` conflicts with `--after`, `--before`, and `--recency`.
+- `--recency` conflicts with `--after`.
+- Summary lists accept `--depth <integer>` and `--kind <leaf|condensed>`.
+- Message lists accept repeatable `--role <system|user|assistant|tool>` and `--include-content`.
+
+### Pagination
+
+Every list command returns at most `--limit` records. The default is 50 and the maximum is 500. Results use deterministic descending order by timestamp plus a stable identifier. `--cursor` is an opaque URL-safe base64 cursor returned by the previous page.
+
+Every list response includes:
+
+```json
+{
+  "pagination": {
+    "limit": 50,
+    "returned": 50,
+    "hasMore": true,
+    "nextCursor": "opaque-or-null"
+  }
+}
+```
+
+The cursor encodes a version, resource type, timestamp, and stable identifier. A cursor for one resource cannot be used with another resource.
+
+### Output contract
+
+JSON is the default. Successful commands write one JSON document to stdout:
+
+```json
+{
+  "ok": true,
+  "command": "messages.list",
+  "data": [],
+  "pagination": null,
+  "meta": {
+    "databasePath": "/home/agent/.openclaw/lcm.db",
+    "configPath": "/home/agent/.openclaw/openclaw.json"
+  }
+}
+```
+
+Failures write one JSON document to stderr:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "CONVERSATION_NOT_FOUND",
+    "message": "No conversation matched session key agent:main:example.",
+    "details": {}
+  }
+}
+```
+
+Exit codes are stable:
+
+- `0`: success
+- `2`: invalid command, option, selector, filter, or cursor
+- `3`: requested conversation, summary, config key, or file not found
+- `4`: config parse, validation, or safe-write failure
+- `5`: database open or query failure
+- `1`: unexpected internal failure
+
+Table output is a compact projection of the same data. It does not change query semantics or omit pagination metadata.
+
+## Path Resolution
+
+The state directory uses this precedence:
+
+1. `--openclaw-dir`
+2. `LCM_OPENCLAW_DIR`
+3. `OPENCLAW_STATE_DIR`
+4. `${OPENCLAW_HOME}/.openclaw`
+5. `${HOME}/.openclaw`
+
+The config file uses this precedence:
+
+1. `--config`
+2. `OPENCLAW_CONFIG_PATH`
+3. `<state-directory>/openclaw.json`
+
+The database uses this precedence:
+
+1. `--db`
+2. `LCM_DATABASE_PATH`
+3. `plugins.entries.lossless-claw.config.databasePath`
+4. `plugins.entries.lossless-claw.config.dbPath`
+5. `<state-directory>/lcm.db`
+
+All returned paths are absolute. `~` expands against `OPENCLAW_HOME` when set and the process home otherwise.
+
+## Command Data
+
+### `status`
+
+Returns package version, database size, conversation count, active conversation count, message count and tokens, summary count and tokens by kind/depth, summarized source tokens, context tokens, fresh-tail configuration, maintenance state counts, earliest/latest activity, and the raw/effective Lossless config boundary.
+
+### `conversations list`
+
+Each row includes conversation ID, session ID, session key, active/archive state, title, created/updated/bootstrap timestamps, message count/tokens, summary count/tokens, context count/tokens, fresh-tail message count/tokens, maximum summary depth, latest message timestamp, and latest summary timestamp.
+
+### `conversations show`
+
+Returns one conversation row plus:
+
+- aggregate message, summary, context, and fresh-tail statistics
+- summary counts and tokens grouped by kind/depth
+- ordered context-item type/token totals
+- compaction telemetry and maintenance records
+- bootstrap frontier record
+- focus-brief counts and active brief metadata
+- large-file counts, bytes, and latest timestamp
+- earliest and latest persisted message and summary timestamps
+
+### `messages list`
+
+Each row includes message ID, conversation ID, sequence, role, token count, created timestamp, large-content reference, and a bounded preview. `--include-content` adds full stored content. Results do not expose message parts unless a later specification adds that surface.
+
+### `messages tail`
+
+Returns messages in ascending sequence order so the result matches runtime prompt order. The default tail uses the effective `freshTailCount` and `freshTailMaxTokens`. `--count` overrides the count for inspection. The response includes configured limits, selected message count, selected tokens, total conversation messages/tokens, and the sequence interval.
+
+The token cap walks newest to oldest, always retains the newest message, and stops before adding an older message that would exceed the cap. This matches the runtime's protected-tail semantics.
+
+### `summaries list`
+
+Each row includes summary ID, conversation ID, kind, depth, token counts, descendant counts/tokens, source-message tokens, model, earliest/latest covered timestamps, created timestamp, file IDs, direct parent count, direct child count, source-message count, and a bounded preview. `--include-content` adds full stored content.
+
+### `summaries show`
+
+Returns the complete summary row plus ordered direct parents, ordered direct children, and ordered source messages. Source messages include ID, sequence, role, token count, timestamp, and content. Every related record must belong to the selected summary's conversation.
+
+### `config show|get|set`
+
+`config show` returns only:
+
+- resolved state, config, and database paths
+- raw `plugins.entries.lossless-claw.config`
+- effective `LcmConfig` after environment overrides and defaults
+- the names of environment variables that override file-backed values
+
+It never returns other OpenClaw config sections.
+
+`config get <path>` reads a dot-separated path relative to the Lossless plugin config. It reports raw and effective values separately.
+
+`config set <path> <json-value>`:
+
+1. Requires the path to exist in `openclaw.plugin.json` `configSchema`.
+2. Parses the value as JSON.
+3. Applies it to a cloned plugin config.
+4. Validates the full cloned plugin config against the manifest schema.
+5. Creates a timestamped sibling backup.
+6. Writes and fsyncs a sibling temporary file.
+7. Atomically renames the temporary file over the config file while preserving its mode.
+8. Returns the old value, new value, config path, and backup path.
+
+The writer refuses symlinks, non-JSON syntax, malformed files, and `$include` at the root, `plugins`, `plugins.entries`, the Lossless entry, or its `config` object. Refusal leaves the source and backup set unchanged.
+
+## Tech Stack
+
+- TypeScript 5.7 with strict checking
+- Node.js 22 ESM
+- `node:sqlite` for read-only queries
+- `node:util.parseArgs` for argument parsing
+- TypeBox, already a direct dependency, for manifest-schema validation
+- esbuild for the executable bundle
+- Vitest for unit and integration tests
+
+No new runtime dependency is required.
+
+## Commands
+
+```bash
+npm run build
+npm run typecheck
+npm test
+npm run test -- --run test/cli-args.test.ts
+npm run test -- --run test/cli-database.test.ts
+npm run test -- --run test/cli-queries.test.ts
+npm run test -- --run test/cli-config.test.ts
+npm pack --dry-run
+```
+
+## Project Structure
+
+```text
+cli.ts                       Executable entrypoint
+src/cli/args.ts              Parsed command contract and validation
+src/cli/config-file.ts       Lossless-only config reads and writes
+src/cli/database.ts          Read-only SQLite connection
+src/cli/main.ts              Command dispatch
+src/cli/output.ts            JSON envelope and table projections
+src/cli/paths.ts             State/config/database resolution
+src/cli/queries.ts           Typed diagnostic queries
+test/cli-args.test.ts        Parser, cursor, selector, and time tests
+test/cli-config.test.ts      Config resolution and safe-write tests
+test/cli-database.test.ts    Read-only connection tests
+test/cli-queries.test.ts     Fixture-backed query tests
+docs/cli.md                  User and agent reference
+```
+
+Each source file has one purpose. Public functions and types include purpose-oriented doc comments. Functions that exceed ten lines include comments for non-obvious internal stages.
+
+## Code Style
+
+Use explicit input and output types at module boundaries. Validate external strings before converting them to domain values. Keep database rows private to the query module and map them to camel-case response types.
+
+```typescript
+/** Resolve one persisted conversation from an explicit CLI selector. */
+export function resolveConversation(
+  db: DatabaseSync,
+  selector: ConversationSelector,
+): ConversationIdentity {
+  const row = selector.kind === "conversationId"
+    ? selectConversationById(db, selector.value)
+    : selectConversationBySessionKey(db, selector.value);
+
+  if (!row) {
+    throw new CliError("CONVERSATION_NOT_FOUND", selector, 3);
+  }
+  return mapConversationIdentity(row);
+}
+```
+
+SQL uses bound parameters for every external value. Dynamic SQL is limited to internal, enumerated fragments such as sort direction and role placeholder counts.
+
+## Testing Strategy
+
+- Write failing tests before behavior code.
+- Unit-test argument parsing, timestamps, durations, selectors, cursors, config paths, and output envelopes.
+- Use temporary real SQLite databases for query integration tests.
+- Run production migrations only when creating test fixtures. Open the fixture through the CLI's dedicated read-only connection for assertions.
+- Prove the read-only boundary by asserting that inserts and schema changes fail through the CLI handle.
+- Exercise pagination across identical timestamps to prove the stable identifier tie-breaker.
+- Exercise config writes against temporary files and assert byte-for-byte preservation on every failure path.
+- Add an end-to-end test that invokes the built `dist/cli.js` against a fixture database.
+- Run the full TypeScript test suite and typecheck before closing the epic.
+
+## Boundaries
+
+### Always
+
+- Open LCM databases read-only and enable `PRAGMA query_only = ON`.
+- Bind external values in SQL.
+- Paginate list commands and return pagination metadata.
+- Return deterministic field names, ordering, errors, and exit codes.
+- Back up the config before a successful replacement.
+- Keep `docs/configuration.md`, the bundled skill config reference, `openclaw.plugin.json`, and runtime defaults synchronized if a config option changes.
+- Add a minor Changeset for the new executable.
+
+### Ask first
+
+- Add a runtime dependency.
+- Change the LCM schema or run migrations from the CLI.
+- Support config includes or comment-preserving JSON5 writes.
+- Add any database mutation command, including doctor repairs.
+- Change an existing dependency version.
+
+### Never
+
+- Create a missing database as a side effect of inspection.
+- Run migrations, vacuum, optimize, checkpoint, cleanup, repair, delete, compact, rotate, rewrite, transplant, or backfill from this CLI.
+- Print unrelated OpenClaw config sections or secrets.
+- Accept unbounded list output.
+- Flatten `$include` config structures.
+- merge the feature branch without explicit maintainer approval.
+
+## Implementation Plan
+
+### Task 1: CLI contract and read-only foundations (`lc-3dd.1`)
+
+Implement path resolution, parsing, shared filters, cursor encoding, response envelopes, and the read-only SQLite handle.
+
+Acceptance:
+
+- Invalid inputs produce stable structured errors.
+- Path precedence matches this specification.
+- A missing database is not created and an open handle cannot write.
+
+Verify with focused parser/path/database tests and `npm run typecheck`.
+
+### Task 2: Status and conversation diagnostics (`lc-3dd.2`)
+
+Implement global status, conversation list, and conversation show.
+
+Acceptance:
+
+- Aggregate and per-conversation fixture results match exact expected values.
+- Conversation pagination has no gaps or duplicates.
+- Session-key selection uses active/newest precedence.
+
+Verify with fixture-backed query tests.
+
+### Task 3: Messages and fresh tail (`lc-3dd.3`)
+
+Implement message listing, shared time filters, and tail selection/statistics.
+
+Acceptance:
+
+- Time boundaries and role filters are exact.
+- Pagination metadata is present on every list response.
+- Tail ordering and count/token caps match runtime semantics.
+
+Verify with fixture-backed query and command tests.
+
+### Task 4: Summary inspection (`lc-3dd.4`)
+
+Implement global/scoped summary listing and summary detail.
+
+Acceptance:
+
+- Depth zero filtering works.
+- Summary pagination has no gaps or duplicates.
+- Parent, child, and source records cannot cross the conversation boundary.
+
+Verify with fixture-backed DAG tests.
+
+### Task 5: Config inspection and editing (`lc-3dd.5`)
+
+Implement config show/get/set with manifest validation, secret isolation, backups, and atomic replacement.
+
+Acceptance:
+
+- Invalid edits leave source bytes unchanged and create no backup.
+- Valid edits change only the targeted Lossless config key.
+- Output never contains unrelated OpenClaw values.
+
+Verify with temporary-file integration tests.
+
+### Task 6: Packaging and documentation (`lc-3dd.6`)
+
+Add the executable bundle, package metadata, help/reference docs, bundled skill updates, Changeset, and end-to-end verification.
+
+Acceptance:
+
+- `npm run build` emits `dist/cli.js` with an executable shebang.
+- `npm pack --dry-run` includes the CLI artifact and docs.
+- The full test suite and typecheck pass.
+- Autoreview findings are resolved before PR preparation.
+
+## Success Criteria
+
+- Agents can discover every command and option from `lcm --help` and command-local help.
+- All list commands are bounded and keyset-paginated.
+- Conversation ID and session key work consistently across scoped commands.
+- ISO time, interval, and recency filters work for messages and summaries.
+- Status and detail commands report persisted token, tail, context, config, and maintenance facts.
+- The CLI cannot modify `lcm.db`, including through accidental helper reuse.
+- Config reads expose only Lossless values; config set is targeted, validated, backed up, and atomic.
+- The npm package installs an `lcm` executable implemented in TypeScript.
+- Tests, typecheck, build, package inspection, runtime smoke tests, documentation, and Changeset are complete.
+
+## Open Questions
+
+- Approve JSON as the default output format.
+- Approve fail-closed config writes for JSON5 and `$include` forms in the first release.
+- Confirm `lcm` as the executable name.

--- a/specs/agent-oriented-cli.md
+++ b/specs/agent-oriented-cli.md
@@ -131,9 +131,11 @@ The database uses this precedence:
 
 1. `--db`
 2. `LCM_DATABASE_PATH`
-3. `plugins.entries.lossless-claw.config.databasePath`
-4. `plugins.entries.lossless-claw.config.dbPath`
+3. `plugins.entries.lossless-claw.config.dbPath`
+4. `plugins.entries.lossless-claw.config.databasePath`
 5. `<state-directory>/lcm.db`
+
+`databasePath` is preferred for new configuration. If both plugin keys exist, the legacy `dbPath` value wins to match the current runtime resolver.
 
 All returned paths are absolute. `~` expands against `OPENCLAW_HOME` when set and the process home otherwise.
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -115,6 +115,10 @@ function parseNonNegativeInteger(value: string | undefined, label: string): numb
 
 // Parse one externally supplied timestamp and normalize its validation error.
 function parseTimestamp(value: string, label: string): Date {
+  const isoTimestamp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+  if (!isoTimestamp.test(value)) {
+    throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });
+  }
   const parsed = new Date(value);
   if (!Number.isFinite(parsed.getTime())) {
     throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,327 @@
+import { parseArgs } from "node:util";
+import { CliError } from "./output.js";
+
+export type ConversationSelector =
+  | { kind: "conversationId"; value: number }
+  | { kind: "sessionKey"; value: string };
+
+export type MessageRole = "system" | "user" | "assistant" | "tool";
+export type SummaryKind = "leaf" | "condensed";
+export type OutputFormat = "json" | "table";
+
+export type CliCommand =
+  | { kind: "help"; topic?: string }
+  | { kind: "version" }
+  | { kind: "status" }
+  | { kind: "conversations.list" }
+  | { kind: "conversations.show" }
+  | { kind: "messages.list" }
+  | { kind: "messages.tail" }
+  | { kind: "summaries.list" }
+  | { kind: "summaries.show"; summaryId: string }
+  | { kind: "config.show" }
+  | { kind: "config.get"; path: string }
+  | { kind: "config.set"; path: string; value: string }
+  | { kind: "doctor" };
+
+export type TimeFilter = {
+  after?: Date;
+  before?: Date;
+};
+
+export type ParsedCliArgs = {
+  command: CliCommand;
+  databasePath?: string;
+  configPath?: string;
+  openclawDir?: string;
+  format: OutputFormat;
+  pretty: boolean;
+  selector?: ConversationSelector;
+  time: TimeFilter;
+  limit: number;
+  cursor?: string;
+  roles: MessageRole[];
+  includeContent: boolean;
+  depth?: number;
+  summaryKind?: SummaryKind;
+  count?: number;
+};
+
+export type CursorResource = "conversations" | "messages" | "summaries";
+export type DecodedCursor = { timestamp: string; id: number | string };
+
+type TimeFilterInput = {
+  after?: string;
+  before?: string;
+  between?: string;
+  recency?: string;
+};
+
+const MESSAGE_ROLES = new Set<MessageRole>(["system", "user", "assistant", "tool"]);
+const SUMMARY_KINDS = new Set<SummaryKind>(["leaf", "condensed"]);
+const CLI_OPTIONS = {
+  db: { type: "string" },
+  config: { type: "string" },
+  "openclaw-dir": { type: "string" },
+  format: { type: "string", default: "json" },
+  pretty: { type: "boolean", default: false },
+  help: { type: "boolean", short: "h", default: false },
+  version: { type: "boolean", short: "v", default: false },
+  "conversation-id": { type: "string" },
+  "session-key": { type: "string" },
+  after: { type: "string" },
+  before: { type: "string" },
+  between: { type: "string" },
+  recency: { type: "string" },
+  limit: { type: "string", default: "50" },
+  cursor: { type: "string" },
+  role: { type: "string", multiple: true },
+  "include-content": { type: "boolean", default: false },
+  depth: { type: "string" },
+  kind: { type: "string" },
+  count: { type: "string" },
+} as const;
+
+// Parse a bounded positive integer option without accepting coercible strings.
+function parsePositiveInteger(value: string | undefined, label: string, maximum?: number): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new CliError("INVALID_ARGUMENT", `${label} must be a positive integer.`, 2, { value });
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (parsed < 1 || (maximum !== undefined && parsed > maximum)) {
+    throw new CliError(
+      "INVALID_ARGUMENT",
+      `${label} must be between 1 and ${maximum ?? Number.MAX_SAFE_INTEGER}.`,
+      2,
+      { value },
+    );
+  }
+  return parsed;
+}
+
+// Parse a zero-based integer option such as summary depth.
+function parseNonNegativeInteger(value: string | undefined, label: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new CliError("INVALID_ARGUMENT", `${label} must be a non-negative integer.`, 2, { value });
+  }
+  return Number.parseInt(value, 10);
+}
+
+// Parse one externally supplied timestamp and normalize its validation error.
+function parseTimestamp(value: string, label: string): Date {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });
+  }
+  return parsed;
+}
+
+// Convert the compact CLI duration grammar to milliseconds.
+function parseDurationMilliseconds(value: string): number {
+  const match = value.match(/^(\d+)([smhdw])$/i);
+  if (!match || Number.parseInt(match[1]!, 10) < 1) {
+    throw new CliError(
+      "INVALID_TIME_FILTER",
+      "recency must be a positive integer followed by s, m, h, d, or w.",
+      2,
+      { value },
+    );
+  }
+  const unitMs = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 };
+  return Number.parseInt(match[1]!, 10) * unitMs[match[2]!.toLowerCase() as keyof typeof unitMs];
+}
+
+/** Parse and validate inclusive lower and exclusive upper CLI time filters. */
+export function parseTimeFilter(input: TimeFilterInput, now: Date = new Date()): TimeFilter {
+  if (input.between && (input.after || input.before || input.recency)) {
+    throw new CliError(
+      "INVALID_TIME_FILTER",
+      "between cannot be combined with after, before, or recency.",
+      2,
+    );
+  }
+  if (input.after && input.recency) {
+    throw new CliError("INVALID_TIME_FILTER", "after cannot be combined with recency.", 2);
+  }
+
+  let after = input.after ? parseTimestamp(input.after, "after") : undefined;
+  let before = input.before ? parseTimestamp(input.before, "before") : undefined;
+  if (input.between) {
+    const parts = input.between.split("..");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      throw new CliError("INVALID_TIME_FILTER", "between must use <start>..<end>.", 2);
+    }
+    after = parseTimestamp(parts[0], "between start");
+    before = parseTimestamp(parts[1], "between end");
+  } else if (input.recency) {
+    after = new Date(now.getTime() - parseDurationMilliseconds(input.recency));
+  }
+
+  if (after && before && after.getTime() >= before.getTime()) {
+    throw new CliError("INVALID_TIME_FILTER", "The lower time bound must precede the upper bound.", 2);
+  }
+  return { ...(after ? { after } : {}), ...(before ? { before } : {}) };
+}
+
+// Enforce the mutually exclusive conversation selector contract.
+function parseSelector(conversationId: string | undefined, sessionKey: string | undefined): ConversationSelector | undefined {
+  if (conversationId && sessionKey) {
+    throw new CliError("INVALID_SELECTOR", "Use conversation-id or session-key, not both.", 2);
+  }
+  if (conversationId) {
+    const value = parsePositiveInteger(conversationId, "conversation-id");
+    return { kind: "conversationId", value: value! };
+  }
+  const normalizedSessionKey = sessionKey?.trim();
+  return normalizedSessionKey ? { kind: "sessionKey", value: normalizedSessionKey } : undefined;
+}
+
+// Map positional resource/action words to the public command union.
+function parseCommand(positionals: string[], help: boolean, version: boolean): CliCommand {
+  if (version) {
+    return { kind: "version" };
+  }
+  if (help || positionals.length === 0) {
+    return { kind: "help", ...(positionals.length ? { topic: positionals.join(" ") } : {}) };
+  }
+  const [resource, action, ...rest] = positionals;
+  const key = action ? `${resource}.${action}` : resource;
+  switch (key) {
+    case "status": return { kind: "status" };
+    case "conversations.list": return { kind: "conversations.list" };
+    case "conversations.show": return { kind: "conversations.show" };
+    case "messages.list": return { kind: "messages.list" };
+    case "messages.tail": return { kind: "messages.tail" };
+    case "summaries.list": return { kind: "summaries.list" };
+    case "summaries.show":
+      if (!rest[0] || rest.length !== 1) {
+        throw new CliError("INVALID_COMMAND", "summaries show requires one summary id.", 2);
+      }
+      return { kind: "summaries.show", summaryId: rest[0] };
+    case "config.show": return { kind: "config.show" };
+    case "config.get":
+      if (!rest[0] || rest.length !== 1) {
+        throw new CliError("INVALID_COMMAND", "config get requires one config path.", 2);
+      }
+      return { kind: "config.get", path: rest[0] };
+    case "config.set":
+      if (!rest[0] || rest[1] === undefined || rest.length !== 2) {
+        throw new CliError("INVALID_COMMAND", "config set requires a path and JSON value.", 2);
+      }
+      return { kind: "config.set", path: rest[0], value: rest[1] };
+    case "doctor": return { kind: "doctor" };
+    default:
+      throw new CliError("INVALID_COMMAND", `Unknown command: ${positionals.join(" ")}.`, 2);
+  }
+}
+
+// Require scope only for commands whose result cannot be global.
+function requireSelector(command: CliCommand, selector: ConversationSelector | undefined): void {
+  if (
+    !selector
+    && ["conversations.show", "messages.list", "messages.tail"].includes(command.kind)
+  ) {
+    throw new CliError(
+      "MISSING_SELECTOR",
+      `${command.kind} requires conversation-id or session-key.`,
+      2,
+    );
+  }
+}
+
+// Keep Node's option-schema inference intact for the normalized parser below.
+function parseRawCliArgs(args: string[]) {
+  return parseArgs({
+    args,
+    allowPositionals: true,
+    strict: true,
+    options: CLI_OPTIONS,
+  });
+}
+
+/** Parse one complete `lcm` invocation into a validated command contract. */
+export function parseCliArgs(args: string[], now: Date = new Date()): ParsedCliArgs {
+  let parsed: ReturnType<typeof parseRawCliArgs>;
+  try {
+    parsed = parseRawCliArgs(args);
+  } catch (error) {
+    throw new CliError(
+      "INVALID_ARGUMENT",
+      error instanceof Error ? error.message : String(error),
+      2,
+    );
+  }
+
+  // Normalize and validate each external option once at the process boundary.
+  const command = parseCommand(parsed.positionals, parsed.values.help === true, parsed.values.version === true);
+  const selector = parseSelector(parsed.values["conversation-id"], parsed.values["session-key"]);
+  requireSelector(command, selector);
+  const format = parsed.values.format;
+  if (format !== "json" && format !== "table") {
+    throw new CliError("INVALID_ARGUMENT", "format must be json or table.", 2, { value: format });
+  }
+  const roleValues = parsed.values.role ?? [];
+  const roles = roleValues.map((role) => {
+    if (!MESSAGE_ROLES.has(role as MessageRole)) {
+      throw new CliError("INVALID_ARGUMENT", `Unsupported message role: ${role}.`, 2);
+    }
+    return role as MessageRole;
+  });
+  const summaryKindValue = parsed.values.kind;
+  if (summaryKindValue && !SUMMARY_KINDS.has(summaryKindValue as SummaryKind)) {
+    throw new CliError("INVALID_ARGUMENT", `Unsupported summary kind: ${summaryKindValue}.`, 2);
+  }
+
+  return {
+    command,
+    databasePath: parsed.values.db,
+    configPath: parsed.values.config,
+    openclawDir: parsed.values["openclaw-dir"],
+    format,
+    pretty: parsed.values.pretty === true,
+    selector,
+    time: parseTimeFilter({
+      after: parsed.values.after,
+      before: parsed.values.before,
+      between: parsed.values.between,
+      recency: parsed.values.recency,
+    }, now),
+    limit: parsePositiveInteger(parsed.values.limit, "limit", 500)!,
+    cursor: parsed.values.cursor,
+    roles,
+    includeContent: parsed.values["include-content"] === true,
+    depth: parseNonNegativeInteger(parsed.values.depth, "depth"),
+    summaryKind: summaryKindValue as SummaryKind | undefined,
+    count: parsePositiveInteger(parsed.values.count, "count", 500),
+  };
+}
+
+/** Encode a stable keyset position as an opaque URL-safe cursor. */
+export function encodeCursor(resource: CursorResource, timestamp: string, id: number | string): string {
+  return Buffer.from(JSON.stringify({ v: 1, resource, timestamp, id }), "utf8").toString("base64url");
+}
+
+/** Decode and validate an opaque cursor for the expected list resource. */
+export function decodeCursor(cursor: string, expectedResource: CursorResource): DecodedCursor {
+  try {
+    const value = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")) as Record<string, unknown>;
+    if (
+      value.v !== 1
+      || value.resource !== expectedResource
+      || typeof value.timestamp !== "string"
+      || !Number.isFinite(new Date(value.timestamp).getTime())
+      || (typeof value.id !== "string" && typeof value.id !== "number")
+    ) {
+      throw new Error("cursor shape mismatch");
+    }
+    return { timestamp: value.timestamp, id: value.id };
+  } catch {
+    throw new CliError("INVALID_CURSOR", `Invalid ${expectedResource} cursor.`, 2);
+  }
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -82,7 +82,7 @@ const CLI_OPTIONS = {
   before: { type: "string" },
   between: { type: "string" },
   recency: { type: "string" },
-  limit: { type: "string", default: "50" },
+  limit: { type: "string" },
   cursor: { type: "string" },
   role: { type: "string", multiple: true },
   "include-content": { type: "boolean", default: false },
@@ -90,6 +90,37 @@ const CLI_OPTIONS = {
   kind: { type: "string" },
   count: { type: "string" },
 } as const;
+
+type CommandSpecificOption =
+  | "conversation-id"
+  | "session-key"
+  | "after"
+  | "before"
+  | "between"
+  | "recency"
+  | "limit"
+  | "cursor"
+  | "role"
+  | "include-content"
+  | "depth"
+  | "kind"
+  | "count";
+
+const COMMAND_OPTION_SUPPORT: Record<CommandSpecificOption, ReadonlySet<CliCommand["kind"]>> = {
+  "conversation-id": new Set(["conversations.show", "messages.list", "messages.tail", "summaries.list"]),
+  "session-key": new Set(["conversations.show", "messages.list", "messages.tail", "summaries.list"]),
+  after: new Set(["messages.list", "summaries.list"]),
+  before: new Set(["messages.list", "summaries.list"]),
+  between: new Set(["messages.list", "summaries.list"]),
+  recency: new Set(["messages.list", "summaries.list"]),
+  limit: new Set(["conversations.list", "messages.list", "summaries.list"]),
+  cursor: new Set(["conversations.list", "messages.list", "summaries.list"]),
+  role: new Set(["messages.list"]),
+  "include-content": new Set(["messages.list", "summaries.list"]),
+  depth: new Set(["summaries.list"]),
+  kind: new Set(["summaries.list"]),
+  count: new Set(["messages.tail"]),
+};
 
 // Parse a bounded positive integer option without accepting coercible strings.
 function parsePositiveInteger(value: string | undefined, label: string, maximum?: number): number | undefined {
@@ -260,6 +291,28 @@ function parseRawCliArgs(args: string[]) {
   });
 }
 
+// Reject command-specific options instead of silently returning unfiltered data.
+function assertSupportedCommandOptions(
+  command: CliCommand,
+  values: ReturnType<typeof parseRawCliArgs>["values"],
+): void {
+  const supplied = (Object.keys(COMMAND_OPTION_SUPPORT) as CommandSpecificOption[])
+    .filter((option) => {
+      const value = values[option];
+      return Array.isArray(value) ? value.length > 0 : value !== undefined && value !== false;
+    });
+  for (const option of supplied) {
+    if (!COMMAND_OPTION_SUPPORT[option].has(command.kind)) {
+      throw new CliError(
+        "INVALID_ARGUMENT",
+        `--${option} is not supported by ${command.kind}.`,
+        2,
+        { option, command: command.kind },
+      );
+    }
+  }
+}
+
 /** Parse one complete `lcm` invocation into a validated command contract. */
 export function parseCliArgs(args: string[], now: Date = new Date()): ParsedCliArgs {
   let parsed: ReturnType<typeof parseRawCliArgs>;
@@ -275,6 +328,7 @@ export function parseCliArgs(args: string[], now: Date = new Date()): ParsedCliA
 
   // Normalize and validate each external option once at the process boundary.
   const command = parseCommand(parsed.positionals, parsed.values.help === true, parsed.values.version === true);
+  assertSupportedCommandOptions(command, parsed.values);
   const selector = parseSelector(parsed.values["conversation-id"], parsed.values["session-key"]);
   requireSelector(command, selector);
   const format = parsed.values.format;
@@ -307,7 +361,7 @@ export function parseCliArgs(args: string[], now: Date = new Date()): ParsedCliA
       between: parsed.values.between,
       recency: parsed.values.recency,
     }, now),
-    limit: parsePositiveInteger(parsed.values.limit, "limit", 500)!,
+    limit: parsePositiveInteger(parsed.values.limit ?? "50", "limit", 500)!,
     cursor: parsed.values.cursor,
     roles,
     includeContent: parsed.values["include-content"] === true,

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -121,6 +121,7 @@ const COMMAND_OPTION_SUPPORT: Record<CommandSpecificOption, ReadonlySet<CliComma
   kind: new Set(["summaries.list"]),
   count: new Set(["messages.tail"]),
 };
+const CONFIG_JSON_VALUE_SENTINEL = "\0lcm-config-json-value";
 
 // Parse a bounded positive integer option without accepting coercible strings.
 function parsePositiveInteger(value: string | undefined, label: string, maximum?: number): number | undefined {
@@ -301,14 +302,61 @@ function requireSelector(command: CliCommand, selector: ConversationSelector | u
   }
 }
 
+// Protect one negative JSON number from option parsing when it is the config-set value.
+function normalizeDashPrefixedConfigValue(args: string[]): {
+  args: string[];
+  originalValue?: string;
+} {
+  for (const [index, originalValue] of args.entries()) {
+    try {
+      if (!originalValue.startsWith("-") || typeof JSON.parse(originalValue) !== "number") {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    // Let the strict parser prove that this candidate is the config-set value positional.
+    const normalized = [...args];
+    normalized[index] = CONFIG_JSON_VALUE_SENTINEL;
+    try {
+      const inspected = parseArgs({
+        args: normalized,
+        allowPositionals: true,
+        strict: true,
+        options: CLI_OPTIONS,
+      });
+      if (
+        inspected.positionals.length === 4
+        && inspected.positionals[0] === "config"
+        && inspected.positionals[1] === "set"
+        && inspected.positionals[3] === CONFIG_JSON_VALUE_SENTINEL
+      ) {
+        return { args: normalized, originalValue };
+      }
+    } catch {
+      // The normal strict parse below owns the final error for invalid invocations.
+    }
+  }
+  return { args };
+}
+
 // Keep Node's option-schema inference intact for the normalized parser below.
 function parseRawCliArgs(args: string[]) {
-  return parseArgs({
-    args,
+  const normalized = normalizeDashPrefixedConfigValue(args);
+  const parsed = parseArgs({
+    args: normalized.args,
     allowPositionals: true,
     strict: true,
     options: CLI_OPTIONS,
   });
+  if (normalized.originalValue !== undefined) {
+    const valueIndex = parsed.positionals.indexOf(CONFIG_JSON_VALUE_SENTINEL);
+    if (valueIndex >= 0) {
+      parsed.positionals[valueIndex] = normalized.originalValue;
+    }
+  }
+  return parsed;
 }
 
 // Reject command-specific options instead of silently returning unfiltered data.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -59,6 +59,15 @@ type TimeFilterInput = {
 
 const MESSAGE_ROLES = new Set<MessageRole>(["system", "user", "assistant", "tool"]);
 const SUMMARY_KINDS = new Set<SummaryKind>(["leaf", "condensed"]);
+const FIXED_COMMANDS = new Set([
+  "conversations.list",
+  "conversations.show",
+  "messages.list",
+  "messages.tail",
+  "summaries.list",
+  "config.show",
+]);
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
 const CLI_OPTIONS = {
   db: { type: "string" },
   config: { type: "string" },
@@ -115,8 +124,7 @@ function parseNonNegativeInteger(value: string | undefined, label: string): numb
 
 // Parse one externally supplied timestamp and normalize its validation error.
 function parseTimestamp(value: string, label: string): Date {
-  const isoTimestamp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
-  if (!isoTimestamp.test(value)) {
+  if (!ISO_TIMESTAMP_PATTERN.test(value)) {
     throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });
   }
   const parsed = new Date(value);
@@ -196,6 +204,9 @@ function parseCommand(positionals: string[], help: boolean, version: boolean): C
   }
   const [resource, action, ...rest] = positionals;
   const key = action ? `${resource}.${action}` : resource;
+  if (FIXED_COMMANDS.has(key) && rest.length > 0) {
+    throw new CliError("INVALID_COMMAND", `${key} does not accept positional arguments.`, 2);
+  }
   switch (key) {
     case "status": return { kind: "status" };
     case "conversations.list": return { kind: "conversations.list" };

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -67,7 +67,7 @@ const FIXED_COMMANDS = new Set([
   "summaries.list",
   "config.show",
 ]);
-const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_TIMESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|([+-])(\d{2}):(\d{2}))$/;
 const CLI_OPTIONS = {
   db: { type: "string" },
   config: { type: "string" },
@@ -155,12 +155,32 @@ function parseNonNegativeInteger(value: string | undefined, label: string): numb
 
 // Parse one externally supplied timestamp and normalize its validation error.
 function parseTimestamp(value: string, label: string): Date {
-  if (!ISO_TIMESTAMP_PATTERN.test(value)) {
+  const match = value.match(ISO_TIMESTAMP_PATTERN);
+  if (!match) {
     throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });
   }
   const parsed = new Date(value);
   if (!Number.isFinite(parsed.getTime())) {
     throw new CliError("INVALID_TIME_FILTER", `${label} must be an ISO-8601 timestamp.`, 2, { value });
+  }
+
+  // Undo the parsed offset, then ensure JavaScript did not normalize an impossible date.
+  const offsetSign = match[9] === "-" ? -1 : 1;
+  const offsetMinutes = match[8] === "Z"
+    ? 0
+    : offsetSign * (Number(match[10]) * 60 + Number(match[11]));
+  const local = new Date(parsed.getTime() + offsetMinutes * 60_000);
+  const expected = match.slice(1, 7).map((part) => Number(part ?? 0));
+  const actual = [
+    local.getUTCFullYear(),
+    local.getUTCMonth() + 1,
+    local.getUTCDate(),
+    local.getUTCHours(),
+    local.getUTCMinutes(),
+    local.getUTCSeconds(),
+  ];
+  if (actual.some((part, index) => part !== expected[index])) {
+    throw new CliError("INVALID_TIME_FILTER", `${label} must be a valid calendar timestamp.`, 2, { value });
   }
   return parsed;
 }

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -144,6 +144,11 @@ function extractLosslessConfig(root: JsonRecord, configPath: string): JsonRecord
   return entry ? optionalRecord(entry, "config", configPath) ?? {} : {};
 }
 
+/** Read the raw Lossless plugin config without requiring its current values to validate. */
+export function readRawLosslessConfig(configPath: string): JsonRecord {
+  return extractLosslessConfig(readRootConfig(configPath), configPath);
+}
+
 // Return environment variable names that can affect effective Lossless values, never values.
 function listEnvironmentOverrides(env: NodeJS.ProcessEnv): string[] {
   return Object.keys(env)
@@ -157,7 +162,7 @@ export function readConfigView(
   configPath: string,
   env: NodeJS.ProcessEnv = process.env,
 ): ConfigView {
-  const raw = extractLosslessConfig(readRootConfig(configPath), configPath);
+  const raw = readRawLosslessConfig(configPath);
   let resolved: ReturnType<typeof resolveLcmConfigWithDiagnostics>;
   try {
     resolved = resolveLcmConfigWithDiagnostics(env, raw);

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -1,0 +1,471 @@
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import manifest from "../../openclaw.plugin.json" with { type: "json" };
+import {
+  resolveLcmConfigWithDiagnostics,
+  type LcmConfig,
+  type LcmConfigDiagnostics,
+} from "../db/config.js";
+import { CliError } from "./output.js";
+
+const LOSSLESS_PLUGIN_ID = "lossless-claw";
+const CONFIG_SCHEMA = manifest.configSchema as unknown as JsonRecord;
+
+type JsonRecord = Record<string, unknown>;
+
+export type ConfigView = {
+  configPath: string;
+  raw: JsonRecord;
+  effective: LcmConfig;
+  diagnostics: LcmConfigDiagnostics;
+  environmentOverrides: string[];
+};
+
+export type ConfigValueView = {
+  path: string;
+  isSet: boolean;
+  rawValue: unknown;
+  effectiveValue: unknown;
+};
+
+export type ConfigSetResult = {
+  path: string;
+  oldValue: unknown;
+  newValue: unknown;
+  configPath: string;
+  backupPath: string;
+};
+
+type SetConfigOptions = {
+  now?: () => Date;
+};
+
+// Narrow arbitrary parsed JSON values to objects with own properties.
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonRecord
+    : undefined;
+}
+
+// Parse a JSON config file without accepting JSON5 syntax or partial values.
+function readRootConfig(configPath: string): JsonRecord {
+  if (!existsSync(configPath)) {
+    throw new CliError("CONFIG_NOT_FOUND", `OpenClaw config not found at ${configPath}.`, 3, {
+      configPath,
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    throw new CliError(
+      "CONFIG_PARSE_FAILED",
+      `OpenClaw config must be strict JSON for Lossless CLI editing: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      4,
+      { configPath },
+    );
+  }
+  const root = asRecord(parsed);
+  if (!root) {
+    throw new CliError("CONFIG_PARSE_FAILED", "OpenClaw config root must be an object.", 4, {
+      configPath,
+    });
+  }
+  return root;
+}
+
+// Read an optional object property and reject incompatible config shapes.
+function optionalRecord(parent: JsonRecord, key: string, configPath: string): JsonRecord | undefined {
+  const value = parent[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    throw new CliError(
+      "CONFIG_SHAPE_INVALID",
+      `OpenClaw config property ${key} must be an object.`,
+      4,
+      { configPath, key },
+    );
+  }
+  return record;
+}
+
+// Extract only the Lossless plugin config so unrelated OpenClaw secrets never escape.
+function extractLosslessConfig(root: JsonRecord, configPath: string): JsonRecord {
+  const plugins = optionalRecord(root, "plugins", configPath);
+  const entries = plugins ? optionalRecord(plugins, "entries", configPath) : undefined;
+  const entry = entries ? optionalRecord(entries, LOSSLESS_PLUGIN_ID, configPath) : undefined;
+  return entry ? optionalRecord(entry, "config", configPath) ?? {} : {};
+}
+
+// Return environment variable names that can affect effective Lossless values, never values.
+function listEnvironmentOverrides(env: NodeJS.ProcessEnv): string[] {
+  return Object.keys(env)
+    .filter((key) => key.startsWith("LCM_") || key === "TZ")
+    .filter((key) => typeof env[key] === "string")
+    .sort();
+}
+
+/** Read the raw plugin config and effective runtime values without exposing other config sections. */
+export function readConfigView(
+  configPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ConfigView {
+  const raw = extractLosslessConfig(readRootConfig(configPath), configPath);
+  const resolved = resolveLcmConfigWithDiagnostics(env, raw);
+  return {
+    configPath,
+    raw,
+    effective: resolved.config,
+    diagnostics: resolved.diagnostics,
+    environmentOverrides: listEnvironmentOverrides(env),
+  };
+}
+
+// Split and validate a dot path before reading or mutating objects.
+function parseConfigPath(path: string): string[] {
+  const segments = path.split(".");
+  if (segments.some((segment) => !segment || segment.trim() !== segment)) {
+    throw new CliError("CONFIG_VALIDATION_FAILED", "Config path must use non-empty dot segments.", 4, {
+      path,
+    });
+  }
+  return segments;
+}
+
+// Resolve a path through own properties only.
+function readValueAtPath(root: JsonRecord, segments: string[]): { found: boolean; value: unknown } {
+  let current: unknown = root;
+  for (const segment of segments) {
+    const record = asRecord(current);
+    if (!record || !Object.hasOwn(record, segment)) {
+      return { found: false, value: null };
+    }
+    current = record[segment];
+  }
+  return { found: true, value: current };
+}
+
+// Map accepted legacy aliases to their effective runtime field names.
+function effectivePathSegments(segments: string[]): string[] {
+  const path = segments.join(".");
+  if (path === "dbPath") {
+    return ["databasePath"];
+  }
+  if (path === "largeFileThresholdTokens") {
+    return ["largeFileTokenThreshold"];
+  }
+  if (path === "incrementalMaxDepth") {
+    return ["sweepMaxDepth"];
+  }
+  return segments;
+}
+
+/** Return raw and effective values for one Lossless config path. */
+export function getConfigValue(view: ConfigView, path: string): ConfigValueView {
+  const segments = parseConfigPath(path);
+  const raw = readValueAtPath(view.raw, segments);
+  const effective = readValueAtPath(
+    view.effective as unknown as JsonRecord,
+    effectivePathSegments(segments),
+  );
+  if (!raw.found && !effective.found) {
+    throw new CliError("CONFIG_KEY_NOT_FOUND", `Unknown Lossless config path: ${path}.`, 3, { path });
+  }
+  return {
+    path,
+    isSet: raw.found,
+    rawValue: raw.found ? raw.value : null,
+    effectiveValue: effective.found ? effective.value : null,
+  };
+}
+
+// Find the manifest schema node for an approved dot path.
+function schemaAtPath(segments: string[]): JsonRecord | undefined {
+  let schema = CONFIG_SCHEMA;
+  for (const segment of segments) {
+    const properties = asRecord(schema.properties);
+    const next = properties?.[segment];
+    const nextSchema = asRecord(next);
+    if (!nextSchema) {
+      return undefined;
+    }
+    schema = nextSchema;
+  }
+  return schema;
+}
+
+type SchemaValidationError = { path: string; message: string };
+
+// Validate the JSON Schema subset used by openclaw.plugin.json.
+function validateSchema(
+  schema: JsonRecord,
+  value: unknown,
+  path = "",
+): SchemaValidationError[] {
+  const errors: SchemaValidationError[] = [];
+  const type = schema.type;
+
+  if (type === "object") {
+    const record = asRecord(value);
+    if (!record) {
+      return [{ path, message: "Expected object" }];
+    }
+    const properties = asRecord(schema.properties) ?? {};
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((item): item is string => typeof item === "string")
+      : [];
+    for (const key of required) {
+      if (!Object.hasOwn(record, key)) {
+        errors.push({ path: `${path}/${key}`, message: "Required property is missing" });
+      }
+    }
+    if (typeof schema.minProperties === "number" && Object.keys(record).length < schema.minProperties) {
+      errors.push({ path, message: `Expected at least ${schema.minProperties} properties` });
+    }
+    for (const [key, childValue] of Object.entries(record)) {
+      const childSchema = asRecord(properties[key]);
+      if (!childSchema) {
+        if (schema.additionalProperties === false) {
+          errors.push({ path: `${path}/${key}`, message: "Unexpected property" });
+        }
+        continue;
+      }
+      errors.push(...validateSchema(childSchema, childValue, `${path}/${key}`));
+    }
+  } else if (type === "array") {
+    if (!Array.isArray(value)) {
+      return [{ path, message: "Expected array" }];
+    }
+    const itemSchema = asRecord(schema.items);
+    if (itemSchema) {
+      value.forEach((item, index) => {
+        errors.push(...validateSchema(itemSchema, item, `${path}/${index}`));
+      });
+    }
+  } else if (type === "string") {
+    if (typeof value !== "string") {
+      return [{ path, message: "Expected string" }];
+    }
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push({ path, message: `Expected at least ${schema.minLength} characters` });
+    }
+  } else if (type === "boolean") {
+    if (typeof value !== "boolean") {
+      return [{ path, message: "Expected boolean" }];
+    }
+  } else if (type === "number" || type === "integer") {
+    if (typeof value !== "number" || !Number.isFinite(value) || (type === "integer" && !Number.isInteger(value))) {
+      return [{ path, message: type === "integer" ? "Expected integer" : "Expected number" }];
+    }
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push({ path, message: `Expected value >= ${schema.minimum}` });
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push({ path, message: `Expected value <= ${schema.maximum}` });
+    }
+  }
+
+  if (Array.isArray(schema.enum) && !schema.enum.some((candidate) => Object.is(candidate, value))) {
+    errors.push({ path, message: `Expected one of ${schema.enum.map(String).join(", ")}` });
+  }
+  return errors;
+}
+
+// Reject include-bearing ancestors because rewriting would flatten their semantics.
+function assertNoRelevantIncludes(root: JsonRecord, configPath: string): void {
+  const ancestors: Array<{ label: string; value: JsonRecord | undefined }> = [{ label: "root", value: root }];
+  const plugins = asRecord(root.plugins);
+  const entries = asRecord(plugins?.entries);
+  const entry = asRecord(entries?.[LOSSLESS_PLUGIN_ID]);
+  const config = asRecord(entry?.config);
+  ancestors.push(
+    { label: "plugins", value: plugins },
+    { label: "plugins.entries", value: entries },
+    { label: `plugins.entries.${LOSSLESS_PLUGIN_ID}`, value: entry },
+    { label: `plugins.entries.${LOSSLESS_PLUGIN_ID}.config`, value: config },
+  );
+  const include = ancestors.find(({ value }) => value && Object.hasOwn(value, "$include"));
+  if (include) {
+    throw new CliError(
+      "CONFIG_INCLUDE_UNSUPPORTED",
+      `Lossless CLI config writes do not flatten $include at ${include.label}.`,
+      4,
+      { configPath, includePath: include.label },
+    );
+  }
+}
+
+// Create one object property while rejecting existing scalar or array shapes.
+function getOrCreateRecord(parent: JsonRecord, key: string, configPath: string): JsonRecord {
+  if (parent[key] === undefined) {
+    parent[key] = {};
+  }
+  const record = asRecord(parent[key]);
+  if (!record) {
+    throw new CliError(
+      "CONFIG_SHAPE_INVALID",
+      `Cannot create Lossless config below non-object property ${key}.`,
+      4,
+      { configPath, key },
+    );
+  }
+  return record;
+}
+
+// Set one nested property after the manifest path has been validated.
+function setValueAtPath(root: JsonRecord, segments: string[], value: unknown, configPath: string): unknown {
+  let parent = root;
+  for (const segment of segments.slice(0, -1)) {
+    parent = getOrCreateRecord(parent, segment, configPath);
+  }
+  const finalSegment = segments.at(-1)!;
+  const oldValue = Object.hasOwn(parent, finalSegment) ? parent[finalSegment] : null;
+  parent[finalSegment] = value;
+  return oldValue;
+}
+
+// Parse a JSON CLI value and normalize its public validation error.
+function parseJsonValue(value: string, path: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new CliError(
+      "CONFIG_VALIDATION_FAILED",
+      `Value for ${path} must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      4,
+      { path },
+    );
+  }
+}
+
+// Validate the complete plugin config to catch both target and surrounding invalid values.
+function validatePluginConfig(config: JsonRecord, path: string): void {
+  const errors = validateSchema(CONFIG_SCHEMA, config).slice(0, 20);
+  if (errors.length === 0) {
+    return;
+  }
+  throw new CliError(
+    "CONFIG_VALIDATION_FAILED",
+    `Lossless config would be invalid after setting ${path}.`,
+    4,
+    { path, errors },
+  );
+}
+
+// Convert an ISO timestamp to a filename-safe, sortable backup suffix.
+function backupTimestamp(now: Date): string {
+  return now.toISOString().replace(/[-:.]/g, "");
+}
+
+// Persist validated JSON through a sibling temp file and atomic rename.
+function writeConfigAtomically(configPath: string, root: JsonRecord, mode: number): void {
+  const tempPath = join(dirname(configPath), `.${basename(configPath)}.lcm-${process.pid}-${randomUUID()}.tmp`);
+  let descriptor: number | undefined;
+  try {
+    writeFileSync(tempPath, `${JSON.stringify(root, null, 2)}\n`, { flag: "wx", mode });
+    chmodSync(tempPath, mode);
+    descriptor = openSync(tempPath, "r+");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(tempPath, configPath);
+  } catch (error) {
+    if (descriptor !== undefined) {
+      closeSync(descriptor);
+    }
+    rmSync(tempPath, { force: true });
+    throw new CliError(
+      "CONFIG_WRITE_FAILED",
+      `Could not atomically replace OpenClaw config: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      4,
+      { configPath },
+    );
+  }
+}
+
+/** Set one manifest-declared Lossless config value with backup-first atomic replacement. */
+export function setConfigValue(
+  configPath: string,
+  path: string,
+  jsonValue: string,
+  options: SetConfigOptions = {},
+): ConfigSetResult {
+  const stat = lstatSync(configPath, { throwIfNoEntry: false });
+  if (!stat) {
+    throw new CliError("CONFIG_NOT_FOUND", `OpenClaw config not found at ${configPath}.`, 3, {
+      configPath,
+    });
+  }
+  if (stat.isSymbolicLink()) {
+    throw new CliError(
+      "CONFIG_SYMLINK_UNSUPPORTED",
+      "Lossless CLI config writes refuse symlink targets.",
+      4,
+      { configPath },
+    );
+  }
+
+  // Complete all parsing and validation before creating the backup or temp file.
+  const root = readRootConfig(configPath);
+  assertNoRelevantIncludes(root, configPath);
+  const segments = parseConfigPath(path);
+  const targetSchema = schemaAtPath(segments);
+  if (!targetSchema) {
+    throw new CliError("CONFIG_VALIDATION_FAILED", `Unknown Lossless config path: ${path}.`, 4, {
+      path,
+    });
+  }
+  const newValue = parseJsonValue(jsonValue, path);
+  const targetErrors = validateSchema(targetSchema, newValue);
+  if (targetErrors.length > 0) {
+    throw new CliError(
+      "CONFIG_VALIDATION_FAILED",
+      `Value does not match the manifest schema for ${path}.`,
+      4,
+      { path, errors: targetErrors.slice(0, 20) },
+    );
+  }
+
+  const plugins = getOrCreateRecord(root, "plugins", configPath);
+  const entries = getOrCreateRecord(plugins, "entries", configPath);
+  const entry = getOrCreateRecord(entries, LOSSLESS_PLUGIN_ID, configPath);
+  const config = getOrCreateRecord(entry, "config", configPath);
+  const oldValue = setValueAtPath(config, segments, newValue, configPath);
+  validatePluginConfig(config, path);
+
+  const backupPath = `${configPath}.lcm-backup-${backupTimestamp((options.now ?? (() => new Date()))())}`;
+  try {
+    copyFileSync(configPath, backupPath, constants.COPYFILE_EXCL);
+  } catch (error) {
+    throw new CliError(
+      "CONFIG_BACKUP_FAILED",
+      `Could not create OpenClaw config backup: ${error instanceof Error ? error.message : String(error)}`,
+      4,
+      { configPath, backupPath },
+    );
+  }
+  writeConfigAtomically(configPath, root, stat.mode & 0o777);
+
+  return { path, oldValue, newValue, configPath, backupPath };
+}

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -14,7 +14,6 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
-import manifest from "../../openclaw.plugin.json" with { type: "json" };
 import {
   resolveLcmConfigWithDiagnostics,
   type LcmConfig,
@@ -23,9 +22,32 @@ import {
 import { CliError } from "./output.js";
 
 const LOSSLESS_PLUGIN_ID = "lossless-claw";
-const CONFIG_SCHEMA = manifest.configSchema as unknown as JsonRecord;
 
 type JsonRecord = Record<string, unknown>;
+
+// Load the packaged manifest in both source-test and dist/cli.js layouts.
+function loadConfigSchema(): JsonRecord {
+  const candidates = [
+    new URL("../openclaw.plugin.json", import.meta.url),
+    new URL("../../openclaw.plugin.json", import.meta.url),
+  ];
+  const manifestUrl = candidates.find((candidate) => existsSync(candidate));
+  if (!manifestUrl) {
+    throw new CliError(
+      "CONFIG_SCHEMA_NOT_FOUND",
+      "Could not locate the packaged Lossless plugin manifest.",
+      4,
+    );
+  }
+  const parsed = JSON.parse(readFileSync(manifestUrl, "utf8")) as unknown;
+  const schema = asRecord(asRecord(parsed)?.configSchema);
+  if (!schema) {
+    throw new CliError("CONFIG_SCHEMA_INVALID", "Lossless plugin manifest has no configSchema.", 4);
+  }
+  return schema;
+}
+
+const CONFIG_SCHEMA = loadConfigSchema();
 
 export type ConfigView = {
   configPath: string;

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -47,7 +47,13 @@ function loadConfigSchema(): JsonRecord {
   return schema;
 }
 
-const CONFIG_SCHEMA = loadConfigSchema();
+let configSchema: JsonRecord | undefined;
+
+// Defer manifest access so help and read-only commands can report their own results.
+function getConfigSchema(): JsonRecord {
+  configSchema ??= loadConfigSchema();
+  return configSchema;
+}
 
 export type ConfigView = {
   configPath: string;
@@ -114,10 +120,10 @@ function readRootConfig(configPath: string): JsonRecord {
 
 // Read an optional object property and reject incompatible config shapes.
 function optionalRecord(parent: JsonRecord, key: string, configPath: string): JsonRecord | undefined {
-  const value = parent[key];
-  if (value === undefined) {
+  if (!Object.hasOwn(parent, key)) {
     return undefined;
   }
+  const value = parent[key];
   const record = asRecord(value);
   if (!record) {
     throw new CliError(
@@ -234,10 +240,13 @@ export function getConfigValue(view: ConfigView, path: string): ConfigValueView 
 
 // Find the manifest schema node for an approved dot path.
 function schemaAtPath(segments: string[]): JsonRecord | undefined {
-  let schema = CONFIG_SCHEMA;
+  let schema = getConfigSchema();
   for (const segment of segments) {
     const properties = asRecord(schema.properties);
-    const next = properties?.[segment];
+    if (!properties || !Object.hasOwn(properties, segment)) {
+      return undefined;
+    }
+    const next = properties[segment];
     const nextSchema = asRecord(next);
     if (!nextSchema) {
       return undefined;
@@ -276,7 +285,7 @@ function validateSchema(
       errors.push({ path, message: `Expected at least ${schema.minProperties} properties` });
     }
     for (const [key, childValue] of Object.entries(record)) {
-      const childSchema = asRecord(properties[key]);
+      const childSchema = Object.hasOwn(properties, key) ? asRecord(properties[key]) : undefined;
       if (!childSchema) {
         if (schema.additionalProperties === false) {
           errors.push({ path: `${path}/${key}`, message: "Unexpected property" });
@@ -350,7 +359,7 @@ function assertNoRelevantIncludes(root: JsonRecord, configPath: string): void {
 
 // Create one object property while rejecting existing scalar or array shapes.
 function getOrCreateRecord(parent: JsonRecord, key: string, configPath: string): JsonRecord {
-  if (parent[key] === undefined) {
+  if (!Object.hasOwn(parent, key)) {
     parent[key] = {};
   }
   const record = asRecord(parent[key]);
@@ -393,7 +402,7 @@ function parseJsonValue(value: string, path: string): unknown {
 
 // Validate the complete plugin config to catch both target and surrounding invalid values.
 function validatePluginConfig(config: JsonRecord, path: string): void {
-  const errors = validateSchema(CONFIG_SCHEMA, config).slice(0, 20);
+  const errors = validateSchema(getConfigSchema(), config).slice(0, 20);
   if (errors.length === 0) {
     return;
   }
@@ -426,6 +435,19 @@ function backupTimestamp(now: Date): string {
   return now.toISOString().replace(/[-:.]/g, "");
 }
 
+// Make a completed rename durable on filesystems that support directory fsync.
+function fsyncParentDirectory(configPath: string): void {
+  if (process.platform === "win32") {
+    return;
+  }
+  const descriptor = openSync(dirname(configPath), "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 // Persist validated JSON through a sibling temp file and atomic rename.
 function writeConfigAtomically(configPath: string, root: JsonRecord, mode: number): void {
   const tempPath = join(dirname(configPath), `.${basename(configPath)}.lcm-${process.pid}-${randomUUID()}.tmp`);
@@ -438,6 +460,7 @@ function writeConfigAtomically(configPath: string, root: JsonRecord, mode: numbe
     closeSync(descriptor);
     descriptor = undefined;
     renameSync(tempPath, configPath);
+    fsyncParentDirectory(configPath);
   } catch (error) {
     if (descriptor !== undefined) {
       closeSync(descriptor);

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -152,7 +152,19 @@ export function readConfigView(
   env: NodeJS.ProcessEnv = process.env,
 ): ConfigView {
   const raw = extractLosslessConfig(readRootConfig(configPath), configPath);
-  const resolved = resolveLcmConfigWithDiagnostics(env, raw);
+  let resolved: ReturnType<typeof resolveLcmConfigWithDiagnostics>;
+  try {
+    resolved = resolveLcmConfigWithDiagnostics(env, raw);
+  } catch (error) {
+    throw new CliError(
+      "CONFIG_VALIDATION_FAILED",
+      `Lossless config at ${configPath} failed runtime validation: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      4,
+      { configPath },
+    );
+  }
   return {
     configPath,
     raw,

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -393,6 +393,22 @@ function validatePluginConfig(config: JsonRecord, path: string): void {
   );
 }
 
+// Apply runtime cross-field validation that the manifest schema cannot express.
+function validateRuntimeConfig(config: JsonRecord, path: string): void {
+  try {
+    resolveLcmConfigWithDiagnostics({}, config);
+  } catch (error) {
+    throw new CliError(
+      "CONFIG_VALIDATION_FAILED",
+      `Lossless config would fail runtime validation after setting ${path}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      4,
+      { path },
+    );
+  }
+}
+
 // Convert an ISO timestamp to a filename-safe, sortable backup suffix.
 function backupTimestamp(now: Date): string {
   return now.toISOString().replace(/[-:.]/g, "");
@@ -475,6 +491,7 @@ export function setConfigValue(
   const config = getOrCreateRecord(entry, "config", configPath);
   const oldValue = setValueAtPath(config, segments, newValue, configPath);
   validatePluginConfig(config, path);
+  validateRuntimeConfig(config, path);
 
   const backupPath = `${configPath}.lcm-backup-${backupTimestamp((options.now ?? (() => new Date()))())}`;
   try {

--- a/src/cli/database.ts
+++ b/src/cli/database.ts
@@ -1,6 +1,9 @@
 import { existsSync, statSync } from "node:fs";
-import { DatabaseSync } from "node:sqlite";
+import { createRequire } from "node:module";
+import type { DatabaseSync } from "node:sqlite";
 import { CliError } from "./output.js";
+
+const require = createRequire(import.meta.url);
 
 /** Open an existing LCM database through a handle that cannot perform writes. */
 export function openReadOnlyDatabase(databasePath: string): DatabaseSync {
@@ -13,11 +16,15 @@ export function openReadOnlyDatabase(databasePath: string): DatabaseSync {
     );
   }
 
-  let database: DatabaseSync;
+  let database: DatabaseSync | undefined;
   try {
+    // Load node:sqlite only for database commands so help/config commands stay warning-free on Node 22.
+    const sqlite = require("node:sqlite") as typeof import("node:sqlite");
+    const { DatabaseSync } = sqlite;
     database = new DatabaseSync(databasePath, { readOnly: true });
     database.exec("PRAGMA query_only = ON");
   } catch (error) {
+    database?.close();
     const message = error instanceof Error ? error.message : String(error);
     throw new CliError(
       "DATABASE_OPEN_FAILED",

--- a/src/cli/database.ts
+++ b/src/cli/database.ts
@@ -1,0 +1,30 @@
+import { existsSync, statSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { CliError } from "./output.js";
+
+/** Open an existing LCM database through a handle that cannot perform writes. */
+export function openReadOnlyDatabase(databasePath: string): DatabaseSync {
+  if (!existsSync(databasePath) || !statSync(databasePath).isFile()) {
+    throw new CliError(
+      "DATABASE_NOT_FOUND",
+      `LCM database not found at ${databasePath}.`,
+      3,
+      { databasePath },
+    );
+  }
+
+  let database: DatabaseSync;
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true });
+    database.exec("PRAGMA query_only = ON");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CliError(
+      "DATABASE_OPEN_FAILED",
+      `Could not open LCM database: ${message}`,
+      5,
+      { databasePath },
+    );
+  }
+  return database;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,257 @@
+import { existsSync, statSync } from "node:fs";
+import packageJson from "../../package.json" with { type: "json" };
+import { parseCliArgs, type ParsedCliArgs } from "./args.js";
+import {
+  getConfigValue,
+  readConfigView,
+  setConfigValue,
+  type ConfigView,
+} from "./config-file.js";
+import { openReadOnlyDatabase } from "./database.js";
+import {
+  CliError,
+  createErrorEnvelope,
+  createSuccessEnvelope,
+  normalizeCliError,
+  renderSuccessEnvelope,
+  type PaginationMetadata,
+} from "./output.js";
+import { resolveCliPaths, type ResolvedCliPaths } from "./paths.js";
+import {
+  getConversationDiagnostics,
+  getFreshTail,
+  getGlobalStatus,
+  getSummaryDetails,
+  listConversations,
+  listMessages,
+  listSummaries,
+} from "./queries.js";
+import { resolveLcmConfigWithDiagnostics } from "../db/config.js";
+
+type CliIo = {
+  env?: NodeJS.ProcessEnv;
+  stdout?: (text: string) => void;
+  stderr?: (text: string) => void;
+};
+
+type CommandResult = {
+  data: unknown;
+  pagination?: PaginationMetadata;
+};
+
+const HELP_DATA = {
+  usage: "lcm <command> [options]",
+  commands: [
+    "status",
+    "conversations list",
+    "conversations show (--conversation-id <id> | --session-key <key>)",
+    "messages list (--conversation-id <id> | --session-key <key>)",
+    "messages tail (--conversation-id <id> | --session-key <key>)",
+    "summaries list [--conversation-id <id> | --session-key <key>]",
+    "summaries show <summary-id>",
+    "config show",
+    "config get <path>",
+    "config set <path> <json-value>",
+    "doctor",
+  ],
+  globalOptions: [
+    "--db <path>",
+    "--config <path>",
+    "--openclaw-dir <path>",
+    "--format <json|table>",
+    "--pretty",
+    "--help",
+    "--version",
+  ],
+  listOptions: ["--limit <1..500>", "--cursor <opaque-cursor>"],
+  timeOptions: [
+    "--after <iso-timestamp>",
+    "--before <iso-timestamp>",
+    "--between <start>..<end>",
+    "--recency <duration: s|m|h|d|w>",
+  ],
+} as const;
+
+// Build a default config view when the OpenClaw config file has not been created.
+function loadConfigView(configPath: string, env: NodeJS.ProcessEnv): ConfigView {
+  if (existsSync(configPath)) {
+    return readConfigView(configPath, env);
+  }
+  const resolved = resolveLcmConfigWithDiagnostics(env, {});
+  return {
+    configPath,
+    raw: {},
+    effective: resolved.config,
+    diagnostics: resolved.diagnostics,
+    environmentOverrides: Object.keys(env)
+      .filter((key) => (key.startsWith("LCM_") || key === "TZ") && env[key] !== undefined)
+      .sort(),
+  };
+}
+
+// Resolve config first, then allow its databasePath/dbPath to participate in DB discovery.
+function resolveInvocationContext(parsed: ParsedCliArgs, env: NodeJS.ProcessEnv): {
+  paths: ResolvedCliPaths;
+  config: ConfigView;
+} {
+  const overrides = {
+    openclawDir: parsed.openclawDir,
+    configPath: parsed.configPath,
+    databasePath: parsed.databasePath,
+  };
+  const basePaths = resolveCliPaths({ env, overrides });
+  const config = loadConfigView(basePaths.configPath, env);
+  const paths = resolveCliPaths({ env, overrides, pluginConfig: config.raw });
+  return { paths, config };
+}
+
+// Dispatch commands whose only mutable surface is one targeted config value.
+function runConfigCommand(parsed: ParsedCliArgs, config: ConfigView): CommandResult | null {
+  switch (parsed.command.kind) {
+    case "config.show":
+      return { data: config };
+    case "config.get":
+      return { data: getConfigValue(config, parsed.command.path) };
+    case "config.set":
+      return {
+        data: setConfigValue(config.configPath, parsed.command.path, parsed.command.value),
+      };
+    default:
+      return null;
+  }
+}
+
+// Dispatch every command that reads the LCM database through one read-only handle.
+function runDatabaseCommand(
+  parsed: ParsedCliArgs,
+  paths: ResolvedCliPaths,
+  config: ConfigView,
+): CommandResult {
+  const db = openReadOnlyDatabase(paths.databasePath);
+  try {
+    switch (parsed.command.kind) {
+      case "status":
+        return {
+          data: {
+            version: packageJson.version,
+            databaseSizeBytes: statSync(paths.databasePath).size,
+            freshTail: {
+              count: config.effective.freshTailCount,
+              maxTokens: config.effective.freshTailMaxTokens ?? null,
+            },
+            status: getGlobalStatus(db),
+          },
+        };
+      case "conversations.list": {
+        const page = listConversations(db, {
+          limit: parsed.limit,
+          cursor: parsed.cursor,
+          freshTailCount: config.effective.freshTailCount,
+          freshTailMaxTokens: config.effective.freshTailMaxTokens,
+        });
+        return { data: { items: page.items }, pagination: page.pagination };
+      }
+      case "conversations.show":
+        return {
+          data: getConversationDiagnostics(db, parsed.selector!, {
+            freshTailCount: config.effective.freshTailCount,
+            freshTailMaxTokens: config.effective.freshTailMaxTokens,
+          }),
+        };
+      case "messages.list": {
+        const page = listMessages(db, {
+          selector: parsed.selector!,
+          roles: parsed.roles,
+          time: parsed.time,
+          limit: parsed.limit,
+          cursor: parsed.cursor,
+          includeContent: parsed.includeContent,
+        });
+        return {
+          data: { conversation: page.conversation, items: page.items },
+          pagination: page.pagination,
+        };
+      }
+      case "messages.tail":
+        return {
+          data: getFreshTail(db, {
+            selector: parsed.selector!,
+            freshTailCount: config.effective.freshTailCount,
+            freshTailMaxTokens: config.effective.freshTailMaxTokens,
+            count: parsed.count,
+          }),
+        };
+      case "summaries.list": {
+        const page = listSummaries(db, {
+          selector: parsed.selector,
+          depth: parsed.depth,
+          kind: parsed.summaryKind,
+          time: parsed.time,
+          limit: parsed.limit,
+          cursor: parsed.cursor,
+          includeContent: parsed.includeContent,
+        });
+        return {
+          data: { conversationId: page.conversationId, items: page.items },
+          pagination: page.pagination,
+        };
+      }
+      case "summaries.show":
+        return { data: getSummaryDetails(db, parsed.command.summaryId) };
+      default:
+        throw new CliError("INVALID_COMMAND", `Command ${parsed.command.kind} does not read the database.`, 2);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** Execute one `lcm` invocation and return its stable process exit code. */
+export function runCli(args: string[], io: CliIo = {}): number {
+  const env = io.env ?? process.env;
+  const writeStdout = io.stdout ?? ((text: string) => process.stdout.write(text));
+  const writeStderr = io.stderr ?? ((text: string) => process.stderr.write(text));
+  let parsed: ParsedCliArgs | undefined;
+  try {
+    parsed = parseCliArgs(args);
+    if (parsed.command.kind === "help") {
+      const envelope = createSuccessEnvelope("help", {
+        ...HELP_DATA,
+        ...(parsed.command.topic ? { topic: parsed.command.topic } : {}),
+      }, {});
+      writeStdout(renderSuccessEnvelope(envelope, parsed.format, parsed.pretty));
+      return 0;
+    }
+    if (parsed.command.kind === "version") {
+      const envelope = createSuccessEnvelope("version", { version: packageJson.version }, {});
+      writeStdout(renderSuccessEnvelope(envelope, parsed.format, parsed.pretty));
+      return 0;
+    }
+    if (parsed.command.kind === "doctor") {
+      const envelope = createSuccessEnvelope("doctor", {
+        available: false,
+        databaseReadOnly: true,
+        message: "Doctor subcommands require a separate approved diagnostic contract.",
+      }, {});
+      writeStdout(renderSuccessEnvelope(envelope, parsed.format, parsed.pretty));
+      return 0;
+    }
+
+    // Config discovery precedes database discovery so configured DB aliases take effect.
+    const context = resolveInvocationContext(parsed, env);
+    const result = runConfigCommand(parsed, context.config)
+      ?? runDatabaseCommand(parsed, context.paths, context.config);
+    const envelope = createSuccessEnvelope(
+      parsed.command.kind,
+      result.data,
+      { databasePath: context.paths.databasePath, configPath: context.paths.configPath },
+      result.pagination,
+    );
+    writeStdout(renderSuccessEnvelope(envelope, parsed.format, parsed.pretty));
+    return 0;
+  } catch (error) {
+    const cliError = normalizeCliError(error);
+    writeStderr(`${JSON.stringify(createErrorEnvelope(cliError), null, parsed?.pretty ? 2 : undefined)}\n`);
+    return cliError.exitCode;
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@ import packageJson from "../../package.json" with { type: "json" };
 import { parseCliArgs, type ParsedCliArgs } from "./args.js";
 import {
   getConfigValue,
+  readRawLosslessConfig,
   readConfigView,
   setConfigValue,
   type ConfigView,
@@ -38,6 +39,13 @@ type CommandResult = {
   data: unknown;
   pagination?: PaginationMetadata;
 };
+
+type InvocationContext = {
+  paths: ResolvedCliPaths;
+  config: ConfigView;
+};
+
+type ConfigSetCommand = Extract<ParsedCliArgs["command"], { kind: "config.set" }>;
 
 const HELP_DATA = {
   usage: "lcm <command> [options]",
@@ -93,16 +101,18 @@ function loadConfigView(configPath: string, env: NodeJS.ProcessEnv): ConfigView 
   };
 }
 
-// Resolve config first, then allow its databasePath/dbPath to participate in DB discovery.
-function resolveInvocationContext(parsed: ParsedCliArgs, env: NodeJS.ProcessEnv): {
-  paths: ResolvedCliPaths;
-  config: ConfigView;
-} {
-  const overrides = {
+// Collect explicit path flags once for config and database discovery.
+function pathOverrides(parsed: ParsedCliArgs) {
+  return {
     openclawDir: parsed.openclawDir,
     configPath: parsed.configPath,
     databasePath: parsed.databasePath,
   };
+}
+
+// Resolve config first, then allow its databasePath/dbPath to participate in DB discovery.
+function resolveInvocationContext(parsed: ParsedCliArgs, env: NodeJS.ProcessEnv): InvocationContext {
+  const overrides = pathOverrides(parsed);
   const basePaths = resolveCliPaths({ env, overrides });
   const configEnv = { ...env, OPENCLAW_STATE_DIR: basePaths.openclawDir };
   const config = loadConfigView(basePaths.configPath, configEnv);
@@ -110,17 +120,27 @@ function resolveInvocationContext(parsed: ParsedCliArgs, env: NodeJS.ProcessEnv)
   return { paths, config };
 }
 
-// Dispatch commands whose only mutable surface is one targeted config value.
+// Apply a targeted repair before loading the effective config, then resolve updated paths.
+function runConfigSetCommand(
+  parsed: ParsedCliArgs,
+  command: ConfigSetCommand,
+  env: NodeJS.ProcessEnv,
+): { paths: ResolvedCliPaths; result: CommandResult } {
+  const overrides = pathOverrides(parsed);
+  const basePaths = resolveCliPaths({ env, overrides });
+  const data = setConfigValue(basePaths.configPath, command.path, command.value);
+  const raw = readRawLosslessConfig(basePaths.configPath);
+  const paths = resolveCliPaths({ env, overrides, pluginConfig: raw });
+  return { paths, result: { data } };
+}
+
+// Dispatch commands that inspect config without opening the database.
 function runConfigCommand(parsed: ParsedCliArgs, config: ConfigView): CommandResult | null {
   switch (parsed.command.kind) {
     case "config.show":
       return { data: config };
     case "config.get":
       return { data: getConfigValue(config, parsed.command.path) };
-    case "config.set":
-      return {
-        data: setConfigValue(config.configPath, parsed.command.path, parsed.command.value),
-      };
     default:
       return null;
   }
@@ -252,14 +272,21 @@ export function runCli(args: string[], io: CliIo = {}): number {
       return 0;
     }
 
-    // Config discovery precedes database discovery so configured DB aliases take effect.
-    const context = resolveInvocationContext(parsed, env);
-    const result = runConfigCommand(parsed, context.config)
-      ?? runDatabaseCommand(parsed, context.paths, context.config);
+    let paths: ResolvedCliPaths;
+    let result: CommandResult;
+    if (parsed.command.kind === "config.set") {
+      ({ paths, result } = runConfigSetCommand(parsed, parsed.command, env));
+    } else {
+      // Config discovery precedes database discovery so configured DB aliases take effect.
+      const context = resolveInvocationContext(parsed, env);
+      paths = context.paths;
+      result = runConfigCommand(parsed, context.config)
+        ?? runDatabaseCommand(parsed, context.paths, context.config);
+    }
     const envelope = createSuccessEnvelope(
       parsed.command.kind,
       result.data,
-      { databasePath: context.paths.databasePath, configPath: context.paths.configPath },
+      { databasePath: paths.databasePath, configPath: paths.configPath },
       result.pagination,
     );
     writeStdout(renderSuccessEnvelope(envelope, parsed.format, parsed.pretty));

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -104,7 +104,8 @@ function resolveInvocationContext(parsed: ParsedCliArgs, env: NodeJS.ProcessEnv)
     databasePath: parsed.databasePath,
   };
   const basePaths = resolveCliPaths({ env, overrides });
-  const config = loadConfigView(basePaths.configPath, env);
+  const configEnv = { ...env, OPENCLAW_STATE_DIR: basePaths.openclawDir };
+  const config = loadConfigView(basePaths.configPath, configEnv);
   const paths = resolveCliPaths({ env, overrides, pluginConfig: config.raw });
   return { paths, config };
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -64,6 +64,10 @@ const HELP_DATA = {
     "--version",
   ],
   listOptions: ["--limit <1..500>", "--cursor <opaque-cursor>"],
+  selectorOptions: ["--conversation-id <id>", "--session-key <key>"],
+  messageOptions: ["--role <role>", "--include-content"],
+  summaryOptions: ["--depth <integer>", "--kind <leaf|condensed>", "--include-content"],
+  tailOptions: ["--count <1..500>"],
   timeOptions: [
     "--after <iso-timestamp>",
     "--before <iso-timestamp>",
@@ -201,6 +205,16 @@ function runDatabaseCommand(
       default:
         throw new CliError("INVALID_COMMAND", `Command ${parsed.command.kind} does not read the database.`, 2);
     }
+  } catch (error) {
+    if (error instanceof CliError) {
+      throw error;
+    }
+    throw new CliError(
+      "DATABASE_QUERY_FAILED",
+      `LCM database query failed: ${error instanceof Error ? error.message : String(error)}`,
+      5,
+      { databasePath: paths.databasePath },
+    );
   } finally {
     db.close();
   }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,76 @@
+/** Stable process exit codes exposed by the `lcm` executable. */
+export type CliExitCode = 1 | 2 | 3 | 4 | 5;
+
+/** Structured CLI failure with a machine-readable code and process exit status. */
+export class CliError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly exitCode: CliExitCode,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "CliError";
+  }
+}
+
+export type PaginationMetadata = {
+  limit: number;
+  returned: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+export type SuccessEnvelope<TData, TMeta extends Record<string, unknown>> = {
+  ok: true;
+  command: string;
+  data: TData;
+  pagination?: PaginationMetadata;
+  meta: TMeta;
+};
+
+export type ErrorEnvelope = {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+};
+
+/** Build the stable success envelope used by every JSON command response. */
+export function createSuccessEnvelope<TData, TMeta extends Record<string, unknown>>(
+  command: string,
+  data: TData,
+  meta: TMeta,
+  pagination?: PaginationMetadata,
+): SuccessEnvelope<TData, TMeta> {
+  return {
+    ok: true,
+    command,
+    data,
+    ...(pagination ? { pagination } : {}),
+    meta,
+  };
+}
+
+/** Build the stable error envelope written to stderr for expected failures. */
+export function createErrorEnvelope(error: CliError): ErrorEnvelope {
+  return {
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.details === undefined ? {} : { details: error.details }),
+    },
+  };
+}
+
+/** Convert an unexpected thrown value into a stable internal CLI error. */
+export function normalizeCliError(error: unknown): CliError {
+  if (error instanceof CliError) {
+    return error;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return new CliError("INTERNAL_ERROR", message || "Unexpected CLI failure.", 1);
+}

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -74,3 +74,60 @@ export function normalizeCliError(error: unknown): CliError {
   const message = error instanceof Error ? error.message : String(error);
   return new CliError("INTERNAL_ERROR", message || "Unexpected CLI failure.", 1);
 }
+
+// Render one scalar or nested value as a single table cell.
+function renderCell(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  const rendered = typeof value === "object" ? JSON.stringify(value) : String(value);
+  return rendered.replace(/[\t\r\n]+/g, " ");
+}
+
+// Render a bounded array of records with deterministic first-seen columns.
+function renderRows(rows: Array<Record<string, unknown>>): string[] {
+  if (rows.length === 0) {
+    return ["(no rows)"];
+  }
+  const columns = [...new Set(rows.flatMap((row) => Object.keys(row)))];
+  return [
+    columns.join("\t"),
+    ...rows.map((row) => columns.map((column) => renderCell(row[column])).join("\t")),
+  ];
+}
+
+// Render nested command data as stable key/value lines when it is not a list.
+function renderObject(prefix: string, value: Record<string, unknown>): string[] {
+  return Object.entries(value).map(([key, child]) => `${prefix}${key}\t${renderCell(child)}`);
+}
+
+/** Serialize one success envelope as JSON or compact tabular text. */
+export function renderSuccessEnvelope(
+  envelope: SuccessEnvelope<unknown, Record<string, unknown>>,
+  format: "json" | "table",
+  pretty: boolean,
+): string {
+  if (format === "json") {
+    return `${JSON.stringify(envelope, null, pretty ? 2 : undefined)}\n`;
+  }
+
+  const lines = [`command\t${envelope.command}`];
+  const data = envelope.data;
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const record = data as Record<string, unknown>;
+    if (Array.isArray(record.items)) {
+      lines.push(...renderRows(record.items as Array<Record<string, unknown>>));
+      const otherData = Object.fromEntries(Object.entries(record).filter(([key]) => key !== "items"));
+      lines.push(...renderObject("data.", otherData));
+    } else {
+      lines.push(...renderObject("data.", record));
+    }
+  } else {
+    lines.push(`data\t${renderCell(data)}`);
+  }
+  if (envelope.pagination) {
+    lines.push(...renderObject("pagination.", envelope.pagination as unknown as Record<string, unknown>));
+  }
+  lines.push(...renderObject("meta.", envelope.meta));
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/paths.ts
+++ b/src/cli/paths.ts
@@ -1,0 +1,85 @@
+import { homedir as defaultHomedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export type CliPathOverrides = {
+  openclawDir?: string;
+  configPath?: string;
+  databasePath?: string;
+};
+
+export type ResolvedCliPaths = {
+  openclawDir: string;
+  configPath: string;
+  databasePath: string;
+};
+
+type ResolveCliPathsInput = {
+  env?: NodeJS.ProcessEnv;
+  overrides?: CliPathOverrides;
+  pluginConfig?: Record<string, unknown>;
+  homedir?: () => string;
+};
+
+// Accept only non-empty string path candidates.
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+// Resolve OpenClaw's home override before deriving state defaults or expanding tildes.
+function resolveOpenClawHome(env: NodeJS.ProcessEnv, homedir: () => string): string {
+  const processHome = resolve(homedir());
+  const configuredHome = nonEmptyString(env.OPENCLAW_HOME);
+  if (!configuredHome) {
+    return processHome;
+  }
+  if (configuredHome === "~") {
+    return processHome;
+  }
+  if (configuredHome.startsWith("~/")) {
+    return resolve(processHome, configuredHome.slice(2));
+  }
+  return isAbsolute(configuredHome) ? resolve(configuredHome) : resolve(configuredHome);
+}
+
+// Expand one user path and return the absolute process-facing path.
+function resolveUserPath(value: string, home: string): string {
+  if (value === "~") {
+    return home;
+  }
+  if (value.startsWith("~/")) {
+    return resolve(home, value.slice(2));
+  }
+  return resolve(value);
+}
+
+/** Resolve the OpenClaw state, config, and LCM database paths for one CLI invocation. */
+export function resolveCliPaths(input: ResolveCliPathsInput = {}): ResolvedCliPaths {
+  const env = input.env ?? process.env;
+  const overrides = input.overrides ?? {};
+  const home = resolveOpenClawHome(env, input.homedir ?? defaultHomedir);
+
+  // Resolve the state directory first because both remaining defaults derive from it.
+  const openclawDirValue = nonEmptyString(overrides.openclawDir)
+    ?? nonEmptyString(env.LCM_OPENCLAW_DIR)
+    ?? nonEmptyString(env.OPENCLAW_STATE_DIR)
+    ?? join(home, ".openclaw");
+  const openclawDir = resolveUserPath(openclawDirValue, home);
+
+  const configPathValue = nonEmptyString(overrides.configPath)
+    ?? nonEmptyString(env.OPENCLAW_CONFIG_PATH)
+    ?? join(openclawDir, "openclaw.json");
+  const configPath = resolveUserPath(configPathValue, home);
+
+  // Explicit and environment database paths override both supported plugin keys.
+  const databasePathValue = nonEmptyString(overrides.databasePath)
+    ?? nonEmptyString(env.LCM_DATABASE_PATH)
+    ?? nonEmptyString(input.pluginConfig?.databasePath)
+    ?? nonEmptyString(input.pluginConfig?.dbPath)
+    ?? join(openclawDir, "lcm.db");
+
+  return {
+    openclawDir,
+    configPath,
+    databasePath: resolveUserPath(databasePathValue, home),
+  };
+}

--- a/src/cli/paths.ts
+++ b/src/cli/paths.ts
@@ -73,8 +73,8 @@ export function resolveCliPaths(input: ResolveCliPathsInput = {}): ResolvedCliPa
   // Explicit and environment database paths override both supported plugin keys.
   const databasePathValue = nonEmptyString(overrides.databasePath)
     ?? nonEmptyString(env.LCM_DATABASE_PATH)
-    ?? nonEmptyString(input.pluginConfig?.databasePath)
     ?? nonEmptyString(input.pluginConfig?.dbPath)
+    ?? nonEmptyString(input.pluginConfig?.databasePath)
     ?? join(openclawDir, "lcm.db");
 
   return {

--- a/src/cli/queries.ts
+++ b/src/cli/queries.ts
@@ -9,6 +9,8 @@ import {
 } from "./args.js";
 import { CliError, type PaginationMetadata } from "./output.js";
 
+const LIST_PREVIEW_SOURCE_CHARACTERS = 1024;
+
 export {
   getSummaryDetails,
   listSummaries,
@@ -674,10 +676,13 @@ export function listMessages(
     args.push(cursor.timestamp, cursor.timestamp, cursor.id);
   }
   args.push(input.limit + 1);
+  const contentProjection = input.includeContent
+    ? "m.content"
+    : `substr(m.content, 1, ${LIST_PREVIEW_SOURCE_CHARACTERS})`;
 
   const rows = db.prepare(`SELECT
       m.message_id AS messageId, m.conversation_id AS conversationId,
-      m.seq, m.role, m.content, m.token_count AS tokenCount,
+      m.seq, m.role, ${contentProjection} AS content, m.token_count AS tokenCount,
       m.created_at AS createdAt, m.large_content AS largeContent
     FROM messages m
     WHERE ${where.join(" AND ")}

--- a/src/cli/queries.ts
+++ b/src/cli/queries.ts
@@ -9,6 +9,15 @@ import {
 } from "./args.js";
 import { CliError, type PaginationMetadata } from "./output.js";
 
+export {
+  getSummaryDetails,
+  listSummaries,
+  type SummaryDetails,
+  type SummaryListItem,
+  type SummaryPage,
+  type SummarySourceMessage,
+} from "./summary-queries.js";
+
 export type SummaryDepthStats = {
   kind: SummaryKind;
   depth: number;

--- a/src/cli/queries.ts
+++ b/src/cli/queries.ts
@@ -306,11 +306,7 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
     && input.freshTailMaxTokens >= 0
       ? Math.floor(input.freshTailMaxTokens)
       : null;
-  const args: Array<number | string | null> = [
-    normalizedTailCount,
-    normalizedTailTokenCap,
-    normalizedTailTokenCap,
-  ];
+  const args: Array<number | string | null> = [];
   if (input.conversationId !== undefined) {
     where.push("c.conversation_id = ?");
     args.push(input.conversationId);
@@ -326,34 +322,50 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
     args.push(cursor.timestamp, cursor.timestamp, cursor.id);
   }
   args.push(input.limit);
+  args.push(normalizedTailCount, normalizedTailTokenCap, normalizedTailTokenCap);
 
   const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
   return db.prepare(`
     WITH
+    selected_conversations AS MATERIALIZED (
+      SELECT c.*
+        FROM conversations c
+        ${whereClause}
+       ORDER BY julianday(c.updated_at) DESC, c.conversation_id DESC
+       LIMIT ?
+    ),
     message_stats AS (
-      SELECT conversation_id, COUNT(*) AS messageCount,
+      SELECT m.conversation_id, COUNT(*) AS messageCount,
              COALESCE(SUM(token_count), 0) AS messageTokens,
-             MIN(created_at) AS earliestMessageAt, MAX(created_at) AS latestMessageAt
-        FROM messages GROUP BY conversation_id
+             MIN(m.created_at) AS earliestMessageAt, MAX(m.created_at) AS latestMessageAt
+        FROM messages m
+        JOIN selected_conversations c ON c.conversation_id = m.conversation_id
+       GROUP BY m.conversation_id
     ),
     summary_stats AS (
-      SELECT conversation_id, COUNT(*) AS summaryCount,
-             COALESCE(SUM(token_count), 0) AS summaryTokens,
-             COALESCE(SUM(source_message_token_count), 0) AS summarizedSourceTokens,
-             MIN(COALESCE(earliest_at, created_at)) AS earliestSummaryAt,
-             MAX(COALESCE(latest_at, created_at)) AS latestSummaryAt,
-             MAX(depth) AS maxSummaryDepth
-        FROM summaries GROUP BY conversation_id
+      SELECT s.conversation_id, COUNT(*) AS summaryCount,
+             COALESCE(SUM(s.token_count), 0) AS summaryTokens,
+             COALESCE(SUM(s.source_message_token_count), 0) AS summarizedSourceTokens,
+             MIN(COALESCE(s.earliest_at, s.created_at)) AS earliestSummaryAt,
+             MAX(COALESCE(s.latest_at, s.created_at)) AS latestSummaryAt,
+             MAX(s.depth) AS maxSummaryDepth
+        FROM summaries s
+        JOIN selected_conversations c ON c.conversation_id = s.conversation_id
+       GROUP BY s.conversation_id
     ),
     context_stats AS (
       SELECT conversation_id, COUNT(*) AS contextItems, COALESCE(SUM(tokens), 0) AS contextTokens
         FROM (
           SELECT ci.conversation_id, m.token_count AS tokens
-            FROM context_items ci JOIN messages m ON m.message_id = ci.message_id
+            FROM context_items ci
+            JOIN selected_conversations c ON c.conversation_id = ci.conversation_id
+            JOIN messages m ON m.message_id = ci.message_id
            WHERE ci.item_type = 'message'
           UNION ALL
           SELECT ci.conversation_id, s.token_count AS tokens
-            FROM context_items ci JOIN summaries s ON s.summary_id = ci.summary_id
+            FROM context_items ci
+            JOIN selected_conversations c ON c.conversation_id = ci.conversation_id
+            JOIN summaries s ON s.summary_id = ci.summary_id
            WHERE ci.item_type = 'summary'
         ) GROUP BY conversation_id
     ),
@@ -367,6 +379,7 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
              ) AS cumulativeTokens
         FROM context_items ci
+        JOIN selected_conversations c ON c.conversation_id = ci.conversation_id
         JOIN messages m ON m.message_id = ci.message_id
        WHERE ci.item_type = 'message'
     ),
@@ -402,14 +415,12 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
       COALESCE(cs.contextTokens, 0) AS contextTokens,
       COALESCE(fts.freshTailMessages, 0) AS freshTailMessages,
       COALESCE(fts.freshTailTokens, 0) AS freshTailTokens
-    FROM conversations c
+    FROM selected_conversations c
     LEFT JOIN message_stats ms ON ms.conversation_id = c.conversation_id
     LEFT JOIN summary_stats ss ON ss.conversation_id = c.conversation_id
     LEFT JOIN context_stats cs ON cs.conversation_id = c.conversation_id
     LEFT JOIN fresh_tail_stats fts ON fts.conversation_id = c.conversation_id
-    ${whereClause}
     ORDER BY julianday(c.updated_at) DESC, c.conversation_id DESC
-    LIMIT ?
   `).all(...args) as ConversationListRow[];
 }
 

--- a/src/cli/queries.ts
+++ b/src/cli/queries.ts
@@ -3,7 +3,9 @@ import {
   decodeCursor,
   encodeCursor,
   type ConversationSelector,
+  type MessageRole,
   type SummaryKind,
+  type TimeFilter,
 } from "./args.js";
 import { CliError, type PaginationMetadata } from "./output.js";
 
@@ -66,6 +68,7 @@ export type ConversationPage = {
 type ConversationQueryInput = {
   limit: number;
   freshTailCount: number;
+  freshTailMaxTokens?: number;
   cursor?: string;
   conversationId?: number;
 };
@@ -288,7 +291,17 @@ export function resolveConversation(
 // Query aggregate conversation rows for either one ID or a keyset-paged list.
 function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput): ConversationListRow[] {
   const where: string[] = [];
-  const args: Array<number | string> = [Math.max(0, Math.floor(input.freshTailCount))];
+  const normalizedTailCount = Math.max(0, Math.floor(input.freshTailCount));
+  const normalizedTailTokenCap = typeof input.freshTailMaxTokens === "number"
+    && Number.isFinite(input.freshTailMaxTokens)
+    && input.freshTailMaxTokens >= 0
+      ? Math.floor(input.freshTailMaxTokens)
+      : null;
+  const args: Array<number | string | null> = [
+    normalizedTailCount,
+    normalizedTailTokenCap,
+    normalizedTailTokenCap,
+  ];
   if (input.conversationId !== undefined) {
     where.push("c.conversation_id = ?");
     args.push(input.conversationId);
@@ -336,14 +349,25 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
         ) GROUP BY conversation_id
     ),
     ranked_messages AS (
-      SELECT conversation_id, token_count,
-             ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY seq DESC) AS tailRank
-        FROM messages
+      SELECT ci.conversation_id, m.token_count,
+             ROW_NUMBER() OVER (
+               PARTITION BY ci.conversation_id ORDER BY ci.ordinal DESC
+             ) AS tailRank,
+             SUM(m.token_count) OVER (
+               PARTITION BY ci.conversation_id ORDER BY ci.ordinal DESC
+               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+             ) AS cumulativeTokens
+        FROM context_items ci
+        JOIN messages m ON m.message_id = ci.message_id
+       WHERE ci.item_type = 'message'
     ),
     fresh_tail_stats AS (
       SELECT conversation_id, COUNT(*) AS freshTailMessages,
              COALESCE(SUM(token_count), 0) AS freshTailTokens
-        FROM ranked_messages WHERE tailRank <= ? GROUP BY conversation_id
+        FROM ranked_messages
+       WHERE tailRank <= ?
+         AND (tailRank = 1 OR ? IS NULL OR cumulativeTokens <= ?)
+       GROUP BY conversation_id
     )
     SELECT
       c.conversation_id AS conversationId,
@@ -383,7 +407,7 @@ function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput):
 /** Return one keyset-paginated page of aggregate conversation diagnostics. */
 export function listConversations(
   db: DatabaseSync,
-  input: { limit: number; freshTailCount: number; cursor?: string },
+  input: { limit: number; freshTailCount: number; freshTailMaxTokens?: number; cursor?: string },
 ): ConversationPage {
   const rows = queryConversationRows(db, { ...input, limit: input.limit + 1 });
   const hasMore = rows.length > input.limit;
@@ -504,12 +528,13 @@ function getLargeFileStats(db: DatabaseSync, conversationId: number): LargeFileS
 export function getConversationDiagnostics(
   db: DatabaseSync,
   selector: ConversationSelector,
-  input: { freshTailCount: number },
+  input: { freshTailCount: number; freshTailMaxTokens?: number },
 ): ConversationDiagnostics {
   const identity = resolveConversation(db, selector);
   const row = queryConversationRows(db, {
     limit: 1,
     freshTailCount: input.freshTailCount,
+    freshTailMaxTokens: input.freshTailMaxTokens,
     conversationId: identity.conversationId,
   })[0];
   if (!row) {
@@ -525,5 +550,200 @@ export function getConversationDiagnostics(
     bootstrap: getBootstrap(db, identity.conversationId),
     focusBriefs: getFocusBriefStats(db, identity.conversationId),
     largeFiles: getLargeFileStats(db, identity.conversationId),
+  };
+}
+
+export type MessageListItem = {
+  messageId: number;
+  conversationId: number;
+  seq: number;
+  role: MessageRole;
+  tokenCount: number;
+  createdAt: string;
+  largeContent: string | null;
+  preview: string;
+  content?: string;
+};
+
+export type MessagePage = {
+  conversation: ConversationIdentity;
+  items: MessageListItem[];
+  pagination: PaginationMetadata;
+};
+
+type MessageRow = {
+  messageId: number;
+  conversationId: number;
+  seq: number;
+  role: MessageRole;
+  content: string;
+  tokenCount: number;
+  createdAt: string;
+  largeContent: string | null;
+};
+
+export type FreshTailResult = {
+  conversationIdentity: ConversationIdentity;
+  limits: { count: number; maxTokens: number | null };
+  selected: { messages: number; tokens: number; firstSeq: number | null; lastSeq: number | null };
+  conversation: { messages: number; tokens: number };
+  messages: Array<MessageListItem & { content: string }>;
+};
+
+// Produce a bounded single-line preview without changing stored content.
+function previewMessageContent(content: string, maximumCharacters = 240): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  return normalized.length <= maximumCharacters
+    ? normalized
+    : `${normalized.slice(0, maximumCharacters - 1)}…`;
+}
+
+// Map a stored message row to the public list representation.
+function mapMessageRow(row: MessageRow, includeContent: boolean): MessageListItem {
+  return {
+    messageId: row.messageId,
+    conversationId: row.conversationId,
+    seq: row.seq,
+    role: row.role,
+    tokenCount: row.tokenCount,
+    createdAt: row.createdAt,
+    largeContent: row.largeContent,
+    preview: previewMessageContent(row.content),
+    ...(includeContent ? { content: row.content } : {}),
+  };
+}
+
+/** Return one filtered, keyset-paginated page of stored conversation messages. */
+export function listMessages(
+  db: DatabaseSync,
+  input: {
+    selector: ConversationSelector;
+    roles: MessageRole[];
+    time: TimeFilter;
+    limit: number;
+    cursor?: string;
+    includeContent: boolean;
+  },
+): MessagePage {
+  const conversation = resolveConversation(db, input.selector);
+  const where = ["m.conversation_id = ?"];
+  const args: Array<number | string> = [conversation.conversationId];
+
+  // Add only enumerated role placeholders and bound timestamp/cursor values.
+  if (input.roles.length > 0) {
+    where.push(`m.role IN (${input.roles.map(() => "?").join(", ")})`);
+    args.push(...input.roles);
+  }
+  if (input.time.after) {
+    where.push("julianday(m.created_at) >= julianday(?)");
+    args.push(input.time.after.toISOString());
+  }
+  if (input.time.before) {
+    where.push("julianday(m.created_at) < julianday(?)");
+    args.push(input.time.before.toISOString());
+  }
+  if (input.cursor) {
+    const cursor = decodeCursor(input.cursor, "messages");
+    if (typeof cursor.id !== "number" || !Number.isInteger(cursor.id)) {
+      throw new CliError("INVALID_CURSOR", "Invalid messages cursor.", 2);
+    }
+    where.push(`(
+      julianday(m.created_at) < julianday(?)
+      OR (julianday(m.created_at) = julianday(?) AND m.message_id < ?)
+    )`);
+    args.push(cursor.timestamp, cursor.timestamp, cursor.id);
+  }
+  args.push(input.limit + 1);
+
+  const rows = db.prepare(`SELECT
+      m.message_id AS messageId, m.conversation_id AS conversationId,
+      m.seq, m.role, m.content, m.token_count AS tokenCount,
+      m.created_at AS createdAt, m.large_content AS largeContent
+    FROM messages m
+    WHERE ${where.join(" AND ")}
+    ORDER BY julianday(m.created_at) DESC, m.message_id DESC
+    LIMIT ?`
+  ).all(...args) as MessageRow[];
+  const hasMore = rows.length > input.limit;
+  const items = (hasMore ? rows.slice(0, input.limit) : rows)
+    .map((row) => mapMessageRow(row, input.includeContent));
+  const last = items.at(-1);
+
+  return {
+    conversation,
+    items,
+    pagination: {
+      limit: input.limit,
+      returned: items.length,
+      hasMore,
+      nextCursor: hasMore && last
+        ? encodeCursor("messages", last.createdAt, last.messageId)
+        : null,
+    },
+  };
+}
+
+/** Return the protected raw-message tail from the current context frontier. */
+export function getFreshTail(
+  db: DatabaseSync,
+  input: {
+    selector: ConversationSelector;
+    freshTailCount: number;
+    freshTailMaxTokens?: number;
+    count?: number;
+  },
+): FreshTailResult {
+  const conversationIdentity = resolveConversation(db, input.selector);
+  const count = Math.max(0, Math.floor(input.count ?? input.freshTailCount));
+  const maxTokens = typeof input.freshTailMaxTokens === "number"
+    && Number.isFinite(input.freshTailMaxTokens)
+    && input.freshTailMaxTokens >= 0
+      ? Math.floor(input.freshTailMaxTokens)
+      : null;
+
+  const rows = db.prepare(`SELECT
+      m.message_id AS messageId, m.conversation_id AS conversationId,
+      m.seq, m.role, m.content, m.token_count AS tokenCount,
+      m.created_at AS createdAt, m.large_content AS largeContent
+    FROM context_items ci
+    JOIN messages m ON m.message_id = ci.message_id
+    WHERE ci.conversation_id = ? AND ci.item_type = 'message'
+    ORDER BY ci.ordinal DESC
+    LIMIT ?`
+  ).all(conversationIdentity.conversationId, count) as MessageRow[];
+
+  // Walk newest to oldest, always preserving the newest row even above the cap.
+  const selectedNewestFirst: MessageRow[] = [];
+  let selectedTokens = 0;
+  for (const row of rows) {
+    if (
+      selectedNewestFirst.length > 0
+      && maxTokens !== null
+      && selectedTokens + row.tokenCount > maxTokens
+    ) {
+      break;
+    }
+    selectedNewestFirst.push(row);
+    selectedTokens += row.tokenCount;
+  }
+  const messages = selectedNewestFirst.reverse().map(
+    (row) => mapMessageRow(row, true) as MessageListItem & { content: string },
+  );
+  const totals = db.prepare(`SELECT COUNT(*) AS messages,
+      COALESCE(SUM(token_count), 0) AS tokens
+    FROM messages WHERE conversation_id = ?`
+  ).get(conversationIdentity.conversationId) as { messages: number; tokens: number };
+
+  return {
+    conversationIdentity,
+    limits: { count, maxTokens },
+    selected: {
+      messages: messages.length,
+      tokens: selectedTokens,
+      firstSeq: messages[0]?.seq ?? null,
+      lastSeq: messages.at(-1)?.seq ?? null,
+    },
+    conversation: totals,
+    messages,
   };
 }

--- a/src/cli/queries.ts
+++ b/src/cli/queries.ts
@@ -1,0 +1,529 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  decodeCursor,
+  encodeCursor,
+  type ConversationSelector,
+  type SummaryKind,
+} from "./args.js";
+import { CliError, type PaginationMetadata } from "./output.js";
+
+export type SummaryDepthStats = {
+  kind: SummaryKind;
+  depth: number;
+  count: number;
+  tokens: number;
+};
+
+export type GlobalStatus = {
+  conversations: { total: number; active: number };
+  messages: { count: number; tokens: number; earliestAt: string | null; latestAt: string | null };
+  summaries: {
+    count: number;
+    tokens: number;
+    sourceMessageTokens: number;
+    earliestAt: string | null;
+    latestAt: string | null;
+    byDepth: SummaryDepthStats[];
+  };
+  context: { items: number; tokens: number };
+  maintenance: { pending: number; running: number; failed: number };
+};
+
+export type ConversationIdentity = {
+  conversationId: number;
+  sessionId: string;
+  sessionKey: string | null;
+  active: boolean;
+  archivedAt: string | null;
+  title: string | null;
+  bootstrappedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ConversationListItem = ConversationIdentity & {
+  messageCount: number;
+  messageTokens: number;
+  earliestMessageAt: string | null;
+  latestMessageAt: string | null;
+  summaryCount: number;
+  summaryTokens: number;
+  summarizedSourceTokens: number;
+  earliestSummaryAt: string | null;
+  latestSummaryAt: string | null;
+  maxSummaryDepth: number | null;
+  contextItems: number;
+  contextTokens: number;
+  freshTailMessages: number;
+  freshTailTokens: number;
+};
+
+export type ConversationPage = {
+  items: ConversationListItem[];
+  pagination: PaginationMetadata;
+};
+
+type ConversationQueryInput = {
+  limit: number;
+  freshTailCount: number;
+  cursor?: string;
+  conversationId?: number;
+};
+
+type GlobalStatusRow = {
+  conversationCount: number;
+  activeConversationCount: number;
+  messageCount: number;
+  messageTokens: number;
+  earliestMessageAt: string | null;
+  latestMessageAt: string | null;
+  summaryCount: number;
+  summaryTokens: number;
+  summarizedSourceTokens: number;
+  earliestSummaryAt: string | null;
+  latestSummaryAt: string | null;
+  contextItems: number;
+  contextTokens: number;
+  maintenancePending: number;
+  maintenanceRunning: number;
+  maintenanceFailed: number;
+};
+
+type ConversationIdentityRow = Omit<ConversationIdentity, "active"> & { active: number };
+type ConversationListRow = Omit<ConversationListItem, "active"> & { active: number };
+
+type TelemetryRow = {
+  lastObservedCacheRead: number | null;
+  lastObservedCacheWrite: number | null;
+  lastObservedPromptTokenCount: number | null;
+  lastObservedCacheHitAt: string | null;
+  lastObservedCacheBreakAt: string | null;
+  cacheState: string;
+  consecutiveColdObservations: number;
+  retention: string | null;
+  lastLeafCompactionAt: string | null;
+  turnsSinceLeafCompaction: number;
+  tokensAccumulatedSinceLeafCompaction: number;
+  lastActivityBand: string;
+  lastApiCallAt: string | null;
+  lastCacheTouchAt: string | null;
+  provider: string | null;
+  model: string | null;
+  updatedAt: string;
+};
+
+type MaintenanceRow = {
+  pending: number;
+  requestedAt: string | null;
+  reason: string | null;
+  running: number;
+  lastStartedAt: string | null;
+  lastFinishedAt: string | null;
+  lastFailureSummary: string | null;
+  tokenBudget: number | null;
+  currentTokenCount: number | null;
+  projectedTokenCount: number | null;
+  rawTokensOutsideTail: number | null;
+  contextThreshold: number | null;
+  contextThresholdSource: string | null;
+  retryAttempts: number;
+  nextAttemptAfter: string | null;
+  updatedAt: string;
+};
+
+type BootstrapRow = {
+  sessionFilePath: string;
+  lastSeenSize: number;
+  lastSeenMtimeMs: number;
+  lastProcessedOffset: number;
+  lastProcessedEntryHash: string | null;
+  sessionHeaderId: string | null;
+  lastProcessedEntryId: string | null;
+  forkBounded: number;
+  forkSourceMessageCount: number;
+  updatedAt: string;
+};
+
+type ActiveFocusBriefRow = {
+  briefId: string;
+  prompt: string;
+  tokenCount: number;
+  targetTokens: number;
+  coveredLatestAt: string | null;
+  coveredMessageSeq: number | null;
+  generatorRunId: string | null;
+  generatorSessionKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ContextStatsRow = { itemType: "message" | "summary"; count: number; tokens: number };
+type LargeFileStatsRow = { count: number; bytes: number; latestAt: string | null };
+
+export type ConversationDiagnostics = {
+  conversation: ConversationListItem;
+  summaryDepths: SummaryDepthStats[];
+  context: ContextStatsRow[];
+  telemetry: TelemetryRow | null;
+  maintenance: (Omit<MaintenanceRow, "pending" | "running"> & { pending: boolean; running: boolean }) | null;
+  bootstrap: (Omit<BootstrapRow, "forkBounded"> & { forkBounded: boolean }) | null;
+  focusBriefs: { count: number; activeBrief: ActiveFocusBriefRow | null };
+  largeFiles: LargeFileStatsRow;
+};
+
+// Map SQLite integer booleans to the stable JSON representation.
+function mapConversationIdentity(row: ConversationIdentityRow): ConversationIdentity {
+  return { ...row, active: row.active === 1 };
+}
+
+// Map an aggregate list row while preserving nullable diagnostic fields.
+function mapConversationListItem(row: ConversationListRow): ConversationListItem {
+  return { ...row, active: row.active === 1 };
+}
+
+// Load grouped summary depth statistics in deterministic depth/kind order.
+function getSummaryDepthStats(db: DatabaseSync, conversationId?: number): SummaryDepthStats[] {
+  const rows = db.prepare(
+    `SELECT kind, depth, COUNT(*) AS count, COALESCE(SUM(token_count), 0) AS tokens
+       FROM summaries
+      ${conversationId === undefined ? "" : "WHERE conversation_id = ?"}
+      GROUP BY kind, depth
+      ORDER BY depth ASC, kind ASC`,
+  ).all(...(conversationId === undefined ? [] : [conversationId])) as SummaryDepthStats[];
+  return rows;
+}
+
+/** Return database-wide counts, token totals, time coverage, and maintenance state. */
+export function getGlobalStatus(db: DatabaseSync): GlobalStatus {
+  const row = db.prepare(`
+    SELECT
+      (SELECT COUNT(*) FROM conversations) AS conversationCount,
+      (SELECT COUNT(*) FROM conversations WHERE active = 1) AS activeConversationCount,
+      (SELECT COUNT(*) FROM messages) AS messageCount,
+      (SELECT COALESCE(SUM(token_count), 0) FROM messages) AS messageTokens,
+      (SELECT MIN(created_at) FROM messages) AS earliestMessageAt,
+      (SELECT MAX(created_at) FROM messages) AS latestMessageAt,
+      (SELECT COUNT(*) FROM summaries) AS summaryCount,
+      (SELECT COALESCE(SUM(token_count), 0) FROM summaries) AS summaryTokens,
+      (SELECT COALESCE(SUM(source_message_token_count), 0) FROM summaries) AS summarizedSourceTokens,
+      (SELECT MIN(COALESCE(earliest_at, created_at)) FROM summaries) AS earliestSummaryAt,
+      (SELECT MAX(COALESCE(latest_at, created_at)) FROM summaries) AS latestSummaryAt,
+      (SELECT COUNT(*) FROM context_items) AS contextItems,
+      (SELECT COALESCE(SUM(tokens), 0) FROM (
+        SELECT m.token_count AS tokens
+          FROM context_items ci JOIN messages m ON m.message_id = ci.message_id
+         WHERE ci.item_type = 'message'
+        UNION ALL
+        SELECT s.token_count AS tokens
+          FROM context_items ci JOIN summaries s ON s.summary_id = ci.summary_id
+         WHERE ci.item_type = 'summary'
+      )) AS contextTokens,
+      (SELECT COUNT(*) FROM conversation_compaction_maintenance WHERE pending = 1) AS maintenancePending,
+      (SELECT COUNT(*) FROM conversation_compaction_maintenance WHERE running = 1) AS maintenanceRunning,
+      (SELECT COUNT(*) FROM conversation_compaction_maintenance
+        WHERE last_failure_summary IS NOT NULL AND TRIM(last_failure_summary) <> '') AS maintenanceFailed
+  `).get() as GlobalStatusRow;
+
+  return {
+    conversations: { total: row.conversationCount, active: row.activeConversationCount },
+    messages: {
+      count: row.messageCount,
+      tokens: row.messageTokens,
+      earliestAt: row.earliestMessageAt,
+      latestAt: row.latestMessageAt,
+    },
+    summaries: {
+      count: row.summaryCount,
+      tokens: row.summaryTokens,
+      sourceMessageTokens: row.summarizedSourceTokens,
+      earliestAt: row.earliestSummaryAt,
+      latestAt: row.latestSummaryAt,
+      byDepth: getSummaryDepthStats(db),
+    },
+    context: { items: row.contextItems, tokens: row.contextTokens },
+    maintenance: {
+      pending: row.maintenancePending,
+      running: row.maintenanceRunning,
+      failed: row.maintenanceFailed,
+    },
+  };
+}
+
+/** Resolve one persisted conversation from a numeric ID or stable session key. */
+export function resolveConversation(
+  db: DatabaseSync,
+  selector: ConversationSelector,
+): ConversationIdentity {
+  const select = `SELECT
+      conversation_id AS conversationId,
+      session_id AS sessionId,
+      session_key AS sessionKey,
+      active,
+      archived_at AS archivedAt,
+      title,
+      bootstrapped_at AS bootstrappedAt,
+      created_at AS createdAt,
+      updated_at AS updatedAt
+    FROM conversations`;
+  const row = selector.kind === "conversationId"
+    ? db.prepare(`${select} WHERE conversation_id = ?`).get(selector.value) as ConversationIdentityRow | undefined
+    : db.prepare(`${select}
+        WHERE session_key = ?
+        ORDER BY active DESC, julianday(created_at) DESC, conversation_id DESC
+        LIMIT 1`).get(selector.value) as ConversationIdentityRow | undefined;
+
+  if (!row) {
+    throw new CliError(
+      "CONVERSATION_NOT_FOUND",
+      selector.kind === "conversationId"
+        ? `No conversation matched id ${selector.value}.`
+        : `No conversation matched session key ${selector.value}.`,
+      3,
+      selector,
+    );
+  }
+  return mapConversationIdentity(row);
+}
+
+// Query aggregate conversation rows for either one ID or a keyset-paged list.
+function queryConversationRows(db: DatabaseSync, input: ConversationQueryInput): ConversationListRow[] {
+  const where: string[] = [];
+  const args: Array<number | string> = [Math.max(0, Math.floor(input.freshTailCount))];
+  if (input.conversationId !== undefined) {
+    where.push("c.conversation_id = ?");
+    args.push(input.conversationId);
+  } else if (input.cursor) {
+    const cursor = decodeCursor(input.cursor, "conversations");
+    if (typeof cursor.id !== "number" || !Number.isInteger(cursor.id)) {
+      throw new CliError("INVALID_CURSOR", "Invalid conversations cursor.", 2);
+    }
+    where.push(`(
+      julianday(c.updated_at) < julianday(?)
+      OR (julianday(c.updated_at) = julianday(?) AND c.conversation_id < ?)
+    )`);
+    args.push(cursor.timestamp, cursor.timestamp, cursor.id);
+  }
+  args.push(input.limit);
+
+  const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  return db.prepare(`
+    WITH
+    message_stats AS (
+      SELECT conversation_id, COUNT(*) AS messageCount,
+             COALESCE(SUM(token_count), 0) AS messageTokens,
+             MIN(created_at) AS earliestMessageAt, MAX(created_at) AS latestMessageAt
+        FROM messages GROUP BY conversation_id
+    ),
+    summary_stats AS (
+      SELECT conversation_id, COUNT(*) AS summaryCount,
+             COALESCE(SUM(token_count), 0) AS summaryTokens,
+             COALESCE(SUM(source_message_token_count), 0) AS summarizedSourceTokens,
+             MIN(COALESCE(earliest_at, created_at)) AS earliestSummaryAt,
+             MAX(COALESCE(latest_at, created_at)) AS latestSummaryAt,
+             MAX(depth) AS maxSummaryDepth
+        FROM summaries GROUP BY conversation_id
+    ),
+    context_stats AS (
+      SELECT conversation_id, COUNT(*) AS contextItems, COALESCE(SUM(tokens), 0) AS contextTokens
+        FROM (
+          SELECT ci.conversation_id, m.token_count AS tokens
+            FROM context_items ci JOIN messages m ON m.message_id = ci.message_id
+           WHERE ci.item_type = 'message'
+          UNION ALL
+          SELECT ci.conversation_id, s.token_count AS tokens
+            FROM context_items ci JOIN summaries s ON s.summary_id = ci.summary_id
+           WHERE ci.item_type = 'summary'
+        ) GROUP BY conversation_id
+    ),
+    ranked_messages AS (
+      SELECT conversation_id, token_count,
+             ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY seq DESC) AS tailRank
+        FROM messages
+    ),
+    fresh_tail_stats AS (
+      SELECT conversation_id, COUNT(*) AS freshTailMessages,
+             COALESCE(SUM(token_count), 0) AS freshTailTokens
+        FROM ranked_messages WHERE tailRank <= ? GROUP BY conversation_id
+    )
+    SELECT
+      c.conversation_id AS conversationId,
+      c.session_id AS sessionId,
+      c.session_key AS sessionKey,
+      c.active,
+      c.archived_at AS archivedAt,
+      c.title,
+      c.bootstrapped_at AS bootstrappedAt,
+      c.created_at AS createdAt,
+      c.updated_at AS updatedAt,
+      COALESCE(ms.messageCount, 0) AS messageCount,
+      COALESCE(ms.messageTokens, 0) AS messageTokens,
+      ms.earliestMessageAt,
+      ms.latestMessageAt,
+      COALESCE(ss.summaryCount, 0) AS summaryCount,
+      COALESCE(ss.summaryTokens, 0) AS summaryTokens,
+      COALESCE(ss.summarizedSourceTokens, 0) AS summarizedSourceTokens,
+      ss.earliestSummaryAt,
+      ss.latestSummaryAt,
+      ss.maxSummaryDepth,
+      COALESCE(cs.contextItems, 0) AS contextItems,
+      COALESCE(cs.contextTokens, 0) AS contextTokens,
+      COALESCE(fts.freshTailMessages, 0) AS freshTailMessages,
+      COALESCE(fts.freshTailTokens, 0) AS freshTailTokens
+    FROM conversations c
+    LEFT JOIN message_stats ms ON ms.conversation_id = c.conversation_id
+    LEFT JOIN summary_stats ss ON ss.conversation_id = c.conversation_id
+    LEFT JOIN context_stats cs ON cs.conversation_id = c.conversation_id
+    LEFT JOIN fresh_tail_stats fts ON fts.conversation_id = c.conversation_id
+    ${whereClause}
+    ORDER BY julianday(c.updated_at) DESC, c.conversation_id DESC
+    LIMIT ?
+  `).all(...args) as ConversationListRow[];
+}
+
+/** Return one keyset-paginated page of aggregate conversation diagnostics. */
+export function listConversations(
+  db: DatabaseSync,
+  input: { limit: number; freshTailCount: number; cursor?: string },
+): ConversationPage {
+  const rows = queryConversationRows(db, { ...input, limit: input.limit + 1 });
+  const hasMore = rows.length > input.limit;
+  const pageRows = hasMore ? rows.slice(0, input.limit) : rows;
+  const items = pageRows.map(mapConversationListItem);
+  const last = items.at(-1);
+  return {
+    items,
+    pagination: {
+      limit: input.limit,
+      returned: items.length,
+      hasMore,
+      nextCursor: hasMore && last
+        ? encodeCursor("conversations", last.updatedAt, last.conversationId)
+        : null,
+    },
+  };
+}
+
+// Load one conversation's context item counts and token totals in prompt order.
+function getContextStats(db: DatabaseSync, conversationId: number): ContextStatsRow[] {
+  return db.prepare(`
+    SELECT ci.item_type AS itemType, COUNT(*) AS count,
+           COALESCE(SUM(COALESCE(m.token_count, s.token_count, 0)), 0) AS tokens
+      FROM context_items ci
+      LEFT JOIN messages m ON m.message_id = ci.message_id
+      LEFT JOIN summaries s ON s.summary_id = ci.summary_id
+     WHERE ci.conversation_id = ?
+     GROUP BY ci.item_type
+     ORDER BY MIN(ci.ordinal)
+  `).all(conversationId) as ContextStatsRow[];
+}
+
+// Load the optional persisted compaction telemetry row.
+function getTelemetry(db: DatabaseSync, conversationId: number): TelemetryRow | null {
+  const row = db.prepare(`SELECT
+      last_observed_cache_read AS lastObservedCacheRead,
+      last_observed_cache_write AS lastObservedCacheWrite,
+      last_observed_prompt_token_count AS lastObservedPromptTokenCount,
+      last_observed_cache_hit_at AS lastObservedCacheHitAt,
+      last_observed_cache_break_at AS lastObservedCacheBreakAt,
+      cache_state AS cacheState,
+      consecutive_cold_observations AS consecutiveColdObservations,
+      retention,
+      last_leaf_compaction_at AS lastLeafCompactionAt,
+      turns_since_leaf_compaction AS turnsSinceLeafCompaction,
+      tokens_accumulated_since_leaf_compaction AS tokensAccumulatedSinceLeafCompaction,
+      last_activity_band AS lastActivityBand,
+      last_api_call_at AS lastApiCallAt,
+      last_cache_touch_at AS lastCacheTouchAt,
+      provider, model, updated_at AS updatedAt
+    FROM conversation_compaction_telemetry WHERE conversation_id = ?`
+  ).get(conversationId) as TelemetryRow | undefined;
+  return row ?? null;
+}
+
+// Load the optional deferred compaction maintenance row.
+function getMaintenance(
+  db: DatabaseSync,
+  conversationId: number,
+): ConversationDiagnostics["maintenance"] {
+  const row = db.prepare(`SELECT
+      pending, requested_at AS requestedAt, reason, running,
+      last_started_at AS lastStartedAt, last_finished_at AS lastFinishedAt,
+      last_failure_summary AS lastFailureSummary, token_budget AS tokenBudget,
+      current_token_count AS currentTokenCount, projected_token_count AS projectedTokenCount,
+      raw_tokens_outside_tail AS rawTokensOutsideTail, context_threshold AS contextThreshold,
+      context_threshold_source AS contextThresholdSource, retry_attempts AS retryAttempts,
+      next_attempt_after AS nextAttemptAfter, updated_at AS updatedAt
+    FROM conversation_compaction_maintenance WHERE conversation_id = ?`
+  ).get(conversationId) as MaintenanceRow | undefined;
+  return row ? { ...row, pending: row.pending === 1, running: row.running === 1 } : null;
+}
+
+// Load the optional transcript bootstrap frontier without reading the session file.
+function getBootstrap(db: DatabaseSync, conversationId: number): ConversationDiagnostics["bootstrap"] {
+  const row = db.prepare(`SELECT
+      session_file_path AS sessionFilePath, last_seen_size AS lastSeenSize,
+      last_seen_mtime_ms AS lastSeenMtimeMs, last_processed_offset AS lastProcessedOffset,
+      last_processed_entry_hash AS lastProcessedEntryHash, session_header_id AS sessionHeaderId,
+      last_processed_entry_id AS lastProcessedEntryId, fork_bounded AS forkBounded,
+      fork_source_message_count AS forkSourceMessageCount, updated_at AS updatedAt
+    FROM conversation_bootstrap_state WHERE conversation_id = ?`
+  ).get(conversationId) as BootstrapRow | undefined;
+  return row ? { ...row, forkBounded: row.forkBounded === 1 } : null;
+}
+
+// Count all focus briefs and expose only the newest active brief metadata.
+function getFocusBriefStats(
+  db: DatabaseSync,
+  conversationId: number,
+): ConversationDiagnostics["focusBriefs"] {
+  const countRow = db.prepare(
+    "SELECT COUNT(*) AS count FROM focus_briefs WHERE conversation_id = ?",
+  ).get(conversationId) as { count: number };
+  const activeBrief = db.prepare(`SELECT
+      brief_id AS briefId, prompt, token_count AS tokenCount,
+      target_tokens AS targetTokens, covered_latest_at AS coveredLatestAt,
+      covered_message_seq AS coveredMessageSeq, generator_run_id AS generatorRunId,
+      generator_session_key AS generatorSessionKey, created_at AS createdAt,
+      updated_at AS updatedAt
+    FROM focus_briefs
+    WHERE conversation_id = ? AND status = 'active'
+    ORDER BY julianday(created_at) DESC, brief_id DESC LIMIT 1`
+  ).get(conversationId) as ActiveFocusBriefRow | undefined;
+  return { count: countRow.count, activeBrief: activeBrief ?? null };
+}
+
+// Aggregate externalized large-file storage without reading file contents.
+function getLargeFileStats(db: DatabaseSync, conversationId: number): LargeFileStatsRow {
+  return db.prepare(`SELECT COUNT(*) AS count,
+      COALESCE(SUM(byte_size), 0) AS bytes, MAX(created_at) AS latestAt
+    FROM large_files WHERE conversation_id = ?`
+  ).get(conversationId) as LargeFileStatsRow;
+}
+
+/** Return the complete read-only diagnostic projection for one conversation. */
+export function getConversationDiagnostics(
+  db: DatabaseSync,
+  selector: ConversationSelector,
+  input: { freshTailCount: number },
+): ConversationDiagnostics {
+  const identity = resolveConversation(db, selector);
+  const row = queryConversationRows(db, {
+    limit: 1,
+    freshTailCount: input.freshTailCount,
+    conversationId: identity.conversationId,
+  })[0];
+  if (!row) {
+    throw new CliError("CONVERSATION_NOT_FOUND", "Conversation disappeared during query.", 3, selector);
+  }
+
+  return {
+    conversation: mapConversationListItem(row),
+    summaryDepths: getSummaryDepthStats(db, identity.conversationId),
+    context: getContextStats(db, identity.conversationId),
+    telemetry: getTelemetry(db, identity.conversationId),
+    maintenance: getMaintenance(db, identity.conversationId),
+    bootstrap: getBootstrap(db, identity.conversationId),
+    focusBriefs: getFocusBriefStats(db, identity.conversationId),
+    largeFiles: getLargeFileStats(db, identity.conversationId),
+  };
+}

--- a/src/cli/summary-queries.ts
+++ b/src/cli/summary-queries.ts
@@ -9,14 +9,21 @@ import {
 } from "./args.js";
 import { CliError, type PaginationMetadata } from "./output.js";
 
+const LIST_PREVIEW_SOURCE_CHARACTERS = 1024;
 const SUMMARY_COVERAGE_TIME = "COALESCE(s.latest_at, s.created_at)";
-const SUMMARY_SELECT = `
+
+// Build the shared summary projection with either full or bounded content.
+function buildSummarySelect(includeContent: boolean): string {
+  const contentProjection = includeContent
+    ? "s.content"
+    : `substr(s.content, 1, ${LIST_PREVIEW_SOURCE_CHARACTERS})`;
+  return `
   SELECT
     s.summary_id AS summaryId,
     s.conversation_id AS conversationId,
     s.kind,
     s.depth,
-    s.content,
+    ${contentProjection} AS content,
     s.token_count AS tokenCount,
     s.earliest_at AS earliestAt,
     s.latest_at AS latestAt,
@@ -40,6 +47,9 @@ const SUMMARY_SELECT = `
      WHERE sm.summary_id = s.summary_id
        AND m.conversation_id = s.conversation_id) AS sourceMessageCount
   FROM summaries s`;
+}
+
+const SUMMARY_SELECT = buildSummarySelect(true);
 
 export type SummaryListItem = {
   summaryId: string;
@@ -209,7 +219,7 @@ export function listSummaries(
   args.push(input.limit + 1);
 
   const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
-  const rows = db.prepare(`${SUMMARY_SELECT}
+  const rows = db.prepare(`${buildSummarySelect(input.includeContent)}
     ${whereClause}
     ORDER BY julianday(${SUMMARY_COVERAGE_TIME}) DESC, s.summary_id DESC
     LIMIT ?`

--- a/src/cli/summary-queries.ts
+++ b/src/cli/summary-queries.ts
@@ -1,0 +1,290 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  decodeCursor,
+  encodeCursor,
+  type ConversationSelector,
+  type MessageRole,
+  type SummaryKind,
+  type TimeFilter,
+} from "./args.js";
+import { CliError, type PaginationMetadata } from "./output.js";
+
+const SUMMARY_COVERAGE_TIME = "COALESCE(s.latest_at, s.created_at)";
+const SUMMARY_SELECT = `
+  SELECT
+    s.summary_id AS summaryId,
+    s.conversation_id AS conversationId,
+    s.kind,
+    s.depth,
+    s.content,
+    s.token_count AS tokenCount,
+    s.earliest_at AS earliestAt,
+    s.latest_at AS latestAt,
+    ${SUMMARY_COVERAGE_TIME} AS coverageAt,
+    s.descendant_count AS descendantCount,
+    s.descendant_token_count AS descendantTokenCount,
+    s.source_message_token_count AS sourceMessageTokenCount,
+    s.created_at AS createdAt,
+    s.file_ids AS fileIdsJson,
+    s.model,
+    (SELECT COUNT(*) FROM summary_parents sp
+      JOIN summaries related ON related.summary_id = sp.summary_id
+     WHERE sp.parent_summary_id = s.summary_id
+       AND related.conversation_id = s.conversation_id) AS parentCount,
+    (SELECT COUNT(*) FROM summary_parents sp
+      JOIN summaries related ON related.summary_id = sp.parent_summary_id
+     WHERE sp.summary_id = s.summary_id
+       AND related.conversation_id = s.conversation_id) AS childCount,
+    (SELECT COUNT(*) FROM summary_messages sm
+      JOIN messages m ON m.message_id = sm.message_id
+     WHERE sm.summary_id = s.summary_id
+       AND m.conversation_id = s.conversation_id) AS sourceMessageCount
+  FROM summaries s`;
+
+export type SummaryListItem = {
+  summaryId: string;
+  conversationId: number;
+  kind: SummaryKind;
+  depth: number;
+  tokenCount: number;
+  earliestAt: string | null;
+  latestAt: string | null;
+  coverageAt: string;
+  descendantCount: number;
+  descendantTokenCount: number;
+  sourceMessageTokenCount: number;
+  createdAt: string;
+  fileIds: string[];
+  model: string;
+  parentCount: number;
+  childCount: number;
+  sourceMessageCount: number;
+  preview: string;
+  content?: string;
+};
+
+export type SummaryPage = {
+  conversationId: number | null;
+  items: SummaryListItem[];
+  pagination: PaginationMetadata;
+};
+
+export type SummarySourceMessage = {
+  messageId: number;
+  seq: number;
+  role: MessageRole;
+  tokenCount: number;
+  createdAt: string;
+  content: string;
+};
+
+export type SummaryDetails = {
+  summary: SummaryListItem & { content: string };
+  parents: Array<SummaryListItem & { content: string }>;
+  children: Array<SummaryListItem & { content: string }>;
+  sourceMessages: SummarySourceMessage[];
+};
+
+type SummaryRow = Omit<SummaryListItem, "fileIds" | "preview" | "content"> & {
+  content: string;
+  fileIdsJson: string;
+};
+
+// Resolve optional summary-list scope without importing the broader query module.
+function resolveConversationId(db: DatabaseSync, selector: ConversationSelector): number {
+  const row = selector.kind === "conversationId"
+    ? db.prepare("SELECT conversation_id AS conversationId FROM conversations WHERE conversation_id = ?")
+      .get(selector.value) as { conversationId: number } | undefined
+    : db.prepare(`SELECT conversation_id AS conversationId
+        FROM conversations WHERE session_key = ?
+        ORDER BY active DESC, julianday(created_at) DESC, conversation_id DESC LIMIT 1`)
+      .get(selector.value) as { conversationId: number } | undefined;
+  if (!row) {
+    throw new CliError(
+      "CONVERSATION_NOT_FOUND",
+      selector.kind === "conversationId"
+        ? `No conversation matched id ${selector.value}.`
+        : `No conversation matched session key ${selector.value}.`,
+      3,
+      selector,
+    );
+  }
+  return row.conversationId;
+}
+
+// Parse persisted file identifiers while treating malformed legacy values as empty.
+function parseFileIds(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+// Produce a bounded one-line summary preview.
+function previewSummaryContent(content: string, maximumCharacters = 240): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  return normalized.length <= maximumCharacters
+    ? normalized
+    : `${normalized.slice(0, maximumCharacters - 1)}…`;
+}
+
+// Map a private SQLite row to the public summary representation.
+function mapSummaryRow(row: SummaryRow, includeContent: boolean): SummaryListItem {
+  return {
+    summaryId: row.summaryId,
+    conversationId: row.conversationId,
+    kind: row.kind,
+    depth: row.depth,
+    tokenCount: row.tokenCount,
+    earliestAt: row.earliestAt,
+    latestAt: row.latestAt,
+    coverageAt: row.coverageAt,
+    descendantCount: row.descendantCount,
+    descendantTokenCount: row.descendantTokenCount,
+    sourceMessageTokenCount: row.sourceMessageTokenCount,
+    createdAt: row.createdAt,
+    fileIds: parseFileIds(row.fileIdsJson),
+    model: row.model,
+    parentCount: row.parentCount,
+    childCount: row.childCount,
+    sourceMessageCount: row.sourceMessageCount,
+    preview: previewSummaryContent(row.content),
+    ...(includeContent ? { content: row.content } : {}),
+  };
+}
+
+/** Return one filtered, keyset-paginated page of summaries. */
+export function listSummaries(
+  db: DatabaseSync,
+  input: {
+    selector?: ConversationSelector;
+    depth?: number;
+    kind?: SummaryKind;
+    time: TimeFilter;
+    limit: number;
+    cursor?: string;
+    includeContent: boolean;
+  },
+): SummaryPage {
+  const conversationId = input.selector ? resolveConversationId(db, input.selector) : null;
+  const where: string[] = [];
+  const args: Array<number | string> = [];
+
+  // Add each optional filter with bound values and an enumerated column expression.
+  if (conversationId !== null) {
+    where.push("s.conversation_id = ?");
+    args.push(conversationId);
+  }
+  if (input.depth !== undefined) {
+    where.push("s.depth = ?");
+    args.push(input.depth);
+  }
+  if (input.kind) {
+    where.push("s.kind = ?");
+    args.push(input.kind);
+  }
+  if (input.time.after) {
+    where.push(`julianday(${SUMMARY_COVERAGE_TIME}) >= julianday(?)`);
+    args.push(input.time.after.toISOString());
+  }
+  if (input.time.before) {
+    where.push(`julianday(${SUMMARY_COVERAGE_TIME}) < julianday(?)`);
+    args.push(input.time.before.toISOString());
+  }
+  if (input.cursor) {
+    const cursor = decodeCursor(input.cursor, "summaries");
+    if (typeof cursor.id !== "string" || !cursor.id) {
+      throw new CliError("INVALID_CURSOR", "Invalid summaries cursor.", 2);
+    }
+    where.push(`(
+      julianday(${SUMMARY_COVERAGE_TIME}) < julianday(?)
+      OR (julianday(${SUMMARY_COVERAGE_TIME}) = julianday(?) AND s.summary_id < ?)
+    )`);
+    args.push(cursor.timestamp, cursor.timestamp, cursor.id);
+  }
+  args.push(input.limit + 1);
+
+  const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const rows = db.prepare(`${SUMMARY_SELECT}
+    ${whereClause}
+    ORDER BY julianday(${SUMMARY_COVERAGE_TIME}) DESC, s.summary_id DESC
+    LIMIT ?`
+  ).all(...args) as SummaryRow[];
+  const hasMore = rows.length > input.limit;
+  const items = (hasMore ? rows.slice(0, input.limit) : rows)
+    .map((row) => mapSummaryRow(row, input.includeContent));
+  const last = items.at(-1);
+
+  return {
+    conversationId,
+    items,
+    pagination: {
+      limit: input.limit,
+      returned: items.length,
+      hasMore,
+      nextCursor: hasMore && last
+        ? encodeCursor("summaries", last.coverageAt, last.summaryId)
+        : null,
+    },
+  };
+}
+
+// Load one summary row and normalize the not-found error contract.
+function getSummaryRow(db: DatabaseSync, summaryId: string): SummaryRow {
+  const row = db.prepare(`${SUMMARY_SELECT} WHERE s.summary_id = ?`).get(summaryId) as
+    | SummaryRow
+    | undefined;
+  if (!row) {
+    throw new CliError("SUMMARY_NOT_FOUND", `No summary matched id ${summaryId}.`, 3, { summaryId });
+  }
+  return row;
+}
+
+// Load intuitive higher-depth parents that consume the selected summary.
+function getSummaryParents(db: DatabaseSync, summary: SummaryRow): SummaryRow[] {
+  return db.prepare(`${SUMMARY_SELECT}
+    JOIN summary_parents edge ON edge.summary_id = s.summary_id
+    WHERE edge.parent_summary_id = ? AND s.conversation_id = ?
+    ORDER BY s.depth ASC, s.summary_id ASC`
+  ).all(summary.summaryId, summary.conversationId) as SummaryRow[];
+}
+
+// Load lower-depth source children in their persisted compaction order.
+function getSummaryChildren(db: DatabaseSync, summary: SummaryRow): SummaryRow[] {
+  return db.prepare(`${SUMMARY_SELECT}
+    JOIN summary_parents edge ON edge.parent_summary_id = s.summary_id
+    WHERE edge.summary_id = ? AND s.conversation_id = ?
+    ORDER BY edge.ordinal ASC`
+  ).all(summary.summaryId, summary.conversationId) as SummaryRow[];
+}
+
+// Load direct raw sources and reject malformed cross-conversation links.
+function getSummarySourceMessages(db: DatabaseSync, summary: SummaryRow): SummarySourceMessage[] {
+  return db.prepare(`SELECT
+      m.message_id AS messageId, m.seq, m.role, m.token_count AS tokenCount,
+      m.created_at AS createdAt, m.content
+    FROM summary_messages sm
+    JOIN messages m ON m.message_id = sm.message_id
+    WHERE sm.summary_id = ? AND m.conversation_id = ?
+    ORDER BY sm.ordinal ASC`
+  ).all(summary.summaryId, summary.conversationId) as SummarySourceMessage[];
+}
+
+/** Return one full summary with direct DAG relations and ordered raw sources. */
+export function getSummaryDetails(db: DatabaseSync, summaryId: string): SummaryDetails {
+  const row = getSummaryRow(db, summaryId);
+  return {
+    summary: mapSummaryRow(row, true) as SummaryListItem & { content: string },
+    parents: getSummaryParents(db, row).map(
+      (parent) => mapSummaryRow(parent, true) as SummaryListItem & { content: string },
+    ),
+    children: getSummaryChildren(db, row).map(
+      (child) => mapSummaryRow(child, true) as SummaryListItem & { content: string },
+    ),
+    sourceMessages: getSummarySourceMessages(db, row),
+  };
+}

--- a/test/cli-config.test.ts
+++ b/test/cli-config.test.ts
@@ -154,6 +154,7 @@ describe("setConfigValue", () => {
 
   it.each([
     ["unknown config path", "notARealSetting", "true"],
+    ["inherited config path", "__proto__", "{}"],
     ["schema-invalid value", "contextThreshold", "2"],
   ])("leaves the file and backup set unchanged for an %s", (_label, path, value) => {
     const original = writeConfig({

--- a/test/cli-config.test.ts
+++ b/test/cli-config.test.ts
@@ -148,6 +148,21 @@ describe("setConfigValue", () => {
     expect(backupFiles()).toEqual([]);
   });
 
+  it("rejects config values that violate runtime cross-field constraints", () => {
+    const original = writeConfig({
+      plugins: { entries: { "lossless-claw": { config: {} } } },
+    });
+    const invalidOverrides = JSON.stringify([{
+      match: { modelContextWindowMin: 100, modelContextWindowMax: 10 },
+      contextThreshold: 0.5,
+    }]);
+
+    expect(() => setConfigValue(configPath, "contextThresholdOverrides", invalidOverrides))
+      .toThrowError(expect.objectContaining({ code: "CONFIG_VALIDATION_FAILED", exitCode: 4 }));
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(backupFiles()).toEqual([]);
+  });
+
   it("refuses JSON5 and include forms before creating a backup", () => {
     writeFileSync(configPath, "{ // comment\n plugins: {}\n}\n", { mode: 0o600 });
     expect(() => setConfigValue(configPath, "freshTailCount", "20")).toThrowError(

--- a/test/cli-config.test.ts
+++ b/test/cli-config.test.ts
@@ -77,6 +77,27 @@ describe("readConfigView", () => {
       effectiveValue: 12,
     });
   });
+
+  it("reports runtime-invalid existing config as a config validation failure", () => {
+    writeConfig({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              contextThresholdOverrides: [{
+                match: { modelContextWindowMin: 100, modelContextWindowMax: 10 },
+                contextThreshold: 0.5,
+              }],
+            },
+          },
+        },
+      },
+    });
+
+    expect(() => readConfigView(configPath, {})).toThrowError(
+      expect.objectContaining({ code: "CONFIG_VALIDATION_FAILED", exitCode: 4 }),
+    );
+  });
 });
 
 describe("setConfigValue", () => {

--- a/test/cli-config.test.ts
+++ b/test/cli-config.test.ts
@@ -1,0 +1,175 @@
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getConfigValue,
+  readConfigView,
+  setConfigValue,
+} from "../src/cli/config-file.js";
+
+let directory: string;
+let configPath: string;
+
+function writeConfig(value: unknown): string {
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  writeFileSync(configPath, content, { mode: 0o600 });
+  return content;
+}
+
+function backupFiles(): string[] {
+  return readdirSync(directory).filter((name) => name.includes(".lcm-backup-"));
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "lcm-cli-config-"));
+  configPath = join(directory, "openclaw.json");
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("readConfigView", () => {
+  it("returns only raw and effective Lossless config without unrelated secrets", () => {
+    writeConfig({
+      gateway: { auth: { token: "unrelated-super-secret" } },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { contextThreshold: 0.7, freshTailCount: 10 },
+          },
+        },
+      },
+    });
+
+    const view = readConfigView(configPath, {
+      HOME: directory,
+      LCM_FRESH_TAIL_COUNT: "12",
+    });
+
+    expect(view.raw).toEqual({ contextThreshold: 0.7, freshTailCount: 10 });
+    expect(view.effective).toMatchObject({ contextThreshold: 0.7, freshTailCount: 12 });
+    expect(view.environmentOverrides).toEqual(["LCM_FRESH_TAIL_COUNT"]);
+    expect(JSON.stringify(view)).not.toContain("unrelated-super-secret");
+  });
+
+  it("reports raw and effective values separately", () => {
+    writeConfig({
+      plugins: { entries: { "lossless-claw": { config: { freshTailCount: 10 } } } },
+    });
+    const view = readConfigView(configPath, { HOME: directory, LCM_FRESH_TAIL_COUNT: "12" });
+
+    expect(getConfigValue(view, "freshTailCount")).toEqual({
+      path: "freshTailCount",
+      isSet: true,
+      rawValue: 10,
+      effectiveValue: 12,
+    });
+  });
+});
+
+describe("setConfigValue", () => {
+  it("changes only the targeted key with a mode-preserving backup and atomic replacement", () => {
+    const original = writeConfig({
+      gateway: { mode: "local" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { freshTailCount: 10, contextThreshold: 0.7 },
+          },
+        },
+      },
+    });
+    chmodSync(configPath, 0o600);
+
+    const result = setConfigValue(configPath, "freshTailCount", "24", {
+      now: () => new Date("2026-07-10T12:34:56.789Z"),
+    });
+
+    expect(result).toEqual({
+      path: "freshTailCount",
+      oldValue: 10,
+      newValue: 24,
+      configPath,
+      backupPath: `${configPath}.lcm-backup-20260710T123456789Z`,
+    });
+    expect(readFileSync(result.backupPath, "utf8")).toBe(original);
+    expect(lstatSync(configPath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+      gateway: { mode: "local" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { freshTailCount: 24, contextThreshold: 0.7 },
+          },
+        },
+      },
+    });
+  });
+
+  it("supports validated nested config paths", () => {
+    writeConfig({ plugins: { entries: { "lossless-claw": { config: {} } } } });
+
+    setConfigValue(configPath, "autoRotateSessionFiles.enabled", "false");
+
+    const written = JSON.parse(readFileSync(configPath, "utf8"));
+    expect(written.plugins.entries["lossless-claw"].config).toEqual({
+      autoRotateSessionFiles: { enabled: false },
+    });
+  });
+
+  it.each([
+    ["unknown config path", "notARealSetting", "true"],
+    ["schema-invalid value", "contextThreshold", "2"],
+  ])("leaves the file and backup set unchanged for an %s", (_label, path, value) => {
+    const original = writeConfig({
+      plugins: {
+        entries: { "lossless-claw": { config: { contextThreshold: 0.7 } } },
+      },
+    });
+
+    expect(() => setConfigValue(configPath, path, value)).toThrowError(
+      expect.objectContaining({ code: "CONFIG_VALIDATION_FAILED", exitCode: 4 }),
+    );
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(backupFiles()).toEqual([]);
+  });
+
+  it("refuses JSON5 and include forms before creating a backup", () => {
+    writeFileSync(configPath, "{ // comment\n plugins: {}\n}\n", { mode: 0o600 });
+    expect(() => setConfigValue(configPath, "freshTailCount", "20")).toThrowError(
+      expect.objectContaining({ code: "CONFIG_PARSE_FAILED", exitCode: 4 }),
+    );
+    expect(backupFiles()).toEqual([]);
+
+    writeConfig({ $include: "./base.json", plugins: {} });
+    expect(() => setConfigValue(configPath, "freshTailCount", "20")).toThrowError(
+      expect.objectContaining({ code: "CONFIG_INCLUDE_UNSUPPORTED", exitCode: 4 }),
+    );
+    expect(backupFiles()).toEqual([]);
+  });
+
+  it("refuses symlink config files", () => {
+    const realPath = join(directory, "real.json");
+    writeFileSync(realPath, "{}\n", { mode: 0o600 });
+    symlinkSync(realPath, configPath);
+
+    expect(() => setConfigValue(configPath, "freshTailCount", "20")).toThrowError(
+      expect.objectContaining({ code: "CONFIG_SYMLINK_UNSUPPORTED", exitCode: 4 }),
+    );
+    expect(backupFiles()).toEqual([]);
+  });
+});

--- a/test/cli-conversations.test.ts
+++ b/test/cli-conversations.test.ts
@@ -1,0 +1,225 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openReadOnlyDatabase } from "../src/cli/database.js";
+import {
+  getConversationDiagnostics,
+  getGlobalStatus,
+  listConversations,
+  resolveConversation,
+} from "../src/cli/queries.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+let directory: string;
+let databasePath: string;
+
+function seedFixture(): void {
+  const db = new DatabaseSync(databasePath);
+  runLcmMigrations(db, { fts5Available: false });
+
+  db.exec(`
+    INSERT INTO conversations (
+      conversation_id, session_id, session_key, active, archived_at, title,
+      bootstrapped_at, created_at, updated_at
+    ) VALUES
+      (1, 'session-old', 'agent:main:shared', 0, '2026-07-03T00:00:00.000Z', 'Old',
+       NULL, '2026-07-01T00:00:00.000Z', '2026-07-10T00:00:00.000Z'),
+      (2, 'session-live', 'agent:main:shared', 1, NULL, 'Live',
+       '2026-07-02T01:00:00.000Z', '2026-07-02T00:00:00.000Z', '2026-07-10T00:00:00.000Z'),
+      (3, 'session-other', 'agent:main:other', 1, NULL, 'Other',
+       NULL, '2026-07-03T00:00:00.000Z', '2026-07-10T00:00:00.000Z');
+
+    INSERT INTO messages (
+      message_id, conversation_id, seq, role, content, token_count, created_at
+    ) VALUES
+      (10, 2, 1, 'user', 'first message', 100, '2026-07-02T02:00:00.000Z'),
+      (11, 2, 2, 'assistant', 'second message', 50, '2026-07-02T03:00:00.000Z'),
+      (12, 3, 1, 'user', 'other message', 20, '2026-07-03T02:00:00.000Z');
+
+    INSERT INTO summaries (
+      summary_id, conversation_id, kind, depth, content, token_count,
+      earliest_at, latest_at, descendant_count, descendant_token_count,
+      source_message_token_count, created_at, file_ids, model
+    ) VALUES
+      ('sum-leaf', 2, 'leaf', 0, 'leaf summary', 30,
+       '2026-07-02T02:00:00.000Z', '2026-07-02T02:00:00.000Z', 1, 100, 150,
+       '2026-07-02T04:00:00.000Z', '[]', 'summary-model'),
+      ('sum-root', 2, 'condensed', 1, 'root summary', 10,
+       '2026-07-02T02:00:00.000Z', '2026-07-02T03:00:00.000Z', 2, 150, 0,
+       '2026-07-02T05:00:00.000Z', '[]', 'summary-model');
+
+    INSERT INTO summary_messages (summary_id, message_id, ordinal)
+      VALUES ('sum-leaf', 10, 0);
+    INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal)
+      VALUES ('sum-root', 'sum-leaf', 0);
+    INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
+      VALUES (2, 0, 'summary', 'sum-root');
+    INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+      VALUES (2, 1, 'message', 11);
+
+    INSERT INTO conversation_compaction_telemetry (
+      conversation_id, last_observed_cache_read, last_observed_cache_write,
+      last_observed_prompt_token_count, cache_state, retention, provider, model, updated_at
+    ) VALUES (2, 40, 4, 600, 'cold', 'short', 'provider-a', 'model-a',
+      '2026-07-02T06:00:00.000Z');
+
+    INSERT INTO conversation_compaction_maintenance (
+      conversation_id, pending, requested_at, reason, running,
+      token_budget, current_token_count, projected_token_count,
+      raw_tokens_outside_tail, context_threshold, context_threshold_source,
+      last_failure_summary, updated_at
+    ) VALUES (2, 1, '2026-07-02T06:00:00.000Z', 'threshold', 0,
+      1000, 600, 650, 150, 0.75, 'default', 'previous failure',
+      '2026-07-02T06:00:00.000Z');
+
+    INSERT INTO conversation_bootstrap_state (
+      conversation_id, session_file_path, last_seen_size, last_seen_mtime_ms,
+      last_processed_offset, last_processed_entry_hash, session_header_id,
+      last_processed_entry_id, fork_bounded, fork_source_message_count, updated_at
+    ) VALUES (2, '/sessions/live.jsonl', 2048, 1000, 1800, 'hash', 'header',
+      'entry-2', 1, 9, '2026-07-02T06:00:00.000Z');
+
+    INSERT INTO focus_briefs (
+      brief_id, conversation_id, session_key, prompt, content, status,
+      token_count, target_tokens, source_context_hash, created_at, updated_at
+    ) VALUES ('brief-active', 2, 'agent:main:shared', 'focus prompt', 'focus content',
+      'active', 20, 40, 'focus-hash', '2026-07-02T07:00:00.000Z',
+      '2026-07-02T07:00:00.000Z');
+
+    INSERT INTO large_files (
+      file_id, conversation_id, file_name, mime_type, byte_size, storage_uri,
+      exploration_summary, created_at
+    ) VALUES ('file-1', 2, 'notes.txt', 'text/plain', 1024, '/files/notes.txt',
+      'file summary', '2026-07-02T08:00:00.000Z');
+  `);
+  db.close();
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "lcm-cli-conversations-"));
+  databasePath = join(directory, "lcm.db");
+  seedFixture();
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("getGlobalStatus", () => {
+  it("reports deterministic database-wide counts and token totals", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const status = getGlobalStatus(db);
+    db.close();
+
+    expect(status).toMatchObject({
+      conversations: { total: 3, active: 2 },
+      messages: {
+        count: 3,
+        tokens: 170,
+        earliestAt: "2026-07-02T02:00:00.000Z",
+        latestAt: "2026-07-03T02:00:00.000Z",
+      },
+      summaries: {
+        count: 2,
+        tokens: 40,
+        sourceMessageTokens: 150,
+        earliestAt: "2026-07-02T02:00:00.000Z",
+        latestAt: "2026-07-02T03:00:00.000Z",
+      },
+      context: { items: 2, tokens: 60 },
+      maintenance: { pending: 1, running: 0, failed: 1 },
+    });
+    expect(status.summaries.byDepth).toEqual([
+      { kind: "leaf", depth: 0, count: 1, tokens: 30 },
+      { kind: "condensed", depth: 1, count: 1, tokens: 10 },
+    ]);
+  });
+});
+
+describe("conversation selection and pagination", () => {
+  it("prefers the active conversation for a reused session key", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const selected = resolveConversation(db, {
+      kind: "sessionKey",
+      value: "agent:main:shared",
+    });
+    db.close();
+    expect(selected).toMatchObject({ conversationId: 2, sessionId: "session-live", active: true });
+  });
+
+  it("keyset-paginates equal timestamps without gaps or duplicates", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const first = listConversations(db, { limit: 2, freshTailCount: 1 });
+    const second = listConversations(db, {
+      limit: 2,
+      freshTailCount: 1,
+      cursor: first.pagination.nextCursor ?? undefined,
+    });
+    db.close();
+
+    expect(first.items.map((item) => item.conversationId)).toEqual([3, 2]);
+    expect(first.pagination).toMatchObject({ returned: 2, hasMore: true });
+    expect(second.items.map((item) => item.conversationId)).toEqual([1]);
+    expect(second.pagination).toMatchObject({ returned: 1, hasMore: false, nextCursor: null });
+    expect(first.items[1]).toMatchObject({
+      messageCount: 2,
+      messageTokens: 150,
+      summaryCount: 2,
+      summaryTokens: 40,
+      contextItems: 2,
+      contextTokens: 60,
+      freshTailMessages: 1,
+      freshTailTokens: 50,
+      maxSummaryDepth: 1,
+    });
+  });
+});
+
+describe("getConversationDiagnostics", () => {
+  it("returns compaction, bootstrap, focus, file, context, and depth diagnostics", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const diagnostics = getConversationDiagnostics(
+      db,
+      { kind: "conversationId", value: 2 },
+      { freshTailCount: 1 },
+    );
+    db.close();
+
+    expect(diagnostics.conversation).toMatchObject({
+      conversationId: 2,
+      freshTailMessages: 1,
+      freshTailTokens: 50,
+    });
+    expect(diagnostics.summaryDepths).toEqual([
+      { kind: "leaf", depth: 0, count: 1, tokens: 30 },
+      { kind: "condensed", depth: 1, count: 1, tokens: 10 },
+    ]);
+    expect(diagnostics.context).toEqual([
+      { itemType: "summary", count: 1, tokens: 10 },
+      { itemType: "message", count: 1, tokens: 50 },
+    ]);
+    expect(diagnostics.telemetry).toMatchObject({ cacheState: "cold", provider: "provider-a" });
+    expect(diagnostics.maintenance).toMatchObject({
+      pending: true,
+      running: false,
+      currentTokenCount: 600,
+      lastFailureSummary: "previous failure",
+    });
+    expect(diagnostics.bootstrap).toMatchObject({
+      sessionFilePath: "/sessions/live.jsonl",
+      lastProcessedEntryId: "entry-2",
+      forkBounded: true,
+    });
+    expect(diagnostics.focusBriefs).toMatchObject({
+      count: 1,
+      activeBrief: { briefId: "brief-active", tokenCount: 20 },
+    });
+    expect(diagnostics.largeFiles).toEqual({
+      count: 1,
+      bytes: 1024,
+      latestAt: "2026-07-02T08:00:00.000Z",
+    });
+  });
+});

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -64,7 +64,7 @@ describe("resolveCliPaths", () => {
         OPENCLAW_STATE_DIR: "/state/openclaw",
         LCM_OPENCLAW_DIR: "/state/lossless",
       },
-      pluginConfig: { databasePath: "~/databases/lcm.db", dbPath: "/ignored.db" },
+      pluginConfig: { databasePath: "/ignored.db", dbPath: "~/databases/lcm.db" },
       homedir: () => "/users/fallback",
     });
     expect(pluginPaths).toEqual({
@@ -72,6 +72,13 @@ describe("resolveCliPaths", () => {
       configPath: "/state/lossless/openclaw.json",
       databasePath: "/users/openclaw/databases/lcm.db",
     });
+
+    const preferredKey = resolveCliPaths({
+      env: { HOME: "/users/process", OPENCLAW_HOME: "/users/openclaw" },
+      pluginConfig: { databasePath: "~/databases/preferred.db" },
+      homedir: () => "/users/fallback",
+    });
+    expect(preferredKey.databasePath).toBe("/users/openclaw/databases/preferred.db");
 
     const defaults = resolveCliPaths({
       env: { HOME: "/users/process", OPENCLAW_HOME: "/users/openclaw" },

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -164,6 +164,33 @@ describe("parseCliArgs", () => {
       expect.objectContaining({ code: "INVALID_ARGUMENT", exitCode: 2 }),
     );
   });
+
+  it.each([
+    ["config", "set", "sweepMaxDepth", "-1"],
+    ["--pretty", "config", "set", "sweepMaxDepth", "-1"],
+    ["config", "set", "sweepMaxDepth", "--pretty", "-1"],
+    ["config", "set", "sweepMaxDepth", "-1", "--pretty"],
+  ])("preserves a dash-prefixed JSON value for config set", (...args) => {
+    const parsed = parseCliArgs(args);
+
+    expect(parsed.command).toEqual({ kind: "config.set", path: "sweepMaxDepth", value: "-1" });
+    expect(parsed.pretty).toBe(args.includes("--pretty"));
+  });
+
+  it.each(["-12", "-1.5", "-1e2", "-10e-1", "-1e-0"])(
+    "preserves the complete dash-prefixed JSON token %s",
+    (value) => {
+      const parsed = parseCliArgs(["config", "set", "sweepMaxDepth", value]);
+
+      expect(parsed.command).toEqual({ kind: "config.set", path: "sweepMaxDepth", value });
+    },
+  );
+
+  it("does not reinterpret a negative config path as the value", () => {
+    expect(() => parseCliArgs(["config", "set", "-1", "2"])).toThrowError(
+      expect.objectContaining({ code: "INVALID_ARGUMENT", exitCode: 2 }),
+    );
+  });
 });
 
 describe("parseTimeFilter", () => {

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -148,6 +148,22 @@ describe("parseCliArgs", () => {
       expect.objectContaining({ code: "INVALID_COMMAND", exitCode: 2 }),
     );
   });
+
+  it.each([
+    ["status", "--after", "2026-07-01T00:00:00Z"],
+    ["conversations", "list", "--role", "user"],
+    ["conversations", "show", "--conversation-id", "1", "--limit", "1"],
+    ["messages", "list", "--conversation-id", "1", "--depth", "0"],
+    ["messages", "tail", "--conversation-id", "1", "--cursor", "opaque"],
+    ["summaries", "list", "--role", "assistant"],
+    ["summaries", "show", "summary-1", "--include-content"],
+    ["config", "show", "--session-key", "agent:main:example"],
+    ["doctor", "--count", "1"],
+  ])("rejects command-specific options that %s does not use", (...args) => {
+    expect(() => parseCliArgs(args)).toThrowError(
+      expect.objectContaining({ code: "INVALID_ARGUMENT", exitCode: 2 }),
+    );
+  });
 });
 
 describe("parseTimeFilter", () => {

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -200,6 +200,12 @@ describe("parseTimeFilter", () => {
       expect.objectContaining({ code: "INVALID_TIME_FILTER", exitCode: 2 }),
     );
   });
+
+  it("rejects ISO-shaped timestamps with impossible calendar dates", () => {
+    expect(() => parseTimeFilter({ after: "2026-02-31T00:00:00Z" })).toThrowError(
+      expect.objectContaining({ code: "INVALID_TIME_FILTER", exitCode: 2 }),
+    );
+  });
 });
 
 describe("opaque cursors", () => {

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -158,6 +158,12 @@ describe("parseTimeFilter", () => {
       }),
     ).toThrowError(expect.objectContaining({ code: "INVALID_TIME_FILTER", exitCode: 2 }));
   });
+
+  it("rejects non-ISO timestamp text", () => {
+    expect(() => parseTimeFilter({ after: "July 1, 2026" })).toThrowError(
+      expect.objectContaining({ code: "INVALID_TIME_FILTER", exitCode: 2 }),
+    );
+  });
 });
 
 describe("opaque cursors", () => {

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -1,0 +1,220 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decodeCursor,
+  encodeCursor,
+  parseCliArgs,
+  parseTimeFilter,
+} from "../src/cli/args.js";
+import { openReadOnlyDatabase } from "../src/cli/database.js";
+import { CliError, createErrorEnvelope, createSuccessEnvelope } from "../src/cli/output.js";
+import { resolveCliPaths } from "../src/cli/paths.js";
+
+const tempDirectories: string[] = [];
+
+function makeTempDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "lcm-cli-foundations-"));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("resolveCliPaths", () => {
+  it("uses explicit paths before Lossless, OpenClaw, and plugin settings", () => {
+    const paths = resolveCliPaths({
+      env: {
+        HOME: "/users/process",
+        OPENCLAW_HOME: "/users/openclaw",
+        OPENCLAW_STATE_DIR: "/state/openclaw",
+        LCM_OPENCLAW_DIR: "/state/lossless",
+        OPENCLAW_CONFIG_PATH: "/config/env.json",
+        LCM_DATABASE_PATH: "/db/env.db",
+      },
+      overrides: {
+        openclawDir: "/state/explicit",
+        configPath: "/config/explicit.json",
+        databasePath: "/db/explicit.db",
+      },
+      pluginConfig: {
+        databasePath: "/db/plugin.db",
+      },
+      homedir: () => "/users/fallback",
+    });
+
+    expect(paths).toEqual({
+      openclawDir: "/state/explicit",
+      configPath: "/config/explicit.json",
+      databasePath: "/db/explicit.db",
+    });
+  });
+
+  it("supports the approved environment and plugin path precedence", () => {
+    const pluginPaths = resolveCliPaths({
+      env: {
+        HOME: "/users/process",
+        OPENCLAW_HOME: "/users/openclaw",
+        OPENCLAW_STATE_DIR: "/state/openclaw",
+        LCM_OPENCLAW_DIR: "/state/lossless",
+      },
+      pluginConfig: { databasePath: "~/databases/lcm.db", dbPath: "/ignored.db" },
+      homedir: () => "/users/fallback",
+    });
+    expect(pluginPaths).toEqual({
+      openclawDir: "/state/lossless",
+      configPath: "/state/lossless/openclaw.json",
+      databasePath: "/users/openclaw/databases/lcm.db",
+    });
+
+    const defaults = resolveCliPaths({
+      env: { HOME: "/users/process", OPENCLAW_HOME: "/users/openclaw" },
+      homedir: () => "/users/fallback",
+    });
+    expect(defaults).toEqual({
+      openclawDir: "/users/openclaw/.openclaw",
+      configPath: "/users/openclaw/.openclaw/openclaw.json",
+      databasePath: "/users/openclaw/.openclaw/lcm.db",
+    });
+  });
+});
+
+describe("parseCliArgs", () => {
+  it("parses a scoped, paginated message-list command", () => {
+    const parsed = parseCliArgs([
+      "messages",
+      "list",
+      "--session-key",
+      "agent:main:example",
+      "--role",
+      "user",
+      "--role",
+      "assistant",
+      "--limit",
+      "25",
+      "--include-content",
+      "--pretty",
+    ]);
+
+    expect(parsed.command).toEqual({ kind: "messages.list" });
+    expect(parsed.selector).toEqual({ kind: "sessionKey", value: "agent:main:example" });
+    expect(parsed.roles).toEqual(["user", "assistant"]);
+    expect(parsed.limit).toBe(25);
+    expect(parsed.includeContent).toBe(true);
+    expect(parsed.pretty).toBe(true);
+  });
+
+  it("rejects ambiguous conversation selectors", () => {
+    expect(() =>
+      parseCliArgs([
+        "conversations",
+        "show",
+        "--conversation-id",
+        "42",
+        "--session-key",
+        "agent:main:example",
+      ]),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_SELECTOR", exitCode: 2 }));
+  });
+
+  it("requires a selector for conversation-scoped commands", () => {
+    expect(() => parseCliArgs(["messages", "tail"])).toThrowError(
+      expect.objectContaining({ code: "MISSING_SELECTOR", exitCode: 2 }),
+    );
+  });
+});
+
+describe("parseTimeFilter", () => {
+  it("parses inclusive after and exclusive before timestamps", () => {
+    const filter = parseTimeFilter({
+      after: "2026-07-01T00:00:00Z",
+      before: "2026-07-02T00:00:00Z",
+    });
+    expect(filter).toEqual({
+      after: new Date("2026-07-01T00:00:00.000Z"),
+      before: new Date("2026-07-02T00:00:00.000Z"),
+    });
+  });
+
+  it("turns recency into one fixed lower bound", () => {
+    const filter = parseTimeFilter(
+      { recency: "6h" },
+      new Date("2026-07-10T12:00:00.000Z"),
+    );
+    expect(filter).toEqual({ after: new Date("2026-07-10T06:00:00.000Z") });
+  });
+
+  it("rejects conflicting interval filters", () => {
+    expect(() =>
+      parseTimeFilter({
+        between: "2026-07-01T00:00:00Z..2026-07-02T00:00:00Z",
+        after: "2026-07-01T12:00:00Z",
+      }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_TIME_FILTER", exitCode: 2 }));
+  });
+});
+
+describe("opaque cursors", () => {
+  it("round-trips a resource-scoped keyset cursor", () => {
+    const encoded = encodeCursor("messages", "2026-07-10T12:00:00.000Z", 123);
+    expect(decodeCursor(encoded, "messages")).toEqual({
+      timestamp: "2026-07-10T12:00:00.000Z",
+      id: 123,
+    });
+    expect(() => decodeCursor(encoded, "summaries")).toThrowError(
+      expect.objectContaining({ code: "INVALID_CURSOR", exitCode: 2 }),
+    );
+  });
+});
+
+describe("CLI response envelopes", () => {
+  it("creates stable success and error shapes", () => {
+    expect(createSuccessEnvelope("status", { conversations: 2 }, { databasePath: "/lcm.db" }))
+      .toEqual({
+        ok: true,
+        command: "status",
+        data: { conversations: 2 },
+        meta: { databasePath: "/lcm.db" },
+      });
+
+    const error = new CliError("DATABASE_NOT_FOUND", "LCM database not found.", 3, {
+      databasePath: "/missing.db",
+    });
+    expect(createErrorEnvelope(error)).toEqual({
+      ok: false,
+      error: {
+        code: "DATABASE_NOT_FOUND",
+        message: "LCM database not found.",
+        details: { databasePath: "/missing.db" },
+      },
+    });
+  });
+});
+
+describe("openReadOnlyDatabase", () => {
+  it("opens an existing database without allowing writes", () => {
+    const directory = makeTempDirectory();
+    const databasePath = join(directory, "lcm.db");
+    const writable = new DatabaseSync(databasePath);
+    writable.exec("CREATE TABLE example (value TEXT); INSERT INTO example VALUES ('stored')");
+    writable.close();
+
+    const readOnly = openReadOnlyDatabase(databasePath);
+    expect(readOnly.prepare("SELECT value FROM example").get()).toEqual({ value: "stored" });
+    expect(() => readOnly.exec("INSERT INTO example VALUES ('forbidden')")).toThrow(/readonly/i);
+    readOnly.close();
+  });
+
+  it("does not create a missing database", () => {
+    const databasePath = join(makeTempDirectory(), "missing", "lcm.db");
+    expect(() => openReadOnlyDatabase(databasePath)).toThrowError(
+      expect.objectContaining({ code: "DATABASE_NOT_FOUND", exitCode: 3 }),
+    );
+  });
+});

--- a/test/cli-foundations.test.ts
+++ b/test/cli-foundations.test.ts
@@ -128,6 +128,19 @@ describe("parseCliArgs", () => {
       expect.objectContaining({ code: "MISSING_SELECTOR", exitCode: 2 }),
     );
   });
+
+  it.each([
+    ["conversations", "list", "unexpected"],
+    ["conversations", "show", "unexpected", "--conversation-id", "1"],
+    ["messages", "list", "unexpected", "--conversation-id", "1"],
+    ["messages", "tail", "unexpected", "--conversation-id", "1"],
+    ["summaries", "list", "unexpected"],
+    ["config", "show", "unexpected"],
+  ])("rejects extra positionals for fixed commands: %s %s", (...args) => {
+    expect(() => parseCliArgs(args)).toThrowError(
+      expect.objectContaining({ code: "INVALID_COMMAND", exitCode: 2 }),
+    );
+  });
 });
 
 describe("parseTimeFilter", () => {

--- a/test/cli-main.test.ts
+++ b/test/cli-main.test.ts
@@ -1,0 +1,174 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runCli } from "../src/cli/main.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+let directory: string;
+let databasePath: string;
+let configPath: string;
+
+function seedFixture(): void {
+  const db = new DatabaseSync(databasePath);
+  runLcmMigrations(db, { fts5Available: false });
+  db.exec(`
+    INSERT INTO conversations (
+      conversation_id, session_id, session_key, active, created_at, updated_at
+    ) VALUES (1, 'session-cli', 'agent:main:cli', 1,
+      '2026-07-01T00:00:00.000Z', '2026-07-03T00:00:00.000Z');
+    INSERT INTO messages (
+      message_id, conversation_id, seq, role, content, token_count, created_at
+    ) VALUES
+      (101, 1, 1, 'user', 'CLI source message', 40, '2026-07-01T00:00:00.000Z'),
+      (102, 1, 2, 'assistant', 'CLI fresh message', 30, '2026-07-02T00:00:00.000Z');
+    INSERT INTO summaries (
+      summary_id, conversation_id, kind, depth, content, token_count,
+      earliest_at, latest_at, descendant_count, descendant_token_count,
+      source_message_token_count, created_at, file_ids, model
+    ) VALUES ('sum-cli', 1, 'leaf', 0, 'CLI summary', 10,
+      '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z', 1, 40, 40,
+      '2026-07-01T01:00:00.000Z', '[]', 'model-cli');
+    INSERT INTO summary_messages (summary_id, message_id, ordinal)
+      VALUES ('sum-cli', 101, 0);
+    INSERT INTO context_items (conversation_id, ordinal, item_type, summary_id)
+      VALUES (1, 0, 'summary', 'sum-cli');
+    INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
+      VALUES (1, 1, 'message', 102);
+  `);
+  db.close();
+
+  writeFileSync(configPath, `${JSON.stringify({
+    plugins: {
+      entries: {
+        "lossless-claw": {
+          config: { databasePath, freshTailCount: 1 },
+        },
+      },
+    },
+  }, null, 2)}\n`, { mode: 0o600 });
+}
+
+function invoke(args: string[]): {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+} {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = runCli(args, {
+    env: { HOME: directory, OPENCLAW_CONFIG_PATH: configPath },
+    stdout: (text) => { stdout += text; },
+    stderr: (text) => { stderr += text; },
+  });
+  return { exitCode, stdout, stderr };
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "lcm-cli-main-"));
+  databasePath = join(directory, "lcm.db");
+  configPath = join(directory, "openclaw.json");
+  seedFixture();
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("runCli", () => {
+  it("dispatches status with config, path, size, and database diagnostics", () => {
+    const result = invoke(["status", "--pretty"]);
+    const envelope = JSON.parse(result.stdout);
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(envelope).toMatchObject({
+      ok: true,
+      command: "status",
+      data: {
+        databaseSizeBytes: expect.any(Number),
+        freshTail: { count: 1, maxTokens: null },
+        status: {
+          conversations: { total: 1, active: 1 },
+          messages: { count: 2, tokens: 70 },
+          summaries: { count: 1, tokens: 10 },
+        },
+      },
+      meta: { databasePath, configPath },
+    });
+  });
+
+  it.each([
+    [
+      ["conversations", "list", "--limit", "1"],
+      "conversations.list",
+      (data: unknown) => expect(data).toMatchObject({ items: [{ conversationId: 1 }] }),
+    ],
+    [
+      ["conversations", "show", "--session-key", "agent:main:cli"],
+      "conversations.show",
+      (data: unknown) => expect(data).toMatchObject({ conversation: { conversationId: 1 } }),
+    ],
+    [
+      ["messages", "list", "--conversation-id", "1", "--include-content"],
+      "messages.list",
+      (data: unknown) => expect(data).toMatchObject({
+        items: expect.arrayContaining([expect.objectContaining({ messageId: 102 })]),
+      }),
+    ],
+    [
+      ["messages", "tail", "--conversation-id", "1"],
+      "messages.tail",
+      (data: unknown) => expect(data).toMatchObject({ selected: { messages: 1, tokens: 30 } }),
+    ],
+    [
+      ["summaries", "list", "--depth", "0"],
+      "summaries.list",
+      (data: unknown) => expect(data).toMatchObject({ items: [{ summaryId: "sum-cli" }] }),
+    ],
+    [
+      ["summaries", "show", "sum-cli"],
+      "summaries.show",
+      (data: unknown) => expect(data).toMatchObject({ summary: { content: "CLI summary" } }),
+    ],
+    [
+      ["config", "get", "freshTailCount"],
+      "config.get",
+      (data: unknown) => expect(data).toMatchObject({ rawValue: 1, effectiveValue: 1 }),
+    ],
+  ])("dispatches %s", (args, command, assertData) => {
+    const result = invoke(args as string[]);
+    const envelope = JSON.parse(result.stdout);
+    expect(result.exitCode).toBe(0);
+    expect(envelope.command).toBe(command);
+    assertData(envelope.data);
+  });
+
+  it("returns a read-only reserved doctor namespace", () => {
+    const result = invoke(["doctor"]);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "doctor",
+      data: { available: false, databaseReadOnly: true },
+    });
+  });
+
+  it("renders compact table output from the same response data", () => {
+    const result = invoke(["conversations", "list", "--format", "table"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("conversationId");
+    expect(result.stdout).toContain("pagination.hasMore");
+  });
+
+  it("writes structured errors to stderr with stable exit codes", () => {
+    const result = invoke(["messages", "list"]);
+    expect(result).toMatchObject({ exitCode: 2, stdout: "" });
+    expect(JSON.parse(result.stderr)).toEqual({
+      ok: false,
+      error: {
+        code: "MISSING_SELECTOR",
+        message: "messages.list requires conversation-id or session-key.",
+      },
+    });
+  });
+});

--- a/test/cli-main.test.ts
+++ b/test/cli-main.test.ts
@@ -153,6 +153,18 @@ describe("runCli", () => {
     });
   });
 
+  it("includes resource-specific options in agent-readable help", () => {
+    const result = invoke(["--help"]);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      data: {
+        selectorOptions: expect.arrayContaining(["--conversation-id <id>", "--session-key <key>"]),
+        messageOptions: expect.arrayContaining(["--role <role>", "--include-content"]),
+        summaryOptions: expect.arrayContaining(["--depth <integer>", "--kind <leaf|condensed>"]),
+        tailOptions: ["--count <1..500>"],
+      },
+    });
+  });
+
   it("renders compact table output from the same response data", () => {
     const result = invoke(["conversations", "list", "--format", "table"]);
     expect(result.exitCode).toBe(0);
@@ -169,6 +181,19 @@ describe("runCli", () => {
         code: "MISSING_SELECTOR",
         message: "messages.list requires conversation-id or session-key.",
       },
+    });
+  });
+
+  it("reports SQLite query failures with database exit code 5", () => {
+    const emptyDatabasePath = join(directory, "empty.db");
+    new DatabaseSync(emptyDatabasePath).close();
+
+    const result = invoke(["status", "--db", emptyDatabasePath]);
+
+    expect(result).toMatchObject({ exitCode: 5, stdout: "" });
+    expect(JSON.parse(result.stderr)).toMatchObject({
+      ok: false,
+      error: { code: "DATABASE_QUERY_FAILED" },
     });
   });
 });

--- a/test/cli-main.test.ts
+++ b/test/cli-main.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -171,6 +171,44 @@ describe("runCli", () => {
     expect(JSON.parse(result.stdout)).toMatchObject({
       data: { isSet: false, effectiveValue: join(stateDirectory, "lcm.db") },
     });
+  });
+
+  it("lets config set repair the targeted value in an invalid current config", () => {
+    writeFileSync(configPath, `${JSON.stringify({
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              databasePath,
+              contextThresholdOverrides: [{
+                match: { modelContextWindowMin: 100, modelContextWindowMax: 10 },
+                contextThreshold: 0.5,
+              }],
+            },
+          },
+        },
+      },
+    })}\n`, { mode: 0o600 });
+
+    const result = invoke(["config", "set", "contextThresholdOverrides", "[]"]);
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      command: "config.set",
+      data: { path: "contextThresholdOverrides", newValue: [] },
+      meta: { databasePath, configPath },
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf8")))
+      .toMatchObject({
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              config: { databasePath, contextThresholdOverrides: [] },
+            },
+          },
+        },
+      });
   });
 
   it("includes resource-specific options in agent-readable help", () => {

--- a/test/cli-main.test.ts
+++ b/test/cli-main.test.ts
@@ -153,6 +153,26 @@ describe("runCli", () => {
     });
   });
 
+  it("uses the invocation state directory for effective config defaults", () => {
+    writeFileSync(configPath, `${JSON.stringify({
+      plugins: { entries: { "lossless-claw": { config: {} } } },
+    })}\n`, { mode: 0o600 });
+    const stateDirectory = join(directory, "profile");
+
+    const result = invoke([
+      "config",
+      "get",
+      "databasePath",
+      "--openclaw-dir",
+      stateDirectory,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      data: { isSet: false, effectiveValue: join(stateDirectory, "lcm.db") },
+    });
+  });
+
   it("includes resource-specific options in agent-readable help", () => {
     const result = invoke(["--help"]);
     expect(JSON.parse(result.stdout)).toMatchObject({

--- a/test/cli-messages.test.ts
+++ b/test/cli-messages.test.ts
@@ -103,6 +103,34 @@ describe("listMessages", () => {
     expect(second.items).toMatchObject([{ messageId: 102, content: "assistant at shared time" }]);
     expect(second.pagination).toMatchObject({ hasMore: false, nextCursor: null });
   });
+
+  it("bounds preview output unless full content is requested", () => {
+    const writable = new DatabaseSync(databasePath);
+    writable.prepare("UPDATE messages SET content = ? WHERE message_id = 104")
+      .run("x".repeat(5000));
+    writable.close();
+
+    const db = openReadOnlyDatabase(databasePath);
+    const previewPage = listMessages(db, {
+      selector: { kind: "conversationId", value: 1 },
+      roles: [],
+      time: {},
+      limit: 1,
+      includeContent: false,
+    });
+    const contentPage = listMessages(db, {
+      selector: { kind: "conversationId", value: 1 },
+      roles: [],
+      time: {},
+      limit: 1,
+      includeContent: true,
+    });
+    db.close();
+
+    expect(previewPage.items[0]).not.toHaveProperty("content");
+    expect(previewPage.items[0]?.preview).toHaveLength(240);
+    expect(contentPage.items[0]?.content).toHaveLength(5000);
+  });
 });
 
 describe("getFreshTail", () => {

--- a/test/cli-messages.test.ts
+++ b/test/cli-messages.test.ts
@@ -1,0 +1,149 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openReadOnlyDatabase } from "../src/cli/database.js";
+import { getFreshTail, listMessages } from "../src/cli/queries.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+let directory: string;
+let databasePath: string;
+
+function seedFixture(): void {
+  const db = new DatabaseSync(databasePath);
+  runLcmMigrations(db, { fts5Available: false });
+  db.exec(`
+    INSERT INTO conversations (
+      conversation_id, session_id, session_key, active, created_at, updated_at
+    ) VALUES (1, 'session-1', 'agent:main:messages', 1,
+      '2026-07-01T00:00:00.000Z', '2026-07-04T00:00:00.000Z');
+
+    INSERT INTO messages (
+      message_id, conversation_id, seq, role, content, token_count, created_at, large_content
+    ) VALUES
+      (101, 1, 1, 'user', 'old user message', 100, '2026-07-01T00:00:00.000Z', NULL),
+      (102, 1, 2, 'assistant', 'assistant at shared time', 60, '2026-07-02T00:00:00.000Z', NULL),
+      (103, 1, 3, 'tool', 'tool at shared time', 30, '2026-07-02T00:00:00.000Z', 'file-103'),
+      (104, 1, 4, 'assistant', 'newest assistant message', 50, '2026-07-03T00:00:00.000Z', NULL);
+
+    INSERT INTO context_items (conversation_id, ordinal, item_type, message_id) VALUES
+      (1, 0, 'message', 101),
+      (1, 1, 'message', 102),
+      (1, 2, 'message', 103),
+      (1, 3, 'message', 104);
+  `);
+  db.close();
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "lcm-cli-messages-"));
+  databasePath = join(directory, "lcm.db");
+  seedFixture();
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("listMessages", () => {
+  it("applies exact role and inclusive-start/exclusive-end time filters", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const page = listMessages(db, {
+      selector: { kind: "sessionKey", value: "agent:main:messages" },
+      roles: ["assistant", "tool"],
+      time: {
+        after: new Date("2026-07-02T00:00:00.000Z"),
+        before: new Date("2026-07-03T00:00:00.000Z"),
+      },
+      limit: 10,
+      includeContent: false,
+    });
+    db.close();
+
+    expect(page.items.map((message) => message.messageId)).toEqual([103, 102]);
+    expect(page.items[0]).toEqual({
+      messageId: 103,
+      conversationId: 1,
+      seq: 3,
+      role: "tool",
+      tokenCount: 30,
+      createdAt: "2026-07-02T00:00:00.000Z",
+      largeContent: "file-103",
+      preview: "tool at shared time",
+    });
+  });
+
+  it("keyset-paginates messages with identical timestamps", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const first = listMessages(db, {
+      selector: { kind: "conversationId", value: 1 },
+      roles: ["assistant", "tool"],
+      time: {
+        after: new Date("2026-07-02T00:00:00.000Z"),
+        before: new Date("2026-07-03T00:00:00.000Z"),
+      },
+      limit: 1,
+      includeContent: true,
+    });
+    const second = listMessages(db, {
+      selector: { kind: "conversationId", value: 1 },
+      roles: ["assistant", "tool"],
+      time: {
+        after: new Date("2026-07-02T00:00:00.000Z"),
+        before: new Date("2026-07-03T00:00:00.000Z"),
+      },
+      limit: 1,
+      cursor: first.pagination.nextCursor ?? undefined,
+      includeContent: true,
+    });
+    db.close();
+
+    expect(first.items).toMatchObject([{ messageId: 103, content: "tool at shared time" }]);
+    expect(second.items).toMatchObject([{ messageId: 102, content: "assistant at shared time" }]);
+    expect(second.pagination).toMatchObject({ hasMore: false, nextCursor: null });
+  });
+});
+
+describe("getFreshTail", () => {
+  it("matches runtime count and token-cap semantics with newest-message protection", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const tail = getFreshTail(db, {
+      selector: { kind: "conversationId", value: 1 },
+      freshTailCount: 3,
+      freshTailMaxTokens: 70,
+    });
+    db.close();
+
+    expect(tail.limits).toEqual({ count: 3, maxTokens: 70 });
+    expect(tail.selected).toEqual({
+      messages: 1,
+      tokens: 50,
+      firstSeq: 4,
+      lastSeq: 4,
+    });
+    expect(tail.conversation).toEqual({ messages: 4, tokens: 240 });
+    expect(tail.messages).toMatchObject([
+      { messageId: 104, seq: 4, content: "newest assistant message" },
+    ]);
+  });
+
+  it("returns the current context tail in ascending prompt order", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const tail = getFreshTail(db, {
+      selector: { kind: "conversationId", value: 1 },
+      freshTailCount: 4,
+      count: 2,
+    });
+    db.close();
+
+    expect(tail.limits).toEqual({ count: 2, maxTokens: null });
+    expect(tail.messages.map((message) => message.messageId)).toEqual([103, 104]);
+    expect(tail.selected).toEqual({
+      messages: 2,
+      tokens: 80,
+      firstSeq: 3,
+      lastSeq: 4,
+    });
+  });
+});

--- a/test/cli-startup.test.ts
+++ b/test/cli-startup.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
+      String(path).endsWith("openclaw.plugin.json") ? false : actual.existsSync(path),
+  };
+});
+
+import { runCli } from "../src/cli/main.js";
+
+const directory = mkdtempSync(join(tmpdir(), "lcm-cli-startup-"));
+const configPath = join(directory, "openclaw.json");
+
+afterAll(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+function invoke(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = runCli(args, {
+    env: { HOME: directory, OPENCLAW_CONFIG_PATH: configPath },
+    stdout: (text) => { stdout += text; },
+    stderr: (text) => { stderr += text; },
+  });
+  return { exitCode, stdout, stderr };
+}
+
+describe("CLI startup without a packaged manifest", () => {
+  it("keeps commands that do not write config available", () => {
+    const result = invoke(["--help"]);
+
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({ ok: true, command: "help" });
+  });
+
+  it("reports config schema discovery failures as structured errors", () => {
+    writeFileSync(configPath, "{}\n", { mode: 0o600 });
+
+    const result = invoke(["config", "set", "freshTailCount", "20"]);
+
+    expect(result).toMatchObject({ exitCode: 4, stdout: "" });
+    expect(JSON.parse(result.stderr)).toEqual({
+      ok: false,
+      error: {
+        code: "CONFIG_SCHEMA_NOT_FOUND",
+        message: "Could not locate the packaged Lossless plugin manifest.",
+      },
+    });
+  });
+});

--- a/test/cli-summaries.test.ts
+++ b/test/cli-summaries.test.ts
@@ -129,6 +129,30 @@ describe("listSummaries", () => {
     expect(second.items.map((summary) => summary.summaryId)).toEqual(["sum-foreign"]);
     expect(second.pagination).toMatchObject({ hasMore: false, nextCursor: null });
   });
+
+  it("bounds preview output unless full content is requested", () => {
+    const writable = new DatabaseSync(databasePath);
+    writable.prepare("UPDATE summaries SET content = ? WHERE summary_id = 'sum-root'")
+      .run("y".repeat(5000));
+    writable.close();
+
+    const db = openReadOnlyDatabase(databasePath);
+    const previewPage = listSummaries(db, {
+      time: {},
+      limit: 1,
+      includeContent: false,
+    });
+    const contentPage = listSummaries(db, {
+      time: {},
+      limit: 1,
+      includeContent: true,
+    });
+    db.close();
+
+    expect(previewPage.items[0]).not.toHaveProperty("content");
+    expect(previewPage.items[0]?.preview).toHaveLength(240);
+    expect(contentPage.items[0]?.content).toHaveLength(5000);
+  });
 });
 
 describe("getSummaryDetails", () => {

--- a/test/cli-summaries.test.ts
+++ b/test/cli-summaries.test.ts
@@ -1,0 +1,168 @@
+import { DatabaseSync } from "node:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openReadOnlyDatabase } from "../src/cli/database.js";
+import { getSummaryDetails, listSummaries } from "../src/cli/queries.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+
+let directory: string;
+let databasePath: string;
+
+function seedFixture(): void {
+  const db = new DatabaseSync(databasePath);
+  runLcmMigrations(db, { fts5Available: false });
+  db.exec(`
+    INSERT INTO conversations (
+      conversation_id, session_id, session_key, active, created_at, updated_at
+    ) VALUES
+      (1, 'session-1', 'agent:main:summaries', 1,
+       '2026-07-01T00:00:00.000Z', '2026-07-04T00:00:00.000Z'),
+      (2, 'session-2', 'agent:main:foreign', 1,
+       '2026-07-01T00:00:00.000Z', '2026-07-04T00:00:00.000Z');
+
+    INSERT INTO messages (
+      message_id, conversation_id, seq, role, content, token_count, created_at
+    ) VALUES
+      (101, 1, 1, 'user', 'local source message', 80, '2026-07-01T00:00:00.000Z'),
+      (201, 2, 1, 'user', 'foreign source message', 90, '2026-07-01T00:00:00.000Z');
+
+    INSERT INTO summaries (
+      summary_id, conversation_id, kind, depth, content, token_count,
+      earliest_at, latest_at, descendant_count, descendant_token_count,
+      source_message_token_count, created_at, file_ids, model
+    ) VALUES
+      ('sum-leaf-a', 1, 'leaf', 0, 'leaf A full content', 20,
+       '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z', 1, 80, 80,
+       '2026-07-02T01:00:00.000Z', '["file-a"]', 'model-a'),
+      ('sum-leaf-b', 1, 'leaf', 0, 'leaf B full content', 25,
+       '2026-07-01T12:00:00.000Z', '2026-07-02T00:00:00.000Z', 1, 70, 70,
+       '2026-07-02T02:00:00.000Z', '[]', 'model-a'),
+      ('sum-root', 1, 'condensed', 1, 'root full content', 15,
+       '2026-07-01T00:00:00.000Z', '2026-07-03T00:00:00.000Z', 3, 150, 0,
+       '2026-07-03T01:00:00.000Z', '[]', 'model-b'),
+      ('sum-foreign', 2, 'leaf', 0, 'foreign content', 30,
+       '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z', 1, 90, 90,
+       '2026-07-02T03:00:00.000Z', '[]', 'model-c');
+
+    INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal) VALUES
+      ('sum-root', 'sum-leaf-a', 0),
+      ('sum-root', 'sum-leaf-b', 1),
+      ('sum-root', 'sum-foreign', 2);
+    INSERT INTO summary_messages (summary_id, message_id, ordinal) VALUES
+      ('sum-leaf-a', 101, 0),
+      ('sum-leaf-a', 201, 1);
+  `);
+  db.close();
+}
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), "lcm-cli-summaries-"));
+  databasePath = join(directory, "lcm.db");
+  seedFixture();
+});
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe("listSummaries", () => {
+  it("filters depth zero, kind, conversation, and coverage timestamps", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const page = listSummaries(db, {
+      selector: { kind: "sessionKey", value: "agent:main:summaries" },
+      depth: 0,
+      kind: "leaf",
+      time: {
+        after: new Date("2026-07-02T00:00:00.000Z"),
+        before: new Date("2026-07-03T00:00:00.000Z"),
+      },
+      limit: 10,
+      includeContent: false,
+    });
+    db.close();
+
+    expect(page.items.map((summary) => summary.summaryId)).toEqual(["sum-leaf-b", "sum-leaf-a"]);
+    expect(page.items[1]).toEqual({
+      summaryId: "sum-leaf-a",
+      conversationId: 1,
+      kind: "leaf",
+      depth: 0,
+      tokenCount: 20,
+      earliestAt: "2026-07-01T00:00:00.000Z",
+      latestAt: "2026-07-02T00:00:00.000Z",
+      coverageAt: "2026-07-02T00:00:00.000Z",
+      descendantCount: 1,
+      descendantTokenCount: 80,
+      sourceMessageTokenCount: 80,
+      createdAt: "2026-07-02T01:00:00.000Z",
+      fileIds: ["file-a"],
+      model: "model-a",
+      parentCount: 1,
+      childCount: 0,
+      sourceMessageCount: 1,
+      preview: "leaf A full content",
+    });
+  });
+
+  it("keyset-paginates equal coverage timestamps globally", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const first = listSummaries(db, {
+      depth: 0,
+      kind: "leaf",
+      time: {},
+      limit: 2,
+      includeContent: true,
+    });
+    const second = listSummaries(db, {
+      depth: 0,
+      kind: "leaf",
+      time: {},
+      limit: 2,
+      cursor: first.pagination.nextCursor ?? undefined,
+      includeContent: true,
+    });
+    db.close();
+
+    expect(first.items.map((summary) => summary.summaryId)).toEqual(["sum-leaf-b", "sum-leaf-a"]);
+    expect(second.items.map((summary) => summary.summaryId)).toEqual(["sum-foreign"]);
+    expect(second.pagination).toMatchObject({ hasMore: false, nextCursor: null });
+  });
+});
+
+describe("getSummaryDetails", () => {
+  it("returns intuitive parents and children without cross-conversation edges", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const root = getSummaryDetails(db, "sum-root");
+    const leaf = getSummaryDetails(db, "sum-leaf-a");
+    db.close();
+
+    expect(root.parents).toEqual([]);
+    expect(root.children.map((summary) => summary.summaryId)).toEqual(["sum-leaf-a", "sum-leaf-b"]);
+    expect(leaf.parents.map((summary) => summary.summaryId)).toEqual(["sum-root"]);
+    expect(leaf.children).toEqual([]);
+  });
+
+  it("returns ordered local source messages with full summary content", () => {
+    const db = openReadOnlyDatabase(databasePath);
+    const details = getSummaryDetails(db, "sum-leaf-a");
+    db.close();
+
+    expect(details.summary).toMatchObject({
+      summaryId: "sum-leaf-a",
+      content: "leaf A full content",
+      fileIds: ["file-a"],
+    });
+    expect(details.sourceMessages).toEqual([
+      {
+        messageId: 101,
+        seq: 1,
+        role: "user",
+        tokenCount: 80,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        content: "local source message",
+      },
+    ]);
+  });
+});

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -9,4 +9,9 @@ describe("package OpenClaw compatibility metadata", () => {
     expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.28"]);
     expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.28");
   });
+
+  it("publishes the TypeScript lcm executable", () => {
+    expect(packageJson.bin).toEqual({ lcm: "dist/cli.js" });
+    expect(packageJson.scripts.build).toContain("build:cli");
+  });
 });

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -11,7 +11,11 @@ describe("package OpenClaw compatibility metadata", () => {
   });
 
   it("publishes the TypeScript lcm executable", () => {
-    expect(packageJson.bin).toEqual({ lcm: "dist/cli.js" });
+    expect(packageJson.bin).toEqual({
+      lcm: "dist/cli.js",
+      "lossless-claw-migrate-sessions": "dist/migrate-sessions.js",
+    });
     expect(packageJson.scripts.build).toContain("build:cli");
+    expect(packageJson.scripts.build).toContain("build:migrate-sessions");
   });
 });


### PR DESCRIPTION
## What

Add a packaged `lcm` TypeScript CLI for structured Lossless Claw diagnostics and targeted configuration edits. The CLI returns JSON by default, supports bounded table output, and reserves the `doctor` namespace for a separate diagnostic contract.

## Why

Agents need a stable way to inspect persisted conversations without reading SQLite tables directly or invoking runtime maintenance. This change provides bounded queries for conversations, messages, summaries, fresh-tail state, token totals, timestamps, and effective configuration while keeping database access read-only.

## Changes

- Add packaged `lcm` executable
- Add read-only database diagnostics
- Add keyset-paginated inspection commands
- Add time and summary filters
- Add validated atomic config editing
- Document commands and path precedence
- Add a minor release changeset

## Changes walkthrough

| File | Change |
|------|--------|
| `cli.ts` | Add executable entry point |
| `src/cli/args.ts` | Parse commands, filters, and cursors |
| `src/cli/database.ts` | Enforce read-only SQLite access |
| `src/cli/queries.ts` | Query status, conversations, and messages |
| `src/cli/summary-queries.ts` | Query summary lists and details |
| `src/cli/config-file.ts` | Validate and atomically edit config |
| `src/cli/main.ts` | Dispatch commands and format errors |
| `test/cli-*.test.ts` | Cover CLI contracts and safety |
| `docs/cli.md` | Document commands and output behavior |
| `package.json` | Package both supported CLI binaries |

## Testing

- `npm test -- --run test/cli-config.test.ts test/cli-conversations.test.ts test/cli-foundations.test.ts test/cli-main.test.ts test/cli-messages.test.ts test/cli-summaries.test.ts test/package-metadata.test.ts test/migrate-sessions.test.ts`
  - 67 tests pass
- `npm run typecheck`
  - Passes
- `npm run build`
  - Builds plugin and CLI bundles
- `npm pack --dry-run`
  - Includes `dist/cli.js` and `docs/cli.md`
- `./dist/cli.js status --pretty`
  - Reads the live database successfully
- Autoreview against the rebased `origin/main`
  - No actionable findings

Repository-wide local validation is affected by this checkout's installed OpenClaw package, which does not export `plugin-sdk/core` or `plugin-sdk/logging-core`. GitHub CI runs against the repository dependency contract.
