### PR TITLE
fix: summarize nested MCP result envelopes

### DIFF
--- a/.changeset/read-mcp-result-envelopes.md
+++ b/.changeset/read-mcp-result-envelopes.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve MCP tool-result text nested inside OpenClaw result envelopes when preparing conversation summaries.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -292,6 +292,7 @@ const MEDIA_ATTACHMENT_RAW_TYPES = new Set(["file", "image", "snapshot"]);
 const PROVIDER_REASONING_RAW_TYPES = new Set(["reasoning", "thinking", "redacted_thinking"]);
 const STRUCTURED_MEDIA_TEXT_KEYS = ["text", "caption", "alt", "title", "summary"] as const;
 const STRUCTURED_MEDIA_NESTED_KEYS = [
+  "value",
   "content",
   "parts",
   "items",
@@ -306,6 +307,7 @@ const STRUCTURED_MEDIA_NESTED_KEYS = [
   "query",
   "command",
 ] as const;
+const MAX_STRUCTURED_TEXT_DEPTH = 8;
 const LEADING_CLOSED_REASONING_TEXT_BLOCK_RE =
   /^<\s*(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\s*\/\s*\1\s*>/i;
 const STANDALONE_CLOSED_REASONING_TEXT_BLOCK_RE =
@@ -465,7 +467,7 @@ function extractSanitizedStructuredText(
   options: MeaningfulTextOptions = {},
   depth = 0,
 ): string[] {
-  if (depth >= 4 || value == null) {
+  if (depth >= MAX_STRUCTURED_TEXT_DEPTH || value == null) {
     return [];
   }
   if (typeof value === "string") {

--- a/test/reasoning-half-fix.test.ts
+++ b/test/reasoning-half-fix.test.ts
@@ -109,6 +109,24 @@ describe("extractMeaningfulMessageText (B2: shared sanitizer)", () => {
     expect(extractMeaningfulMessageText(content)).toBe("Yes — see runbook §3.");
   });
 
+  it("extracts text from an OpenClaw MCP result envelope", () => {
+    const content = JSON.stringify({
+      ok: true,
+      value: {
+        tool: { description: "Tool metadata should not become summary source." },
+        result: {
+          content: [{ type: "text", text: "The meeting notes remain available." }],
+        },
+      },
+      logs: ["transport metadata should not become summary source"],
+      telemetry: { durationMs: 12 },
+    });
+
+    expect(extractMeaningfulMessageText(content)).toBe(
+      "The meeting notes remain available.",
+    );
+  });
+
   it("does not apply structured handling to non-JSON strings", () => {
     expect(
       extractMeaningfulMessageText("Just a plain log line about reasoning."),


### PR DESCRIPTION
## Summary

OpenClaw can persist MCP tool results inside an {ok, value, logs, telemetry} envelope, with the meaningful result text under value.result.content[].text. Lossless did not traverse value, and its structured-content depth limit stopped before the nested text. A pending-summary leaf containing only these results therefore produced an empty source and failed the batch.

This change:

- traverses the value field when extracting structured summary text;
- raises the bounded traversal depth from 4 to 8 so nested MCP result content is reachable;
- adds regression coverage proving result text is preserved while tool metadata, logs, and telemetry remain excluded;
- includes a patch changeset.

## Verification

- npm run typecheck
- npm test (1,632 tests)
- npm run build
- production verification on Phaedrus: the previously failed leaf completed with zero retries, and all 13 nodes in the stalled batch were promoted and published.