### PR TITLE
fix: prefer active runtime recall scope

### DIFF
--- a/.changeset/fix-stale-recall-scope.md
+++ b/.changeset/fix-stale-recall-scope.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prefer the active runtime session when a stale tool session key points scoped `lcm_*` recall at another conversation family.

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -219,7 +219,7 @@ export async function resolveLcmConversationScope(input: {
         byRuntimeSession?.active === true
         && byRuntimeSession.conversationId !== bySessionKey.conversationId;
       const conversation = runtimeSessionOverridesStaleKey ? byRuntimeSession : bySessionKey;
-      const conversationSessionKey = conversation.sessionKey?.trim() || normalizedSessionKey;
+      const conversationSessionKey = conversation.sessionKey?.trim();
       if (runtimeSessionOverridesStaleKey) {
         input.deps?.log.warn(
           `[lcm] recall scope: active runtime session overrides stale tool session key requestedSessionKey=${normalizedSessionKey} resolvedConversation=${bySessionKey.conversationId} resolvedSessionKey=${bySessionKey.sessionKey ?? ""} resolvedActive=${bySessionKey.active} runtimeSessionId=${normalizedInputSessionId} alternativeConversation=${byRuntimeSession.conversationId} alternativeSessionKey=${byRuntimeSession.sessionKey ?? ""} alternativeActive=${byRuntimeSession.active}`,

--- a/src/tools/lcm-conversation-scope.ts
+++ b/src/tools/lcm-conversation-scope.ts
@@ -94,7 +94,10 @@ export async function resolveLcmConversationScope(input: {
   params: Record<string, unknown>;
   sessionId?: string;
   sessionKey?: string;
-  deps?: Pick<LcmDependencies, "isSubagentSessionKey" | "resolveSessionIdFromSessionKey">;
+  deps?: Pick<
+    LcmDependencies,
+    "isSubagentSessionKey" | "resolveSessionIdFromSessionKey" | "log"
+  >;
 }): Promise<LcmConversationScope> {
   const { lcm, params } = input;
   const explicitSessionKey = input.sessionKey?.trim();
@@ -205,9 +208,23 @@ export async function resolveLcmConversationScope(input: {
   }
 
   if (normalizedSessionKey) {
-    const bySessionKey =
-      await lcm.getConversationStore().getConversationBySessionKey(normalizedSessionKey);
+    const store = lcm.getConversationStore();
+    const bySessionKey = await store.getConversationBySessionKey(normalizedSessionKey);
     if (bySessionKey) {
+      const byRuntimeSession =
+        !isDelegatedSession && normalizedInputSessionId && !sessionIdAsSessionKey
+          ? await store.getConversationBySessionId(normalizedInputSessionId)
+          : null;
+      const runtimeSessionOverridesStaleKey =
+        byRuntimeSession?.active === true
+        && byRuntimeSession.conversationId !== bySessionKey.conversationId;
+      const conversation = runtimeSessionOverridesStaleKey ? byRuntimeSession : bySessionKey;
+      const conversationSessionKey = conversation.sessionKey?.trim() || normalizedSessionKey;
+      if (runtimeSessionOverridesStaleKey) {
+        input.deps?.log.warn(
+          `[lcm] recall scope: active runtime session overrides stale tool session key requestedSessionKey=${normalizedSessionKey} resolvedConversation=${bySessionKey.conversationId} resolvedSessionKey=${bySessionKey.sessionKey ?? ""} resolvedActive=${bySessionKey.active} runtimeSessionId=${normalizedInputSessionId} alternativeConversation=${byRuntimeSession.conversationId} alternativeSessionKey=${byRuntimeSession.sessionKey ?? ""} alternativeActive=${byRuntimeSession.active}`,
+        );
+      }
       if (isDelegatedSession && !allowedConversationIds.includes(bySessionKey.conversationId)) {
         return {
           allConversations: false,
@@ -215,21 +232,23 @@ export async function resolveLcmConversationScope(input: {
           error: `Conversation ${bySessionKey.conversationId} is outside delegated conversation scope.`,
         };
       }
-      const familyIds = isolateCurrentSessionFamily
-        ? [bySessionKey.conversationId]
+      const isolateResolvedSessionFamily = isIsolatedCronSessionKey(conversationSessionKey);
+      const familyIds = isolateResolvedSessionFamily
+        ? [conversation.conversationId]
         : typeof (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds === "function"
           ? await (lcm.getConversationStore() as ConversationScopeStore).getConversationFamilyIds({
-              conversationId: bySessionKey.conversationId,
-              sessionKey: normalizedSessionKey,
+              conversationId: conversation.conversationId,
+              sessionId: runtimeSessionOverridesStaleKey ? normalizedInputSessionId : undefined,
+              sessionKey: conversationSessionKey,
             })
-          : [bySessionKey.conversationId];
-      const scopedFamilyIds = familyIds.length > 0 ? familyIds : [bySessionKey.conversationId];
+          : [conversation.conversationId];
+      const scopedFamilyIds = familyIds.length > 0 ? familyIds : [conversation.conversationId];
       const conversationIds = isDelegatedSession
         ? scopedFamilyIds.filter((conversationId) => allowedConversationIds.includes(conversationId))
         : scopedFamilyIds;
       return {
-        conversationId: bySessionKey.conversationId,
-        conversationIds: conversationIds.length > 0 ? conversationIds : [bySessionKey.conversationId],
+        conversationId: conversation.conversationId,
+        conversationIds: conversationIds.length > 0 ? conversationIds : [conversation.conversationId],
         allConversations: false,
         delegated: isDelegatedSession,
       };

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -91,6 +91,7 @@ function buildLcmEngine(params: {
   conversationId?: number;
   conversationIdBySessionKey?: number;
   conversationFamilyIds?: number[];
+  conversationFamilyIdsByRoot?: Record<number, number[]>;
   timezone?: string;
 }) {
   return {
@@ -104,26 +105,35 @@ function buildLcmEngine(params: {
           : {
               conversationId: params.conversationId,
               sessionId: "session-1",
+              sessionKey: "agent:main:main",
+              active: true,
               title: null,
               bootstrappedAt: null,
               createdAt: new Date("2026-01-01T00:00:00.000Z"),
               updatedAt: new Date("2026-01-01T00:00:00.000Z"),
             },
       ),
-      getConversationBySessionKey: vi.fn(async () =>
+      getConversationBySessionKey: vi.fn(async (sessionKey: string) =>
         params.conversationIdBySessionKey == null
           ? null
           : {
               conversationId: params.conversationIdBySessionKey,
               sessionId: "legacy-session",
-              sessionKey: "agent:main:main",
+              sessionKey,
+              active: true,
               title: null,
               bootstrappedAt: null,
               createdAt: new Date("2026-01-01T00:00:00.000Z"),
               updatedAt: new Date("2026-01-01T00:00:00.000Z"),
             },
       ),
-      getConversationFamilyIds: vi.fn(async () => {
+      getConversationFamilyIds: vi.fn(async (input: { conversationId?: number }) => {
+        const idsForRoot = input.conversationId == null
+          ? undefined
+          : params.conversationFamilyIdsByRoot?.[input.conversationId];
+        if (idsForRoot) {
+          return idsForRoot;
+        }
         if (params.conversationFamilyIds && params.conversationFamilyIds.length > 0) {
           return params.conversationFamilyIds;
         }
@@ -461,6 +471,65 @@ describe("LCM tools session scoping", () => {
         conversationId: 42,
         conversationIds: [42],
       }),
+    );
+  });
+
+  it("lcm_grep prefers the active runtime session when the tool sessionKey is stale", async () => {
+    const retrieval = {
+      grep: vi.fn(async (input: { conversationIds?: number[] }) => {
+        const found = input.conversationIds?.includes(1987) === true;
+        return {
+          messages: found
+            ? [{
+                messageId: 987,
+                conversationId: 1987,
+                role: "assistant",
+                snippet: "SMOKE_OK",
+                createdAt: new Date("2026-07-11T13:19:00.000Z"),
+                rank: 0,
+              }]
+            : [],
+          summaries: [],
+          totalMatches: found ? 1 : 0,
+        };
+      }),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const deps = makeDeps();
+    const tool = createLcmGrepTool({
+      deps,
+      lcm: buildLcmEngine({
+        retrieval,
+        conversationId: 1987,
+        conversationIdBySessionKey: 1884,
+        conversationFamilyIdsByRoot: {
+          1884: [1884],
+          1987: [1987, 1986],
+        },
+      }) as never,
+      sessionId: "02b94cf7-f5bd-49d2-8883-90d7a92cfc8f",
+      sessionKey: "agent:main:telegram:default:direct:stale-chat",
+    });
+    const result = await tool.execute("call-stale-key", { pattern: "SMOKE_OK" });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 1987,
+        conversationIds: [1987, 1986],
+      }),
+    );
+    expect((result.content[0] as { text: string }).text).toContain("SMOKE_OK");
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "requestedSessionKey=agent:main:telegram:default:direct:stale-chat resolvedConversation=1884",
+      ),
+    );
+    expect(deps.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "alternativeConversation=1987 alternativeSessionKey=agent:main:main alternativeActive=true",
+      ),
     );
   });
 

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -89,6 +89,7 @@ function buildLcmEngine(params: {
     describe: ReturnType<typeof vi.fn>;
   };
   conversationId?: number;
+  conversationSessionKey?: string | null;
   conversationIdBySessionKey?: number;
   conversationFamilyIds?: number[];
   conversationFamilyIdsByRoot?: Record<number, number[]>;
@@ -105,7 +106,9 @@ function buildLcmEngine(params: {
           : {
               conversationId: params.conversationId,
               sessionId: "session-1",
-              sessionKey: "agent:main:main",
+              sessionKey: params.conversationSessionKey === undefined
+                ? "agent:main:main"
+                : params.conversationSessionKey,
               active: true,
               title: null,
               bootstrappedAt: null,
@@ -531,6 +534,75 @@ describe("LCM tools session scoping", () => {
         "alternativeConversation=1987 alternativeSessionKey=agent:main:main alternativeActive=true",
       ),
     );
+  });
+
+  it("lcm_grep does not reuse a stale cron key when the active runtime has no sessionKey", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({
+        retrieval,
+        conversationId: 1987,
+        conversationSessionKey: null,
+        conversationIdBySessionKey: 1884,
+        conversationFamilyIdsByRoot: {
+          1884: [1884],
+          1987: [1987, 1986],
+        },
+      }) as never,
+      sessionId: "active-runtime-session",
+      sessionKey: "agent:main:cron:stale-run",
+    });
+    await tool.execute("call-null-runtime-key", { pattern: "SMOKE_OK" });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 1987,
+        conversationIds: [1987, 1986],
+      }),
+    );
+  });
+
+  it("lcm_grep does not warn when runtime and tool identities resolve to one conversation", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const deps = makeDeps();
+    const tool = createLcmGrepTool({
+      deps,
+      lcm: buildLcmEngine({
+        retrieval,
+        conversationId: 42,
+        conversationIdBySessionKey: 42,
+      }) as never,
+      sessionId: "runtime-session-42",
+      sessionKey: "agent:main:main",
+    });
+    await tool.execute("call-same-conversation", { pattern: "deployment" });
+
+    expect(retrieval.grep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 42,
+        conversationIds: [42],
+      }),
+    );
+    expect(deps.log.warn).not.toHaveBeenCalled();
   });
 
   it("lcm_grep searches across a resolved session family", async () => {


### PR DESCRIPTION
## What

Make default `lcm_*` recall prefer the active runtime session when a stale tool session key resolves to a different conversation family. Emit a warning with both bindings when the mismatch occurs.

## Why

After a main-session rollover, OpenClaw can supply a stale channel key alongside the active runtime session ID. The stale key previously won unconditionally, so scoped recall could return zero matches even though the active conversation still contained the requested history.

## Changes

- Prefer active runtime-session conversation
- Preserve stable-key continuity otherwise
- Log mismatched recall bindings
- Cover stale rollover scope regression
- Add patch release changeset

## Testing

- `npm test` (96 files, 1,715 tests)
- `npm run typecheck`
- `npm run build`
- Thermonuclear review: no findings
- Autoreview: no actionable findings

Fixes #987
