### PR TITLE
fix: detect Lossless Claw version splits in doctor

### DIFF
--- a/.changeset/doctor-version-split.md
+++ b/.changeset/doctor-version-split.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Report the active Lossless Claw version and source path in doctor output, and warn when live or generated OpenClaw package copies use a different version.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1744,6 +1744,7 @@ function wirePluginHandlers(
       db: shared.waitForDatabase,
       config: deps.config,
       openClawConfig,
+      activeSourcePath: typeof api.source === "string" ? api.source : undefined,
       deps,
       getLcm: shared.waitForEngine,
     }),

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -37,6 +37,7 @@ import {
   type RolloverSplitCounts,
   type RolloverSplitExample,
 } from "./lcm-doctor-rollover-splits.js";
+import { scanLcmVersionCopies, type LcmVersionDoctorScan } from "./lcm-version-doctor.js";
 import {
   CompactionMaintenanceStore,
   type ConversationCompactionMaintenanceRecord,
@@ -413,6 +414,29 @@ function buildInstallTrackWarningSection(warning: LcmInstallTrackWarning): strin
       formatCommand(`openclaw plugins update ${LOSSLESS_NPM_PACKAGE}@latest`),
     ),
   ]);
+}
+
+/** Format the active package identity and every distinct copy discovered by doctor. */
+function buildVersionDoctorSection(scan: LcmVersionDoctorScan): string {
+  const lines = [
+    buildStatLine("active version", scan.active.version),
+    buildStatLine("active path", formatCommand(scan.active.path)),
+    ...scan.shadows.map((copy) =>
+      buildStatLine(`shadow copy (${copy.kind})`, `${formatCommand(copy.path)} (v${copy.version})`),
+    ),
+  ];
+  if (scan.shadows.length === 0) {
+    lines.push(buildStatLine("shadow copies", "none found"));
+  }
+  if (scan.split) {
+    lines.push(
+      buildStatLine(
+        "impact",
+        "A generated or live copy differs from the active Lossless Claw copy; update the active path above before restarting OpenClaw.",
+      ),
+    );
+  }
+  return buildSection(scan.split ? "⚠️ Version split" : "🧩 Installed copies", lines);
 }
 
 function formatCompressionRatio(contextTokens: number, compressedTokens: number): string {
@@ -1431,6 +1455,7 @@ async function buildDoctorText(params: {
   ctx: PluginCommandContext;
   db: DatabaseSync;
   openClawConfig?: unknown;
+  activeSourcePath?: string;
 }): Promise<string> {
   const rolloverSplits = scanRolloverSplits(params.db);
   const installTrackWarning = detectLcmInstallTrackWarning({
@@ -1438,6 +1463,13 @@ async function buildDoctorText(params: {
     fallbackConfig: params.openClawConfig,
   });
   const current = await resolveCurrentConversation(params);
+  const versionScan = params.activeSourcePath
+    ? scanLcmVersionCopies({
+        activeSourcePath: params.activeSourcePath,
+        activeVersion: packageJson.version,
+        stateDir: resolveOpenclawStateDir(),
+      })
+    : null;
 
   if (current.kind === "unavailable") {
     const lines = [
@@ -1448,6 +1480,9 @@ async function buildDoctorText(params: {
     ];
     if (installTrackWarning) {
       lines.push(buildInstallTrackWarningSection(installTrackWarning), "");
+    }
+    if (versionScan) {
+      lines.push(buildVersionDoctorSection(versionScan), "");
     }
     lines.push(
       buildSection("📍 Current conversation", [
@@ -1470,6 +1505,9 @@ async function buildDoctorText(params: {
   ];
   if (installTrackWarning) {
     lines.push(buildInstallTrackWarningSection(installTrackWarning), "");
+  }
+  if (versionScan) {
+    lines.push(buildVersionDoctorSection(versionScan), "");
   }
   lines.push(
     buildSection("📍 Current conversation", [
@@ -3174,6 +3212,7 @@ export function createLcmCommand(params: {
   db: DatabaseSync | (() => DatabaseSync | Promise<DatabaseSync>);
   config: LcmConfig;
   openClawConfig?: unknown;
+  activeSourcePath?: string;
   deps?: LcmDependencies;
   summarize?: LcmSummarizeFn;
   getLcm?: () => Promise<RuntimeCommandEngine>;
@@ -3271,6 +3310,7 @@ export function createLcmCommand(params: {
                   ctx,
                   db: await getDb(),
                   openClawConfig: params.openClawConfig,
+                  activeSourcePath: params.activeSourcePath,
                 }),
               };
         case "doctor_rollover_splits":

--- a/src/plugin/lcm-version-doctor.ts
+++ b/src/plugin/lcm-version-doctor.ts
@@ -1,0 +1,129 @@
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const LOSSLESS_PACKAGE_NAME = "@martian-engineering/lossless-claw";
+const LOSSLESS_PACKAGE_SEGMENTS = ["@martian-engineering", "lossless-claw"];
+
+/** A discovered Lossless Claw package copy relevant to the active OpenClaw installation. */
+export type LcmPackageCopy = {
+  kind: "active" | "live" | "generated";
+  path: string;
+  version: string;
+};
+
+/** The active package plus any other installed copies and whether their versions diverge. */
+export type LcmVersionDoctorScan = {
+  active: LcmPackageCopy;
+  shadows: LcmPackageCopy[];
+  split: boolean;
+};
+
+/** Normalize the loader-provided source to the directory that contains active code. */
+function normalizePackageRoot(sourcePath: string): string {
+  const absolutePath = resolve(sourcePath);
+  if (!existsSync(absolutePath)) {
+    return absolutePath;
+  }
+  try {
+    return statSync(absolutePath).isDirectory() ? absolutePath : dirname(absolutePath);
+  } catch {
+    return absolutePath;
+  }
+}
+
+/** Read only a valid Lossless Claw manifest from a candidate package root. */
+function readPackageCopy(
+  packageRoot: string,
+  kind: LcmPackageCopy["kind"],
+): LcmPackageCopy | null {
+  const packagePath = join(packageRoot, "package.json");
+  if (!existsSync(packagePath)) {
+    return null;
+  }
+  try {
+    const manifest = JSON.parse(readFileSync(packagePath, "utf8")) as {
+      name?: unknown;
+      version?: unknown;
+    };
+    return manifest.name === LOSSLESS_PACKAGE_NAME && typeof manifest.version === "string"
+      ? { kind, path: packageRoot, version: manifest.version }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve generated-project package roots without recursively walking node_modules. */
+function listGeneratedProjectRoots(stateDir: string): string[] {
+  const projectsRoot = join(stateDir, "npm", "projects");
+  if (!existsSync(projectsRoot)) {
+    return [];
+  }
+  try {
+    return readdirSync(projectsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(projectsRoot, entry.name, "node_modules", ...LOSSLESS_PACKAGE_SEGMENTS));
+  } catch {
+    return [];
+  }
+}
+
+/** Prefer real paths for deduplication while retaining missing paths for reporting. */
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+/** Scan the active package and OpenClaw's fixed live and generated-project install locations. */
+export function scanLcmVersionCopies(params: {
+  activeSourcePath: string;
+  activeVersion: string;
+  stateDir: string;
+}): LcmVersionDoctorScan {
+  const activePath = normalizePackageRoot(params.activeSourcePath);
+  const active: LcmPackageCopy = {
+    kind: "active",
+    path: activePath,
+    version: params.activeVersion,
+  };
+  const activeCanonicalPath = canonicalPath(activePath);
+  const candidates = [
+    {
+      kind: "live" as const,
+      path: join(params.stateDir, "node_modules", ...LOSSLESS_PACKAGE_SEGMENTS),
+    },
+    {
+      kind: "live" as const,
+      path: join(params.stateDir, "extensions", "node_modules", ...LOSSLESS_PACKAGE_SEGMENTS),
+    },
+    ...listGeneratedProjectRoots(params.stateDir).map((path) => ({
+      kind: "generated" as const,
+      path,
+    })),
+  ];
+  const seen = new Set([activeCanonicalPath]);
+  const shadows: LcmPackageCopy[] = [];
+
+  for (const candidate of candidates) {
+    const copy = readPackageCopy(candidate.path, candidate.kind);
+    if (!copy) {
+      continue;
+    }
+    const canonical = canonicalPath(copy.path);
+    if (seen.has(canonical)) {
+      continue;
+    }
+    seen.add(canonical);
+    shadows.push(copy);
+  }
+
+  shadows.sort((left, right) => left.path.localeCompare(right.path));
+  return {
+    active,
+    shadows,
+    split: shadows.some((copy) => copy.version !== active.version),
+  };
+}

--- a/src/plugin/lcm-version-doctor.ts
+++ b/src/plugin/lcm-version-doctor.ts
@@ -18,14 +18,25 @@ export type LcmVersionDoctorScan = {
   split: boolean;
 };
 
-/** Normalize the loader-provided source to the directory that contains active code. */
+/** Resolve the loader-provided source to its enclosing Lossless Claw package root. */
 function normalizePackageRoot(sourcePath: string): string {
   const absolutePath = resolve(sourcePath);
   if (!existsSync(absolutePath)) {
     return absolutePath;
   }
   try {
-    return statSync(absolutePath).isDirectory() ? absolutePath : dirname(absolutePath);
+    const sourceDir = statSync(absolutePath).isDirectory() ? absolutePath : dirname(absolutePath);
+    let currentDir = sourceDir;
+    while (true) {
+      if (readPackageCopy(currentDir, "active")) {
+        return currentDir;
+      }
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) {
+        return sourceDir;
+      }
+      currentDir = parentDir;
+    }
   } catch {
     return absolutePath;
   }

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -20,6 +20,7 @@ import {
 import { FALLBACK_DIRECTIVE_SUMMARY_MARKER } from "../src/summary-fallback.js";
 import type { LcmSummarizeFn } from "../src/summarize.js";
 import type { LcmDependencies } from "../src/types.js";
+import packageJson from "../package.json" with { type: "json" };
 
 function createCommandFixture(options?: {
   summarize?: LcmSummarizeFn;
@@ -460,6 +461,76 @@ describe("lcm command", () => {
     expect(result.text).toContain("🩺 Lossless Claw Doctor");
     expect(result.text).toContain("**⚠️ Update track**");
     expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
+  });
+
+  it("warns when doctor finds a generated project copy newer than the active copy", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const stateDir = join(fixture.tempDir, "openclaw-state");
+    const activePath = join(stateDir, "active-loaded-copy");
+    const liveShadowPath = join(
+      stateDir,
+      "node_modules",
+      "@martian-engineering",
+      "lossless-claw",
+    );
+    const generatedPath = join(
+      stateDir,
+      "npm",
+      "projects",
+      "generated-project",
+      "node_modules",
+      "@martian-engineering",
+      "lossless-claw",
+    );
+    const extensionShadowPath = join(
+      stateDir,
+      "extensions",
+      "node_modules",
+      "@martian-engineering",
+      "lossless-claw",
+    );
+    mkdirSync(activePath, { recursive: true });
+    mkdirSync(liveShadowPath, { recursive: true });
+    mkdirSync(extensionShadowPath, { recursive: true });
+    mkdirSync(generatedPath, { recursive: true });
+    writeFileSync(
+      join(activePath, "package.json"),
+      JSON.stringify({ name: "@martian-engineering/lossless-claw", version: packageJson.version }),
+    );
+    writeFileSync(
+      join(liveShadowPath, "package.json"),
+      JSON.stringify({ name: "@martian-engineering/lossless-claw", version: packageJson.version }),
+    );
+    writeFileSync(
+      join(extensionShadowPath, "package.json"),
+      JSON.stringify({ name: "@martian-engineering/lossless-claw", version: packageJson.version }),
+    );
+    writeFileSync(
+      join(generatedPath, "package.json"),
+      JSON.stringify({ name: "@martian-engineering/lossless-claw", version: "999.0.0" }),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const command = createLcmCommand({
+      db: fixture.db,
+      config: fixture.config,
+      activeSourcePath: activePath,
+    });
+
+    const result = await command.handler(createCommandContext("doctor"));
+
+    expect(result.text).toContain("**⚠️ Version split**");
+    expect(result.text).toContain(`active version: ${packageJson.version}`);
+    expect(result.text).toContain(`active path: \`${activePath}\``);
+    expect(result.text).toContain(
+      `shadow copy (live): \`${liveShadowPath}\` (v${packageJson.version})`,
+    );
+    expect(result.text).toContain(
+      `shadow copy (live): \`${extensionShadowPath}\` (v${packageJson.version})`,
+    );
+    expect(result.text).toContain(`shadow copy (generated): \`${generatedPath}\` (v999.0.0)`);
+    expect(result.text).toContain("generated or live copy differs from the active Lossless Claw copy");
   });
 
   it("surfaces rollover split memory from the default status command", async () => {

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -538,17 +538,25 @@ describe("lcm command", () => {
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
     const stateDir = join(fixture.tempDir, "openclaw-state");
-    const activePath = join(stateDir, "active-loaded-copy");
-    mkdirSync(activePath, { recursive: true });
+    const activePath = join(
+      stateDir,
+      "extensions",
+      "node_modules",
+      "@martian-engineering",
+      "lossless-claw",
+    );
+    const activeSourcePath = join(activePath, "dist", "index.js");
+    mkdirSync(join(activePath, "dist"), { recursive: true });
     writeFileSync(
       join(activePath, "package.json"),
       JSON.stringify({ name: "@martian-engineering/lossless-claw", version: packageJson.version }),
     );
+    writeFileSync(activeSourcePath, "export default {};\n");
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     const command = createLcmCommand({
       db: fixture.db,
       config: fixture.config,
-      activeSourcePath: activePath,
+      activeSourcePath,
     });
 
     const result = await command.handler(createCommandContext("doctor"));

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -533,6 +533,33 @@ describe("lcm command", () => {
     expect(result.text).toContain("generated or live copy differs from the active Lossless Claw copy");
   });
 
+  it("reports clean version diagnostics when doctor finds no shadow copies", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const stateDir = join(fixture.tempDir, "openclaw-state");
+    const activePath = join(stateDir, "active-loaded-copy");
+    mkdirSync(activePath, { recursive: true });
+    writeFileSync(
+      join(activePath, "package.json"),
+      JSON.stringify({ name: "@martian-engineering/lossless-claw", version: packageJson.version }),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const command = createLcmCommand({
+      db: fixture.db,
+      config: fixture.config,
+      activeSourcePath: activePath,
+    });
+
+    const result = await command.handler(createCommandContext("doctor"));
+
+    expect(result.text).toContain("**🧩 Installed copies**");
+    expect(result.text).toContain(`active version: ${packageJson.version}`);
+    expect(result.text).toContain(`active path: \`${activePath}\``);
+    expect(result.text).toContain("shadow copies: none found");
+    expect(result.text).not.toContain("**⚠️ Version split**");
+  });
+
   it("surfaces rollover split memory from the default status command", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);


### PR DESCRIPTION
## What

Add read-only version diagnostics to `/lossless doctor`. Doctor reports the loaded Lossless Claw version and source path, lists other live and generated npm copies, and warns when their versions differ.

## Why

OpenClaw can retain an older active plugin copy while a generated npm project contains a newer release. The version split makes operators believe a fix is active when the gateway still runs older code.

## Changes

- Scan fixed OpenClaw package locations
- Deduplicate copies by canonical path
- Report active and shadow package versions
- Warn when installed versions diverge
- Add version-split regression coverage
- Add patch release note

## Testing

- `npm test -- test/lcm-command.test.ts`
- `npm run release:verify`
- Expected: 1,715 tests pass
- Expected: typecheck, builds, package dry-run pass

Fixes #988
