### PR TITLE
fix: prefer real tool results during transcript repair

### DIFF
--- a/.changeset/prefer-real-tool-results.md
+++ b/.changeset/prefer-real-tool-results.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve real tool results when compacted history displaces them past later tool calls or an earlier synthetic repair result.

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -271,6 +271,17 @@ function isSyntheticMissingToolResult(message: AgentMessageLike): boolean {
   );
 }
 
+/** Prefer a candidate only when no result exists or it replaces a synthetic repair. */
+function shouldUseCandidateToolResult(
+  existing: AgentMessageLike | undefined,
+  candidate: AgentMessageLike,
+): boolean {
+  return (
+    !existing ||
+    (isSyntheticMissingToolResult(existing) && !isSyntheticMissingToolResult(candidate))
+  );
+}
+
 function makeMissingToolResult(params: {
   toolCallId: string;
   toolName?: string;
@@ -331,11 +342,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       const existingIndex = toolResultPositions.get(id);
       if (existingIndex !== undefined) {
         const existing = out[existingIndex];
-        if (
-          existing &&
-          isSyntheticMissingToolResult(existing) &&
-          !isSyntheticMissingToolResult(msg)
-        ) {
+        if (existing && shouldUseCandidateToolResult(existing, msg)) {
           out[existingIndex] = msg;
         }
       }
@@ -486,15 +493,10 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
                 continue;
               }
               const existing = spanResultsById.get(id);
-              if (!existing) {
+              if (shouldUseCandidateToolResult(existing, candidate)) {
                 spanResultsById.set(id, candidate);
-              } else if (
-                isSyntheticMissingToolResult(existing) &&
-                !isSyntheticMissingToolResult(candidate)
-              ) {
-                spanResultsById.set(id, candidate);
-                droppedDuplicateCount += 1;
-              } else {
+              }
+              if (existing) {
                 droppedDuplicateCount += 1;
               }
               moved = true;
@@ -523,16 +525,10 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
             continue;
           }
           const existing = spanResultsById.get(id);
-          if (!existing) {
+          if (shouldUseCandidateToolResult(existing, next)) {
             spanResultsById.set(id, next);
-          } else if (
-            isSyntheticMissingToolResult(existing) &&
-            !isSyntheticMissingToolResult(next)
-          ) {
-            spanResultsById.set(id, next);
-            droppedDuplicateCount += 1;
-            changed = true;
-          } else {
+          }
+          if (existing) {
             droppedDuplicateCount += 1;
             changed = true;
           }
@@ -562,11 +558,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
         continue;
       }
       const existing = laterResultsById.get(id);
-      if (
-        !existing ||
-        (isSyntheticMissingToolResult(existing.message) &&
-          !isSyntheticMissingToolResult(candidate))
-      ) {
+      if (shouldUseCandidateToolResult(existing?.message, candidate)) {
         laterResultsById.set(id, { message: candidate, index: k });
       }
     }
@@ -581,12 +573,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     for (const call of toolCalls) {
       let existing = spanResultsById.get(call.id);
       const later = laterResultsById.get(call.id);
-      if (
-        later &&
-        (!existing ||
-          (isSyntheticMissingToolResult(existing) &&
-            !isSyntheticMissingToolResult(later.message)))
-      ) {
+      if (later && shouldUseCandidateToolResult(existing, later.message)) {
         existing = later.message;
         movedToolResultIndexes.add(later.index);
         moved = true;

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -255,6 +255,22 @@ function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
 
 // -- Repair logic (from session-transcript-repair.ts) --
 
+const MISSING_TOOL_RESULT_TEXT =
+  "[lossless-claw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+
+function isSyntheticMissingToolResult(message: AgentMessageLike): boolean {
+  if (message.isError !== true || !Array.isArray(message.content)) {
+    return false;
+  }
+  return message.content.some(
+    (block) =>
+      !!block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      (block as { text?: unknown }).text === MISSING_TOOL_RESULT_TEXT,
+  );
+}
+
 function makeMissingToolResult(params: {
   toolCallId: string;
   toolName?: string;
@@ -266,7 +282,7 @@ function makeMissingToolResult(params: {
     content: [
       {
         type: "text",
-        text: "[lossless-claw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+        text: MISSING_TOOL_RESULT_TEXT,
       },
     ],
     isError: true,
@@ -289,6 +305,7 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
 ): T[] {
   const out: T[] = [];
   const seenToolResultIds = new Set<string>();
+  const toolResultPositions = new Map<string, number>();
   const seenToolUseIds = new Set<string>();
   const movedToolResultIndexes = new Set<number>();
   let droppedDuplicateCount = 0;
@@ -311,12 +328,24 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
   const pushToolResult = (msg: T) => {
     const id = extractToolResultId(msg);
     if (id && seenToolResultIds.has(id)) {
+      const existingIndex = toolResultPositions.get(id);
+      if (existingIndex !== undefined) {
+        const existing = out[existingIndex];
+        if (
+          existing &&
+          isSyntheticMissingToolResult(existing) &&
+          !isSyntheticMissingToolResult(msg)
+        ) {
+          out[existingIndex] = msg;
+        }
+      }
       droppedDuplicateCount += 1;
       changed = true;
       return;
     }
     if (id) {
       seenToolResultIds.add(id);
+      toolResultPositions.set(id, out.length);
     }
     out.push(msg);
   };
@@ -451,12 +480,23 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
                 continue;
               }
               movedToolResultIndexes.add(k);
-              if (seenToolResultIds.has(id) || spanResultsById.has(id)) {
+              if (seenToolResultIds.has(id)) {
                 droppedDuplicateCount += 1;
                 changed = true;
                 continue;
               }
-              spanResultsById.set(id, candidate);
+              const existing = spanResultsById.get(id);
+              if (!existing) {
+                spanResultsById.set(id, candidate);
+              } else if (
+                isSyntheticMissingToolResult(existing) &&
+                !isSyntheticMissingToolResult(candidate)
+              ) {
+                spanResultsById.set(id, candidate);
+                droppedDuplicateCount += 1;
+              } else {
+                droppedDuplicateCount += 1;
+              }
               moved = true;
               changed = true;
             }
@@ -477,12 +517,25 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       if (nextRole === "toolResult") {
         const id = extractToolResultId(next);
         if (id && toolCallIds.has(id)) {
-          if (seenToolResultIds.has(id) || spanResultsById.has(id)) {
+          if (seenToolResultIds.has(id)) {
             droppedDuplicateCount += 1;
             changed = true;
             continue;
           }
-          spanResultsById.set(id, next);
+          const existing = spanResultsById.get(id);
+          if (!existing) {
+            spanResultsById.set(id, next);
+          } else if (
+            isSyntheticMissingToolResult(existing) &&
+            !isSyntheticMissingToolResult(next)
+          ) {
+            spanResultsById.set(id, next);
+            droppedDuplicateCount += 1;
+            changed = true;
+          } else {
+            droppedDuplicateCount += 1;
+            changed = true;
+          }
           continue;
         }
       }
@@ -495,6 +548,29 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       }
     }
 
+    const laterResultsById = new Map<string, { message: T; index: number }>();
+    for (let k = j + 1; k < messages.length; k += 1) {
+      if (movedToolResultIndexes.has(k)) {
+        continue;
+      }
+      const candidate = messages[k];
+      if (!candidate || typeof candidate !== "object" || candidate.role !== "toolResult") {
+        continue;
+      }
+      const id = extractToolResultId(candidate);
+      if (!id || !toolCallIds.has(id) || seenToolResultIds.has(id)) {
+        continue;
+      }
+      const existing = laterResultsById.get(id);
+      if (
+        !existing ||
+        (isSyntheticMissingToolResult(existing.message) &&
+          !isSyntheticMissingToolResult(candidate))
+      ) {
+        laterResultsById.set(id, { message: candidate, index: k });
+      }
+    }
+
     out.push(assistantMsg);
 
     if (spanResultsById.size > 0 && remainder.length > 0) {
@@ -503,7 +579,19 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     }
 
     for (const call of toolCalls) {
-      const existing = spanResultsById.get(call.id);
+      let existing = spanResultsById.get(call.id);
+      const later = laterResultsById.get(call.id);
+      if (
+        later &&
+        (!existing ||
+          (isSyntheticMissingToolResult(existing) &&
+            !isSyntheticMissingToolResult(later.message)))
+      ) {
+        existing = later.message;
+        movedToolResultIndexes.add(later.index);
+        moved = true;
+        changed = true;
+      }
       if (existing) {
         pushToolResult(existing);
       } else {

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -1378,6 +1378,66 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_2");
   });
 
+  it("preserves real results displaced past later fresh-tail tool calls", async () => {
+    const engine = createEngine();
+    const sessionId = "session-displaced-real-tool-results";
+
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "Check both files." } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_a", name: "read", input: { path: "a.txt" } }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_b", name: "read", input: { path: "b.txt" } }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_a",
+        toolName: "read",
+        content: [{ type: "text", text: "real result A" }],
+      } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_b",
+        toolName: "read",
+        content: [{ type: "text", text: "real result B" }],
+      } as AgentMessage,
+    });
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [],
+      tokenBudget: 10_000,
+    });
+
+    const resultByCallId = new Map(
+      result.messages
+        .filter((message) => message.role === "toolResult")
+        .map((message) => [(message as { toolCallId?: string }).toolCallId, message]),
+    );
+    expect(resultByCallId.size).toBe(2);
+    expect(JSON.stringify(resultByCallId.get("call_a")?.content)).toContain("real result A");
+    expect(JSON.stringify(resultByCallId.get("call_b")?.content)).toContain("real result B");
+    expect(JSON.stringify(result.messages)).not.toContain(
+      "[lossless-claw] missing tool result in session history",
+    );
+  });
+
   it("protects repaired fresh-tail assistant messages after cross-message tool-use dedupe", async () => {
     const engine = createEngineWithConfig({ freshTailCount: 3 });
     const sessionId = "session-fresh-tail-dedupe-protection";

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -132,6 +132,129 @@ describe("sanitizeToolUseResultPairing", () => {
     ]);
   });
 
+  it("prefers a later real result over an earlier synthetic repair result", () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_real", name: "read", input: {} }],
+    };
+    const synthetic = {
+      role: "toolResult",
+      toolCallId: "call_real",
+      toolName: "read",
+      content: [
+        {
+          type: "text",
+          text: "[lossless-claw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+        },
+      ],
+      isError: true,
+    };
+    const real = {
+      role: "toolResult",
+      toolCallId: "call_real",
+      toolName: "read",
+      content: [{ type: "text", text: "real output" }],
+      isError: false,
+    };
+
+    expect(sanitizeToolUseResultPairing([assistant, synthetic, real])).toEqual([
+      assistant,
+      real,
+    ]);
+  });
+
+  it("finds real results displaced past a later assistant tool-call turn", () => {
+    const callA = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_a", name: "read", input: {} }],
+    };
+    const callB = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_b", name: "read", input: {} }],
+    };
+    const resultA = {
+      role: "toolResult",
+      toolCallId: "call_a",
+      toolName: "read",
+      content: [{ type: "text", text: "result A" }],
+    };
+    const resultB = {
+      role: "toolResult",
+      toolCallId: "call_b",
+      toolName: "read",
+      content: [{ type: "text", text: "result B" }],
+    };
+
+    expect(sanitizeToolUseResultPairing([callA, callB, resultA, resultB])).toEqual([
+      callA,
+      resultA,
+      callB,
+      resultB,
+    ]);
+  });
+
+  it("does not classify a real error containing the repair marker as synthetic", () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_error", name: "read", input: {} }],
+    };
+    const realError = {
+      role: "toolResult",
+      toolCallId: "call_error",
+      toolName: "read",
+      content: [
+        {
+          type: "text",
+          text: "Provider returned [lossless-claw] missing tool result with additional real context.",
+        },
+      ],
+      isError: true,
+    };
+    const laterReal = {
+      role: "toolResult",
+      toolCallId: "call_error",
+      toolName: "read",
+      content: [{ type: "text", text: "later output" }],
+      isError: false,
+    };
+
+    expect(sanitizeToolUseResultPairing([assistant, realError, laterReal])).toEqual([
+      assistant,
+      realError,
+    ]);
+  });
+
+  it("keeps a real result when a synthetic duplicate appears later", () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_first_real", name: "read", input: {} }],
+    };
+    const real = {
+      role: "toolResult",
+      toolCallId: "call_first_real",
+      toolName: "read",
+      content: [{ type: "text", text: "real output" }],
+      isError: false,
+    };
+    const synthetic = {
+      role: "toolResult",
+      toolCallId: "call_first_real",
+      toolName: "read",
+      content: [
+        {
+          type: "text",
+          text: "[lossless-claw] missing tool result in session history; inserted synthetic error result for transcript repair.",
+        },
+      ],
+      isError: true,
+    };
+
+    expect(sanitizeToolUseResultPairing([assistant, real, synthetic])).toEqual([
+      assistant,
+      real,
+    ]);
+  });
+
   // -- Duplicate assistant tool_use dedup (INC-2026-03-24 class) --
 
   type Block = { type?: string; id?: string; call_id?: string; name?: string; text?: string };


### PR DESCRIPTION
## What

Preserve real tool results when assembled history contains an earlier synthetic repair result or places the real result after a later assistant tool-call turn.

Closes #992.

## Why

Lossless Claw's transcript sanitizer kept the first result for a call ID and stopped searching at the next assistant tool-call turn. A synthetic missing-result row could therefore replace a real result that remained present later in canonical storage, polluting subsequent context with a false error.

## Changes

- Prefer real results over synthetic repairs
- Recover results beyond later tool-call turns
- Match the synthetic marker exactly
- Add unit and assembly regressions
- Add a patch Changeset

## Testing

- `npm test`: 96 files, 1,724 tests passed
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run`
- Thermonuclear review: no findings
- Autoreview: clean, no actionable findings
