### PR TITLE
fix: bound delegated expansion by request deadline

### DIFF
--- a/.changeset/bounded-delegated-expansion.md
+++ b/.changeset/bounded-delegated-expansion.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Bound each delegated recall request by one deadline, abort timed-out child runs, preserve completed cross-conversation evidence, and return structured failure diagnostics.
+Bound each delegated recall request by one deadline, cancel timed-out child work through host-owned session cleanup, preserve completed cross-conversation evidence, and return structured failure diagnostics.

--- a/.changeset/bounded-delegated-expansion.md
+++ b/.changeset/bounded-delegated-expansion.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Bound each delegated recall request by one deadline, abort timed-out child runs, preserve completed cross-conversation evidence, and return structured failure diagnostics.

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -144,7 +144,7 @@ When `allConversations: true` is set, `lcm_expand_query` can synthesize one answ
 - `truncated` — Whether source expansion was truncated or any selected conversation was skipped or failed
 - `conversationBreakdown` — Optional per-conversation success/failure diagnostics for bounded multi-conversation runs
 
-Successful single-conversation results keep the response shape above. When delegated recall fails, the result keeps the human-readable `error` and adds `errorCode`, empty source counters, and a `conversationBreakdown`. Failed entries identify the conversation, attempted summary IDs, failure phase, elapsed time, and error code. A timed-out child run is aborted before its temporary session is cleaned up. Completed conversation buckets still contribute evidence when another bucket times out; timed-out buckets do not contribute guessed answer text or citations.
+Successful single-conversation results keep the response shape above. When delegated recall fails, the result keeps the human-readable `error` and adds `errorCode`, empty source counters, and a `conversationBreakdown`. Failed entries identify the conversation, attempted summary IDs, failure phase, elapsed time, and error code. Timed-out child work is cancelled through the host-owned temporary-session cleanup path. Completed conversation buckets still contribute evidence when another bucket times out; timed-out buckets do not contribute guessed answer text or citations.
 
 **Examples:**
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -119,7 +119,7 @@ lcm_describe(id: "file_789abc012345")
 
 Answer a focused question by expanding summaries through the DAG. Spawns a bounded sub-agent that walks parent links down to source material and returns a compact answer.
 
-When `allConversations: true` is set, `lcm_expand_query` can now synthesize one answer across multiple conversations. That cross-conversation mode is bounded, not exhaustive: it ranks conversation buckets, expands only the top few, and marks the result truncated when lower-ranked buckets are skipped or fail.
+When `allConversations: true` is set, `lcm_expand_query` can synthesize one answer across multiple conversations. That cross-conversation mode is bounded, not exhaustive: it ranks conversation buckets, expands only the top few under one shared deadline, and marks the result truncated when lower-ranked buckets are skipped or fail. The selected buckets share the existing `tokenCap`, so concurrent recall does not multiply the retrieval budget.
 
 **Parameters:**
 
@@ -141,8 +141,10 @@ When `allConversations: true` is set, `lcm_expand_query` can now synthesize one 
 - `sourceConversationIds` — Conversations that were successfully expanded
 - `expandedSummaryCount` — How many summaries were expanded
 - `totalSourceTokens` — Total tokens read from the DAG
-- `truncated` — Whether the answer was truncated to fit maxTokens
+- `truncated` — Whether source expansion was truncated or any selected conversation was skipped or failed
 - `conversationBreakdown` — Optional per-conversation success/failure diagnostics for bounded multi-conversation runs
+
+Successful single-conversation results keep the response shape above. When delegated recall fails, the result keeps the human-readable `error` and adds `errorCode`, empty source counters, and a `conversationBreakdown`. Failed entries identify the conversation, attempted summary IDs, failure phase, elapsed time, and error code. A timed-out child run is aborted before its temporary session is cleaned up. Completed conversation buckets still contribute evidence when another bucket times out; timed-out buckets do not contribute guessed answer text or citations.
 
 **Examples:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,7 +272,7 @@ the raw copied transcript.
 | `largeFileSummaryProvider` | `string` | `""` | `LCM_LARGE_FILE_SUMMARY_PROVIDER` | Large-file summarizer provider hint for bare model names. |
 | `expansionModel` | `string` | `""` | `LCM_EXPANSION_MODEL` | `lcm_expand_query` sub-agent model override. |
 | `expansionProvider` | `string` | `""` | `LCM_EXPANSION_PROVIDER` | `lcm_expand_query` sub-agent provider hint for bare model names. |
-| `delegationTimeoutMs` | `integer` | `120000` | `LCM_DELEGATION_TIMEOUT_MS` | Maximum time to wait for delegated expansion work. `lcm_expand_query` advertises a dynamic tool `timeoutMs` default with 30 seconds of extra RPC headroom so OpenClaw's tool watchdog does not fire before this wait completes. |
+| `delegationTimeoutMs` | `integer` | `120000` | `LCM_DELEGATION_TIMEOUT_MS` | Maximum wall-clock budget for delegated expansion work across one `lcm_expand_query` call. Cross-conversation buckets share this deadline. The dynamic tool advertises a `timeoutMs` default with 30 seconds of extra RPC headroom for cancellation, cleanup, and result delivery. |
 | `summaryTimeoutMs` | `integer` | `60000` | `LCM_SUMMARY_TIMEOUT_MS` | Maximum time to wait for one model-backed summarizer call. |
 | `summaryCallWindowMs` | `integer` | `600000` | `LCM_SUMMARY_CALL_WINDOW_MS` | Rolling window for the per-session summarization spend guard. |
 | `summaryMaxCallsPerWindow` | `integer` | `24` | `LCM_SUMMARY_MAX_CALLS_PER_WINDOW` | Maximum model-backed summarization calls per session/window before Lossless opens a non-auth spend backoff. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -177,7 +177,7 @@
     },
     "delegationTimeoutMs": {
       "label": "Delegation Timeout (ms)",
-      "help": "Maximum time to wait for delegated lcm_expand_query sub-agent completion before timing out"
+      "help": "Wall-clock budget shared by delegated work in one lcm_expand_query call; the tool keeps 30 seconds of RPC headroom for cancellation and cleanup"
     },
     "summaryTimeoutMs": {
       "label": "Summary Timeout (ms)",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -581,12 +581,12 @@ See high-impact settings above.
 
 ### `delegationTimeoutMs`
 
-Maximum time to wait for delegated recall completion.
+Maximum wall-clock budget for delegated recall work across one `lcm_expand_query` call. Cross-conversation buckets share this deadline, and the tool keeps 30 seconds of RPC headroom for cancellation, cleanup, and result delivery.
 
 Why it matters:
 
 - lower values fail faster under slow sub-agent paths
-- higher values tolerate deeper recall but can make calls feel stuck longer
+- higher values give the bounded recall request more time to finish
 
 ### `maxAssemblyTokenBudget`
 

--- a/skills/lossless-claw/references/recall-tools.md
+++ b/skills/lossless-claw/references/recall-tools.md
@@ -33,6 +33,8 @@ Use for:
 - focused questions that need richer detail recovered from summaries
 - evidence-oriented follow-up after `lcm_grep` or `lcm_describe`
 
+Cross-conversation expansion runs its selected conversation buckets under one shared deadline and one shared token budget. Completed buckets still return evidence when a sibling bucket times out. Failure results identify the affected conversation, summary IDs, phase, and error code; they never invent answer text for interrupted work.
+
 This is the best recall tool when the user asks for:
 
 - exact commands

--- a/src/tools/lcm-expand-query-delegation.ts
+++ b/src/tools/lcm-expand-query-delegation.ts
@@ -1,0 +1,587 @@
+import crypto from "node:crypto";
+import {
+  createDelegatedExpansionGrant,
+  revokeDelegatedExpansionGrantForSession,
+} from "../expansion-auth.js";
+import type { LcmDependencies } from "../types.js";
+import { remainingDeadlineMs, type ExpansionDeadline } from "./lcm-expansion-deadline.js";
+import { normalizeSummaryIds } from "./lcm-expand-tool.delegation.js";
+import {
+  clearDelegatedExpansionContext,
+  recordExpansionDelegationTelemetry,
+  stampDelegatedExpansionContext,
+} from "./lcm-expansion-recursion-guard.js";
+
+const GATEWAY_TIMEOUT_MS = 10_000;
+
+export type DelegatedExpandQueryReply = {
+  answer: string;
+  citedIds: string[];
+  expandedSummaryCount: number;
+  totalSourceTokens: number;
+  truncated: boolean;
+};
+
+export type DelegatedFailurePhase = "spawn" | "wait" | "read_reply" | "parse_reply";
+
+export type DelegatedFailureCode =
+  | "DELEGATED_EXPANSION_TIMEOUT"
+  | "DELEGATED_EXPANSION_SPAWN_FAILED"
+  | "DELEGATED_EXPANSION_WAIT_FAILED"
+  | "DELEGATED_EXPANSION_REPLY_MISSING"
+  | "DELEGATED_EXPANSION_REPLY_INVALID";
+
+export type DelegatedBucketOutcome =
+  | {
+      status: "success";
+      conversationId: number;
+      summaryIds: string[];
+      elapsedMs: number;
+      reply: DelegatedExpandQueryReply;
+    }
+  | {
+      status: "failed";
+      conversationId: number;
+      summaryIds: string[];
+      elapsedMs: number;
+      phase: DelegatedFailurePhase;
+      code: DelegatedFailureCode;
+      error: string;
+      timedOut: boolean;
+      cleanup: "complete" | "partial";
+    };
+
+export type DelegatedConversationBucket = {
+  conversationId: number;
+  summaryIds: string[];
+  messageBackedSummaryIds: string[];
+};
+
+type ParsedExpandQueryReply =
+  | { ok: true; value: DelegatedExpandQueryReply }
+  | { ok: false; error: string };
+
+type RunDelegatedExpandQueryParams = {
+  deps: LcmDependencies;
+  callerSessionKey: string;
+  requesterAgentId: string;
+  bucket: DelegatedConversationBucket;
+  query?: string;
+  prompt: string;
+  maxTokens: number;
+  tokenCap: number;
+  requestId: string;
+  childExpansionDepth: number;
+  originSessionKey: string;
+  deadline: ExpansionDeadline;
+  delegatedWaitTimeoutSeconds: number;
+};
+
+// Collect nested gateway/provider failure text without exposing object formatting artifacts.
+function collectExpansionFailureText(value: unknown, parts: string[], depth = 0): void {
+  if (depth > 3 || value == null) {
+    return;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed) {
+      parts.push(trimmed);
+    }
+    return;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    parts.push(String(value));
+    return;
+  }
+  if (value instanceof Error) {
+    if (value.message.trim()) {
+      parts.push(value.message.trim());
+    }
+    collectExpansionFailureText(value.cause, parts, depth + 1);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectExpansionFailureText(entry, parts, depth + 1);
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    for (const key of ["message", "error", "reason", "details", "response", "cause", "code"]) {
+      collectExpansionFailureText(record[key], parts, depth + 1);
+    }
+  }
+}
+
+/** Convert gateway and provider failures to the existing human-readable error text. */
+export function formatExpansionFailure(error: unknown): string {
+  const parts: string[] = [];
+  collectExpansionFailureText(error, parts);
+  const message = parts.join(" ").replace(/\s+/g, " ").trim();
+  if (message) {
+    return message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+  return "Delegated expansion query failed.";
+}
+
+// Retry only override/auth/model-selection failures that can succeed on the default route.
+function shouldRetryWithoutOverride(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return [
+    "model.request",
+    "missing scopes",
+    "insufficient scope",
+    "unauthorized",
+    "not authorized",
+    "forbidden",
+    "provider/model overrides are not authorized",
+    "model override is not authorized",
+    "not allowed for agent",
+    "not allowlisted for plugin",
+    "unknown model",
+    "model not found",
+    "invalid model",
+    "not available",
+    "not supported",
+    "401",
+    "403",
+  ].some((signal) => normalized.includes(signal));
+}
+
+// Map the phase model to the stable public failure code.
+function delegatedFailureCode(
+  phase: DelegatedFailurePhase,
+  timedOut: boolean,
+): DelegatedFailureCode {
+  if (timedOut) {
+    return "DELEGATED_EXPANSION_TIMEOUT";
+  }
+  switch (phase) {
+    case "spawn":
+      return "DELEGATED_EXPANSION_SPAWN_FAILED";
+    case "wait":
+      return "DELEGATED_EXPANSION_WAIT_FAILED";
+    case "read_reply":
+      return "DELEGATED_EXPANSION_REPLY_MISSING";
+    case "parse_reply":
+      return "DELEGATED_EXPANSION_REPLY_INVALID";
+  }
+}
+
+// Build the child task with explicit scope, budgets, and a machine-readable response contract.
+function buildDelegatedExpandQueryTask(params: {
+  summaryIds: string[];
+  messageBackedSummaryIds: string[];
+  conversationId: number;
+  query?: string;
+  prompt: string;
+  maxTokens: number;
+  tokenCap: number;
+  requestId: string;
+  expansionDepth: number;
+  originSessionKey: string;
+}) {
+  const seedSummaryIds = params.summaryIds.length > 0 ? params.summaryIds.join(", ") : "(none)";
+  const messageBackedSummaryIds =
+    params.messageBackedSummaryIds.length > 0
+      ? params.messageBackedSummaryIds.join(", ")
+      : "(none)";
+  return [
+    "You are an autonomous LCM retrieval navigator. Plan and execute retrieval before answering.",
+    "",
+    "Available tools: lcm_describe, lcm_expand, lcm_grep",
+    `Conversation scope: ${params.conversationId}`,
+    `Expansion token budget (total across this run): ${params.tokenCap}`,
+    `Seed summary IDs: ${seedSummaryIds}`,
+    `Seed summaries requiring raw message expansion: ${messageBackedSummaryIds}`,
+    params.query ? `Routing query: ${params.query}` : undefined,
+    "",
+    "Strategy:",
+    "1. Start with `lcm_describe` on seed summaries to inspect subtree manifests and branch costs.",
+    "2. If additional candidates are needed, use `lcm_grep` scoped to summaries. Prefer `mode: \"full_text\"` for short literal terms, use `mode: \"regex\"` for alternation or other regex syntax, quote exact multi-word phrases, use `sort: \"relevance\"` for older-topic recall, and `sort: \"hybrid\"` when recency should still matter.",
+    "3. Select branches that fit remaining budget; prefer high-signal paths first.",
+    "4. Call `lcm_expand` selectively (do not expand everything blindly).",
+    "5. Keep includeMessages=false by default; use includeMessages=true for the message-backed seed summaries above and any other specific leaf evidence.",
+    `6. Stay within ${params.tokenCap} total expansion tokens across all lcm_expand calls.`,
+    "",
+    "User prompt to answer:",
+    params.prompt,
+    "",
+    "Delegated expansion metadata (for tracing):",
+    `- requestId: ${params.requestId}`,
+    `- expansionDepth: ${params.expansionDepth}`,
+    `- originSessionKey: ${params.originSessionKey}`,
+    "",
+    "Return ONLY JSON with this shape:",
+    "{",
+    '  "answer": "string",',
+    '  "citedIds": ["sum_xxx"],',
+    '  "expandedSummaryCount": 0,',
+    '  "totalSourceTokens": 0,',
+    '  "truncated": false',
+    "}",
+    "",
+    "Rules:",
+    "- In delegated context, call `lcm_expand` directly for source retrieval.",
+    "- DO NOT call `lcm_expand_query` from this delegated session.",
+    "- Synthesize the final answer from retrieved evidence, not assumptions.",
+    `- Keep answer concise and focused (target <= ${params.maxTokens} tokens).`,
+    "- citedIds must be unique summary IDs.",
+    "- expandedSummaryCount should reflect how many summaries were expanded/used.",
+    "- totalSourceTokens should estimate the total source tokens consumed for retrieval. Include both: (a) the `totalTokens` returned by each `lcm_expand` call you made, AND (b) for any explicit leaf summary used as evidence, the leaf summary's own `tok` value from `lcm_describe`, even if you did not call `lcm_expand` for that leaf. This avoids reporting `totalSourceTokens: 0` when the answer was actually derived from a leaf summary's content.",
+    "- truncated should indicate whether source expansion appears truncated.",
+  ]
+    .filter((line): line is string => typeof line === "string")
+    .join("\n");
+}
+
+// Format a bounded reply excerpt for parse failures.
+function formatInvalidDelegatedReply(reply: string, reason: string): string {
+  const compact = reply.replace(/\s+/g, " ").trim();
+  const snippet = compact.length <= 240 ? compact : `${compact.slice(0, 240)}...`;
+  return `Delegated expansion query returned ${reason}: ${snippet}`;
+}
+
+// Validate the untrusted child reply before using it in the public tool result.
+function parseDelegatedExpandQueryReply(
+  rawReply: string,
+  fallbackExpandedSummaryCount: number,
+): ParsedExpandQueryReply {
+  const reply = rawReply.trim();
+  const candidates: string[] = [reply];
+  const fenced = reply.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) {
+    candidates.unshift(fenced[1].trim());
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as {
+        answer?: unknown;
+        citedIds?: unknown;
+        expandedSummaryCount?: unknown;
+        totalSourceTokens?: unknown;
+        truncated?: unknown;
+      };
+      const answer = typeof parsed.answer === "string" ? parsed.answer.trim() : "";
+      if (!answer) {
+        return {
+          ok: false,
+          error: formatInvalidDelegatedReply(reply, 'JSON without a non-empty "answer"'),
+        };
+      }
+      const citedIds = normalizeSummaryIds(
+        Array.isArray(parsed.citedIds)
+          ? parsed.citedIds.filter((value): value is string => typeof value === "string")
+          : undefined,
+      );
+      const expandedSummaryCount =
+        typeof parsed.expandedSummaryCount === "number" &&
+        Number.isFinite(parsed.expandedSummaryCount)
+          ? Math.max(0, Math.floor(parsed.expandedSummaryCount))
+          : fallbackExpandedSummaryCount;
+      const totalSourceTokens =
+        typeof parsed.totalSourceTokens === "number" && Number.isFinite(parsed.totalSourceTokens)
+          ? Math.max(0, Math.floor(parsed.totalSourceTokens))
+          : 0;
+      return {
+        ok: true,
+        value: {
+          answer,
+          citedIds,
+          expandedSummaryCount,
+          totalSourceTokens,
+          truncated: parsed.truncated === true,
+        },
+      };
+    } catch {
+      // Try the next plain or fenced JSON candidate.
+    }
+  }
+  return {
+    ok: false,
+    error: formatInvalidDelegatedReply(reply, "non-JSON output"),
+  };
+}
+
+// Run one child session, classify its terminal state, and finish owned cleanup.
+async function runDelegatedQueryAttempt(
+  params: RunDelegatedExpandQueryParams & { task: string; provider?: string; model?: string },
+): Promise<DelegatedBucketOutcome> {
+  const attemptStartedAtMs = performance.now();
+  const childSessionKey = `agent:${params.requesterAgentId}:subagent:${crypto.randomUUID()}`;
+  const childIdem = crypto.randomUUID();
+  let grantCreated = false;
+  let runId = "";
+  let phase: DelegatedFailurePhase = "spawn";
+  let timedOut = false;
+  let abortComplete = true;
+  let sessionCleanupComplete = false;
+  let outcome: DelegatedBucketOutcome;
+
+  try {
+    // Refuse new child work after candidate resolution has consumed the work budget.
+    if (remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()) <= 0) {
+      phase = "wait";
+      timedOut = true;
+      throw new Error(
+        `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
+      );
+    }
+
+    // Bind the temporary child to this bucket and the preallocated token cap.
+    createDelegatedExpansionGrant({
+      delegatedSessionKey: childSessionKey,
+      issuerSessionId: params.callerSessionKey || "main",
+      allowedConversationIds: [params.bucket.conversationId],
+      tokenCap: params.tokenCap,
+      ttlMs: Math.max(
+        1,
+        remainingDeadlineMs(params.deadline.totalDeadlineMs, performance.now()),
+      ),
+    });
+    stampDelegatedExpansionContext({
+      sessionKey: childSessionKey,
+      requestId: params.requestId,
+      expansionDepth: params.childExpansionDepth,
+      originSessionKey: params.originSessionKey,
+      stampedBy: "lcm_expand_query",
+    });
+    grantCreated = true;
+
+    // Spawn and wait consume the same absolute work deadline.
+    const spawnTimeoutMs = Math.max(
+      1,
+      Math.min(
+        GATEWAY_TIMEOUT_MS,
+        remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
+      ),
+    );
+    const response = (await params.deps.callGateway({
+      method: "agent",
+      params: {
+        message: params.task,
+        sessionKey: childSessionKey,
+        deliver: false,
+        lane: params.deps.agentLaneSubagent,
+        idempotencyKey: childIdem,
+        ...(params.provider ? { provider: params.provider } : {}),
+        ...(params.model ? { model: params.model } : {}),
+        extraSystemPrompt: params.deps.buildSubagentSystemPrompt({
+          depth: 1,
+          maxDepth: 8,
+          taskSummary: "Run lcm_expand and return prompt-focused JSON answer",
+        }),
+      },
+      timeoutMs: spawnTimeoutMs,
+    })) as { runId?: unknown; error?: unknown };
+
+    runId = typeof response?.runId === "string" ? response.runId.trim() : "";
+    if (!runId) {
+      throw new Error(
+        response?.error == null
+          ? "Delegated expansion did not return a runId."
+          : formatExpansionFailure(response.error),
+      );
+    }
+
+    phase = "wait";
+    const waitTimeoutMs = Math.max(
+      1,
+      remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
+    );
+    const wait = (await params.deps.callGateway({
+      method: "agent.wait",
+      params: { runId, timeoutMs: waitTimeoutMs },
+      timeoutMs: waitTimeoutMs,
+    })) as { status?: string; error?: unknown };
+    const status = typeof wait?.status === "string" ? wait.status : "error";
+    if (status === "timeout") {
+      timedOut = true;
+      recordExpansionDelegationTelemetry({
+        deps: params.deps,
+        component: "lcm_expand_query",
+        event: "timeout",
+        requestId: params.requestId,
+        sessionKey: params.callerSessionKey,
+        expansionDepth: params.childExpansionDepth,
+        originSessionKey: params.originSessionKey,
+        runId,
+      });
+      throw new Error(
+        `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
+      );
+    }
+    if (status !== "ok") {
+      throw new Error(formatExpansionFailure(wait?.error));
+    }
+
+    // Read and validate the terminal child reply before treating the bucket as evidence.
+    const replyTimeoutMs = remainingDeadlineMs(
+      params.deadline.workDeadlineMs,
+      performance.now(),
+    );
+    if (replyTimeoutMs <= 0) {
+      timedOut = true;
+      throw new Error(
+        `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
+      );
+    }
+    phase = "read_reply";
+    const replyPayload = (await params.deps.callGateway({
+      method: "sessions.get",
+      params: { key: childSessionKey, limit: 80 },
+      timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, replyTimeoutMs),
+    })) as { messages?: unknown[] };
+    const reply = params.deps.readLatestAssistantReply(
+      Array.isArray(replyPayload.messages) ? replyPayload.messages : [],
+    );
+    if (!reply?.trim()) {
+      throw new Error("Delegated expansion query returned an empty reply.");
+    }
+    phase = "parse_reply";
+    const parsed = parseDelegatedExpandQueryReply(reply, params.bucket.summaryIds.length);
+    if (!parsed.ok) {
+      throw new Error(parsed.error);
+    }
+    recordExpansionDelegationTelemetry({
+      deps: params.deps,
+      component: "lcm_expand_query",
+      event: "success",
+      requestId: params.requestId,
+      sessionKey: params.callerSessionKey,
+      expansionDepth: params.childExpansionDepth,
+      originSessionKey: params.originSessionKey,
+      runId,
+    });
+    outcome = {
+      status: "success",
+      conversationId: params.bucket.conversationId,
+      summaryIds: params.bucket.summaryIds,
+      elapsedMs: 0,
+      reply: parsed.value,
+    };
+  } catch (error) {
+    // Expected gateway and reply failures become typed outcomes for public accounting.
+    outcome = {
+      status: "failed",
+      conversationId: params.bucket.conversationId,
+      summaryIds: params.bucket.summaryIds,
+      elapsedMs: 0,
+      phase,
+      code: delegatedFailureCode(phase, timedOut),
+      error: formatExpansionFailure(error),
+      timedOut,
+      cleanup: "partial",
+    };
+  } finally {
+    // Abort timed-out model work before deleting its temporary session.
+    if (timedOut && runId) {
+      const abortTimeoutMs = remainingDeadlineMs(
+        params.deadline.totalDeadlineMs,
+        performance.now(),
+      );
+      if (abortTimeoutMs <= 0) {
+        abortComplete = false;
+      } else {
+        try {
+          await params.deps.callGateway({
+            method: "sessions.abort",
+            params: { key: childSessionKey, runId },
+            timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, abortTimeoutMs),
+          });
+        } catch {
+          abortComplete = false;
+        }
+      }
+    }
+
+    // Cleanup may use only the headroom left before the total tool deadline.
+    const cleanupTimeoutMs = remainingDeadlineMs(
+      params.deadline.totalDeadlineMs,
+      performance.now(),
+    );
+    if (!grantCreated) {
+      sessionCleanupComplete = true;
+    } else if (cleanupTimeoutMs > 0) {
+      try {
+        await params.deps.callGateway({
+          method: "sessions.delete",
+          params: { key: childSessionKey, deleteTranscript: true },
+          timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, cleanupTimeoutMs),
+        });
+        sessionCleanupComplete = true;
+      } catch {
+        // Cleanup is best-effort.
+      }
+    }
+    if (grantCreated) {
+      revokeDelegatedExpansionGrantForSession(childSessionKey, { removeBinding: true });
+    }
+    clearDelegatedExpansionContext(childSessionKey);
+  }
+
+  const elapsedMs = Math.max(0, Math.floor(performance.now() - attemptStartedAtMs));
+  if (outcome.status === "success") {
+    return { ...outcome, elapsedMs };
+  }
+  return {
+    ...outcome,
+    elapsedMs,
+    cleanup: abortComplete && sessionCleanupComplete ? "complete" : "partial",
+  };
+}
+
+/** Run one delegated expansion bucket, including authorized override fallback. */
+export async function runDelegatedExpandQuery(
+  params: RunDelegatedExpandQueryParams,
+): Promise<DelegatedBucketOutcome> {
+  const task = buildDelegatedExpandQueryTask({
+    summaryIds: params.bucket.summaryIds,
+    messageBackedSummaryIds: params.bucket.messageBackedSummaryIds,
+    conversationId: params.bucket.conversationId,
+    query: params.query,
+    prompt: params.prompt,
+    maxTokens: params.maxTokens,
+    tokenCap: params.tokenCap,
+    requestId: params.requestId,
+    expansionDepth: params.childExpansionDepth,
+    originSessionKey: params.originSessionKey,
+  });
+  const expansionProvider = params.deps.config.expansionProvider || undefined;
+  const expansionModel = params.deps.config.expansionModel || undefined;
+  const canonicalExpansionModel = expansionModel?.includes("/") ? expansionModel : undefined;
+  const overrideProvider = canonicalExpansionModel ? undefined : expansionProvider;
+  const overrideModel = canonicalExpansionModel || expansionModel;
+  if (!expansionProvider && !expansionModel) {
+    return await runDelegatedQueryAttempt({ ...params, task });
+  }
+
+  const outcome = await runDelegatedQueryAttempt({
+    ...params,
+    task,
+    provider: overrideProvider,
+    model: overrideModel,
+  });
+  if (outcome.status === "success") {
+    return outcome;
+  }
+  const overrideLabel =
+    overrideProvider && overrideModel
+      ? `${overrideProvider}/${overrideModel}`
+      : overrideModel || overrideProvider || "configured override";
+  params.deps.log.warn(
+    `[lcm] delegated expansion override failed (${overrideLabel}) for conversation ${params.bucket.conversationId}: ${outcome.error}`,
+  );
+  if (!shouldRetryWithoutOverride(outcome.error)) {
+    return outcome;
+  }
+  params.deps.log.warn(
+    `[lcm] retrying delegated expansion without provider/model override after: ${outcome.error}`,
+  );
+  return await runDelegatedQueryAttempt({ ...params, task });
+}

--- a/src/tools/lcm-expand-query-delegation.ts
+++ b/src/tools/lcm-expand-query-delegation.ts
@@ -319,7 +319,6 @@ async function runDelegatedQueryAttempt(
   let runId = "";
   let phase: DelegatedFailurePhase = "spawn";
   let timedOut = false;
-  let abortComplete = true;
   let sessionCleanupComplete = false;
   let outcome: DelegatedBucketOutcome;
 
@@ -479,27 +478,7 @@ async function runDelegatedQueryAttempt(
       cleanup: "partial",
     };
   } finally {
-    // Abort timed-out model work before deleting its temporary session.
-    if (timedOut && runId) {
-      const abortTimeoutMs = remainingDeadlineMs(
-        params.deadline.totalDeadlineMs,
-        performance.now(),
-      );
-      if (abortTimeoutMs <= 0) {
-        abortComplete = false;
-      } else {
-        try {
-          await params.deps.callGateway({
-            method: "sessions.abort",
-            params: { key: childSessionKey, runId },
-            timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, abortTimeoutMs),
-          });
-        } catch {
-          abortComplete = false;
-        }
-      }
-    }
-
+    // The host-owned deletion path cancels active child work before removing its session.
     // Cleanup may use only the headroom left before the total tool deadline.
     const cleanupTimeoutMs = remainingDeadlineMs(
       params.deadline.totalDeadlineMs,
@@ -532,7 +511,7 @@ async function runDelegatedQueryAttempt(
   return {
     ...outcome,
     elapsedMs,
-    cleanup: abortComplete && sessionCleanupComplete ? "complete" : "partial",
+    cleanup: sessionCleanupComplete ? "complete" : "partial",
   };
 }
 

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -9,6 +9,7 @@ import type { LcmDependencies } from "../types.js";
 import { jsonResult, type AnyAgentTool } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import {
+  allocateExpansionTokenCaps,
   createExpansionDeadline,
   remainingDeadlineMs,
   type ExpansionDeadline,
@@ -102,6 +103,10 @@ type ConversationBreakdown = {
   truncated: boolean;
   status?: "success" | "failed" | "skipped";
   error?: string;
+  summaryIds?: string[];
+  phase?: DelegatedFailurePhase;
+  elapsedMs?: number;
+  errorCode?: DelegatedFailureCode;
 };
 
 type ExpandQueryReply = {
@@ -181,22 +186,13 @@ type ConversationBucket = {
 };
 
 type BucketExecutionResult =
-  | {
-      conversationId: number;
-      status: "success";
-      candidateCount: number;
-      reply: DelegatedExpandQueryReply;
-    }
-  | {
-      conversationId: number;
-      status: "failed";
-      candidateCount: number;
-      error: string;
-    }
+  | (Extract<DelegatedBucketOutcome, { status: "success" }> & { candidateCount: number })
+  | (Extract<DelegatedBucketOutcome, { status: "failed" }> & { candidateCount: number })
   | {
       conversationId: number;
       status: "skipped";
       candidateCount: number;
+      summaryIds: string[];
       error: string;
     };
 
@@ -496,6 +492,65 @@ function buildExpandQueryReply(params: {
     totalSourceTokens: params.totalSourceTokens,
     truncated: params.truncated,
     ...(params.conversationBreakdown ? { conversationBreakdown: params.conversationBreakdown } : {}),
+  };
+}
+
+/** Build the public per-conversation accounting for delegated bucket outcomes. */
+function buildConversationBreakdown(results: BucketExecutionResult[]): ConversationBreakdown[] {
+  return results.map((result) => {
+    if (result.status === "success") {
+      return {
+        conversationId: result.conversationId,
+        expandedSummaryCount: result.reply.expandedSummaryCount,
+        citedIds: result.reply.citedIds,
+        totalSourceTokens: result.reply.totalSourceTokens,
+        truncated: result.reply.truncated,
+        status: "success",
+      };
+    }
+    if (result.status === "failed") {
+      return {
+        conversationId: result.conversationId,
+        expandedSummaryCount: 0,
+        citedIds: [],
+        totalSourceTokens: 0,
+        truncated: true,
+        status: "failed",
+        summaryIds: result.summaryIds,
+        phase: result.phase,
+        elapsedMs: result.elapsedMs,
+        errorCode: result.code,
+        error: result.error,
+      };
+    }
+    return {
+      conversationId: result.conversationId,
+      expandedSummaryCount: 0,
+      citedIds: [],
+      totalSourceTokens: 0,
+      truncated: true,
+      status: "skipped",
+      error: result.error,
+    };
+  });
+}
+
+/** Preserve the legacy error text while adding structured failure accounting. */
+function buildDelegatedFailureReply(results: BucketExecutionResult[]) {
+  const firstFailure = results.find(
+    (result): result is Extract<BucketExecutionResult, { status: "failed" }> =>
+      result.status === "failed",
+  );
+  const error = firstFailure?.error ?? "Delegated expansion query failed.";
+  return {
+    error,
+    ...(firstFailure ? { errorCode: firstFailure.code } : {}),
+    truncated: true,
+    citedIds: [],
+    sourceConversationIds: [],
+    expandedSummaryCount: 0,
+    totalSourceTokens: 0,
+    conversationBreakdown: buildConversationBreakdown(results),
   };
 }
 
@@ -1380,7 +1435,11 @@ export function createLcmExpandQueryTool(input: {
             delegatedWaitTimeoutSeconds,
           });
           if (delegatedOutcome.status === "failed") {
-            throw new Error(delegatedOutcome.error);
+            return jsonResult(
+              buildDelegatedFailureReply([
+                { ...delegatedOutcome, candidateCount: bucket.candidateCount },
+              ]),
+            );
           }
           const delegatedReply = delegatedOutcome.reply;
 
@@ -1397,25 +1456,18 @@ export function createLcmExpandQueryTool(input: {
         }
 
         const rankedBuckets = [...conversationBuckets].sort(compareConversationBuckets);
-        const bucketResults: BucketExecutionResult[] = [];
-        const bucketsToExpand = rankedBuckets.slice(0, DEFAULT_MAX_CONVERSATION_BUCKETS);
-        const skippedBuckets = rankedBuckets.slice(DEFAULT_MAX_CONVERSATION_BUCKETS);
-        let remainingTokenCap = expansionTokenCap;
-        let firstFailure: string | undefined;
+        const selectedBuckets = rankedBuckets.slice(0, DEFAULT_MAX_CONVERSATION_BUCKETS);
+        const tokenAllocations = allocateExpansionTokenCaps({
+          bucketCount: selectedBuckets.length,
+          tokenCap: expansionTokenCap,
+        });
+        const runnableBuckets = selectedBuckets.slice(0, tokenAllocations.length);
+        const tokenSkippedBuckets = selectedBuckets.slice(tokenAllocations.length);
+        const limitSkippedBuckets = rankedBuckets.slice(DEFAULT_MAX_CONVERSATION_BUCKETS);
 
-        for (const bucket of bucketsToExpand) {
-          if (remainingTokenCap <= 0) {
-            bucketResults.push({
-              conversationId: bucket.conversationId,
-              status: "skipped",
-              candidateCount: bucket.candidateCount,
-              error: "global token budget exhausted",
-            });
-            continue;
-          }
-
-          try {
-            const delegatedOutcome = await runDelegatedExpandQuery({
+        const delegatedOutcomes = await Promise.all(
+          runnableBuckets.map((bucket, index) =>
+            runDelegatedExpandQuery({
               deps: input.deps,
               callerSessionKey,
               requesterAgentId,
@@ -1423,43 +1475,36 @@ export function createLcmExpandQueryTool(input: {
               query: query || undefined,
               prompt,
               maxTokens,
-              tokenCap: remainingTokenCap,
+              tokenCap: tokenAllocations[index] ?? 1,
               requestId,
               childExpansionDepth,
               originSessionKey,
               deadline,
               delegatedWaitTimeoutSeconds,
-            });
-            if (delegatedOutcome.status === "failed") {
-              throw new Error(delegatedOutcome.error);
-            }
-            const delegatedReply = delegatedOutcome.reply;
-            bucketResults.push({
-              conversationId: bucket.conversationId,
-              status: "success",
-              candidateCount: bucket.candidateCount,
-              reply: delegatedReply,
-            });
-            remainingTokenCap = Math.max(
-              0,
-              remainingTokenCap - Math.max(0, delegatedReply.totalSourceTokens),
-            );
-          } catch (error) {
-            const failure = formatExpansionFailure(error);
-            firstFailure ??= failure;
-            bucketResults.push({
-              conversationId: bucket.conversationId,
-              status: "failed",
-              candidateCount: bucket.candidateCount,
-              error: failure,
-            });
-          }
-        }
+            }),
+          ),
+        );
 
-        for (const bucket of skippedBuckets) {
+        const bucketResults: BucketExecutionResult[] = delegatedOutcomes.map(
+          (outcome, index) => ({
+            ...outcome,
+            candidateCount: runnableBuckets[index]?.candidateCount ?? outcome.summaryIds.length,
+          }),
+        );
+        for (const bucket of tokenSkippedBuckets) {
           bucketResults.push({
             conversationId: bucket.conversationId,
             status: "skipped",
+            summaryIds: bucket.summaryIds,
+            candidateCount: bucket.candidateCount,
+            error: "global token budget exhausted",
+          });
+        }
+        for (const bucket of limitSkippedBuckets) {
+          bucketResults.push({
+            conversationId: bucket.conversationId,
+            status: "skipped",
+            summaryIds: bucket.summaryIds,
             candidateCount: bucket.candidateCount,
             error: `skipped after reaching max conversation bucket limit (${DEFAULT_MAX_CONVERSATION_BUCKETS})`,
           });
@@ -1470,30 +1515,8 @@ export function createLcmExpandQueryTool(input: {
             result.status === "success",
         );
         if (successfulResults.length === 0) {
-          throw new Error(firstFailure ?? "Delegated expansion query failed.");
+          return jsonResult(buildDelegatedFailureReply(bucketResults));
         }
-
-        const conversationBreakdown: ConversationBreakdown[] = bucketResults.map((result) => {
-          if (result.status === "success") {
-            return {
-              conversationId: result.conversationId,
-              expandedSummaryCount: result.reply.expandedSummaryCount,
-              citedIds: result.reply.citedIds,
-              totalSourceTokens: result.reply.totalSourceTokens,
-              truncated: result.reply.truncated,
-              status: "success",
-            };
-          }
-          return {
-            conversationId: result.conversationId,
-            expandedSummaryCount: 0,
-            citedIds: [],
-            totalSourceTokens: 0,
-            truncated: true,
-            status: result.status,
-            error: result.error,
-          };
-        });
 
         return jsonResult(
           buildExpandQueryReply({
@@ -1514,7 +1537,7 @@ export function createLcmExpandQueryTool(input: {
             truncated:
               successfulResults.some((result) => result.reply.truncated)
               || bucketResults.some((result) => result.status !== "success"),
-            conversationBreakdown,
+            conversationBreakdown: buildConversationBreakdown(bucketResults),
           }),
         );
       } catch (error) {

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -1,18 +1,19 @@
 import { Type } from "@sinclair/typebox";
-import crypto from "node:crypto";
 import type { LcmContextEngine } from "../engine.js";
-import {
-  createDelegatedExpansionGrant,
-  revokeDelegatedExpansionGrantForSession,
-} from "../expansion-auth.js";
 import type { LcmDependencies } from "../types.js";
 import { jsonResult, type AnyAgentTool } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import {
+  formatExpansionFailure,
+  runDelegatedExpandQuery,
+  type DelegatedBucketOutcome,
+  type DelegatedExpandQueryReply,
+  type DelegatedFailureCode,
+  type DelegatedFailurePhase,
+} from "./lcm-expand-query-delegation.js";
+import {
   allocateExpansionTokenCaps,
   createExpansionDeadline,
-  remainingDeadlineMs,
-  type ExpansionDeadline,
 } from "./lcm-expansion-deadline.js";
 import {
   normalizeSummaryIds,
@@ -20,17 +21,14 @@ import {
 } from "./lcm-expand-tool.delegation.js";
 import {
   acquireExpansionConcurrencySlot,
-  clearDelegatedExpansionContext,
   evaluateExpansionRecursionGuard,
   recordExpansionDelegationTelemetry,
   releaseExpansionConcurrencySlot,
   resolveExpansionRequestId,
   resolveNextExpansionDepth,
-  stampDelegatedExpansionContext,
 } from "./lcm-expansion-recursion-guard.js";
 
 const DEFAULT_DELEGATED_WAIT_TIMEOUT_MS = 120_000;
-const GATEWAY_TIMEOUT_MS = 10_000;
 const DYNAMIC_TOOL_TIMEOUT_HEADROOM_MS = 30_000;
 const MAX_DYNAMIC_TOOL_TIMEOUT_MS = 600_000;
 const DEFAULT_MAX_ANSWER_TOKENS = 2_000;
@@ -120,53 +118,6 @@ type ExpandQueryReply = {
   sourceConversationId?: number;
 };
 
-type DelegatedExpandQueryReply = {
-  answer: string;
-  citedIds: string[];
-  expandedSummaryCount: number;
-  totalSourceTokens: number;
-  truncated: boolean;
-};
-
-type DelegatedFailurePhase = "spawn" | "wait" | "read_reply" | "parse_reply";
-
-type DelegatedFailureCode =
-  | "DELEGATED_EXPANSION_TIMEOUT"
-  | "DELEGATED_EXPANSION_SPAWN_FAILED"
-  | "DELEGATED_EXPANSION_WAIT_FAILED"
-  | "DELEGATED_EXPANSION_REPLY_MISSING"
-  | "DELEGATED_EXPANSION_REPLY_INVALID";
-
-type DelegatedBucketOutcome =
-  | {
-      status: "success";
-      conversationId: number;
-      summaryIds: string[];
-      elapsedMs: number;
-      reply: DelegatedExpandQueryReply;
-    }
-  | {
-      status: "failed";
-      conversationId: number;
-      summaryIds: string[];
-      elapsedMs: number;
-      phase: DelegatedFailurePhase;
-      code: DelegatedFailureCode;
-      error: string;
-      timedOut: boolean;
-      cleanup: "complete" | "partial";
-    };
-
-type ParsedExpandQueryReply =
-  | {
-      ok: true;
-      value: DelegatedExpandQueryReply;
-    }
-  | {
-      ok: false;
-      error: string;
-    };
-
 type SummaryCandidate = {
   summaryId: string;
   conversationId: number;
@@ -196,114 +147,6 @@ type BucketExecutionResult =
       error: string;
     };
 
-type RunDelegatedExpandQueryParams = {
-  deps: LcmDependencies;
-  callerSessionKey: string;
-  requesterAgentId: string;
-  bucket: ConversationBucket;
-  query?: string;
-  prompt: string;
-  maxTokens: number;
-  tokenCap: number;
-  requestId: string;
-  childExpansionDepth: number;
-  originSessionKey: string;
-  deadline: ExpansionDeadline;
-  delegatedWaitTimeoutSeconds: number;
-};
-
-function collectExpansionFailureText(value: unknown, parts: string[], depth = 0): void {
-  if (depth > 3 || value == null) {
-    return;
-  }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (trimmed) {
-      parts.push(trimmed);
-    }
-    return;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    parts.push(String(value));
-    return;
-  }
-  if (value instanceof Error) {
-    if (value.message.trim()) {
-      parts.push(value.message.trim());
-    }
-    collectExpansionFailureText(value.cause, parts, depth + 1);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      collectExpansionFailureText(entry, parts, depth + 1);
-    }
-    return;
-  }
-  if (typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    for (const key of ["message", "error", "reason", "details", "response", "cause", "code"]) {
-      collectExpansionFailureText(record[key], parts, depth + 1);
-    }
-  }
-}
-
-function formatExpansionFailure(error: unknown): string {
-  const parts: string[] = [];
-  collectExpansionFailureText(error, parts);
-  const message = parts.join(" ").replace(/\s+/g, " ").trim();
-  if (message) {
-    return message;
-  }
-  if (typeof error === "string" && error.trim()) {
-    return error.trim();
-  }
-  return "Delegated expansion query failed.";
-}
-
-function shouldRetryWithoutOverride(message: string): boolean {
-  const normalized = message.toLowerCase();
-  return [
-    "model.request",
-    "missing scopes",
-    "insufficient scope",
-    "unauthorized",
-    "not authorized",
-    "forbidden",
-    "provider/model overrides are not authorized",
-    "model override is not authorized",
-    "not allowed for agent",
-    "not allowlisted for plugin",
-    "unknown model",
-    "model not found",
-    "invalid model",
-    "not available",
-    "not supported",
-    "401",
-    "403",
-  ].some((signal) => normalized.includes(signal));
-}
-
-/** Map a delegated failure phase to its stable machine-readable code. */
-function delegatedFailureCode(
-  phase: DelegatedFailurePhase,
-  timedOut: boolean,
-): DelegatedFailureCode {
-  if (timedOut) {
-    return "DELEGATED_EXPANSION_TIMEOUT";
-  }
-  switch (phase) {
-    case "spawn":
-      return "DELEGATED_EXPANSION_SPAWN_FAILED";
-    case "wait":
-      return "DELEGATED_EXPANSION_WAIT_FAILED";
-    case "read_reply":
-      return "DELEGATED_EXPANSION_REPLY_MISSING";
-    case "parse_reply":
-      return "DELEGATED_EXPANSION_REPLY_INVALID";
-  }
-}
-
 function maxDate(left?: Date, right?: Date): Date | undefined {
   if (!left) {
     return right;
@@ -312,81 +155,6 @@ function maxDate(left?: Date, right?: Date): Date | undefined {
     return left;
   }
   return left.getTime() >= right.getTime() ? left : right;
-}
-
-/**
- * Build the sub-agent task message for delegated expansion and prompt answering.
- */
-function buildDelegatedExpandQueryTask(params: {
-  summaryIds: string[];
-  messageBackedSummaryIds: string[];
-  conversationId: number;
-  query?: string;
-  prompt: string;
-  maxTokens: number;
-  tokenCap: number;
-  requestId: string;
-  expansionDepth: number;
-  originSessionKey: string;
-}) {
-  const seedSummaryIds = params.summaryIds.length > 0 ? params.summaryIds.join(", ") : "(none)";
-  const messageBackedSummaryIds =
-    params.messageBackedSummaryIds.length > 0
-      ? params.messageBackedSummaryIds.join(", ")
-      : "(none)";
-  return [
-    "You are an autonomous LCM retrieval navigator. Plan and execute retrieval before answering.",
-    "",
-    "Available tools: lcm_describe, lcm_expand, lcm_grep",
-    `Conversation scope: ${params.conversationId}`,
-    `Expansion token budget (total across this run): ${params.tokenCap}`,
-    `Seed summary IDs: ${seedSummaryIds}`,
-    `Seed summaries requiring raw message expansion: ${messageBackedSummaryIds}`,
-    params.query ? `Routing query: ${params.query}` : undefined,
-    "",
-    "Strategy:",
-    "1. Start with `lcm_describe` on seed summaries to inspect subtree manifests and branch costs.",
-    "2. If additional candidates are needed, use `lcm_grep` scoped to summaries. Prefer `mode: \"full_text\"` for short literal terms, use `mode: \"regex\"` for alternation or other regex syntax, quote exact multi-word phrases, use `sort: \"relevance\"` for older-topic recall, and `sort: \"hybrid\"` when recency should still matter.",
-    "3. Select branches that fit remaining budget; prefer high-signal paths first.",
-    "4. Call `lcm_expand` selectively (do not expand everything blindly).",
-    "5. Keep includeMessages=false by default; use includeMessages=true for the message-backed seed summaries above and any other specific leaf evidence.",
-    `6. Stay within ${params.tokenCap} total expansion tokens across all lcm_expand calls.`,
-    "",
-    "User prompt to answer:",
-    params.prompt,
-    "",
-    "Delegated expansion metadata (for tracing):",
-    `- requestId: ${params.requestId}`,
-    `- expansionDepth: ${params.expansionDepth}`,
-    `- originSessionKey: ${params.originSessionKey}`,
-    "",
-    "Return ONLY JSON with this shape:",
-    "{",
-    '  "answer": "string",',
-    '  "citedIds": ["sum_xxx"],',
-    '  "expandedSummaryCount": 0,',
-    '  "totalSourceTokens": 0,',
-    '  "truncated": false',
-    "}",
-    "",
-    "Rules:",
-    "- In delegated context, call `lcm_expand` directly for source retrieval.",
-    "- DO NOT call `lcm_expand_query` from this delegated session.",
-    "- Synthesize the final answer from retrieved evidence, not assumptions.",
-    `- Keep answer concise and focused (target <= ${params.maxTokens} tokens).`,
-    "- citedIds must be unique summary IDs.",
-    "- expandedSummaryCount should reflect how many summaries were expanded/used.",
-    "- totalSourceTokens should estimate the total source tokens consumed for retrieval. Include both: (a) the `totalTokens` returned by each `lcm_expand` call you made, AND (b) for any explicit leaf summary used as evidence, the leaf summary's own `tok` value from `lcm_describe`, even if you did not call `lcm_expand` for that leaf. This avoids reporting `totalSourceTokens: 0` when the answer was actually derived from a leaf summary's content.",
-    "- truncated should indicate whether source expansion appears truncated.",
-  ]
-    .filter((line): line is string => typeof line === "string")
-    .join("\n");
-}
-
-function formatInvalidDelegatedReply(reply: string, reason: string): string {
-  const compact = reply.replace(/\s+/g, " ").trim();
-  const snippet = compact.length <= 240 ? compact : `${compact.slice(0, 240)}...`;
-  return `Delegated expansion query returned ${reason}: ${snippet}`;
 }
 
 function buildConversationBuckets(candidates: SummaryCandidate[]): ConversationBucket[] {
@@ -617,80 +385,6 @@ function synthesizeConversationAnswers(params: {
 }
 
 /**
- * Parse the child reply; accepts plain JSON or fenced JSON and rejects malformed fallbacks.
- */
-function parseDelegatedExpandQueryReply(
-  rawReply: string | undefined,
-  fallbackExpandedSummaryCount: number,
-): ParsedExpandQueryReply {
-  const reply = rawReply?.trim();
-  if (!reply) {
-    return {
-      ok: false,
-      error: "Delegated expansion query returned an empty reply.",
-    };
-  }
-
-  const candidates: string[] = [reply];
-  const fenced = reply.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  if (fenced?.[1]) {
-    candidates.unshift(fenced[1].trim());
-  }
-
-  for (const candidate of candidates) {
-    try {
-      const parsed = JSON.parse(candidate) as {
-        answer?: unknown;
-        citedIds?: unknown;
-        expandedSummaryCount?: unknown;
-        totalSourceTokens?: unknown;
-        truncated?: unknown;
-      };
-      const answer = typeof parsed.answer === "string" ? parsed.answer.trim() : "";
-      if (!answer) {
-        return {
-          ok: false,
-          error: formatInvalidDelegatedReply(reply, 'JSON without a non-empty "answer"'),
-        };
-      }
-      const citedIds = normalizeSummaryIds(
-        Array.isArray(parsed.citedIds)
-          ? parsed.citedIds.filter((value): value is string => typeof value === "string")
-          : undefined,
-      );
-      const expandedSummaryCount =
-        typeof parsed.expandedSummaryCount === "number" &&
-        Number.isFinite(parsed.expandedSummaryCount)
-          ? Math.max(0, Math.floor(parsed.expandedSummaryCount))
-          : fallbackExpandedSummaryCount;
-      const totalSourceTokens =
-        typeof parsed.totalSourceTokens === "number" && Number.isFinite(parsed.totalSourceTokens)
-          ? Math.max(0, Math.floor(parsed.totalSourceTokens))
-          : 0;
-      const truncated = parsed.truncated === true;
-
-      return {
-        ok: true,
-        value: {
-          answer,
-          citedIds,
-          expandedSummaryCount,
-          totalSourceTokens,
-          truncated,
-        },
-      };
-    } catch {
-      // Try next candidate.
-    }
-  }
-
-  return {
-    ok: false,
-    error: formatInvalidDelegatedReply(reply, "non-JSON output"),
-  };
-}
-
-/**
  * Resolve a single source conversation for delegated expansion.
  */
 function resolveSourceConversationId(params: {
@@ -896,298 +590,6 @@ async function resolveSummaryCandidates(params: {
   }
 
   return Array.from(candidates.values());
-}
-
-/**
- * Run a single delegated lcm_expand_query bucket against one conversation.
- */
-async function runDelegatedExpandQuery(
-  params: RunDelegatedExpandQueryParams,
-): Promise<DelegatedBucketOutcome> {
-  const task = buildDelegatedExpandQueryTask({
-    summaryIds: params.bucket.summaryIds,
-    messageBackedSummaryIds: params.bucket.messageBackedSummaryIds,
-    conversationId: params.bucket.conversationId,
-    query: params.query,
-    prompt: params.prompt,
-    maxTokens: params.maxTokens,
-    tokenCap: params.tokenCap,
-    requestId: params.requestId,
-    expansionDepth: params.childExpansionDepth,
-    originSessionKey: params.originSessionKey,
-  });
-
-  const expansionProvider = params.deps.config.expansionProvider || undefined;
-  const expansionModel = params.deps.config.expansionModel || undefined;
-  const canonicalExpansionModel = expansionModel?.includes("/") ? expansionModel : undefined;
-  const delegatedOverrideProvider = canonicalExpansionModel ? undefined : expansionProvider;
-  const delegatedOverrideModel = canonicalExpansionModel || expansionModel;
-  const configuredOverrideLabel =
-    delegatedOverrideProvider && delegatedOverrideModel
-      ? `${delegatedOverrideProvider}/${delegatedOverrideModel}`
-      : delegatedOverrideModel || delegatedOverrideProvider || "configured override";
-
-  const runDelegatedQuery = async (
-    provider?: string,
-    model?: string,
-  ): Promise<DelegatedBucketOutcome> => {
-    const attemptStartedAtMs = performance.now();
-    const childSessionKey = `agent:${params.requesterAgentId}:subagent:${crypto.randomUUID()}`;
-    const childIdem = crypto.randomUUID();
-    let grantCreated = false;
-    let runId = "";
-    let phase: DelegatedFailurePhase = "spawn";
-    let timedOut = false;
-    let abortComplete = true;
-    let sessionCleanupComplete = false;
-    let outcome: DelegatedBucketOutcome;
-
-    try {
-      const initialWorkTimeoutMs = remainingDeadlineMs(
-        params.deadline.workDeadlineMs,
-        performance.now(),
-      );
-      if (initialWorkTimeoutMs <= 0) {
-        phase = "wait";
-        timedOut = true;
-        throw new Error(
-          `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
-        );
-      }
-
-      createDelegatedExpansionGrant({
-        delegatedSessionKey: childSessionKey,
-        issuerSessionId: params.callerSessionKey || "main",
-        allowedConversationIds: [params.bucket.conversationId],
-        tokenCap: params.tokenCap,
-        ttlMs: Math.max(
-          1,
-          remainingDeadlineMs(params.deadline.totalDeadlineMs, performance.now()),
-        ),
-      });
-      stampDelegatedExpansionContext({
-        sessionKey: childSessionKey,
-        requestId: params.requestId,
-        expansionDepth: params.childExpansionDepth,
-        originSessionKey: params.originSessionKey,
-        stampedBy: "lcm_expand_query",
-      });
-      grantCreated = true;
-
-      const spawnTimeoutMs = Math.max(
-        1,
-        Math.min(
-          GATEWAY_TIMEOUT_MS,
-          remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
-        ),
-      );
-      const response = (await params.deps.callGateway({
-        method: "agent",
-        params: {
-          message: task,
-          sessionKey: childSessionKey,
-          deliver: false,
-          lane: params.deps.agentLaneSubagent,
-          idempotencyKey: childIdem,
-          ...(provider ? { provider } : {}),
-          ...(model ? { model } : {}),
-          extraSystemPrompt: params.deps.buildSubagentSystemPrompt({
-            depth: 1,
-            maxDepth: 8,
-            taskSummary: "Run lcm_expand and return prompt-focused JSON answer",
-          }),
-        },
-        timeoutMs: spawnTimeoutMs,
-      })) as { runId?: unknown; error?: unknown };
-
-      runId = typeof response?.runId === "string" ? response.runId.trim() : "";
-      if (!runId) {
-        throw new Error(
-          response?.error == null
-            ? "Delegated expansion did not return a runId."
-            : formatExpansionFailure(response.error),
-        );
-      }
-
-      phase = "wait";
-      const waitTimeoutMs = Math.max(
-        1,
-        remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
-      );
-      const wait = (await params.deps.callGateway({
-        method: "agent.wait",
-        params: {
-          runId,
-          timeoutMs: waitTimeoutMs,
-        },
-        timeoutMs: waitTimeoutMs,
-      })) as { status?: string; error?: unknown };
-      const status = typeof wait?.status === "string" ? wait.status : "error";
-      if (status === "timeout") {
-        timedOut = true;
-        recordExpansionDelegationTelemetry({
-          deps: params.deps,
-          component: "lcm_expand_query",
-          event: "timeout",
-          requestId: params.requestId,
-          sessionKey: params.callerSessionKey,
-          expansionDepth: params.childExpansionDepth,
-          originSessionKey: params.originSessionKey,
-          runId,
-        });
-        throw new Error(
-          `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
-        );
-      }
-      if (status !== "ok") {
-        throw new Error(formatExpansionFailure(wait?.error));
-      }
-
-      const replyTimeoutMs = remainingDeadlineMs(
-        params.deadline.workDeadlineMs,
-        performance.now(),
-      );
-      if (replyTimeoutMs <= 0) {
-        timedOut = true;
-        throw new Error(
-          `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
-        );
-      }
-      phase = "read_reply";
-      const replyPayload = (await params.deps.callGateway({
-        method: "sessions.get",
-        params: { key: childSessionKey, limit: 80 },
-        timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, replyTimeoutMs),
-      })) as { messages?: unknown[] };
-      const reply = params.deps.readLatestAssistantReply(
-        Array.isArray(replyPayload.messages) ? replyPayload.messages : [],
-      );
-      if (!reply?.trim()) {
-        throw new Error("Delegated expansion query returned an empty reply.");
-      }
-      phase = "parse_reply";
-      const parsed = parseDelegatedExpandQueryReply(reply, params.bucket.summaryIds.length);
-      if (!parsed.ok) {
-        throw new Error(parsed.error);
-      }
-      recordExpansionDelegationTelemetry({
-        deps: params.deps,
-        component: "lcm_expand_query",
-        event: "success",
-        requestId: params.requestId,
-        sessionKey: params.callerSessionKey,
-        expansionDepth: params.childExpansionDepth,
-        originSessionKey: params.originSessionKey,
-        runId,
-      });
-
-      outcome = {
-        status: "success",
-        conversationId: params.bucket.conversationId,
-        summaryIds: params.bucket.summaryIds,
-        elapsedMs: 0,
-        reply: parsed.value,
-      };
-    } catch (error) {
-      outcome = {
-        status: "failed",
-        conversationId: params.bucket.conversationId,
-        summaryIds: params.bucket.summaryIds,
-        elapsedMs: 0,
-        phase,
-        code: delegatedFailureCode(phase, timedOut),
-        error: formatExpansionFailure(error),
-        timedOut,
-        cleanup: "partial",
-      };
-    } finally {
-      if (timedOut && runId) {
-        const abortTimeoutMs = remainingDeadlineMs(
-          params.deadline.totalDeadlineMs,
-          performance.now(),
-        );
-        if (abortTimeoutMs <= 0) {
-          abortComplete = false;
-        } else {
-          try {
-            await params.deps.callGateway({
-              method: "sessions.abort",
-              params: { key: childSessionKey, runId },
-              timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, abortTimeoutMs),
-            });
-          } catch {
-            abortComplete = false;
-          }
-        }
-      }
-
-      const cleanupTimeoutMs = remainingDeadlineMs(
-        params.deadline.totalDeadlineMs,
-        performance.now(),
-      );
-      if (!grantCreated) {
-        sessionCleanupComplete = true;
-      } else if (cleanupTimeoutMs > 0) {
-        try {
-          await params.deps.callGateway({
-            method: "sessions.delete",
-            params: { key: childSessionKey, deleteTranscript: true },
-            timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, cleanupTimeoutMs),
-          });
-          sessionCleanupComplete = true;
-        } catch {
-          // Cleanup is best-effort.
-        }
-      }
-      if (grantCreated) {
-        revokeDelegatedExpansionGrantForSession(childSessionKey, { removeBinding: true });
-      }
-      clearDelegatedExpansionContext(childSessionKey);
-    }
-
-    const elapsedMs = Math.max(0, Math.floor(performance.now() - attemptStartedAtMs));
-    if (outcome.status === "success") {
-      return { ...outcome, elapsedMs };
-    }
-    return {
-      ...outcome,
-      elapsedMs,
-      cleanup: abortComplete && sessionCleanupComplete ? "complete" : "partial",
-    };
-  };
-
-  if (!expansionProvider && !expansionModel) {
-    return await runDelegatedQuery();
-  }
-
-  try {
-    const outcome = await runDelegatedQuery(delegatedOverrideProvider, delegatedOverrideModel);
-    if (outcome.status === "success") {
-      return outcome;
-    }
-    params.deps.log.warn(
-      `[lcm] delegated expansion override failed (${configuredOverrideLabel}) for conversation ${params.bucket.conversationId}: ${outcome.error}`,
-    );
-    if (!shouldRetryWithoutOverride(outcome.error)) {
-      return outcome;
-    }
-    params.deps.log.warn(
-      `[lcm] retrying delegated expansion without provider/model override after: ${outcome.error}`,
-    );
-    return await runDelegatedQuery();
-  } catch (error) {
-    return {
-      status: "failed",
-      conversationId: params.bucket.conversationId,
-      summaryIds: params.bucket.summaryIds,
-      elapsedMs: 0,
-      phase: "spawn",
-      code: "DELEGATED_EXPANSION_SPAWN_FAILED",
-      error: formatExpansionFailure(error),
-      timedOut: false,
-      cleanup: "partial",
-    };
-  }
 }
 
 /**

--- a/src/tools/lcm-expand-query-tool.ts
+++ b/src/tools/lcm-expand-query-tool.ts
@@ -9,6 +9,11 @@ import type { LcmDependencies } from "../types.js";
 import { jsonResult, type AnyAgentTool } from "./common.js";
 import { resolveLcmConversationScope } from "./lcm-conversation-scope.js";
 import {
+  createExpansionDeadline,
+  remainingDeadlineMs,
+  type ExpansionDeadline,
+} from "./lcm-expansion-deadline.js";
+import {
   normalizeSummaryIds,
   resolveRequesterConversationScopeId,
 } from "./lcm-expand-tool.delegation.js";
@@ -36,23 +41,6 @@ function clampPositiveTimeoutMs(value: number): number {
 
 function resolveAdvertisedDynamicToolTimeoutMs(delegatedWaitTimeoutMs: number): number {
   return clampPositiveTimeoutMs(delegatedWaitTimeoutMs + DYNAMIC_TOOL_TIMEOUT_HEADROOM_MS);
-}
-
-function resolveDelegatedWaitTimeoutMs(params: {
-  configuredTimeoutMs: number;
-  requestedDynamicToolTimeoutMs?: number;
-}): number {
-  if (
-    params.requestedDynamicToolTimeoutMs == null
-    || !Number.isFinite(params.requestedDynamicToolTimeoutMs)
-    || params.requestedDynamicToolTimeoutMs <= DYNAMIC_TOOL_TIMEOUT_HEADROOM_MS
-  ) {
-    return params.configuredTimeoutMs;
-  }
-  return Math.min(
-    params.configuredTimeoutMs,
-    Math.max(1, Math.floor(params.requestedDynamicToolTimeoutMs - DYNAMIC_TOOL_TIMEOUT_HEADROOM_MS)),
-  );
 }
 
 function createLcmExpandQuerySchema(dynamicToolTimeoutMs: number) {
@@ -135,6 +123,35 @@ type DelegatedExpandQueryReply = {
   truncated: boolean;
 };
 
+type DelegatedFailurePhase = "spawn" | "wait" | "read_reply" | "parse_reply";
+
+type DelegatedFailureCode =
+  | "DELEGATED_EXPANSION_TIMEOUT"
+  | "DELEGATED_EXPANSION_SPAWN_FAILED"
+  | "DELEGATED_EXPANSION_WAIT_FAILED"
+  | "DELEGATED_EXPANSION_REPLY_MISSING"
+  | "DELEGATED_EXPANSION_REPLY_INVALID";
+
+type DelegatedBucketOutcome =
+  | {
+      status: "success";
+      conversationId: number;
+      summaryIds: string[];
+      elapsedMs: number;
+      reply: DelegatedExpandQueryReply;
+    }
+  | {
+      status: "failed";
+      conversationId: number;
+      summaryIds: string[];
+      elapsedMs: number;
+      phase: DelegatedFailurePhase;
+      code: DelegatedFailureCode;
+      error: string;
+      timedOut: boolean;
+      cleanup: "complete" | "partial";
+    };
+
 type ParsedExpandQueryReply =
   | {
       ok: true;
@@ -195,7 +212,7 @@ type RunDelegatedExpandQueryParams = {
   requestId: string;
   childExpansionDepth: number;
   originSessionKey: string;
-  delegatedWaitTimeoutMs: number;
+  deadline: ExpansionDeadline;
   delegatedWaitTimeoutSeconds: number;
 };
 
@@ -269,6 +286,26 @@ function shouldRetryWithoutOverride(message: string): boolean {
     "401",
     "403",
   ].some((signal) => normalized.includes(signal));
+}
+
+/** Map a delegated failure phase to its stable machine-readable code. */
+function delegatedFailureCode(
+  phase: DelegatedFailurePhase,
+  timedOut: boolean,
+): DelegatedFailureCode {
+  if (timedOut) {
+    return "DELEGATED_EXPANSION_TIMEOUT";
+  }
+  switch (phase) {
+    case "spawn":
+      return "DELEGATED_EXPANSION_SPAWN_FAILED";
+    case "wait":
+      return "DELEGATED_EXPANSION_WAIT_FAILED";
+    case "read_reply":
+      return "DELEGATED_EXPANSION_REPLY_MISSING";
+    case "parse_reply":
+      return "DELEGATED_EXPANSION_REPLY_INVALID";
+  }
 }
 
 function maxDate(left?: Date, right?: Date): Date | undefined {
@@ -811,7 +848,7 @@ async function resolveSummaryCandidates(params: {
  */
 async function runDelegatedExpandQuery(
   params: RunDelegatedExpandQueryParams,
-): Promise<DelegatedExpandQueryReply> {
+): Promise<DelegatedBucketOutcome> {
   const task = buildDelegatedExpandQueryTask({
     summaryIds: params.bucket.summaryIds,
     messageBackedSummaryIds: params.bucket.messageBackedSummaryIds,
@@ -835,18 +872,43 @@ async function runDelegatedExpandQuery(
       ? `${delegatedOverrideProvider}/${delegatedOverrideModel}`
       : delegatedOverrideModel || delegatedOverrideProvider || "configured override";
 
-  const runDelegatedQuery = async (provider?: string, model?: string) => {
+  const runDelegatedQuery = async (
+    provider?: string,
+    model?: string,
+  ): Promise<DelegatedBucketOutcome> => {
+    const attemptStartedAtMs = performance.now();
     const childSessionKey = `agent:${params.requesterAgentId}:subagent:${crypto.randomUUID()}`;
     const childIdem = crypto.randomUUID();
     let grantCreated = false;
+    let runId = "";
+    let phase: DelegatedFailurePhase = "spawn";
+    let timedOut = false;
+    let abortComplete = true;
+    let sessionCleanupComplete = false;
+    let outcome: DelegatedBucketOutcome;
 
     try {
+      const initialWorkTimeoutMs = remainingDeadlineMs(
+        params.deadline.workDeadlineMs,
+        performance.now(),
+      );
+      if (initialWorkTimeoutMs <= 0) {
+        phase = "wait";
+        timedOut = true;
+        throw new Error(
+          `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
+        );
+      }
+
       createDelegatedExpansionGrant({
         delegatedSessionKey: childSessionKey,
         issuerSessionId: params.callerSessionKey || "main",
         allowedConversationIds: [params.bucket.conversationId],
         tokenCap: params.tokenCap,
-        ttlMs: params.delegatedWaitTimeoutMs + 30_000,
+        ttlMs: Math.max(
+          1,
+          remainingDeadlineMs(params.deadline.totalDeadlineMs, performance.now()),
+        ),
       });
       stampDelegatedExpansionContext({
         sessionKey: childSessionKey,
@@ -857,6 +919,13 @@ async function runDelegatedExpandQuery(
       });
       grantCreated = true;
 
+      const spawnTimeoutMs = Math.max(
+        1,
+        Math.min(
+          GATEWAY_TIMEOUT_MS,
+          remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
+        ),
+      );
       const response = (await params.deps.callGateway({
         method: "agent",
         params: {
@@ -873,27 +942,34 @@ async function runDelegatedExpandQuery(
             taskSummary: "Run lcm_expand and return prompt-focused JSON answer",
           }),
         },
-        timeoutMs: GATEWAY_TIMEOUT_MS,
+        timeoutMs: spawnTimeoutMs,
       })) as { runId?: unknown; error?: unknown };
 
-      const runId = typeof response?.runId === "string" ? response.runId.trim() : "";
+      runId = typeof response?.runId === "string" ? response.runId.trim() : "";
       if (!runId) {
         throw new Error(
-          formatExpansionFailure(response?.error ?? response)
-            || "Delegated expansion did not return a runId.",
+          response?.error == null
+            ? "Delegated expansion did not return a runId."
+            : formatExpansionFailure(response.error),
         );
       }
 
+      phase = "wait";
+      const waitTimeoutMs = Math.max(
+        1,
+        remainingDeadlineMs(params.deadline.workDeadlineMs, performance.now()),
+      );
       const wait = (await params.deps.callGateway({
         method: "agent.wait",
         params: {
           runId,
-          timeoutMs: params.delegatedWaitTimeoutMs,
+          timeoutMs: waitTimeoutMs,
         },
-        timeoutMs: params.delegatedWaitTimeoutMs,
+        timeoutMs: waitTimeoutMs,
       })) as { status?: string; error?: unknown };
       const status = typeof wait?.status === "string" ? wait.status : "error";
       if (status === "timeout") {
+        timedOut = true;
         recordExpansionDelegationTelemetry({
           deps: params.deps,
           component: "lcm_expand_query",
@@ -912,14 +988,29 @@ async function runDelegatedExpandQuery(
         throw new Error(formatExpansionFailure(wait?.error));
       }
 
+      const replyTimeoutMs = remainingDeadlineMs(
+        params.deadline.workDeadlineMs,
+        performance.now(),
+      );
+      if (replyTimeoutMs <= 0) {
+        timedOut = true;
+        throw new Error(
+          `lcm_expand_query timed out waiting for delegated expansion (${params.delegatedWaitTimeoutSeconds}s).`,
+        );
+      }
+      phase = "read_reply";
       const replyPayload = (await params.deps.callGateway({
         method: "sessions.get",
         params: { key: childSessionKey, limit: 80 },
-        timeoutMs: GATEWAY_TIMEOUT_MS,
+        timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, replyTimeoutMs),
       })) as { messages?: unknown[] };
       const reply = params.deps.readLatestAssistantReply(
         Array.isArray(replyPayload.messages) ? replyPayload.messages : [],
       );
+      if (!reply?.trim()) {
+        throw new Error("Delegated expansion query returned an empty reply.");
+      }
+      phase = "parse_reply";
       const parsed = parseDelegatedExpandQueryReply(reply, params.bucket.summaryIds.length);
       if (!parsed.ok) {
         throw new Error(parsed.error);
@@ -935,22 +1026,79 @@ async function runDelegatedExpandQuery(
         runId,
       });
 
-      return parsed.value;
+      outcome = {
+        status: "success",
+        conversationId: params.bucket.conversationId,
+        summaryIds: params.bucket.summaryIds,
+        elapsedMs: 0,
+        reply: parsed.value,
+      };
+    } catch (error) {
+      outcome = {
+        status: "failed",
+        conversationId: params.bucket.conversationId,
+        summaryIds: params.bucket.summaryIds,
+        elapsedMs: 0,
+        phase,
+        code: delegatedFailureCode(phase, timedOut),
+        error: formatExpansionFailure(error),
+        timedOut,
+        cleanup: "partial",
+      };
     } finally {
-      try {
-        await params.deps.callGateway({
-          method: "sessions.delete",
-          params: { key: childSessionKey, deleteTranscript: true },
-          timeoutMs: GATEWAY_TIMEOUT_MS,
-        });
-      } catch {
-        // Cleanup is best-effort.
+      if (timedOut && runId) {
+        const abortTimeoutMs = remainingDeadlineMs(
+          params.deadline.totalDeadlineMs,
+          performance.now(),
+        );
+        if (abortTimeoutMs <= 0) {
+          abortComplete = false;
+        } else {
+          try {
+            await params.deps.callGateway({
+              method: "sessions.abort",
+              params: { key: childSessionKey, runId },
+              timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, abortTimeoutMs),
+            });
+          } catch {
+            abortComplete = false;
+          }
+        }
+      }
+
+      const cleanupTimeoutMs = remainingDeadlineMs(
+        params.deadline.totalDeadlineMs,
+        performance.now(),
+      );
+      if (!grantCreated) {
+        sessionCleanupComplete = true;
+      } else if (cleanupTimeoutMs > 0) {
+        try {
+          await params.deps.callGateway({
+            method: "sessions.delete",
+            params: { key: childSessionKey, deleteTranscript: true },
+            timeoutMs: Math.min(GATEWAY_TIMEOUT_MS, cleanupTimeoutMs),
+          });
+          sessionCleanupComplete = true;
+        } catch {
+          // Cleanup is best-effort.
+        }
       }
       if (grantCreated) {
         revokeDelegatedExpansionGrantForSession(childSessionKey, { removeBinding: true });
       }
       clearDelegatedExpansionContext(childSessionKey);
     }
+
+    const elapsedMs = Math.max(0, Math.floor(performance.now() - attemptStartedAtMs));
+    if (outcome.status === "success") {
+      return { ...outcome, elapsedMs };
+    }
+    return {
+      ...outcome,
+      elapsedMs,
+      cleanup: abortComplete && sessionCleanupComplete ? "complete" : "partial",
+    };
   };
 
   if (!expansionProvider && !expansionModel) {
@@ -958,19 +1106,32 @@ async function runDelegatedExpandQuery(
   }
 
   try {
-    return await runDelegatedQuery(delegatedOverrideProvider, delegatedOverrideModel);
-  } catch (error) {
-    const failure = formatExpansionFailure(error);
-    params.deps.log.warn(
-      `[lcm] delegated expansion override failed (${configuredOverrideLabel}) for conversation ${params.bucket.conversationId}: ${failure}`,
-    );
-    if (!shouldRetryWithoutOverride(failure)) {
-      throw new Error(failure);
+    const outcome = await runDelegatedQuery(delegatedOverrideProvider, delegatedOverrideModel);
+    if (outcome.status === "success") {
+      return outcome;
     }
     params.deps.log.warn(
-      `[lcm] retrying delegated expansion without provider/model override after: ${failure}`,
+      `[lcm] delegated expansion override failed (${configuredOverrideLabel}) for conversation ${params.bucket.conversationId}: ${outcome.error}`,
+    );
+    if (!shouldRetryWithoutOverride(outcome.error)) {
+      return outcome;
+    }
+    params.deps.log.warn(
+      `[lcm] retrying delegated expansion without provider/model override after: ${outcome.error}`,
     );
     return await runDelegatedQuery();
+  } catch (error) {
+    return {
+      status: "failed",
+      conversationId: params.bucket.conversationId,
+      summaryIds: params.bucket.summaryIds,
+      elapsedMs: 0,
+      phase: "spawn",
+      code: "DELEGATED_EXPANSION_SPAWN_FAILED",
+      error: formatExpansionFailure(error),
+      timedOut: false,
+      cleanup: "partial",
+    };
   }
 }
 
@@ -1003,6 +1164,7 @@ export function createLcmExpandQueryTool(input: {
       "and return a compact prompt-focused answer. Tool output includes cited summary IDs for follow-up.",
     parameters: createLcmExpandQuerySchema(advertisedDynamicToolTimeoutMs),
     async execute(_toolCallId, params) {
+      const requestStartedAtMs = performance.now();
       const lcm = input.lcm ?? (await input.getLcm?.());
       if (!lcm) {
         throw new Error("LCM engine is unavailable.");
@@ -1027,10 +1189,16 @@ export function createLcmExpandQueryTool(input: {
         typeof p.timeoutMs === "number" && Number.isFinite(p.timeoutMs)
           ? clampPositiveTimeoutMs(p.timeoutMs)
           : undefined;
-      const delegatedWaitTimeoutMs = resolveDelegatedWaitTimeoutMs({
-        configuredTimeoutMs: configuredDelegatedWaitTimeoutMs,
-        requestedDynamicToolTimeoutMs,
+      const deadline = createExpansionDeadline({
+        nowMs: requestStartedAtMs,
+        dynamicToolTimeoutMs: requestedDynamicToolTimeoutMs ?? advertisedDynamicToolTimeoutMs,
+        delegationTimeoutMs: configuredDelegatedWaitTimeoutMs,
+        headroomMs: DYNAMIC_TOOL_TIMEOUT_HEADROOM_MS,
       });
+      const delegatedWaitTimeoutMs = Math.max(
+        1,
+        Math.floor(deadline.workDeadlineMs - deadline.startedAtMs),
+      );
       const delegatedWaitTimeoutSeconds = Math.ceil(delegatedWaitTimeoutMs / 1000);
 
       if (!prompt) {
@@ -1196,7 +1364,7 @@ export function createLcmExpandQueryTool(input: {
             sourceConversationId,
             buckets: conversationBuckets,
           });
-          const delegatedReply = await runDelegatedExpandQuery({
+          const delegatedOutcome = await runDelegatedExpandQuery({
             deps: input.deps,
             callerSessionKey,
             requesterAgentId,
@@ -1208,9 +1376,13 @@ export function createLcmExpandQueryTool(input: {
             requestId,
             childExpansionDepth,
             originSessionKey,
-            delegatedWaitTimeoutMs,
+            deadline,
             delegatedWaitTimeoutSeconds,
           });
+          if (delegatedOutcome.status === "failed") {
+            throw new Error(delegatedOutcome.error);
+          }
+          const delegatedReply = delegatedOutcome.reply;
 
           return jsonResult(
             buildExpandQueryReply({
@@ -1243,7 +1415,7 @@ export function createLcmExpandQueryTool(input: {
           }
 
           try {
-            const delegatedReply = await runDelegatedExpandQuery({
+            const delegatedOutcome = await runDelegatedExpandQuery({
               deps: input.deps,
               callerSessionKey,
               requesterAgentId,
@@ -1255,9 +1427,13 @@ export function createLcmExpandQueryTool(input: {
               requestId,
               childExpansionDepth,
               originSessionKey,
-              delegatedWaitTimeoutMs,
+              deadline,
               delegatedWaitTimeoutSeconds,
             });
+            if (delegatedOutcome.status === "failed") {
+              throw new Error(delegatedOutcome.error);
+            }
+            const delegatedReply = delegatedOutcome.reply;
             bucketResults.push({
               conversationId: bucket.conversationId,
               status: "success",

--- a/src/tools/lcm-expansion-deadline.ts
+++ b/src/tools/lcm-expansion-deadline.ts
@@ -24,7 +24,7 @@ export function createExpansionDeadline(params: {
     totalDeadlineMs,
     workDeadlineMs: Math.min(
       params.nowMs + delegationTimeoutMs,
-      Math.max(params.nowMs + 1, totalDeadlineMs - headroomMs),
+      Math.max(params.nowMs, totalDeadlineMs - headroomMs),
     ),
   };
 }

--- a/src/tools/lcm-expansion-deadline.ts
+++ b/src/tools/lcm-expansion-deadline.ts
@@ -1,0 +1,58 @@
+export type ExpansionDeadline = {
+  startedAtMs: number;
+  totalDeadlineMs: number;
+  workDeadlineMs: number;
+};
+
+/**
+ * Derive the total tool deadline and delegated-work deadline from existing
+ * caller and plugin timeout budgets.
+ */
+export function createExpansionDeadline(params: {
+  nowMs: number;
+  dynamicToolTimeoutMs: number;
+  delegationTimeoutMs: number;
+  headroomMs: number;
+}): ExpansionDeadline {
+  const dynamicToolTimeoutMs = Math.max(1, Math.floor(params.dynamicToolTimeoutMs));
+  const delegationTimeoutMs = Math.max(1, Math.floor(params.delegationTimeoutMs));
+  const headroomMs = Math.max(0, Math.floor(params.headroomMs));
+  const totalDeadlineMs = params.nowMs + dynamicToolTimeoutMs;
+
+  return {
+    startedAtMs: params.nowMs,
+    totalDeadlineMs,
+    workDeadlineMs: Math.min(
+      params.nowMs + delegationTimeoutMs,
+      Math.max(params.nowMs + 1, totalDeadlineMs - headroomMs),
+    ),
+  };
+}
+
+/** Return the non-negative whole milliseconds left before a deadline. */
+export function remainingDeadlineMs(deadlineMs: number, nowMs: number): number {
+  return Math.max(0, Math.floor(deadlineMs - nowMs));
+}
+
+/**
+ * Split a global token cap across ranked buckets without exceeding the cap.
+ * The returned array contains one positive allocation per runnable bucket.
+ */
+export function allocateExpansionTokenCaps(params: {
+  bucketCount: number;
+  tokenCap: number;
+}): number[] {
+  const bucketCount = Math.max(0, Math.floor(params.bucketCount));
+  const tokenCap = Math.max(1, Math.floor(params.tokenCap));
+  const allocatedBucketCount = Math.min(bucketCount, tokenCap);
+  if (allocatedBucketCount === 0) {
+    return [];
+  }
+
+  const baseAllocation = Math.floor(tokenCap / allocatedBucketCount);
+  const remainder = tokenCap % allocatedBucketCount;
+  return Array.from(
+    { length: allocatedBucketCount },
+    (_, index) => baseAllocation + (index < remainder ? 1 : 0),
+  );
+}

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -1038,7 +1038,18 @@ describe("createLcmExpandQueryTool", () => {
     const methods = callGatewayMock.mock.calls.map(
       ([opts]) => (opts as { method?: string }).method,
     );
+    expect(methods.indexOf("sessions.abort")).toBeGreaterThan(methods.indexOf("agent.wait"));
+    expect(methods.indexOf("sessions.delete")).toBeGreaterThan(methods.indexOf("sessions.abort"));
     expect(methods).toContain("sessions.delete");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.abort",
+        params: {
+          key: delegatedSessionKey,
+          runId: "run-timeout",
+        },
+      }),
+    );
     expect(delegatedSessionKey).not.toBe("");
     expect(resolveDelegatedExpansionGrantId(delegatedSessionKey)).toBeNull();
     expect(getExpansionDelegationTelemetrySnapshotForTests()).toMatchObject({
@@ -1046,6 +1057,91 @@ describe("createLcmExpandQueryTool", () => {
       block: 0,
       timeout: 1,
       success: 0,
+    });
+  });
+
+  it("holds the origin slot through timeout cancellation and releases it afterward", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    let agentCalls = 0;
+    let releaseAbort!: () => void;
+    const abortGate = new Promise<void>((resolve) => {
+      releaseAbort = resolve;
+    });
+    let signalAbortStarted!: () => void;
+    const abortStarted = new Promise<void>((resolve) => {
+      signalAbortStarted = resolve;
+    });
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        agentCalls += 1;
+        return { runId: agentCalls === 1 ? "run-timeout" : "run-success" };
+      }
+      if (request.method === "agent.wait") {
+        return agentCalls === 1 ? { status: "timeout" } : { status: "ok" };
+      }
+      if (request.method === "sessions.abort") {
+        signalAbortStarted();
+        await abortGate;
+        return { ok: true };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: JSON.stringify({
+                answer: "Follow-up expansion succeeded.",
+                citedIds: ["sum_a"],
+                expandedSummaryCount: 1,
+                totalSourceTokens: 100,
+                truncated: false,
+              }),
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const firstPromise = tool.execute("call-timeout-first", {
+      summaryIds: ["sum_a"],
+      prompt: "First attempt",
+      conversationId: 42,
+    });
+
+    await abortStarted;
+    const blocked = await tool.execute("call-timeout-blocked", {
+      summaryIds: ["sum_a"],
+      prompt: "Must wait for timeout cleanup",
+      conversationId: 42,
+    });
+    expect(blocked.details).toMatchObject({
+      errorCode: "EXPANSION_CONCURRENCY_BLOCKED",
+      reason: "origin_session_in_flight",
+    });
+
+    releaseAbort();
+    await firstPromise;
+    const followUp = await tool.execute("call-timeout-follow-up", {
+      summaryIds: ["sum_a"],
+      prompt: "Retry after timeout cleanup",
+      conversationId: 42,
+    });
+    expect(followUp.details).toMatchObject({
+      answer: "Follow-up expansion succeeded.",
+      citedIds: ["sum_a"],
     });
   });
 
@@ -1101,12 +1197,10 @@ describe("createLcmExpandQueryTool", () => {
     expect(result.details).toMatchObject({
       error: "lcm_expand_query timed out waiting for delegated expansion (300s).",
     });
-    expect(waitCalls).toEqual([
-      {
-        paramsTimeoutMs: 300000,
-        timeoutMs: 300000,
-      },
-    ]);
+    expect(waitCalls).toHaveLength(1);
+    expect(waitCalls[0]?.paramsTimeoutMs).toBe(waitCalls[0]?.timeoutMs);
+    expect(Number(waitCalls[0]?.timeoutMs)).toBeGreaterThanOrEqual(299000);
+    expect(Number(waitCalls[0]?.timeoutMs)).toBeLessThanOrEqual(300000);
   });
 
   it("caps delegated wait below caller-provided dynamic tool timeout", async () => {
@@ -1162,12 +1256,54 @@ describe("createLcmExpandQueryTool", () => {
     expect(result.details).toMatchObject({
       error: "lcm_expand_query timed out waiting for delegated expansion (30s).",
     });
-    expect(waitCalls).toEqual([
-      {
-        paramsTimeoutMs: 30000,
-        timeoutMs: 30000,
-      },
-    ]);
+    expect(waitCalls).toHaveLength(1);
+    expect(waitCalls[0]?.paramsTimeoutMs).toBe(waitCalls[0]?.timeoutMs);
+    expect(Number(waitCalls[0]?.timeoutMs)).toBeGreaterThanOrEqual(29000);
+    expect(Number(waitCalls[0]?.timeoutMs)).toBeLessThanOrEqual(30000);
+  });
+
+  it("does not expand a caller timeout shorter than the cleanup reserve", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    const waitCalls: number[] = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: Record<string, unknown>;
+        timeoutMs?: number;
+      };
+      if (request.method === "agent") {
+        return { runId: "run-short-timeout" };
+      }
+      if (request.method === "agent.wait") {
+        waitCalls.push(Number(request.timeoutMs));
+        return { status: "timeout" };
+      }
+      return { ok: true };
+    });
+
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("call-short-timeout", {
+      summaryIds: ["sum_a"],
+      prompt: "Summarize root cause",
+      conversationId: 42,
+      timeoutMs: 20_000,
+    });
+
+    expect(waitCalls).toEqual([]);
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      error: "lcm_expand_query timed out waiting for delegated expansion (1s).",
+    });
   });
 
   it("cleans up delegated session and grant when agent call fails", async () => {

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -1033,7 +1033,23 @@ describe("createLcmExpandQueryTool", () => {
 
     expect(result.details).toMatchObject({
       error: "lcm_expand_query timed out waiting for delegated expansion (120s).",
+      errorCode: "DELEGATED_EXPANSION_TIMEOUT",
+      truncated: true,
+      citedIds: [],
+      sourceConversationIds: [],
+      expandedSummaryCount: 0,
+      totalSourceTokens: 0,
+      conversationBreakdown: [
+        expect.objectContaining({
+          conversationId: 42,
+          summaryIds: ["sum_a"],
+          status: "failed",
+          phase: "wait",
+          errorCode: "DELEGATED_EXPANSION_TIMEOUT",
+        }),
+      ],
     });
+    expect(result.details).not.toHaveProperty("runId");
 
     const methods = callGatewayMock.mock.calls.map(
       ([opts]) => (opts as { method?: string }).method,
@@ -1340,6 +1356,15 @@ describe("createLcmExpandQueryTool", () => {
 
     expect(result.details).toMatchObject({
       error: "agent spawn failed",
+      errorCode: "DELEGATED_EXPANSION_SPAWN_FAILED",
+      conversationBreakdown: [
+        expect.objectContaining({
+          conversationId: 42,
+          summaryIds: ["sum_a"],
+          phase: "spawn",
+          errorCode: "DELEGATED_EXPANSION_SPAWN_FAILED",
+        }),
+      ],
     });
 
     const methods = callGatewayMock.mock.calls.map(
@@ -1348,6 +1373,68 @@ describe("createLcmExpandQueryTool", () => {
     expect(methods).toContain("sessions.delete");
     expect(delegatedSessionKey).not.toBe("");
     expect(resolveDelegatedExpansionGrantId(delegatedSessionKey)).toBeNull();
+  });
+
+  it("classifies a missing delegated reply separately from a malformed reply", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.describe.mockResolvedValue({
+      type: "summary",
+      summary: { conversationId: 42 },
+    });
+
+    let returnMalformedReply = false;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-invalid-reply" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return returnMalformedReply
+          ? { messages: [{ role: "assistant", content: "not JSON" }] }
+          : { messages: [] };
+      }
+      return { ok: true };
+    });
+
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval }),
+      sessionId: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+    });
+    const missing = await tool.execute("call-missing-reply", {
+      summaryIds: ["sum_a"],
+      prompt: "Answer this",
+      conversationId: 42,
+    });
+    expect(missing.details).toMatchObject({
+      errorCode: "DELEGATED_EXPANSION_REPLY_MISSING",
+      conversationBreakdown: [
+        expect.objectContaining({
+          phase: "read_reply",
+          errorCode: "DELEGATED_EXPANSION_REPLY_MISSING",
+        }),
+      ],
+    });
+
+    returnMalformedReply = true;
+    const malformed = await tool.execute("call-malformed-reply", {
+      summaryIds: ["sum_a"],
+      prompt: "Answer this",
+      conversationId: 42,
+    });
+    expect(malformed.details).toMatchObject({
+      errorCode: "DELEGATED_EXPANSION_REPLY_INVALID",
+      conversationBreakdown: [
+        expect.objectContaining({
+          phase: "parse_reply",
+          errorCode: "DELEGATED_EXPANSION_REPLY_INVALID",
+        }),
+      ],
+    });
   });
 
   it("greps summaries first when query is provided", async () => {
@@ -1824,18 +1911,18 @@ describe("createLcmExpandQueryTool", () => {
       totalMatches: 2,
     });
 
-    let agentCalls = 0;
     callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
+      const request = opts as { method?: string; params?: Record<string, unknown> };
       if (request.method === "agent") {
-        agentCalls += 1;
-        return { runId: `run-timeout-${agentCalls}` };
+        const message = String(request.params?.message ?? "");
+        return {
+          runId: message.includes("Conversation scope: 9") ? "run-timeout" : "run-ok",
+        };
       }
       if (request.method === "agent.wait") {
-        if (agentCalls === 1) {
-          return { status: "timeout" };
-        }
-        return { status: "ok" };
+        return request.params?.runId === "run-timeout"
+          ? { status: "timeout" }
+          : { status: "ok" };
       }
       if (request.method === "sessions.get") {
         return {
@@ -1888,7 +1975,10 @@ describe("createLcmExpandQueryTool", () => {
       conversationBreakdown: expect.arrayContaining([
         expect.objectContaining({
           conversationId: 9,
+          summaryIds: ["sum_timeout"],
           status: "failed",
+          phase: "wait",
+          errorCode: "DELEGATED_EXPANSION_TIMEOUT",
           error: "lcm_expand_query timed out waiting for delegated expansion (120s).",
         }),
         expect.objectContaining({
@@ -1903,7 +1993,169 @@ describe("createLcmExpandQueryTool", () => {
     expect((result.details as { answer?: string }).answer).toContain("failed conversations");
   });
 
-  it("returns partial coverage when the global token budget is exhausted mid-run", async () => {
+  it("preserves every bucket diagnostic when all delegated buckets time out", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.grep.mockResolvedValue({
+      messages: [],
+      summaries: [
+        {
+          summaryId: "sum_new",
+          conversationId: 9,
+          kind: "leaf",
+          snippet: "new",
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+        {
+          summaryId: "sum_old",
+          conversationId: 7,
+          kind: "leaf",
+          snippet: "old",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      totalMatches: 2,
+    });
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        const message = String(request.params?.message ?? "");
+        return { runId: message.includes("Conversation scope: 9") ? "run-9" : "run-7" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return { ok: true };
+    });
+
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval }),
+      sessionId: "session-1",
+      requesterSessionKey: "agent:main:main",
+    });
+    const result = await tool.execute("call-all-timeout", {
+      query: "release evidence",
+      prompt: "What happened?",
+      allConversations: true,
+      tokenCap: 2000,
+    });
+
+    expect(result.details).toMatchObject({
+      error: "lcm_expand_query timed out waiting for delegated expansion (120s).",
+      errorCode: "DELEGATED_EXPANSION_TIMEOUT",
+      truncated: true,
+      citedIds: [],
+      sourceConversationIds: [],
+      expandedSummaryCount: 0,
+      totalSourceTokens: 0,
+      conversationBreakdown: [
+        expect.objectContaining({
+          conversationId: 9,
+          summaryIds: ["sum_new"],
+          status: "failed",
+          phase: "wait",
+          errorCode: "DELEGATED_EXPANSION_TIMEOUT",
+        }),
+        expect.objectContaining({
+          conversationId: 7,
+          summaryIds: ["sum_old"],
+          status: "failed",
+          phase: "wait",
+          errorCode: "DELEGATED_EXPANSION_TIMEOUT",
+        }),
+      ],
+    });
+  });
+
+  it("starts every selected bucket before waiting for delegated completion", async () => {
+    const retrieval = makeRetrieval();
+    retrieval.grep.mockResolvedValue({
+      messages: [],
+      summaries: [
+        {
+          summaryId: "sum_b",
+          conversationId: 9,
+          kind: "leaf",
+          snippet: "b",
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+        {
+          summaryId: "sum_a",
+          conversationId: 7,
+          kind: "leaf",
+          snippet: "a",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      totalMatches: 2,
+    });
+
+    let startedBuckets = 0;
+    let signalBothStarted!: () => void;
+    const bothStarted = new Promise<void>((resolve) => {
+      signalBothStarted = resolve;
+    });
+    let releaseWaits!: () => void;
+    const waitGate = new Promise<void>((resolve) => {
+      releaseWaits = resolve;
+    });
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "agent") {
+        startedBuckets += 1;
+        if (startedBuckets === 2) {
+          signalBothStarted();
+        }
+        return { runId: `run-${startedBuckets}` };
+      }
+      if (request.method === "agent.wait") {
+        await waitGate;
+        return { status: "ok" };
+      }
+      if (request.method === "sessions.get") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: JSON.stringify({
+                answer: "Concurrent bucket completed.",
+                citedIds: [],
+                expandedSummaryCount: 1,
+                totalSourceTokens: 10,
+                truncated: false,
+              }),
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    const tool = createLcmExpandQueryTool({
+      deps: makeDeps(),
+      lcm: makeEngine({ retrieval }),
+      sessionId: "session-1",
+      requesterSessionKey: "agent:main:main",
+    });
+    const resultPromise = tool.execute("call-concurrent-buckets", {
+      query: "release evidence",
+      prompt: "What happened?",
+      allConversations: true,
+      tokenCap: 2000,
+    });
+
+    await bothStarted;
+    expect(startedBuckets).toBe(2);
+    releaseWaits();
+    const result = await resultPromise;
+    expect(result.details).toMatchObject({
+      sourceConversationIds: [7, 9],
+      expandedSummaryCount: 2,
+    });
+  });
+
+  it("partitions the global token budget across concurrent buckets", async () => {
     const retrieval = makeRetrieval();
     retrieval.grep.mockResolvedValue({
       messages: [],
@@ -1926,17 +2178,23 @@ describe("createLcmExpandQueryTool", () => {
       totalMatches: 2,
     });
 
-    let sessionGetCalls = 0;
+    const agentMessages: string[] = [];
+    const sessionConversation = new Map<string, number>();
     callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string };
+      const request = opts as { method?: string; params?: Record<string, unknown> };
       if (request.method === "agent") {
-        return { runId: "run-budget" };
+        const message = String(request.params?.message ?? "");
+        const conversationId = message.includes("Conversation scope: 9") ? 9 : 7;
+        const sessionKey = String(request.params?.sessionKey ?? "");
+        agentMessages.push(message);
+        sessionConversation.set(sessionKey, conversationId);
+        return { runId: `run-budget-${conversationId}` };
       }
       if (request.method === "agent.wait") {
         return { status: "ok" };
       }
       if (request.method === "sessions.get") {
-        sessionGetCalls += 1;
+        const conversationId = sessionConversation.get(String(request.params?.key ?? "")) ?? 0;
         return {
           messages: [
             {
@@ -1945,10 +2203,10 @@ describe("createLcmExpandQueryTool", () => {
                 {
                   type: "text",
                   text: JSON.stringify({
-                    answer: "Conversation 9 used the whole retrieval budget.",
-                    citedIds: ["sum_large"],
+                    answer: `Conversation ${conversationId} used its retrieval allocation.`,
+                    citedIds: [conversationId === 9 ? "sum_large" : "sum_small"],
                     expandedSummaryCount: 1,
-                    totalSourceTokens: 500,
+                    totalSourceTokens: 250,
                     truncated: false,
                   }),
                 },
@@ -1976,13 +2234,17 @@ describe("createLcmExpandQueryTool", () => {
       tokenCap: 500,
     });
 
-    expect(sessionGetCalls).toBe(1);
+    expect(agentMessages).toHaveLength(2);
+    expect(agentMessages).toEqual([
+      expect.stringContaining("Expansion token budget (total across this run): 250"),
+      expect.stringContaining("Expansion token budget (total across this run): 250"),
+    ]);
     expect(result.details).toMatchObject({
-      sourceConversationIds: [9],
-      citedIds: ["sum_large"],
-      expandedSummaryCount: 1,
+      sourceConversationIds: [7, 9],
+      citedIds: ["sum_large", "sum_small"],
+      expandedSummaryCount: 2,
       totalSourceTokens: 500,
-      truncated: true,
+      truncated: false,
     });
     expect(result.details).toMatchObject({
       conversationBreakdown: expect.arrayContaining([
@@ -1992,12 +2254,10 @@ describe("createLcmExpandQueryTool", () => {
         }),
         expect.objectContaining({
           conversationId: 7,
-          status: "skipped",
-          error: "global token budget exhausted",
+          status: "success",
         }),
       ]),
     });
-    expect((result.details as { answer?: string }).answer).toContain("skipped conversations");
   });
 
   it("falls back to messages for shallow trees when summary grep misses", async () => {

--- a/test/lcm-expand-query-tool.test.ts
+++ b/test/lcm-expand-query-tool.test.ts
@@ -1054,18 +1054,9 @@ describe("createLcmExpandQueryTool", () => {
     const methods = callGatewayMock.mock.calls.map(
       ([opts]) => (opts as { method?: string }).method,
     );
-    expect(methods.indexOf("sessions.abort")).toBeGreaterThan(methods.indexOf("agent.wait"));
-    expect(methods.indexOf("sessions.delete")).toBeGreaterThan(methods.indexOf("sessions.abort"));
+    expect(methods.indexOf("sessions.delete")).toBeGreaterThan(methods.indexOf("agent.wait"));
+    expect(methods).not.toContain("sessions.abort");
     expect(methods).toContain("sessions.delete");
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "sessions.abort",
-        params: {
-          key: delegatedSessionKey,
-          runId: "run-timeout",
-        },
-      }),
-    );
     expect(delegatedSessionKey).not.toBe("");
     expect(resolveDelegatedExpansionGrantId(delegatedSessionKey)).toBeNull();
     expect(getExpansionDelegationTelemetrySnapshotForTests()).toMatchObject({
@@ -1084,13 +1075,13 @@ describe("createLcmExpandQueryTool", () => {
     });
 
     let agentCalls = 0;
-    let releaseAbort!: () => void;
-    const abortGate = new Promise<void>((resolve) => {
-      releaseAbort = resolve;
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
     });
-    let signalAbortStarted!: () => void;
-    const abortStarted = new Promise<void>((resolve) => {
-      signalAbortStarted = resolve;
+    let signalCleanupStarted!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      signalCleanupStarted = resolve;
     });
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: Record<string, unknown> };
@@ -1101,9 +1092,9 @@ describe("createLcmExpandQueryTool", () => {
       if (request.method === "agent.wait") {
         return agentCalls === 1 ? { status: "timeout" } : { status: "ok" };
       }
-      if (request.method === "sessions.abort") {
-        signalAbortStarted();
-        await abortGate;
+      if (request.method === "sessions.delete") {
+        signalCleanupStarted();
+        await cleanupGate;
         return { ok: true };
       }
       if (request.method === "sessions.get") {
@@ -1137,7 +1128,7 @@ describe("createLcmExpandQueryTool", () => {
       conversationId: 42,
     });
 
-    await abortStarted;
+    await cleanupStarted;
     const blocked = await tool.execute("call-timeout-blocked", {
       summaryIds: ["sum_a"],
       prompt: "Must wait for timeout cleanup",
@@ -1148,7 +1139,7 @@ describe("createLcmExpandQueryTool", () => {
       reason: "origin_session_in_flight",
     });
 
-    releaseAbort();
+    releaseCleanup();
     await firstPromise;
     const followUp = await tool.execute("call-timeout-follow-up", {
       summaryIds: ["sum_a"],

--- a/test/lcm-expansion-deadline.test.ts
+++ b/test/lcm-expansion-deadline.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  allocateExpansionTokenCaps,
+  createExpansionDeadline,
+  remainingDeadlineMs,
+} from "../src/tools/lcm-expansion-deadline.js";
+
+describe("createExpansionDeadline", () => {
+  it("keeps the default delegated work window and cleanup reserve", () => {
+    expect(
+      createExpansionDeadline({
+        nowMs: 1_000,
+        dynamicToolTimeoutMs: 150_000,
+        delegationTimeoutMs: 120_000,
+        headroomMs: 30_000,
+      }),
+    ).toEqual({
+      startedAtMs: 1_000,
+      totalDeadlineMs: 151_000,
+      workDeadlineMs: 121_000,
+    });
+  });
+
+  it("uses the configured delegation timeout when the caller provides more time", () => {
+    expect(
+      createExpansionDeadline({
+        nowMs: 500,
+        dynamicToolTimeoutMs: 600_000,
+        delegationTimeoutMs: 180_000,
+        headroomMs: 30_000,
+      }).workDeadlineMs,
+    ).toBe(180_500);
+  });
+
+  it("does not expand short caller timeouts to the configured delegation timeout", () => {
+    expect(
+      createExpansionDeadline({
+        nowMs: 2_000,
+        dynamicToolTimeoutMs: 20_000,
+        delegationTimeoutMs: 120_000,
+        headroomMs: 30_000,
+      }),
+    ).toEqual({
+      startedAtMs: 2_000,
+      totalDeadlineMs: 22_000,
+      workDeadlineMs: 2_001,
+    });
+  });
+});
+
+describe("remainingDeadlineMs", () => {
+  it("returns the remaining whole milliseconds without extending the deadline", () => {
+    expect(remainingDeadlineMs(5_000, 1_250.4)).toBe(3_749);
+    expect(remainingDeadlineMs(5_000, 5_000)).toBe(0);
+    expect(remainingDeadlineMs(5_000, 6_000)).toBe(0);
+  });
+});
+
+describe("allocateExpansionTokenCaps", () => {
+  it("splits the cap evenly and assigns remainder in rank order", () => {
+    expect(allocateExpansionTokenCaps({ bucketCount: 3, tokenCap: 10 })).toEqual([4, 3, 3]);
+  });
+
+  it("skips lower-ranked buckets when the cap is smaller than the bucket count", () => {
+    expect(allocateExpansionTokenCaps({ bucketCount: 3, tokenCap: 2 })).toEqual([1, 1]);
+  });
+
+  it("never allocates more than the normalized positive token cap", () => {
+    expect(allocateExpansionTokenCaps({ bucketCount: 3, tokenCap: 1.9 })).toEqual([1]);
+    expect(allocateExpansionTokenCaps({ bucketCount: 0, tokenCap: 100 })).toEqual([]);
+  });
+});

--- a/test/lcm-expansion-deadline.test.ts
+++ b/test/lcm-expansion-deadline.test.ts
@@ -43,7 +43,7 @@ describe("createExpansionDeadline", () => {
     ).toEqual({
       startedAtMs: 2_000,
       totalDeadlineMs: 22_000,
-      workDeadlineMs: 2_001,
+      workDeadlineMs: 2_000,
     });
   });
 });

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -788,6 +788,37 @@ describe("lcm plugin registration", () => {
     }));
   });
 
+  it("routes delegated session cleanup through the runtime subagent adapter", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+
+    const engine = getFactory()!() as {
+      deps?: {
+        callGateway: (params: {
+          method: string;
+          params?: Record<string, unknown>;
+        }) => Promise<unknown>;
+      };
+    };
+    const deleteSession = api.runtime.subagent.deleteSession as ReturnType<typeof vi.fn>;
+
+    await engine.deps?.callGateway({
+      method: "sessions.delete",
+      params: {
+        key: "agent:main:subagent:delegated-expansion",
+        deleteTranscript: true,
+      },
+    });
+
+    expect(deleteSession).toHaveBeenCalledWith({
+      sessionKey: "agent:main:subagent:delegated-expansion",
+      deleteTranscript: true,
+    });
+  });
+
   it("prefers env summary overrides over plugin config model overrides", () => {
     vi.stubEnv("LCM_SUMMARY_PROVIDER", "anthropic");
     vi.stubEnv("LCM_SUMMARY_MODEL", "claude-3-5-haiku");


### PR DESCRIPTION
## What

Bound each `lcm_expand_query` invocation by one request deadline. Selected cross-conversation buckets run concurrently within that deadline and share the existing global token cap. Completed buckets remain available when another bucket times out, and failures include structured per-conversation diagnostics.

## Why

Delegated expansion applied the full wait timeout to each conversation bucket in sequence. A slow bucket could consume the tool window before later buckets ran, and the caller received no usable evidence or bucket-level failure details. The same timeout symptom also affected the narrow known-summary path reported in #432.

Successful single-conversation responses keep their existing shape. This change adds no configuration and does not raise the OpenClaw compatibility floor.

## Changes

- Share one deadline across delegated buckets
- Partition the global token budget deterministically
- Preserve completed cross-conversation evidence
- Return typed per-bucket failure diagnostics
- Clean up timed-out child sessions
- Document behavior and add a Changeset

## Testing

- `npm run release:verify`
- 97 test files and 1,737 tests passed
- TypeScript typecheck and all builds passed
- Package dry run passed
- Thermonuclear maintainability review completed
- Autoreview reported no actionable findings

Closes #432
