### PR TITLE
feat: add capture-only mode for CLI hosts

### DIFF
--- a/.changeset/soft-cli-capture.md
+++ b/.changeset/soft-cli-capture.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add an opt-in `unsupportedHostMode: "capture-only"` compatibility mode so generic CLI backends and CLI-backed children can continue agent turns while Lossless bootstraps, ingests, and maintains their transcripts without claiming context assembly, projected child context, or compaction support.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,14 @@ a native host that provides the full context-engine lifecycle: session bootstrap
 pre-prompt assembly, after-turn ingestion, maintenance, compaction, and runtime
 LLM completion. Native Codex and Pi embedded runs provide those capabilities;
 generic CLI harnesses such as `claude-cli` and `codex-cli` do not. If you must
-use a generic CLI harness, set `plugins.slots.contextEngine` to `legacy` for
-that run instead of `lossless-claw`.
+use a generic CLI harness, either set `plugins.slots.contextEngine` to `legacy`
+or explicitly set `unsupportedHostMode` to `capture-only`. Capture-only mode
+allows hosts that provide bootstrap, after-turn ingestion, and maintenance to
+continue the agent turn and persist its transcript, but those runs do not
+receive LCM-assembled context or LCM-owned compaction. Native Codex and Pi
+embedded runs retain the full lifecycle in a mixed-runtime installation. CLI
+subagent context remains host-managed rather than receiving an LCM-projected
+parent context.
 
 The optional programmatic `status` / `doctor` / `rotate` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
@@ -38,6 +44,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "ignoreSessionPatterns": [],
   "statelessSessionPatterns": [],
   "skipStatelessSessions": true,
+  "unsupportedHostMode": "error",
   "contextThreshold": 0.75,
   "contextThresholdOverrides": [
     {
@@ -202,6 +209,7 @@ output.
 | `ignoreSessionPatterns` | `string[]` | `[]` | `LCM_IGNORE_SESSION_PATTERNS` | Session-key glob patterns that skip LCM entirely. |
 | `statelessSessionPatterns` | `string[]` | `[]` | `LCM_STATELESS_SESSION_PATTERNS` | Session-key glob patterns that may read from LCM but never write to it. |
 | `skipStatelessSessions` | `boolean` | `true` | `LCM_SKIP_STATELESS_SESSIONS` | Enforces `statelessSessionPatterns` when enabled. |
+| `unsupportedHostMode` | `"error" \| "capture-only"` | `"error"` | `LCM_UNSUPPORTED_HOST_MODE` | `error` requires the full native lifecycle. `capture-only` permits hosts with bootstrap, after-turn ingestion, and maintenance while disabling LCM assembly and LCM-owned compaction for those runs; CLI child context remains host-managed. |
 | `newSessionRetainDepth` | `integer` | `2` | `LCM_NEW_SESSION_RETAIN_DEPTH` | Controls what survives `/new`. `-1` keeps all context, `0` keeps summaries only, higher values keep only deeper summaries. |
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -143,6 +143,10 @@
       "label": "Skip Stateless Sessions",
       "help": "When enabled, matching stateless session keys skip LCM persistence and grant writes"
     },
+    "unsupportedHostMode": {
+      "label": "Unsupported Host Mode",
+      "help": "Controls runtimes that cannot project LCM context: error (default) blocks them; capture-only permits bootstrap, after-turn ingestion, and maintenance without LCM assembly or compaction"
+    },
     "largeFileThresholdTokens": {
       "label": "Large File Threshold Tokens",
       "help": "Token threshold that routes text attachments into large-file summarization"
@@ -482,6 +486,13 @@
       },
       "skipStatelessSessions": {
         "type": "boolean"
+      },
+      "unsupportedHostMode": {
+        "type": "string",
+        "enum": [
+          "error",
+          "capture-only"
+        ]
       },
       "largeFileThresholdTokens": {
         "type": "integer",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -569,6 +569,20 @@ Why it matters:
 - when enabled, matching stateless sessions skip LCM persistence entirely
 - use carefully, because it affects whether those sessions behave as readers only or are effectively bypassed for writes
 
+### `unsupportedHostMode`
+
+Controls how Lossless behaves on agent runtimes that cannot project LCM-assembled context.
+
+- `error` is the default and requires the full native context-engine lifecycle
+- `capture-only` permits hosts with bootstrap, after-turn ingestion, and maintenance
+- capture-only CLI runs persist transcripts but do not receive LCM-assembled context or LCM-owned compaction
+- CLI-backed child context remains host-managed instead of receiving an LCM-projected parent context
+- native Codex and Pi embedded runs keep the full lifecycle in mixed-runtime installations
+
+Env override:
+
+- `LCM_UNSUPPORTED_HOST_MODE`
+
 ## Recall-path and delegation controls
 
 ### `expansionModel`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -46,6 +46,7 @@ export type DynamicLeafChunkTokensConfig = {
 };
 
 export type ProactiveThresholdCompactionMode = "deferred" | "inline";
+export type UnsupportedHostMode = "error" | "capture-only";
 export type AutoRotateSessionFileMode = "rotate" | "warn" | "off";
 
 export type AutoRotateSessionFilesConfig = {
@@ -99,6 +100,8 @@ export type LcmConfig = {
   statelessSessionPatterns: string[];
   /** When true, stateless session pattern matching is enforced. */
   skipStatelessSessions: boolean;
+  /** Behavior when an agent runtime cannot project LCM-assembled context. */
+  unsupportedHostMode: UnsupportedHostMode;
   contextThreshold: number;
   /** Optional ordered rules that override contextThreshold for matching runtime contexts. */
   contextThresholdOverrides?: ContextThresholdOverride[];
@@ -326,6 +329,14 @@ function toProactiveThresholdCompactionMode(
 ): ProactiveThresholdCompactionMode | undefined {
   const normalized = toStr(value)?.toLowerCase();
   if (normalized === "inline" || normalized === "deferred") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function toUnsupportedHostMode(value: unknown): UnsupportedHostMode | undefined {
+  const normalized = toStr(value)?.toLowerCase();
+  if (normalized === "error" || normalized === "capture-only") {
     return normalized;
   }
   return undefined;
@@ -697,6 +708,10 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_SKIP_STATELESS_SESSIONS !== undefined
           ? env.LCM_SKIP_STATELESS_SESSIONS === "true"
           : toBool(pc.skipStatelessSessions) ?? true,
+      unsupportedHostMode:
+        toUnsupportedHostMode(env.LCM_UNSUPPORTED_HOST_MODE)
+          ?? toUnsupportedHostMode(pc.unsupportedHostMode)
+          ?? "error",
       contextThreshold:
         parseFiniteNumber(env.LCM_CONTEXT_THRESHOLD)
           ?? toNumber(pc.contextThreshold) ?? 0.75,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -101,6 +101,11 @@ const LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability
   "compact",
   "runtime-llm-complete",
 ];
+const LOSSLESS_CAPTURE_ONLY_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
+  "bootstrap",
+  "after-turn",
+  "maintain",
+];
 const LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
   "thread-bootstrap-projection",
 ];
@@ -358,6 +363,7 @@ export class LcmContextEngine implements ContextEngine {
     // Only claim ownership of compaction when the DB is operational.
     // Without a working schema, ownsCompaction would disable the runtime's
     // built-in compaction safeguard and inflate the context budget.
+    const captureOnlyHostMode = this.config.unsupportedHostMode === "capture-only";
     this.info = {
       id: "lossless-claw",
       name: "Lossless Context Management Engine",
@@ -366,21 +372,45 @@ export class LcmContextEngine implements ContextEngine {
       turnMaintenanceMode: "background",
       hostRequirements: {
         "agent-run": {
-          requiredCapabilities: LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
-          unsupportedMessage: [
-            "lossless-claw requires a native OpenClaw runtime with the full context-engine agent-run lifecycle.",
-            "Use the native Codex or Pi embedded runtime, or switch plugins.slots.contextEngine to legacy for CLI harness runs.",
-          ].join(" "),
+          requiredCapabilities: captureOnlyHostMode
+            ? LOSSLESS_CAPTURE_ONLY_AGENT_RUN_REQUIRED_HOST_CAPABILITIES
+            : LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
+          unsupportedMessage: captureOnlyHostMode
+            ? [
+                "lossless-claw capture-only mode requires bootstrap, after-turn ingestion, and maintenance support.",
+                "Use a compatible OpenClaw CLI runner or switch plugins.slots.contextEngine to legacy.",
+              ].join(" ")
+            : [
+                "lossless-claw requires a native OpenClaw runtime with the full context-engine agent-run lifecycle.",
+                "Use the native Codex or Pi embedded runtime, enable unsupportedHostMode=capture-only, or switch plugins.slots.contextEngine to legacy for CLI harness runs.",
+              ].join(" "),
         },
         "subagent-spawn": {
-          requiredCapabilities: LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES,
-          unsupportedMessage: [
-            "lossless-claw-managed forked children require host thread bootstrap projection.",
-            "Without it, the host may replay a raw parent JSONL branch into the child instead of the LCM-assembled compact view.",
-          ].join(" "),
+          requiredCapabilities: captureOnlyHostMode
+            ? []
+            : LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES,
+          unsupportedMessage: captureOnlyHostMode
+            ? "lossless-claw capture-only mode leaves child context projection to the host."
+            : [
+                "lossless-claw-managed forked children require host thread bootstrap projection.",
+                "Without it, the host may replay a raw parent JSONL branch into the child instead of the LCM-assembled compact view.",
+              ].join(" "),
         },
       },
     } as ContextEngineInfo;
+
+    if (captureOnlyHostMode) {
+      logStartupBannerOnce({
+        key: "unsupported-host-capture-only",
+        log: (message) => (this.deps.log.hostWarn ?? this.deps.log.warn)(message),
+        message: [
+          "[lcm] WARNING: unsupportedHostMode=capture-only permits agent runtimes that cannot project LCM-assembled context.",
+          "Compatible CLI runs can be bootstrapped, ingested, and maintained, but LCM context assembly and LCM-owned compaction are unavailable on those runs.",
+          "CLI-backed child context remains host-managed.",
+          "Native Codex and Pi embedded runs retain the full lifecycle.",
+        ].join(" "),
+      });
+    }
 
     this.conversationStore = new ConversationStore(this.db, {
       fts5Available: this.fts5Available,

--- a/src/startup-banner-log.ts
+++ b/src/startup-banner-log.ts
@@ -8,6 +8,7 @@ type StartupBannerKey =
   | "stateless-session-patterns"
   | "ignore-session-patterns-env-override"
   | "stateless-session-patterns-env-override"
+  | "unsupported-host-capture-only"
   | "runtime-llm-unavailable"
   | "runtime-llm-policy-summary-models"
   | "state-dir";

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -30,6 +30,7 @@ describe("resolveLcmConfig", () => {
     expect(config.ignoreSessionPatterns).toEqual([]);
     expect(config.statelessSessionPatterns).toEqual([]);
     expect(config.skipStatelessSessions).toBe(true);
+    expect(config.unsupportedHostMode).toBe("error");
     expect(config.contextThreshold).toBe(0.75);
     expect(config.contextThresholdOverrides).toEqual([]);
     expect(config.freshTailCount).toBe(64);
@@ -110,6 +111,7 @@ describe("resolveLcmConfig", () => {
       ignoreSessionPatterns: ["agent:*:cron:*", "agent:main:subagent:**"],
       statelessSessionPatterns: ["agent:*:ephemeral:**"],
       skipStatelessSessions: false,
+      unsupportedHostMode: "capture-only",
       leafMinFanout: 4,
       condensedMinFanout: 2,
       pruneHeartbeatOk: true,
@@ -143,6 +145,7 @@ describe("resolveLcmConfig", () => {
     ]);
     expect(config.statelessSessionPatterns).toEqual(["agent:*:ephemeral:**"]);
     expect(config.skipStatelessSessions).toBe(false);
+    expect(config.unsupportedHostMode).toBe("capture-only");
     expect(config.contextThreshold).toBe(0.5);
     expect(config.contextThresholdOverrides).toEqual([
       {
@@ -209,6 +212,7 @@ describe("resolveLcmConfig", () => {
       LCM_IGNORE_SESSION_PATTERNS: "agent:*:cron:*, agent:main:subagent:**",
       LCM_STATELESS_SESSION_PATTERNS: "agent:*:ephemeral:**, agent:main:preview:*",
       LCM_SKIP_STATELESS_SESSIONS: "false",
+      LCM_UNSUPPORTED_HOST_MODE: "capture-only",
       LCM_TRANSCRIPT_GC_ENABLED: "true",
       LCM_AUTO_ROTATE_SESSION_FILES_ENABLED: "false",
       LCM_AUTO_ROTATE_SESSION_FILES_CREATE_BACKUPS: "true",
@@ -251,6 +255,7 @@ describe("resolveLcmConfig", () => {
       ignoreSessionPatterns: ["agent:*:test:*"],
       statelessSessionPatterns: ["agent:*:preview:*"],
       skipStatelessSessions: true,
+      unsupportedHostMode: "error",
       transcriptGcEnabled: false,
       proactiveThresholdCompactionMode: "deferred",
       autoRotateSessionFiles: {
@@ -285,6 +290,7 @@ describe("resolveLcmConfig", () => {
       "agent:main:preview:*",
     ]);
     expect(config.skipStatelessSessions).toBe(false);
+    expect(config.unsupportedHostMode).toBe("capture-only");
     expect(config.transcriptGcEnabled).toBe(true);
     expect(config.proactiveThresholdCompactionMode).toBe("inline");
     expect(config.autoRotateSessionFiles).toEqual({
@@ -845,6 +851,13 @@ describe("resolveLcmConfig", () => {
     expect(manifest.configSchema.properties.proactiveThresholdCompactionMode).toEqual({
       type: "string",
       enum: ["deferred", "inline"],
+    });
+  });
+
+  it("ships a manifest with unsupportedHostMode in schema", () => {
+    expect(manifest.configSchema.properties.unsupportedHostMode).toEqual({
+      type: "string",
+      enum: ["error", "capture-only"],
     });
   });
 

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -52,6 +52,18 @@ describe("LcmContextEngine metadata", () => {
     });
   });
 
+  it("requires only capture lifecycle hooks when capture-only mode is enabled", () => {
+    const engine = createEngineWithConfig({ unsupportedHostMode: "capture-only" });
+    expect(engine.info.hostRequirements?.["agent-run"]).toEqual({
+      requiredCapabilities: ["bootstrap", "after-turn", "maintain"],
+      unsupportedMessage: expect.stringContaining("capture-only mode"),
+    });
+    expect(engine.info.hostRequirements?.["subagent-spawn"]).toEqual({
+      requiredCapabilities: [],
+      unsupportedMessage: expect.stringContaining("host"),
+    });
+  });
+
   it("requires host thread bootstrap projection for subagent forks", () => {
     const engine = createEngine();
     expect(engine.info.hostRequirements?.["subagent-spawn"]).toEqual({

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -10,6 +10,7 @@ const BASE_CONFIG: LcmConfig = {
   ignoreSessionPatterns: [],
   statelessSessionPatterns: [],
   skipStatelessSessions: true,
+  unsupportedHostMode: "error",
   contextThreshold: 0.75,
   freshTailCount: 8,
   promptAwareEviction: false,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -52,6 +52,7 @@ export function createTestConfig(
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
+    unsupportedHostMode: "error",
     contextThreshold: 0.75,
     freshTailCount: 8,
     promptAwareEviction: false,

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -37,6 +37,7 @@ function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
     ignoreSessionPatterns: [],
     statelessSessionPatterns: [],
     skipStatelessSessions: true,
+    unsupportedHostMode: "error",
     contextThreshold: 0.75,
     freshTailCount: 64,
     promptAwareEviction: false,


### PR DESCRIPTION
## Summary

Adds an explicit, opt-in `unsupportedHostMode: "capture-only"` compatibility mode for generic CLI-backed agent runtimes such as `claude-cli`.

Strict compatibility remains the default. When capture-only is enabled:

- `agent-run` requires the generic CLI lifecycle OpenClaw actually provides: `bootstrap`, `after-turn`, and `maintain`
- CLI turns can continue and be persisted/maintained instead of failing before inference
- LCM does not claim pre-prompt assembly, LCM-owned compaction, or runtime LLM completion for those CLI runs
- CLI-backed child context remains host-managed instead of requiring LCM thread bootstrap projection
- native Codex and Pi embedded runs still receive the full context-engine lifecycle in mixed-runtime installations

The mode is available through plugin config or `LCM_UNSUPPORTED_HOST_MODE=capture-only`. Enabling it emits a once-per-process warning describing the degraded guarantees.

## Why

Lossless Claw currently declares the full native `agent-run` capability set unconditionally. OpenClaw's generic CLI runner advertises `bootstrap`, `after-turn`, and `maintain`, so selecting a `claude-cli`-backed model fails before inference even though the host can safely capture and maintain the completed turn.

Fail-closed remains the right default, but mixed fleets need an explicit middle ground between full LCM projection and globally switching the context engine to `legacy`.

Closes #849.
Addresses #928.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` (96 files, 1,726 tests)
- `npm pack --dry-run`
- `git diff --check`

## Safety

- default behavior is unchanged (`unsupportedHostMode: "error"`)
- no persistence, reconciliation, assembly, or compaction implementation was modified
- the relaxed capability list exactly matches OpenClaw's current generic CLI host capability set
- config schema, UI hints, exhaustive docs, bundled skill reference, and patch changeset are included
