### PR TITLE
feat: opt-in `hostFallbackMode: "capture-only"` for CLI-backed hosts

### DIFF
--- a/.changeset/soft-cli-capture.md
+++ b/.changeset/soft-cli-capture.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add an opt-in `hostFallbackMode: "capture-only"` setting so generic CLI backends can persist turns and use recall tools without Lossless prompt assembly or compaction. Strict full-lifecycle validation remains the default, and subagent projection requirements remain unchanged.

--- a/.changeset/soft-cli-capture.md
+++ b/.changeset/soft-cli-capture.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Add an opt-in `hostFallbackMode: "capture-only"` setting so generic CLI backends can persist turns and use recall tools without Lossless prompt assembly or compaction. Strict full-lifecycle validation remains the default, and subagent projection requirements remain unchanged.
+Add an opt-in `hostFallbackMode: "capture-only"` setting so generic CLI backends can persist turns and use recall tools without Lossless prompt assembly or host-triggered Lossless compaction. Strict full-lifecycle validation remains the default, backend-native compaction remains host-owned, and subagent projection requirements remain unchanged.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,14 @@ a native host that provides the full context-engine lifecycle: session bootstrap
 pre-prompt assembly, after-turn ingestion, maintenance, compaction, and runtime
 LLM completion. Native Codex and Pi embedded runs provide those capabilities;
 generic CLI harnesses such as `claude-cli` and `codex-cli` do not. If you must
-use a generic CLI harness, set `plugins.slots.contextEngine` to `legacy` for
-that run instead of `lossless-claw`.
+use a generic CLI harness, either set `plugins.slots.contextEngine` to `legacy`
+or explicitly set `hostFallbackMode` to `capture-only`. Capture-only mode lowers
+the installation-wide `agent-run` requirement to bootstrap, after-turn ingestion,
+and maintenance. Generic CLI runs can persist transcripts and use recall tools,
+but they do not receive Lossless prompt assembly or compaction. Fully capable
+native hosts still advertise and execute the full lifecycle, and Lossless retains
+compaction ownership for those runs. Subagent forks continue to require
+`thread-bootstrap-projection`.
 
 The optional programmatic `status` / `doctor` / `rotate` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
@@ -38,6 +44,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "ignoreSessionPatterns": [],
   "statelessSessionPatterns": [],
   "skipStatelessSessions": true,
+  "hostFallbackMode": "error",
   "contextThreshold": 0.75,
   "contextThresholdOverrides": [
     {
@@ -202,6 +209,7 @@ output.
 | `ignoreSessionPatterns` | `string[]` | `[]` | `LCM_IGNORE_SESSION_PATTERNS` | Session-key glob patterns that skip LCM entirely. |
 | `statelessSessionPatterns` | `string[]` | `[]` | `LCM_STATELESS_SESSION_PATTERNS` | Session-key glob patterns that may read from LCM but never write to it. |
 | `skipStatelessSessions` | `boolean` | `true` | `LCM_SKIP_STATELESS_SESSIONS` | Enforces `statelessSessionPatterns` when enabled. |
+| `hostFallbackMode` | `"error" \| "capture-only"` | `"error"` | `LCM_HOST_FALLBACK_MODE` | `error` requires the full agent-run lifecycle. `capture-only` accepts bootstrap, after-turn ingestion, and maintenance so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or compaction. Subagent projection requirements remain strict. |
 | `newSessionRetainDepth` | `integer` | `2` | `LCM_NEW_SESSION_RETAIN_DEPTH` | Controls what survives `/new`. `-1` keeps all context, `0` keeps summaries only, higher values keep only deeper summaries. |
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,10 +12,12 @@ use a generic CLI harness, either set `plugins.slots.contextEngine` to `legacy`
 or explicitly set `hostFallbackMode` to `capture-only`. Capture-only mode lowers
 the installation-wide `agent-run` requirement to bootstrap, after-turn ingestion,
 and maintenance. Generic CLI runs can persist transcripts and use recall tools,
-but they do not receive Lossless prompt assembly or compaction. Fully capable
-native hosts still advertise and execute the full lifecycle, and Lossless retains
-compaction ownership for those runs. Subagent forks continue to require
-`thread-bootstrap-projection`.
+but they do not receive Lossless prompt assembly or host-triggered Lossless
+compaction. Backend-native compaction remains host-owned. Explicit Lossless
+compaction requires `fallbackProviders` because generic CLI hosts do not provide
+runtime LLM completion. Fully capable native hosts still advertise and execute
+the full lifecycle, and Lossless retains compaction ownership for those runs.
+Subagent forks continue to require `thread-bootstrap-projection`.
 
 The optional programmatic `status` / `doctor` / `rotate` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
@@ -209,7 +211,7 @@ output.
 | `ignoreSessionPatterns` | `string[]` | `[]` | `LCM_IGNORE_SESSION_PATTERNS` | Session-key glob patterns that skip LCM entirely. |
 | `statelessSessionPatterns` | `string[]` | `[]` | `LCM_STATELESS_SESSION_PATTERNS` | Session-key glob patterns that may read from LCM but never write to it. |
 | `skipStatelessSessions` | `boolean` | `true` | `LCM_SKIP_STATELESS_SESSIONS` | Enforces `statelessSessionPatterns` when enabled. |
-| `hostFallbackMode` | `"error" \| "capture-only"` | `"error"` | `LCM_HOST_FALLBACK_MODE` | `error` requires the full agent-run lifecycle. `capture-only` accepts bootstrap, after-turn ingestion, and maintenance so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or compaction. Subagent projection requirements remain strict. |
+| `hostFallbackMode` | `"error" \| "capture-only"` | `"error"` | `LCM_HOST_FALLBACK_MODE` | `error` requires the full agent-run lifecycle. `capture-only` accepts bootstrap, after-turn ingestion, and maintenance so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or host-triggered Lossless compaction. Backend-native compaction remains host-owned. Subagent projection requirements remain strict. |
 | `newSessionRetainDepth` | `integer` | `2` | `LCM_NEW_SESSION_RETAIN_DEPTH` | Controls what survives `/new`. `-1` keeps all context, `0` keeps summaries only, higher values keep only deeper summaries. |
 | `timezone` | `string` | `TZ` or system timezone | `TZ` | IANA timezone used for timestamp rendering in summaries. |
 | `pruneHeartbeatOk` | `boolean` | `false` | `LCM_PRUNE_HEARTBEAT_OK` | Retroactively removes `HEARTBEAT_OK` turn cycles from persisted storage. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -33,7 +33,7 @@
     },
     "hostFallbackMode": {
       "label": "Host Fallback Mode",
-      "help": "How to declare agent-run host requirements. \"error\" (default): require the full context-engine lifecycle and fail closed on CLI-backed hosts. \"capture-only\": relax the requirement to bootstrap/after-turn/maintain so CLI-backed runs (e.g. claude-cli) continue with transcript capture and recall tools but WITHOUT lossless prompt assembly; native runtimes keep the full engine."
+      "help": "Controls the installation-wide agent-run host requirement. error (default) requires the full lifecycle and fails closed on CLI hosts. capture-only accepts bootstrap/after-turn/maintain so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or compaction. Fully capable native hosts still run the full lifecycle. Subagent projection requirements are unchanged."
     },
     "contextThreshold": {
       "label": "Context Threshold",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -31,6 +31,10 @@
       "label": "Enabled",
       "help": "Enable or disable lossless-claw without uninstalling it"
     },
+    "hostFallbackMode": {
+      "label": "Host Fallback Mode",
+      "help": "How to declare agent-run host requirements. \"error\" (default): require the full context-engine lifecycle and fail closed on CLI-backed hosts. \"capture-only\": relax the requirement to bootstrap/after-turn/maintain so CLI-backed runs (e.g. claude-cli) continue with transcript capture and recall tools but WITHOUT lossless prompt assembly; native runtimes keep the full engine."
+    },
     "contextThreshold": {
       "label": "Context Threshold",
       "help": "Fraction of context window that triggers compaction (0.0–1.0)"
@@ -330,6 +334,10 @@
     "properties": {
       "enabled": {
         "type": "boolean"
+      },
+      "hostFallbackMode": {
+        "type": "string",
+        "enum": ["error", "capture-only"]
       },
       "contextThreshold": {
         "type": "number",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -33,7 +33,7 @@
     },
     "hostFallbackMode": {
       "label": "Host Fallback Mode",
-      "help": "Controls the installation-wide agent-run host requirement. error (default) requires the full lifecycle and fails closed on CLI hosts. capture-only accepts bootstrap/after-turn/maintain so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or compaction. Fully capable native hosts still run the full lifecycle. Subagent projection requirements are unchanged."
+      "help": "Controls the installation-wide agent-run host requirement. error (default) requires the full lifecycle and fails closed on CLI hosts. capture-only accepts bootstrap/after-turn/maintain so generic CLI runs keep transcript capture and recall without Lossless prompt assembly or host-triggered Lossless compaction. Backend-native compaction remains host-owned. Fully capable native hosts still run the full lifecycle. Subagent projection requirements are unchanged."
     },
     "contextThreshold": {
       "label": "Context Threshold",

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -575,7 +575,8 @@ Controls the installation-wide `agent-run` host requirement.
 
 - `error` is the default and requires the full context-engine lifecycle
 - `capture-only` accepts hosts that provide bootstrap, after-turn ingestion, and maintenance
-- generic CLI runs in capture-only mode persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or compaction
+- generic CLI runs in capture-only mode persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or host-triggered Lossless compaction
+- backend-native compaction remains host-owned; explicit Lossless compaction requires `fallbackProviders`
 - fully capable native hosts still execute the full lifecycle, and Lossless retains compaction ownership for those runs
 - subagent forks continue to require `thread-bootstrap-projection`
 

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -569,6 +569,20 @@ Why it matters:
 - when enabled, matching stateless sessions skip LCM persistence entirely
 - use carefully, because it affects whether those sessions behave as readers only or are effectively bypassed for writes
 
+### `hostFallbackMode`
+
+Controls the installation-wide `agent-run` host requirement.
+
+- `error` is the default and requires the full context-engine lifecycle
+- `capture-only` accepts hosts that provide bootstrap, after-turn ingestion, and maintenance
+- generic CLI runs in capture-only mode persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or compaction
+- fully capable native hosts still execute the full lifecycle, and Lossless retains compaction ownership for those runs
+- subagent forks continue to require `thread-bootstrap-projection`
+
+Env override:
+
+- `LCM_HOST_FALLBACK_MODE`
+
 ## Recall-path and delegation controls
 
 ### `expansionModel`

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -90,6 +90,14 @@ export type LcmConfigDiagnostics = {
 
 export type LcmConfig = {
   enabled: boolean;
+  /**
+   * How to declare agent-run host requirements. "error" (default): require the full
+   * context-engine lifecycle and fail closed on CLI-backed hosts. "capture-only": relax the
+   * requirement to bootstrap/after-turn/maintain so CLI-backed runs (e.g. claude-cli) continue
+   * with transcript capture and recall tools but WITHOUT lossless prompt assembly; native
+   * runtimes advertise the full set and keep the full engine.
+   */
+  hostFallbackMode: "error" | "capture-only";
   databasePath: string;
   /** Directory for persisting large-file text payloads. */
   largeFilesDir: string;
@@ -682,6 +690,10 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_ENABLED !== undefined
           ? env.LCM_ENABLED !== "false"
           : toBool(pc.enabled) ?? true,
+      hostFallbackMode: (() => {
+        const raw = env.LCM_HOST_FALLBACK_MODE?.trim() || toStr(pc.hostFallbackMode) || "";
+        return raw === "capture-only" ? "capture-only" : "error";
+      })(),
       databasePath:
         env.LCM_DATABASE_PATH
         ?? toStr(pc.dbPath)

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -402,9 +402,15 @@ export class LcmContextEngine implements ContextEngine {
     } as ContextEngineInfo;
 
     if (this.config.hostFallbackMode === "capture-only") {
-      this.deps.log.warn(
-        "[lcm] hostFallbackMode=capture-only: agent-run host requirement relaxed to bootstrap/after-turn/maintain. On CLI-backed hosts (e.g. claude-cli) lossless assembly is NOT projected into the prompt; turns are captured to lcm.db and recall tools remain available. Summary compaction on such hosts requires fallbackProviders (no runtime-llm-complete capability).",
-      );
+      logStartupBannerOnce({
+        key: "host-fallback-capture-only",
+        log: (message) => (this.deps.log.hostWarn ?? this.deps.log.warn)(message),
+        message: [
+          "[lcm] WARNING: hostFallbackMode=capture-only relaxes the installation-wide agent-run host requirement to bootstrap/after-turn/maintain.",
+          "Generic CLI runs persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or compaction.",
+          "Fully capable native hosts still run the full lifecycle, and subagent forks still require thread-bootstrap-projection.",
+        ].join(" "),
+      });
     }
 
     this.conversationStore = new ConversationStore(this.db, {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -104,6 +104,15 @@ const LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability
 const LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
   "thread-bootstrap-projection",
 ];
+// Opt-in reduced requirement set (config hostFallbackMode="capture-only"): exactly the
+// capability set OpenClaw's generic CLI backends (e.g. claude-cli) advertise. Turns on such
+// hosts run with transcript capture + recall tools but WITHOUT lossless prompt assembly —
+// the CLI harness owns the prompt, so there is no assemble-before-prompt seam to project into.
+const LOSSLESS_AGENT_RUN_CAPTURE_ONLY_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
+  "bootstrap",
+  "after-turn",
+  "maintain",
+];
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
 
@@ -365,13 +374,23 @@ export class LcmContextEngine implements ContextEngine {
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
       hostRequirements: {
-        "agent-run": {
-          requiredCapabilities: LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
-          unsupportedMessage: [
-            "lossless-claw requires a native OpenClaw runtime with the full context-engine agent-run lifecycle.",
-            "Use the native Codex or Pi embedded runtime, or switch plugins.slots.contextEngine to legacy for CLI harness runs.",
-          ].join(" "),
-        },
+        "agent-run":
+          this.config.hostFallbackMode === "capture-only"
+            ? {
+                requiredCapabilities: LOSSLESS_AGENT_RUN_CAPTURE_ONLY_HOST_CAPABILITIES,
+                unsupportedMessage: [
+                  "lossless-claw (hostFallbackMode=capture-only) still requires the bootstrap, after-turn and maintain host capabilities for transcript capture.",
+                  "This host does not provide them; switch plugins.slots.contextEngine to legacy for such runs.",
+                ].join(" "),
+              }
+            : {
+                requiredCapabilities: LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES,
+                unsupportedMessage: [
+                  "lossless-claw requires a native OpenClaw runtime with the full context-engine agent-run lifecycle.",
+                  "Use the native Codex or Pi embedded runtime, switch plugins.slots.contextEngine to legacy for CLI harness runs,",
+                  'or set plugin config hostFallbackMode:"capture-only" to run CLI-backed turns with transcript capture but no lossless assembly.',
+                ].join(" "),
+              },
         "subagent-spawn": {
           requiredCapabilities: LOSSLESS_SUBAGENT_SPAWN_REQUIRED_HOST_CAPABILITIES,
           unsupportedMessage: [
@@ -381,6 +400,12 @@ export class LcmContextEngine implements ContextEngine {
         },
       },
     } as ContextEngineInfo;
+
+    if (this.config.hostFallbackMode === "capture-only") {
+      this.deps.log.warn(
+        "[lcm] hostFallbackMode=capture-only: agent-run host requirement relaxed to bootstrap/after-turn/maintain. On CLI-backed hosts (e.g. claude-cli) lossless assembly is NOT projected into the prompt; turns are captured to lcm.db and recall tools remain available. Summary compaction on such hosts requires fallbackProviders (no runtime-llm-complete capability).",
+      );
+    }
 
     this.conversationStore = new ConversationStore(this.db, {
       fts5Available: this.fts5Available,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -367,6 +367,9 @@ export class LcmContextEngine implements ContextEngine {
     // Only claim ownership of compaction when the DB is operational.
     // Without a working schema, ownsCompaction would disable the runtime's
     // built-in compaction safeguard and inflate the context budget.
+    // Capture-only changes agent-run admission, not this global ownership signal.
+    // Generic CLI turns do not consume it; capable native hosts and explicit
+    // Lossless compaction paths still need it to route compaction through LCM.
     this.info = {
       id: "lossless-claw",
       name: "Lossless Context Management Engine",
@@ -407,7 +410,8 @@ export class LcmContextEngine implements ContextEngine {
         log: (message) => (this.deps.log.hostWarn ?? this.deps.log.warn)(message),
         message: [
           "[lcm] WARNING: hostFallbackMode=capture-only relaxes the installation-wide agent-run host requirement to bootstrap/after-turn/maintain.",
-          "Generic CLI runs persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or compaction.",
+          "Generic CLI runs persist transcripts and keep recall tools, but do not receive Lossless prompt assembly or host-triggered Lossless compaction.",
+          "Backend-native compaction remains host-owned; explicit Lossless compaction requires fallbackProviders.",
           "Fully capable native hosts still run the full lifecycle, and subagent forks still require thread-bootstrap-projection.",
         ].join(" "),
       });

--- a/src/startup-banner-log.ts
+++ b/src/startup-banner-log.ts
@@ -8,6 +8,7 @@ type StartupBannerKey =
   | "stateless-session-patterns"
   | "ignore-session-patterns-env-override"
   | "stateless-session-patterns-env-override"
+  | "host-fallback-capture-only"
   | "runtime-llm-unavailable"
   | "runtime-llm-policy-summary-models"
   | "state-dir";

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -25,6 +25,7 @@ describe("resolveLcmConfig", () => {
   it("uses hardcoded defaults when no env or plugin config", () => {
     const config = resolveLcmConfig({}, {});
     expect(config.enabled).toBe(true);
+    expect(config.hostFallbackMode).toBe("error");
     expect(config.databasePath).toBe(join(homedir(), ".openclaw", "lcm.db"));
     expect(config.largeFilesDir).toBe(join(homedir(), ".openclaw", "lcm-files"));
     expect(config.ignoreSessionPatterns).toEqual([]);
@@ -196,6 +197,25 @@ describe("resolveLcmConfig", () => {
       enabled: true,
       max: 80000,
     });
+  });
+
+  it("resolves hostFallbackMode from plugin config and env override", () => {
+    expect(resolveLcmConfig({}, { hostFallbackMode: "capture-only" }).hostFallbackMode).toBe(
+      "capture-only",
+    );
+    expect(
+      resolveLcmConfig(
+        { LCM_HOST_FALLBACK_MODE: "capture-only" } as NodeJS.ProcessEnv,
+        {},
+      ).hostFallbackMode,
+    ).toBe("capture-only");
+    expect(
+      resolveLcmConfig(
+        { LCM_HOST_FALLBACK_MODE: "error" } as NodeJS.ProcessEnv,
+        { hostFallbackMode: "capture-only" },
+      ).hostFallbackMode,
+    ).toBe("error");
+    expect(resolveLcmConfig({}, { hostFallbackMode: "bogus" }).hostFallbackMode).toBe("error");
   });
 
   it("env vars override plugin config", () => {

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { resetStartupBannerLogsForTests } from "../src/startup-banner-log.js";
 import { createDelegatedExpansionGrant, getRuntimeExpansionAuthManager, resolveDelegatedExpansionGrantId } from "../src/expansion-auth.js";
 import {
   cleanupEngineTestState,
@@ -25,7 +26,11 @@ import {
   tempDirs,
 } from "./helpers.js";
 
-afterEach(cleanupEngineTestState);
+afterEach(() => {
+  cleanupEngineTestState();
+  resetStartupBannerLogsForTests();
+});
+
 describe("LcmContextEngine metadata", () => {
   it("reports the registered lossless-claw engine id", () => {
     const engine = createEngine();
@@ -58,6 +63,24 @@ describe("LcmContextEngine metadata", () => {
       requiredCapabilities: ["bootstrap", "after-turn", "maintain"],
       unsupportedMessage: expect.stringContaining("capture-only"),
     });
+    expect(engine.info.ownsCompaction).toBe(true);
+  });
+
+  it("warns only once per process when capture-only mode is enabled", () => {
+    const hostWarn = vi.fn();
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      hostWarn,
+    };
+
+    createEngineWithDeps({ hostFallbackMode: "capture-only" }, { log });
+    createEngineWithDeps({ hostFallbackMode: "capture-only" }, { log });
+
+    expect(hostWarn).toHaveBeenCalledOnce();
+    expect(hostWarn).toHaveBeenCalledWith(expect.stringContaining("hostFallbackMode=capture-only"));
   });
 
   it("keeps the subagent-spawn requirement unchanged in capture-only mode", () => {

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -52,6 +52,22 @@ describe("LcmContextEngine metadata", () => {
     });
   });
 
+  it("relaxes agent-run requirements to the generic CLI host set in capture-only mode", () => {
+    const engine = createEngineWithConfig({ hostFallbackMode: "capture-only" });
+    expect(engine.info.hostRequirements?.["agent-run"]).toEqual({
+      requiredCapabilities: ["bootstrap", "after-turn", "maintain"],
+      unsupportedMessage: expect.stringContaining("capture-only"),
+    });
+  });
+
+  it("keeps the subagent-spawn requirement unchanged in capture-only mode", () => {
+    const engine = createEngineWithConfig({ hostFallbackMode: "capture-only" });
+    expect(engine.info.hostRequirements?.["subagent-spawn"]).toEqual({
+      requiredCapabilities: ["thread-bootstrap-projection"],
+      unsupportedMessage: expect.stringContaining("raw parent JSONL branch"),
+    });
+  });
+
   it("requires host thread bootstrap projection for subagent forks", () => {
     const engine = createEngine();
     expect(engine.info.hostRequirements?.["subagent-spawn"]).toEqual({

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -5,6 +5,7 @@ import { buildExpansionToolDefinition } from "../src/expansion.js";
 
 const BASE_CONFIG: LcmConfig = {
   enabled: true,
+  hostFallbackMode: "error",
   databasePath: ":memory:",
   largeFilesDir: "/tmp/lcm-files",
   ignoreSessionPatterns: [],

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -47,6 +47,7 @@ export function createTestConfig(
   const tempDir = join(databasePath, "..", "lcm-files");
   return {
     enabled: true,
+    hostFallbackMode: "error",
     databasePath,
     largeFilesDir: tempDir,
     ignoreSessionPatterns: [],

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -32,6 +32,7 @@ afterEach(() => {
 function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
   return {
     enabled: true,
+    hostFallbackMode: "error",
     databasePath: path.join(tempDir, "lcm.db"),
     largeFilesDir: path.join(tempDir, "lcm-files"),
     ignoreSessionPatterns: [],


### PR DESCRIPTION
Implements #849 (opt-in capture-only mode); refs #928 and #971.

## Problem

Since 0.11.3 (#740), the engine declares `agent-run` host requirements of
`bootstrap, assemble-before-prompt, after-turn, maintain, compact, runtime-llm-complete`.
OpenClaw's generic CLI backends (e.g. `claude-cli`) advertise only
`bootstrap, after-turn, maintain`, and OpenClaw core enforces the requirement fail-closed, so
every CLI-backed turn dies before reaching the model:

```
Context engine "lossless-claw" cannot run operation "agent-run" on CLI backend "claude-cli".
Missing host capabilities: assemble-before-prompt, compact, runtime-llm-complete.
```

To the operator this surfaces as a silent no-reply on chat channels (openclaw/openclaw#93337
describes the signature). Setting the slot back to `legacy` un-breaks replies but freezes ingest
fleet-wide (#971) — all-or-nothing. OpenClaw core rejected automatic per-session demotion
(openclaw/openclaw#93569) as a reversal of the fail-closed contract, and pointed at a product-level
opt-in instead. This PR adds that opt-in where it belongs: in the engine's own declaration.

## Change

New plugin config key `hostFallbackMode` (env override `LCM_HOST_FALLBACK_MODE`):

- `"error"` (default) — exactly today's behavior: full lifecycle required, fail closed on CLI
  hosts. The unsupported-message now additionally mentions the opt-in.
- `"capture-only"` — the engine declares `agent-run` requirements of
  `bootstrap, after-turn, maintain` (the generic-CLI host set; anything weaker still fails
  closed). CLI-backed turns then run with full transcript capture into lcm.db and all recall
  tools, but WITHOUT lossless prompt assembly — the CLI harness owns the prompt, so there is no
  `assemble-before-prompt` seam to project into. This is an explicit, documented trade-off chosen
  by the operator, not a silent degradation.

Details:

- Native runtimes (Codex / Pi embedded) advertise the full capability set, so capture-only never
  changes behavior there — hosts invoke every seam they support regardless; `hostRequirements`
  is a fail-closed minimum, not a negotiation.
- The `subagent-spawn` requirement (`thread-bootstrap-projection`) is untouched.
- A one-time warning is logged at engine construction when capture-only is active, spelling out
  that assembly is not projected on CLI hosts and that summary compaction there needs
  `fallbackProviders` (no `runtime-llm-complete`).
- Unrecognized values resolve to `"error"`.
- Manifest `configSchema` extended (it is `additionalProperties: false`).

## Testing

- `npm run typecheck` clean.
- Full suite: 1730 passed, 0 failed.
- New tests: config resolution (default / plugin-config / env precedence / bogus value) and
  engine metadata in capture-only mode (reduced agent-run set, unchanged subagent-spawn).
- End-to-end on OpenClaw 2026.7.1-beta.5 with a claude-cli agent behind a live gateway:
  - default mode: reproduces the pre-model fail-closed kill verbatim;
  - capture-only: replies flow, engine active, one-time warning logged, all turns captured to
    lcm.db (including startup backfill of a pre-activation session), recall tools functional.
