### PR TITLE
chore: cut v0.14.0-beta.0

### DIFF
--- a/.changeset/blue-signs-swim.md
+++ b/.changeset/blue-signs-swim.md
@@ -1,5 +1,5 @@
 ---
-"lossless-claw": patch
+"@martian-engineering/lossless-claw": patch
 ---
 
 Fix `doctor-contract` model reference generation to honor the explicit `provider` field in `fallbackProviders` when the model value also contains a slash, preventing false "Missing allowedModels entries" override-policy warnings.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,33 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@martian-engineering/lossless-claw": "0.13.2"
+  },
+  "changesets": [
+    "agent-oriented-cli",
+    "blue-signs-swim",
+    "bounded-delegated-expansion",
+    "cron-sessionid-recovery",
+    "demote-fork-suffix-append-log",
+    "doctor-skip-deliberate-reset",
+    "doctor-version-split",
+    "fix-stale-recall-scope",
+    "ignored-session-runtime-compact",
+    "prefer-real-tool-results",
+    "preserve-conversation-on-new-soft-reset",
+    "quiet-ambiguous-rollover-rebind-logs",
+    "quiet-control-plane",
+    "qwen-fresh-tail-overrides",
+    "read-mcp-result-envelopes",
+    "read-truncation-recovery",
+    "reasoning-block-text-fallback",
+    "recognize-memory-first-current-turns",
+    "replay-twin-entry-id-guard",
+    "same-turn-collapse-frontier",
+    "scoped-doctor-repair-backup",
+    "strip-host-recap-inbound-reduction",
+    "tidy-dreams-rest",
+    "wet-bags-create"
+  ]
+}

--- a/.changeset/qwen-fresh-tail-overrides.md
+++ b/.changeset/qwen-fresh-tail-overrides.md
@@ -1,5 +1,5 @@
 ---
-"lossless-claw": patch
+"@martian-engineering/lossless-claw": patch
 ---
 
 Allow context-threshold override rules to set model-specific fresh-tail and leaf chunk sizing for assembly and threshold compaction.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,10 +42,12 @@ jobs:
       - name: Build package bundle
         run: npm run build
 
-      - name: Read package version
+      - name: Read package version and release channel
         id: package
         run: |
-          printf 'version=%s\n' "$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          version="$(node -p "require('./package.json').version")"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          node scripts/release-channel.mjs "$version" >> "$GITHUB_OUTPUT"
 
       - name: Ensure release tag does not already exist
         run: |
@@ -56,7 +58,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -87,7 +89,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="v${{ steps.package.outputs.version }}"
-          gh release create "$tag" \
-            --generate-notes \
-            --notes "$(cat release-notes.md)" \
+          release_args=(
+            --generate-notes
+            --notes "$(cat release-notes.md)"
             --verify-tag
+          )
+          if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "$tag" "${release_args[@]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,18 @@ jobs:
             exit 1
           fi
 
+      - name: Append release verification
+        run: |
+          version="${{ steps.package.outputs.version }}"
+          source_sha="$(git rev-parse HEAD)"
+          {
+            printf '\n## Release Verification\n\n'
+            printf -- '- Source: [%s](https://github.com/%s/commit/%s)\n' "$source_sha" "$GITHUB_REPOSITORY" "$source_sha"
+            printf -- '- Package: [@martian-engineering/lossless-claw@%s](https://www.npmjs.com/package/@martian-engineering/lossless-claw/v/%s)\n' "$version" "$version"
+            printf -- '- Workflow: [%s](https://github.com/%s/actions/runs/%s)\n' "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+            printf -- '- Rollback: install @martian-engineering/lossless-claw@latest.\n'
+          } >> release-notes.md
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,12 @@ jobs:
           dist_tags="$(npm view "$package_name" dist-tags --json)"
           channel_version="$(node -e 'const tags=JSON.parse(process.argv[1]); process.stdout.write(tags[process.argv[2]] || "")' "$dist_tags" "$npm_tag")"
           stable_version="$(node -e 'const tags=JSON.parse(process.argv[1]); process.stdout.write(tags.latest || "")' "$dist_tags")"
+          rollback_version="$(node scripts/release-channel.mjs --read-rollback "$version" < CHANGELOG.md)"
+          published_rollback="$(npm view "$package_name@$rollback_version" version)"
+          if [ "$published_rollback" != "$rollback_version" ]; then
+            echo "Rollback version $rollback_version is not published"
+            exit 1
+          fi
 
           npm_exists=false
           if npm_state="$(npm view "$package_name@$version" version gitHead --json 2>/dev/null)"; then
@@ -86,8 +92,19 @@ jobs:
               exit 1
             fi
             npm_exists=true
-          elif [ -n "$channel_version" ]; then
-            node scripts/release-channel.mjs --assert-newer "$version" "$channel_version"
+          else
+            if [ -n "$channel_version" ]; then
+              node scripts/release-channel.mjs --assert-newer "$version" "$channel_version"
+            fi
+            if [ "$prerelease" = true ]; then
+              expected_rollback="$stable_version"
+            else
+              expected_rollback="$channel_version"
+            fi
+            if [ "$rollback_version" != "$expected_rollback" ]; then
+              echo "Rollback marker $rollback_version does not match current release state $expected_rollback"
+              exit 1
+            fi
           fi
 
           tag_exists=false
@@ -124,8 +141,7 @@ jobs:
             printf 'npm_exists=%s\n' "$npm_exists"
             printf 'tag_exists=%s\n' "$tag_exists"
             printf 'release_exists=%s\n' "$release_exists"
-            printf 'previous_channel_version=%s\n' "$channel_version"
-            printf 'stable_version=%s\n' "$stable_version"
+            printf 'rollback_version=%s\n' "$rollback_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Extract release notes from CHANGELOG
@@ -146,11 +162,7 @@ jobs:
         run: |
           version="${{ steps.package.outputs.version }}"
           source_sha="${{ steps.package.outputs.source_sha }}"
-          if [ "${{ steps.package.outputs.prerelease }}" = true ]; then
-            rollback_version="${{ steps.preflight.outputs.stable_version }}"
-          else
-            rollback_version="${{ steps.preflight.outputs.previous_channel_version }}"
-          fi
+          rollback_version="${{ steps.preflight.outputs.rollback_version }}"
           if [ -z "$rollback_version" ]; then
             echo "Cannot determine an exact rollback version"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,25 +2,24 @@ name: Publish Package
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Optional git ref to publish. Leave blank to use the selected branch or tag.
-        required: false
-        type: string
 
 permissions:
   contents: write
   id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
-      - name: Checkout
+      - name: Checkout approved commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -45,30 +44,89 @@ jobs:
       - name: Read package version and release channel
         id: package
         run: |
-          version="$(node -p "require('./package.json').version")"
-          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
-          node scripts/release-channel.mjs "$version" >> "$GITHUB_OUTPUT"
-
-      - name: Ensure release tag does not already exist
-        run: |
-          tag="v${{ steps.package.outputs.version }}"
-          if git rev-parse "$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists"
+          source_sha="$(git rev-parse HEAD)"
+          if [ "$source_sha" != "$GITHUB_SHA" ]; then
+            echo "Checked out $source_sha, expected approved commit $GITHUB_SHA"
             exit 1
           fi
 
-      - name: Publish to npm
-        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          version="$(node -p "require('./package.json').version")"
+          {
+            printf 'source_sha=%s\n' "$source_sha"
+            printf 'version=%s\n' "$version"
+            node scripts/release-channel.mjs "$version"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Create and push release tag
+      - name: Verify release state
+        id: preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          tag="v${{ steps.package.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$tag" -m "$tag"
-          git push origin "$tag"
+          package_name="$(node -p "require('./package.json').name")"
+          version="${{ steps.package.outputs.version }}"
+          npm_tag="${{ steps.package.outputs.npm_tag }}"
+          prerelease="${{ steps.package.outputs.prerelease }}"
+          source_sha="${{ steps.package.outputs.source_sha }}"
+          tag="v$version"
+
+          dist_tags="$(npm view "$package_name" dist-tags --json)"
+          channel_version="$(node -e 'const tags=JSON.parse(process.argv[1]); process.stdout.write(tags[process.argv[2]] || "")' "$dist_tags" "$npm_tag")"
+          stable_version="$(node -e 'const tags=JSON.parse(process.argv[1]); process.stdout.write(tags.latest || "")' "$dist_tags")"
+
+          npm_exists=false
+          if npm_state="$(npm view "$package_name@$version" version gitHead --json 2>/dev/null)"; then
+            published_version="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.version || "")' "$npm_state")"
+            published_sha="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.gitHead || "")' "$npm_state")"
+            if [ "$published_version" != "$version" ] || [ "$published_sha" != "$source_sha" ]; then
+              echo "Existing npm version identity does not match $version at $source_sha"
+              exit 1
+            fi
+            if [ "$channel_version" != "$version" ]; then
+              echo "Existing npm version is not the active $npm_tag dist-tag"
+              exit 1
+            fi
+            npm_exists=true
+          elif [ -n "$channel_version" ]; then
+            node scripts/release-channel.mjs --assert-newer "$version" "$channel_version"
+          fi
+
+          tag_exists=false
+          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+            tag_sha="$(git rev-list -n 1 "refs/tags/$tag")"
+            if [ "$tag_sha" != "$source_sha" ]; then
+              echo "Existing tag $tag points to $tag_sha, expected $source_sha"
+              exit 1
+            fi
+            tag_exists=true
+          fi
+
+          release_exists=false
+          if release_state="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json tagName,isPrerelease,isDraft 2>/dev/null)"; then
+            node -e '
+              const release = JSON.parse(process.argv[1]);
+              const expectedTag = process.argv[2];
+              const expectedPrerelease = process.argv[3] === "true";
+              if (
+                release.tagName !== expectedTag ||
+                release.isDraft ||
+                release.isPrerelease !== expectedPrerelease
+              ) process.exit(1);
+            ' "$release_state" "$tag" "$prerelease"
+            release_exists=true
+          fi
+
+          if [ "$release_exists" = true ] && { [ "$npm_exists" != true ] || [ "$tag_exists" != true ]; }; then
+            echo "GitHub Release exists without matching npm and tag identities"
+            exit 1
+          fi
+
+          {
+            printf 'npm_exists=%s\n' "$npm_exists"
+            printf 'tag_exists=%s\n' "$tag_exists"
+            printf 'release_exists=%s\n' "$release_exists"
+            printf 'previous_channel_version=%s\n' "$channel_version"
+            printf 'stable_version=%s\n' "$stable_version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Extract release notes from CHANGELOG
         run: |
@@ -87,16 +145,42 @@ jobs:
       - name: Append release verification
         run: |
           version="${{ steps.package.outputs.version }}"
-          source_sha="$(git rev-parse HEAD)"
+          source_sha="${{ steps.package.outputs.source_sha }}"
+          if [ "${{ steps.package.outputs.prerelease }}" = true ]; then
+            rollback_version="${{ steps.preflight.outputs.stable_version }}"
+          else
+            rollback_version="${{ steps.preflight.outputs.previous_channel_version }}"
+          fi
+          if [ -z "$rollback_version" ]; then
+            echo "Cannot determine an exact rollback version"
+            exit 1
+          fi
+
           {
             printf '\n## Release Verification\n\n'
             printf -- '- Source: [%s](https://github.com/%s/commit/%s)\n' "$source_sha" "$GITHUB_REPOSITORY" "$source_sha"
             printf -- '- Package: [@martian-engineering/lossless-claw@%s](https://www.npmjs.com/package/@martian-engineering/lossless-claw/v/%s)\n' "$version" "$version"
             printf -- '- Workflow: [%s](https://github.com/%s/actions/runs/%s)\n' "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
-            printf -- '- Rollback: install @martian-engineering/lossless-claw@latest.\n'
+            printf -- '- Rollback: install @martian-engineering/lossless-claw@%s.\n' "$rollback_version"
           } >> release-notes.md
 
+      - name: Publish to npm
+        if: steps.preflight.outputs.npm_exists != 'true'
+        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create and push release tag
+        if: steps.preflight.outputs.tag_exists != 'true'
+        run: |
+          tag="v${{ steps.package.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"
+
       - name: Create GitHub release
+        if: steps.preflight.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -109,4 +193,4 @@ jobs:
           if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then
             release_args+=(--prerelease)
           fi
-          gh release create "$tag" "${release_args[@]}"
+          gh release create "$tag" --repo "$GITHUB_REPOSITORY" "${release_args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # @martian-engineering/lossless-claw
 
+## 0.14.0-beta.0
+
+This beta opens the next Lossless Claw release line for broader testing. It
+adds a packaged diagnostics CLI and combines the continuity, reconciliation,
+doctor, recall, and compaction fixes merged since `0.13.2`.
+
+### Highlights
+
+- Inspect conversations, messages, summaries, effective configuration, and
+  fresh-tail state through the new packaged `lcm` CLI.
+- Preserve more live and recovered context across resets, rollovers, replayed
+  entries, metadata-wrapped turns, truncated reads, and MCP result envelopes.
+- Improve operational safety with scoped-repair backups, version-split
+  detection, bounded delegated recall, and quieter healthy-path telemetry.
+
+### Known Boundaries
+
+- This is a prerelease testing build, not a stable-channel promotion.
+- Install with `npm install @martian-engineering/lossless-claw@beta`; existing
+  stable users remain on npm's `latest` channel.
+- Runtime and customer-specific canary results remain separate from package,
+  tag, and GitHub Release verification.
+
+### Minor Changes
+
+- [#983](https://github.com/Martian-Engineering/lossless-claw/pull/983) [`367df4e`](https://github.com/Martian-Engineering/lossless-claw/commit/367df4ec10bbaa9065204340d41a33ffdf1fabba) Thanks [@jalehman](https://github.com/jalehman)! - Add the TypeScript `lcm` executable for paginated read-only conversation diagnostics, message and fresh-tail inspection, depth- and time-filtered summary inspection, effective config viewing, and manifest-validated targeted config edits.
+
+### Patch Changes
+
+- [#958](https://github.com/Martian-Engineering/lossless-claw/pull/958) [`5442e8e`](https://github.com/Martian-Engineering/lossless-claw/commit/5442e8e3f68169530a7543f9a777fe495c63ad4e) Thanks [@mpz4life](https://github.com/mpz4life)! - Fix `doctor-contract` model reference generation to honor the explicit `provider` field in `fallbackProviders` when the model value also contains a slash, preventing false "Missing allowedModels entries" override-policy warnings.
+
+- [#994](https://github.com/Martian-Engineering/lossless-claw/pull/994) [`669e01d`](https://github.com/Martian-Engineering/lossless-claw/commit/669e01d8b07ae1d82c109b624c8362c99420b7d7) Thanks [@jalehman](https://github.com/jalehman)! - Bound each delegated recall request by one deadline, cancel timed-out child work through host-owned session cleanup, preserve completed cross-conversation evidence, and return structured failure diagnostics.
+
+- [#947](https://github.com/Martian-Engineering/lossless-claw/pull/947) [`70805c1`](https://github.com/Martian-Engineering/lossless-claw/commit/70805c1a1e698ba127b31966b64148ad896ea927) Thanks [@ralf003](https://github.com/ralf003)! - Allow isolated cron sessions with a matching durable sessionKey to recover from a checkpoint-missing reconciliation state even when the conversation's sessionId has been overwritten by a newer cron run.
+
+- [#960](https://github.com/Martian-Engineering/lossless-claw/pull/960) [`6dcc525`](https://github.com/Martian-Engineering/lossless-claw/commit/6dcc525ee15f71d7277a8c77a9f278617c74dfa6) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Demote the per-assemble "appended fork-bounded live suffix" log from warn to debug on the healthy path. Thread-fork sessions append this suffix on essentially every assemble, so the line was warn-level noise in routine operation. The log stays at warn when the append evicted messages or ran over budget, the states that need operator attention. Assembly behavior is unchanged; only the log level moves.
+
+- [#957](https://github.com/Martian-Engineering/lossless-claw/pull/957) [`2b89cdf`](https://github.com/Martian-Engineering/lossless-claw/commit/2b89cdf635a8b18dd5de58d79ad9a51b3d08e0c9) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Stop the rollover-split doctor from auto-restoring conversations a user deliberately wiped with `/reset`. A new nullable `archive_cause` column records why each conversation was archived, written at the single archive funnel for both the `before_reset` and `session_end` lifecycle events a `/reset` surfaces. The doctor excludes deliberate causes (`manual-reset`) from its merge sources, so a `/reset` archive is never re-merged into the active conversation. Incidental archives (`rollover-fallback`, `cron-rotation`, `session-end`, idle/daily/compaction) and legacy NULL-cause rows stay merge-eligible, so genuine crash and rollover splits are still recovered.
+
+- [#990](https://github.com/Martian-Engineering/lossless-claw/pull/990) [`b89e192`](https://github.com/Martian-Engineering/lossless-claw/commit/b89e1920643c3c9f4c146b856f940db4f4522928) Thanks [@jalehman](https://github.com/jalehman)! - Report the active Lossless Claw version and source path in doctor output, and warn when live or generated OpenClaw package copies use a different version.
+
+- [#989](https://github.com/Martian-Engineering/lossless-claw/pull/989) [`c16c2ef`](https://github.com/Martian-Engineering/lossless-claw/commit/c16c2effbf046b805996a6d2a5ba93b9ecd9bf60) Thanks [@jalehman](https://github.com/jalehman)! - Prefer the active runtime session when a stale tool session key points scoped `lcm_*` recall at another conversation family.
+
+- [#959](https://github.com/Martian-Engineering/lossless-claw/pull/959) [`992bf00`](https://github.com/Martian-Engineering/lossless-claw/commit/992bf002f5b6f0a9e037ec43711e1b50d9346795) Thanks [@spiral-cmd](https://github.com/spiral-cmd)! - Delegate ignored-session compaction to OpenClaw's runtime compaction path when the host exposes it, so sessions excluded from LCM can still recover from raw transcript pressure.
+
+- [#993](https://github.com/Martian-Engineering/lossless-claw/pull/993) [`27cda30`](https://github.com/Martian-Engineering/lossless-claw/commit/27cda302a545b97d5974fa8336c0d8c891437a14) Thanks [@jalehman](https://github.com/jalehman)! - Preserve real tool results when compacted history displaces them past later tool calls or an earlier synthetic repair result.
+
+- [#972](https://github.com/Martian-Engineering/lossless-claw/pull/972) [`1a89b30`](https://github.com/Martian-Engineering/lossless-claw/commit/1a89b30a669ae8cf648bc7ad4e67307ea01bf740) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Preserve the conversation on a /new soft reset. The host archives the old transcript by renaming it to `${file}.reset.<ts>` and mints a fresh session id, so the next-turn rollover detector saw a stale session key whose tracked transcript had vanished and destructively archived the pruned conversation, stranding the retained summary band it was documented to carry forward. Lossless now records its own durable /new prune marker, requires that marker plus the reset archive sibling before standing down the destructive guard, keeps foreign reused-key identity-overlap cases at warn, and rebinds once the first turn of the new session lands.
+
+- [#954](https://github.com/Martian-Engineering/lossless-claw/pull/954) [`0b8e2b2`](https://github.com/Martian-Engineering/lossless-claw/commit/0b8e2b29b99de15bc1541d226adb77ac02f168ff) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Demote the happy-path ambiguous session-key rollover recovery logs from warn to info or debug, context-aware. The successful fresh-transcript rebind and transient not-provably-fresh decisions now log at info; the assemble pass's per-phase preserve restatement logs at debug; the fresh-rebind new-epoch import logs at info, and the afterTurn "frontier not covered" line logs at debug only on the benign ambiguous-rollover path.
+
+  The bootstrap and afterTurn preserve log keys off the freshness disposition carried out of the rebind attempt: a transient or unjudgeable verdict (no usable timestamps, delivery-only traffic, nothing comparable) is a pending state the next turn re-evaluates and logs at debug, while a conflicting verdict (identity overlap, or candidate entries predating persistence) is a genuine freeze and stays at warn. The rebind-failed and freshness-check exception paths, the no-anchor import-cap aborts, and every non-rollover unsafe-to-advance frontier skip also stay at warn. The freeze and no-merge protection is unchanged throughout; only log levels move.
+
+- [#951](https://github.com/Martian-Engineering/lossless-claw/pull/951) [`0bfb7e9`](https://github.com/Martian-Engineering/lossless-claw/commit/0bfb7e9bf686717da593feb4a8ce77b7711c0754) Thanks [@SYU8384](https://github.com/SYU8384)! - Document the optional programmatic status/doctor/rotate control surface and keep status free of non-durable rotation timestamps.
+
+- [#956](https://github.com/Martian-Engineering/lossless-claw/pull/956) [`f18ccd4`](https://github.com/Martian-Engineering/lossless-claw/commit/f18ccd42bc8feaa538c599b5e90b3b6ef5a63104) Thanks [@jalehman](https://github.com/jalehman)! - Allow context-threshold override rules to set model-specific fresh-tail and leaf chunk sizing for assembly and threshold compaction.
+
+- [#984](https://github.com/Martian-Engineering/lossless-claw/pull/984) [`e4a36d7`](https://github.com/Martian-Engineering/lossless-claw/commit/e4a36d7a71c55ee5f3f91c055fe6c1f5ab509048) Thanks [@jalehman](https://github.com/jalehman)! - Preserve MCP tool-result text nested inside OpenClaw result envelopes when preparing conversation summaries.
+
+- [#950](https://github.com/Martian-Engineering/lossless-claw/pull/950) [`9561470`](https://github.com/Martian-Engineering/lossless-claw/commit/9561470f911509496ccf11de969349fbad31ca7d) Thanks [@mpz4life](https://github.com/mpz4life)! - When OpenClaw's built-in `read` tool returns truncated output, recover the full file content before externalizing the oversized tool result — but only for the live `assemble()` current turn. The truncated text is preserved on ingest, bootstrap, and replay paths so transcript fidelity is not compromised by current disk state. Fallback to the truncated fragment when the original path is missing, relative, unreadable, non-regular, or too large for bounded live recovery.
+
+- [#953](https://github.com/Martian-Engineering/lossless-claw/pull/953) [`7e0cff2`](https://github.com/Martian-Engineering/lossless-claw/commit/7e0cff2f5fd177130c9db8c65dc943205e4fa35c) Thanks [@cxbAsDev](https://github.com/cxbAsDev)! - Avoid requesting summary-thinking controls for Ollama summarizer calls, so extended-thinking models return usable text summaries without promoting typed reasoning blocks into persisted summary content.
+
+- [#978](https://github.com/Martian-Engineering/lossless-claw/pull/978) [`013de1f`](https://github.com/Martian-Engineering/lossless-claw/commit/013de1f1b0592eb97139c9387790daafdcb2653c) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Recognize memory-first current turns in live coverage. When a memory or context plugin decorates the current turn with injected-context markers (for example `relevant-memories`, `relevant_memories`, `hindsight_memories`, or `active_memory_plugin`) and the channel adds no timestamp, the decorated current turn was previously dropped from live assembly and the model saw only the tag-stripped stored row. It is now re-appended so the decorated current turn is preserved. Because marker presence alone is not provenance proof, marker-based recognition is constrained to the last assembled user row (the current turn's persisted face), so a distinct turn that merely ends with an earlier row's body cannot be matched through a typed marker.
+
+- [#968](https://github.com/Martian-Engineering/lossless-claw/pull/968) [`3e05747`](https://github.com/Martian-Engineering/lossless-claw/commit/3e057473dbd1c6b4badfb6c040ff5e61f2299820) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Skip replayed transcript entries that OpenClaw re-appends under fresh entry ids when the persisted row and new entry share the same canonical identity and full-precision inner source timestamp.
+
+- [#967](https://github.com/Martian-Engineering/lossless-claw/pull/967) [`8664c6e`](https://github.com/Martian-Engineering/lossless-claw/commit/8664c6ea674c37f766da900d3b78a01ed841a88c) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Collapse metadata-wrapped OpenClaw runtime copies onto their bare persisted rows only when the covered transcript frontier proves same-turn alignment. Degraded after-turn dedup remains timestamp-gated, so repeated short user messages wrapped in forgeable metadata-shaped text are preserved instead of silently collapsed.
+
+- [#970](https://github.com/Martian-Engineering/lossless-claw/pull/970) [`004e266`](https://github.com/Martian-Engineering/lossless-claw/commit/004e266410a3f638e600fd047f04b56ae001825b) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Create and report a SQLite backup before scoped doctor summary repair writes, matching the backup-first safety behavior used by rollover-split repair.
+
+- [#974](https://github.com/Martian-Engineering/lossless-claw/pull/974) [`421e7cb`](https://github.com/Martian-Engineering/lossless-claw/commit/421e7cb0606600991edc2feec4b85b22487a974a) Thanks [@gorkem2020](https://github.com/gorkem2020)! - Strip a structurally validated host chat-history recap block when reducing an OpenClaw inbound turn to its model-facing body, and when canonicalizing it for identity hashing. Building on the metadata-block strip landed in [#967](https://github.com/Martian-Engineering/lossless-claw/pull/967), a decorated inbound turn that also carries a recap of unread channel messages previously kept the recap embedded in its reduced body, so it never matched its bare persisted row and both got replayed to the model (see [#973](https://github.com/Martian-Engineering/lossless-claw/issues/973)).
+
+  The matcher recognizes the two recap headings OpenClaw core emits ("Chat history since last reply (untrusted, for context):" and "Conversation context (untrusted, chronological, selected for current message):", kept in a single extensible list) across both observed body grammars: the JSON-fenced message array and the older per-message prose line format. It also consumes the exact host JSON context blocks OpenClaw can emit between metadata and recap, such as reply target, thread starter, forwarded-message, and location context. Each combination is validated fail-closed: the strip requires a positive host `history_count`, an exact known heading, and a body that parses under the expected grammar, so user-authored recap-shaped text, a quoted heading, or a malformed payload is left untouched.
+
+  The identity canonicalization also excludes the host's volatile recap count, media count, and truncation fields whenever trusted history is present. On upgrade, the versioned OpenClaw identity repair refreshes message and bootstrap hashes that were already canonicalized before recap removal, preventing stale identity state from re-importing those rows.
+
+- [#977](https://github.com/Martian-Engineering/lossless-claw/pull/977) [`c71af2a`](https://github.com/Martian-Engineering/lossless-claw/commit/c71af2ae0723c4e5208a25fb47c58add39acf9b8) Thanks [@ryanngit](https://github.com/ryanngit)! - Document optional storage exclusions for OpenClaw active-memory and memory-core dreaming narrative sessions, including the breadth and data-retention implications of the recommended patterns.
+
+- [#945](https://github.com/Martian-Engineering/lossless-claw/pull/945) [`093ac5b`](https://github.com/Martian-Engineering/lossless-claw/commit/093ac5ba2db88eb4339cb97bf0d641773b4888db) Thanks [@mpz4life](https://github.com/mpz4life)! - Teach `lcm_grep` to search the first 512,000 bytes of externalized `large_files` text rows via the new `scope="files"` option. Add an optional `fileIds` parameter to restrict the search to specific file IDs. Each match reports the file ID, line number, byte offset, matched text, and a contextual snippet. Update `lcm_describe` to give accurate bounded-search guidance when inlined content is truncated. Honor `allConversations=true` for `scope="files"` by searching large files across all conversations.
+
 ## 0.13.2
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.14.0-beta.0
 
+<!-- release-rollback-version: 0.13.2 -->
+
 This beta opens the next Lossless Claw release line for broader testing. It
 adds a packaged diagnostics CLI and combines the continuity, reconciliation,
 doctor, recall, and compaction fixes merged since `0.13.2`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,3 +64,18 @@ Recommended external setup:
 When configuring npm trusted publishing, register the GitHub workflow using the exact workflow filename in this repo: `.github/workflows/publish.yml`.
 
 The publish workflow is intentionally manual. Release issuance should stay deliberate even after trusted publishing is enabled.
+
+## Beta releases
+
+Use a Changesets prerelease when `main` needs broader testing before a stable release:
+
+1. Run `npx changeset pre enter beta` on the reviewed release branch.
+2. Run `npm run version-packages` and refresh `package-lock.json`.
+3. Review and merge the generated prerelease version and changelog.
+4. Dispatch `Publish Package` on the exact merged commit.
+
+The publish workflow maps `X.Y.Z-beta.N` to npm's `beta` dist-tag and marks the
+GitHub Release as a prerelease. Stable `X.Y.Z` versions map to npm's `latest`
+dist-tag. Other prerelease identifiers fail closed.
+
+Never use a beta publication to move or repair `latest` manually.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,15 +71,18 @@ Use a Changesets prerelease when `main` needs broader testing before a stable re
 
 1. Run `npx changeset pre enter beta` on the reviewed release branch.
 2. Run `npm run version-packages` and refresh `package-lock.json`.
-3. Review and merge the generated prerelease version and changelog.
-4. Dispatch `Publish Package` from the branch containing the exact merged commit.
+3. Add exactly one `<!-- release-rollback-version: X.Y.Z -->` marker to the
+   generated changelog section, where `X.Y.Z` is the current stable `latest`.
+4. Review and merge the generated prerelease version and changelog.
+5. Dispatch `Publish Package` from the branch containing the exact merged commit.
 
 The publish workflow maps `X.Y.Z-beta.N` to npm's `beta` dist-tag and marks the
 GitHub Release as a prerelease. Stable `X.Y.Z` versions map to npm's `latest`
 dist-tag. Other prerelease identifiers fail closed.
 
 The workflow pins the dispatch event's immutable commit, serializes publication,
-and refuses to move a dist-tag backward. A retry resumes only when any existing
+and refuses to move a dist-tag backward. The reviewed changelog commit binds the
+exact rollback version across retries. A retry resumes only when any existing
 npm version, Git tag, and GitHub Release identities match that commit exactly.
 
 Never use a beta publication to move or repair `latest` manually.
@@ -91,11 +94,13 @@ After the beta is accepted for stable release:
 1. Run `npx changeset pre exit` on a new release branch from the beta-bearing
    `main` commit.
 2. Run `npm run version-packages` and `npm install --package-lock-only`.
-3. Verify `package.json`, the root lockfile version, and the lockfile root
+3. Add exactly one `<!-- release-rollback-version: X.Y.Z -->` marker to the
+   stable changelog section, where `X.Y.Z` is the current npm `latest` version.
+4. Verify `package.json`, the root lockfile version, and the lockfile root
    package version all equal the expected stable version, such as `0.14.0`.
-4. Review the stable changelog, run `npm run release:verify`, and merge the
+5. Review the stable changelog, run `npm run release:verify`, and merge the
    stable release PR only after exact-head CI and review gates pass.
-5. Dispatch `Publish Package` from that exact merged stable commit.
+6. Dispatch `Publish Package` from that exact merged stable commit.
 
 The stable publish moves npm's `latest` dist-tag only after the workflow proves
 the candidate is newer than the current stable version. Its release notes pin

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,10 +72,31 @@ Use a Changesets prerelease when `main` needs broader testing before a stable re
 1. Run `npx changeset pre enter beta` on the reviewed release branch.
 2. Run `npm run version-packages` and refresh `package-lock.json`.
 3. Review and merge the generated prerelease version and changelog.
-4. Dispatch `Publish Package` on the exact merged commit.
+4. Dispatch `Publish Package` from the branch containing the exact merged commit.
 
 The publish workflow maps `X.Y.Z-beta.N` to npm's `beta` dist-tag and marks the
 GitHub Release as a prerelease. Stable `X.Y.Z` versions map to npm's `latest`
 dist-tag. Other prerelease identifiers fail closed.
 
+The workflow pins the dispatch event's immutable commit, serializes publication,
+and refuses to move a dist-tag backward. A retry resumes only when any existing
+npm version, Git tag, and GitHub Release identities match that commit exactly.
+
 Never use a beta publication to move or repair `latest` manually.
+
+### Promote a beta line to stable
+
+After the beta is accepted for stable release:
+
+1. Run `npx changeset pre exit` on a new release branch from the beta-bearing
+   `main` commit.
+2. Run `npm run version-packages` and `npm install --package-lock-only`.
+3. Verify `package.json`, the root lockfile version, and the lockfile root
+   package version all equal the expected stable version, such as `0.14.0`.
+4. Review the stable changelog, run `npm run release:verify`, and merge the
+   stable release PR only after exact-head CI and review gates pass.
+5. Dispatch `Publish Package` from that exact merged stable commit.
+
+The stable publish moves npm's `latest` dist-tag only after the workflow proves
+the candidate is newer than the current stable version. Its release notes pin
+rollback guidance to the exact prior `latest` version.

--- a/docs/superpowers/plans/2026-07-13-beta-release.md
+++ b/docs/superpowers/plans/2026-07-13-beta-release.md
@@ -29,7 +29,8 @@
 - Retries may skip npm, tag, or GitHub Release creation only after exact source
   identity and release-kind checks pass; identity mismatches fail closed.
 - Beta rollback notes pin the current stable version. Stable rollback notes pin
-  the exact previous `latest` version.
+  the exact previous `latest` version through a source-bound changelog marker
+  validated before first publication and reused on retries.
 - Stable promotion requires `npx changeset pre exit`, version generation,
   lockfile refresh, exact version checks, and a separately reviewed publish.
 

--- a/docs/superpowers/plans/2026-07-13-beta-release.md
+++ b/docs/superpowers/plans/2026-07-13-beta-release.md
@@ -1,0 +1,387 @@
+# Lossless Claw Beta Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish canonical `main` as `@martian-engineering/lossless-claw@0.14.0-beta.0` while keeping npm `latest` on `0.13.2`.
+
+**Architecture:** A dependency-free Node helper classifies stable and beta SemVer versions and emits GitHub Actions outputs. The publish workflow consumes those outputs to select the npm dist-tag and GitHub prerelease flag; Changesets remains the source of package version and changelog truth.
+
+**Tech Stack:** Node.js 22, Vitest, Changesets, npm, GitHub Actions, GitHub CLI.
+
+## Global Constraints
+
+- Canonical repository: `Martian-Engineering/lossless-claw`.
+- Target version: `0.14.0-beta.0`; target Git tag: `v0.14.0-beta.0`.
+- npm must end with `beta=0.14.0-beta.0` and `latest=0.13.2`.
+- Unsupported prerelease identifiers such as `rc` must fail closed.
+- Do not manually create or move tags if npm publication fails.
+- Do not manually repair npm dist-tags in the normal path.
+- The `npm-publish` protected environment remains the publication approval gate.
+- Do not change OpenClaw compatibility declarations in this release lane.
+
+---
+
+### Task 1: Add tested release-channel classification
+
+**Files:**
+- Create: `scripts/release-channel.mjs`
+- Create: `test/release-channel.test.mjs`
+- Modify: `.github/workflows/publish.yml`
+
+**Interfaces:**
+- Consumes: package version string from `package.json`.
+- Produces: `classifyReleaseVersion(version): { npmTag: "latest" | "beta", prerelease: boolean }` and CLI outputs `npm_tag=<tag>` plus `prerelease=<true|false>`.
+
+- [ ] **Step 1: Write the failing classifier tests**
+
+```js
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { classifyReleaseVersion } from "../scripts/release-channel.mjs";
+
+describe("classifyReleaseVersion", () => {
+  it("routes stable versions to latest", () => {
+    expect(classifyReleaseVersion("0.13.2")).toEqual({ npmTag: "latest", prerelease: false });
+  });
+
+  it("routes beta versions to beta and GitHub prerelease", () => {
+    expect(classifyReleaseVersion("0.14.0-beta.0")).toEqual({ npmTag: "beta", prerelease: true });
+  });
+
+  it.each(["0.14.0-rc.0", "0.14.0-alpha.1", "banana", "1.2"])(
+    "rejects unsupported version %s",
+    (version) => expect(() => classifyReleaseVersion(version)).toThrow(/Unsupported release version/),
+  );
+});
+
+describe("publish workflow", () => {
+  it("uses classified npm and GitHub release channels", async () => {
+    const workflow = await readFile(new URL("../.github/workflows/publish.yml", import.meta.url), "utf8");
+    expect(workflow).toContain("node scripts/release-channel.mjs");
+    expect(workflow).toContain('npm publish --tag "${{ steps.package.outputs.npm_tag }}"');
+    expect(workflow).toContain('if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then');
+    expect(workflow).toContain("release_args+=(--prerelease)");
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails because the helper is absent**
+
+Run: `npx vitest run test/release-channel.test.mjs`
+
+Expected: FAIL resolving `../scripts/release-channel.mjs`.
+
+- [ ] **Step 3: Implement the dependency-free classifier and CLI**
+
+```js
+import { pathToFileURL } from "node:url";
+
+const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const BETA_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/;
+
+export function classifyReleaseVersion(version) {
+  if (STABLE_VERSION.test(version)) {
+    return { npmTag: "latest", prerelease: false };
+  }
+  if (BETA_VERSION.test(version)) {
+    return { npmTag: "beta", prerelease: true };
+  }
+  throw new Error(`Unsupported release version: ${version}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const version = process.argv[2];
+  const channel = classifyReleaseVersion(version);
+  process.stdout.write(`npm_tag=${channel.npmTag}\nprerelease=${channel.prerelease}\n`);
+}
+```
+
+- [ ] **Step 4: Wire classifier outputs into publishing and GitHub Release creation**
+
+Replace the package-version step with:
+
+```yaml
+      - name: Read package version and release channel
+        id: package
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+          node scripts/release-channel.mjs "$version" >> "$GITHUB_OUTPUT"
+```
+
+Replace `npm publish` with:
+
+```yaml
+        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
+```
+
+Create the GitHub Release with:
+
+```bash
+release_args=(
+  --generate-notes
+  --notes "$(cat release-notes.md)"
+  --verify-tag
+)
+if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then
+  release_args+=(--prerelease)
+fi
+gh release create "$tag" "${release_args[@]}"
+```
+
+- [ ] **Step 5: Run focused tests and direct CLI checks**
+
+Run:
+
+```bash
+npx vitest run test/release-channel.test.mjs
+node scripts/release-channel.mjs 0.14.0-beta.0
+node scripts/release-channel.mjs 0.13.2
+! node scripts/release-channel.mjs 0.14.0-rc.0
+```
+
+Expected: test PASS; beta emits `npm_tag=beta` and `prerelease=true`; stable emits `npm_tag=latest` and `prerelease=false`; `rc` exits nonzero.
+
+- [ ] **Step 6: Commit the beta-safe publish behavior**
+
+```bash
+git add scripts/release-channel.mjs test/release-channel.test.mjs .github/workflows/publish.yml
+git commit -m "ci: make package publishing beta-safe"
+```
+
+### Task 2: Repair release metadata and document the beta lane
+
+**Files:**
+- Modify: `.changeset/blue-signs-swim.md`
+- Modify: `.changeset/qwen-fresh-tail-overrides.md`
+- Modify: `RELEASING.md`
+
+**Interfaces:**
+- Consumes: Changesets package key `@martian-engineering/lossless-claw`.
+- Produces: a valid release plan and operator instructions for stable versus beta publication.
+
+- [ ] **Step 1: Reproduce the malformed Changesets failure**
+
+Run: `npx changeset status --output /tmp/lossless-claw-release-status.json`
+
+Expected: nonzero with `package lossless-claw which is not in the workspace`.
+
+- [ ] **Step 2: Replace both obsolete package keys**
+
+In each affected changeset, replace:
+
+```yaml
+"lossless-claw": patch
+```
+
+with:
+
+```yaml
+"@martian-engineering/lossless-claw": patch
+```
+
+- [ ] **Step 3: Document the beta release flow**
+
+Add a `## Beta releases` section to `RELEASING.md` that requires:
+
+```markdown
+## Beta releases
+
+Use a Changesets prerelease when `main` needs broader testing before a stable release:
+
+1. Run `npx changeset pre enter beta` on the reviewed release branch.
+2. Run `npm run version-packages` and refresh `package-lock.json`.
+3. Review and merge the generated prerelease version and changelog.
+4. Dispatch `Publish Package` on the exact merged commit.
+
+The publish workflow maps `X.Y.Z-beta.N` to npm's `beta` dist-tag and marks the GitHub Release as a prerelease. Stable `X.Y.Z` versions map to npm's `latest` dist-tag. Other prerelease identifiers fail closed.
+
+Never use a beta publication to move or repair `latest` manually.
+```
+
+- [ ] **Step 4: Verify Changesets accepts all pending metadata**
+
+Run: `npx changeset status --output /tmp/lossless-claw-release-status.json && node -e 'const s=require("/tmp/lossless-claw-release-status.json"); if (!s.releases.some((r)=>r.name==="@martian-engineering/lossless-claw"&&r.type==="minor")) process.exit(1)'`
+
+Expected: exit 0 with a minor release plan.
+
+- [ ] **Step 5: Commit the metadata repair and documentation**
+
+```bash
+git add .changeset/blue-signs-swim.md .changeset/qwen-fresh-tail-overrides.md RELEASING.md
+git commit -m "fix: restore changesets release planning"
+```
+
+### Task 3: Generate the first 0.14 beta
+
+**Files:**
+- Create: `.changeset/pre.json`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `CHANGELOG.md`
+- Delete: consumed `.changeset/*.md` files as selected by Changesets.
+
+**Interfaces:**
+- Consumes: valid pending changesets with a highest bump of `minor`.
+- Produces: package and changelog identity `0.14.0-beta.0` in Changesets beta mode.
+
+- [ ] **Step 1: Enter beta prerelease mode**
+
+Run: `npx changeset pre enter beta`
+
+Expected: `.changeset/pre.json` records mode `pre`, tag `beta`, initial version `0.13.2`, and pending changeset names.
+
+- [ ] **Step 2: Generate prerelease versions and changelog**
+
+Run: `npm run version-packages`
+
+Expected: `package.json` becomes `0.14.0-beta.0` and `CHANGELOG.md` gains `## 0.14.0-beta.0`.
+
+- [ ] **Step 3: Refresh and verify lock metadata**
+
+Run:
+
+```bash
+npm install --package-lock-only
+npm ci --package-lock-only --ignore-scripts
+node -e 'const p=require("./package.json"); const l=require("./package-lock.json"); if (p.version!=="0.14.0-beta.0" || l.version!==p.version || l.packages[""].version!==p.version) process.exit(1)'
+```
+
+Expected: all three version fields equal `0.14.0-beta.0` and commands exit 0.
+
+- [ ] **Step 4: Verify generated release notes exist**
+
+Run: `awk '$0 == "## 0.14.0-beta.0" { found=1 } END { exit !found }' CHANGELOG.md`
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit the generated beta release metadata**
+
+```bash
+git add .changeset package.json package-lock.json CHANGELOG.md
+git commit -m "chore: version packages for 0.14.0-beta.0"
+```
+
+### Task 4: Run the complete local release gate
+
+**Files:**
+- Verify only; no expected source edits.
+
+**Interfaces:**
+- Consumes: the complete beta release branch.
+- Produces: clean local release evidence suitable for PR publication.
+
+- [ ] **Step 1: Verify workspace and install exact dependencies**
+
+Run: `pwd && npm ci`
+
+Expected: path is the isolated beta worktree and install exits 0.
+
+- [ ] **Step 2: Run the repository release gate**
+
+Run: `npm run release:verify`
+
+Expected: typecheck, build, all tests, and package dry-run exit 0.
+
+- [ ] **Step 3: Inspect package contents and release-channel identity**
+
+Run:
+
+```bash
+npm pack --dry-run --json > /tmp/lossless-claw-beta-pack.json
+node -e 'const p=require("/tmp/lossless-claw-beta-pack.json")[0]; if (p.id!=="@martian-engineering/lossless-claw@0.14.0-beta.0") process.exit(1)'
+node scripts/release-channel.mjs "$(node -p "require('./package.json').version")"
+git diff --check martian/main...HEAD
+git status --short
+```
+
+Expected: package id is exact, classifier emits beta/prerelease, diff check exits 0, worktree is clean.
+
+### Task 5: Publish, review, and merge the release PR
+
+**Files:**
+- External state: branch and pull request in `Martian-Engineering/lossless-claw`.
+
+**Interfaces:**
+- Consumes: locally validated branch head.
+- Produces: reviewed, exact-head green commit merged to canonical `main`.
+
+- [ ] **Step 1: Re-fetch canonical state and stop on drift**
+
+Run:
+
+```bash
+git fetch martian main
+test "$(git rev-parse martian/main)" = "421e7cb0606600991edc2feec4b85b22487a974a"
+```
+
+Expected: exit 0. If it fails, rebase or merge only after reviewing the new commits and rerunning Task 4.
+
+- [ ] **Step 2: Push the branch and open the PR**
+
+Run:
+
+```bash
+git push -u martian release/v0.14.0-beta.0
+gh pr create --repo Martian-Engineering/lossless-claw --base main --head release/v0.14.0-beta.0 --title "chore: cut v0.14.0-beta.0" --body-file /tmp/lossless-claw-beta-pr.md
+```
+
+Expected: a new non-draft PR URL.
+
+- [ ] **Step 3: Wait for and hydrate exact-head review state**
+
+Run `gh pr checks <PR> --repo Martian-Engineering/lossless-claw --watch`, then inspect PR reviews, review threads, top-level comments, check runs, and annotations for the exact head SHA.
+
+Expected: required CI successful, no unresolved actionable review thread, no release/beta blocker.
+
+- [ ] **Step 4: Re-fetch live PR state immediately before merge**
+
+Expected: same head SHA, non-draft, mergeable/clean, checks successful, and no new blocker.
+
+- [ ] **Step 5: Merge through GitHub**
+
+Run: `gh pr merge <PR> --repo Martian-Engineering/lossless-claw --squash --delete-branch --match-head-commit <HEAD_SHA>`
+
+Expected: PR merged and canonical `main` points to the resulting release commit.
+
+### Task 6: Dispatch and verify the protected beta publication
+
+**Files:**
+- External state: GitHub Actions, npm registry, Git tag, and GitHub Release.
+
+**Interfaces:**
+- Consumes: exact merged release commit.
+- Produces: verified npm beta and GitHub prerelease without stable-channel drift.
+
+- [ ] **Step 1: Rehydrate merged-main and public preconditions**
+
+Confirm package version `0.14.0-beta.0`, no existing tag or npm version, `latest=0.13.2`, and exact merged SHA.
+
+- [ ] **Step 2: Dispatch the protected publish workflow**
+
+Run: `gh workflow run publish.yml --repo Martian-Engineering/lossless-claw --ref main -f ref=<MERGED_SHA>`
+
+Expected: a new workflow run enters queued or waiting state for `npm-publish` approval.
+
+- [ ] **Step 3: Respect the environment approval gate**
+
+If the run is waiting, report the run URL and required `jalehman` approval. Do not bypass, replace, or manually publish.
+
+- [ ] **Step 4: Watch the approved run to completion**
+
+Run: `gh run watch <RUN_ID> --repo Martian-Engineering/lossless-claw --exit-status`
+
+Expected: exit 0 after npm publication, tag push, and GitHub Release creation.
+
+- [ ] **Step 5: Verify public release truth**
+
+Run:
+
+```bash
+npm view @martian-engineering/lossless-claw@0.14.0-beta.0 version gitHead dist.integrity --json
+npm view @martian-engineering/lossless-claw dist-tags --json
+gh release view v0.14.0-beta.0 --repo Martian-Engineering/lossless-claw --json tagName,isPrerelease,isDraft,targetCommitish,url
+gh api repos/Martian-Engineering/lossless-claw/git/ref/tags/v0.14.0-beta.0
+```
+
+Expected: version exists at the merged SHA, `beta=0.14.0-beta.0`, `latest=0.13.2`, GitHub Release is a non-draft prerelease, and the tag resolves to the published commit.

--- a/docs/superpowers/plans/2026-07-13-beta-release.md
+++ b/docs/superpowers/plans/2026-07-13-beta-release.md
@@ -25,7 +25,7 @@
 
 **Files:**
 - Create: `scripts/release-channel.mjs`
-- Create: `test/release-channel.test.mjs`
+- Create: `test/release-channel.test.ts`
 - Modify: `.github/workflows/publish.yml`
 
 **Interfaces:**
@@ -71,7 +71,7 @@ describe("release-channel CLI", () => {
 
 - [ ] **Step 2: Run the focused test and confirm it fails because the helper is absent**
 
-Run: `npx vitest run test/release-channel.test.mjs`
+Run: `npx vitest run test/release-channel.test.ts`
 
 Expected: FAIL resolving `../scripts/release-channel.mjs`.
 
@@ -139,7 +139,7 @@ gh release create "$tag" "${release_args[@]}"
 Run:
 
 ```bash
-npx vitest run test/release-channel.test.mjs
+npx vitest run test/release-channel.test.ts
 node scripts/release-channel.mjs 0.14.0-beta.0
 node scripts/release-channel.mjs 0.13.2
 ! node scripts/release-channel.mjs 0.14.0-rc.0
@@ -150,7 +150,7 @@ Expected: test PASS; beta emits `npm_tag=beta` and `prerelease=true`; stable emi
 - [ ] **Step 6: Commit the beta-safe publish behavior**
 
 ```bash
-git add scripts/release-channel.mjs test/release-channel.test.mjs .github/workflows/publish.yml
+git add scripts/release-channel.mjs test/release-channel.test.ts .github/workflows/publish.yml
 git commit -m "ci: make package publishing beta-safe"
 ```
 

--- a/docs/superpowers/plans/2026-07-13-beta-release.md
+++ b/docs/superpowers/plans/2026-07-13-beta-release.md
@@ -19,6 +19,20 @@
 - The `npm-publish` protected environment remains the publication approval gate.
 - Do not change OpenClaw compatibility declarations in this release lane.
 
+## Adversarial Hardening Amendment
+
+- Checkout must use immutable `${{ github.sha }}` and verify it equals `HEAD`
+  after the protected-environment approval wait.
+- npm publication is serialized with `concurrency.group: npm-publish`.
+- Before an unpublished version can move `beta` or `latest`, its SemVer must be
+  strictly newer than the current version on that same channel.
+- Retries may skip npm, tag, or GitHub Release creation only after exact source
+  identity and release-kind checks pass; identity mismatches fail closed.
+- Beta rollback notes pin the current stable version. Stable rollback notes pin
+  the exact previous `latest` version.
+- Stable promotion requires `npx changeset pre exit`, version generation,
+  lockfile refresh, exact version checks, and a separately reviewed publish.
+
 ---
 
 ### Task 1: Add tested release-channel classification
@@ -364,7 +378,7 @@ Confirm package version `0.14.0-beta.0`, no existing tag or npm version, `latest
 
 - [ ] **Step 2: Dispatch the protected publish workflow**
 
-Run: `gh workflow run publish.yml --repo Martian-Engineering/lossless-claw --ref main -f ref=<MERGED_SHA>`
+Run: `gh workflow run publish.yml --repo Martian-Engineering/lossless-claw --ref main`
 
 Expected: a new workflow run enters queued or waiting state for `npm-publish` approval.
 

--- a/docs/superpowers/plans/2026-07-13-beta-release.md
+++ b/docs/superpowers/plans/2026-07-13-beta-release.md
@@ -30,38 +30,42 @@
 
 **Interfaces:**
 - Consumes: package version string from `package.json`.
-- Produces: `classifyReleaseVersion(version): { npmTag: "latest" | "beta", prerelease: boolean }` and CLI outputs `npm_tag=<tag>` plus `prerelease=<true|false>`.
+- Produces: CLI outputs `npm_tag=<tag>` plus `prerelease=<true|false>` for GitHub Actions. This CLI is the public test seam; its internal classification structure is not part of the contract.
 
 - [ ] **Step 1: Write the failing classifier tests**
 
 ```js
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { classifyReleaseVersion } from "../scripts/release-channel.mjs";
 
-describe("classifyReleaseVersion", () => {
+const script = fileURLToPath(new URL("../scripts/release-channel.mjs", import.meta.url));
+
+function classify(version) {
+  return spawnSync(process.execPath, [script, version], { encoding: "utf8" });
+}
+
+describe("release-channel CLI", () => {
   it("routes stable versions to latest", () => {
-    expect(classifyReleaseVersion("0.13.2")).toEqual({ npmTag: "latest", prerelease: false });
+    const result = classify("0.13.2");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("npm_tag=latest\nprerelease=false\n");
   });
 
   it("routes beta versions to beta and GitHub prerelease", () => {
-    expect(classifyReleaseVersion("0.14.0-beta.0")).toEqual({ npmTag: "beta", prerelease: true });
+    const result = classify("0.14.0-beta.0");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("npm_tag=beta\nprerelease=true\n");
   });
 
   it.each(["0.14.0-rc.0", "0.14.0-alpha.1", "banana", "1.2"])(
     "rejects unsupported version %s",
-    (version) => expect(() => classifyReleaseVersion(version)).toThrow(/Unsupported release version/),
+    (version) => {
+      const result = classify(version);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`Unsupported release version: ${version}`);
+    },
   );
-});
-
-describe("publish workflow", () => {
-  it("uses classified npm and GitHub release channels", async () => {
-    const workflow = await readFile(new URL("../.github/workflows/publish.yml", import.meta.url), "utf8");
-    expect(workflow).toContain("node scripts/release-channel.mjs");
-    expect(workflow).toContain('npm publish --tag "${{ steps.package.outputs.npm_tag }}"');
-    expect(workflow).toContain('if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then');
-    expect(workflow).toContain("release_args+=(--prerelease)");
-  });
 });
 ```
 
@@ -74,12 +78,10 @@ Expected: FAIL resolving `../scripts/release-channel.mjs`.
 - [ ] **Step 3: Implement the dependency-free classifier and CLI**
 
 ```js
-import { pathToFileURL } from "node:url";
-
 const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const BETA_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/;
 
-export function classifyReleaseVersion(version) {
+function classifyReleaseVersion(version) {
   if (STABLE_VERSION.test(version)) {
     return { npmTag: "latest", prerelease: false };
   }
@@ -89,10 +91,13 @@ export function classifyReleaseVersion(version) {
   throw new Error(`Unsupported release version: ${version}`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+try {
   const version = process.argv[2];
   const channel = classifyReleaseVersion(version);
   process.stdout.write(`npm_tag=${channel.npmTag}\nprerelease=${channel.prerelease}\n`);
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
 }
 ```
 

--- a/docs/superpowers/specs/2026-07-13-beta-release-design.md
+++ b/docs/superpowers/specs/2026-07-13-beta-release-design.md
@@ -34,7 +34,8 @@ the first prerelease for that line.
 4. Update `RELEASING.md` to document the beta channel and stable-channel
    protection.
 5. Enter Changesets prerelease mode for `beta` and generate
-   `0.14.0-beta.0`, including the package lock and changelog.
+   `0.14.0-beta.0`, including the package lock, changelog, and immutable
+   rollback marker for stable `0.13.2`.
 6. Open a PR, require exact-head CI and clear review state, then merge.
 7. Dispatch `Publish Package` on the merged release commit. The configured
    `npm-publish` environment remains the human approval gate.
@@ -50,6 +51,8 @@ the first prerelease for that line.
   gate and leave the workflow pending.
 - Pin checkout to the immutable dispatch SHA, serialize publish runs, and refuse
   any non-monotonic npm dist-tag move.
+- Bind rollback truth to one validated marker in the reviewed changelog section
+  so partial-publication retries cannot lose the pre-publish channel version.
 - If `main`, the PR head, checks, or review threads drift before merge or
   publication, rehydrate live state and stop until the new head is reviewed.
 - If npm publishes but a later tag or GitHub Release step fails, rerun the same

--- a/docs/superpowers/specs/2026-07-13-beta-release-design.md
+++ b/docs/superpowers/specs/2026-07-13-beta-release-design.md
@@ -48,10 +48,13 @@ the first prerelease for that line.
 - Do not repair npm dist-tags manually as part of the normal path.
 - If the protected environment is awaiting approval, report that as the active
   gate and leave the workflow pending.
+- Pin checkout to the immutable dispatch SHA, serialize publish runs, and refuse
+  any non-monotonic npm dist-tag move.
 - If `main`, the PR head, checks, or review threads drift before merge or
   publication, rehydrate live state and stop until the new head is reviewed.
-- If npm publishes but a later tag or GitHub Release step fails, stop and
-  reconcile from the workflow logs without republishing the same version.
+- If npm publishes but a later tag or GitHub Release step fails, rerun the same
+  workflow commit. Resume only when the existing npm version and tag identities
+  match the approved source SHA; otherwise fail closed.
 
 ## Validation
 

--- a/docs/superpowers/specs/2026-07-13-beta-release-design.md
+++ b/docs/superpowers/specs/2026-07-13-beta-release-design.md
@@ -1,0 +1,85 @@
+# Lossless Claw Beta Release Design
+
+## Goal
+
+Publish the current canonical `main` line as an installable prerelease without
+moving npm's stable `latest` channel, while preserving the repository's normal
+Changesets, CI, protected-environment, tag, and GitHub Release controls.
+
+The target version is `0.14.0-beta.0`. The minor bump is required by the
+existing `agent-oriented-cli.md` changeset; the beta suffix identifies this as
+the first prerelease for that line.
+
+## Considered Approaches
+
+1. **Raw Git tag from `main`.** Fast, but the package would still declare
+   `0.13.2`, which is already published. It would not create an installable npm
+   beta and would misalign source, package, and tag identities.
+2. **Direct prerelease publish outside the repository workflow.** Technically
+   possible for an npm owner, but it bypasses protected-environment approval,
+   exact-head CI, release-note generation, and established release provenance.
+3. **Changesets prerelease through a beta-safe publish workflow.** Repair the
+   pending release metadata, generate a reviewed prerelease version, publish
+   with the npm `beta` dist-tag, and create a GitHub prerelease. This is the
+   selected approach.
+
+## Release Flow
+
+1. Start from the current canonical `Martian-Engineering/lossless-claw` `main`.
+2. Repair changesets that reference the obsolete unscoped package name.
+3. Teach `publish.yml` to classify SemVer prereleases before publication:
+   - stable versions publish with npm's existing `latest` behavior;
+   - prerelease versions publish with `npm publish --tag beta`;
+   - prerelease versions create GitHub Releases with `--prerelease`.
+4. Update `RELEASING.md` to document the beta channel and stable-channel
+   protection.
+5. Enter Changesets prerelease mode for `beta` and generate
+   `0.14.0-beta.0`, including the package lock and changelog.
+6. Open a PR, require exact-head CI and clear review state, then merge.
+7. Dispatch `Publish Package` on the merged release commit. The configured
+   `npm-publish` environment remains the human approval gate.
+8. Verify all public identities independently: Git tag, GitHub prerelease,
+   npm version metadata, npm `beta` dist-tag, unchanged npm `latest` dist-tag,
+   and package `gitHead`.
+
+## Failure Handling
+
+- Do not create or move tags manually if npm publication fails.
+- Do not repair npm dist-tags manually as part of the normal path.
+- If the protected environment is awaiting approval, report that as the active
+  gate and leave the workflow pending.
+- If `main`, the PR head, checks, or review threads drift before merge or
+  publication, rehydrate live state and stop until the new head is reviewed.
+- If npm publishes but a later tag or GitHub Release step fails, stop and
+  reconcile from the workflow logs without republishing the same version.
+
+## Validation
+
+Before PR publication:
+
+- validate the workflow syntax and prerelease classification logic;
+- run Changesets status/version checks against the corrected metadata;
+- run `npm ci`, typecheck, tests, build, and package dry-run;
+- confirm the generated version and changelog section are exactly
+  `0.14.0-beta.0`.
+
+Before merge and publish:
+
+- confirm the PR is non-draft and current with `main`;
+- confirm exact-head CI is successful;
+- inspect top-level reviews, unresolved review threads, and check annotations;
+- re-fetch canonical `main` immediately before merge and publication.
+
+After publication:
+
+- confirm `@martian-engineering/lossless-claw@0.14.0-beta.0` exists;
+- confirm `beta=0.14.0-beta.0` and `latest=0.13.2`;
+- confirm tag `v0.14.0-beta.0` points to the published `gitHead`;
+- confirm the matching GitHub Release is marked as a prerelease.
+
+## Non-Goals
+
+- Promoting the beta to `latest`.
+- Claiming the beta is stable or customer-runtime proven.
+- Changing OpenClaw compatibility declarations without separate evidence.
+- Publishing from the `100yenadmin/lossless-claw` fork.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.13.1",
+  "version": "0.14.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.13.1",
+      "version": "0.14.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "skills/",
     "openclaw.plugin.json",
     "docs/",
+    "!docs/superpowers/",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.13.2",
+  "version": "0.14.0-beta.0",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -1,0 +1,14 @@
+const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const BETA_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/;
+
+const version = process.argv[2];
+
+if (STABLE_VERSION.test(version)) {
+  process.stdout.write("npm_tag=latest\nprerelease=false\n");
+} else if (BETA_VERSION.test(version)) {
+  process.stdout.write("npm_tag=beta\nprerelease=true\n");
+} else {
+  process.stderr.write(`Unsupported release version: ${version}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -2,13 +2,66 @@ const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const BETA_VERSION =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/;
 
-const version = process.argv[2];
+function parseVersion(version) {
+  const stable = STABLE_VERSION.exec(version);
+  if (stable) {
+    return {
+      channel: "latest",
+      parts: stable.slice(1).map(BigInt),
+      prerelease: false,
+    };
+  }
 
-if (STABLE_VERSION.test(version)) {
-  process.stdout.write("npm_tag=latest\nprerelease=false\n");
-} else if (BETA_VERSION.test(version)) {
-  process.stdout.write("npm_tag=beta\nprerelease=true\n");
-} else {
-  process.stderr.write(`Unsupported release version: ${version}\n`);
+  const beta = BETA_VERSION.exec(version);
+  if (beta) {
+    return {
+      channel: "beta",
+      parts: beta.slice(1).map(BigInt),
+      prerelease: true,
+    };
+  }
+
+  return null;
+}
+
+function compareParts(candidate, current) {
+  for (let index = 0; index < candidate.length; index += 1) {
+    if (candidate[index] > current[index]) return 1;
+    if (candidate[index] < current[index]) return -1;
+  }
+  return 0;
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
   process.exitCode = 1;
+}
+
+if (process.argv[2] === "--assert-newer") {
+  const candidateVersion = process.argv[3];
+  const currentVersion = process.argv[4];
+  const candidate = parseVersion(candidateVersion);
+  const current = parseVersion(currentVersion);
+
+  if (
+    !candidate ||
+    !current ||
+    candidate.channel !== current.channel ||
+    compareParts(candidate.parts, current.parts) <= 0
+  ) {
+    fail(
+      `Release version ${candidateVersion} must be newer than ${currentVersion} on the same channel`,
+    );
+  }
+} else {
+  const version = process.argv[2];
+  const release = parseVersion(version);
+
+  if (release) {
+    process.stdout.write(
+      `npm_tag=${release.channel}\nprerelease=${release.prerelease}\n`,
+    );
+  } else {
+    fail(`Unsupported release version: ${version}`);
+  }
 }

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const BETA_VERSION =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.(0|[1-9]\d*)$/;
@@ -37,7 +39,56 @@ function fail(message) {
   process.exitCode = 1;
 }
 
-if (process.argv[2] === "--assert-newer") {
+function isValidRollback(candidateVersion, rollbackVersion) {
+  const candidate = parseVersion(candidateVersion);
+  const rollback = parseVersion(rollbackVersion);
+
+  return Boolean(
+    candidate &&
+      rollback &&
+      rollback.channel === "latest" &&
+      compareParts(candidate.parts.slice(0, 3), rollback.parts) > 0,
+  );
+}
+
+if (process.argv[2] === "--read-rollback") {
+  const candidateVersion = process.argv[3];
+  const lines = readFileSync(0, "utf8").split(/\r?\n/);
+  const heading = `## ${candidateVersion}`;
+  const headingIndexes = lines.flatMap((line, index) =>
+    line === heading ? [index] : [],
+  );
+  const start = headingIndexes[0];
+  const end = lines.findIndex(
+    (line, index) => index > start && line.startsWith("## "),
+  );
+  const section =
+    headingIndexes.length === 1
+      ? lines.slice(start + 1, end === -1 ? lines.length : end)
+      : [];
+  const markers = section.flatMap((line) => {
+    const match = /^<!-- release-rollback-version: ([^ ]+) -->$/.exec(line);
+    return match ? [match[1]] : [];
+  });
+
+  if (
+    markers.length !== 1 ||
+    !isValidRollback(candidateVersion, markers[0])
+  ) {
+    fail(`Expected exactly one valid rollback marker for ${candidateVersion}`);
+  } else {
+    process.stdout.write(`${markers[0]}\n`);
+  }
+} else if (process.argv[2] === "--assert-rollback") {
+  const candidateVersion = process.argv[3];
+  const rollbackVersion = process.argv[4];
+
+  if (!isValidRollback(candidateVersion, rollbackVersion)) {
+    fail(
+      `Rollback version ${rollbackVersion} must be a stable version older than ${candidateVersion}`,
+    );
+  }
+} else if (process.argv[2] === "--assert-newer") {
   const candidateVersion = process.argv[3];
   const currentVersion = process.argv[4];
   const candidate = parseVersion(candidateVersion);

--- a/test/release-channel.test.ts
+++ b/test/release-channel.test.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const script = fileURLToPath(
+  new URL("../scripts/release-channel.mjs", import.meta.url),
+);
+
+function classify(version: string) {
+  return spawnSync(process.execPath, [script, version], { encoding: "utf8" });
+}
+
+describe("release-channel CLI", () => {
+  it("routes stable versions to latest", () => {
+    const result = classify("0.13.2");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("npm_tag=latest\nprerelease=false\n");
+  });
+
+  it("routes beta versions to beta and GitHub prerelease", () => {
+    const result = classify("0.14.0-beta.0");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("npm_tag=beta\nprerelease=true\n");
+  });
+
+  it.each(["0.14.0-rc.0", "0.14.0-alpha.1", "banana", "1.2"])(
+    "rejects unsupported version %s",
+    (version) => {
+      const result = classify(version);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(`Unsupported release version: ${version}`);
+    },
+  );
+});

--- a/test/release-channel.test.ts
+++ b/test/release-channel.test.ts
@@ -6,8 +6,12 @@ const script = fileURLToPath(
   new URL("../scripts/release-channel.mjs", import.meta.url),
 );
 
+function run(...args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], { encoding: "utf8" });
+}
+
 function classify(version: string) {
-  return spawnSync(process.execPath, [script, version], { encoding: "utf8" });
+  return run(version);
 }
 
 describe("release-channel CLI", () => {
@@ -34,4 +38,32 @@ describe("release-channel CLI", () => {
       expect(result.stderr).toContain(`Unsupported release version: ${version}`);
     },
   );
+});
+
+describe("release ordering CLI", () => {
+  it.each([
+    ["0.14.0", "0.13.2"],
+    ["0.14.0-beta.1", "0.14.0-beta.0"],
+    ["1.0.0-beta.0", "0.99.9-beta.99"],
+  ])("accepts newer candidate %s over %s", (candidate, current) => {
+    const result = run("--assert-newer", candidate, current);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  it.each([
+    ["0.13.2", "0.13.2"],
+    ["0.13.1", "0.13.2"],
+    ["0.14.0-beta.0", "0.14.0-beta.0"],
+    ["0.14.0-beta.0", "0.14.0-beta.1"],
+    ["0.14.0-beta.0", "0.13.2"],
+  ])("rejects non-newer candidate %s over %s", (candidate, current) => {
+    const result = run("--assert-newer", candidate, current);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `Release version ${candidate} must be newer than ${current} on the same channel`,
+    );
+  });
 });

--- a/test/release-channel.test.ts
+++ b/test/release-channel.test.ts
@@ -10,6 +10,13 @@ function run(...args: string[]) {
   return spawnSync(process.execPath, [script, ...args], { encoding: "utf8" });
 }
 
+function runWithInput(input: string, ...args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+    input,
+  });
+}
+
 function classify(version: string) {
   return run(version);
 }
@@ -64,6 +71,88 @@ describe("release ordering CLI", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
       `Release version ${candidate} must be newer than ${current} on the same channel`,
+    );
+  });
+});
+
+describe("release rollback CLI", () => {
+  it.each([
+    ["0.14.0-beta.0", "0.13.2"],
+    ["0.14.0", "0.13.2"],
+    ["0.14.1-beta.0", "0.14.0"],
+  ])("accepts rollback %s -> %s", (candidate, rollback) => {
+    const result = run("--assert-rollback", candidate, rollback);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+
+  it.each([
+    ["0.14.0-beta.0", "0.14.0"],
+    ["0.14.0", "0.14.0"],
+    ["0.14.0", "0.14.0-beta.0"],
+    ["banana", "0.13.2"],
+  ])("rejects rollback %s -> %s", (candidate, rollback) => {
+    const result = run("--assert-rollback", candidate, rollback);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `Rollback version ${rollback} must be a stable version older than ${candidate}`,
+    );
+  });
+});
+
+describe("release rollback metadata CLI", () => {
+  const validChangelog = `# Package
+
+## 0.14.0-beta.0
+
+<!-- release-rollback-version: 0.13.2 -->
+
+Beta notes.
+
+## 0.13.2
+
+Stable notes.
+`;
+
+  it("reads the exact release section rollback", () => {
+    const result = runWithInput(
+      validChangelog,
+      "--read-rollback",
+      "0.14.0-beta.0",
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("0.13.2\n");
+  });
+
+  it.each([
+    ["missing", validChangelog.replace("<!-- release-rollback-version: 0.13.2 -->\n\n", "")],
+    [
+      "duplicate",
+      validChangelog.replace(
+        "<!-- release-rollback-version: 0.13.2 -->",
+        "<!-- release-rollback-version: 0.13.2 -->\n<!-- release-rollback-version: 0.13.1 -->",
+      ),
+    ],
+    [
+      "wrong section",
+      validChangelog.replace(
+        "<!-- release-rollback-version: 0.13.2 -->\n\nBeta notes.",
+        "Beta notes.",
+      ).replace("Stable notes.", "<!-- release-rollback-version: 0.13.2 -->\n\nStable notes."),
+    ],
+  ])("rejects %s rollback metadata", (_name, changelog) => {
+    const result = runWithInput(
+      changelog,
+      "--read-rollback",
+      "0.14.0-beta.0",
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "Expected exactly one valid rollback marker for 0.14.0-beta.0",
     );
   });
 });


### PR DESCRIPTION
## Summary

- cut the accumulated post-`0.13.2` changes as `0.14.0-beta.0` through Changesets prerelease mode
- keep npm `latest` stable while routing prereleases to the `beta` dist-tag and GitHub prerelease surface
- repair malformed Changesets metadata, add human-readable beta notes, and append release verification links from the publish workflow
- pin publication to the approved SHA, serialize releases, refuse backward dist-tag moves, and resume partial releases only after exact identity checks

## Release outcome

After merge and protected workflow approval, testers can install:

```bash
npm install @martian-engineering/lossless-claw@beta
```

Expected registry state:

- `beta=0.14.0-beta.0`
- `latest=0.13.2`

Unsupported prerelease identifiers fail closed instead of publishing to `latest`.

## Validation

- `actionlint .github/workflows/publish.yml`
- `npm run release:verify`
  - typecheck passed
  - build passed
  - 99 test files / 1,818 tests passed
  - package dry-run passed
- tarball identity: `@martian-engineering/lossless-claw@0.14.0-beta.0`
- tarball contents: 23 files; maintainer design/plan artifacts excluded
- direct classifier checks: beta, stable, and unsupported prerelease paths
- monotonic release-order checks for stable and beta channels
- first-publish and existing-release recovery preflight checks
- source-bound rollback metadata checks, including stable partial-publication retry

## Boundaries

- This PR does not publish by itself; publication remains behind the `npm-publish` protected environment.
- This PR does not promote or manually repair npm `latest`.
- Package/tag/GitHub Release proof does not claim customer-runtime canary proof.
