### PR TITLE
fix: safely deduplicate missing-transcript replays

### DIFF
--- a/.changeset/missing-transcript-checkpoint-dedup.md
+++ b/.changeset/missing-transcript-checkpoint-dedup.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Avoid duplicate runtime rows when a tracked transcript is temporarily unavailable while preserving genuinely new rows from partially overlapping batches.

--- a/.changeset/missing-transcript-checkpoint-dedup.md
+++ b/.changeset/missing-transcript-checkpoint-dedup.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Avoid duplicate runtime rows when a tracked transcript is temporarily unavailable while preserving genuinely new rows from partially overlapping batches.
+Avoid duplicate runtime rows with already-persisted transcript identities when a tracked transcript is temporarily unavailable, while preserving ambiguous rows that the unavailable transcript cannot recover.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -33,7 +33,7 @@ import {
   extractToolPairingIdFromRecord,
   extractToolResultIdForPairing,
 } from "./tool-pairing.js";
-import { resolveTranscriptMessageInnerTimestamp } from "./transcript.js";
+import { getTranscriptEntryId } from "./transcript.js";
 import type { LcmDependencies } from "./types.js";
 
 type RedactSensitiveText = (content: string) => string;
@@ -355,10 +355,10 @@ export class BatchDeduplicator {
   }
 
   /**
-   * Remove an exact full replay when the transcript is unavailable but its
-   * checkpoint was preserved. Any batch that is not fully persisted returns
-   * to the degraded deduplicator, which prefers duplicates over dropping an
-   * ambiguous genuinely new row.
+   * Remove a full replay with already-persisted transcript identities when the
+   * transcript is unavailable but its checkpoint was preserved. Batches
+   * without complete identity proof retain the established degraded dedup
+   * behavior; this path adds no timestamp-based reason to drop them.
    */
   async deduplicateAfterTurnBatchAgainstPreservedCheckpoint(
     sessionId: string,
@@ -374,7 +374,7 @@ export class BatchDeduplicator {
     if (!conversation) return batch;
 
     if (
-      await this.batchIsFullyPersistedAtDistinctSourceSeconds(
+      await this.batchIsFullyPersistedByTranscriptEntryId(
         conversation.conversationId,
         batch,
       )
@@ -390,36 +390,19 @@ export class BatchDeduplicator {
   }
 
   /**
-   * Prove that every runtime row is already stored at its inner source-time
-   * second. Envelope timestamps are re-stamped on append and therefore fail
-   * open. Repeated rows within one second also fail open because the store
-   * truncates timestamps to seconds.
+   * Prove that every runtime row carries a canonical transcript entry id that
+   * is already persisted. Missing or unfamiliar ids fail open because content
+   * and second-truncated timestamps cannot distinguish a replay from a
+   * genuinely new same-second repeat.
    */
-  private async batchIsFullyPersistedAtDistinctSourceSeconds(
+  private async batchIsFullyPersistedByTranscriptEntryId(
     conversationId: number,
     batch: AgentMessage[],
   ): Promise<boolean> {
-    const claimedSourceSeconds = new Set<string>();
     for (const message of batch) {
-      const innerTimestamp = resolveTranscriptMessageInnerTimestamp(message);
-      if (innerTimestamp === null) return false;
-      const createdAt =
-        typeof innerTimestamp === "number" ? new Date(innerTimestamp) : innerTimestamp;
-      const parsedCreatedAt = createdAt instanceof Date ? createdAt : new Date(createdAt);
-      if (!Number.isFinite(parsedCreatedAt.getTime())) return false;
-
-      const stored = toStoredMessage(message);
-      const sourceTimeKey = parsedCreatedAt.toISOString().slice(0, 19);
-      if (claimedSourceSeconds.has(sourceTimeKey)) return false;
-      claimedSourceSeconds.add(sourceTimeKey);
-      if (
-        !(await this.conversationStore.hasPersistedIdentityAtCreatedAtSecond(
-          conversationId,
-          stored.role,
-          stored.content,
-          createdAt,
-        ))
-      ) {
+      const entryId = getTranscriptEntryId(message);
+      if (!entryId) return false;
+      if (!(await this.conversationStore.hasMessageByTranscriptEntryId(conversationId, entryId))) {
         return false;
       }
     }

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -33,6 +33,7 @@ import {
   extractToolPairingIdFromRecord,
   extractToolResultIdForPairing,
 } from "./tool-pairing.js";
+import { resolveTranscriptMessageCreatedAt } from "./transcript.js";
 import type { LcmDependencies } from "./types.js";
 
 type RedactSensitiveText = (content: string) => string;
@@ -351,6 +352,69 @@ export class BatchDeduplicator {
       return [];
     }
     return batch;
+  }
+
+  /**
+   * Remove an exact full replay when the transcript is unavailable but its
+   * checkpoint was preserved. Any batch that is not fully persisted returns
+   * to the degraded deduplicator, which prefers duplicates over dropping an
+   * ambiguous genuinely new row.
+   */
+  async deduplicateAfterTurnBatchAgainstPreservedCheckpoint(
+    sessionId: string,
+    sessionKey: string | undefined,
+    batch: AgentMessage[],
+  ): Promise<AgentMessage[]> {
+    if (batch.length === 0) return batch;
+
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    if (!conversation) return batch;
+
+    if (await this.batchIsFullyPersistedAtDistinctSourceTimes(conversation.conversationId, batch)) {
+      this.deps.log.debug(
+        `[lcm] afterTurn: transcript unavailable with preserved checkpoint; skipping fully persisted runtime replay conversation=${conversation.conversationId} batchLen=${batch.length}`,
+      );
+      return [];
+    }
+    return this.deduplicateAfterTurnBatch(sessionId, sessionKey, batch, {
+      oversizedNoOverlap: "ingest",
+    });
+  }
+
+  /**
+   * Prove that every runtime row is already stored at its original source
+   * timestamp. Repeated rows within the same second are ambiguous because the
+   * store truncates timestamps to seconds, so they deliberately fail open.
+   */
+  private async batchIsFullyPersistedAtDistinctSourceTimes(
+    conversationId: number,
+    batch: AgentMessage[],
+  ): Promise<boolean> {
+    const claimedSourceTimes = new Set<string>();
+    for (const message of batch) {
+      const createdAt = resolveTranscriptMessageCreatedAt(message);
+      const parsedCreatedAt = createdAt instanceof Date ? createdAt : new Date(createdAt ?? "");
+      if (!Number.isFinite(parsedCreatedAt.getTime())) return false;
+
+      const stored = toStoredMessage(message);
+      const sourceTimeKey = parsedCreatedAt.toISOString().slice(0, 19);
+      if (claimedSourceTimes.has(sourceTimeKey)) return false;
+      claimedSourceTimes.add(sourceTimeKey);
+      if (
+        !(await this.conversationStore.hasPersistedIdentityAtCreatedAtSecond(
+          conversationId,
+          stored.role,
+          stored.content,
+          createdAt,
+        ))
+      ) {
+        return false;
+      }
+    }
+    return true;
   }
 
   async deduplicateAfterTurnBatch(

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -33,7 +33,7 @@ import {
   extractToolPairingIdFromRecord,
   extractToolResultIdForPairing,
 } from "./tool-pairing.js";
-import { resolveTranscriptMessageCreatedAt } from "./transcript.js";
+import { resolveTranscriptMessageInnerTimestamp } from "./transcript.js";
 import type { LcmDependencies } from "./types.js";
 
 type RedactSensitiveText = (content: string) => string;
@@ -373,7 +373,12 @@ export class BatchDeduplicator {
     });
     if (!conversation) return batch;
 
-    if (await this.batchIsFullyPersistedAtDistinctSourceTimes(conversation.conversationId, batch)) {
+    if (
+      await this.batchIsFullyPersistedAtDistinctSourceSeconds(
+        conversation.conversationId,
+        batch,
+      )
+    ) {
       this.deps.log.debug(
         `[lcm] afterTurn: transcript unavailable with preserved checkpoint; skipping fully persisted runtime replay conversation=${conversation.conversationId} batchLen=${batch.length}`,
       );
@@ -385,24 +390,28 @@ export class BatchDeduplicator {
   }
 
   /**
-   * Prove that every runtime row is already stored at its original source
-   * timestamp. Repeated rows within the same second are ambiguous because the
-   * store truncates timestamps to seconds, so they deliberately fail open.
+   * Prove that every runtime row is already stored at its inner source-time
+   * second. Envelope timestamps are re-stamped on append and therefore fail
+   * open. Repeated rows within one second also fail open because the store
+   * truncates timestamps to seconds.
    */
-  private async batchIsFullyPersistedAtDistinctSourceTimes(
+  private async batchIsFullyPersistedAtDistinctSourceSeconds(
     conversationId: number,
     batch: AgentMessage[],
   ): Promise<boolean> {
-    const claimedSourceTimes = new Set<string>();
+    const claimedSourceSeconds = new Set<string>();
     for (const message of batch) {
-      const createdAt = resolveTranscriptMessageCreatedAt(message);
-      const parsedCreatedAt = createdAt instanceof Date ? createdAt : new Date(createdAt ?? "");
+      const innerTimestamp = resolveTranscriptMessageInnerTimestamp(message);
+      if (innerTimestamp === null) return false;
+      const createdAt =
+        typeof innerTimestamp === "number" ? new Date(innerTimestamp) : innerTimestamp;
+      const parsedCreatedAt = createdAt instanceof Date ? createdAt : new Date(createdAt);
       if (!Number.isFinite(parsedCreatedAt.getTime())) return false;
 
       const stored = toStoredMessage(message);
       const sourceTimeKey = parsedCreatedAt.toISOString().slice(0, 19);
-      if (claimedSourceTimes.has(sourceTimeKey)) return false;
-      claimedSourceTimes.add(sourceTimeKey);
+      if (claimedSourceSeconds.has(sourceTimeKey)) return false;
+      claimedSourceSeconds.add(sourceTimeKey);
       if (
         !(await this.conversationStore.hasPersistedIdentityAtCreatedAtSecond(
           conversationId,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3051,6 +3051,18 @@ export class LcmContextEngine implements ContextEngine {
         await runRuntimeAutoRotate();
         return;
       }
+    } else if (transcriptReconcileResult.transcriptUnavailableWithCheckpoint) {
+      dedupedNewMessages =
+        await this.batchDeduplicator.deduplicateAfterTurnBatchAgainstPreservedCheckpoint(
+          params.sessionId,
+          params.sessionKey,
+          newMessages,
+        );
+      if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
+        this.deps.log.debug(
+          `[lcm] afterTurn: transcript unavailable with preserved checkpoint; runtime batch deduplicated to ${dedupedNewMessages.length}/${newMessages.length} messages ${sessionLabel}`,
+        );
+      }
     } else if (transcriptReconcileResult.transcriptCovered) {
       // The transcript reconcile read the file to its frontier, so the DB
       // tail is exact — use precise alignment instead of the heuristic

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -116,4 +116,11 @@ export type TranscriptReconcileResult = {
    * transcript was missing, unreadable, or skipped.
    */
   transcriptCovered?: boolean;
+  /**
+   * True when this call could not read the transcript but preserved an
+   * existing checkpoint. The persisted frontier can still remove a fully
+   * replayed runtime batch, but ambiguous rows must use degraded dedup because
+   * the unavailable transcript cannot be relied on to deliver them later.
+   */
+  transcriptUnavailableWithCheckpoint?: boolean;
 };

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -118,9 +118,10 @@ export type TranscriptReconcileResult = {
   transcriptCovered?: boolean;
   /**
    * True when this call could not read the transcript but preserved an
-   * existing checkpoint. The persisted frontier can still remove a fully
-   * replayed runtime batch, but ambiguous rows must use degraded dedup because
-   * the unavailable transcript cannot be relied on to deliver them later.
+   * existing checkpoint. Already-persisted transcript entry ids can still
+   * remove a fully replayed runtime batch; all other rows retain degraded
+   * dedup behavior because the unavailable transcript cannot be relied on to
+   * deliver them later.
    */
   transcriptUnavailableWithCheckpoint?: boolean;
 };

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2204,7 +2204,7 @@ export class TranscriptReconciler {
         importedMessages: 0,
         blockedByImportCap: false,
         hasOverlap: true,
-        transcriptCovered: true,
+        transcriptUnavailableWithCheckpoint: true,
       };
     }
 
@@ -2317,6 +2317,7 @@ export class TranscriptReconciler {
           importedMessages: 0,
           blockedByImportCap: false,
           hasOverlap: true,
+          ...(checkpoint ? { transcriptUnavailableWithCheckpoint: true } : {}),
         };
       }
       if (sessionFileState.size === 0) {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2191,11 +2191,15 @@ export class TranscriptReconciler {
         this.host.deps.log.warn(
           `[lcm] afterTurn: session file missing; skipping transcript reconcile full reread; could not stat/read transcript; allowing live afterTurn persistence and seeding placeholder bootstrap_state at offset=0 to unblock next-turn recovery conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
         );
-      } else {
-        this.host.deps.log.warn(
-          `[lcm] afterTurn: session file missing; skipping transcript reconcile full reread; preserving existing checkpoint (offset=${checkpoint.lastProcessedOffset}) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
-        );
+        return {
+          importedMessages: 0,
+          blockedByImportCap: false,
+          hasOverlap: true,
+        };
       }
+      this.host.deps.log.warn(
+        `[lcm] afterTurn: session file missing; skipping transcript reconcile full reread; preserving existing checkpoint (offset=${checkpoint.lastProcessedOffset}) conversation=${conversation.conversationId} reason=${reason} sessionFile=${params.sessionFile}`,
+      );
       return {
         importedMessages: 0,
         blockedByImportCap: false,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -2200,6 +2200,7 @@ export class TranscriptReconciler {
         importedMessages: 0,
         blockedByImportCap: false,
         hasOverlap: true,
+        transcriptCovered: true,
       };
     }
 

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1497,7 +1497,7 @@ describe("LcmContextEngine afterTurn", () => {
   it("distinguishes missing transcripts with and without a preserved checkpoint", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-missing-transcript-checkpoint-proof";
-    await engine.getConversationStore().getOrCreateConversation(sessionId);
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId);
 
     const withoutCheckpoint = await engine
       .getTranscriptReconciler()
@@ -1508,11 +1508,22 @@ describe("LcmContextEngine afterTurn", () => {
     expect(withoutCheckpoint.transcriptCovered).toBeUndefined();
     expect(withoutCheckpoint.transcriptUnavailableWithCheckpoint).toBeUndefined();
 
+    const withCheckpointSessionFile = createSessionFilePath(
+      "missing-transcript-with-checkpoint",
+    );
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: withCheckpointSessionFile,
+      lastSeenSize: 512,
+      lastSeenMtimeMs: 1_700_000_000_000,
+      lastProcessedOffset: 512,
+      lastProcessedEntryHash: "preserved-checkpoint-hash",
+    });
     const withCheckpoint = await engine
       .getTranscriptReconciler()
       .reconcileTranscriptTailForAfterTurn({
         sessionId,
-        sessionFile: createSessionFilePath("missing-transcript-with-checkpoint"),
+        sessionFile: withCheckpointSessionFile,
       });
     expect(withCheckpoint.transcriptCovered).toBeUndefined();
     expect(withCheckpoint.transcriptUnavailableWithCheckpoint).toBe(true);

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -1494,6 +1494,30 @@ describe("LcmContextEngine afterTurn", () => {
     ).toBe(false);
   });
 
+  it("distinguishes missing transcripts with and without a preserved checkpoint", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-missing-transcript-checkpoint-proof";
+    await engine.getConversationStore().getOrCreateConversation(sessionId);
+
+    const withoutCheckpoint = await engine
+      .getTranscriptReconciler()
+      .reconcileTranscriptTailForAfterTurn({
+        sessionId,
+        sessionFile: createSessionFilePath("missing-transcript-without-checkpoint"),
+      });
+    expect(withoutCheckpoint.transcriptCovered).toBeUndefined();
+    expect(withoutCheckpoint.transcriptUnavailableWithCheckpoint).toBeUndefined();
+
+    const withCheckpoint = await engine
+      .getTranscriptReconciler()
+      .reconcileTranscriptTailForAfterTurn({
+        sessionId,
+        sessionFile: createSessionFilePath("missing-transcript-with-checkpoint"),
+      });
+    expect(withCheckpoint.transcriptCovered).toBeUndefined();
+    expect(withCheckpoint.transcriptUnavailableWithCheckpoint).toBe(true);
+  });
+
   it("afterTurn fails closed when the transcript reconcile throws: no batch persistence, no checkpoint advance", async () => {
     // The catch handler used to leave the initialized in-sync default in place,
     // so a thrown reconcile persisted the live batch AND refreshed the

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -550,14 +550,37 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     const sessionId = "dedup-oversized-no-overlap-all-persisted";
     const oldBTimestamp = Date.UTC(2026, 0, 1, 0, 0, 1);
     const lastDTimestamp = Date.UTC(2026, 0, 1, 0, 0, 4);
+    const messageWithEntryId = (
+      role: "user" | "assistant",
+      content: string,
+      timestamp: number,
+      entryId: string,
+      parentId: string | null,
+    ): AgentMessage =>
+      attachTranscriptEntryMeta(
+        { role, content, timestamp } as AgentMessage,
+        { entryId, parentId, timestamp: new Date(timestamp).toISOString() },
+      );
 
     await engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted"),
       messages: [
-        { role: "user", content: "old A", timestamp: Date.UTC(2026, 0, 1, 0, 0, 0) } as AgentMessage,
-        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
-        { role: "user", content: "old C", timestamp: Date.UTC(2026, 0, 1, 0, 0, 2) } as AgentMessage,
+        messageWithEntryId(
+          "user",
+          "old A",
+          Date.UTC(2026, 0, 1, 0, 0, 0),
+          "old-a",
+          null,
+        ),
+        messageWithEntryId("assistant", "old B", oldBTimestamp, "old-b", "old-a"),
+        messageWithEntryId(
+          "user",
+          "old C",
+          Date.UTC(2026, 0, 1, 0, 0, 2),
+          "old-c",
+          "old-b",
+        ),
       ],
       prePromptMessageCount: 0,
       tokenBudget: 4096,
@@ -567,10 +590,22 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       sessionId,
       sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted-summary"),
       messages: [
-        { role: "user", content: "old A", timestamp: Date.UTC(2026, 0, 1, 0, 0, 0) } as AgentMessage,
-        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
-        { role: "user", content: "old C", timestamp: Date.UTC(2026, 0, 1, 0, 0, 2) } as AgentMessage,
-        { role: "assistant", content: "last D", timestamp: lastDTimestamp } as AgentMessage,
+        messageWithEntryId(
+          "user",
+          "old A",
+          Date.UTC(2026, 0, 1, 0, 0, 0),
+          "old-a",
+          null,
+        ),
+        messageWithEntryId("assistant", "old B", oldBTimestamp, "old-b", "old-a"),
+        messageWithEntryId(
+          "user",
+          "old C",
+          Date.UTC(2026, 0, 1, 0, 0, 2),
+          "old-c",
+          "old-b",
+        ),
+        messageWithEntryId("assistant", "last D", lastDTimestamp, "last-d", "old-c"),
       ],
       prePromptMessageCount: 0,
       tokenBudget: 4096,
@@ -583,8 +618,8 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       sessionId,
       sessionFile: createSessionFilePath("dedup-oversized-no-overlap-all-persisted-2"),
       messages: [
-        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
-        { role: "assistant", content: "last D", timestamp: lastDTimestamp } as AgentMessage,
+        messageWithEntryId("assistant", "old B", oldBTimestamp, "old-b", "old-a"),
+        messageWithEntryId("assistant", "last D", lastDTimestamp, "last-d", "old-c"),
       ],
       prePromptMessageCount: 0,
       tokenBudget: 4096,
@@ -603,13 +638,29 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       "last D",
     ]);
 
+    const partialBatch = [
+      messageWithEntryId("assistant", "old B", oldBTimestamp, "old-b", "old-a"),
+      messageWithEntryId(
+        "assistant",
+        "new E",
+        Date.UTC(2026, 0, 1, 0, 0, 5),
+        "new-e",
+        "last-d",
+      ),
+    ];
+    const partialDeduped = await engine
+      .getBatchDeduplicator()
+      .deduplicateAfterTurnBatchAgainstPreservedCheckpoint(
+        sessionId,
+        undefined,
+        partialBatch,
+      );
+    expect(partialDeduped).toEqual(partialBatch);
+
     await engine.afterTurn({
       sessionId,
       sessionFile: createSessionFilePath("dedup-oversized-no-overlap-partial-live"),
-      messages: [
-        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
-        { role: "assistant", content: "new E", timestamp: Date.UTC(2026, 0, 1, 0, 0, 5) } as AgentMessage,
-      ],
+      messages: partialBatch,
       prePromptMessageCount: 0,
       tokenBudget: 4096,
     });
@@ -623,12 +674,11 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       "old C",
       "[summary] compacted older context",
       "last D",
-      "old B",
       "new E",
     ]);
-    // Partial overlap is ambiguous without the transcript. Re-ingesting the
-    // known row is intentional: duplicates are safer than dropping new E.
-    expect(afterPartialOverlap.filter((message) => message.content === "old B")).toHaveLength(2);
+    // The missing-transcript helper returns the ambiguous batch intact. The
+    // later raw-id guard can safely remove old B by its exact persisted id.
+    expect(afterPartialOverlap.filter((message) => message.content === "old B")).toHaveLength(1);
   });
 
   it("fails open when a missing-transcript replay only has re-stamped envelope timestamps", async () => {

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -536,7 +536,7 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
     );
   });
 
-  it("ingests oversized no-overlap batches that only timestamp-match around auto-compaction summaries", async () => {
+  it("deduplicates full replays and preserves partial-overlap rows when a tracked transcript is missing", async () => {
     const warnLog = vi.fn();
     const engine = createEngineWithDepsOverrides({
       log: {
@@ -591,16 +591,39 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    // v2 fix: the ENOENT checkpoint-present branch now returns transcriptCovered:true,
-    // routing through alignRuntimeBatchAgainstCoveredFrontier instead of the
-    // aggressive ingest path. The batch [old B, last D] timestamp-matches existing
-    // messages and is correctly deduplicated rather than ingested as duplicates.
+    // The preserved checkpoint proves that both timestamped rows already exist,
+    // so the missing transcript path can skip the full replay without claiming
+    // that the transcript itself was covered this turn.
     expect(stored.map((m) => m.content)).toEqual([
       "old A",
       "old B",
       "old C",
       "[summary] compacted older context",
       "last D",
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-oversized-no-overlap-partial-live"),
+      messages: [
+        { role: "assistant", content: "old B", timestamp: oldBTimestamp } as AgentMessage,
+        { role: "assistant", content: "new E", timestamp: Date.UTC(2026, 0, 1, 0, 0, 5) } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const afterPartialOverlap = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(afterPartialOverlap.map((m) => m.content)).toEqual([
+      "old A",
+      "old B",
+      "old C",
+      "[summary] compacted older context",
+      "last D",
+      "old B",
+      "new E",
     ]);
   });
 

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -591,18 +591,17 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
 
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    // v2 fix: the ENOENT checkpoint-present branch now returns transcriptCovered:true,
+    // routing through alignRuntimeBatchAgainstCoveredFrontier instead of the
+    // aggressive ingest path. The batch [old B, last D] timestamp-matches existing
+    // messages and is correctly deduplicated rather than ingested as duplicates.
     expect(stored.map((m) => m.content)).toEqual([
       "old A",
       "old B",
       "old C",
       "[summary] compacted older context",
       "last D",
-      "old B",
-      "last D",
     ]);
-    expect(warnLog).toHaveBeenCalledWith(
-      `[lcm] dedup: oversized, storedCount=5 batchLen=2, no overlap found — ingesting full batch`,
-    );
   });
 
   it("ingests oversized no-overlap repeated content without auto-compaction summary proof", async () => {

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -11,6 +11,7 @@ import { estimateTokens } from "../src/estimate-tokens.js";
 import { formatFileReference } from "../src/large-files.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 import { buildMessageIdentityHash } from "../src/store/message-identity.js";
+import { attachTranscriptEntryMeta } from "../src/transcript.js";
 import {
   cleanupEngineTestState,
   firstCompleteCall,
@@ -624,6 +625,83 @@ describe("LcmContextEngine afterTurn dedup guard", () => {
       "last D",
       "old B",
       "new E",
+    ]);
+    // Partial overlap is ambiguous without the transcript. Re-ingesting the
+    // known row is intentional: duplicates are safer than dropping new E.
+    expect(afterPartialOverlap.filter((message) => message.content === "old B")).toHaveLength(2);
+  });
+
+  it("fails open when a missing-transcript replay only has re-stamped envelope timestamps", async () => {
+    const engine = createEngine();
+    const sessionId = "dedup-missing-transcript-envelope-timestamp";
+    const firstTimestamp = Date.UTC(2026, 0, 1, 0, 0, 1);
+    const secondTimestamp = Date.UTC(2026, 0, 1, 0, 0, 2);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-missing-transcript-envelope-timestamp"),
+      messages: [
+        { role: "user", content: "old A", timestamp: firstTimestamp - 1000 } as AgentMessage,
+        { role: "assistant", content: "old B", timestamp: firstTimestamp } as AgentMessage,
+        { role: "user", content: "old C", timestamp: secondTimestamp } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-missing-transcript-envelope-timestamp-summary"),
+      messages: [
+        { role: "user", content: "old A", timestamp: firstTimestamp - 1000 } as AgentMessage,
+        { role: "assistant", content: "old B", timestamp: firstTimestamp } as AgentMessage,
+        { role: "user", content: "old C", timestamp: secondTimestamp } as AgentMessage,
+        {
+          role: "assistant",
+          content: "last D",
+          timestamp: secondTimestamp + 2000,
+        } as AgentMessage,
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+      autoCompactionSummary: "[summary] compacted older context",
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("dedup-missing-transcript-envelope-timestamp-replay"),
+      messages: [
+        attachTranscriptEntryMeta(
+          { role: "assistant", content: "old B" } as AgentMessage,
+          {
+            entryId: "restamped-old-b",
+            parentId: null,
+            timestamp: new Date(firstTimestamp).toISOString(),
+          },
+        ),
+        attachTranscriptEntryMeta(
+          { role: "assistant", content: "last D" } as AgentMessage,
+          {
+            entryId: "restamped-last-d",
+            parentId: "restamped-old-b",
+            timestamp: new Date(secondTimestamp + 2000).toISOString(),
+          },
+        ),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(stored.map((message) => message.content)).toEqual([
+      "old A",
+      "old B",
+      "old C",
+      "[summary] compacted older context",
+      "last D",
+      "old B",
+      "last D",
     ]);
   });
 


### PR DESCRIPTION
## What
Handle `afterTurn` when Lossless cannot read a tracked transcript but retains its checkpoint. The reconciler emits `transcriptUnavailableWithCheckpoint`, and the dedup path suppresses a full runtime replay only when every transcript entry ID is already persisted.

## Why
`transcriptCovered` means the transcript was read through its frontier, so the missing-file path cannot assert it. Treating second-truncated timestamps as replay proof can discard a genuinely new repeated row. Exact transcript entry IDs provide deterministic proof while ambiguous batches retain the established degraded dedup behavior.

## Changes

- Add missing-transcript checkpoint signal
- Require persisted IDs for replay drops
- Preserve degraded ambiguous-batch dedup
- Cover full and partial overlaps
- Add patch release changeset

## Testing

- `npm test`: 105 files passed
- `npm run typecheck`: passed
- `npm run build`: passed
- Exact merge tree: 1,895 tests passed
- Final autoreview: no actionable findings