### PR TITLE
fix: use context_items instead of inflated liveMessages for debt pressure

### DIFF
--- a/.changeset/calm-context-pressure.md
+++ b/.changeset/calm-context-pressure.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent stale deferred-compaction token counts from forcing repeated emergency drains after the stored context has already been compacted.

--- a/src/assemble-debug.ts
+++ b/src/assemble-debug.ts
@@ -152,13 +152,13 @@ export function describeAssembledPrefixChange(
 export function shouldLogOverflowDiagnostics(params: {
   diagnostics: AssemblyOverflowDiagnostics;
   assembledTokens: number;
-  liveContextTokens: number;
+  storedContextTokens: number;
 }): boolean {
   const budget = Math.max(1, params.diagnostics.tokenBudget);
   return (
     params.diagnostics.totalContextTokens > budget ||
     params.assembledTokens >= Math.floor(budget * 0.9) ||
-    params.liveContextTokens >= Math.floor(budget * 0.9) ||
+    params.storedContextTokens >= Math.floor(budget * 0.9) ||
     params.diagnostics.duplicateRefClusters.length > 0 ||
     params.diagnostics.duplicateMessageClusters.length > 0
   );

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -197,14 +197,12 @@ export function resolveDeferredAssemblyPressure(params: {
   const recordedProjectedTokens = normalizeNonNegativeInteger(
     params.maintenance?.projectedTokenCount,
   );
-  const observedContextTokens = Math.max(
-    params.liveContextTokens,
-    recordedContextTokens ?? 0,
-  );
-  const pressureTokenCount = Math.max(
-    observedContextTokens,
-    recordedProjectedTokens ?? 0,
-  );
+  // Use live context_items as the primary pressure measure. Recorded values
+  // from debt creation time become stale after compaction reduces stored.
+  // Inflating pressure with stale recorded values keeps the system in
+  // permanent emergency drain even though the actual context fits budget.
+  const observedContextTokens = params.liveContextTokens;
+  const pressureTokenCount = observedContextTokens;
   return {
     observedContextTokens,
     projectedTokenCount: recordedProjectedTokens ?? null,

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -183,30 +183,28 @@ export function buildDegradedLiveAssembleResult(params: {
   };
 }
 
+/**
+ * Resolve deferred compaction pressure from the canonical stored projection.
+ *
+ * Debt-time current and projected counts remain diagnostic because compaction
+ * can make them stale. Only the current `context_items` total decides whether
+ * another assemble-time drain could reduce the model context.
+ */
 export function resolveDeferredAssemblyPressure(params: {
-  liveContextTokens: number;
+  storedContextTokens: number;
   maintenance: ConversationCompactionMaintenanceRecord | null;
 }): {
-  observedContextTokens: number;
+  storedContextTokens: number;
   projectedTokenCount: number | null;
   pressureTokenCount: number;
 } {
-  const recordedContextTokens = normalizeNonNegativeInteger(
-    params.maintenance?.currentTokenCount,
-  );
   const recordedProjectedTokens = normalizeNonNegativeInteger(
     params.maintenance?.projectedTokenCount,
   );
-  // Use live context_items as the primary pressure measure. Recorded values
-  // from debt creation time become stale after compaction reduces stored.
-  // Inflating pressure with stale recorded values keeps the system in
-  // permanent emergency drain even though the actual context fits budget.
-  const observedContextTokens = params.liveContextTokens;
-  const pressureTokenCount = observedContextTokens;
   return {
-    observedContextTokens,
+    storedContextTokens: params.storedContextTokens,
     projectedTokenCount: recordedProjectedTokens ?? null,
-    pressureTokenCount,
+    pressureTokenCount: params.storedContextTokens,
   };
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3570,7 +3570,9 @@ export class LcmContextEngine implements ContextEngine {
         }
         return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
       };
-      const liveContextTokens = await this.summaryStore.getContextTokenCount(conversation.conversationId);
+      const storedContextTokens = await this.summaryStore.getContextTokenCount(
+        conversation.conversationId,
+      );
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );
@@ -3588,12 +3590,12 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO,
         );
         let pressure = resolveDeferredAssemblyPressure({
-          liveContextTokens,
+          storedContextTokens,
           maintenance,
         });
         if (pressure.pressureTokenCount > tokenBudget) {
           this.deps.log.warn(
-            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
+            `[lcm] assemble: emergency deferred compaction debt draining pre-assembly conversation=${conversation.conversationId} ${sessionLabel} storedContextTokens=${pressure.storedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=over-budget`,
           );
           let emergencyDrainResult: { exhausted: boolean } | null = null;
           try {
@@ -3602,7 +3604,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
               tokenBudget,
-              currentTokenCount: pressure.observedContextTokens,
+              currentTokenCount: pressure.storedContextTokens,
             });
           } catch (error) {
             this.deps.log.warn(
@@ -3615,7 +3617,7 @@ export class LcmContextEngine implements ContextEngine {
             );
           if (latestMaintenance?.pending || latestMaintenance?.running) {
             pressure = resolveDeferredAssemblyPressure({
-              liveContextTokens,
+              storedContextTokens,
               maintenance: latestMaintenance,
             });
             if (pressure.pressureTokenCount > pressureThreshold) {
@@ -3640,7 +3642,7 @@ export class LcmContextEngine implements ContextEngine {
           };
         } else {
           this.deps.log.debug(
-            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} currentTokenCount=${pressure.observedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=not-over-budget`,
+            `[lcm] assemble: deferred compaction debt left pending conversation=${conversation.conversationId} ${sessionLabel} storedContextTokens=${pressure.storedContextTokens} projectedTokenCount=${pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} reason=not-over-budget`,
           );
         }
       }
@@ -3650,7 +3652,7 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget,
         });
         this.deps.log.warn(
-          `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} currentTokenCount=${deferredAssemblyDegradation.pressure.observedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
+          `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} storedContextTokens=${deferredAssemblyDegradation.pressure.storedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
         );
         return degraded;
       }
@@ -3953,7 +3955,7 @@ export class LcmContextEngine implements ContextEngine {
         const overflowDiagnostics = shouldLogOverflowDiagnostics({
           diagnostics: assembled.debug.overflowDiagnostics,
           assembledTokens: assembled.estimatedTokens,
-          liveContextTokens,
+          storedContextTokens,
         })
           ? ` overflowDiagnostics=${formatOverflowDiagnosticsForLog({
               diagnostics: assembled.debug.overflowDiagnostics,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3570,7 +3570,7 @@ export class LcmContextEngine implements ContextEngine {
         }
         return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
       };
-      const liveContextTokens = estimateSessionTokenCountForAfterTurn(liveMessages);
+      const liveContextTokens = await this.summaryStore.getContextTokenCount(conversation.conversationId);
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
         conversation.conversationId,
       );

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3570,7 +3570,7 @@ export class LcmContextEngine implements ContextEngine {
         }
         return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
       };
-      const storedContextTokens = await this.summaryStore.getContextTokenCount(
+      let storedContextTokens = await this.summaryStore.getContextTokenCount(
         conversation.conversationId,
       );
       const maintenance = await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
@@ -3611,6 +3611,9 @@ export class LcmContextEngine implements ContextEngine {
               `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
             );
           }
+          storedContextTokens = await this.summaryStore.getContextTokenCount(
+            conversation.conversationId,
+          );
           const latestMaintenance =
             await this.compactionMaintenanceStore.getConversationCompactionMaintenance(
               conversation.conversationId,

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1666,6 +1666,63 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(maintenance?.pending).toBe(true);
   });
 
+  it("assemble() does not trigger emergency drain when recorded values are stale after compaction", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-stale-recorded-no-emergency";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    // Store a modest amount of context_items
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "recent small context after compaction",
+        tokenCount: 100,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    // Maintenance debt with high stale recorded values (from before compaction)
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+      projectedTokenCount: 6_000,
+    });
+    const executeCompactionCoreSpy = vi.spyOn(privateEngine, "executeCompactionCore");
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current delivery turn" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    // Should NOT trigger emergency drain: stored context (100) is well below
+    // threshold (0.75 * 4096 = 3072), even though recorded values are high
+    expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
+    expect(maintenance?.pending).toBe(true);
+    expect(assembleResult.messages).toHaveLength(1);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: emergency deferred compaction debt draining pre-assembly"),
+    );
+  });
+
   it("maintain() uses the stricter current token budget for deferred threshold debt", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1531,6 +1531,67 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     );
   });
 
+  it("assemble() refreshes stored pressure after a partial emergency drain", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-refreshes-pressure-after-partial-drain";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "context compacted below the degradation threshold",
+        tokenCount: 100,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 4_096,
+      currentTokenCount: 5_000,
+      projectedTokenCount: 6_000,
+    });
+    const contextTokenCountSpy = vi
+      .spyOn(engine.getSummaryStore(), "getContextTokenCount")
+      .mockResolvedValueOnce(5_000)
+      .mockResolvedValue(100);
+    vi.spyOn(privateEngine, "executeCompactionCore").mockResolvedValue({
+      ok: false,
+      compacted: true,
+      reason: "compacted but still over target",
+    });
+
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current delivery turn" })],
+      tokenBudget: 4_096,
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(contextTokenCountSpy).toHaveBeenCalledTimes(2);
+    expect(maintenance?.pending).toBe(true);
+    expect(assembleResult.messages.length).toBeGreaterThan(0);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[lcm] assemble: degraded live fallback"),
+    );
+  });
+
   it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -997,7 +997,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         seq: 0,
         role: "user",
         content: "stored context should be skipped while maintenance is pending",
-        tokenCount: 20,
+        tokenCount: 80,
       },
     ]);
     await engine
@@ -1059,7 +1059,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         seq: 0,
         role: "user",
         content: "stored content",
-        tokenCount: 20,
+        tokenCount: 80,
       },
     ]);
     await engine
@@ -1144,6 +1144,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 30,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1192,6 +1204,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 500,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1249,7 +1273,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         seq: 0,
         role: "user",
         content: "stored context should not be used after failed emergency compaction",
-        tokenCount: 20,
+        tokenCount: 150,
       },
     ]);
     await engine
@@ -1320,6 +1344,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 11,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1372,6 +1408,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 5000,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1419,6 +1467,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 5000,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1450,7 +1510,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         conversationId: conversation.conversationId,
         sessionId,
         tokenBudget: 4_096,
-        currentTokenCount: 300,
+        currentTokenCount: 5000,
         compactionTarget: "threshold",
       }),
     );
@@ -1517,6 +1577,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context message",
+        tokenCount: 90,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1458,8 +1458,14 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(assembleResult.messages).toHaveLength(1);
   });
 
-  it("assemble() uses projected deferred pressure for emergency drain without passing it as observed tokens", async () => {
-    const engine = createEngine();
+  it("assemble() drains stored over-budget context while keeping projected debt as telemetry", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
     const privateEngine = engine as unknown as {
       executeCompactionCore: (params: unknown) => Promise<unknown>;
     };
@@ -1517,6 +1523,12 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(maintenance?.pending).toBe(false);
     expect(maintenance?.running).toBe(false);
     expect(assembleResult.messages).toHaveLength(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("storedContextTokens=5000"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("projectedTokenCount=5000"),
+    );
   });
 
   it("assemble() does not wait for the session queue when deferred threshold debt is not urgent", async () => {
@@ -1681,7 +1693,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
-    // Store a modest amount of context_items
+    // Store a modest amount of context_items.
     const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
       {
         conversationId: conversation.conversationId,
@@ -1694,7 +1706,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     await engine
       .getSummaryStore()
       .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
-    // Maintenance debt with high stale recorded values (from before compaction)
+    // Maintenance debt retains high values recorded before compaction.
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",
@@ -1713,13 +1725,19 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const maintenance = await engine
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation.conversationId);
-    // Should NOT trigger emergency drain: stored context (100) is well below
-    // threshold (0.75 * 4096 = 3072), even though recorded values are high
+    // Stored context (100) is well below threshold (0.75 * 4096 = 3072),
+    // so neither recorded value may trigger emergency drain.
     expect(executeCompactionCoreSpy).not.toHaveBeenCalled();
     expect(maintenance?.pending).toBe(true);
     expect(assembleResult.messages).toHaveLength(1);
     expect(log.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("[lcm] assemble: emergency deferred compaction debt draining pre-assembly"),
+    );
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("storedContextTokens=100"),
+    );
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("projectedTokenCount=6000"),
     );
   });
 

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1709,6 +1709,18 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
     });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context requiring emergency drain",
+        tokenCount: 90,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
     await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
       conversationId: conversation.conversationId,
       reason: "threshold",


### PR DESCRIPTION
## Summary

`resolveDeferredAssemblyPressure()` takes `Math.max(liveContextTokens, recordedContextTokens)` to conservatively estimate assembly pressure when deferred compaction debt is pending. After a compact successfully reduces stored context, the recorded token count from debt creation time becomes stale, forcing the system into permanent emergency drain with an impossible compaction target.

## Root cause

Two issues:

1. **`liveContextTokens` source**: `estimateSessionTokenCountForAfterTurn(liveMessages)` estimates ALL raw session messages (~210K), not the compressed context_items (~47K). Even after a successful compact, this still returns the inflated count.

2. **`resolveDeferredAssemblyPressure` max**: `Math.max(liveContextTokens, recordedContextTokens)` picks up the stale debt-time API input count (168K) even when current context is 47K. This makes the emergency drain compute `runtimeAdjustedSweepTargetTokens = max(1, target - overhead)` where overhead is the stale gap, resulting in a target of ~1 token. Compaction cannot meet this, so the debt stays pending forever.

## Fix

- **`engine.ts`**: `liveContextTokens` uses `summaryStore.getContextTokenCount()` (47K) instead of `estimateSessionTokenCountForAfterTurn(liveMessages)` (210K)
- **`assemble-fallback.ts`**: `resolveDeferredAssemblyPressure` uses `liveContextTokens` directly without inflating with stale recorded values

## Verification

Tested on a production session with 1099 turns and pending debt:

**Before fix (stuck in deadlock):**
```
mode: pending=1, current=167934, projected=182408
failure: "compacted but still over target"
behavior: each assemble() triggers emergency drain → compact target ~1 → fail → degraded live fallback → "Context is too large" error
```

**After fix (recovered normally):**
```
mode: pending=0, current=74690, projected=92280
failure: (cleared)
behavior: assemble() uses context_items (47K) within budget → normal assembly → session resumed with no errors
```

**Test suite:** 1815/1818 tests pass (3 pre-existing log redaction failures unrelated to this change)