### PR TITLE
fix(compaction): guard leafPass against empty messageContents

### DIFF
--- a/.changeset/leaf-skip-empty-message-contents.md
+++ b/.changeset/leaf-skip-empty-message-contents.md
@@ -1,5 +1,5 @@
 ---
-"lossless-claw": patch
+"@martian-engineering/lossless-claw": patch
 ---
 
-Guard leaf compaction against empty messageContents. When selectOldestLeafChunk returns items whose messageId fields are all null, or whose referenced messages no longer exist, messageContents is empty. Previously leafPass would still call summarizer, create a summary with removedTokens=0, and grow the context (tokensAfter = tokensBefore + tokenCount). Now it returns null early, letting callers bail without wasted LLM calls or context inflation.
+Skip leaf compaction when selected raw messages are missing or contain no meaningful content, preventing zero-source fallback summaries and context growth. Full sweeps continue past empty-source chunks, clamp tracked token deltas at zero, and stop leaf passes once `stopAtTokens` is reached.

--- a/.changeset/leaf-skip-empty-message-contents.md
+++ b/.changeset/leaf-skip-empty-message-contents.md
@@ -1,0 +1,5 @@
+---
+"lossless-claw": patch
+---
+
+Guard leaf compaction against empty messageContents. When selectOldestLeafChunk returns items whose messageId fields are all null, or whose referenced messages no longer exist, messageContents is empty. Previously leafPass would still call summarizer, create a summary with removedTokens=0, and grow the context (tokensAfter = tokensBefore + tokenCount). Now it returns null early, letting callers bail without wasted LLM calls or context inflation.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ BRIEF.md
 PROGRESS.md
 pnpm-lock.yaml
 
+.codegraph/

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ BRIEF.md
 PROGRESS.md
 pnpm-lock.yaml
 
-.codegraph/

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -131,10 +131,11 @@ type PassResult = {
   /** Token count of the newly created summary. */
   addedTokens: number;
 };
-type CondensedPassSkipped = {
+type CompactionPassSkipped = {
   skipped: "empty-source";
 };
-type CondensedPassResult = PassResult | CondensedPassSkipped;
+type LeafPassResult = (PassResult & { content: string }) | CompactionPassSkipped;
+type CondensedPassResult = PassResult | CompactionPassSkipped;
 type LeafChunkSelection = {
   items: ContextItemRecord[];
   rawTokensOutsideTail: number;
@@ -1079,6 +1080,7 @@ export class CompactionEngine {
     // Delta tracking: maintain a running token count instead of re-querying DB
     // after each pass. The arithmetic is exact: tokensAfter = tokensBefore - removed + added.
     let runningTokens = tokensBefore;
+    let leafScanAfterOrdinal: number | undefined;
     while (true) {
       if (sweepBudgetExhausted("leaf")) {
         break;
@@ -1087,6 +1089,7 @@ export class CompactionEngine {
         conversationId,
         leafChunkTokensOverride,
         freshTailCountOverride,
+        leafScanAfterOrdinal,
       );
       if (leafChunk.items.length === 0) {
         break;
@@ -1109,7 +1112,9 @@ export class CompactionEngine {
         break;
       }
       if ("skipped" in leafResult) {
-        break;
+        leafScanAfterOrdinal = leafChunk.items[leafChunk.items.length - 1]?.ordinal;
+        await yieldToEventLoop();
+        continue;
       }
       const passTokensAfter = Math.max(0, passTokensBefore - leafResult.removedTokens + leafResult.addedTokens);
       await this.persistCompactionEvents({
@@ -1585,6 +1590,7 @@ export class CompactionEngine {
     conversationId: number,
     leafChunkTokensOverride?: number,
     freshTailCountOverride?: number,
+    afterOrdinal?: number,
   ): Promise<LeafChunkSelection> {
     const contextItems = await this.getContextItemsCached(conversationId);
     const freshTailOrdinal = await this.resolveFreshTailOrdinal(contextItems, freshTailCountOverride);
@@ -1607,6 +1613,9 @@ export class CompactionEngine {
     for (const item of contextItems) {
       if (item.ordinal >= freshTailOrdinal) {
         break;
+      }
+      if (afterOrdinal !== undefined && item.ordinal <= afterOrdinal) {
+        continue;
       }
 
       if (!started) {
@@ -2190,7 +2199,7 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn,
     previousSummaryContent?: string,
     summaryModel?: string,
-  ): Promise<PassResult & { content: string } | null | CondensedPassSkipped> {
+  ): Promise<LeafPassResult | null> {
     // Fetch full message content for each context item
     const messageContents: { messageId: number; content: string; createdAt: Date; tokenCount: number }[] =
       [];

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -1100,11 +1100,16 @@ export class CompactionEngine {
 
       sweepIterations++;
       const passTokensBefore = runningTokens;
+      const passPreviousSummaryContent =
+        previousSummaryContent ??
+        (leafScanAfterOrdinal !== undefined
+          ? await this.resolvePriorLeafSummaryContext(conversationId, leafChunk.items)
+          : undefined);
       const leafResult = await this.leafPass(
         conversationId,
         leafChunk.items,
         summarize,
-        previousSummaryContent,
+        passPreviousSummaryContent,
         input.summaryModel,
       );
       if (!leafResult) {

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -867,8 +867,16 @@ export class CompactionEngine {
         authFailure: true,
       };
     }
+    if ("skipped" in leafResult) {
+      return {
+        actionTaken: false,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        condensed: false,
+      };
+    }
     // Delta tracking: compute token change from pass results instead of re-querying DB
-    const tokensAfterLeaf = tokensBefore - leafResult.removedTokens + leafResult.addedTokens;
+    const tokensAfterLeaf = Math.max(0, tokensBefore - leafResult.removedTokens + leafResult.addedTokens);
 
     await this.persistCompactionEvents({
       conversationId,
@@ -906,7 +914,7 @@ export class CompactionEngine {
         if (!condenseResult || "skipped" in condenseResult) {
           break;
         }
-        const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
+        const passTokensAfter = Math.max(0, passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens);
         await this.persistCompactionEvents({
           conversationId,
           tokensBefore: passTokensBefore,
@@ -1100,7 +1108,10 @@ export class CompactionEngine {
         hadAuthFailure = true;
         break;
       }
-      const passTokensAfter = passTokensBefore - leafResult.removedTokens + leafResult.addedTokens;
+      if ("skipped" in leafResult) {
+        break;
+      }
+      const passTokensAfter = Math.max(0, passTokensBefore - leafResult.removedTokens + leafResult.addedTokens);
       await this.persistCompactionEvents({
         conversationId,
         tokensBefore: passTokensBefore,
@@ -1116,6 +1127,9 @@ export class CompactionEngine {
       previousSummaryContent = leafResult.content;
       runningTokens = passTokensAfter;
 
+      if (stopAtTokens !== undefined && runningTokens <= stopAtTokens) {
+        break;
+      }
       if (passTokensAfter >= passTokensBefore || passTokensAfter >= previousTokens) {
         break;
       }
@@ -1174,7 +1188,7 @@ export class CompactionEngine {
       if ("skipped" in condenseResult) {
         return "no-progress";
       }
-      const passTokensAfter = passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens;
+      const passTokensAfter = Math.max(0, passTokensBefore - condenseResult.removedTokens + condenseResult.addedTokens);
       await this.persistCompactionEvents({
         conversationId,
         tokensBefore: passTokensBefore,
@@ -2176,7 +2190,7 @@ export class CompactionEngine {
     summarize: CompactionSummarizeFn,
     previousSummaryContent?: string,
     summaryModel?: string,
-  ): Promise<{ summaryId: string; level: CompactionLevel; content: string; removedTokens: number; addedTokens: number } | null> {
+  ): Promise<PassResult & { content: string } | null | CondensedPassSkipped> {
     // Fetch full message content for each context item
     const messageContents: { messageId: number; content: string; createdAt: Date; tokenCount: number }[] =
       [];
@@ -2195,6 +2209,13 @@ export class CompactionEngine {
       }
     }
 
+    if (messageContents.length === 0) {
+      this.log.warn(
+        `[lcm] leaf compaction skipped; no valid messages; conversationId=${conversationId}; items=${messageItems.length}`,
+      );
+      return { skipped: "empty-source" };
+    }
+
     const concatenated = messageContents
       .map((message) => {
         // Strip injected plugin context blocks (memory/hindsight XML tags) first,
@@ -2207,6 +2228,13 @@ export class CompactionEngine {
       })
       .filter((s): s is string => s !== null)
       .join("\n\n");
+    if (!concatenated.trim()) {
+      this.log.warn(
+        `[lcm] leaf compaction skipped; no meaningful content; conversationId=${conversationId}; chunkMessages=${messageContents.length}`,
+      );
+      return { skipped: "empty-source" };
+    }
+
     const fileIds = dedupeOrderedIds(
       messageContents.flatMap((message) => extractFileIdsFromContent(message.content)),
     );

--- a/test/lcm-integration-compaction.test.ts
+++ b/test/lcm-integration-compaction.test.ts
@@ -2218,12 +2218,53 @@ describe("LCM integration: compaction", () => {
 
     expect(result.actionTaken).toBe(false);
     expect(result.tokensAfter).toBe(result.tokensBefore);
-    expect((result as any).authFailure).toBeFalsy();
+    expect(result.authFailure).toBeUndefined();
     expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it("compactFullSweep continues past an empty-source raw chunk", async () => {
+    const sweepEngine = new CompactionEngine(convStore as any, sumStore as any, {
+      ...defaultCompactionConfig,
+      freshTailCount: 0,
+      leafChunkTokens: 200,
+      summaryPrefixTargetTokens: 10_000,
+    });
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Missing source ${i}`,
+      tokenCountFn: () => 100,
+    });
+    await sumStore.insertSummary({
+      summaryId: "sum_empty_source_boundary",
+      conversationId: CONV_ID,
+      kind: "leaf",
+      content: "Existing summary boundary",
+      tokenCount: 20,
+    });
+    await sumStore.appendContextSummary(CONV_ID, "sum_empty_source_boundary");
+    await ingestMessages(convStore, sumStore, 2, {
+      contentFn: (i) => `Valid source ${i}`,
+      tokenCountFn: () => 100,
+    });
+
+    convStore._messages.splice(0, 2);
+    const summarize = vi.fn(async () => "Valid leaf summary");
+
+    const result = await sweepEngine.compactFullSweep({
+      conversationId: CONV_ID,
+      tokenBudget: 1_000,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(true);
+    expect(result.authFailure).toBeUndefined();
+    expect(summarize).toHaveBeenCalledOnce();
+    expect(sumStore._summaries.some((summary) => summary.content === "Valid leaf summary")).toBe(
+      true,
+    );
   });
 });
 
 // ═════════════════════════════════════════════════════════════════════════════
 // Test Suite: Full-sweep bounds (iteration cap + wall-clock deadline)
 // ═════════════════════════════════════════════════════════════════════════════
-

--- a/test/lcm-integration-compaction.test.ts
+++ b/test/lcm-integration-compaction.test.ts
@@ -2259,6 +2259,11 @@ describe("LCM integration: compaction", () => {
     expect(result.actionTaken).toBe(true);
     expect(result.authFailure).toBeUndefined();
     expect(summarize).toHaveBeenCalledOnce();
+    expect(summarize).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Boolean),
+      expect.objectContaining({ previousSummary: "Existing summary boundary" }),
+    );
     expect(sumStore._summaries.some((summary) => summary.content === "Valid leaf summary")).toBe(
       true,
     );

--- a/test/lcm-integration-compaction.test.ts
+++ b/test/lcm-integration-compaction.test.ts
@@ -2196,6 +2196,31 @@ describe("LCM integration: compaction", () => {
     expect(result.actionTaken).toBe(false);
     expect(summarize).not.toHaveBeenCalled();
   });
+
+  it("compactLeaf skips when messageContents is empty (all messages missing from store)", async () => {
+    await ingestMessages(convStore, sumStore, 5, {
+      contentFn: (i) => `Turn ${i}: content to compact`,
+      tokenCountFn: () => 100,
+    });
+
+    // Remove messages from the mock store so getMessageById returns null.
+    // Context items still reference the message IDs, simulating stale references.
+    convStore._messages.length = 0;
+
+    const summarize = vi.fn(async () => "should not be called");
+
+    const result = await compactionEngine.compactLeaf({
+      conversationId: CONV_ID,
+      tokenBudget: 1000,
+      summarize,
+      force: true,
+    });
+
+    expect(result.actionTaken).toBe(false);
+    expect(result.tokensAfter).toBe(result.tokensBefore);
+    expect((result as any).authFailure).toBeFalsy();
+    expect(summarize).not.toHaveBeenCalled();
+  });
 });
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

When `selectOldestLeafChunk` returns items whose `messageId` fields are all null, or whose referenced messages no longer exist, `messageContents` in `leafPass` is empty. Previously the method would still call the summarizer, create a summary with `removedTokens=0`, and grow the context (`tokensAfter = tokensBefore + tokenCount`).

## Fix

Added an early return guard after building `messageContents` — if empty, `leafPass` logs a warning and returns `null`, letting callers bail without wasted LLM calls or context inflation.