### PR TITLE
fix(afterTurn): use context_items token count as fallback instead of full session messages

### DIFF
--- a/.changeset/respect-openclaw-state-dir-all-paths.md
+++ b/.changeset/respect-openclaw-state-dir-all-paths.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Respect `OPENCLAW_STATE_DIR` in all code paths. The `tui`, `stub-tier-live-watcher`, and `stub-tier-assemble-bench` scripts now honor the `OPENCLAW_STATE_DIR` environment variable instead of hardcoding `~/.openclaw`. A `resolveOpenclawStateDir` helper was extracted for `tui/data.go` matching the existing pattern in `src/db/config.ts`.

--- a/scripts/stub-tier-assemble-bench.mjs
+++ b/scripts/stub-tier-assemble-bench.mjs
@@ -21,6 +21,7 @@
 
 import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 const args = process.argv.slice(2);
@@ -48,6 +49,11 @@ if (!existsSync(dbPath)) {
 }
 const log = (msg) => { if (verbose) console.error(`[bench] ${msg}`); };
 
+function resolveOpenclawDir() {
+  const explicit = process.env.OPENCLAW_STATE_DIR?.trim();
+  return explicit || join(homedir(), ".openclaw");
+}
+
 const cwd = process.cwd();
 const repoRootHint = `Run from repo root (cwd has src/db/migration.ts). Current cwd: ${cwd}`;
 if (!existsSync(`${cwd}/src/db/migration.ts`)) {
@@ -70,7 +76,7 @@ const { LcmContextEngine } = await import(`${cwd}/src/engine.ts`);
 const config = {
   enabled: true,
   databasePath: dbPath,
-  largeFilesDir: `${homedir()}/.openclaw/lcm-files`,
+  largeFilesDir: join(resolveOpenclawDir(), "lcm-files"),
   ignoreSessionPatterns: [],
   statelessSessionPatterns: [],
   skipStatelessSessions: false,

--- a/scripts/stub-tier-live-watcher.mjs
+++ b/scripts/stub-tier-live-watcher.mjs
@@ -35,8 +35,13 @@ const getArg = (n) => {
 };
 const hasFlag = (n) => args.includes(`--${n}`);
 
-const logPath = getArg("log") ?? join(homedir(), ".openclaw", "logs", "gateway.log");
-const dbPath = getArg("db") ?? join(homedir(), ".openclaw", "lcm.db");
+function resolveOpenclawDir() {
+  const explicit = process.env.OPENCLAW_STATE_DIR?.trim();
+  return explicit || join(homedir(), ".openclaw");
+}
+
+const logPath = getArg("log") ?? join(resolveOpenclawDir(), "logs", "gateway.log");
+const dbPath = getArg("db") ?? join(resolveOpenclawDir(), "lcm.db");
 const snapshotSecs = Number(getArg("snapshot-secs") ?? 30);
 const quiet = hasFlag("quiet");
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3201,7 +3201,15 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
 
-    const estimatedContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    const contextItemsTokenCount = conversation
+      ? await this.summaryStore.getContextTokenCount(conversation.conversationId)
+      : undefined;
+    const estimatedContextTokens =
+      contextItemsTokenCount ?? estimateSessionTokenCountForAfterTurn(params.messages);
     const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
     const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
       params.currentTokenCount ??
@@ -3215,13 +3223,9 @@ export class LcmContextEngine implements ContextEngine {
       runtimePromptTokens ?? suppliedCurrentTokenCount ?? estimatedContextTokens;
     if (runtimePromptTokens !== undefined) {
       this.deps.log.debug(
-        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} estimatedTokenCount=${estimatedContextTokens}`,
+        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} contextItemsTokenCount=${contextItemsTokenCount} estimatedTokenCount=${estimatedContextTokens}`,
       );
     }
-    const conversation = await this.conversationStore.getConversationForSession({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-    });
     if (!conversation) {
       this.deps.log.debug(
         `[lcm] afterTurn: conversation lookup missed ${sessionLabel} ingestBatch=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/test/migrate-sessions.test.ts
+++ b/test/migrate-sessions.test.ts
@@ -1,12 +1,12 @@
 import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
-import { runSessionMigration } from "../src/migrate-sessions.js";
+import { defaultStateDir, runSessionMigration } from "../src/migrate-sessions.js";
 
 const roots: string[] = [];
 
@@ -375,5 +375,42 @@ describe("runSessionMigration", () => {
         expect.objectContaining({ file: expect.stringContaining("good.jsonl"), status: "imported" }),
       ]),
     );
+  });
+});
+
+describe("defaultStateDir", () => {
+  const ORIG = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    if (ORIG === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIG;
+    }
+  });
+
+  it("falls back to ~/.openclaw when OPENCLAW_STATE_DIR is unset", () => {
+    delete process.env.OPENCLAW_STATE_DIR;
+    expect(defaultStateDir()).toBe(join(homedir(), ".openclaw"));
+  });
+
+  it("returns OPENCLAW_STATE_DIR when set", () => {
+    process.env.OPENCLAW_STATE_DIR = "/custom/state";
+    expect(defaultStateDir()).toBe("/custom/state");
+  });
+
+  it("trims whitespace from OPENCLAW_STATE_DIR", () => {
+    process.env.OPENCLAW_STATE_DIR = "  /custom/state  ";
+    expect(defaultStateDir()).toBe("/custom/state");
+  });
+
+  it("falls back when OPENCLAW_STATE_DIR is an empty string", () => {
+    process.env.OPENCLAW_STATE_DIR = "";
+    expect(defaultStateDir()).toBe(join(homedir(), ".openclaw"));
+  });
+
+  it("falls back when OPENCLAW_STATE_DIR is whitespace only", () => {
+    process.env.OPENCLAW_STATE_DIR = "   ";
+    expect(defaultStateDir()).toBe(join(homedir(), ".openclaw"));
   });
 });

--- a/tui/data.go
+++ b/tui/data.go
@@ -207,12 +207,19 @@ type lineMessage struct {
 	Timestamp any             `json:"timestamp"`
 }
 
-func resolveDataPaths() (appDataPaths, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return appDataPaths{}, fmt.Errorf("resolve home dir: %w", err)
+func resolveOpenclawStateDir() string {
+	if d := os.Getenv("OPENCLAW_STATE_DIR"); d != "" {
+		return d
 	}
-	base := filepath.Join(home, ".openclaw")
+	home, err := os.UserHomeDir()
+	if err == nil {
+		return filepath.Join(home, ".openclaw")
+	}
+	return ".openclaw"
+}
+
+func resolveDataPaths() (appDataPaths, error) {
+	base := resolveOpenclawStateDir()
 	return appDataPaths{
 		agentsDir:        filepath.Join(base, "agents"),
 		lcmDBPath:        filepath.Join(base, "lcm.db"),

--- a/tui/data.go
+++ b/tui/data.go
@@ -207,19 +207,23 @@ type lineMessage struct {
 	Timestamp any             `json:"timestamp"`
 }
 
-func resolveOpenclawStateDir() string {
-	if d := os.Getenv("OPENCLAW_STATE_DIR"); d != "" {
-		return d
+func resolveOpenclawStateDir() (string, error) {
+	d := strings.TrimSpace(os.Getenv("OPENCLAW_STATE_DIR"))
+	if d != "" {
+		return d, nil
 	}
 	home, err := os.UserHomeDir()
-	if err == nil {
-		return filepath.Join(home, ".openclaw")
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
 	}
-	return ".openclaw"
+	return filepath.Join(home, ".openclaw"), nil
 }
 
 func resolveDataPaths() (appDataPaths, error) {
-	base := resolveOpenclawStateDir()
+	base, err := resolveOpenclawStateDir()
+	if err != nil {
+		return appDataPaths{}, err
+	}
 	return appDataPaths{
 		agentsDir:        filepath.Join(base, "agents"),
 		lcmDBPath:        filepath.Join(base, "lcm.db"),

--- a/tui/data_test.go
+++ b/tui/data_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestResolveOpenclawStateDirDefaultsToDotOpenclaw(t *testing.T) {
 	t.Setenv("OPENCLAW_STATE_DIR", "")
-	dir := resolveOpenclawStateDir()
+	dir, err := resolveOpenclawStateDir()
+	if err != nil {
+		t.Fatalf("resolveOpenclawStateDir: %v", err)
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("UserHomeDir: %v", err)
@@ -21,9 +25,34 @@ func TestResolveOpenclawStateDirDefaultsToDotOpenclaw(t *testing.T) {
 
 func TestResolveOpenclawStateDirUsesEnvVar(t *testing.T) {
 	t.Setenv("OPENCLAW_STATE_DIR", "/custom/state")
-	dir := resolveOpenclawStateDir()
+	dir, err := resolveOpenclawStateDir()
+	if err != nil {
+		t.Fatalf("resolveOpenclawStateDir: %v", err)
+	}
 	if dir != "/custom/state" {
 		t.Fatalf("expected /custom/state, got %q", dir)
+	}
+}
+
+func TestResolveOpenclawStateDirTrimsWhitespace(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "  /custom/state  ")
+	dir, err := resolveOpenclawStateDir()
+	if err != nil {
+		t.Fatalf("resolveOpenclawStateDir: %v", err)
+	}
+	if dir != "/custom/state" {
+		t.Fatalf("expected /custom/state, got %q", dir)
+	}
+}
+
+func TestResolveOpenclawStateDirFallsBackOnWhitespaceOnly(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "   ")
+	dir, err := resolveOpenclawStateDir()
+	if err != nil {
+		t.Fatalf("resolveOpenclawStateDir: %v", err)
+	}
+	if strings.HasPrefix(dir, "/") {
+		t.Fatalf("expected fallback path starting with home, got absolute %q", dir)
 	}
 }
 

--- a/tui/data_test.go
+++ b/tui/data_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveOpenclawStateDirDefaultsToDotOpenclaw(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	dir := resolveOpenclawStateDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	expected := filepath.Join(home, ".openclaw")
+	if dir != expected {
+		t.Fatalf("expected %q, got %q", expected, dir)
+	}
+}
+
+func TestResolveOpenclawStateDirUsesEnvVar(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "/custom/state")
+	dir := resolveOpenclawStateDir()
+	if dir != "/custom/state" {
+		t.Fatalf("expected /custom/state, got %q", dir)
+	}
+}
+
+func TestResolveDataPathsUsesOpenclawStateDir(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "/custom/tui")
+	paths, err := resolveDataPaths()
+	if err != nil {
+		t.Fatalf("resolveDataPaths: %v", err)
+	}
+	if paths.openclawDir != "/custom/tui" {
+		t.Fatalf("expected openclawDir /custom/tui, got %q", paths.openclawDir)
+	}
+	if paths.lcmDBPath != "/custom/tui/lcm.db" {
+		t.Fatalf("expected lcmDBPath /custom/tui/lcm.db, got %q", paths.lcmDBPath)
+	}
+	if paths.agentsDir != "/custom/tui/agents" {
+		t.Fatalf("expected agentsDir /custom/tui/agents, got %q", paths.agentsDir)
+	}
+}
+
+func TestResolveDataPathsFallsBackToDotOpenclaw(t *testing.T) {
+	t.Setenv("OPENCLAW_STATE_DIR", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	paths, err := resolveDataPaths()
+	if err != nil {
+		t.Fatalf("resolveDataPaths: %v", err)
+	}
+	expected := filepath.Join(home, ".openclaw")
+	if paths.openclawDir != expected {
+		t.Fatalf("expected openclawDir %q, got %q", expected, paths.openclawDir)
+	}
+}


### PR DESCRIPTION
Fix afterTurn fallback to use context_items token count instead of full session messages.