### PR TITLE
fix(afterTurn): use context_items token count as fallback instead of full session messages

### DIFF
--- a/.changeset/honest-afterturn-pressure.md
+++ b/.changeset/honest-afterturn-pressure.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Avoid unnecessary after-turn compaction when OpenClaw does not provide a live prompt token count by evaluating the stored context without double-counting its raw prefix.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -89,7 +89,7 @@ import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./me
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
 import { listTranscriptToolResultEntryIdsByCallId } from "./replay-metadata.js";
-import { estimateSessionTokenCountForAfterTurn, extractRuntimePromptTokenCount } from "./token-accounting.js";
+import { extractRuntimePromptTokenCount } from "./token-accounting.js";
 import { asRecord, formatDurationMs, resolvePositiveInteger } from "./value-utils.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
@@ -3205,11 +3205,6 @@ export class LcmContextEngine implements ContextEngine {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
     });
-    const contextItemsTokenCount = conversation
-      ? await this.summaryStore.getContextTokenCount(conversation.conversationId)
-      : undefined;
-    const estimatedContextTokens =
-      contextItemsTokenCount ?? estimateSessionTokenCountForAfterTurn(params.messages);
     const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
     const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
       params.currentTokenCount ??
@@ -3219,11 +3214,10 @@ export class LcmContextEngine implements ContextEngine {
         }
       ).currentTokenCount,
     );
-    const observedCurrentTokenCount =
-      runtimePromptTokens ?? suppliedCurrentTokenCount ?? estimatedContextTokens;
+    const observedCurrentTokenCount = runtimePromptTokens ?? suppliedCurrentTokenCount;
     if (runtimePromptTokens !== undefined) {
       this.deps.log.debug(
-        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} contextItemsTokenCount=${contextItemsTokenCount} estimatedTokenCount=${estimatedContextTokens}`,
+        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens}`,
       );
     }
     if (!conversation) {
@@ -3276,7 +3270,7 @@ export class LcmContextEngine implements ContextEngine {
       | {
           reason: string;
           tokenBudget: number;
-          currentTokenCount: number;
+          currentTokenCount?: number;
         }
       | null = null;
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3201,7 +3201,15 @@ export class LcmContextEngine implements ContextEngine {
       );
     }
 
-    const estimatedContextTokens = estimateSessionTokenCountForAfterTurn(params.messages);
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    const contextItemsTokenCount = conversation
+      ? await this.summaryStore.getContextTokenCount(conversation.conversationId)
+      : undefined;
+    const estimatedContextTokens =
+      contextItemsTokenCount ?? estimateSessionTokenCountForAfterTurn(params.messages);
     const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
     const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
       params.currentTokenCount ??
@@ -3215,13 +3223,9 @@ export class LcmContextEngine implements ContextEngine {
       runtimePromptTokens ?? suppliedCurrentTokenCount ?? estimatedContextTokens;
     if (runtimePromptTokens !== undefined) {
       this.deps.log.debug(
-        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} estimatedTokenCount=${estimatedContextTokens}`,
+        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens} contextItemsTokenCount=${contextItemsTokenCount} estimatedTokenCount=${estimatedContextTokens}`,
       );
     }
-    const conversation = await this.conversationStore.getConversationForSession({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-    });
     if (!conversation) {
       this.deps.log.debug(
         `[lcm] afterTurn: conversation lookup missed ${sessionLabel} ingestBatch=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,

--- a/src/token-accounting.ts
+++ b/src/token-accounting.ts
@@ -61,18 +61,6 @@ export function estimateContentTokensForRole(params: {
   return estimateTokens(fallbackContent);
 }
 
-/**
- * Estimate live transcript tokens at the model boundary.
- *
- * Uses full-message serialization so structured tool-call payloads count.
- * A text-block-only estimate undercounts tool-heavy transcripts by 2-3x,
- * which previously let over-budget prompts pass every live pressure check
- * while the host's LLM-boundary estimate rejected them.
- */
-export function estimateSessionTokenCountForAfterTurn(messages: AgentMessage[]): number {
-  return estimateSerializedMessagesTokens(messages);
-}
-
 export function normalizeNonNegativeInteger(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     return undefined;

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4603,6 +4603,63 @@ describe("LcmContextEngine afterTurn", () => {
     );
   });
 
+  it("afterTurn falls back to context_items token count when runtimeContext has no currentTokenCount", async () => {
+    const engine = createEngine();
+    const conversationStore = engine.getConversationStore();
+    const summaryStore = engine.getSummaryStore();
+    const sessionId = "after-turn-context-items-fallback";
+
+    // Create a conversation and seed context_items directly.
+    const conversation = await conversationStore.createConversation({
+      sessionId,
+      sessionKey: undefined,
+    });
+    const messages = await conversationStore.createMessagesBulk([
+      { conversationId: conversation.conversationId, seq: 0, role: "user", content: "previous turn", tokenCount: 200, skipReplayTimestampFloodGuard: true },
+      { conversationId: conversation.conversationId, seq: 1, role: "assistant", content: "previous reply", tokenCount: 150, skipReplayTimestampFloodGuard: true },
+      { conversationId: conversation.conversationId, seq: 2, role: "user", content: "more context", tokenCount: 150, skipReplayTimestampFloodGuard: true },
+    ]);
+    await summaryStore.appendContextMessages(conversation.conversationId, messages.map((m) => m.messageId));
+    const ctxTokenCount = await summaryStore.getContextTokenCount(conversation.conversationId);
+    expect(ctxTokenCount).toBe(500);
+
+    // Messages passed to afterTurn are much larger than seeded context_items.
+    const oversizedMessages = Array.from({ length: 20 }, (_, i) =>
+      makeMessage({ role: i % 2 === 0 ? "user" : "assistant", content: "x".repeat(1000) }),
+    );
+
+    const evaluateSpy = vi.spyOn(
+      (engine as unknown as { compaction: { evaluate: (...args: unknown[]) => unknown } }).compaction,
+      "evaluate",
+    ).mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 500,
+      threshold: 3000,
+    });
+
+    const sessionFile = createSessionFilePath("after-turn-context-items-fallback");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "seed" },
+    ]);
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: oversizedMessages,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+      // No runtimeContext with currentTokenCount — fallback to context_items
+    });
+
+    const evaluateCall = evaluateSpy.mock.calls[0];
+    expect(evaluateCall).toBeDefined();
+    const budget = evaluateCall[1] as number;
+    const observedTokenCount = evaluateCall[2] as number;
+    expect(budget).toBe(4096);
+    expect(observedTokenCount).toBe(500); // context_items, not ~5000 from all messages
+  });
+
   it("afterTurn skips compaction when ingest fails", async () => {
     const errorLog = vi.fn();
     const engine = createEngineWithDepsOverrides({

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -848,7 +848,7 @@ describe("LcmContextEngine afterTurn", () => {
     });
   });
 
-  it("afterTurn falls back to context_items token count when runtimeContext.currentTokenCount is absent", async () => {
+  it("afterTurn leaves live token pressure unset when runtimeContext.currentTokenCount is absent", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-local-current-token-count-fallback";
     const privateEngine = engine as unknown as {
@@ -886,15 +886,10 @@ describe("LcmContextEngine afterTurn", () => {
       },
     });
 
-    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
-    expect(conversation).not.toBeNull();
-    const ctxTokenCount = await engine.getSummaryStore().getContextTokenCount(conversation!.conversationId);
-
-    // Uses context_items token count (from DB), not serialized estimate from all messages.
     expect(evaluateSpy).toHaveBeenCalledWith(
       expect.any(Number),
       4_096,
-      ctxTokenCount,
+      undefined,
       { contextThreshold: 0.75 },
     );
   });
@@ -4612,61 +4607,36 @@ describe("LcmContextEngine afterTurn", () => {
     );
   });
 
-  it("afterTurn falls back to context_items token count when runtimeContext has no currentTokenCount", async () => {
-    const engine = createEngine();
-    const conversationStore = engine.getConversationStore();
-    const summaryStore = engine.getSummaryStore();
-    const sessionId = "after-turn-context-items-fallback";
-
-    // Create a conversation and seed context_items directly.
-    const conversation = await conversationStore.createConversation({
-      sessionId,
-      sessionKey: undefined,
-    });
-    const messages = await conversationStore.createMessagesBulk([
-      { conversationId: conversation.conversationId, seq: 0, role: "user", content: "previous turn", tokenCount: 200, skipReplayTimestampFloodGuard: true },
-      { conversationId: conversation.conversationId, seq: 1, role: "assistant", content: "previous reply", tokenCount: 150, skipReplayTimestampFloodGuard: true },
-      { conversationId: conversation.conversationId, seq: 2, role: "user", content: "more context", tokenCount: 150, skipReplayTimestampFloodGuard: true },
-    ]);
-    await summaryStore.appendContextMessages(conversation.conversationId, messages.map((m) => m.messageId));
-    const ctxTokenCount = await summaryStore.getContextTokenCount(conversation.conversationId);
-    expect(ctxTokenCount).toBe(500);
-
-    // Messages passed to afterTurn are much larger than seeded context_items.
-    const oversizedMessages = Array.from({ length: 20 }, (_, i) =>
-      makeMessage({ role: i % 2 === 0 ? "user" : "assistant", content: "x".repeat(1000) }),
-    );
-
-    const evaluateSpy = vi.spyOn(
-      (engine as unknown as { compaction: { evaluate: (...args: unknown[]) => unknown } }).compaction,
-      "evaluate",
-    ).mockResolvedValue({
-      shouldCompact: false,
-      reason: "none",
-      currentTokens: 500,
-      threshold: 3000,
-    });
-
-    const sessionFile = createSessionFilePath("after-turn-context-items-fallback");
-    writeLeafTranscript(sessionFile, [
-      { role: "user", content: "seed" },
-    ]);
+  it("afterTurn does not project stored context as additional live pressure", async () => {
+    const engine = createEngineWithConfig({ freshTailCount: 1 });
+    const sessionId = "after-turn-stored-context-is-not-live-pressure";
+    await seedBacklogContext(engine, sessionId, [100, 100, 100]);
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const privateEngine = engine as unknown as {
+      scheduleDeferredCompactionDebtDrain: (params: unknown) => void;
+    };
+    const scheduleSpy = vi
+      .spyOn(privateEngine, "scheduleDeferredCompactionDebtDrain")
+      .mockImplementation(() => undefined);
 
     await engine.afterTurn({
       sessionId,
-      sessionFile,
-      messages: oversizedMessages,
+      sessionFile: createSessionFilePath(sessionId),
+      messages: [],
       prePromptMessageCount: 0,
-      tokenBudget: 4096,
-      // No runtimeContext with currentTokenCount — fallback to context_items
+      tokenBudget: 600,
     });
 
-    const evaluateCall = evaluateSpy.mock.calls[0];
-    expect(evaluateCall).toBeDefined();
-    const budget = evaluateCall[1] as number;
-    const observedTokenCount = evaluateCall[2] as number;
-    expect(budget).toBe(4096);
-    expect(observedTokenCount).toBe(500); // context_items, not ~5000 from all messages
+    await expect(
+      engine.getSummaryStore().getContextTokenCount(conversation!.conversationId),
+    ).resolves.toBe(300);
+    await expect(
+      engine
+        .getCompactionMaintenanceStore()
+        .getConversationCompactionMaintenance(conversation!.conversationId),
+    ).resolves.toBeNull();
+    expect(scheduleSpy).not.toHaveBeenCalled();
   });
 
   it("afterTurn skips compaction when ingest fails", async () => {

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -848,7 +848,7 @@ describe("LcmContextEngine afterTurn", () => {
     });
   });
 
-  it("afterTurn falls back to local message token estimates when runtimeContext.currentTokenCount is absent", async () => {
+  it("afterTurn falls back to context_items token count when runtimeContext.currentTokenCount is absent", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-local-current-token-count-fallback";
     const privateEngine = engine as unknown as {
@@ -869,9 +869,14 @@ describe("LcmContextEngine afterTurn", () => {
     });
 
     const turnMessage = makeMessage({ role: "assistant", content: "tiny" });
+    const sessionFile = createSessionFilePath("after-turn-local-current-token-count-fallback");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "seed" },
+    ]);
+
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("after-turn-local-current-token-count-fallback"),
+      sessionFile,
       messages: [turnMessage],
       prePromptMessageCount: 0,
       tokenBudget: 4_096,
@@ -881,11 +886,15 @@ describe("LcmContextEngine afterTurn", () => {
       },
     });
 
-    // Local estimates use full-message serialization so structured payloads count.
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const ctxTokenCount = await engine.getSummaryStore().getContextTokenCount(conversation!.conversationId);
+
+    // Uses context_items token count (from DB), not serialized estimate from all messages.
     expect(evaluateSpy).toHaveBeenCalledWith(
       expect.any(Number),
       4_096,
-      estimateSerializedMessageTokens(turnMessage),
+      ctxTokenCount,
       { contextThreshold: 0.75 },
     );
   });


### PR DESCRIPTION
## Problem

When the runtime does not provide a live prompt token count in `afterTurn`, estimating all session messages overstates the current compacted context and can schedule unnecessary compaction.

## Fix

- Leave the live observation unset when OpenClaw supplies no prompt token count
- Let `CompactionEngine.evaluate()` use its canonical stored `context_items` count
- Preserve runtime or supplied token counts as the preferred live signal
- Add a regression covering raw messages outside the protected fresh tail

## Testing

- `npx vitest run test/engine-after-turn.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm pack --dry-run`