### PR TITLE
fix: preserve preassembly overflow precheck

### DIFF
--- a/.changeset/degraded-prompt-authority.md
+++ b/.changeset/degraded-prompt-authority.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep OpenClaw's preemptive overflow check enabled when deferred compaction debt forces Lossless Claw to return degraded live context.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -180,6 +180,7 @@ export function buildDegradedLiveAssembleResult(params: {
   return {
     messages,
     estimatedTokens: estimateAgentMessageTokens(messages),
+    promptAuthority: "preassembly_may_overflow",
   };
 }
 

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -36,6 +36,8 @@ export type ContextEngineProjection = {
 export type AssembleResult = {
   messages: AgentMessage[];
   estimatedTokens: number;
+  /** Ask OpenClaw to include pre-assembly history in its overflow precheck. */
+  promptAuthority?: "assembled" | "preassembly_may_overflow";
   systemPromptAddition?: string;
   contextProjection?: ContextEngineProjection;
 };

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -93,6 +93,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       mode: "thread_bootstrap",
       epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
     });
+    expect(result).not.toHaveProperty("promptAuthority");
   });
 
   async function seedPromptRecallFixture(params: {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1026,6 +1026,10 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       "current delivery turn",
     ]);
     expect(assembleResult.estimatedTokens).toBeLessThanOrEqual(100);
+    expect(assembleResult).toHaveProperty(
+      "promptAuthority",
+      "preassembly_may_overflow",
+    );
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("[lcm] assemble: degraded live fallback"),
     );
@@ -1168,6 +1172,10 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       "critical runtime policy",
       "current delivery turn",
     ]);
+    expect(assembleResult).toHaveProperty(
+      "promptAuthority",
+      "preassembly_may_overflow",
+    );
     const maintenance = await engine
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation.conversationId);
@@ -1292,6 +1300,10 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(assembleResult.messages.map((message) => message.content)).toEqual([
       "current emergency turn",
     ]);
+    expect(assembleResult).toHaveProperty(
+      "promptAuthority",
+      "preassembly_may_overflow",
+    );
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "[lcm] assemble: emergency deferred compaction debt draining pre-assembly",


### PR DESCRIPTION
## What

Declare `promptAuthority: "preassembly_may_overflow"` when Lossless Claw returns degraded live context because deferred compaction debt remains near or over the assembly budget.

## Why

OpenClaw treats an omitted authority as `"assembled"`. For a context engine that owns compaction, that default can suppress the host's preemptive overflow check even though the degraded assembly hides pressure in the pre-assembly transcript. The explicit authority keeps OpenClaw's safety check active for these degraded results.

## Changes

- Add the OpenClaw prompt-authority result type
- Mark deferred-debt degraded assembly results
- Cover near-budget and emergency-debt outcomes
- Prove canonical assemblies remain unmarked
- Add a patch changeset

## Compatibility

No minimum OpenClaw version change is required.

- Official source commit [`42584964`](https://github.com/openclaw/openclaw/commit/42584964ac08d824c5ce12cb196e70920a3e2f49) introduced `AssembleResult.promptAuthority` and the `"preassembly_may_overflow"` value.
- `v2026.5.2-beta.1` is the first prerelease tag/package containing the commit.
- [OpenClaw v2026.5.2](https://github.com/openclaw/openclaw/releases/tag/v2026.5.2) is the first stable release containing it; GitHub marks that release as non-prerelease, and the [published npm package](https://www.npmjs.com/package/openclaw/v/2026.5.2) includes the field and value in its type declarations.
- Lossless Claw already requires OpenClaw `>=2026.5.28`. The [published 2026.5.28 package](https://www.npmjs.com/package/openclaw/v/2026.5.28) still publishes and honors the contract, so the existing compatibility declarations remain accurate.

## Testing

- `npx vitest run test/engine-maintenance.test.ts test/engine-assemble.test.ts` (84 passed)
- `npm run typecheck`
- `npm run build`
- `npm test` (1,888 passed)
- `npm pack --dry-run`
- Thermonuclear maintainability review: no findings
- Autoreview: no accepted or actionable findings

Fixes #1015
