### PR TITLE
fix: match doctor cleaners to configured agents

### DIFF
--- a/.changeset/configured-agent-doctor-cleaners.md
+++ b/.changeset/configured-agent-doctor-cleaners.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Match `/lossless doctor clean` cron and archived-subagent candidates under every configured OpenClaw agent id. The cleaner now compares exact agent and lane segments so unrelated or malformed session keys remain excluded from scan and apply.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The native OpenClaw command surface provides in-session operations:
 - `/lossless doctor` scans for broken or truncated summaries
 - `/lossless doctor apply` repairs broken summaries in the current conversation after the normal safety preflight
 - `/lossless doctor apply <conversation-id> confirm-offline` repairs a specific conversation after its active channel path has been paused or moved away; targeted repair is restricted to authorized OpenClaw command senders and always requires the explicit offline confirmation
-- `/lossless doctor clean` shows read-only high-confidence junk diagnostics for archived subagents, cron sessions, and NULL-key orphaned subagent runs
+- `/lossless doctor clean` shows read-only high-confidence junk diagnostics for archived subagents and cron sessions under every configured OpenClaw agent id, plus NULL-key orphaned subagent runs
 - `/lossless status` shows plugin, conversation, and maintenance state including deferred compaction debt
 - `/lcm` is the shorter alias for `/lossless`
 

--- a/skills/lossless-claw/references/architecture.md
+++ b/skills/lossless-claw/references/architecture.md
@@ -59,8 +59,8 @@ The cleaners flow is also diagnostic first.
 
 It reports high-confidence junk patterns that are structurally safe to review as standalone cleanup candidates, including:
 
-- archived subagent sessions
-- cron sessions
+- archived subagent sessions under configured OpenClaw agent ids
+- cron sessions under configured OpenClaw agent ids
 - NULL-key orphaned subagent context conversations
 
-This keeps cleanup discovery separate from summary-health diagnostics while still using the same native command surface.
+The keyed-session predicates compare exact colon-delimited agent and lane prefixes, so an agent id cannot consume another session-key segment. This keeps cleanup discovery separate from summary-health diagnostics while still using the same native command surface.

--- a/skills/lossless-claw/references/diagnostics.md
+++ b/skills/lossless-claw/references/diagnostics.md
@@ -85,12 +85,13 @@ Use this when the user wants read-only diagnostics for high-confidence junk patt
 
 It should help confirm:
 
-- whether archived subagent sessions are present
-- whether cron sessions are accumulating unexpectedly
+- whether archived subagent sessions are present under any configured OpenClaw agent id
+- whether cron sessions are accumulating unexpectedly under any configured OpenClaw agent id
 - whether NULL-key orphaned subagent conversations are present
 - which high-confidence filters match the most conversations and messages
 
 This command is read-only. Use it to identify likely cleanup candidates before taking any separate cleanup action.
+Its keyed-session filters require an exact configured agent-id segment, an exact `cron` or `subagent` lane segment, and a non-empty lane suffix.
 
 ## Interpreting common states
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -33,6 +33,7 @@ import type {
   RuntimeCompactionDelegateFn,
   StartupSessionFileCandidate,
 } from "../types.js";
+import { listConfiguredAgentIds, normalizeAgentId } from "./openclaw-agent-ids.js";
 
 const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.28";
 
@@ -93,12 +94,6 @@ function createRuntimeCompactionDelegate(log: LcmDependencies["log"]): RuntimeCo
     }
     return await delegate(params);
   };
-}
-
-/** Return a stable normalized agent id. */
-function normalizeAgentId(agentId: string | undefined): string {
-  const normalized = (agentId ?? "").trim();
-  return normalized.length > 0 ? normalized : "main";
 }
 
 type RuntimeSessionStoreEntry = {
@@ -299,28 +294,6 @@ function getRuntimeAgentSessionApi(api: OpenClawPluginApi): RuntimeAgentSessionA
     return undefined;
   }
   return sessionApi as RuntimeAgentSessionApi;
-}
-
-/** List configured OpenClaw agent ids whose session stores can be active at startup. */
-function listConfiguredAgentIds(config: unknown): string[] {
-  const agents = isRecord(config) ? config.agents : undefined;
-  const list = isRecord(agents) && Array.isArray(agents.list) ? agents.list : [];
-  const seen = new Set<string>();
-  const ids: string[] = [];
-
-  for (const entry of list) {
-    if (!isRecord(entry) || entry.enabled === false || typeof entry.id !== "string") {
-      continue;
-    }
-    const agentId = normalizeAgentId(entry.id);
-    if (seen.has(agentId)) {
-      continue;
-    }
-    seen.add(agentId);
-    ids.push(agentId);
-  }
-
-  return ids.length > 0 ? ids : ["main"];
 }
 
 /** Read a string value from an unknown object field. */

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -19,6 +19,7 @@ import type {
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import { describeLogError } from "../lcm-log.js";
+import { listConfiguredAgentIds } from "./openclaw-agent-ids.js";
 import {
   applyDoctorCleaners,
   getDoctorCleanerApplyUnavailableReason,
@@ -1665,8 +1666,9 @@ function buildRolloverSplitScanSection(scan: ReturnType<typeof scanRolloverSplit
 
 async function buildDoctorCleanersText(params: {
   db: DatabaseSync;
+  agentIds: string[];
 }): Promise<string> {
-  const scan = scanDoctorCleaners(params.db);
+  const scan = scanDoctorCleaners(params.db, undefined, params.agentIds);
   const lines = [
     ...buildHeaderLines(),
     "",
@@ -2887,6 +2889,7 @@ async function buildUnfocusText(params: {
 async function buildDoctorCleanersApplyText(params: {
   db: DatabaseSync;
   config: LcmConfig;
+  agentIds: string[];
   filterId?: DoctorCleanerId;
   vacuum: boolean;
 }): Promise<string> {
@@ -2918,7 +2921,7 @@ async function buildDoctorCleanersApplyText(params: {
     return lines.join("\n");
   }
 
-  const before = scanDoctorCleaners(params.db, filterIds);
+  const before = scanDoctorCleaners(params.db, filterIds, params.agentIds);
   lines.splice(
     lines.length - 1,
     0,
@@ -2949,6 +2952,7 @@ async function buildDoctorCleanersApplyText(params: {
     result = applyDoctorCleaners(params.db, {
       databasePath: params.config.databasePath,
       filterIds,
+      agentIds: params.agentIds,
       vacuum: params.vacuum,
     });
   } catch (error) {
@@ -3307,6 +3311,10 @@ export function createLcmCommand(params: {
     acceptsArgs: true,
     handler: async (ctx) => {
       const parsed = parseLcmCommand(ctx.args);
+      const doctorCleanerAgentIds = listConfiguredAgentIds(
+        asRecord(ctx)?.config,
+        params.openClawConfig,
+      );
       switch (parsed.kind) {
         case "status":
           return {
@@ -3411,11 +3419,17 @@ export function createLcmCommand(params: {
                 text: await buildDoctorCleanersApplyText({
                   db: await getDb(),
                   config: params.config,
+                  agentIds: doctorCleanerAgentIds,
                   filterId: parsed.filterId,
                   vacuum: parsed.vacuum,
                 }),
               }
-            : { text: await buildDoctorCleanersText({ db: await getDb() }) };
+            : {
+                text: await buildDoctorCleanersText({
+                  db: await getDb(),
+                  agentIds: doctorCleanerAgentIds,
+                }),
+              };
         case "help":
           return { text: buildHelpText(parsed.error) };
       }

--- a/src/plugin/lcm-doctor-cleaners.ts
+++ b/src/plugin/lcm-doctor-cleaners.ts
@@ -49,6 +49,7 @@ type CleanerDefinition = {
   description: string;
   candidatePredicateSql: string;
   predicateSql: string;
+  sessionKeyLane?: "cron" | "subagent";
   needsFirstMessage?: boolean;
 };
 
@@ -72,16 +73,18 @@ const CLEANER_DEFINITIONS: CleanerDefinition[] = [
   {
     id: "archived_subagents",
     label: "Archived subagents",
-    description: "Archived subagent conversations keyed as agent:main:subagent:*.",
-    candidatePredicateSql: "(c.active = 0 AND c.session_key LIKE 'agent:main:subagent:%')",
-    predicateSql: "(c.active = 0 AND c.session_key LIKE 'agent:main:subagent:%')",
+    description: "Archived subagent conversations for configured OpenClaw agent IDs.",
+    candidatePredicateSql: "(c.active = 0)",
+    predicateSql: "(c.active = 0)",
+    sessionKeyLane: "subagent",
   },
   {
     id: "cron_sessions",
     label: "Cron sessions",
-    description: "Background cron conversations keyed as agent:main:cron:*.",
-    candidatePredicateSql: "(c.session_key LIKE 'agent:main:cron:%')",
-    predicateSql: "(c.session_key LIKE 'agent:main:cron:%')",
+    description: "Background cron conversations for configured OpenClaw agent IDs.",
+    candidatePredicateSql: "1",
+    predicateSql: "1",
+    sessionKeyLane: "cron",
   },
   {
     id: "null_subagent_context",
@@ -105,6 +108,48 @@ function getCleanerDefinitions(filterIds?: DoctorCleanerId[]): CleanerDefinition
   }
   const requested = new Set(filterIds);
   return CLEANER_DEFINITIONS.filter((definition) => requested.has(definition.id));
+}
+
+function normalizeCleanerAgentIds(agentIds?: string[]): string[] {
+  const normalized = [...new Set(agentIds?.map((agentId) => agentId.trim()).filter(Boolean))];
+  return normalized.length > 0 ? normalized : ["main"];
+}
+
+function buildConfiguredSessionKeyPredicateSql(lane: "cron" | "subagent"): string {
+  const prefixSql = `('agent:' || configured_agent.agent_id || ':${lane}:')`;
+  return `EXISTS (
+                SELECT 1
+                FROM temp.doctor_cleaner_agent_ids configured_agent
+                WHERE length(c.session_key) > length(${prefixSql})
+                  AND substr(c.session_key, 1, length(${prefixSql})) = ${prefixSql} COLLATE BINARY
+              )`;
+}
+
+function buildCleanerPredicateSql(
+  definition: CleanerDefinition,
+  kind: "candidate" | "matched",
+): string {
+  const basePredicate = kind === "candidate"
+    ? definition.candidatePredicateSql
+    : definition.predicateSql;
+  if (!definition.sessionKeyLane) {
+    return basePredicate;
+  }
+  return `(${basePredicate} AND ${buildConfiguredSessionKeyPredicateSql(definition.sessionKeyLane)})`;
+}
+
+function stageCleanerAgentIds(db: DatabaseSync, agentIds?: string[]): void {
+  db.exec(`
+    CREATE TEMP TABLE doctor_cleaner_agent_ids (
+      agent_id TEXT PRIMARY KEY
+    ) WITHOUT ROWID
+  `);
+  const insert = db.prepare(
+    `INSERT INTO temp.doctor_cleaner_agent_ids (agent_id) VALUES (?)`,
+  );
+  for (const agentId of normalizeCleanerAgentIds(agentIds)) {
+    insert.run(agentId);
+  }
 }
 
 function truncatePreview(value: string | null): string | null {
@@ -141,7 +186,7 @@ function buildMatchedConversationsSql(params: {
       return `${selectSql}
               FROM conversations c
               ${joinSql}
-              WHERE ${definition.predicateSql}`;
+              WHERE ${buildCleanerPredicateSql(definition, "matched")}`;
     })
     .join(`\nUNION ALL\n`);
 }
@@ -154,7 +199,7 @@ function buildCandidateConversationsSql(definitions: CleanerDefinition[]): strin
     .map(
       (definition) => `SELECT c.conversation_id
               FROM conversations c
-              WHERE ${definition.candidatePredicateSql}`,
+              WHERE ${buildCleanerPredicateSql(definition, "candidate")}`,
     )
     .join(`\nUNION\n`);
 }
@@ -163,13 +208,19 @@ function dropTempCleanerScanTables(db: DatabaseSync): void {
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_scan_matches`);
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_scan_message_stats`);
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_candidate_conversations`);
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_agent_ids`);
 }
 
-function stageCleanerScanTables(db: DatabaseSync, definitions: CleanerDefinition[]): void {
+function stageCleanerScanTables(
+  db: DatabaseSync,
+  definitions: CleanerDefinition[],
+  agentIds?: string[],
+): void {
   dropTempCleanerScanTables(db);
   if (definitions.length === 0) {
     return;
   }
+  stageCleanerAgentIds(db, agentIds);
   db.exec(`
     CREATE TEMP TABLE doctor_cleaner_candidate_conversations (
       conversation_id INTEGER PRIMARY KEY
@@ -263,6 +314,7 @@ export function getDoctorCleanerFilterIds(): DoctorCleanerId[] {
 export function scanDoctorCleaners(
   db: DatabaseSync,
   filterIds?: DoctorCleanerId[],
+  agentIds?: string[],
 ): DoctorCleanerScan {
   const definitions = getCleanerDefinitions(filterIds);
   if (definitions.length === 0) {
@@ -273,7 +325,7 @@ export function scanDoctorCleaners(
     };
   }
   try {
-    stageCleanerScanTables(db, definitions);
+    stageCleanerScanTables(db, definitions, agentIds);
     const counts = db
       .prepare(
         `WITH filter_counts AS (
@@ -391,6 +443,7 @@ function dropTempCleanerTables(db: DatabaseSync): void {
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_message_ids`);
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_summary_ids`);
   db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_conversation_ids`);
+  db.exec(`DROP TABLE IF EXISTS temp.doctor_cleaner_agent_ids`);
 }
 
 function stageTempCleanerFirstMessages(db: DatabaseSync): void {
@@ -426,6 +479,7 @@ function stageTempCleanerFirstMessages(db: DatabaseSync): void {
 function stageCleanerConversationIds(
   db: DatabaseSync,
   definitions: CleanerDefinition[],
+  agentIds?: string[],
 ): void {
   dropTempCleanerTables(db);
   db.exec(`CREATE TEMP TABLE doctor_cleaner_conversation_ids (conversation_id INTEGER PRIMARY KEY)`);
@@ -435,6 +489,7 @@ function stageCleanerConversationIds(
   if (definitions.length === 0) {
     return;
   }
+  stageCleanerAgentIds(db, agentIds);
 
   const needsFirstMessage = definitions.some((definition) => definition.needsFirstMessage);
   if (needsFirstMessage) {
@@ -569,6 +624,7 @@ export function applyDoctorCleaners(
   options: {
     databasePath: string;
     filterIds?: DoctorCleanerId[];
+    agentIds?: string[];
     vacuum?: boolean;
   },
 ): DoctorCleanerApplyResult {
@@ -607,7 +663,7 @@ export function applyDoctorCleaners(
   try {
     db.exec("BEGIN IMMEDIATE");
     transactionActive = true;
-    stageCleanerConversationIds(db, definitions);
+    stageCleanerConversationIds(db, definitions, options.agentIds);
     const counts = readTempCleanerDeleteCounts(db);
     deletedMessages = counts.messageCount;
     if (counts.conversationCount > 0) {

--- a/src/plugin/openclaw-agent-ids.ts
+++ b/src/plugin/openclaw-agent-ids.ts
@@ -1,0 +1,36 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Return a stable agent id for validated OpenClaw configuration values. */
+export function normalizeAgentId(agentId: string | undefined): string {
+  const normalized = (agentId ?? "").trim();
+  return normalized.length > 0 ? normalized : "main";
+}
+
+/** List enabled OpenClaw agent ids, using a fallback config before the default agent. */
+export function listConfiguredAgentIds(config: unknown, fallbackConfig?: unknown): string[] {
+  const agents = isRecord(config) ? config.agents : undefined;
+  const list = isRecord(agents) && Array.isArray(agents.list) ? agents.list : undefined;
+  if (!list) {
+    return fallbackConfig === undefined
+      ? ["main"]
+      : listConfiguredAgentIds(fallbackConfig);
+  }
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const entry of list) {
+    if (!isRecord(entry) || entry.enabled === false || typeof entry.id !== "string") {
+      continue;
+    }
+    const agentId = normalizeAgentId(entry.id);
+    if (seen.has(agentId)) {
+      continue;
+    }
+    seen.add(agentId);
+    ids.push(agentId);
+  }
+
+  return ids.length > 0 ? ids : ["main"];
+}

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -26,6 +26,7 @@ function createCommandFixture(options?: {
   summarize?: LcmSummarizeFn;
   deps?: LcmDependencies;
   getLcm?: () => Promise<any>;
+  openClawConfig?: unknown;
 }) {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-command-"));
   const dbPath = join(tempDir, "lcm.db");
@@ -38,6 +39,7 @@ function createCommandFixture(options?: {
   const command = createLcmCommand({
     db,
     config,
+    openClawConfig: options?.openClawConfig,
     summarize: options?.summarize,
     deps: options?.deps,
     getLcm: options?.getLcm,
@@ -2309,6 +2311,104 @@ describe("lcm command", () => {
     expect(result.text).not.toContain("ordinary conversation");
   });
 
+  it("matches cron and archived-subagent keys for configured agent ids only", async () => {
+    const fixture = createCommandFixture({
+      openClawConfig: {
+        agents: {
+          list: [{ id: "ops" }, { id: "qa" }],
+        },
+      },
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const matchingKeys = [
+      "agent:ops:cron:nightly",
+      "agent:qa:cron:weekly:run:run-1",
+      "agent:ops:subagent:archived-worker",
+    ];
+    for (const [index, sessionKey] of matchingKeys.entries()) {
+      const conversation = await fixture.conversationStore.createConversation({
+        sessionId: `doctor-configured-match-${index}`,
+        sessionKey,
+      });
+      await fixture.conversationStore.createMessagesBulk([
+        {
+          conversationId: conversation.conversationId,
+          seq: 0,
+          role: "assistant",
+          content: `configured match ${index}`,
+          tokenCount: 3,
+        },
+      ]);
+      if (sessionKey.includes(":subagent:")) {
+        await fixture.conversationStore.archiveConversation(
+          conversation.conversationId,
+          "rollover-fallback",
+        );
+      }
+    }
+
+    const activeSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-configured-active-subagent",
+      sessionKey: "agent:qa:subagent:active-worker",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: activeSubagent.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "active configured subagent",
+        tokenCount: 3,
+      },
+    ]);
+
+    const excludedKeys = [
+      "agent:main:cron:unconfigured",
+      "agent:OPS:cron:different-case",
+      "agent:ops-admin:cron:other-agent",
+      "agent:ops:channel:cron:nested-lane",
+      "agent:qa:channel:subagent:nested-lane",
+      "agent:ops:cron:",
+      "agent:qa:subagent:",
+      "agent::cron:missing-agent",
+      "ops:cron:missing-agent-prefix",
+    ];
+    for (const [index, sessionKey] of excludedKeys.entries()) {
+      const conversation = await fixture.conversationStore.createConversation({
+        sessionId: `doctor-configured-excluded-${index}`,
+        sessionKey,
+      });
+      await fixture.conversationStore.createMessagesBulk([
+        {
+          conversationId: conversation.conversationId,
+          seq: 0,
+          role: "assistant",
+          content: `excluded shape ${index}`,
+          tokenCount: 3,
+        },
+      ]);
+      if (sessionKey.includes(":subagent:")) {
+        await fixture.conversationStore.archiveConversation(
+          conversation.conversationId,
+          "rollover-fallback",
+        );
+      }
+    }
+
+    const result = await fixture.command.handler(createCommandContext("doctor clean"));
+
+    expect(result.text).toContain("matched conversations: 3");
+    expect(result.text).toContain("matched messages: 3");
+    for (const sessionKey of matchingKeys) {
+      expect(result.text).toContain(sessionKey);
+    }
+    expect(result.text).not.toContain("agent:qa:subagent:active-worker");
+    for (const sessionKey of excludedKeys) {
+      expect(result.text).not.toContain(`session key \`${sessionKey}\``);
+    }
+  });
+
   it("reports a clean doctor clean scan when no high-confidence candidates exist", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
@@ -2426,6 +2526,7 @@ describe("lcm command", () => {
       },
     ]);
 
+    const execSpy = vi.spyOn(fixture.db, "exec");
     const result = await fixture.command.handler(createCommandContext("doctor clean apply"));
 
     const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
@@ -2450,6 +2551,120 @@ describe("lcm command", () => {
     expect(removedArchived).toBeNull();
     expect(removedCron).toBeNull();
     expect(removedNull).toBeNull();
+    const executedSql = execSpy.mock.calls.map(([sql]) => String(sql));
+    expect(executedSql.findIndex((sql) => sql.startsWith("VACUUM INTO "))).toBeLessThan(
+      executedSql.indexOf("BEGIN IMMEDIATE"),
+    );
+  });
+
+  it("applies exactly the configured-agent candidates reported by doctor clean", async () => {
+    const fixture = createCommandFixture({
+      openClawConfig: {
+        agents: {
+          list: [{ id: "main" }],
+        },
+      },
+    });
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const cron = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-configured-apply-cron",
+      sessionKey: "agent:ops:cron:apply-nightly",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: cron.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "configured cron candidate",
+        tokenCount: 4,
+      },
+    ]);
+
+    const archivedSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-configured-apply-subagent",
+      sessionKey: "agent:qa:subagent:apply-worker",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: archivedSubagent.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "configured archived subagent candidate",
+        tokenCount: 5,
+      },
+    ]);
+    await fixture.conversationStore.archiveConversation(
+      archivedSubagent.conversationId,
+      "rollover-fallback",
+    );
+
+    const activeSubagent = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-configured-apply-active",
+      sessionKey: "agent:qa:subagent:active-worker",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: activeSubagent.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "active configured subagent",
+        tokenCount: 4,
+      },
+    ]);
+
+    const unrelated = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-configured-apply-unrelated",
+      sessionKey: "agent:ops:channel:cron:not-a-cron-lane",
+    });
+    await fixture.conversationStore.createMessagesBulk([
+      {
+        conversationId: unrelated.conversationId,
+        seq: 0,
+        role: "assistant",
+        content: "unrelated nested cron segment",
+        tokenCount: 4,
+      },
+    ]);
+
+    const commandConfig = {
+      agents: {
+        list: [{ id: "ops" }, { id: "qa" }],
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+          },
+        },
+        slots: {
+          contextEngine: "lossless-claw",
+        },
+      },
+    };
+    const scan = await fixture.command.handler(
+      createCommandContext("doctor clean", { config: commandConfig }),
+    );
+    const apply = await fixture.command.handler(
+      createCommandContext("doctor clean apply", { config: commandConfig }),
+    );
+
+    expect(scan.text).toContain("matched conversations: 2");
+    expect(scan.text).toContain("matched messages: 2");
+    expect(apply.text).toContain("matched conversations before apply: 2");
+    expect(apply.text).toContain("deleted conversations: 2");
+    expect(apply.text).toContain("deleted messages: 2");
+    await expect(fixture.conversationStore.getConversation(cron.conversationId)).resolves.toBeNull();
+    await expect(
+      fixture.conversationStore.getConversation(archivedSubagent.conversationId),
+    ).resolves.toBeNull();
+    await expect(
+      fixture.conversationStore.getConversation(activeSubagent.conversationId),
+    ).resolves.not.toBeNull();
+    await expect(
+      fixture.conversationStore.getConversation(unrelated.conversationId),
+    ).resolves.not.toBeNull();
   });
 
   it("applies a single doctor clean filter without deleting other candidate classes", async () => {


### PR DESCRIPTION
## What

Updates `/lossless doctor clean` and its explicit apply path to match cron and archived-subagent conversations under every configured OpenClaw agent id. Command-time OpenClaw config takes precedence over the registration snapshot, with `main` preserved as the fallback when no agent list is available.

## Why

The cleaner hard-coded `agent:main:cron:*` and `agent:main:subagent:*`, so installations with non-`main` agent ids received a zero-candidate report and could not apply the approved cleanup. The new predicate stages configured ids through prepared statements and compares an exact `agent:<id>:<lane>:` prefix with a required non-empty suffix. It does not use a wildcard for the agent segment, so nested, malformed, unconfigured, or differently cased keys cannot enter the delete set.

Fixes #1001

## Changes

- Resolve command-time configured agent ids
- Stage ids through prepared SQL parameters
- Compare exact cron and subagent prefixes
- Preserve archived-only subagent eligibility
- Keep scan and apply predicates identical
- Document configured-agent cleaner behavior
- Add a patch changeset

## Testing

- `npm exec -- vitest run test/lcm-command.test.ts test/plugin-config-registration.test.ts`
- `npm run release:verify`
- `git diff --check`
- Thermonuclear maintainability review: no findings
- Autoreview: clean after two accepted safety fixes

Expected outcomes:

- Main and configured non-main cron keys match
- Configured archived subagents match
- Active subagents remain excluded
- Malformed and unrelated keys remain excluded
- Scan counts equal apply delete counts
- Database backup precedes the delete transaction

## Compatibility

No OpenClaw compatibility floor change is required. The fix uses the validated `agents.list` config surface already supported by the declared minimum OpenClaw version, `2026.5.28`, and does not depend on file-backed OpenClaw session storage. It remains compatible with the SQLite transcript runtime in PR #952.
