### PR TITLE
feat(plugin): register lcm-control session action

### DIFF
--- a/.changeset/session-action-lcm-control.md
+++ b/.changeset/session-action-lcm-control.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add the `lcm-control` OpenClaw session action so authorized operators can invoke Lossless Claw control operations through the host session-action API.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,6 +24,9 @@
       "lcm_describe",
       "lcm_expand",
       "lcm_expand_query"
+    ],
+    "sessionActions": [
+      "lcm-control"
     ]
   },
   "uiHints": {

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -184,8 +184,33 @@ export type OpenClawPluginApi = {
     eventName: string,
     handler: (event: PluginLifecycleEvent, ctx: PluginLifecycleContext) => unknown | Promise<unknown>,
   ) => void;
+  session?: {
+    controls?: {
+      registerSessionAction?: (action: PluginSessionActionRegistration) => void;
+    };
+  };
   [key: string]: any;
 };
+
+export type PluginSessionActionRegistration = {
+  id: string;
+  description?: string;
+  schema?: unknown;
+  requiredScopes?: string[];
+  handler: (ctx: PluginSessionActionContext) => Promise<PluginSessionActionResult>;
+};
+
+export type PluginSessionActionContext = {
+  pluginId: string;
+  actionId: string;
+  sessionKey?: string;
+  payload?: Record<string, unknown>;
+  client?: { connId?: string; scopes: string[] };
+};
+
+export type PluginSessionActionResult =
+  | { ok?: true; result?: unknown }
+  | { ok: false; error: string; code?: string; details?: unknown };
 
 export type AgentMessage = {
   role: string;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1726,6 +1726,35 @@ function wirePluginHandlers(
       : shared.waitForEngine().then((nextEngine) => new MemorySupplementContextEngine(nextEngine));
   });
 
+  // Expose the already-implemented ContextEngine.control() through the host's
+  // session-action surface. Without this the control path is unreachable: the
+  // host has no ContextEngine control contract, so control() is never invoked.
+  api.session?.controls?.registerSessionAction?.({
+    id: "lcm-control",
+    description: "Run an LCM control operation (status | doctor | rotate) for a session.",
+    schema: {
+      type: "object",
+      properties: { operation: { enum: ["status", "doctor", "rotate"] } },
+      required: ["operation"],
+    },
+    handler: async (ctx) => {
+      const operation = ctx.payload?.operation;
+      if (operation !== "status" && operation !== "doctor" && operation !== "rotate") {
+        return { ok: false, error: `unsupported operation: ${String(operation)}`, code: "unsupported_operation" };
+      }
+      try {
+        const engine = await shared.waitForEngine();
+        return { ok: true, result: await engine.control({ operation, sessionKey: ctx.sessionKey }) };
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+          code: (err as { reason?: string })?.reason ?? "unavailable",
+        };
+      }
+    },
+  });
+
   api.registerTool(
     (ctx) =>
       createLcmGrepTool({

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -10,6 +10,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type {
   AssembleResult,
   ContextEngine,
+  ContextEngineControlOperation,
   ContextEngineFactory,
   OpenClawPluginApi,
 } from "../openclaw-bridge.js";
@@ -1738,18 +1739,18 @@ function wirePluginHandlers(
       required: ["operation"],
     },
     handler: async (ctx) => {
-      const operation = ctx.payload?.operation;
-      if (operation !== "status" && operation !== "doctor" && operation !== "rotate") {
-        return { ok: false, error: `unsupported operation: ${String(operation)}`, code: "unsupported_operation" };
-      }
+      // Operation validation is left to normalizeControlOperation() inside
+      // control(); it already throws LcmProgrammaticControlUnavailableError
+      // with a structured reasonCode. Duplicating it here would shadow that.
       try {
         const engine = await shared.waitForEngine();
+        const operation = ctx.payload?.operation as ContextEngineControlOperation;
         return { ok: true, result: await engine.control({ operation, sessionKey: ctx.sessionKey }) };
       } catch (err) {
         return {
           ok: false,
           error: err instanceof Error ? err.message : String(err),
-          code: (err as { reason?: string })?.reason ?? "unavailable",
+          code: (err as { reasonCode?: string })?.reasonCode ?? "unavailable",
         };
       }
     },

--- a/test/session-action-lcm-control.test.ts
+++ b/test/session-action-lcm-control.test.ts
@@ -1,0 +1,184 @@
+// Coverage for the `lcm-control` session action registered in src/plugin/index.ts.
+// The handler is the only bridge between the host's session-action surface and
+// ContextEngine.control(); before this file it had no automated tests, and the
+// structured-reasonCode passthrough had only been verified by hand against a
+// live gateway.
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "../src/openclaw-bridge.js";
+import lcmPlugin from "../index.js";
+import { closeLcmConnection } from "../src/db/connection.js";
+import {
+  LcmProgrammaticControlFailedError,
+  LcmProgrammaticControlUnavailableError,
+} from "../src/plugin/lcm-command.js";
+import { removeSharedInit, setSharedInit } from "../src/plugin/shared-init.js";
+
+type SessionActionRegistration = {
+  id: string;
+  description?: string;
+  schema?: { properties?: { operation?: { enum?: string[] } }; required?: string[] };
+  handler: (ctx: {
+    sessionKey?: string;
+    payload?: Record<string, unknown>;
+  }) => Promise<Record<string, unknown>>;
+};
+
+function buildHarness(control: (input: unknown) => Promise<unknown>) {
+  const dbPath = join(tmpdir(), `lossless-claw-action-${Date.now()}-${Math.random().toString(16)}.db`);
+  let registration: SessionActionRegistration | undefined;
+
+  // Inject the engine ahead of register() so the handler's waitForEngine()
+  // resolves to a controllable double instead of a real initialized engine.
+  const engine = { control: vi.fn(control) };
+  setSharedInit(dbPath, {
+    stopped: false,
+    startupMaintenanceStarted: true,
+    getCachedEngine: () => engine as never,
+    waitForEngine: async () => engine as never,
+    waitForDatabase: async () => ({}) as never,
+    runStartupMaintenanceOnce: () => {},
+  });
+
+  const api = {
+    id: "lossless-claw",
+    name: "Lossless Context Management",
+    source: "/tmp/lossless-claw",
+    config: {},
+    pluginConfig: { enabled: true, dbPath },
+    runtime: { config: { loadConfig: vi.fn(() => ({})) } },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    session: {
+      controls: {
+        registerSessionAction: vi.fn((next: SessionActionRegistration) => {
+          registration = next;
+        }),
+      },
+    },
+    registerContextEngine: vi.fn(),
+    registerTool: vi.fn(),
+    registerHook: vi.fn(),
+    registerHttpHandler: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerCommand: vi.fn(),
+    resolvePath: vi.fn(() => "/tmp/fake-agent"),
+    on: vi.fn(),
+  } as unknown as OpenClawPluginApi;
+
+  lcmPlugin.register(api);
+  if (!registration) {
+    throw new Error("Expected the lcm-control session action to be registered.");
+  }
+  return { registration, engine, dbPath };
+}
+
+const created: string[] = [];
+
+afterEach(() => {
+  for (const dbPath of created.splice(0)) {
+    removeSharedInit(dbPath);
+  }
+  closeLcmConnection();
+  vi.clearAllMocks();
+});
+
+function harness(control: (input: unknown) => Promise<unknown>) {
+  const built = buildHarness(control);
+  created.push(built.dbPath);
+  return built;
+}
+
+describe("lcm-control session action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers under a stable id and constrains the operation set", () => {
+    const { registration } = harness(async () => ({}));
+
+    expect(registration.id).toBe("lcm-control");
+    expect(registration.schema?.properties?.operation?.enum).toEqual([
+      "status",
+      "doctor",
+      "rotate",
+    ]);
+    expect(registration.schema?.required).toContain("operation");
+  });
+
+  it("passes the engine result through on success", async () => {
+    const { registration, engine } = harness(async () => ({ rotated: true, bytes: 1259 }));
+
+    const response = await registration.handler({
+      sessionKey: "agent:main:feishu:direct:u1",
+      payload: { operation: "rotate" },
+    });
+
+    expect(response).toEqual({ ok: true, result: { rotated: true, bytes: 1259 } });
+    expect(engine.control).toHaveBeenCalledWith({
+      operation: "rotate",
+      sessionKey: "agent:main:feishu:direct:u1",
+    });
+  });
+
+  it("preserves the structured reasonCode when control is unavailable", async () => {
+    const { registration } = harness(async () => {
+      throw new LcmProgrammaticControlUnavailableError("rotate", "conversation_unavailable");
+    });
+
+    const response = await registration.handler({ payload: { operation: "rotate" } });
+
+    // Regression guard: the handler once read `.reason`, collapsing every
+    // structured skip reason to the generic "unavailable".
+    expect(response.ok).toBe(false);
+    expect(response.code).toBe("conversation_unavailable");
+  });
+
+  it("preserves the structured reasonCode when control fails after starting", async () => {
+    const { registration } = harness(async () => {
+      throw new LcmProgrammaticControlFailedError("rotate", "rotate_write_failed");
+    });
+
+    const response = await registration.handler({ payload: { operation: "rotate" } });
+
+    expect(response.ok).toBe(false);
+    expect(response.code).toBe("rotate_write_failed");
+  });
+
+  it("keeps distinct skip reasons distinct", async () => {
+    const codes: unknown[] = [];
+    for (const reasonCode of ["runtime_unavailable", "session_id_unavailable", "transcript_unavailable"]) {
+      const { registration } = harness(async () => {
+        throw new LcmProgrammaticControlUnavailableError("rotate", reasonCode);
+      });
+      const response = await registration.handler({ payload: { operation: "rotate" } });
+      codes.push(response.code);
+    }
+
+    expect(codes).toEqual([
+      "runtime_unavailable",
+      "session_id_unavailable",
+      "transcript_unavailable",
+    ]);
+    expect(new Set(codes).size).toBe(3);
+  });
+
+  it("falls back to a generic code when the failure carries no reasonCode", async () => {
+    const { registration } = harness(async () => {
+      throw new Error("socket hang up");
+    });
+
+    const response = await registration.handler({ payload: { operation: "status" } });
+
+    expect(response).toEqual({
+      ok: false,
+      error: "socket hang up",
+      code: "unavailable",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`LcmContextEngine` already implements `control()` supporting `status` / `doctor` / `rotate`, backed by `runLcmProgrammaticControl()` and a structured failure classifier (`classifyProgrammaticRotateUnavailableReason`). All of that machinery is unreachable from outside the plugin.

The reason is subtle: `ContextEngineControlRequest` / `ContextEngineControlResult` / the optional `control?()` member exist **only in this plugin's own `src/openclaw-bridge.ts`**. The OpenClaw host has no such contract — grepping the host's shipped `dist/` for `ContextEngineControl` returns nothing. So `control()` is implemented against an interface the host never calls.

The host's actual extension point for this is `api.session.controls.registerSessionAction`, which the plugin does not use.

## Change

Wiring only — **no rotation logic is added**:

- `src/openclaw-bridge.ts` — declare the host's `registerSessionAction` surface and its context/result types
- `src/plugin/index.ts` — register `lcm-control`, delegating to the existing `engine.control()`
- `openclaw.plugin.json` — declare `contracts.sessionActions`

The manifest entry is required: registrations not declared there are silently dropped by the host, with no error.

57 insertions, 0 deletions.

## Verification

Built and installed against a live OpenClaw gateway (2026.7.1-2), plugin v0.14.0:

```
$ openclaw gateway call plugins.sessionAction --json \
    --params '{"pluginId":"lossless-claw","actionId":"lcm-control","payload":{"operation":"status"}}'
{"ok": true, "result": {"operation": "status", "active": false, "messageCount": 0}}
```

Real `rotate` against a canary session:

```
[ws] ⇄ res ✓ plugins.sessionAction 90651ms
transcript: 2344 bytes -> 2088 bytes
```

Before the gateway restart the same call returned `unknown plugin session action: lossless-claw/lcm-control`, confirming the registration is what makes it reachable.

## Note for reviewers: a timeout footgun

The gateway client transport times out at **10000ms**, while `rotate` legitimately took **~90s** on a 2.3KB transcript. Our first call surfaced:

```
{"ok": false, "error": {"kind": "timeout", "message": "gateway timeout after 10000ms"}}
```

…even though the operation succeeded server-side. Callers must treat a client timeout as **inconclusive**, not failed, and re-read state before retrying — a naive retry would re-run a rotation that already happened.

Happy to split the bridge type declarations into a separate commit if you'd prefer, or to adjust the action id / add `requiredScopes` to match your intended authorization model — we left `requiredScopes` unset since we did not want to guess at your scope taxonomy.