### PR TITLE
docs(readme): correct LCM_LEAF_TARGET_TOKENS default to 2400

### DIFF
--- a/.changeset/readme-leaf-target-tokens-default.md
+++ b/.changeset/readme-leaf-target-tokens-default.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Correct the documented default for `LCM_LEAF_TARGET_TOKENS` in the README environment-variable table from `1200` to `2400`, matching the runtime default in `src/db/config.ts` and the configuration reference.

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The `ignoreSessionPatterns` entries in this example are storage exclusions. Matc
 | `LCM_CONDENSED_MIN_FANOUT_HARD` | `2` | Relaxed fanout for forced compaction sweeps |
 | `LCM_INCREMENTAL_MAX_DEPTH` | `1` | How deep incremental compaction goes (0 = leaf only, 1 = one condensed pass, -1 = unlimited) |
 | `LCM_LEAF_CHUNK_TOKENS` | `20000` | Max source tokens per leaf compaction chunk |
-| `LCM_LEAF_TARGET_TOKENS` | `1200` | Target token count for leaf summaries |
+| `LCM_LEAF_TARGET_TOKENS` | `2400` | Target token count for leaf summaries |
 | `LCM_CONDENSED_TARGET_TOKENS` | `2000` | Target token count for condensed summaries |
 | `LCM_MAX_EXPAND_TOKENS` | `4000` | Token cap for sub-agent expansion queries |
 | `LCM_LARGE_FILE_TOKEN_THRESHOLD` | `25000` | File blocks above this size are intercepted and stored separately |


### PR DESCRIPTION
The README environment-variable table listed `LCM_LEAF_TARGET_TOKENS` default as `1200`, but the runtime default has been `2400` since the config resolver update. This aligns the README with `src/db/config.ts` and `docs/configuration.md`.

- Updated README.md table entry from 1200 to 2400
- Added patch changeset

Verification: `npm test -- test/config.test.ts` passes and asserts the 2400 default.