### PR TITLE
fix(manifest): remove duplicate largeFilesDir declarations

### DIFF
--- a/.changeset/plugin-json-duplicate-largefilesdir.md
+++ b/.changeset/plugin-json-duplicate-largefilesdir.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove duplicate `largeFilesDir` declarations from `openclaw.plugin.json`. The surviving entries describe the default as relative to `OPENCLAW_STATE_DIR`, consistent with the runtime resolver and configuration reference. A regression test now guards against duplicate keys and stale default descriptions.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -129,11 +129,7 @@
     },
     "largeFilesDir": {
       "label": "Large Files Directory",
-      "help": "Directory for persisting large-file text payloads (default: <stateDir>/lcm-files). Uses OPENCLAW_STATE_DIR when set."
-    },
-    "largeFilesDir": {
-      "label": "Large Files Directory",
-      "help": "Directory for externalized large files and inline-image payloads (default: ~/.openclaw/lcm-files)"
+      "help": "Directory for persisting large-file text payloads (default: <OPENCLAW_STATE_DIR>/lcm-files). Uses OPENCLAW_STATE_DIR when set."
     },
     "ignoreSessionPatterns": {
       "label": "Ignored Sessions",
@@ -471,9 +467,6 @@
         "minimum": 2
       },
       "dbPath": {
-        "type": "string"
-      },
-      "largeFilesDir": {
         "type": "string"
       },
       "ignoreSessionPatterns": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -129,7 +129,7 @@
     },
     "largeFilesDir": {
       "label": "Large Files Directory",
-      "help": "Directory for persisting large-file text payloads (default: <OPENCLAW_STATE_DIR>/lcm-files). Uses OPENCLAW_STATE_DIR when set."
+      "help": "Directory for persisting externalized large-file text and inline-image payloads (default: <OPENCLAW_STATE_DIR>/lcm-files)"
     },
     "ignoreSessionPatterns": {
       "label": "Ignored Sessions",
@@ -681,7 +681,7 @@
         "type": "string"
       },
       "largeFilesDir": {
-        "description": "Directory for persisting large-file text payloads (default: <OPENCLAW_STATE_DIR>/lcm-files)",
+        "description": "Directory for persisting externalized large-file text and inline-image payloads (default: <OPENCLAW_STATE_DIR>/lcm-files)",
         "type": "string"
       },
       "fallbackProviders": {

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -142,4 +142,9 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
       { name: "lcm", kind: "runtime-slash" },
     ]);
   });
+
+  it("describes largeFilesDir relative to OPENCLAW_STATE_DIR without duplicate keys", () => {
+    expect(manifest.uiHints.largeFilesDir?.help).toContain("OPENCLAW_STATE_DIR");
+    expect(manifest.configSchema.properties.largeFilesDir?.description).toContain("OPENCLAW_STATE_DIR");
+  });
 });

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -7,6 +7,7 @@ import manifest from "../openclaw.plugin.json" with { type: "json" };
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SRC_TOOLS_DIR = resolve(HERE, "..", "src", "tools");
 const PLUGIN_INDEX = resolve(HERE, "..", "src", "plugin", "index.ts");
+const PLUGIN_MANIFEST = resolve(HERE, "..", "openclaw.plugin.json");
 
 /**
  * These tests guard against drift between the names registered at runtime via
@@ -144,6 +145,10 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
   });
 
   it("describes largeFilesDir relative to OPENCLAW_STATE_DIR without duplicate keys", () => {
+    const manifestSource = readFileSync(PLUGIN_MANIFEST, "utf8");
+    const largeFilesDirKeys = manifestSource.match(/^\s*"largeFilesDir"\s*:/gm) ?? [];
+
+    expect(largeFilesDirKeys).toHaveLength(2);
     expect(manifest.uiHints.largeFilesDir?.help).toContain("OPENCLAW_STATE_DIR");
     expect(manifest.configSchema.properties.largeFilesDir?.description).toContain("OPENCLAW_STATE_DIR");
   });


### PR DESCRIPTION
`openclaw.plugin.json` contained duplicate `largeFilesDir` keys in both `uiHints` and `configSchema.properties`. JSON parsers keep the last value, so the first declaration was silently ignored. The surviving entries now consistently describe the default as `<OPENCLAW_STATE_DIR>/lcm-files`, matching the runtime resolver and `docs/configuration.md`.

Changes:
- Removed the duplicate `uiHints.largeFilesDir` entry that described a hard-coded `~/.openclaw/lcm-files` default.
- Removed the bare duplicate `configSchema.properties.largeFilesDir` entry so the described entry survives.
- Added a regression test in `test/manifest.test.ts` asserting the surviving descriptions reference `OPENCLAW_STATE_DIR`.

Verification: `npm test -- test/manifest.test.ts` passes.