### PR TITLE
fix(engine): recover safe no-anchor bootstrap checkpoints

### DIFF
--- a/.changeset/bootstrap-persist-checkpoint-no-overlap.md
+++ b/.changeset/bootstrap-persist-checkpoint-no-overlap.md
@@ -1,0 +1,18 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix a race in the bootstrap existing-conversation path where a conversation
+with a non-anchoring DB frontier (no overlapping content between the stored
+messages and the JSONL transcript) would have `bootstrapped_at` set but no
+`conversation_bootstrap_state` row persisted.
+
+Without a checkpoint, every subsequent `afterTurn` reconcile classified the
+conversation as `reason="checkpoint-missing"` with `allowNoAnchorImport=false`,
+imported 0 messages, and skipped all persistence permanently. The conversation
+froze at its pre-bootstrap message count while the JSONL transcript grew
+unbounded.
+
+The fix persists a bootstrap_state checkpoint whenever `markConversationBootstrapped`
+succeeds, including the no-overlap/no-import case. This gives `afterTurn` a
+checkpoint to work from and restores normal ingest/compaction operation.

--- a/.changeset/bootstrap-persist-checkpoint-no-overlap.md
+++ b/.changeset/bootstrap-persist-checkpoint-no-overlap.md
@@ -2,10 +2,9 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Fix a race in the bootstrap existing-conversation path where a conversation
-with a non-anchoring DB frontier (no overlapping content between the stored
-messages and the JSONL transcript) would have `bootstrapped_at` set but no
-`conversation_bootstrap_state` row persisted.
+Fix an ingest-before-bootstrap race where a conversation with only
+non-anchoring injected metadata rows could not establish a safe transcript
+checkpoint when those rows did not overlap the JSONL transcript.
 
 Without a checkpoint, every subsequent `afterTurn` reconcile classified the
 conversation as `reason="checkpoint-missing"` with `allowNoAnchorImport=false`,
@@ -13,6 +12,8 @@ imported 0 messages, and skipped all persistence permanently. The conversation
 froze at its pre-bootstrap message count while the JSONL transcript grew
 unbounded.
 
-The fix persists a bootstrap_state checkpoint whenever `markConversationBootstrapped`
-succeeds, including the no-overlap/no-import case. This gives `afterTurn` a
-checkpoint to work from and restores normal ingest/compaction operation.
+The fix reuses the bounded non-anchoring-frontier proof from checkpoint-missing
+recovery. Bootstrap imports the readable transcript before persisting its
+checkpoint, then subsequent `afterTurn` calls resume normally. Conversations
+with real divergent history or unreadable transcripts remain fail-closed so an
+unrelated transcript cannot contaminate stored history.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2338,6 +2338,16 @@ export class LcmContextEngine implements ContextEngine {
             await persistBootstrapState(conversationId);
           }
 
+          // Without a bootstrap_state checkpoint the afterTurn reconcile
+          // classifies the conversation as "checkpoint-missing" and skips all
+          // persistence, permanently freezing the conversation with only the
+          // pre-bootstrap messages.  A conversation that reached this point
+          // has enough forward progress (bootstrapped_at set, messages in DB)
+          // to warrant a checkpoint so afterTurn can recover on the next turn.
+          if (!bootstrapState && !conversation.bootstrappedAt) {
+            await persistBootstrapState(conversationId);
+          }
+
           if (conversation.bootstrappedAt) {
             return {
               bootstrapped: false,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2321,7 +2321,9 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
-          if (!conversation.bootstrappedAt) {
+          const firstBootstrapHasReadableProgress =
+            reconcile.importedMessages > 0 || reconcile.hasOverlap || historicalMessages.length > 0;
+          if (!conversation.bootstrappedAt && firstBootstrapHasReadableProgress) {
             await this.conversationStore.markConversationBootstrapped(conversationId);
           }
 
@@ -2334,10 +2336,14 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
-          // The first bootstrap attempt must establish a checkpoint even when
-          // the DB frontier does not overlap the transcript. Otherwise the next
-          // afterTurn cannot resume from the current transcript offset.
-          if (reconcile.hasOverlap || (!bootstrapState && !conversation.bootstrappedAt)) {
+          // The first bootstrap attempt must establish a checkpoint after a
+          // successful transcript read, even when the DB frontier does not
+          // overlap the transcript. Otherwise the next afterTurn cannot resume
+          // from the current transcript offset.
+          if (
+            reconcile.hasOverlap ||
+            (historicalMessages.length > 0 && !bootstrapState && !conversation.bootstrappedAt)
+          ) {
             await persistBootstrapState(conversationId);
           }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2284,6 +2284,13 @@ export class LcmContextEngine implements ContextEngine {
 
           // Existing conversation path: reconcile crash gaps by appending JSONL
           // messages that were never persisted to LCM.
+          const isFirstBootstrap = !conversation.bootstrappedAt;
+          const firstBootstrapFrontierIsNonAnchoring =
+            !bootstrapState &&
+            isFirstBootstrap &&
+            (await this.transcriptReconciler.conversationFrontierIsEntirelyNonAnchoring(
+              conversationId,
+            ));
           const reconcile = await this.transcriptReconciler.reconcileSessionTail({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
@@ -2298,8 +2305,14 @@ export class LcmContextEngine implements ContextEngine {
                 ? undefined
                 : bootstrapState?.lastProcessedEntryId,
             skipContentAnchorScan: transcriptEpochReason === "same-path-shrink",
-            allowNoAnchorImport: transcriptEpochRotated,
-            noAnchorImportReason: transcriptEpochReason,
+            allowNoAnchorImport:
+              transcriptEpochRotated || firstBootstrapFrontierIsNonAnchoring,
+            allowFullNonAnchoringFrontierImport: firstBootstrapFrontierIsNonAnchoring,
+            noAnchorImportReason:
+              transcriptEpochReason ??
+              (firstBootstrapFrontierIsNonAnchoring
+                ? "checkpoint-missing-recovery"
+                : undefined),
           });
           this.deps.log.debug(
             `[lcm] bootstrap: reconcile finished conversation=${conversationId} ${sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -2321,14 +2334,9 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
-          // Only mark bootstrapped when the transcript was successfully read.
-          // An unreadable or empty transcript intentionally leaves the
-          // conversation unbootstrapped so a later successful read can retry
-          // (the old path set bootstrapped_at regardless, freezing afterTurn
-          // at checkpoint-missing with no recovery path).
           const firstBootstrapHasReadableProgress =
-            reconcile.importedMessages > 0 || reconcile.hasOverlap || historicalMessages.length > 0;
-          if (!conversation.bootstrappedAt && firstBootstrapHasReadableProgress) {
+            reconcile.importedMessages > 0 || reconcile.hasOverlap;
+          if (isFirstBootstrap && firstBootstrapHasReadableProgress) {
             await this.conversationStore.markConversationBootstrapped(conversationId);
           }
 
@@ -2341,19 +2349,7 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
-          // The first bootstrap attempt must establish a checkpoint after a
-          // successful transcript read, even when the DB frontier does not
-          // overlap the transcript. Otherwise the next afterTurn cannot resume
-          // from the current transcript offset.
-          //
-          // conversation.bootstrappedAt here reflects the in-memory state
-          // *before* markConversationBootstrapped above — it is intentionally
-          // stale. A refactor that refreshes the local record after the mark
-          // call should also update this gate to prevent a silent regression.
-          if (
-            reconcile.hasOverlap ||
-            (historicalMessages.length > 0 && !bootstrapState && !conversation.bootstrappedAt)
-          ) {
+          if (reconcile.hasOverlap) {
             await persistBootstrapState(conversationId);
           }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2334,17 +2334,10 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
-          if (reconcile.hasOverlap) {
-            await persistBootstrapState(conversationId);
-          }
-
-          // Without a bootstrap_state checkpoint the afterTurn reconcile
-          // classifies the conversation as "checkpoint-missing" and skips all
-          // persistence, permanently freezing the conversation with only the
-          // pre-bootstrap messages.  A conversation that reached this point
-          // has enough forward progress (bootstrapped_at set, messages in DB)
-          // to warrant a checkpoint so afterTurn can recover on the next turn.
-          if (!bootstrapState && !conversation.bootstrappedAt) {
+          // The first bootstrap attempt must establish a checkpoint even when
+          // the DB frontier does not overlap the transcript. Otherwise the next
+          // afterTurn cannot resume from the current transcript offset.
+          if (reconcile.hasOverlap || (!bootstrapState && !conversation.bootstrappedAt)) {
             await persistBootstrapState(conversationId);
           }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2321,6 +2321,11 @@ export class LcmContextEngine implements ContextEngine {
             };
           }
 
+          // Only mark bootstrapped when the transcript was successfully read.
+          // An unreadable or empty transcript intentionally leaves the
+          // conversation unbootstrapped so a later successful read can retry
+          // (the old path set bootstrapped_at regardless, freezing afterTurn
+          // at checkpoint-missing with no recovery path).
           const firstBootstrapHasReadableProgress =
             reconcile.importedMessages > 0 || reconcile.hasOverlap || historicalMessages.length > 0;
           if (!conversation.bootstrappedAt && firstBootstrapHasReadableProgress) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2340,6 +2340,11 @@ export class LcmContextEngine implements ContextEngine {
           // successful transcript read, even when the DB frontier does not
           // overlap the transcript. Otherwise the next afterTurn cannot resume
           // from the current transcript offset.
+          //
+          // conversation.bootstrappedAt here reflects the in-memory state
+          // *before* markConversationBootstrapped above — it is intentionally
+          // stale. A refactor that refreshes the local record after the mark
+          // call should also update this gate to prevent a silent regression.
           if (
             reconcile.hasOverlap ||
             (historicalMessages.length > 0 && !bootstrapState && !conversation.bootstrappedAt)

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -610,16 +610,15 @@ export class TranscriptReconciler {
   }
 
   /**
-   * Decide whether a placeholder-checkpoint conversation may recover by importing
-   * its on-disk transcript as a new epoch (#822). Safe ONLY when the persisted
-   * frontier holds no real conversation content that a rotated/unrelated transcript
-   * could overwrite. Generalizes #837's single-injected-metadata-preamble check to
-   * any frontier composed entirely of non-anchoring injected-metadata rows; an
-   * empty frontier is trivially safe, and a larger or non-metadata frontier
-   * conservatively returns false so the conversation freezes (#649) rather than
-   * risk contaminating real history (the failure that closed #824).
+   * Decide whether a conversation may recover without a content anchor.
+   *
+   * Safe ONLY when the persisted frontier holds no real conversation content
+   * that a rotated or unrelated transcript could overwrite. Generalizes #837's
+   * single injected-metadata preamble to any frontier composed entirely of
+   * non-anchoring metadata rows; a larger or real-content frontier remains
+   * fail-closed per #649 and the contamination failure that closed #824.
    */
-  private async conversationFrontierIsEntirelyNonAnchoring(
+  async conversationFrontierIsEntirelyNonAnchoring(
     conversationId: number,
   ): Promise<boolean> {
     const existingMessageCount = await this.host.conversationStore.getMessageCount(conversationId);

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3711,6 +3711,72 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(stored.map((message) => message.content)).toEqual(["db only user", "db only assistant"]);
   });
 
+  it("persists a bootstrap checkpoint when reconcile finds no anchor or overlap, so afterTurn does not freeze in checkpoint-missing", async () => {
+    // When ingest() runs before bootstrap() (race), the conversation has
+    // messages but no bootstrap_state.  If the transcript content does not
+    // overlap with the DB messages, reconcile finds no anchor.  Without a
+    // checkpoint row, afterTurn classifies the conversation as
+    // "checkpoint-missing" and skips all persistence permanently.
+    //
+    // This test asserts that bootstrap creates the checkpoint even in the
+    // no-overlap case, so afterTurn can recover on the next turn.
+    const sessionFile = createSessionFilePath("bootstrap-checkpoint-no-overlap");
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, {
+      role: "user",
+      content: [{ type: "text", text: "transcript only user" }],
+    } as AgentMessage);
+    appendSessionMessage(sm, {
+      role: "assistant",
+      content: [{ type: "text", text: "transcript only assistant" }],
+    } as AgentMessage);
+
+    const engine = createEngine();
+    const sessionId = "bootstrap-checkpoint-no-overlap";
+
+    // Simulate ingest-before-bootstrap: store messages that do NOT overlap
+    // with the transcript content above.
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "db preamble" } as AgentMessage,
+    });
+    await engine.ingest({
+      sessionId,
+      message: { role: "assistant", content: "db preamble response" } as AgentMessage,
+    });
+
+    const result = await engine.bootstrap({ sessionId, sessionFile });
+    expect(result.bootstrapped).toBe(false);
+    expect(result.importedMessages).toBe(0);
+    // The conversation has pre-existing messages with no transcript overlap.
+    expect(result.reason).toBe("conversation already has messages");
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    expect(conversation!.bootstrappedAt).not.toBeNull();
+
+    // The key invariant: bootstrap_state must exist so afterTurn can
+    // find a checkpoint.
+    const bootstrapState = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(bootstrapState).not.toBeNull();
+    expect(bootstrapState!.sessionFilePath).toBe(sessionFile);
+    expect(bootstrapState!.lastSeenSize).toBe(statSync(sessionFile).size);
+    expect(bootstrapState!.lastProcessedOffset).toBe(statSync(sessionFile).size);
+
+    // DB messages are preserved (no import, no corruption).
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored.map((m) => m.content)).toEqual([
+      "db preamble",
+      "db preamble response",
+    ]);
+  });
+
   it("does not advance the bootstrap checkpoint when reconcile aborts at the import cap", async () => {
     const warnLog = vi.fn();
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-engine-"));

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3728,6 +3728,9 @@ describe("LcmContextEngine.bootstrap", () => {
     // checkpoint row, afterTurn classifies the conversation as
     // "checkpoint-missing" and skips all persistence permanently.
     //
+    // Before the fix, bootstrap skipped persistBootstrapState when
+    // reconcile had no overlap — leaving the conversation permanently
+    // frozen at checkpoint-missing on every subsequent afterTurn.
     // This test asserts that bootstrap creates the checkpoint even in the
     // no-overlap case, so afterTurn can recover on the next turn.
     const sessionFile = createSessionFilePath("bootstrap-checkpoint-no-overlap");
@@ -3802,6 +3805,12 @@ describe("LcmContextEngine.bootstrap", () => {
       "next transcript user",
       "next transcript assistant",
     ]);
+
+    // Re-bootstrap must be idempotent — a second call returns
+    // "already bootstrapped" without re-persisting.
+    const reResult = await engine.bootstrap({ sessionId, sessionFile });
+    expect(reResult.bootstrapped).toBe(false);
+    expect(reResult.reason).toBe("already bootstrapped");
   });
 
   it("does not advance the bootstrap checkpoint when reconcile aborts at the import cap", async () => {

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3767,13 +3767,30 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(bootstrapState!.lastSeenSize).toBe(statSync(sessionFile).size);
     expect(bootstrapState!.lastProcessedOffset).toBe(statSync(sessionFile).size);
 
-    // DB messages are preserved (no import, no corruption).
+    const nextTurn = [
+      makeMessage({ role: "user", content: "next transcript user" }),
+      makeMessage({ role: "assistant", content: "next transcript assistant" }),
+    ];
+    for (const message of nextTurn) {
+      appendSessionMessage(sm, message as AgentMessage);
+    }
+    await engine.afterTurn({
+      sessionId,
+      sessionFile,
+      messages: nextTurn,
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // DB messages are preserved and the next turn advances normally.
     const stored = await engine
       .getConversationStore()
       .getMessages(conversation!.conversationId);
     expect(stored.map((m) => m.content)).toEqual([
       "db preamble",
       "db preamble response",
+      "next transcript user",
+      "next transcript assistant",
     ]);
   });
 

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -461,6 +461,16 @@ describe("LcmContextEngine.bootstrap", () => {
       importedMessages: 0,
       reason: "conversation already has messages",
     });
+
+    const checkpoint = await engine
+      .getSummaryStore()
+      .getConversationBootstrapState(conversation!.conversationId);
+    expect(checkpoint).toBeNull();
+
+    const rereadConversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(rereadConversation?.bootstrappedAt).toBeNull();
   });
 
   it("preserves existing conversation data when the session file rotates", async () => {

--- a/test/engine-bootstrap.test.ts
+++ b/test/engine-bootstrap.test.ts
@@ -3719,20 +3719,22 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(conversation).not.toBeNull();
     const stored = await engine.getConversationStore().getMessages(conversation!.conversationId);
     expect(stored.map((message) => message.content)).toEqual(["db only user", "db only assistant"]);
+    expect(conversation!.bootstrappedAt).toBeNull();
+    await expect(
+      engine
+        .getSummaryStore()
+        .getConversationBootstrapState(conversation!.conversationId),
+    ).resolves.toBeNull();
   });
 
-  it("persists a bootstrap checkpoint when reconcile finds no anchor or overlap, so afterTurn does not freeze in checkpoint-missing", async () => {
+  it("recovers a first bootstrap with a non-anchoring DB frontier, so afterTurn does not freeze in checkpoint-missing", async () => {
     // When ingest() runs before bootstrap() (race), the conversation has
-    // messages but no bootstrap_state.  If the transcript content does not
-    // overlap with the DB messages, reconcile finds no anchor.  Without a
-    // checkpoint row, afterTurn classifies the conversation as
-    // "checkpoint-missing" and skips all persistence permanently.
+    // only injected metadata and no bootstrap_state. If the transcript does
+    // not overlap those non-anchoring rows, importing the readable transcript
+    // is safe because there is no real DB history to contaminate.
     //
-    // Before the fix, bootstrap skipped persistBootstrapState when
-    // reconcile had no overlap — leaving the conversation permanently
-    // frozen at checkpoint-missing on every subsequent afterTurn.
-    // This test asserts that bootstrap creates the checkpoint even in the
-    // no-overlap case, so afterTurn can recover on the next turn.
+    // Bootstrap must import that transcript before establishing its checkpoint
+    // so afterTurn can safely resume from the verified frontier.
     const sessionFile = createSessionFilePath("bootstrap-checkpoint-no-overlap");
     const sm = SessionManager.open(sessionFile);
     appendSessionMessage(sm, {
@@ -3747,22 +3749,26 @@ describe("LcmContextEngine.bootstrap", () => {
     const engine = createEngine();
     const sessionId = "bootstrap-checkpoint-no-overlap";
 
-    // Simulate ingest-before-bootstrap: store messages that do NOT overlap
-    // with the transcript content above.
+    // Simulate ingest-before-bootstrap with a proven non-anchoring frontier.
     await engine.ingest({
       sessionId,
-      message: { role: "user", content: "db preamble" } as AgentMessage,
+      message: {
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble one",
+      } as AgentMessage,
     });
     await engine.ingest({
       sessionId,
-      message: { role: "assistant", content: "db preamble response" } as AgentMessage,
+      message: {
+        role: "user",
+        content: "Conversation info (untrusted metadata): injected preamble two",
+      } as AgentMessage,
     });
 
     const result = await engine.bootstrap({ sessionId, sessionFile });
-    expect(result.bootstrapped).toBe(false);
-    expect(result.importedMessages).toBe(0);
-    // The conversation has pre-existing messages with no transcript overlap.
-    expect(result.reason).toBe("conversation already has messages");
+    expect(result.bootstrapped).toBe(true);
+    expect(result.importedMessages).toBe(2);
+    expect(result.reason).toBe("reconciled missing session messages");
 
     const conversation = await engine
       .getConversationStore()
@@ -3770,8 +3776,7 @@ describe("LcmContextEngine.bootstrap", () => {
     expect(conversation).not.toBeNull();
     expect(conversation!.bootstrappedAt).not.toBeNull();
 
-    // The key invariant: bootstrap_state must exist so afterTurn can
-    // find a checkpoint.
+    // The transcript import establishes the checkpoint after verified progress.
     const bootstrapState = await engine
       .getSummaryStore()
       .getConversationBootstrapState(conversation!.conversationId);
@@ -3795,13 +3800,15 @@ describe("LcmContextEngine.bootstrap", () => {
       tokenBudget: 4096,
     });
 
-    // DB messages are preserved and the next turn advances normally.
+    // Metadata is preserved, transcript history imports, and the next turn advances.
     const stored = await engine
       .getConversationStore()
       .getMessages(conversation!.conversationId);
     expect(stored.map((m) => m.content)).toEqual([
-      "db preamble",
-      "db preamble response",
+      "Conversation info (untrusted metadata): injected preamble one",
+      "Conversation info (untrusted metadata): injected preamble two",
+      "transcript only user",
+      "transcript only assistant",
       "next transcript user",
       "next transcript assistant",
     ]);


### PR DESCRIPTION
## What

Recover ingest-before-bootstrap conversations whose persisted frontier contains only proven non-anchoring OpenClaw metadata. Bootstrap imports the readable transcript through the existing guarded no-anchor recovery path before marking the conversation bootstrapped and persisting its checkpoint.

## Why

Without a checkpoint, subsequent `afterTurn` reconciliation can remain stuck at `checkpoint-missing` forever. Persisting an EOF checkpoint without lineage proof is also unsafe because it can splice an unrelated transcript into real stored history. This change restores progress only where the existing bounded frontier proof shows there is no real history to contaminate.

## Changes

- Reuse non-anchoring frontier proof
- Import transcript before checkpointing
- Preserve real-history fail-closed behavior
- Preserve unreadable-transcript retry behavior
- Prove `afterTurn` and re-bootstrap recovery
- Add patch release changeset

## Testing

- `npx vitest run test/engine-bootstrap.test.ts` — 73 passed
- `npm test` — 1,896 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm pack --dry-run` — passed
- Autoreview against `origin/main` — clean