### PR TITLE
fix(config): remove duplicate largeFilesDir key in configHints

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -131,10 +131,6 @@
       "label": "Large Files Directory",
       "help": "Directory for persisting large-file text payloads (default: <stateDir>/lcm-files). Uses OPENCLAW_STATE_DIR when set."
     },
-    "largeFilesDir": {
-      "label": "Large Files Directory",
-      "help": "Directory for externalized large files and inline-image payloads (default: ~/.openclaw/lcm-files)"
-    },
     "ignoreSessionPatterns": {
       "label": "Ignored Sessions",
       "help": "Glob patterns for session keys to exclude from LCM storage"
@@ -471,9 +467,6 @@
         "minimum": 2
       },
       "dbPath": {
-        "type": "string"
-      },
-      "largeFilesDir": {
         "type": "string"
       },
       "ignoreSessionPatterns": {


### PR DESCRIPTION
Closes #1022

The second `largeFilesDir` entry in `configHints` had stale text contradicting the schema and `OPENCLAW_STATE_DIR` support (#1012). Remove it, keeping the correct entry.