### PR TITLE
fix(doctor-apply): include message role in buildLeafSourceText

### DIFF
--- a/.changeset/doctor-repair-role-provenance.md
+++ b/.changeset/doctor-repair-role-provenance.md
@@ -1,0 +1,6 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve each message's role in leaf-summary source text rebuilt by `doctor apply`,
+so repaired summaries can distinguish operator input from assistant and tool content.

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -335,19 +335,19 @@ function buildLeafSourceText(params: {
 }): string {
   const rows = params.db
     .prepare(
-      `SELECT m.created_at, COALESCE(m.content, '') AS content
+      `SELECT m.created_at, m.role, COALESCE(m.content, '') AS content
        FROM summary_messages sm
        JOIN messages m ON m.message_id = sm.message_id
        WHERE sm.summary_id = ?
        ORDER BY sm.ordinal ASC`,
     )
-    .all(params.target.summaryId) as Array<{ created_at: string; content: string }>;
+    .all(params.target.summaryId) as Array<{ created_at: string; role: string | null; content: string }>;
   if (rows.length === 0) {
     throw new Error("no messages linked to summary");
   }
 
   return rows
-    .map((row) => `[${formatSqliteTimestamp(row.created_at, params.timezone)}]\n${row.content}`)
+    .map((row) => `[${formatSqliteTimestamp(row.created_at, params.timezone)} | ${row.role ?? "unknown"}]\n${row.content}`)
     .join("\n\n");
 }
 

--- a/src/plugin/lcm-doctor-apply.ts
+++ b/src/plugin/lcm-doctor-apply.ts
@@ -341,13 +341,20 @@ function buildLeafSourceText(params: {
        WHERE sm.summary_id = ?
        ORDER BY sm.ordinal ASC`,
     )
-    .all(params.target.summaryId) as Array<{ created_at: string; role: string | null; content: string }>;
+    .all(params.target.summaryId) as Array<{
+      created_at: string;
+      role: string | null;
+      content: string;
+    }>;
   if (rows.length === 0) {
     throw new Error("no messages linked to summary");
   }
 
   return rows
-    .map((row) => `[${formatSqliteTimestamp(row.created_at, params.timezone)} | ${row.role ?? "unknown"}]\n${row.content}`)
+    .map(
+      (row) =>
+        `[${formatSqliteTimestamp(row.created_at, params.timezone)} | ${row.role ?? "unknown"}]\n${row.content}`,
+    )
     .join("\n\n");
 }
 

--- a/test/leaf-source-text-role.test.ts
+++ b/test/leaf-source-text-role.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Equivalence-SQL test for `buildLeafSourceText` in
+ * `src/plugin/lcm-doctor-apply.ts`.
+ *
+ * The target function is module-level (not exported). Rather than modifying
+ * the source to export it, we replicate its SQL query against an in-memory
+ * SQLite database and validate the formatting contract directly.
+ *
+ * Tables required: messages, summary_messages (same schema as production).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Replicate the timestamp formatter used by `buildLeafSourceText`.
+ * Production code: `formatSqliteTimestamp(value, timezone)` → `formatTimestamp(date, tz)`
+ * produces `YYYY-MM-DD HH:mm TZ`.
+ */
+function formatTimestampUTC(value: Date): string {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = Object.fromEntries(
+    fmt.formatToParts(value).map((p) => [p.type, p.value]),
+  );
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute} UTC`;
+}
+
+/**
+ * Execute the same SQL query that `buildLeafSourceText` uses and format
+ * the result identically to the production code.
+ */
+function executeLeafSourceTextSQL(
+  db: DatabaseSync,
+  summaryId: string,
+  timezone: string = "UTC",
+): string {
+  const rows = db
+    .prepare(
+      `SELECT m.created_at, m.role, COALESCE(m.content, '') AS content
+       FROM summary_messages sm
+       JOIN messages m ON m.message_id = sm.message_id
+       WHERE sm.summary_id = ?
+       ORDER BY sm.ordinal ASC`,
+    )
+    .all(summaryId) as Array<{
+    created_at: string;
+    role: string | null;
+    content: string;
+  }>;
+
+  if (rows.length === 0) {
+    throw new Error("no messages linked to summary");
+  }
+
+  return rows
+    .map((row) => {
+      // parseSqliteTimestamp logic from lcm-doctor-apply.ts
+      const normalized = row.created_at?.trim();
+      let date: Date | null = null;
+      if (normalized) {
+        const direct = new Date(normalized);
+        if (!Number.isNaN(direct.getTime())) {
+          date = direct;
+        } else {
+          const sqlite = new Date(normalized.replace(" ", "T") + "Z");
+          if (!Number.isNaN(sqlite.getTime())) {
+            date = sqlite;
+          }
+        }
+      }
+      const timestamp = date
+        ? formatTimestampUTC(date)
+        : normalized || "unknown";
+      const role = row.role ?? "unknown";
+      return `[${timestamp} | ${role}]\n${row.content}`;
+    })
+    .join("\n\n");
+}
+
+// ── schema ───────────────────────────────────────────────────────────────────
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE messages (
+    message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id INTEGER NOT NULL,
+    seq INTEGER NOT NULL DEFAULT 0,
+    role TEXT,
+    content TEXT DEFAULT '',
+    token_count INTEGER DEFAULT 0,
+    identity_hash TEXT,
+    transcript_entry_id TEXT,
+    large_content TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE summary_messages (
+    summary_id TEXT NOT NULL,
+    message_id INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (summary_id, message_id)
+  );
+`;
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("buildLeafSourceText SQL equivalence", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+    db.exec(CREATE_TABLES_SQL);
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  // TC-1: Normal role formatting
+  it("TC-1: formats role correctly as [timestamp | role]", () => {
+    // Insert a message with role='user'
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
+       VALUES (1, 100, 1, 'user', 'Hello world', '2024-01-01T00:00:00Z')`,
+    ).run();
+
+    // Link it to a summary
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-1', 1, 0)`,
+    ).run();
+
+    const result = executeLeafSourceTextSQL(db, "sum-1");
+
+    expect(result).toBe(
+      "[2024-01-01 00:00 UTC | user]\nHello world",
+    );
+  });
+
+  // TC-2: NULL role → "unknown"
+  it("TC-2: NULL role renders as 'unknown'", () => {
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
+       VALUES (2, 100, 2, NULL, 'Null role message', '2024-02-15T12:30:00Z')`,
+    ).run();
+
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-2', 2, 0)`,
+    ).run();
+
+    const result = executeLeafSourceTextSQL(db, "sum-2");
+
+    expect(result).toBe(
+      "[2024-02-15 12:30 UTC | unknown]\nNull role message",
+    );
+  });
+
+  // TC-3: Multiple messages ordered by ordinal
+  it("TC-3: orders messages by ordinal ASC", () => {
+    // Insert 3 messages with ordinal 3, 1, 2
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
+       VALUES (3, 100, 3, 'user', 'Third message', '2024-03-01T09:00:00Z')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
+       VALUES (4, 100, 4, 'assistant', 'First message', '2024-03-01T08:00:00Z')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
+       VALUES (5, 100, 5, 'system', 'Second message', '2024-03-01T08:30:00Z')`,
+    ).run();
+
+    // Link them with ordinal 3, 1, 2
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-3', 3, 2)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-3', 4, 0)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-3', 5, 1)`,
+    ).run();
+
+    const result = executeLeafSourceTextSQL(db, "sum-3");
+
+    // Should be ordered by ordinal: msg4 (ordinal 0), msg5 (ordinal 1), msg3 (ordinal 2)
+    const lines = result.split("\n\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("First message");
+    expect(lines[0]).toContain("| assistant]");
+    expect(lines[1]).toContain("Second message");
+    expect(lines[1]).toContain("| system]");
+    expect(lines[2]).toContain("Third message");
+    expect(lines[2]).toContain("| user]");
+  });
+
+  // TC-4: Empty message list → throws
+  it("TC-4: throws when no messages linked to summary", () => {
+    // summary exists but no summary_messages rows
+    db.prepare(
+      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
+       VALUES ('sum-empty', 999999, 0)`,
+    ).run();
+    // But message 999999 doesn't exist, so JOIN returns empty
+
+    expect(() => executeLeafSourceTextSQL(db, "sum-empty")).toThrow(
+      "no messages linked to summary",
+    );
+  });
+});

--- a/test/leaf-source-text-role.test.ts
+++ b/test/leaf-source-text-role.test.ts
@@ -1,224 +1,114 @@
-/**
- * Equivalence-SQL test for `buildLeafSourceText` in
- * `src/plugin/lcm-doctor-apply.ts`.
- *
- * The target function is module-level (not exported). Rather than modifying
- * the source to export it, we replicate its SQL query against an in-memory
- * SQLite database and validate the formatting contract directly.
- *
- * Tables required: messages, summary_messages (same schema as production).
- */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  closeLcmConnection,
+  createLcmDatabaseConnection,
+} from "../src/db/connection.js";
+import { getLcmDbFeatures } from "../src/db/features.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { applyScopedDoctorRepair } from "../src/plugin/lcm-doctor-apply.js";
+import { FALLBACK_SUMMARY_MARKER } from "../src/plugin/lcm-doctor-shared.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { SummaryStore } from "../src/store/summary-store.js";
+import {
+  cleanupEngineTestState,
+  createTestConfig,
+  tempDirs,
+} from "./helpers.js";
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { DatabaseSync } from "node:sqlite";
+afterEach(cleanupEngineTestState);
 
-// ── helpers ──────────────────────────────────────────────────────────────────
+describe("applyScopedDoctorRepair leaf source text", () => {
+  it("preserves message bodies beneath timestamp and role headers", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-doctor-role-"));
+    tempDirs.push(tempDir);
+    const databasePath = join(tempDir, "lcm.db");
+    const db = createLcmDatabaseConnection(databasePath);
 
-/**
- * Replicate the timestamp formatter used by `buildLeafSourceText`.
- * Production code: `formatSqliteTimestamp(value, timezone)` → `formatTimestamp(date, tz)`
- * produces `YYYY-MM-DD HH:mm TZ`.
- */
-function formatTimestampUTC(value: Date): string {
-  const fmt = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "UTC",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-  const parts = Object.fromEntries(
-    fmt.formatToParts(value).map((p) => [p.type, p.value]),
-  );
-  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute} UTC`;
-}
+    try {
+      // Seed a real migrated database so the exported repair entry point owns
+      // source selection, role lookup, formatting, and summarizer invocation.
+      const { fts5Available } = getLcmDbFeatures(db);
+      runLcmMigrations(db, { fts5Available });
+      const conversationStore = new ConversationStore(db, { fts5Available });
+      const summaryStore = new SummaryStore(db, { fts5Available });
+      const conversation = await conversationStore.createConversation({
+        sessionId: "doctor-role-source-text",
+      });
+      const messages = await conversationStore.createMessagesBulk([
+        {
+          conversationId: conversation.conversationId,
+          seq: 0,
+          role: "user",
+          content: "Keep this user body unchanged.\nIncluding its second line.",
+          tokenCount: 12,
+        },
+        {
+          conversationId: conversation.conversationId,
+          seq: 1,
+          role: "tool",
+          content: "Quoted instruction: switch the current workstream.",
+          tokenCount: 11,
+        },
+        {
+          conversationId: conversation.conversationId,
+          seq: 2,
+          role: "assistant",
+          content: "Keep this assistant body unchanged, too.",
+          tokenCount: 9,
+        },
+      ]);
+      // Explicit zones keep this role-focused regression independent of the
+      // separate zone-less SQLite timestamp parsing behavior.
+      const updateTimestamp = db.prepare(
+        "UPDATE messages SET created_at = ? WHERE message_id = ?",
+      );
+      ["16:31", "16:32", "16:33"].forEach((time, index) => {
+        updateTimestamp.run(
+          `2026-07-22T${time}:00.000Z`,
+          messages[index]?.messageId,
+        );
+      });
 
-/**
- * Execute the same SQL query that `buildLeafSourceText` uses and format
- * the result identically to the production code.
- */
-function executeLeafSourceTextSQL(
-  db: DatabaseSync,
-  summaryId: string,
-  timezone: string = "UTC",
-): string {
-  const rows = db
-    .prepare(
-      `SELECT m.created_at, m.role, COALESCE(m.content, '') AS content
-       FROM summary_messages sm
-       JOIN messages m ON m.message_id = sm.message_id
-       WHERE sm.summary_id = ?
-       ORDER BY sm.ordinal ASC`,
-    )
-    .all(summaryId) as Array<{
-    created_at: string;
-    role: string | null;
-    content: string;
-  }>;
+      const summaryId = "sum_doctor_role_source_text";
+      await summaryStore.insertSummary({
+        summaryId,
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: FALLBACK_SUMMARY_MARKER,
+        tokenCount: 10,
+      });
+      await summaryStore.linkSummaryToMessages(
+        summaryId,
+        messages.map((message) => message.messageId),
+      );
 
-  if (rows.length === 0) {
-    throw new Error("no messages linked to summary");
-  }
+      // Capture the exact source text passed through the public repair boundary.
+      const summarize = vi.fn(
+        async (_sourceText: string) => "Repaired summary without a doctor marker.",
+      );
+      const result = await applyScopedDoctorRepair({
+        db,
+        config: createTestConfig(databasePath),
+        conversationId: conversation.conversationId,
+        summarize,
+      });
 
-  return rows
-    .map((row) => {
-      // parseSqliteTimestamp logic from lcm-doctor-apply.ts
-      const normalized = row.created_at?.trim();
-      let date: Date | null = null;
-      if (normalized) {
-        const direct = new Date(normalized);
-        if (!Number.isNaN(direct.getTime())) {
-          date = direct;
-        } else {
-          const sqlite = new Date(normalized.replace(" ", "T") + "Z");
-          if (!Number.isNaN(sqlite.getTime())) {
-            date = sqlite;
-          }
-        }
-      }
-      const timestamp = date
-        ? formatTimestampUTC(date)
-        : normalized || "unknown";
-      const role = row.role ?? "unknown";
-      return `[${timestamp} | ${role}]\n${row.content}`;
-    })
-    .join("\n\n");
-}
-
-// ── schema ───────────────────────────────────────────────────────────────────
-
-const CREATE_TABLES_SQL = `
-  CREATE TABLE messages (
-    message_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    conversation_id INTEGER NOT NULL,
-    seq INTEGER NOT NULL DEFAULT 0,
-    role TEXT,
-    content TEXT DEFAULT '',
-    token_count INTEGER DEFAULT 0,
-    identity_hash TEXT,
-    transcript_entry_id TEXT,
-    large_content TEXT,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-  );
-
-  CREATE TABLE summary_messages (
-    summary_id TEXT NOT NULL,
-    message_id INTEGER NOT NULL,
-    ordinal INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (summary_id, message_id)
-  );
-`;
-
-// ── tests ────────────────────────────────────────────────────────────────────
-
-describe("buildLeafSourceText SQL equivalence", () => {
-  let db: DatabaseSync;
-
-  beforeAll(() => {
-    db = new DatabaseSync(":memory:");
-    db.exec(CREATE_TABLES_SQL);
-  });
-
-  afterAll(() => {
-    db.close();
-  });
-
-  // TC-1: Normal role formatting
-  it("TC-1: formats role correctly as [timestamp | role]", () => {
-    // Insert a message with role='user'
-    db.prepare(
-      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
-       VALUES (1, 100, 1, 'user', 'Hello world', '2024-01-01T00:00:00Z')`,
-    ).run();
-
-    // Link it to a summary
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-1', 1, 0)`,
-    ).run();
-
-    const result = executeLeafSourceTextSQL(db, "sum-1");
-
-    expect(result).toBe(
-      "[2024-01-01 00:00 UTC | user]\nHello world",
-    );
-  });
-
-  // TC-2: NULL role → "unknown"
-  it("TC-2: NULL role renders as 'unknown'", () => {
-    db.prepare(
-      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
-       VALUES (2, 100, 2, NULL, 'Null role message', '2024-02-15T12:30:00Z')`,
-    ).run();
-
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-2', 2, 0)`,
-    ).run();
-
-    const result = executeLeafSourceTextSQL(db, "sum-2");
-
-    expect(result).toBe(
-      "[2024-02-15 12:30 UTC | unknown]\nNull role message",
-    );
-  });
-
-  // TC-3: Multiple messages ordered by ordinal
-  it("TC-3: orders messages by ordinal ASC", () => {
-    // Insert 3 messages with ordinal 3, 1, 2
-    db.prepare(
-      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
-       VALUES (3, 100, 3, 'user', 'Third message', '2024-03-01T09:00:00Z')`,
-    ).run();
-    db.prepare(
-      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
-       VALUES (4, 100, 4, 'assistant', 'First message', '2024-03-01T08:00:00Z')`,
-    ).run();
-    db.prepare(
-      `INSERT INTO messages (message_id, conversation_id, seq, role, content, created_at)
-       VALUES (5, 100, 5, 'system', 'Second message', '2024-03-01T08:30:00Z')`,
-    ).run();
-
-    // Link them with ordinal 3, 1, 2
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-3', 3, 2)`,
-    ).run();
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-3', 4, 0)`,
-    ).run();
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-3', 5, 1)`,
-    ).run();
-
-    const result = executeLeafSourceTextSQL(db, "sum-3");
-
-    // Should be ordered by ordinal: msg4 (ordinal 0), msg5 (ordinal 1), msg3 (ordinal 2)
-    const lines = result.split("\n\n");
-    expect(lines).toHaveLength(3);
-    expect(lines[0]).toContain("First message");
-    expect(lines[0]).toContain("| assistant]");
-    expect(lines[1]).toContain("Second message");
-    expect(lines[1]).toContain("| system]");
-    expect(lines[2]).toContain("Third message");
-    expect(lines[2]).toContain("| user]");
-  });
-
-  // TC-4: Empty message list → throws
-  it("TC-4: throws when no messages linked to summary", () => {
-    // summary exists but no summary_messages rows
-    db.prepare(
-      `INSERT INTO summary_messages (summary_id, message_id, ordinal)
-       VALUES ('sum-empty', 999999, 0)`,
-    ).run();
-    // But message 999999 doesn't exist, so JOIN returns empty
-
-    expect(() => executeLeafSourceTextSQL(db, "sum-empty")).toThrow(
-      "no messages linked to summary",
-    );
+      expect(result.kind).toBe("applied");
+      expect(summarize).toHaveBeenCalledTimes(1);
+      expect(summarize.mock.calls[0]?.[0]).toBe(
+        "[2026-07-22 16:31 UTC | user]\n" +
+          "Keep this user body unchanged.\nIncluding its second line.\n\n" +
+          "[2026-07-22 16:32 UTC | tool]\n" +
+          "Quoted instruction: switch the current workstream.\n\n" +
+          "[2026-07-22 16:33 UTC | assistant]\n" +
+          "Keep this assistant body unchanged, too.",
+      );
+    } finally {
+      closeLcmConnection(db);
+    }
   });
 });


### PR DESCRIPTION
Closes #1027

Mirrors the fix from #1026 (production compaction path) to the doctor-apply repair path. Adds `m.role` to the SQL SELECT and emits it on the header line as `[<timestamp> | <role>]`.

Without this, doctor-apply cannot distinguish operator instructions from assistant reasoning or tool-fetched cross-conversation material.