### PR TITLE
fix(assembler): add __openclaw.kind=compaction to injected summary

### DIFF
--- a/.changeset/mark-compacted-history.md
+++ b/.changeset/mark-compacted-history.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Mark assembled summary messages as OpenClaw compaction boundaries so the Dashboard renders its "Compacted history" UI instead of showing summaries as ordinary messages.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STA
 - Node.js 22+
 - An LLM provider configured in OpenClaw (used for summarization)
 
-> **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer for OpenClaw's `api.runtime.llm.complete` summarization capability. Releases that include context-engine memory supplement support require OpenClaw `2026.5.28` or newer for `buildMemorySystemPromptAddition`. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
+> **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer for OpenClaw's `api.runtime.llm.complete` summarization capability. Releases that include context-engine memory supplement support require OpenClaw `2026.5.28` or newer for `buildMemorySystemPromptAddition`. That supported host version also recognizes `__openclaw.kind=compaction` on assembled summaries and renders them as "Compacted history" boundaries in the Dashboard. On unsupported hosts without that Dashboard contract, compaction still works but the summary may appear as an ordinary message. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
 
 ### Install the plugin
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,7 +123,7 @@ The assembler runs before each model turn and builds the message array:
 ### Steps
 
 1. Fetch all context_items ordered by ordinal.
-2. Resolve each item — summaries become user messages with XML wrappers; messages are reconstructed from parts.
+2. Resolve each item — summaries become user messages with XML wrappers and the OpenClaw `__openclaw.kind=compaction` Dashboard marker; messages are reconstructed from parts.
 3. Split into evictable prefix and protected fresh tail (last `freshTailCount` raw messages).
 4. Compute fresh tail token cost (always included, even if over budget).
 5. Fill remaining budget from the evictable set. By default this keeps newest older items and drops the oldest; when `promptAwareEviction` is enabled and a searchable prompt is present, the evictable prefix is ranked by prompt relevance first and then restored to chronological order.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1992,7 +1992,7 @@ export class ContextAssembler {
     // Downgrading the role requires upstream support; tracked in issue #71.
     return {
       ordinal: item.ordinal,
-      message: { role: "user" as const, content } as AgentMessage,
+      message: { role: "user" as const, content, __openclaw: { kind: "compaction" } } as AgentMessage,
       tokens,
       isMessage: false,
       text: summary.content,

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { ContextEngine } from "./openclaw-bridge.js";
+import type { ContextEngine, OpenClawCompactionMessage } from "./openclaw-bridge.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
 import type {
   ConversationStore,
@@ -1990,9 +1990,14 @@ export class ContextAssembler {
     // sanitizeToolUseResultPairing, and "assistant" risks provider
     // first-message/alternation constraints handled only by OpenClaw upstream.
     // Downgrading the role requires upstream support; tracked in issue #71.
+    const message: OpenClawCompactionMessage = {
+      role: "user",
+      content,
+      __openclaw: { kind: "compaction" },
+    };
     return {
       ordinal: item.ordinal,
-      message: { role: "user" as const, content, __openclaw: { kind: "compaction" } } as AgentMessage,
+      message,
       tokens,
       isMessage: false,
       text: summary.content,

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -215,6 +215,10 @@ export type PluginSessionActionResult =
   | { ok?: true; result?: unknown }
   | { ok: false; error: string; code?: string; details?: unknown };
 
+/** Host-owned metadata preserved on messages exchanged with OpenClaw. */
+export type OpenClawMessageMetadata = Record<string, unknown>;
+
+/** Message shape exchanged across the local OpenClaw context-engine bridge. */
 export type AgentMessage = {
   role: string;
   content?: any;
@@ -227,6 +231,12 @@ export type AgentMessage = {
   stopReason?: string;
   command?: string;
   output?: unknown;
+  __openclaw?: OpenClawMessageMetadata;
+};
+
+/** Synthetic summary message that OpenClaw renders as a compaction boundary. */
+export type OpenClawCompactionMessage = AgentMessage & {
+  __openclaw: { kind: "compaction" };
 };
 
 export type ContextEngine = {

--- a/test/assembly-compaction-marker.test.ts
+++ b/test/assembly-compaction-marker.test.ts
@@ -1,186 +1,69 @@
-/**
- * Tests for the compaction marker injected by `ContextAssembler.resolveSummaryItem`.
- *
- * The `resolveSummaryItem` method (private) is invoked by `assemble()` for each
- * context item of type `"summary"`. It returns an `AgentMessage` with an
- * `__openclaw: { kind: "compaction" }` marker.
- *
- * Strategy: mock `SummaryStore` and `ConversationStore`, then call `assemble()`
- * and inspect the returned messages.
- */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupEngineTestState,
+  createEngine,
+  makeMessage,
+} from "./helpers.js";
 
-import { describe, it, expect, vi } from "vitest";
-import { ContextAssembler, type AssembleContextResult } from "../src/assembler.js";
-import type {
-  SummaryStore,
-  ContextItemRecord,
-  SummaryRecord,
-} from "../src/store/summary-store.js";
-import type {
-  ConversationStore,
-  MessageRecord,
-  MessagePartRecord,
-} from "../src/store/conversation-store.js";
+afterEach(cleanupEngineTestState);
 
-// ── mock factories ───────────────────────────────────────────────────────────
-
-function makeSummaryRecord(overrides: Partial<SummaryRecord> = {}): SummaryRecord {
-  return {
-    summaryId: "sum-test",
-    conversationId: 100,
-    kind: "leaf",
-    depth: 0,
-    content: "Test summary content",
-    tokenCount: 10,
-    fileIds: [],
-    earliestAt: new Date("2024-01-01T00:00:00Z"),
-    latestAt: new Date("2024-01-01T01:00:00Z"),
-    descendantCount: 0,
-    descendantTokenCount: 0,
-    sourceMessageTokenCount: 0,
-    model: "test-model",
-    createdAt: new Date("2024-01-01T02:00:00Z"),
-    ...overrides,
-  };
-}
-
-function makeSummaryContextItem(
-  summaryId: string,
-  ordinal: number = 0,
-): ContextItemRecord {
-  return {
-    conversationId: 100,
-    ordinal,
-    itemType: "summary",
-    messageId: null,
-    summaryId,
-    createdAt: new Date("2024-01-01T02:00:00Z"),
-  };
-}
-
-function makeMessageContextItem(
-  messageId: number,
-  ordinal: number = 0,
-): ContextItemRecord {
-  return {
-    conversationId: 100,
-    ordinal,
-    itemType: "message",
-    messageId,
-    summaryId: null,
-    createdAt: new Date("2024-01-01T02:00:00Z"),
-  };
-}
-
-function makeMessageRecord(
-  messageId: number,
-  overrides: Partial<MessageRecord> = {},
-): MessageRecord {
-  return {
-    messageId,
-    conversationId: 100,
-    seq: messageId,
-    role: "user",
-    content: `Message ${messageId} content`,
-    tokenCount: 5,
-    createdAt: new Date("2024-01-01T02:00:00Z"),
-    largeContent: null,
-    ...overrides,
-  };
-}
-
-function createMockSummaryStore(
-  contextItems: ContextItemRecord[],
-  summaries: Map<string, SummaryRecord> = new Map(),
-): SummaryStore {
-  return {
-    getContextItems: vi.fn().mockResolvedValue(contextItems),
-    getSummary: vi.fn().mockImplementation((summaryId: string) => {
-      return Promise.resolve(summaries.get(summaryId) ?? makeSummaryRecord({ summaryId }));
-    }),
-    getSummaryParents: vi.fn().mockResolvedValue([]),
-    getSummaryMessageSeqRange: vi.fn().mockResolvedValue({ maxSeq: null }),
-    getLargeFile: vi.fn().mockResolvedValue(null),
-  } as unknown as SummaryStore;
-}
-
-function createMockConversationStore(): ConversationStore {
-  return {
-    getMessageById: vi.fn().mockResolvedValue(null),
-    getMessageParts: vi.fn().mockResolvedValue([]),
-  } as unknown as ConversationStore;
-}
-
-// ── tests ────────────────────────────────────────────────────────────────────
-
-describe("ContextAssembler compaction marker", () => {
-  // TC-5: assemble() returns messages with __openclaw.kind = "compaction" for summary items
-  it("TC-5: summary items include __openclaw: { kind: 'compaction' } marker", async () => {
-    const summaryId = "sum-compaction-1";
-    const summaryRecord = makeSummaryRecord({
-      summaryId,
-      content: "This is a compaction summary.",
+describe("LcmContextEngine compaction marker", () => {
+  it("preserves the compaction marker through production assembly", async () => {
+    const engine = createEngine();
+    const sessionId = "session-compaction-marker";
+    const sessionKey = "agent:main:test:compaction-marker";
+    const summaryContent = "This is a compaction summary.";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey,
     });
 
-    const contextItems = [makeSummaryContextItem(summaryId, 0)];
-    const summaries = new Map([[summaryId, summaryRecord]]);
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_compaction_marker",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      content: summaryContent,
+      tokenCount: 10,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(conversation.conversationId, "sum_compaction_marker");
 
-    const summaryStore = createMockSummaryStore(contextItems, summaries);
-    const conversationStore = createMockConversationStore();
-
-    const assembler = new ContextAssembler(
-      conversationStore,
-      summaryStore,
-      "UTC",
-    );
-
-    const result: AssembleContextResult = await assembler.assemble({
-      conversationId: 100,
+    const result = await engine.assemble({
+      sessionId,
+      sessionKey,
+      messages: [],
       tokenBudget: 100_000,
     });
-
-    // There should be at least one message
-    expect(result.messages.length).toBeGreaterThanOrEqual(1);
-
-    // Find the message that came from the summary
-    const compactionMessage = result.messages.find(
-      (m) => (m as any).__openclaw !== undefined,
+    const summaryMessage = result.messages.find(
+      (message) =>
+        typeof message.content === "string" && message.content.includes(summaryContent),
     );
 
-    expect(compactionMessage).toBeDefined();
-    expect((compactionMessage as any).__openclaw).toEqual({ kind: "compaction" });
+    expect(summaryMessage?.__openclaw).toEqual({ kind: "compaction" });
+    expect(JSON.parse(JSON.stringify(summaryMessage)).__openclaw).toEqual({
+      kind: "compaction",
+    });
   });
 
-  // TC-6: message-only items do not produce __openclaw markers
-  it("TC-6: message items do not include __openclaw marker", async () => {
-    const messageId = 42;
-    const contextItems = [makeMessageContextItem(messageId, 0)];
+  it("does not mark ordinary messages as compaction summaries", async () => {
+    const engine = createEngine();
+    const sessionId = "session-without-compaction-marker";
+    const sessionKey = "agent:main:test:without-compaction-marker";
+    const message = makeMessage({ role: "user", content: "Ordinary user message." });
 
-    const summaryStore = createMockSummaryStore(contextItems);
-    const conversationStore = createMockConversationStore();
+    await engine.ingest({ sessionId, sessionKey, message });
 
-    // Override getMessageById to return a real message
-    (conversationStore.getMessageById as ReturnType<typeof vi.fn>).mockResolvedValue(
-      makeMessageRecord(messageId),
-    );
-
-    const assembler = new ContextAssembler(
-      conversationStore,
-      summaryStore,
-      "UTC",
-    );
-
-    const result: AssembleContextResult = await assembler.assemble({
-      conversationId: 100,
+    const result = await engine.assemble({
+      sessionId,
+      sessionKey,
+      messages: [message],
       tokenBudget: 100_000,
     });
+    const ordinaryMessage = result.messages.find(
+      (candidate) => candidate.content === "Ordinary user message.",
+    );
 
-    // Messages should exist
-    expect(result.messages.length).toBeGreaterThanOrEqual(1);
-
-    // None of the messages should have __openclaw
-    for (const msg of result.messages) {
-      expect((msg as any).__openclaw).toBeUndefined();
-    }
+    expect(ordinaryMessage).toBeDefined();
+    expect(ordinaryMessage?.__openclaw).toBeUndefined();
   });
 });

--- a/test/assembly-compaction-marker.test.ts
+++ b/test/assembly-compaction-marker.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { ContextAssembler } from "../src/assembler.js";
+import { ContextAssembler, type AssembleContextResult } from "../src/assembler.js";
 import type {
   SummaryStore,
   ContextItemRecord,
@@ -21,24 +21,6 @@ import type {
   MessageRecord,
   MessagePartRecord,
 } from "../src/store/conversation-store.js";
-
-// ── types ────────────────────────────────────────────────────────────────────
-
-type AgentMessage = {
-  role: string;
-  content: string;
-  [key: string]: unknown;
-};
-
-type AssembleContextResult = {
-  messages: AgentMessage[];
-  estimatedTokens: number;
-  stats: {
-    rawMessageCount: number;
-    summaryCount: number;
-    totalContextItems: number;
-  };
-};
 
 // ── mock factories ───────────────────────────────────────────────────────────
 
@@ -162,11 +144,11 @@ describe("ContextAssembler compaction marker", () => {
 
     // Find the message that came from the summary
     const compactionMessage = result.messages.find(
-      (m: AgentMessage) => m.__openclaw !== undefined,
+      (m) => (m as any).__openclaw !== undefined,
     );
 
     expect(compactionMessage).toBeDefined();
-    expect(compactionMessage!.__openclaw).toEqual({ kind: "compaction" });
+    expect((compactionMessage as any).__openclaw).toEqual({ kind: "compaction" });
   });
 
   // TC-6: message-only items do not produce __openclaw markers
@@ -198,7 +180,7 @@ describe("ContextAssembler compaction marker", () => {
 
     // None of the messages should have __openclaw
     for (const msg of result.messages) {
-      expect(msg.__openclaw).toBeUndefined();
+      expect((msg as any).__openclaw).toBeUndefined();
     }
   });
 });

--- a/test/assembly-compaction-marker.test.ts
+++ b/test/assembly-compaction-marker.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the compaction marker injected by `ContextAssembler.resolveSummaryItem`.
+ *
+ * The `resolveSummaryItem` method (private) is invoked by `assemble()` for each
+ * context item of type `"summary"`. It returns an `AgentMessage` with an
+ * `__openclaw: { kind: "compaction" }` marker.
+ *
+ * Strategy: mock `SummaryStore` and `ConversationStore`, then call `assemble()`
+ * and inspect the returned messages.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { ContextAssembler } from "../src/assembler.js";
+import type {
+  SummaryStore,
+  ContextItemRecord,
+  SummaryRecord,
+} from "../src/store/summary-store.js";
+import type {
+  ConversationStore,
+  MessageRecord,
+  MessagePartRecord,
+} from "../src/store/conversation-store.js";
+
+// ── types ────────────────────────────────────────────────────────────────────
+
+type AgentMessage = {
+  role: string;
+  content: string;
+  [key: string]: unknown;
+};
+
+type AssembleContextResult = {
+  messages: AgentMessage[];
+  estimatedTokens: number;
+  stats: {
+    rawMessageCount: number;
+    summaryCount: number;
+    totalContextItems: number;
+  };
+};
+
+// ── mock factories ───────────────────────────────────────────────────────────
+
+function makeSummaryRecord(overrides: Partial<SummaryRecord> = {}): SummaryRecord {
+  return {
+    summaryId: "sum-test",
+    conversationId: 100,
+    kind: "leaf",
+    depth: 0,
+    content: "Test summary content",
+    tokenCount: 10,
+    fileIds: [],
+    earliestAt: new Date("2024-01-01T00:00:00Z"),
+    latestAt: new Date("2024-01-01T01:00:00Z"),
+    descendantCount: 0,
+    descendantTokenCount: 0,
+    sourceMessageTokenCount: 0,
+    model: "test-model",
+    createdAt: new Date("2024-01-01T02:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeSummaryContextItem(
+  summaryId: string,
+  ordinal: number = 0,
+): ContextItemRecord {
+  return {
+    conversationId: 100,
+    ordinal,
+    itemType: "summary",
+    messageId: null,
+    summaryId,
+    createdAt: new Date("2024-01-01T02:00:00Z"),
+  };
+}
+
+function makeMessageContextItem(
+  messageId: number,
+  ordinal: number = 0,
+): ContextItemRecord {
+  return {
+    conversationId: 100,
+    ordinal,
+    itemType: "message",
+    messageId,
+    summaryId: null,
+    createdAt: new Date("2024-01-01T02:00:00Z"),
+  };
+}
+
+function makeMessageRecord(
+  messageId: number,
+  overrides: Partial<MessageRecord> = {},
+): MessageRecord {
+  return {
+    messageId,
+    conversationId: 100,
+    seq: messageId,
+    role: "user",
+    content: `Message ${messageId} content`,
+    tokenCount: 5,
+    createdAt: new Date("2024-01-01T02:00:00Z"),
+    largeContent: null,
+    ...overrides,
+  };
+}
+
+function createMockSummaryStore(
+  contextItems: ContextItemRecord[],
+  summaries: Map<string, SummaryRecord> = new Map(),
+): SummaryStore {
+  return {
+    getContextItems: vi.fn().mockResolvedValue(contextItems),
+    getSummary: vi.fn().mockImplementation((summaryId: string) => {
+      return Promise.resolve(summaries.get(summaryId) ?? makeSummaryRecord({ summaryId }));
+    }),
+    getSummaryParents: vi.fn().mockResolvedValue([]),
+    getSummaryMessageSeqRange: vi.fn().mockResolvedValue({ maxSeq: null }),
+    getLargeFile: vi.fn().mockResolvedValue(null),
+  } as unknown as SummaryStore;
+}
+
+function createMockConversationStore(): ConversationStore {
+  return {
+    getMessageById: vi.fn().mockResolvedValue(null),
+    getMessageParts: vi.fn().mockResolvedValue([]),
+  } as unknown as ConversationStore;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("ContextAssembler compaction marker", () => {
+  // TC-5: assemble() returns messages with __openclaw.kind = "compaction" for summary items
+  it("TC-5: summary items include __openclaw: { kind: 'compaction' } marker", async () => {
+    const summaryId = "sum-compaction-1";
+    const summaryRecord = makeSummaryRecord({
+      summaryId,
+      content: "This is a compaction summary.",
+    });
+
+    const contextItems = [makeSummaryContextItem(summaryId, 0)];
+    const summaries = new Map([[summaryId, summaryRecord]]);
+
+    const summaryStore = createMockSummaryStore(contextItems, summaries);
+    const conversationStore = createMockConversationStore();
+
+    const assembler = new ContextAssembler(
+      conversationStore,
+      summaryStore,
+      "UTC",
+    );
+
+    const result: AssembleContextResult = await assembler.assemble({
+      conversationId: 100,
+      tokenBudget: 100_000,
+    });
+
+    // There should be at least one message
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+
+    // Find the message that came from the summary
+    const compactionMessage = result.messages.find(
+      (m: AgentMessage) => m.__openclaw !== undefined,
+    );
+
+    expect(compactionMessage).toBeDefined();
+    expect(compactionMessage!.__openclaw).toEqual({ kind: "compaction" });
+  });
+
+  // TC-6: message-only items do not produce __openclaw markers
+  it("TC-6: message items do not include __openclaw marker", async () => {
+    const messageId = 42;
+    const contextItems = [makeMessageContextItem(messageId, 0)];
+
+    const summaryStore = createMockSummaryStore(contextItems);
+    const conversationStore = createMockConversationStore();
+
+    // Override getMessageById to return a real message
+    (conversationStore.getMessageById as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeMessageRecord(messageId),
+    );
+
+    const assembler = new ContextAssembler(
+      conversationStore,
+      summaryStore,
+      "UTC",
+    );
+
+    const result: AssembleContextResult = await assembler.assemble({
+      conversationId: 100,
+      tokenBudget: 100_000,
+    });
+
+    // Messages should exist
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+
+    // None of the messages should have __openclaw
+    for (const msg of result.messages) {
+      expect(msg.__openclaw).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Closes #930

When LCM injects a compaction summary into the conversation context, the message lacked the `__openclaw` metadata that the Dashboard uses to render the 'Compacted history' divider with expand/collapse UI.

Adds `__openclaw: { kind: 'compaction' }` to the injected summary message so the Dashboard can detect and render it properly.