### PR TITLE
fix: see through injected plugin context on decorated current turns

### DIFF
--- a/.changeset/decorated-turn-injected-context-collapse.md
+++ b/.changeset/decorated-turn-injected-context-collapse.md
@@ -1,0 +1,17 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+See through plugin-injected context blocks on decorated channel turns.
+
+Memory/context plugins prepend blocks like `<relevant-memories>` to the
+model-facing body via `before_prompt_build`. On decorated channels those blocks
+sit between the inbound metadata prelude and the user body, which defeated both
+the same-turn body collapse and the current-turn live-face recognition: the
+memory-bearing live copy was neither collapsed onto its bare persisted row nor
+re-appended after assembly, so the injected context silently vanished from the
+outbound prompt. The inbound-body reduction now strips validated, complete
+leading injected-context tag blocks (known tag names only, fail-closed), and
+the structural current-turn recognizer accepts a metadata-decorated assembled
+face whose extracted body equals the live copy's extracted body (the last
+assembled user row and recognized-marker gates are unchanged).

--- a/.changeset/decorated-turn-injected-context-collapse.md
+++ b/.changeset/decorated-turn-injected-context-collapse.md
@@ -12,11 +12,12 @@ prelude and the user body, which defeated both the same-turn body collapse and
 the current-turn live-face recognition: the
 memory-bearing live copy was neither collapsed onto its bare persisted row nor
 re-appended after assembly, so the injected context silently vanished from the
-outbound prompt. The inbound-body reduction now strips validated, complete
-leading injected-context tag blocks (known tag names only, fail-closed), and
-the structural current-turn recognizer accepts a metadata-decorated assembled
-face whose extracted body equals the live copy's extracted body (the last
-assembled user row and recognized-marker gates are unchanged).
+outbound prompt. Anchored covered-frontier alignment now strips validated,
+complete leading injected-context tag blocks (known tag names only), while
+unanchored transcript adoption keeps user-authored tags verbatim. The
+structural current-turn recognizer also accepts a metadata-decorated assembled
+face whose extracted body exactly equals the live copy's extracted body (the
+last assembled user row and recognized-marker gates are unchanged).
 
 The line-form history recap matcher is now a linear line walker instead of a
 composite backtracking regex. The old pattern went catastrophic (minutes of

--- a/.changeset/decorated-turn-injected-context-collapse.md
+++ b/.changeset/decorated-turn-injected-context-collapse.md
@@ -17,3 +17,11 @@ leading injected-context tag blocks (known tag names only, fail-closed), and
 the structural current-turn recognizer accepts a metadata-decorated assembled
 face whose extracted body equals the live copy's extracted body (the last
 assembled user row and recognized-marker gates are unchanged).
+
+The line-form history recap matcher is now a linear line walker instead of a
+composite backtracking regex. The old pattern went catastrophic (minutes of
+event-loop blocking per call) on entry runs that fail the trailing terminator
+check while containing per-line ambiguity, a shape real group-chat recaps
+produce and which the reduction above newly exposes to routine traffic.
+Semantics are unchanged and pinned by tests, including the all-or-nothing
+fail-closed rejection of an unterminated run.

--- a/.changeset/decorated-turn-injected-context-collapse.md
+++ b/.changeset/decorated-turn-injected-context-collapse.md
@@ -5,9 +5,11 @@
 See through plugin-injected context blocks on decorated channel turns.
 
 Memory/context plugins prepend blocks like `<relevant-memories>` to the
-model-facing body via `before_prompt_build`. On decorated channels those blocks
-sit between the inbound metadata prelude and the user body, which defeated both
-the same-turn body collapse and the current-turn live-face recognition: the
+model-facing body via `before_prompt_build`, at prompt-build time — strictly
+after the bare transcript row is persisted, so persisted rows never carry
+them. On decorated channels those blocks sit between the inbound metadata
+prelude and the user body, which defeated both the same-turn body collapse and
+the current-turn live-face recognition: the
 memory-bearing live copy was neither collapsed onto its bare persisted row nor
 re-appended after assembly, so the injected context silently vanished from the
 outbound prompt. The inbound-body reduction now strips validated, complete

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -24,7 +24,7 @@ import {
 } from "./message-content.js";
 import { messageIdentity } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
-import { openClawInboundBodiesMatch } from "./openclaw-inbound-metadata.js";
+import { openClawInboundBodiesMatchWithInjectedContext } from "./openclaw-inbound-metadata.js";
 import type { ConversationStore, MessageRecord } from "./store/conversation-store.js";
 import { buildMessageIdentityHash } from "./store/message-identity.js";
 import type { LargeFileRecord, SummaryStore } from "./store/summary-store.js";
@@ -223,13 +223,14 @@ export class BatchDeduplicator {
         return true;
       }
     }
-    // A metadata block alone is user-forgeable, so body equality after stripping
-    // it is not proof of same-turn decoration. Covered-frontier callers may use
-    // this no-timestamp match only as alignment support; another exact or
-    // timestamp-backed row must still anchor the slice.
+    // Metadata blocks and injected-context tags are user-forgeable, so body
+    // equality after stripping them is not proof of same-turn decoration.
+    // Covered-frontier callers may use this no-timestamp match only as
+    // alignment support; another exact or timestamp-backed row must still
+    // anchor the slice.
     if (
       options?.allowUntimestampedInboundBodyMatch === true &&
-      openClawInboundBodiesMatch(batchContent, persistedContent)
+      openClawInboundBodiesMatchWithInjectedContext(batchContent, persistedContent)
     ) {
       return true;
     }

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -7,7 +7,10 @@ import { contentFromParts } from "./assembler.js";
 import { buildMessageParts, toStoredMessage, toSyntheticMessagePartRecord } from "./message-content.js";
 import { createLiveCoverageSignature, hashAgentMessageForAssemblyProtection, messagesHaveSameLiveCoverageSignature } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
-import { stripLeadingOpenClawInboundTimestamp } from "./openclaw-inbound-metadata.js";
+import {
+  extractBodyAfterOpenClawInboundMetadataBlock,
+  stripLeadingOpenClawInboundTimestamp,
+} from "./openclaw-inbound-metadata.js";
 import { estimateAgentMessageTokens } from "./token-accounting.js";
 import { buildToolPairIndexesByAssembledIndex, expandProtectedToolPairIndexes, expandToolPairLiveSortIndexes } from "./tool-pairing.js";
 import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
@@ -668,6 +671,30 @@ function assembledRowIsStructuralBareCurrentTurn(params: {
     })
   ) {
     return true;
+  }
+  // Decorated channels can persist the metadata-decorated face itself as the
+  // current-turn row. Injected plugin blocks on the live side then interpose
+  // between the metadata prelude and the body, so raw containment fails even
+  // though both faces reduce to the same body. Reduce BOTH through the
+  // metadata extraction (which strips timestamp, metadata, recap, and
+  // validated injected blocks) and require full-body equality — still gated
+  // on the last assembled user row plus a recognized injected marker.
+  if (
+    params.assembledIsLastUserRow &&
+    liveContentCarriesRecognizedInjectedContextMarker(params.liveContent)
+  ) {
+    const liveBody = extractBodyAfterOpenClawInboundMetadataBlock(params.liveContent.trimStart());
+    const assembledBody = extractBodyAfterOpenClawInboundMetadataBlock(
+      params.assembledContent.trimStart(),
+    );
+    if (
+      liveBody !== null &&
+      assembledBody !== null &&
+      liveBody.trim().length > 0 &&
+      liveBody.trim() === assembledBody.trim()
+    ) {
+      return true;
+    }
   }
   return liveContentIsRecognizedDecoratedBareBody({
     liveContent: params.liveContent,

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -8,8 +8,8 @@ import { buildMessageParts, toStoredMessage, toSyntheticMessagePartRecord } from
 import { createLiveCoverageSignature, hashAgentMessageForAssemblyProtection, messagesHaveSameLiveCoverageSignature } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
 import {
-  extractBodyAfterOpenClawInboundMetadataBlock,
   OPENCLAW_INJECTED_CONTEXT_TAG_NAMES,
+  openClawInboundDecoratedBodiesMatch,
   stripLeadingOpenClawInboundTimestamp,
 } from "./openclaw-inbound-metadata.js";
 import { estimateAgentMessageTokens } from "./token-accounting.js";
@@ -624,15 +624,11 @@ function liveContentCarriesRecognizedInjectedContextMarker(liveContent: string):
 
 /**
  * Recognize whether an assembled user row is a BARE copy of the live current
- * turn (its persisted face): it must be a line-aligned trailing segment of the
- * live content, strictly shorter than it, AND the live content must carry
- * recognized decoration evidence -- EITHER a channel timestamp (see
- * liveContentIsRecognizedDecoratedBareBody) OR a recognized injected-context
- * marker (memory-first turns are not always channel-timestamped). The
- * strictly-shorter guard distinguishes a bare/timestamped body row from the
- * decorated live copy itself (equal length, never collapsed); the decoration
- * gate prevents collapsing an unrelated turn that merely ends with the same
- * trailing line.
+ * turn (its persisted face). A marker-bearing current row may either be a
+ * line-aligned trailing body or a metadata-decorated face that reduces to the
+ * exact same body. Timestamp decoration uses the existing structural matcher.
+ * Every recognized row must be strictly shorter than the live copy, which
+ * distinguishes it from that copy itself.
  *
  * Marker presence is not treated as proof of provenance. Some recognized
  * plugin tags are ordinary user-typeable text and are stripped from stored
@@ -660,36 +656,13 @@ function assembledRowIsStructuralBareCurrentTurn(params: {
   if (
     params.assembledIsLastUserRow &&
     liveContentCarriesRecognizedInjectedContextMarker(params.liveContent) &&
-    liveContentContainsBareBody({
+    (liveContentContainsBareBody({
       liveContent: params.liveContent,
       bareContent: params.assembledContent,
-    })
+    }) ||
+      openClawInboundDecoratedBodiesMatch(params.liveContent, params.assembledContent))
   ) {
     return true;
-  }
-  // Decorated channels can persist the metadata-decorated face itself as the
-  // current-turn row. Injected plugin blocks on the live side then interpose
-  // between the metadata prelude and the body, so raw containment fails even
-  // though both faces reduce to the same body. Reduce BOTH through the
-  // metadata extraction (which strips timestamp, metadata, recap, and
-  // validated injected blocks) and require full-body equality — still gated
-  // on the last assembled user row plus a recognized injected marker.
-  if (
-    params.assembledIsLastUserRow &&
-    liveContentCarriesRecognizedInjectedContextMarker(params.liveContent)
-  ) {
-    const liveBody = extractBodyAfterOpenClawInboundMetadataBlock(params.liveContent.trimStart());
-    const assembledBody = extractBodyAfterOpenClawInboundMetadataBlock(
-      params.assembledContent.trimStart(),
-    );
-    if (
-      liveBody !== null &&
-      assembledBody !== null &&
-      liveBody.trim().length > 0 &&
-      liveBody.trim() === assembledBody.trim()
-    ) {
-      return true;
-    }
   }
   return liveContentIsRecognizedDecoratedBareBody({
     liveContent: params.liveContent,

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -9,6 +9,7 @@ import { createLiveCoverageSignature, hashAgentMessageForAssemblyProtection, mes
 import type { AgentMessage } from "./openclaw-bridge.js";
 import {
   extractBodyAfterOpenClawInboundMetadataBlock,
+  OPENCLAW_INJECTED_CONTEXT_TAG_NAMES,
   stripLeadingOpenClawInboundTimestamp,
 } from "./openclaw-inbound-metadata.js";
 import { estimateAgentMessageTokens } from "./token-accounting.js";
@@ -613,13 +614,7 @@ export function liveContentIsRecognizedDecoratedBareBody(params: {
  * assembledRowIsStructuralBareCurrentTurn).
  */
 const INJECTED_CONTEXT_MARKERS = [
-  "<relevant-memories>",
-  "<relevant_memories>",
-  "<hindsight_memories>",
-  "<inherited-rules>",
-  "<derived-focus>",
-  "<error-detected>",
-  "<active_memory_plugin>",
+  ...OPENCLAW_INJECTED_CONTEXT_TAG_NAMES.map((tag) => `<${tag}>` as const),
   INTERNAL_CONTEXT_BEGIN_MARKER,
 ] as const;
 

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -56,26 +56,107 @@ const OPENCLAW_INBOUND_HISTORY_RECAP_BLOCK_RE = new RegExp(
 // "<sender>: <content>". A line carrying NEITHER token is indistinguishable
 // from ordinary prose, so it is deliberately excluded from recognition here
 // (fail-closed: at least one anchor token is required).
-const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ID_TOKEN = String.raw`#\S+`;
-const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_TOKEN =
-  String.raw`[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+`;
-const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ENTRY_SRC = String.raw`(?:${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ID_TOKEN} ${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_TOKEN} |${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ID_TOKEN} |${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_TOKEN} ).+: .+`;
+const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ID_PREFIX_RE = /^#\S+ /;
+const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_PREFIX_RE =
+  /^[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+ /;
 
 // Unlike the JSON form (self-delimiting via the closing fence), prose lines
 // have no hard terminator: the real emitter just stops emitting lines, and
 // buildInboundUserContextPrefix joins every block (including this one) with
 // blocks.filter(Boolean).join("\n\n"). So the only structurally valid ways
 // for a run of entry lines to end are a blank-line block separator or end of
-// content; the trailing lookahead enforces that. A run that peters out into
-// anything else (a line that is neither a valid entry nor a blank separator)
-// fails the WHOLE match, so it is never partially stripped up to that point.
-const OPENCLAW_INBOUND_HISTORY_RECAP_LINE_BLOCK_RE = new RegExp(
-  `^${OPENCLAW_INBOUND_HISTORY_RECAP_HEADER_SRC}` +
-    String.raw`\r?\n` +
-    `(?:${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ENTRY_SRC})` +
-    `(?:\r?\n(?:${OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ENTRY_SRC}))*` +
-    String.raw`(?=\r?\n\r?\n|\r?\n?$)`,
-);
+// content. A run that peters out into anything else (a line that is neither a
+// valid entry nor a blank separator) fails the WHOLE match, so it is never
+// partially stripped up to that point.
+//
+// Deliberately implemented as a line walker rather than one composite
+// `(?:ENTRY)(?:\r?\n(?:ENTRY))*(?=terminator)` regex: entry lines are
+// internally ambiguous (three optional-prefix alternates, sender/content
+// split at any ": "), so on a long run whose terminator check fails the
+// backtracking engine explores the cross-product of every per-line ambiguity
+// and goes catastrophic (minutes of blocking on a ~200-entry colon-heavy
+// recap; the shape real group chats produce whenever a recap entry contains
+// its own newlines). A shorter run can never satisfy the terminator that the
+// maximal run failed (the next char after an intermediate entry is always its
+// successor line, never a blank separator or end), so the walk is all-or-
+// nothing greedy and strictly linear.
+function matchLeadingOpenClawInboundHistoryRecapLineBlock(candidate: string): number {
+  const header = OPENCLAW_INBOUND_HISTORY_RECAP_HEADERS.find((headerText) =>
+    candidate.startsWith(headerText),
+  );
+  if (header === undefined) {
+    return 0;
+  }
+  let cursor = header.length;
+  if (candidate.startsWith("\r\n", cursor)) {
+    cursor += 2;
+  } else if (candidate.startsWith("\n", cursor)) {
+    cursor += 1;
+  } else {
+    return 0;
+  }
+
+  let matchedEnd = -1;
+  while (cursor < candidate.length) {
+    const newlineIndex = candidate.indexOf("\n", cursor);
+    let lineTextEnd = newlineIndex === -1 ? candidate.length : newlineIndex;
+    if (lineTextEnd > cursor && candidate.charCodeAt(lineTextEnd - 1) === 13) {
+      lineTextEnd -= 1;
+    }
+    if (!isOpenClawInboundHistoryRecapEntryLine(candidate.slice(cursor, lineTextEnd))) {
+      break;
+    }
+    matchedEnd = lineTextEnd;
+    if (newlineIndex === -1) {
+      break;
+    }
+    cursor = newlineIndex + 1;
+  }
+  if (matchedEnd < 0) {
+    return 0;
+  }
+
+  const rest = candidate.slice(matchedEnd);
+  const terminated =
+    rest.length === 0 ||
+    rest === "\n" ||
+    rest === "\r\n" ||
+    rest.startsWith("\n\n") ||
+    rest.startsWith("\n\r\n") ||
+    rest.startsWith("\r\n\n") ||
+    rest.startsWith("\r\n\r\n");
+  return terminated ? matchedEnd : 0;
+}
+
+// "<sender>: <content>" with both sides non-empty: at least one character
+// before the first eligible ": " and at least one after it. (A CR-only
+// content survives the composite-regex form via `.` matching \r; the walker
+// treats it as empty and rejects -- the conservative direction.)
+function recapEntryLineHasSenderAndContent(remainder: string): boolean {
+  const separatorIndex = remainder.indexOf(": ", 1);
+  return separatorIndex !== -1 && separatorIndex + 2 < remainder.length;
+}
+
+function isOpenClawInboundHistoryRecapEntryLine(line: string): boolean {
+  const idMatch = OPENCLAW_INBOUND_HISTORY_RECAP_LINE_ID_PREFIX_RE.exec(line);
+  if (idMatch) {
+    const afterId = line.slice(idMatch[0].length);
+    const timestampMatch =
+      OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_PREFIX_RE.exec(afterId);
+    if (
+      timestampMatch &&
+      recapEntryLineHasSenderAndContent(afterId.slice(timestampMatch[0].length))
+    ) {
+      return true;
+    }
+    return recapEntryLineHasSenderAndContent(afterId);
+  }
+  const timestampMatch = OPENCLAW_INBOUND_HISTORY_RECAP_LINE_TIMESTAMP_PREFIX_RE.exec(line);
+  return (
+    timestampMatch !== null &&
+    recapEntryLineHasSenderAndContent(line.slice(timestampMatch[0].length))
+  );
+}
 
 // OpenClaw-version-coupled inbound decoration string: the header an OpenClaw
 // runtime prepends to a user turn that carries an ambient room event (channel
@@ -583,8 +664,7 @@ function matchLeadingOpenClawInboundHistoryRecap(candidate: string): number {
   if (jsonMatch) {
     return isValidOpenClawInboundHistoryRecapPayload(jsonMatch[1] ?? "") ? jsonMatch[0].length : 0;
   }
-  const lineMatch = OPENCLAW_INBOUND_HISTORY_RECAP_LINE_BLOCK_RE.exec(candidate);
-  return lineMatch ? lineMatch[0].length : 0;
+  return matchLeadingOpenClawInboundHistoryRecapLineBlock(candidate);
 }
 
 function canonicalizeMetadataJson(

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -472,11 +472,12 @@ function hasOpenClawInboundHistory(record: Record<string, unknown>): boolean {
 // Injected-context tag blocks that memory/context plugins prepend to the
 // model-facing body via before_prompt_build. On decorated channels they sit
 // between the metadata prelude and the user body on the RUNTIME face only;
-// persisted rows never carry them (stripped at persist), so reducing them off
-// the runtime side is what lets the same-turn collapse see through a
-// memory-bearing decorated copy. Only a COMPLETE <tag>...</tag> block for
-// these exact names is stripped; an unclosed or unknown tag stays in the body
-// and blocks the match (fail-closed).
+// persisted rows never carry them (plugins inject at prompt-build, strictly
+// after the bare row is persisted), so reducing them off the runtime side is
+// what lets the same-turn collapse see through a memory-bearing decorated
+// copy. Only a COMPLETE <tag>...</tag> block for these exact names is
+// stripped; an unclosed or unknown tag stays in the body and blocks the match
+// (fail-closed).
 // Exported as the single source of truth for injected-context TAG names:
 // live-coverage.ts derives its marker-recognition list from this same const,
 // so the reduction here and the recognition gate there can never disagree on

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -208,6 +208,16 @@ export function contentBeginsWithOpenClawInboundMetadataBlock(content: string): 
  * prelude, or null when the content does not begin with one.
  */
 export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): string | null {
+  return extractBodyAfterOpenClawInboundMetadataBlockWithPolicy(content, true);
+}
+
+// Shared metadata/recap reduction. The body matcher first disables injected
+// stripping to preserve an exact user-authored-tag match, then enables it as
+// the plugin-injection fallback.
+function extractBodyAfterOpenClawInboundMetadataBlockWithPolicy(
+  content: string,
+  stripInjectedContext: boolean,
+): string | null {
   const afterTimestamp = stripLeadingOpenClawInboundTimestamp(content.trimStart());
   const { metadataCandidate } = splitOpenClawInboundMetadataPrelude(afterTimestamp);
   const firstCandidate = metadataCandidate.trimStart();
@@ -233,7 +243,9 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
     remaining = secondCandidate.slice(secondMatch[0].length);
   }
 
-  remaining = stripLeadingInjectedContextTagBlocks(remaining);
+  if (stripInjectedContext) {
+    remaining = stripLeadingInjectedContextTagBlocks(remaining);
+  }
   if (hasOpenClawInboundHistory(firstRecord)) {
     const contextSplit = splitLeadingOpenClawInboundContextBlocks(remaining);
     const recapCandidate = contextSplit.remaining.trimStart();
@@ -242,7 +254,9 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
       remaining = recapCandidate.slice(recapLength);
     }
   }
-  remaining = stripLeadingInjectedContextTagBlocks(remaining);
+  if (stripInjectedContext) {
+    remaining = stripLeadingInjectedContextTagBlocks(remaining);
+  }
 
   return stripMetadataSeparator(remaining);
 }
@@ -259,6 +273,30 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
  * different body is never treated as the same turn (fail-closed).
  */
 export function openClawInboundBodiesMatch(liveContent: string, bareContent: string): boolean {
+  const bareBody = stripLeadingOpenClawInboundTimestamp(bareContent);
+  const exactLiveBodyAfterMetadata = extractBodyAfterOpenClawInboundMetadataBlockWithPolicy(
+    liveContent,
+    false,
+  );
+  if (exactLiveBodyAfterMetadata === null) {
+    return false;
+  }
+  const exactLiveBody = stripLeadingOpenClawInboundTimestamp(exactLiveBodyAfterMetadata);
+  return exactLiveBody.trim().length > 0 && exactLiveBody === bareBody;
+}
+
+/**
+ * Match after stripping known injected-context blocks from the runtime face.
+ * Use only where another strong signal proves the aligned rows are the same
+ * turn, because the tag names themselves are user-typeable.
+ */
+export function openClawInboundBodiesMatchWithInjectedContext(
+  liveContent: string,
+  bareContent: string,
+): boolean {
+  if (openClawInboundBodiesMatch(liveContent, bareContent)) {
+    return true;
+  }
   const liveBodyAfterMetadata = extractBodyAfterOpenClawInboundMetadataBlock(liveContent);
   if (liveBodyAfterMetadata === null) {
     return false;
@@ -266,6 +304,29 @@ export function openClawInboundBodiesMatch(liveContent: string, bareContent: str
   const liveBody = stripLeadingOpenClawInboundTimestamp(liveBodyAfterMetadata);
   const bareBody = stripLeadingOpenClawInboundTimestamp(bareContent);
   return liveBody.trim().length > 0 && liveBody === bareBody;
+}
+
+/**
+ * True when a live metadata-decorated face reduces to the same non-empty body
+ * as an assembled face. Injected tags are stripped only from the live side;
+ * the assembled side stays verbatim because those tags are user-typeable.
+ * Use only after the caller proves both faces belong to the current turn.
+ */
+export function openClawInboundDecoratedBodiesMatch(
+  liveContent: string,
+  assembledContent: string,
+): boolean {
+  const liveBody = extractBodyAfterOpenClawInboundMetadataBlock(liveContent);
+  const assembledBody = extractBodyAfterOpenClawInboundMetadataBlockWithPolicy(
+    assembledContent,
+    false,
+  );
+  return (
+    liveBody !== null &&
+    assembledBody !== null &&
+    liveBody.trim().length > 0 &&
+    liveBody === assembledBody
+  );
 }
 
 const CONVERSATION_INFO_KEYS = new Set([

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -152,6 +152,7 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
     remaining = secondCandidate.slice(secondMatch[0].length);
   }
 
+  remaining = stripLeadingInjectedContextTagBlocks(remaining);
   if (hasOpenClawInboundHistory(firstRecord)) {
     const contextSplit = splitLeadingOpenClawInboundContextBlocks(remaining);
     const recapCandidate = contextSplit.remaining.trimStart();
@@ -160,6 +161,7 @@ export function extractBodyAfterOpenClawInboundMetadataBlock(content: string): s
       remaining = recapCandidate.slice(recapLength);
     }
   }
+  remaining = stripLeadingInjectedContextTagBlocks(remaining);
 
   return stripMetadataSeparator(remaining);
 }
@@ -465,6 +467,43 @@ function parseOpenClawInboundMetadataRecord(
 function hasOpenClawInboundHistory(record: Record<string, unknown>): boolean {
   const historyCount = record.history_count;
   return typeof historyCount === "number" && Number.isInteger(historyCount) && historyCount > 0;
+}
+
+// Injected-context tag blocks that memory/context plugins prepend to the
+// model-facing body via before_prompt_build. On decorated channels they sit
+// between the metadata prelude and the user body on the RUNTIME face only;
+// persisted rows never carry them (stripped at persist), so reducing them off
+// the runtime side is what lets the same-turn collapse see through a
+// memory-bearing decorated copy. Only a COMPLETE <tag>...</tag> block for
+// these exact names is stripped; an unclosed or unknown tag stays in the body
+// and blocks the match (fail-closed).
+const OPENCLAW_INJECTED_CONTEXT_TAG_NAMES = [
+  "relevant-memories",
+  "relevant_memories",
+  "hindsight_memories",
+  "inherited-rules",
+  "derived-focus",
+  "error-detected",
+  "active_memory_plugin",
+] as const;
+
+function stripLeadingInjectedContextTagBlocks(content: string): string {
+  let remaining = content;
+  while (true) {
+    const candidate = remaining.trimStart();
+    const name = OPENCLAW_INJECTED_CONTEXT_TAG_NAMES.find((tag) =>
+      candidate.startsWith(`<${tag}>`),
+    );
+    if (name === undefined) {
+      return remaining;
+    }
+    const closeTag = `</${name}>`;
+    const closeIndex = candidate.indexOf(closeTag);
+    if (closeIndex < 0) {
+      return remaining;
+    }
+    remaining = candidate.slice(closeIndex + closeTag.length);
+  }
 }
 
 function splitLeadingOpenClawInboundContextBlocks(content: string): {

--- a/src/openclaw-inbound-metadata.ts
+++ b/src/openclaw-inbound-metadata.ts
@@ -477,7 +477,11 @@ function hasOpenClawInboundHistory(record: Record<string, unknown>): boolean {
 // memory-bearing decorated copy. Only a COMPLETE <tag>...</tag> block for
 // these exact names is stripped; an unclosed or unknown tag stays in the body
 // and blocks the match (fail-closed).
-const OPENCLAW_INJECTED_CONTEXT_TAG_NAMES = [
+// Exported as the single source of truth for injected-context TAG names:
+// live-coverage.ts derives its marker-recognition list from this same const,
+// so the reduction here and the recognition gate there can never disagree on
+// which tags count as injected plugin context.
+export const OPENCLAW_INJECTED_CONTEXT_TAG_NAMES = [
   "relevant-memories",
   "relevant_memories",
   "hindsight_memories",

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -123,6 +123,21 @@ function toolResultMessage(content: string, toolCallId: string): AgentMessage {
   } as AgentMessage;
 }
 
+function metadataWrappedWithInjectedContext(body: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({ chat_id: "telegram:100000001", sender: "sam.rivera" }, null, 2),
+    "```",
+    "",
+    "<derived-focus>",
+    "injected focus",
+    "</derived-focus>",
+    "",
+    body,
+  ].join("\n");
+}
+
 describe("BatchDeduplicator.deduplicateAfterTurnBatch", () => {
   it("returns an empty batch unchanged", async () => {
     const dedup = makeDedup({ conversationId: 1, messages: [] });
@@ -404,6 +419,46 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     });
     const batch = [makeMessage({ role: "user", content: decoratedContent })];
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+    expect(result).toEqual([]);
+  });
+
+  it("keeps an injected-context body match when no strong frontier anchor exists", async () => {
+    const bareContent = "please summarize";
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [storedMessage("user", bareContent)],
+    });
+    const batch = [
+      makeMessage({
+        role: "user",
+        content: metadataWrappedWithInjectedContext(bareContent),
+      }),
+    ];
+
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+
+    expect(result).toEqual(batch);
+  });
+
+  it("uses an injected-context body match only alongside a strong frontier anchor", async () => {
+    const bareContent = "please summarize";
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [
+        storedMessage("assistant", "prior exact reply", 1),
+        { ...storedMessage("user", bareContent, 2), seq: 1 },
+      ],
+    });
+    const batch = [
+      makeMessage({ role: "assistant", content: "prior exact reply" }),
+      makeMessage({
+        role: "user",
+        content: metadataWrappedWithInjectedContext(bareContent),
+      }),
+    ];
+
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
+
     expect(result).toEqual([]);
   });
 

--- a/test/inbound-recap-line-matcher.test.ts
+++ b/test/inbound-recap-line-matcher.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractBodyAfterOpenClawInboundMetadataBlock,
+  openClawInboundBodiesMatch,
+} from "../src/openclaw-inbound-metadata.js";
+
+const RECAP_HEADER = "Chat history since last reply (untrusted, for context):";
+const TS = "Sat 2026-07-25 14:05:00 GMT+3";
+const BODY = "final body line for the current turn";
+
+function metadataPrelude(): string {
+  const conversation = {
+    chat_id: "slack:channel:c0example01",
+    sender: "sam.rivera",
+    history_count: 30,
+  };
+  return (
+    "Conversation info (untrusted metadata):\n```json\n" +
+    JSON.stringify(conversation, null, 2) +
+    "\n```"
+  );
+}
+
+function face(afterMetadata: string): string {
+  return `${metadataPrelude()}\n\n${afterMetadata}`;
+}
+
+describe("line-form history recap matching stays linear (no backtracking blowup)", () => {
+  it("rejects a colon-heavy unterminated entry run in bounded time", () => {
+    // The composite-regex form of this matcher went catastrophic on exactly
+    // this shape: a run of internally ambiguous entry lines (three optional
+    // prefix alternates, sender/content split at any ": ") that fails the
+    // trailing terminator check. Even ~15 such entries exceeded 90s per call;
+    // the line walker rejects in well under a millisecond.
+    const lines: string[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      lines.push(`#10${i} ${TS} sam.rivera: status: ok: retry: none: queue: ${i}: still: fine`);
+    }
+    lines.push("a continuation line with no anchor token that breaks the run");
+    const recap = `${RECAP_HEADER}\n${lines.join("\n")}`;
+
+    const startedAt = process.hrtime.bigint();
+    const matched = openClawInboundBodiesMatch(face(`${recap}\n\n${BODY}`), BODY);
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+    expect(matched).toBe(false);
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});
+
+describe("line-form history recap walker semantics", () => {
+  it("strips a well-formed run mixing all three entry anchor shapes", () => {
+    const recap = [
+      RECAP_HEADER,
+      `#201 ${TS} sam.rivera: queue item one looks fine`,
+      "#202 lee.chen: replying without a timestamp",
+      `${TS} sam.rivera: untagged line with content`,
+    ].join("\n");
+    expect(extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\n\n${BODY}`))).toBe(BODY);
+  });
+
+  it("strips a run that ends at end of content, with or without a trailing newline", () => {
+    const recap = `${RECAP_HEADER}\n#201 ${TS} sam.rivera: queue item one looks fine`;
+    expect(extractBodyAfterOpenClawInboundMetadataBlock(face(recap))).toBe("");
+    expect(extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\n`))).toBe("");
+  });
+
+  it("strips a CRLF-delimited run", () => {
+    const recap = [
+      RECAP_HEADER,
+      `#201 ${TS} sam.rivera: queue item one looks fine`,
+      "#202 lee.chen: second entry line",
+    ].join("\r\n");
+    expect(extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\r\n\r\n${BODY}`))).toBe(
+      BODY,
+    );
+  });
+
+  it("strips nothing when the run peters out into an unanchored line", () => {
+    const recap = [
+      RECAP_HEADER,
+      `#201 ${TS} sam.rivera: queue item one looks fine`,
+      "a continuation line with no anchor token",
+    ].join("\n");
+    const extracted = extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\n\n${BODY}`));
+    expect(extracted).toContain(RECAP_HEADER);
+    expect(openClawInboundBodiesMatch(face(`${recap}\n\n${BODY}`), BODY)).toBe(false);
+  });
+
+  it("stops at an internal blank line and never conceals the remainder", () => {
+    const recap = [
+      RECAP_HEADER,
+      `#201 ${TS} sam.rivera: queue item one looks fine`,
+      "",
+      `#202 ${TS} lee.chen: entry after an internal blank separator`,
+    ].join("\n");
+    const extracted = extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\n\n${BODY}`));
+    expect(extracted).toContain("entry after an internal blank separator");
+    expect(openClawInboundBodiesMatch(face(`${recap}\n\n${BODY}`), BODY)).toBe(false);
+  });
+
+  it("strips nothing for a header with no entry lines", () => {
+    const extracted = extractBodyAfterOpenClawInboundMetadataBlock(
+      face(`${RECAP_HEADER}\n\n${BODY}`),
+    );
+    expect(extracted).toContain(RECAP_HEADER);
+  });
+
+  it("strips nothing for an entry line whose sender/content split is missing", () => {
+    const recap = `${RECAP_HEADER}\n#201 ${TS} a line without the separator`;
+    const extracted = extractBodyAfterOpenClawInboundMetadataBlock(face(`${recap}\n\n${BODY}`));
+    expect(extracted).toContain(RECAP_HEADER);
+  });
+});

--- a/test/inbound-recap-line-matcher.test.ts
+++ b/test/inbound-recap-line-matcher.test.ts
@@ -45,7 +45,31 @@ describe("line-form history recap matching stays linear (no backtracking blowup)
     const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
 
     expect(matched).toBe(false);
-    expect(elapsedMs).toBeLessThan(2000);
+    // Measured ~0.1ms for this shape. The ceiling is deliberately far above
+    // that so a loaded CI runner cannot flake, but three orders of magnitude
+    // BELOW the old 2s bound, which a mild (non-catastrophic) backtracking
+    // regression of a few hundred ms per call would have passed.
+    expect(elapsedMs).toBeLessThan(250);
+  });
+
+  it("stays under the same ceiling when the entry run grows 64x (linear, not quadratic)", () => {
+    // An absolute ceiling alone cannot tell linear from quadratic. Growing the
+    // run to 2560 entries does: measured ~1ms (the walker visits each line
+    // once), whereas a quadratic reintroduction would land in the hundreds of
+    // ms from the same 0.1ms base, and a catastrophic one would not return.
+    const lines: string[] = [];
+    for (let i = 0; i < 2560; i += 1) {
+      lines.push(`#10${i} ${TS} sam.rivera: status: ok: retry: none: queue: ${i}: still: fine`);
+    }
+    lines.push("a continuation line with no anchor token that breaks the run");
+    const recap = `${RECAP_HEADER}\n${lines.join("\n")}`;
+
+    const startedAt = process.hrtime.bigint();
+    const matched = openClawInboundBodiesMatch(face(`${recap}\n\n${BODY}`), BODY);
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+    expect(matched).toBe(false);
+    expect(elapsedMs).toBeLessThan(250);
   });
 });
 

--- a/test/live-turn-structural-supersede.test.ts
+++ b/test/live-turn-structural-supersede.test.ts
@@ -1032,4 +1032,50 @@ describe("appendUncoveredVolatileLiveInputsWithinBudget: decorated channel turn 
     expect(userContents).toHaveLength(2);
     expect(userContents).not.toContain(liveDecorated);
   });
+
+  it("does NOT append when bodies differ only by user-authored whitespace (fail-closed)", () => {
+    const assembledMessages: AgentMessage[] = [
+      { role: "user", content: "earlier persisted turn" },
+      { role: "assistant", content: "earlier reply" },
+      { role: "user", content: metadataDecorated(` ${CHANNEL_BODY} `) },
+    ] as AgentMessage[];
+    const liveMessages: AgentMessage[] = [{ role: "user", content: liveDecorated }] as AgentMessage[];
+
+    const result = appendUncoveredVolatileLiveInputsWithinBudget({
+      assembledMessages,
+      assembledEstimatedTokens: 10,
+      liveMessages,
+      tokenBudget: 1_000_000,
+    });
+
+    const userContents = result.messages
+      .filter((message) => (message as { role: string }).role === "user")
+      .map((message) => (message as { content: string }).content);
+    expect(userContents).toHaveLength(2);
+    expect(userContents).not.toContain(liveDecorated);
+  });
+
+  it("does NOT strip a user-authored known tag from the assembled face", () => {
+    const assembledBody =
+      "<derived-focus>\nuser-authored note\n</derived-focus>\n\n" + CHANNEL_BODY;
+    const assembledMessages: AgentMessage[] = [
+      { role: "user", content: "earlier persisted turn" },
+      { role: "assistant", content: "earlier reply" },
+      { role: "user", content: metadataDecorated(assembledBody) },
+    ] as AgentMessage[];
+    const liveMessages: AgentMessage[] = [{ role: "user", content: liveDecorated }] as AgentMessage[];
+
+    const result = appendUncoveredVolatileLiveInputsWithinBudget({
+      assembledMessages,
+      assembledEstimatedTokens: 10,
+      liveMessages,
+      tokenBudget: 1_000_000,
+    });
+
+    const userContents = result.messages
+      .filter((message) => (message as { role: string }).role === "user")
+      .map((message) => (message as { content: string }).content);
+    expect(userContents).toHaveLength(2);
+    expect(userContents).not.toContain(liveDecorated);
+  });
 });

--- a/test/live-turn-structural-supersede.test.ts
+++ b/test/live-turn-structural-supersede.test.ts
@@ -968,3 +968,68 @@ describe("engine.assemble preserves webchat decoration + memory (no-preamble, me
     expect(bodyTurns.filter((content) => content === REPEAT)).toHaveLength(2);
   });
 });
+
+describe("appendUncoveredVolatileLiveInputsWithinBudget: decorated channel turn whose assembled face is the metadata-decorated row", () => {
+  // The real Slack/Telegram failing shape: assemble reconstructs the current
+  // turn as a plain body row PLUS the metadata-decorated persisted row (the
+  // decorated row lands LAST), while the live face is timestamp + metadata
+  // prelude + injected memory blocks + body. The live memory-bearing copy must
+  // be recognized as the decorated face of that last row and appended.
+  const CHANNEL_BODY = "morning check: did the deploy pipeline finish?";
+  const INJECTED =
+    "<derived-focus>\nfocus\n</derived-focus>\n" +
+    "<inherited-rules>\nrules\n</inherited-rules>\n" +
+    "<relevant-memories>\nmemories\n</relevant-memories>";
+  const liveDecorated = `[Sat 2026-07-25 11:25 GMT+3] ${metadataDecorated(
+    INJECTED + "\n\n" + CHANNEL_BODY,
+  )}`;
+
+  it("appends the live memory-bearing copy when the last assembled user row is the decorated persisted face", () => {
+    const assembledMessages: AgentMessage[] = [
+      { role: "user", content: "earlier persisted turn" },
+      { role: "assistant", content: "earlier reply" },
+      { role: "user", content: CHANNEL_BODY },
+      { role: "user", content: metadataDecorated(CHANNEL_BODY) },
+    ] as AgentMessage[];
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: liveDecorated },
+    ] as AgentMessage[];
+
+    const result = appendUncoveredVolatileLiveInputsWithinBudget({
+      assembledMessages,
+      assembledEstimatedTokens: 10,
+      liveMessages,
+      tokenBudget: 1_000_000,
+    });
+
+    const userContents = result.messages
+      .filter((message) => (message as { role: string }).role === "user")
+      .map((message) => (message as { content: string }).content);
+    expect(userContents[userContents.length - 1]).toBe(liveDecorated);
+    expect(userContents).toHaveLength(4);
+  });
+
+  it("does NOT append when the decorated faces carry DIFFERENT bodies (fail-closed)", () => {
+    const assembledMessages: AgentMessage[] = [
+      { role: "user", content: "earlier persisted turn" },
+      { role: "assistant", content: "earlier reply" },
+      { role: "user", content: metadataDecorated("a completely different question") },
+    ] as AgentMessage[];
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: liveDecorated },
+    ] as AgentMessage[];
+
+    const result = appendUncoveredVolatileLiveInputsWithinBudget({
+      assembledMessages,
+      assembledEstimatedTokens: 10,
+      liveMessages,
+      tokenBudget: 1_000_000,
+    });
+
+    const userContents = result.messages
+      .filter((message) => (message as { role: string }).role === "user")
+      .map((message) => (message as { content: string }).content);
+    expect(userContents).toHaveLength(2);
+    expect(userContents).not.toContain(liveDecorated);
+  });
+});

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -585,3 +585,84 @@ describe("canonicalizeOpenClawInboundMetadataIdentityContent / buildMessageIdent
     ).not.toBe(canonicalizeOpenClawInboundMetadataIdentityContent("user", withoutRecap));
   });
 });
+
+describe("openClawInboundBodiesMatch with plugin-injected context blocks between metadata and body", () => {
+  // Memory plugins prepend their blocks to the model-facing body via
+  // before_prompt_build, so on decorated channels the runtime face is
+  // metadata prelude + injected tag blocks + body, while the persisted bare
+  // row carries only the body (tags stripped at persist). The reduction must
+  // strip validated, COMPLETE leading blocks for the known tag names only.
+  const INJECTED_BLOCKS =
+    "<derived-focus>\n[UNTRUSTED DATA]\nfocus text\n[END UNTRUSTED DATA]\n</derived-focus>\n" +
+    "<inherited-rules>\nrule text\n</inherited-rules>\n" +
+    "<relevant-memories>\nmemory text\n</relevant-memories>";
+
+  it("matches when injected blocks sit between the metadata block and the body", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrapped(INJECTED_BLOCKS + "\n\nmorning check: did the deploy pipeline finish?"),
+        "morning check: did the deploy pipeline finish?",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the full channel shape: timestamp + metadata + injected blocks + multi-line body", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        channelTimestamped(metadataWrapped(INJECTED_BLOCKS + "\n\nline one\nline two")),
+        "line one\nline two",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches with injected blocks AFTER the recap on a history-bearing turn", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrappedWithRecap(TWO_ENTRY_RECAP, INJECTED_BLOCKS + "\n\nok"),
+        "ok",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches with injected blocks BEFORE the recap too", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrappedWithHistory(INJECTED_BLOCKS + "\n\n" + TWO_ENTRY_RECAP + "\n\nok"),
+        "ok",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT strip an unclosed injected-context tag (fail-closed)", () => {
+    expect(
+      openClawInboundBodiesMatch(metadataWrapped("<relevant-memories>\nunclosed\n\nok"), "ok"),
+    ).toBe(false);
+  });
+
+  it("does NOT strip an unknown tag name (fail-closed)", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrapped("<totally-novel-block>\nx\n</totally-novel-block>\n\nok"),
+        "ok",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match when injected blocks conceal a DIFFERENT body", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrapped(INJECTED_BLOCKS + "\n\nsomething else entirely"),
+        "ok",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps injected-tag text embedded MID-body untouched (only leading blocks strip)", () => {
+    expect(
+      openClawInboundBodiesMatch(
+        metadataWrapped("I saw <relevant-memories>\nquoted\n</relevant-memories> in a log\nok"),
+        "ok",
+      ),
+    ).toBe(false);
+  });
+});

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -677,3 +677,51 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
     expect(openClawInboundBodiesMatch(memoryFirst, "ok")).toBe(false);
   });
 });
+
+// Injected-block stripping lives in the body-match layer ONLY. Identity
+// canonicalization keeps those blocks verbatim, which is prior behavior rather
+// than an oversight: body-match is the relaxation that lets a decorated live
+// turn collapse onto its bare persisted row, while identity stays conservative.
+// Neither half may move alone. If identity began stripping, two live faces
+// carrying different injected content would collide on one hash; if body-match
+// stopped stripping, the decorated turn would no longer collapse at all. Rows
+// already written at the current identity version have no repair path, so the
+// asymmetry is pinned here rather than "aligned" later by accident.
+describe("injected-context stripping is a body-match relaxation, never an identity change", () => {
+  const bare = "what's the status on the deploy?";
+  const injected = [
+    "<relevant-memories>",
+    "- the deploy queue drains at midnight",
+    "</relevant-memories>",
+  ].join("\n");
+  const decorated = metadataWrapped(`${injected}\n\n${bare}`);
+
+  it("body-match sees through a leading injected block", () => {
+    expect(openClawInboundBodiesMatch(decorated, bare)).toBe(true);
+  });
+
+  it("identity canonicalization keeps the injected block verbatim", () => {
+    const canonicalDecorated = canonicalizeOpenClawInboundMetadataIdentityContent("user", decorated);
+    expect(canonicalDecorated).toContain("relevant-memories");
+    expect(canonicalDecorated).not.toBe(
+      canonicalizeOpenClawInboundMetadataIdentityContent("user", metadataWrapped(bare)),
+    );
+  });
+
+  it("so a decorated turn and its bare row hash differently, by design", () => {
+    expect(buildMessageIdentityHash("user", decorated)).not.toBe(
+      buildMessageIdentityHash("user", metadataWrapped(bare)),
+    );
+  });
+
+  it("and two different injected payloads on the same body stay distinct in identity", () => {
+    const otherInjected = [
+      "<relevant-memories>",
+      "- the deploy queue drains at noon",
+      "</relevant-memories>",
+    ].join("\n");
+    expect(buildMessageIdentityHash("user", decorated)).not.toBe(
+      buildMessageIdentityHash("user", metadataWrapped(`${otherInjected}\n\n${bare}`)),
+    );
+  });
+});

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -3,16 +3,16 @@
 // decorated face of the same turn as its bare persisted row: the runtime side
 // reduces to the same full model-facing body as the bare side once a
 // structurally validated leading block and a leading channel timestamp are
-// stripped. openClawInboundBodiesMatch is the shared directional reduction the
-// after-turn batch matcher uses to collapse that pair; it is byte-equality of
-// the FULL stripped bodies (not containment), so a forged frame concealing a
-// different body, or a distinct turn whose trailing line merely matches, stays
-// fail-closed.
+// stripped. openClawInboundBodiesMatch is the conservative directional
+// reduction; the injected-context relaxation is separate and used only where
+// another frontier anchor proves alignment. Both compare the FULL reduced
+// bodies (not containment).
 import { describe, expect, it } from "vitest";
 import {
   canonicalizeOpenClawInboundMetadataIdentityContent,
   extractBodyAfterOpenClawInboundMetadataBlock,
   openClawInboundBodiesMatch,
+  openClawInboundBodiesMatchWithInjectedContext,
 } from "../src/openclaw-inbound-metadata.js";
 import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 
@@ -600,16 +600,26 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("matches when injected blocks sit between the metadata block and the body", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrapped(INJECTED_BLOCKS + "\n\nmorning check: did the deploy pipeline finish?"),
         "morning check: did the deploy pipeline finish?",
       ),
     ).toBe(true);
   });
 
+  it("preserves a user-authored known tag when the persisted row carries the same body", () => {
+    const body = "<derived-focus>\nuser-authored note\n</derived-focus>\n\nok";
+    expect(openClawInboundBodiesMatch(metadataWrapped(body), body)).toBe(true);
+  });
+
+  it("does NOT collapse a user-authored known tag onto a shorter bare body", () => {
+    const body = "<derived-focus>\nuser-authored note\n</derived-focus>\n\nok";
+    expect(openClawInboundBodiesMatch(metadataWrapped(body), "ok")).toBe(false);
+  });
+
   it("matches the full channel shape: timestamp + metadata + injected blocks + multi-line body", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         channelTimestamped(metadataWrapped(INJECTED_BLOCKS + "\n\nline one\nline two")),
         "line one\nline two",
       ),
@@ -618,7 +628,7 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("matches with injected blocks AFTER the recap on a history-bearing turn", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrappedWithRecap(TWO_ENTRY_RECAP, INJECTED_BLOCKS + "\n\nok"),
         "ok",
       ),
@@ -627,7 +637,7 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("matches with injected blocks BEFORE the recap too", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrappedWithHistory(INJECTED_BLOCKS + "\n\n" + TWO_ENTRY_RECAP + "\n\nok"),
         "ok",
       ),
@@ -636,13 +646,16 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("does NOT strip an unclosed injected-context tag (fail-closed)", () => {
     expect(
-      openClawInboundBodiesMatch(metadataWrapped("<relevant-memories>\nunclosed\n\nok"), "ok"),
+      openClawInboundBodiesMatchWithInjectedContext(
+        metadataWrapped("<relevant-memories>\nunclosed\n\nok"),
+        "ok",
+      ),
     ).toBe(false);
   });
 
   it("does NOT strip an unknown tag name (fail-closed)", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrapped("<totally-novel-block>\nx\n</totally-novel-block>\n\nok"),
         "ok",
       ),
@@ -651,7 +664,7 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("does NOT match when injected blocks conceal a DIFFERENT body", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrapped(INJECTED_BLOCKS + "\n\nsomething else entirely"),
         "ok",
       ),
@@ -660,7 +673,7 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
 
   it("keeps injected-tag text embedded MID-body untouched (only leading blocks strip)", () => {
     expect(
-      openClawInboundBodiesMatch(
+      openClawInboundBodiesMatchWithInjectedContext(
         metadataWrapped("I saw <relevant-memories>\nquoted\n</relevant-memories> in a log\nok"),
         "ok",
       ),
@@ -674,17 +687,14 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
     const memoryFirst =
       "<relevant-memories>\nmemory text\n</relevant-memories>\n\n" + metadataWrapped("ok");
     expect(extractBodyAfterOpenClawInboundMetadataBlock(memoryFirst)).toBeNull();
-    expect(openClawInboundBodiesMatch(memoryFirst, "ok")).toBe(false);
+    expect(openClawInboundBodiesMatchWithInjectedContext(memoryFirst, "ok")).toBe(false);
   });
 });
 
-// Injected-block stripping lives in the body-match layer ONLY. Identity
-// canonicalization keeps those blocks verbatim, which is prior behavior rather
-// than an oversight: body-match is the relaxation that lets a decorated live
-// turn collapse onto its bare persisted row, while identity stays conservative.
-// Neither half may move alone. If identity began stripping, two live faces
-// carrying different injected content would collide on one hash; if body-match
-// stopped stripping, the decorated turn would no longer collapse at all. Rows
+// Injected-block stripping lives only in the anchored body-match relaxation.
+// Identity canonicalization keeps those blocks verbatim, which is prior
+// behavior rather than an oversight. If identity began stripping, two live
+// faces carrying different injected content would collide on one hash. Rows
 // already written at the current identity version have no repair path, so the
 // asymmetry is pinned here rather than "aligned" later by accident.
 describe("injected-context stripping is a body-match relaxation, never an identity change", () => {
@@ -697,7 +707,7 @@ describe("injected-context stripping is a body-match relaxation, never an identi
   const decorated = metadataWrapped(`${injected}\n\n${bare}`);
 
   it("body-match sees through a leading injected block", () => {
-    expect(openClawInboundBodiesMatch(decorated, bare)).toBe(true);
+    expect(openClawInboundBodiesMatchWithInjectedContext(decorated, bare)).toBe(true);
   });
 
   it("identity canonicalization keeps the injected block verbatim", () => {

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -590,8 +590,9 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
   // Memory plugins prepend their blocks to the model-facing body via
   // before_prompt_build, so on decorated channels the runtime face is
   // metadata prelude + injected tag blocks + body, while the persisted bare
-  // row carries only the body (tags stripped at persist). The reduction must
-  // strip validated, COMPLETE leading blocks for the known tag names only.
+  // row carries only the body (injection happens at prompt-build, after
+  // persist). The reduction must strip validated, COMPLETE leading blocks
+  // for the known tag names only.
   const INJECTED_BLOCKS =
     "<derived-focus>\n[UNTRUSTED DATA]\nfocus text\n[END UNTRUSTED DATA]\n</derived-focus>\n" +
     "<inherited-rules>\nrule text\n</inherited-rules>\n" +

--- a/test/same-turn-body-collapse.test.ts
+++ b/test/same-turn-body-collapse.test.ts
@@ -665,4 +665,14 @@ describe("openClawInboundBodiesMatch with plugin-injected context blocks between
       ),
     ).toBe(false);
   });
+
+  it("boundary pin: memory blocks BEFORE the metadata prelude leave extraction null (shape not reduced)", () => {
+    // The reduction requires the metadata block first; a face with injected
+    // blocks ahead of the prelude is not a recognized decorated shape. Not an
+    // observed channel emission; pinned so the boundary is deliberate.
+    const memoryFirst =
+      "<relevant-memories>\nmemory text\n</relevant-memories>\n\n" + metadataWrapped("ok");
+    expect(extractBodyAfterOpenClawInboundMetadataBlock(memoryFirst)).toBeNull();
+    expect(openClawInboundBodiesMatch(memoryFirst, "ok")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

Plugin context injected via `before_prompt_build` (blocks such as `<relevant-memories>`, `<derived-focus>`, `<inherited-rules>`) silently disappears from the outbound prompt on channel turns that carry the inbound metadata decoration (Slack and Telegram shapes). Webchat turns are unaffected.

On the model-facing runtime face, the injected blocks land between the inbound metadata prelude and the user body. That interposition defeats two mechanisms at once:

1. `extractBodyAfterOpenClawInboundMetadataBlock` reduces the runtime face to `injected blocks + body`, never just `body`, so `openClawInboundBodiesMatch` returns false and the decorated runtime copy fails to collapse onto its bare persisted row. The store double-writes, and the metadata-decorated face lands as the last assembled user row.
2. `liveContentContainsBareBody` then cannot see that decorated row as a line-aligned trailing segment of the live face (the injected blocks split the prelude from the body), so `assembledRowIsStructuralBareCurrentTurn` rejects it on both sub-gates and the live memory-bearing copy is never re-appended after assembly. The memory-stripped assembled face is what reaches the model.

A session reset does not help, because the drop is self-contained to the current turn: the live face loses to its own persisted bare row. The webchat shape survives because it has no metadata prelude for the blocks to interpose into, so the existing marker path recognizes it.

## Fix (two fail-closed layers)

- `openclaw-inbound-metadata.ts`: the inbound-body reduction now strips validated, complete leading injected-context tag blocks (exact known tag names only, exported as `OPENCLAW_INJECTED_CONTEXT_TAG_NAMES`) after the metadata blocks and again after the recap handling. An unclosed or unknown tag stays in the body and blocks the match. Because `openClawInboundBodiesMatch` rides this same reduction, the change also restores the persist-side same-turn collapse, preventing the double-write that produces the decorated-last row in the first place.
- `live-coverage.ts`: `assembledRowIsStructuralBareCurrentTurn` gains a reduced-face equality branch: both faces go through the metadata extraction and must reduce to the same non-empty body, still gated on the last assembled user row plus a recognized injected marker. This rescues conversations whose store already carries the decorated face as the current-turn row. `INJECTED_CONTEXT_MARKERS` now derives from the exported tag list, so the reduction and the recognition gate cannot disagree on which tags count as injected context.

## Third commit: the line-form recap matcher is now linear

Deploying the first two commits surfaced a latent performance bug that the reduction above newly exposes, so the fix ships with it.

`OPENCLAW_INBOUND_HISTORY_RECAP_LINE_BLOCK_RE` had the shape `(?:ENTRY)(?:\r?\n(?:ENTRY))*(?=terminator)`, where ENTRY itself carries three optional-prefix alternates and a `.+: .+` split that matches at any `": "`. Whenever a long entry run fails the trailing terminator check, the engine explores the cross-product of every per-line ambiguity: about fifteen colon-heavy entries already exceed ninety seconds of blocking in one synchronous call. Before this PR the injected blocks made the reduction bail out early, so live decorated traffic rarely reached the matcher; after it, ordinary group-channel turns do. On our deployment that produced Socket Mode disconnects within two minutes of load, with no event-loop warning to show for it (the liveness sampler could not run either).

The replacement walks the lines once and keeps the semantics:

- All-or-nothing terminator behavior is preserved. A shorter run can never satisfy the terminator that the maximal run failed, because the character after an intermediate entry is always its successor line, so greedy matching loses nothing.
- Entry recognition mirrors the old alternation exactly, with one deliberately conservative divergence: an entry whose content is a lone carriage return is now rejected rather than accepted (the old `.` matched `\r`). That direction only ever strips less.
- Worst case measured at 0.23ms on a 200-entry colon-heavy face, against a matcher that previously did not return within ninety seconds on fifteen.

This matcher also feeds identity canonicalization, so a semantic drift would change persisted `identity_hash` values with no repair path for rows already at the current version. Two independent reviewers diff-fuzzed the old regex against the new walker over 400,000 generated inputs each (both headers, all three entry anchor shapes, LF and CRLF, thirteen terminator shapes): identical match length on every realistic input, and every divergence was the documented trailing-lone-CR-at-EOF shape, always in the strip-nothing direction.

## Fail-closed properties

- Only a complete `<tag>...</tag>` block for the known names is stripped; unclosed or unknown tags stay in the body and block the match.
- The new recognizer branch uses full-body equality, not containment, and keeps the existing last-assembled-user-row and marker gates, so distinct turns are never collapsed.
- A face carrying injected blocks ahead of the metadata prelude stays unreduced, pinned by a boundary test.
- The recap walker strips nothing on a header with no entries, an entry run that peters out into unanchored prose, or an entry line with no sender/content split.

## Tests

19 new tests. `test/same-turn-body-collapse.test.ts` and `test/live-turn-structural-supersede.test.ts` cover the reduction and the append path plus fail-closed pins (unclosed tag, unknown tag, concealed different body, mid-body quoted tags, before-prelude boundary, distinct-body guard), written red-first against the pristine tip. `test/inbound-recap-line-matcher.test.ts` adds a bounded-time regression pin for the backtracking shape plus walker semantics pins (mixed anchor shapes, CRLF, end-of-content termination, unanchored petering out, internal blank line, missing sender split). Full suite 1924/1924, typecheck clean. Changeset included.

Verified live on a deployment running this branch: a decorated channel turn that previously reached the model with no injected blocks now carries all three in the final request's last user message, and the webchat shape is unchanged.

## Validation

- `npm run build` clean
- `npx tsc --noEmit` clean
- Focused Vitest: `test/batch-dedup.test.ts`, `test/same-turn-body-collapse.test.ts`, `test/live-turn-structural-supersede.test.ts`, and `test/inbound-recap-line-matcher.test.ts` all green; the new cells fail on the previous code
- Full suite green
- GitHub checks green on the current head
- Running in production since 2026-07-27 with the collapse behavior verified on live traffic
