### PR TITLE
fix: repair 0.15.0 release metadata

### DIFF
--- a/.changeset/assemble-emergency-drain-force.md
+++ b/.changeset/assemble-emergency-drain-force.md
@@ -1,5 +1,5 @@
 ---
-"lossless-claw": patch
+"@martian-engineering/lossless-claw": patch
 ---
 
 Skip deferred compaction retry backoff in assemble emergency drain when token pressure exceeds budget. The emergency drain now passes `force: true` to `consumeDeferredCompactionDebt`, bypassing the `nextAttemptAfter` backoff check so compaction can retry immediately instead of waiting for the backoff timer. Normal deferred drain paths (`drainDeferredCompactionDebtIfIdle`, `maintain`) continue to respect backoff. To prevent infinite retries when compaction persistently fails, `force: true` is only applied when `retryAttempts < 3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.15.0
 
+<!-- release-rollback-version: 0.14.0 -->
+
 ### Minor Changes
 
 - [#981](https://github.com/Martian-Engineering/lossless-claw/pull/981) [`189efba`](https://github.com/Martian-Engineering/lossless-claw/commit/189efbaf792cd93ee10579747168ff0f75b2511a) Thanks [@cxbAsDev](https://github.com/cxbAsDev)! - `/lossless doctor apply` can now repair a specific conversation with `doctor apply <conversation-id> confirm-offline`. Targeted repair is limited to authorized OpenClaw command senders and requires the explicit offline confirmation after the target's active channel path is isolated. The existing current-conversation behavior is unchanged when no id is provided.


### PR DESCRIPTION
## What

Repair the two metadata errors that block the `0.15.0` release and the next Changesets release plan.

## Why

The Version Packages workflow cannot process `.changeset/assemble-emergency-drain-force.md` because it names a package outside the workspace. The Publish Package workflow also rejects `0.15.0` because its changelog section does not identify the published rollback version.

## Changes

- Correct the scoped Changesets package name
- Pin the `0.15.0` rollback to `0.14.0`

## Testing

- `npx changeset status`
- `node scripts/release-channel.mjs --read-rollback 0.15.0 < CHANGELOG.md`
- `node scripts/release-channel.mjs --assert-newer 0.15.0 0.14.0`
- `npm run release:verify` (107 files, 1,905 tests)
- Autoreview: no accepted or actionable findings