### PR TITLE
fix: guard sqlite: sessionFile paths against filesystem stat operations

### DIFF
--- a/.changeset/sqlite-sessionfile-guard.md
+++ b/.changeset/sqlite-sessionfile-guard.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Guard SQLite-backed session file paths (`sqlite:`) against filesystem stat/read/write operations in auto-rotate, rollover detection, transcript reconciliation, and bootstrap checkpoint refresh. OpenClaw 7.2+ sessions stored in SQLite use `sqlite:` prefixed paths that were passed through to `fs.stat`, `fs.createReadStream`, and `fs.open`, causing ENOENT errors on every agent turn. SQLite sessions now skip file-based rotation, rollover stat checks, and transcript I/O.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -90,7 +90,7 @@ import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-i
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
 import { listTranscriptToolResultEntryIdsByCallId } from "./replay-metadata.js";
 import { extractRuntimePromptTokenCount } from "./token-accounting.js";
-import { asRecord, formatDurationMs, resolvePositiveInteger } from "./value-utils.js";
+import { asRecord, formatDurationMs, isSqliteSessionFile, resolvePositiveInteger } from "./value-utils.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 const LOSSLESS_AGENT_RUN_REQUIRED_HOST_CAPABILITIES: ContextEngineHostCapability[] = [
@@ -1859,7 +1859,8 @@ export class LcmContextEngine implements ContextEngine {
     this.ensureMigrated();
     const startedAt = Date.now();
     const sessionLabel = formatSessionLabel(params.sessionId, params.sessionKey);
-    const sessionFileStats = await stat(params.sessionFile);
+    const sqliteSession = isSqliteSessionFile(params.sessionFile);
+    const sessionFileStats = sqliteSession ? { size: 0, mtimeMs: 0 } : await stat(params.sessionFile);
     const sessionFileSize = sessionFileStats.size;
     const sessionFileMtimeMs = Math.trunc(sessionFileStats.mtimeMs);
     const parentSessionReference = await readSessionParentSessionReference(params.sessionFile);

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -16,7 +16,7 @@ import type { AgentMessage } from "./openclaw-bridge.js";
 import { isIsolatedCronSessionKey } from "./session-patterns.js";
 import type { ArchiveCause, ConversationStore } from "./store/conversation-store.js";
 import { getTranscriptEntryMeta } from "./transcript.js";
-import { isMissingFileError } from "./value-utils.js";
+import { isMissingFileError, isSqliteSessionFile } from "./value-utils.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { LcmDependencies } from "./types.js";
 
@@ -242,6 +242,12 @@ export class SessionRolloverDetector {
       return false;
     }
 
+    // OpenClaw 7.2+: SQLite-backed sessions always have their transcript
+    // present in SQLite; skip the stat-based rotation check.
+    if (isSqliteSessionFile(trackedSessionFile)) {
+      return false;
+    }
+
     try {
       await stat(trackedSessionFile);
       return false;
@@ -365,6 +371,12 @@ export class SessionRolloverDetector {
       softResetPrunedAt: activeBootstrapState?.softResetPrunedAt,
       trackedSessionFile,
     });
+
+    // OpenClaw 7.2+: SQLite-backed sessions always have their transcript
+    // present in SQLite; skip the stat-based ambiguity check.
+    if (isSqliteSessionFile(trackedSessionFile)) {
+      return null;
+    }
 
     try {
       await stat(trackedSessionFile);

--- a/src/session-rotation.ts
+++ b/src/session-rotation.ts
@@ -20,7 +20,7 @@ import {
   withExclusiveDatabaseLock,
 } from "./transaction-mutex.js";
 import { readLeafPathRawEntries, type TranscriptRawEntry } from "./transcript.js";
-import { asRecord, isMissingFileError, normalizeSessionFilePathForComparison } from "./value-utils.js";
+import { asRecord, isMissingFileError, isSqliteSessionFile, normalizeSessionFilePathForComparison } from "./value-utils.js";
 import type { CompactionEngine } from "./compaction.js";
 import type { CompactionGuards } from "./compaction-guards.js";
 import type { LcmConfig } from "./db/config.js";
@@ -354,6 +354,10 @@ export class SessionRotationService {
       skip("missing-session-file");
       return;
     }
+    if (isSqliteSessionFile(sessionFile)) {
+      skip("sqlite-session");
+      return;
+    }
     if (this.host.shouldIgnoreSession({ sessionId, sessionKey })) {
       skip("session-excluded");
       return;
@@ -598,6 +602,9 @@ export class SessionRotationService {
     }
 
     let sizeBytes: number;
+    if (isSqliteSessionFile(sessionFile)) {
+      return { kind: "skipped" };
+    }
     try {
       sizeBytes = (await stat(sessionFile)).size;
     } catch (error) {
@@ -1014,6 +1021,11 @@ export class SessionRotationService {
       // the host's problem to recover, not ours to rotate.
       throw new Error("session file has no session header; refusing to rotate");
     }
+    // SQLite-backed sessions never reach the rewrite path (auto-rotate
+    // skips them upstream), but stat here anyway as a defense-in-depth.
+    if (isSqliteSessionFile(params.sessionFile)) {
+      throw new Error("sqlite sessions cannot be rotated via file rewrite");
+    }
     const originalStats = await stat(params.sessionFile);
 
     const messageIndices: number[] = [];
@@ -1090,6 +1102,10 @@ export class SessionRotationService {
     ].join("\n") + "\n";
     await writeFile(params.sessionFile, serialized, "utf8");
 
+    // Defense-in-depth: sqlite sessions never reach rotate-rewrite.
+    if (isSqliteSessionFile(params.sessionFile)) {
+      throw new Error("sqlite sessions cannot be rotated via file rewrite");
+    }
     const rewrittenStats = await stat(params.sessionFile);
     await this.host.refreshBootstrapState({
       conversationId: params.conversationId,

--- a/src/session-rotation.ts
+++ b/src/session-rotation.ts
@@ -1014,17 +1014,18 @@ export class SessionRotationService {
     conversationId: number;
     sessionFile: string;
   }): Promise<RotateTranscriptRewriteResult> {
+    // SQLite-backed sessions never reach the rewrite path (auto-rotate
+    // skips them upstream). Block at the top before any I/O.
+    if (isSqliteSessionFile(params.sessionFile)) {
+      throw new Error("sqlite sessions cannot be rotated via file rewrite");
+    }
+
     const { header, entries: branch } = await readLeafPathRawEntries(params.sessionFile);
     if (!header) {
       // SessionManager.open used to synthesize a header (and rewrite the
       // file) here; reading is now side-effect free, so a headerless file is
       // the host's problem to recover, not ours to rotate.
       throw new Error("session file has no session header; refusing to rotate");
-    }
-    // SQLite-backed sessions never reach the rewrite path (auto-rotate
-    // skips them upstream), but stat here anyway as a defense-in-depth.
-    if (isSqliteSessionFile(params.sessionFile)) {
-      throw new Error("sqlite sessions cannot be rotated via file rewrite");
     }
     const originalStats = await stat(params.sessionFile);
 
@@ -1102,10 +1103,6 @@ export class SessionRotationService {
     ].join("\n") + "\n";
     await writeFile(params.sessionFile, serialized, "utf8");
 
-    // Defense-in-depth: sqlite sessions never reach rotate-rewrite.
-    if (isSqliteSessionFile(params.sessionFile)) {
-      throw new Error("sqlite sessions cannot be rotated via file rewrite");
-    }
     const rewrittenStats = await stat(params.sessionFile);
     await this.host.refreshBootstrapState({
       conversationId: params.conversationId,

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1892,13 +1892,16 @@ export class TranscriptReconciler {
       // No persisted conversation exists yet. Prefer the transcript over
       // the runtime delta so foreground prompts that are omitted from
       // afterTurn's messages array are not lost.
+      const sqliteSession = isSqliteSessionFile(params.sessionFile);
       let sessionFileState: { size: number } | undefined;
-      try {
-        const sessionFileStats = await stat(params.sessionFile);
-        sessionFileState = { size: sessionFileStats.size };
-      } catch {
-        // Missing files are common for brand-new live sessions; allow the
-        // runtime batch to seed the conversation in that case.
+      if (!sqliteSession) {
+        try {
+          const sessionFileStats = await stat(params.sessionFile);
+          sessionFileState = { size: sessionFileStats.size };
+        } catch {
+          // Missing files are common for brand-new live sessions; allow the
+          // runtime batch to seed the conversation in that case.
+        }
       }
       const historicalMessages = await readLeafPathMessages(params.sessionFile);
       if (historicalMessages.length === 0) {

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -58,7 +58,7 @@ import {
   resolveTranscriptMessageCreatedAt,
   resolveTranscriptMessageInnerTimestamp,
 } from "./transcript.js";
-import { asRecord, formatDurationMs, isMissingFileError, safeString } from "./value-utils.js";
+import { asRecord, formatDurationMs, isMissingFileError, isSqliteSessionFile, safeString } from "./value-utils.js";
 
 /**
  * How deep into the conversation tail a flush-lagged runtime row can sit.
@@ -2507,15 +2507,17 @@ export class TranscriptReconciler {
     );
     let sessionFileState: { size: number; mtimeMs: number } | undefined;
     let sessionFileStatError: unknown;
-    try {
-      const sessionFileStats = await stat(params.sessionFile);
-      sessionFileState = {
-        size: sessionFileStats.size,
-        mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
-      };
-    } catch (error) {
-      sessionFileStatError = error;
-      // Leave undefined: without stat proof, do not use append-only guards or slow-read caps.
+    if (!isSqliteSessionFile(params.sessionFile)) {
+      try {
+        const sessionFileStats = await stat(params.sessionFile);
+        sessionFileState = {
+          size: sessionFileStats.size,
+          mtimeMs: Math.trunc(sessionFileStats.mtimeMs),
+        };
+      } catch (error) {
+        sessionFileStatError = error;
+        // Leave undefined: without stat proof, do not use append-only guards or slow-read caps.
+      }
     }
     const transcriptEpochShrank = checkpointIsPastTranscriptEof(
       checkpoint,
@@ -2697,7 +2699,16 @@ export class TranscriptReconciler {
     forkSourceMessageCount?: number;
   }): Promise<void> {
     const latestDbMessage = await this.host.conversationStore.getLastMessage(params.conversationId);
-    const fileStats = params.fileStats ?? (await stat(params.sessionFile));
+    let fileStats: { size: number; mtimeMs: number };
+    if (params.fileStats) {
+      fileStats = params.fileStats;
+    } else if (isSqliteSessionFile(params.sessionFile)) {
+      // OpenClaw 7.2+: SQLite-backed sessions have no filesystem file.
+      // Use a 0-size placeholder; the read path will return null.
+      fileStats = { size: 0, mtimeMs: Date.now() };
+    } else {
+      fileStats = await stat(params.sessionFile);
+    }
     // The checkpoint marks the whole file processed (offset = size), so the
     // exact resume anchor is the envelope id of the file's last message entry.
     let lastProcessedEntryId: string | null = null;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -116,6 +116,9 @@ export type TranscriptHeader = {
  */
 export async function readTranscriptHeader(sessionFile: string): Promise<TranscriptHeader> {
   const empty: TranscriptHeader = { sessionHeaderId: null, parentSession: null };
+  if (isSqliteSessionFile(sessionFile)) {
+    return empty;
+  }
   try {
     const stream = createReadStream(sessionFile, { encoding: "utf8" });
     const lines = createInterface({

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -3,6 +3,7 @@ import { open } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import type { ContextEngine } from "./openclaw-bridge.js";
+import { isSqliteSessionFile } from "./value-utils.js";
 
 type AgentMessage = Parameters<ContextEngine["ingest"]>[0]["message"];
 
@@ -292,6 +293,9 @@ function selectLeafPathRecords<T extends TranscriptTreeNode>(records: T[]): T[] 
  * without full id coverage keep the legacy flatten-in-file-order behavior.
  */
 export async function readLeafPathMessages(sessionFile: string): Promise<AgentMessage[]> {
+  if (isSqliteSessionFile(sessionFile)) {
+    return [];
+  }
   try {
     let sawNonWhitespace = false;
     let jsonArrayMode = false;
@@ -405,6 +409,9 @@ export type TranscriptRawLeafPath = {
  */
 export async function readLeafPathRawEntries(sessionFile: string): Promise<TranscriptRawLeafPath> {
   const result: TranscriptRawLeafPath = { header: null, entries: [] };
+  if (isSqliteSessionFile(sessionFile)) {
+    return result;
+  }
   try {
     const stream = createReadStream(sessionFile, { encoding: "utf8" });
     const lines = createInterface({
@@ -443,6 +450,9 @@ export async function readLeafPathRawEntries(sessionFile: string): Promise<Trans
 }
 
 export async function readSessionParentSessionReference(sessionFile: string): Promise<string | null> {
+  if (isSqliteSessionFile(sessionFile)) {
+    return null;
+  }
   try {
     const stream = createReadStream(sessionFile, { encoding: "utf8" });
     const lines = createInterface({
@@ -477,6 +487,9 @@ export async function readSessionParentSessionReference(sessionFile: string): Pr
 }
 
 export async function readFileSegment(sessionFile: string, offset: number): Promise<string | null> {
+  if (isSqliteSessionFile(sessionFile)) {
+    return null;
+  }
   let fh: FileHandle | null = null;
   try {
     fh = await open(sessionFile, "r");
@@ -502,6 +515,9 @@ export async function readLastJsonlEntryBeforeOffset(
   messageOnly = false,
   matcher?: (message: AgentMessage) => boolean,
 ): Promise<string | null> {
+  if (isSqliteSessionFile(sessionFile)) {
+    return null;
+  }
   const chunkSize = 16_384;
   const safeOffset = Math.max(0, Math.floor(offset));
   if (safeOffset <= 0) {

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -19,9 +19,15 @@ export function isMissingFileError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
+export function isSqliteSessionFile(sessionFile: string | null | undefined): boolean {
+  return (sessionFile?.startsWith("sqlite:") ?? false);
+}
+
 export function normalizeSessionFilePathForComparison(filePath: string): string {
   const trimmed = filePath.trim();
-  return trimmed ? resolvePath(trimmed) : "";
+  if (!trimmed) return "";
+  if (trimmed.startsWith("sqlite:")) return trimmed;
+  return resolvePath(trimmed);
 }
 
 export function toJson(value: unknown): string {

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -19,14 +19,17 @@ export function isMissingFileError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
+const SQLITE_SESSION_FILE_PREFIX = "sqlite:";
+
 export function isSqliteSessionFile(sessionFile: string | null | undefined): boolean {
-  return (sessionFile?.startsWith("sqlite:") ?? false);
+  if (!sessionFile) return false;
+  return sessionFile.trim().toLowerCase().startsWith(SQLITE_SESSION_FILE_PREFIX);
 }
 
 export function normalizeSessionFilePathForComparison(filePath: string): string {
   const trimmed = filePath.trim();
   if (!trimmed) return "";
-  if (trimmed.startsWith("sqlite:")) return trimmed;
+  if (trimmed.toLowerCase().startsWith(SQLITE_SESSION_FILE_PREFIX)) return trimmed;
   return resolvePath(trimmed);
 }
 

--- a/test/transcript-leaf-path.test.ts
+++ b/test/transcript-leaf-path.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getTranscriptEntryId, readLeafPathMessages } from "../src/transcript.js";
+import { getTranscriptEntryId, readLeafPathMessages, readTranscriptHeader, readLeafPathRawEntries, readSessionParentSessionReference, readFileSegment, readLastJsonlEntryBeforeOffset } from "../src/transcript.js";
 
 const tempDirs: string[] = [];
 
@@ -176,5 +176,74 @@ describe("readLeafPathMessages leaf-path selection", () => {
     ]);
     const messages = await readLeafPathMessages(sessionFile);
     expect(contents(messages)).toEqual(["one", "two"]);
+  });
+});
+
+describe("sqlite: session file no-op guards", () => {
+  it("readLeafPathMessages returns empty for sqlite: path", async () => {
+    const messages = await readLeafPathMessages("sqlite:conversation/42");
+    expect(messages).toEqual([]);
+  });
+
+  it("readTranscriptHeader returns empty header for sqlite: path", async () => {
+    const result = await readTranscriptHeader("sqlite:conversation/42");
+    expect(result).toEqual({ sessionHeaderId: null, parentSession: null });
+  });
+
+  it("readLeafPathRawEntries returns empty result for sqlite: path", async () => {
+    const result = await readLeafPathRawEntries("sqlite:conversation/42");
+    expect(result).toEqual({ header: null, entries: [] });
+  });
+
+  it("readSessionParentSessionReference returns null for sqlite: path", async () => {
+    const result = await readSessionParentSessionReference("sqlite:conversation/42");
+    expect(result).toBeNull();
+  });
+
+  it("readFileSegment returns null for sqlite: path", async () => {
+    const result = await readFileSegment("sqlite:conversation/42", 0);
+    expect(result).toBeNull();
+  });
+
+  it("readLastJsonlEntryBeforeOffset returns null for sqlite: path", async () => {
+    const result = await readLastJsonlEntryBeforeOffset("sqlite:conversation/42", 100);
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    "Sqlite:conversation/1",
+    "SQLITE:2",
+    "  sqlite:3  ",
+  ])("handles case/whitespace variants of sqlite: path %s", async (path) => {
+    const messages = await readLeafPathMessages(path);
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("isSqliteSessionFile", () => {
+  it.each([
+    ["sqlite:123", true],
+    ["Sqlite:abc", true],
+    ["SQLITE:x", true],
+    ["  sqlite:456  ", true],
+  ])("identifies %s as sqlite session file", async (input, expected) => {
+    const { isSqliteSessionFile } = await import("../src/value-utils.js");
+    expect(isSqliteSessionFile(input)).toBe(expected);
+  });
+
+  it.each([
+    ["file.jsonl", false],
+    ["/absolute/path.jsonl", false],
+    ["sqlite", false],
+    ["sqlite2:not", false],
+  ])("returns false for %s", async (input, expected) => {
+    const { isSqliteSessionFile } = await import("../src/value-utils.js");
+    expect(isSqliteSessionFile(input)).toBe(expected);
+  });
+
+  it("returns false for null and undefined", async () => {
+    const { isSqliteSessionFile } = await import("../src/value-utils.js");
+    expect(isSqliteSessionFile(null)).toBe(false);
+    expect(isSqliteSessionFile(undefined)).toBe(false);
   });
 });

--- a/test/value-utils.test.ts
+++ b/test/value-utils.test.ts
@@ -6,6 +6,7 @@ import {
   getErrorCode,
   hashSerializedMessages,
   isMissingFileError,
+  isSqliteSessionFile,
   normalizeOptionalCount,
   normalizeSessionFilePathForComparison,
   resolvePositiveInteger,
@@ -89,6 +90,30 @@ describe("isMissingFileError", () => {
   });
 });
 
+describe("isSqliteSessionFile", () => {
+  it.each([
+    ["sqlite:123", true],
+    ["Sqlite:abc", true],
+    ["SQLITE:x", true],
+    ["  sqlite:456  ", true],
+  ])("identifies %s as sqlite session file", (input, expected) => {
+    expect(isSqliteSessionFile(input)).toBe(expected);
+  });
+
+  it.each([
+    ["file.jsonl", false],
+    ["/absolute/path.jsonl", false],
+    ["sqlite", false],
+    ["sqlite2:not", false],
+    ["", false],
+    ["   ", false],
+    [null, false],
+    [undefined, false],
+  ])("returns false for %s", (input, expected) => {
+    expect(isSqliteSessionFile(input as string | null | undefined)).toBe(expected);
+  });
+});
+
 describe("normalizeSessionFilePathForComparison", () => {
   it.each([
     ["absolute path", "/foo/bar/session.jsonl", resolvePath("/foo/bar/session.jsonl")],
@@ -100,6 +125,21 @@ describe("normalizeSessionFilePathForComparison", () => {
 
   it.each(["", "   "])("returns empty string for empty input %j", (input) => {
     expect(normalizeSessionFilePathForComparison(input)).toBe("");
+  });
+
+  it.each([
+    ["sqlite:123", "sqlite:123"],
+    ["SQLITE:abc", "SQLITE:abc"],
+    ["  sqlite:456  ", "sqlite:456"],
+  ])("preserves sqlite: prefix path %j as-is", (input, expected) => {
+    expect(normalizeSessionFilePathForComparison(input)).toBe(expected);
+  });
+
+  it("does not resolve sqlite: paths with path.resolve", () => {
+    const result = normalizeSessionFilePathForComparison("sqlite:conversation/123");
+    expect(result).toBe("sqlite:conversation/123");
+    expect(result).not.toContain(":\\");
+    expect(result).not.toContain("sqlite:\\");
   });
 });
 


### PR DESCRIPTION
## Problem

OpenClaw 7.2+ stores sessions in SQLite and passes sessionFile values with a `sqlite:` prefix (e.g. `sqlite:linus:c0e057d2:path`). Before this fix, the lossless-claw plugin passed these values through to `fs.stat`, `fs.createReadStream`, and `fs.open` in three paths:

1. **auto-rotate** - stat fails with ENOENT, every turn logs `session-file-stat-failed`
2. **transcript reconcile** - `session file missing; skipping transcript reconcile`, checkpoint offset stays 0 forever
3. **bootstrap checkpoint refresh** - ENOENT on every turn, leading to full re-reads instead of incremental updates

On Windows, the stat fails with the path resolved against `C:\Windows\system32\sqlite:...`, causing 532 warn lines and 196 error lines in a single day of logs.

## Solution

This patch introduces `isSqliteSessionFile()` in value-utils and applies it in every call site that previously performed filesystem I/O on session files.

| File | Change |
|------|--------|
| `value-utils.ts` | + `isSqliteSessionFile()` + `normalizeSessionFilePathForComparison` no longer resolve()s sqlite: paths |
| `engine.ts` | bootstrap uses 0-size placeholder stat for sqlite sessions |
| `transcript.ts` | 5 I/O functions return early for sqlite paths |
| `session-rotation.ts` | auto-rotate skips sqlite sessions entirely |
| `session-rollover.ts` | rotation/ambiguity checks skip sqlite-tracked transcripts |
| `transcript-reconciler.ts` | stat wrapped in `!isSqliteSessionFile` guard; refreshBootstrapState uses placeholder |

**6 files, +78 -16**

## Evidence

### Before (production logs, OpenClaw 2026.7.2-beta.4 + LCM 0.14.0)

Each agent turn produces 3 warn lines:
```
[lcm] afterTurn: session file missing; skipping transcript reconcile
  reason=append-only-ineligible sessionFile=sqlite:linus:c0e057d2:...

[lcm] afterTurn: bootstrap checkpoint refresh failed
  ENOENT: stat 'C:\Windows\system32\sqlite:linus:c0e057d2:...'

[lcm] auto-rotate: session-file-stat-failed
  error=ENOENT stat 'C:\Windows\system32\sqlite:linus:c0e057d2:...'
```

### After (ECS smoke test)

Patched dist loaded on OpenClaw 2026.7.2-beta.4, manual verification:
- `isSqliteSessionFile` present in minified dist (4 occurrences)
- Module loads without errors
- No ENOENT / stat-fail / checkpoint-refresh-fail in plugin initialization

### Build & lint

- `npm run build` - passes
- `npx oxlint` - 0 errors (127 pre-existing warnings unchanged)

## Changes

- `src/value-utils.ts`: add `isSqliteSessionFile`, adapt `normalizeSessionFilePathForComparison`
- `src/engine.ts`: replace `stat()` with placeholder for sqlite sessions
- `src/transcript.ts`: add guards to `readLeafPathMessages`, `readLeafPathRawEntries`, `readSessionParentSessionReference`, `readFileSegment`, `readLastJsonlEntryBeforeOffset`
- `src/session-rotation.ts`: skip rotation for sqlite sessions in `maybeAutoRotateManagedSessionFile`, `prepareStartupAutoRotateCandidate`, `rewriteTranscriptForRotate`
- `src/session-rollover.ts`: skip stat checks for sqlite-tracked transcripts
- `src/transcript-reconciler.ts`: wrap stat in guard; placeholder stat for sqlite in `refreshBootstrapState`
