### PR TITLE
fix(maintenance): supersede stale persisted context thresholds against live config

### DIFF
--- a/.changeset/supersede-stale-context-threshold-debt.md
+++ b/.changeset/supersede-stale-context-threshold-debt.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Deferred maintenance drains no longer honour a persisted context-threshold override that current config can no longer produce: the persisted value is kept only while a plausibly-matching override rule still carries the same threshold and recorded sizing, and a persisted global threshold that diverges from the configured global is superseded, so stale rows from removed or reverted threshold experiments cannot wedge compaction.

--- a/src/context-threshold.ts
+++ b/src/context-threshold.ts
@@ -186,6 +186,34 @@ function rulePayloadProduces(
   return true;
 }
 
+function resolvedPayloadMatchesPersisted(
+  resolved: Pick<
+    ResolvedContextThreshold,
+    "contextThreshold" | "freshTailCount" | "leafChunkTokens"
+  >,
+  persisted: Pick<
+    ResolvedContextThreshold,
+    "contextThreshold" | "freshTailCount" | "leafChunkTokens"
+  >,
+): boolean {
+  if (resolved.contextThreshold !== persisted.contextThreshold) {
+    return false;
+  }
+  if (
+    persisted.freshTailCount !== undefined &&
+    resolved.freshTailCount !== persisted.freshTailCount
+  ) {
+    return false;
+  }
+  if (
+    persisted.leafChunkTokens !== undefined &&
+    resolved.leafChunkTokens !== persisted.leafChunkTokens
+  ) {
+    return false;
+  }
+  return true;
+}
+
 // Summarize which matchers selected the winning rule for log lines.
 function describeRuleMatch(
   rule: ContextThresholdOverride,
@@ -266,7 +294,10 @@ export function reconcilePersistedContextThreshold(params: {
     return { resolved: live, supersededStalePersisted: false };
   }
   if (persisted.source === "override") {
-    if (params.anyRuleCouldProducePersisted) {
+    if (
+      params.anyRuleCouldProducePersisted &&
+      (live.source !== "override" || resolvedPayloadMatchesPersisted(live, persisted))
+    ) {
       return { resolved: persisted, supersededStalePersisted: false };
     }
     return { resolved: live, supersededStalePersisted: true };

--- a/src/context-threshold.ts
+++ b/src/context-threshold.ts
@@ -107,6 +107,54 @@ function ruleMatches(params: {
   return true;
 }
 
+// Like ruleMatches, but a matcher whose runtime metadata is absent counts as
+// potentially satisfiable instead of failed. Backs the staleness check on
+// persisted deferred-maintenance thresholds: a background drain often lacks
+// model metadata, so "no rule could match even as a wildcard" is the only
+// safe proof that a persisted override no longer originates from live config.
+function rulePossiblyMatches(params: {
+  compiled: CompiledOverrideRule;
+  sessionKey?: string;
+  runtime: RuntimeModelContext;
+}): boolean {
+  const { rule, sessionPattern } = params.compiled;
+  const runtime = params.runtime;
+
+  if (rule.match.model) {
+    const normalizedRuleModel = rule.match.model.trim();
+    const candidates = [runtime.modelRef, runtime.model].filter(
+      (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+    );
+    if (candidates.length > 0 && !candidates.includes(normalizedRuleModel)) {
+      return false;
+    }
+  }
+
+  if (sessionPattern) {
+    const sessionKey = params.sessionKey?.trim();
+    if (sessionKey && !sessionPattern.test(sessionKey)) {
+      return false;
+    }
+  }
+
+  if (runtime.modelContextWindow !== undefined) {
+    if (
+      rule.match.modelContextWindowMin !== undefined &&
+      runtime.modelContextWindow < rule.match.modelContextWindowMin
+    ) {
+      return false;
+    }
+    if (
+      rule.match.modelContextWindowMax !== undefined &&
+      runtime.modelContextWindow > rule.match.modelContextWindowMax
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // Summarize which matchers selected the winning rule for log lines.
 function describeRuleMatch(
   rule: ContextThresholdOverride,
@@ -164,6 +212,38 @@ export function persistedContextThresholdOverride(maintenance: {
       ? { leafChunkTokens: Math.floor(maintenance.contextLeafChunkTokens) }
       : {}),
   };
+}
+
+/**
+ * Decide which threshold a deferred-maintenance drain should honour: the one
+ * persisted with the debt row, or a fresh resolution against live config.
+ * The persisted value protects drains that lack the runtime metadata which
+ * originally selected an override; it stays authoritative only while live
+ * config could still plausibly produce it. A persisted override with no
+ * possibly-matching rule left, and a persisted global that diverges from the
+ * configured global, are provably stale (the config changed after the row was
+ * written) and are superseded so a dead experiment value cannot wedge
+ * compaction forever.
+ */
+export function reconcilePersistedContextThreshold(params: {
+  persisted: ResolvedContextThreshold | undefined;
+  live: ResolvedContextThreshold;
+  anyRuleCouldMatch: boolean;
+}): { resolved: ResolvedContextThreshold; supersededStalePersisted: boolean } {
+  const { persisted, live } = params;
+  if (!persisted) {
+    return { resolved: live, supersededStalePersisted: false };
+  }
+  if (persisted.source === "override") {
+    if (params.anyRuleCouldMatch) {
+      return { resolved: persisted, supersededStalePersisted: false };
+    }
+    return { resolved: live, supersededStalePersisted: true };
+  }
+  if (live.source === "override" || live.contextThreshold !== persisted.contextThreshold) {
+    return { resolved: live, supersededStalePersisted: true };
+  }
+  return { resolved: persisted, supersededStalePersisted: false };
 }
 
 /** Format the resolved-threshold fields shared by all selection log lines. */
@@ -249,5 +329,19 @@ export class ContextThresholdResolver {
         ? { leafChunkTokens: best.rule.leafChunkTokens }
         : {}),
     };
+  }
+
+  /**
+   * Whether any configured rule could match this context when matchers whose
+   * runtime metadata is absent are treated as satisfiable. Backs the stale
+   * check in {@link reconcilePersistedContextThreshold}.
+   */
+  couldAnyRuleMatch(params: {
+    sessionKey?: string;
+    runtime: RuntimeModelContext;
+  }): boolean {
+    return this.rules.some((compiled) =>
+      rulePossiblyMatches({ compiled, sessionKey: params.sessionKey, runtime: params.runtime }),
+    );
   }
 }

--- a/src/context-threshold.ts
+++ b/src/context-threshold.ts
@@ -271,6 +271,10 @@ export function reconcilePersistedContextThreshold(params: {
     }
     return { resolved: live, supersededStalePersisted: true };
   }
+  // Persisted globals are validated by scalar equality only, unlike
+  // overrides, which prove rule-plus-payload producibility above: the
+  // configured global is a single threshold today. If global-level sizing
+  // ever becomes configurable, this check must grow a payload comparison.
   if (live.source === "override" || live.contextThreshold !== persisted.contextThreshold) {
     return { resolved: live, supersededStalePersisted: true };
   }

--- a/src/context-threshold.ts
+++ b/src/context-threshold.ts
@@ -155,6 +155,37 @@ function rulePossiblyMatches(params: {
   return true;
 }
 
+// Whether a rule's configured payload could have produced the persisted
+// resolution. The threshold must match exactly; the sizing fields must match
+// wherever the row recorded them. A row without a recorded sizing field
+// predates those columns (legacy schema), so an absent value means
+// "not recorded", never "recorded as absent" — it cannot count against the
+// rule, and the engine's runtime fill-in covers it on the kept path.
+function rulePayloadProduces(
+  rule: ContextThresholdOverride,
+  persisted: Pick<
+    ResolvedContextThreshold,
+    "contextThreshold" | "freshTailCount" | "leafChunkTokens"
+  >,
+): boolean {
+  if (rule.contextThreshold !== persisted.contextThreshold) {
+    return false;
+  }
+  if (
+    persisted.freshTailCount !== undefined &&
+    rule.freshTailCount !== persisted.freshTailCount
+  ) {
+    return false;
+  }
+  if (
+    persisted.leafChunkTokens !== undefined &&
+    rule.leafChunkTokens !== persisted.leafChunkTokens
+  ) {
+    return false;
+  }
+  return true;
+}
+
 // Summarize which matchers selected the winning rule for log lines.
 function describeRuleMatch(
   rule: ContextThresholdOverride,
@@ -220,22 +251,22 @@ export function persistedContextThresholdOverride(maintenance: {
  * The persisted value protects drains that lack the runtime metadata which
  * originally selected an override; it stays authoritative only while live
  * config could still plausibly produce it. A persisted override with no
- * possibly-matching rule left, and a persisted global that diverges from the
- * configured global, are provably stale (the config changed after the row was
- * written) and are superseded so a dead experiment value cannot wedge
- * compaction forever.
+ * plausibly-matching rule that could produce its payload, and a persisted
+ * global that diverges from the configured global, are provably stale (the
+ * config changed after the row was written) and are superseded so a dead
+ * experiment value cannot wedge compaction forever.
  */
 export function reconcilePersistedContextThreshold(params: {
   persisted: ResolvedContextThreshold | undefined;
   live: ResolvedContextThreshold;
-  anyRuleCouldMatch: boolean;
+  anyRuleCouldProducePersisted: boolean;
 }): { resolved: ResolvedContextThreshold; supersededStalePersisted: boolean } {
   const { persisted, live } = params;
   if (!persisted) {
     return { resolved: live, supersededStalePersisted: false };
   }
   if (persisted.source === "override") {
-    if (params.anyRuleCouldMatch) {
+    if (params.anyRuleCouldProducePersisted) {
       return { resolved: persisted, supersededStalePersisted: false };
     }
     return { resolved: live, supersededStalePersisted: true };
@@ -332,16 +363,26 @@ export class ContextThresholdResolver {
   }
 
   /**
-   * Whether any configured rule could match this context when matchers whose
-   * runtime metadata is absent are treated as satisfiable. Backs the stale
-   * check in {@link reconcilePersistedContextThreshold}.
+   * Whether any configured rule could have produced the persisted resolution:
+   * the rule must both plausibly match this context (matchers whose runtime
+   * metadata is absent count as satisfiable) and carry a payload that yields
+   * the persisted threshold and recorded sizing. A rule that merely might
+   * match is not enough — an unrelated surviving override must not keep a
+   * removed rule's stale value alive. Backs the stale check in
+   * {@link reconcilePersistedContextThreshold}.
    */
-  couldAnyRuleMatch(params: {
+  couldAnyRuleProduce(params: {
     sessionKey?: string;
     runtime: RuntimeModelContext;
+    persisted: Pick<
+      ResolvedContextThreshold,
+      "contextThreshold" | "freshTailCount" | "leafChunkTokens"
+    >;
   }): boolean {
-    return this.rules.some((compiled) =>
-      rulePossiblyMatches({ compiled, sessionKey: params.sessionKey, runtime: params.runtime }),
+    return this.rules.some(
+      (compiled) =>
+        rulePossiblyMatches({ compiled, sessionKey: params.sessionKey, runtime: params.runtime }) &&
+        rulePayloadProduces(compiled.rule, params.persisted),
     );
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -896,7 +896,8 @@ export class LcmContextEngine implements ContextEngine {
       // may lack the runtime model metadata that originally selected it, and
       // re-resolving could silently flip the compaction decision. That trust
       // ends where live config can no longer produce the persisted value —
-      // a stale row otherwise outlives the config edit and wedges compaction
+      // some plausibly-matching rule must still carry the persisted payload,
+      // or the stale row outlives the config edit and wedges compaction
       // forever (#942). New debt rows also persist selected fresh-tail and
       // leaf chunk sizing; the runtime fallback only helps older rows written
       // before those columns existed.
@@ -904,10 +905,13 @@ export class LcmContextEngine implements ContextEngine {
       const reconciledContextThreshold = reconcilePersistedContextThreshold({
         persisted: persistedContextThreshold,
         live: runtimeResolvedContextThreshold,
-        anyRuleCouldMatch: this.contextThresholdResolver.couldAnyRuleMatch({
-          sessionKey: params.sessionKey,
-          runtime: runtimeModelContext,
-        }),
+        anyRuleCouldProducePersisted:
+          persistedContextThreshold !== undefined &&
+          this.contextThresholdResolver.couldAnyRuleProduce({
+            sessionKey: params.sessionKey,
+            runtime: runtimeModelContext,
+            persisted: persistedContextThreshold,
+          }),
       });
       if (reconciledContextThreshold.supersededStalePersisted && persistedContextThreshold) {
         this.deps.log.info(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -26,6 +26,7 @@ import {
   ContextThresholdResolver,
   describeResolvedContextThreshold,
   persistedContextThresholdOverride,
+  reconcilePersistedContextThreshold,
   type ResolvedContextThreshold,
 } from "./context-threshold.js";
 import { LargeFileInterceptor } from "./large-file-interceptor.js";
@@ -883,32 +884,51 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
         maintenance.projectedTokenCount ?? undefined,
       );
+      const runtimeModelContext = readRuntimeModelContext(
+        asRecord(params.runtimeContext),
+        asRecord(params.legacyParams),
+      );
       const runtimeResolvedContextThreshold = this.contextThresholdResolver.resolve({
         sessionKey: params.sessionKey,
-        runtime: readRuntimeModelContext(
-          asRecord(params.runtimeContext),
-          asRecord(params.legacyParams),
-        ),
+        runtime: runtimeModelContext,
       });
       // Prefer the threshold persisted with the debt row: a background drain
       // may lack the runtime model metadata that originally selected it, and
-      // re-resolving could silently flip the compaction decision. New debt rows
-      // also persist selected fresh-tail and leaf chunk sizing; the runtime
-      // fallback only helps older rows written before those columns existed.
+      // re-resolving could silently flip the compaction decision. That trust
+      // ends where live config can no longer produce the persisted value —
+      // a stale row otherwise outlives the config edit and wedges compaction
+      // forever (#942). New debt rows also persist selected fresh-tail and
+      // leaf chunk sizing; the runtime fallback only helps older rows written
+      // before those columns existed.
       const persistedContextThreshold = persistedContextThresholdOverride(maintenance);
-      const resolvedContextThreshold = persistedContextThreshold
-        ? {
-            ...persistedContextThreshold,
-            ...(persistedContextThreshold.freshTailCount === undefined &&
-            runtimeResolvedContextThreshold.freshTailCount !== undefined
-              ? { freshTailCount: runtimeResolvedContextThreshold.freshTailCount }
-              : {}),
-            ...(persistedContextThreshold.leafChunkTokens === undefined &&
-            runtimeResolvedContextThreshold.leafChunkTokens !== undefined
-              ? { leafChunkTokens: runtimeResolvedContextThreshold.leafChunkTokens }
-              : {}),
-          }
-        : runtimeResolvedContextThreshold;
+      const reconciledContextThreshold = reconcilePersistedContextThreshold({
+        persisted: persistedContextThreshold,
+        live: runtimeResolvedContextThreshold,
+        anyRuleCouldMatch: this.contextThresholdResolver.couldAnyRuleMatch({
+          sessionKey: params.sessionKey,
+          runtime: runtimeModelContext,
+        }),
+      });
+      if (reconciledContextThreshold.supersededStalePersisted && persistedContextThreshold) {
+        this.deps.log.info(
+          `[lcm] maintain: stale persisted context threshold superseded by live config conversation=${params.conversationId} ${sessionLabel} persistedThreshold=${persistedContextThreshold.contextThreshold} persistedSource=${persistedContextThreshold.source} liveThreshold=${runtimeResolvedContextThreshold.contextThreshold} liveSource=${runtimeResolvedContextThreshold.source}`,
+        );
+      }
+      const resolvedContextThreshold =
+        persistedContextThreshold &&
+        reconciledContextThreshold.resolved === persistedContextThreshold
+          ? {
+              ...persistedContextThreshold,
+              ...(persistedContextThreshold.freshTailCount === undefined &&
+              runtimeResolvedContextThreshold.freshTailCount !== undefined
+                ? { freshTailCount: runtimeResolvedContextThreshold.freshTailCount }
+                : {}),
+              ...(persistedContextThreshold.leafChunkTokens === undefined &&
+              runtimeResolvedContextThreshold.leafChunkTokens !== undefined
+                ? { leafChunkTokens: runtimeResolvedContextThreshold.leafChunkTokens }
+                : {}),
+            }
+          : reconciledContextThreshold.resolved;
 
       const isThresholdDebt = maintenance.reason?.trim() === "threshold";
       if (!isThresholdDebt) {

--- a/test/context-threshold.test.ts
+++ b/test/context-threshold.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   ContextThresholdResolver,
   persistedContextThresholdOverride,
+  reconcilePersistedContextThreshold,
 } from "../src/context-threshold.js";
 import { readRuntimeModelContext } from "../src/runtime-model.js";
 
@@ -223,5 +224,145 @@ describe("persistedContextThresholdOverride", () => {
         contextLeafChunkTokens: null,
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("ContextThresholdResolver.couldAnyRuleMatch", () => {
+  it("is false when no rules are configured", () => {
+    const resolver = new ContextThresholdResolver(0.75, []);
+    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(false);
+  });
+
+  it("treats absent window metadata as satisfiable for window-range rules", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { modelContextWindowMax: 250_000 }, contextThreshold: 0.1 },
+    ]);
+    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
+    expect(resolver.couldAnyRuleMatch({ runtime: { modelContextWindow: 500_000 } })).toBe(false);
+  });
+
+  it("rejects on a known session key that fails the rule's session pattern", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { sessionPattern: "agent:alpha:**" }, contextThreshold: 0.1 },
+    ]);
+    expect(resolver.couldAnyRuleMatch({ sessionKey: "agent:beta:main", runtime: {} })).toBe(false);
+    expect(resolver.couldAnyRuleMatch({ sessionKey: "agent:alpha:main", runtime: {} })).toBe(true);
+    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
+  });
+
+  it("rejects on present model metadata that fails the rule's model matcher", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { model: "openai/gpt-5.5" }, contextThreshold: 0.1 },
+    ]);
+    expect(
+      resolver.couldAnyRuleMatch({ runtime: { model: "claude", modelRef: "anthropic/claude" } }),
+    ).toBe(false);
+    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
+  });
+});
+
+describe("reconcilePersistedContextThreshold", () => {
+  const liveGlobal = {
+    contextThreshold: 0.75,
+    source: "global" as const,
+    reason: "no_override_matched",
+    specificity: 0,
+  };
+
+  it("uses the live resolution when nothing was persisted", () => {
+    const result = reconcilePersistedContextThreshold({
+      persisted: undefined,
+      live: liveGlobal,
+      anyRuleCouldMatch: false,
+    });
+    expect(result.resolved).toBe(liveGlobal);
+    expect(result.supersededStalePersisted).toBe(false);
+  });
+
+  it("keeps a persisted override while a configured rule could still match", () => {
+    const persisted = {
+      contextThreshold: 0.1,
+      source: "override" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveGlobal,
+      anyRuleCouldMatch: true,
+    });
+    expect(result.resolved).toBe(persisted);
+    expect(result.supersededStalePersisted).toBe(false);
+  });
+
+  it("supersedes a persisted override when no configured rule could match", () => {
+    const persisted = {
+      contextThreshold: 0.02,
+      source: "override" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveGlobal,
+      anyRuleCouldMatch: false,
+    });
+    expect(result.resolved).toBe(liveGlobal);
+    expect(result.supersededStalePersisted).toBe(true);
+  });
+
+  it("supersedes a persisted global that diverges from the configured global", () => {
+    const persisted = {
+      contextThreshold: 0.02,
+      source: "global" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveGlobal,
+      anyRuleCouldMatch: false,
+    });
+    expect(result.resolved).toBe(liveGlobal);
+    expect(result.supersededStalePersisted).toBe(true);
+  });
+
+  it("keeps a persisted global equal to the configured global", () => {
+    const persisted = {
+      contextThreshold: 0.75,
+      source: "global" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+      freshTailCount: 4,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveGlobal,
+      anyRuleCouldMatch: false,
+    });
+    expect(result.resolved).toBe(persisted);
+    expect(result.supersededStalePersisted).toBe(false);
+  });
+
+  it("prefers a live override over a persisted global", () => {
+    const persisted = {
+      contextThreshold: 0.75,
+      source: "global" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+    };
+    const liveOverride = {
+      contextThreshold: 0.3,
+      source: "override" as const,
+      reason: "sessionPattern=agent:alpha:**",
+      specificity: 50,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveOverride,
+      anyRuleCouldMatch: true,
+    });
+    expect(result.resolved).toBe(liveOverride);
+    expect(result.supersededStalePersisted).toBe(true);
   });
 });

--- a/test/context-threshold.test.ts
+++ b/test/context-threshold.test.ts
@@ -227,27 +227,46 @@ describe("persistedContextThresholdOverride", () => {
   });
 });
 
-describe("ContextThresholdResolver.couldAnyRuleMatch", () => {
+describe("ContextThresholdResolver.couldAnyRuleProduce", () => {
+  const persistedTenth = { contextThreshold: 0.1 };
+
   it("is false when no rules are configured", () => {
     const resolver = new ContextThresholdResolver(0.75, []);
-    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(false);
+    expect(resolver.couldAnyRuleProduce({ runtime: {}, persisted: persistedTenth })).toBe(false);
   });
 
   it("treats absent window metadata as satisfiable for window-range rules", () => {
     const resolver = new ContextThresholdResolver(0.75, [
       { match: { modelContextWindowMax: 250_000 }, contextThreshold: 0.1 },
     ]);
-    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
-    expect(resolver.couldAnyRuleMatch({ runtime: { modelContextWindow: 500_000 } })).toBe(false);
+    expect(resolver.couldAnyRuleProduce({ runtime: {}, persisted: persistedTenth })).toBe(true);
+    expect(
+      resolver.couldAnyRuleProduce({
+        runtime: { modelContextWindow: 500_000 },
+        persisted: persistedTenth,
+      }),
+    ).toBe(false);
   });
 
   it("rejects on a known session key that fails the rule's session pattern", () => {
     const resolver = new ContextThresholdResolver(0.75, [
       { match: { sessionPattern: "agent:alpha:**" }, contextThreshold: 0.1 },
     ]);
-    expect(resolver.couldAnyRuleMatch({ sessionKey: "agent:beta:main", runtime: {} })).toBe(false);
-    expect(resolver.couldAnyRuleMatch({ sessionKey: "agent:alpha:main", runtime: {} })).toBe(true);
-    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
+    expect(
+      resolver.couldAnyRuleProduce({
+        sessionKey: "agent:beta:main",
+        runtime: {},
+        persisted: persistedTenth,
+      }),
+    ).toBe(false);
+    expect(
+      resolver.couldAnyRuleProduce({
+        sessionKey: "agent:alpha:main",
+        runtime: {},
+        persisted: persistedTenth,
+      }),
+    ).toBe(true);
+    expect(resolver.couldAnyRuleProduce({ runtime: {}, persisted: persistedTenth })).toBe(true);
   });
 
   it("rejects on present model metadata that fails the rule's model matcher", () => {
@@ -255,9 +274,85 @@ describe("ContextThresholdResolver.couldAnyRuleMatch", () => {
       { match: { model: "openai/gpt-5.5" }, contextThreshold: 0.1 },
     ]);
     expect(
-      resolver.couldAnyRuleMatch({ runtime: { model: "claude", modelRef: "anthropic/claude" } }),
+      resolver.couldAnyRuleProduce({
+        runtime: { model: "claude", modelRef: "anthropic/claude" },
+        persisted: persistedTenth,
+      }),
     ).toBe(false);
-    expect(resolver.couldAnyRuleMatch({ runtime: {} })).toBe(true);
+    expect(resolver.couldAnyRuleProduce({ runtime: {}, persisted: persistedTenth })).toBe(true);
+  });
+
+  it("rejects a plausibly-matching rule whose threshold differs from the persisted value", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { modelContextWindowMax: 250_000 }, contextThreshold: 0.4 },
+    ]);
+    expect(
+      resolver.couldAnyRuleProduce({ runtime: {}, persisted: { contextThreshold: 0.1 } }),
+    ).toBe(false);
+  });
+
+  it("requires recorded sizing fields to match the rule's payload", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      {
+        match: { modelContextWindowMax: 250_000 },
+        contextThreshold: 0.1,
+        freshTailCount: 16,
+        leafChunkTokens: 12_000,
+      },
+    ]);
+    expect(
+      resolver.couldAnyRuleProduce({
+        runtime: {},
+        persisted: { contextThreshold: 0.1, freshTailCount: 16, leafChunkTokens: 12_000 },
+      }),
+    ).toBe(true);
+    expect(
+      resolver.couldAnyRuleProduce({
+        runtime: {},
+        persisted: { contextThreshold: 0.1, freshTailCount: 8, leafChunkTokens: 12_000 },
+      }),
+    ).toBe(false);
+    expect(
+      resolver.couldAnyRuleProduce({
+        runtime: {},
+        persisted: { contextThreshold: 0.1, freshTailCount: 16, leafChunkTokens: 9_000 },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats sizing the row never recorded as producible by a sizing-carrying rule", () => {
+    // Rows written before the sizing columns existed persist only the
+    // threshold; an absent field means "not recorded", not "recorded absent".
+    const resolver = new ContextThresholdResolver(0.75, [
+      {
+        match: { modelContextWindowMax: 250_000 },
+        contextThreshold: 0.1,
+        freshTailCount: 16,
+      },
+    ]);
+    expect(
+      resolver.couldAnyRuleProduce({ runtime: {}, persisted: { contextThreshold: 0.1 } }),
+    ).toBe(true);
+  });
+
+  it("requires one rule to both plausibly match and produce the payload", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      { match: { modelContextWindowMax: 250_000 }, contextThreshold: 0.4 },
+      { match: { sessionPattern: "agent:alpha:**" }, contextThreshold: 0.1 },
+    ]);
+    expect(
+      resolver.couldAnyRuleProduce({ runtime: {}, persisted: { contextThreshold: 0.1 } }),
+    ).toBe(true);
+    // A session key that fails the producing rule's pattern leaves only the
+    // wrong-threshold rule standing: matching and producing must not be
+    // satisfied by two different rules.
+    expect(
+      resolver.couldAnyRuleProduce({
+        sessionKey: "agent:beta:main",
+        runtime: {},
+        persisted: { contextThreshold: 0.1 },
+      }),
+    ).toBe(false);
   });
 });
 
@@ -273,13 +368,13 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted: undefined,
       live: liveGlobal,
-      anyRuleCouldMatch: false,
+      anyRuleCouldProducePersisted: false,
     });
     expect(result.resolved).toBe(liveGlobal);
     expect(result.supersededStalePersisted).toBe(false);
   });
 
-  it("keeps a persisted override while a configured rule could still match", () => {
+  it("keeps a persisted override while a configured rule could still produce it", () => {
     const persisted = {
       contextThreshold: 0.1,
       source: "override" as const,
@@ -289,13 +384,13 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted,
       live: liveGlobal,
-      anyRuleCouldMatch: true,
+      anyRuleCouldProducePersisted: true,
     });
     expect(result.resolved).toBe(persisted);
     expect(result.supersededStalePersisted).toBe(false);
   });
 
-  it("supersedes a persisted override when no configured rule could match", () => {
+  it("supersedes a persisted override when no configured rule could produce it", () => {
     const persisted = {
       contextThreshold: 0.02,
       source: "override" as const,
@@ -305,7 +400,7 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted,
       live: liveGlobal,
-      anyRuleCouldMatch: false,
+      anyRuleCouldProducePersisted: false,
     });
     expect(result.resolved).toBe(liveGlobal);
     expect(result.supersededStalePersisted).toBe(true);
@@ -321,7 +416,7 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted,
       live: liveGlobal,
-      anyRuleCouldMatch: false,
+      anyRuleCouldProducePersisted: false,
     });
     expect(result.resolved).toBe(liveGlobal);
     expect(result.supersededStalePersisted).toBe(true);
@@ -338,7 +433,7 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted,
       live: liveGlobal,
-      anyRuleCouldMatch: false,
+      anyRuleCouldProducePersisted: false,
     });
     expect(result.resolved).toBe(persisted);
     expect(result.supersededStalePersisted).toBe(false);
@@ -360,7 +455,7 @@ describe("reconcilePersistedContextThreshold", () => {
     const result = reconcilePersistedContextThreshold({
       persisted,
       live: liveOverride,
-      anyRuleCouldMatch: true,
+      anyRuleCouldProducePersisted: true,
     });
     expect(result.resolved).toBe(liveOverride);
     expect(result.supersededStalePersisted).toBe(true);

--- a/test/context-threshold.test.ts
+++ b/test/context-threshold.test.ts
@@ -460,4 +460,34 @@ describe("reconcilePersistedContextThreshold", () => {
     expect(result.resolved).toBe(liveOverride);
     expect(result.supersededStalePersisted).toBe(true);
   });
+
+  it("prefers an equal-threshold live override over a persisted global, adopting its payload", () => {
+    // The override wins on source even when the thresholds are numerically
+    // equal, and the drain adopts the override's sizing over the sizing
+    // recorded with the persisted global.
+    const persisted = {
+      contextThreshold: 0.75,
+      source: "global" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+      freshTailCount: 4,
+    };
+    const liveOverride = {
+      contextThreshold: 0.75,
+      source: "override" as const,
+      reason: "sessionPattern=agent:alpha:**",
+      specificity: 50,
+      freshTailCount: 8,
+      leafChunkTokens: 9_000,
+    };
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveOverride,
+      anyRuleCouldProducePersisted: true,
+    });
+    expect(result.resolved).toBe(liveOverride);
+    expect(result.resolved.freshTailCount).toBe(8);
+    expect(result.resolved.leafChunkTokens).toBe(9_000);
+    expect(result.supersededStalePersisted).toBe(true);
+  });
 });

--- a/test/context-threshold.test.ts
+++ b/test/context-threshold.test.ts
@@ -406,6 +406,44 @@ describe("reconcilePersistedContextThreshold", () => {
     expect(result.supersededStalePersisted).toBe(true);
   });
 
+  it("supersedes a persisted override when a known live override selects a conflicting payload", () => {
+    const resolver = new ContextThresholdResolver(0.75, [
+      {
+        match: { modelContextWindowMax: 250_000 },
+        contextThreshold: 0.1,
+        freshTailCount: 16,
+      },
+      {
+        match: { model: "openai/gpt-5.5" },
+        contextThreshold: 0.2,
+        freshTailCount: 8,
+      },
+    ]);
+    const runtime = { model: "openai/gpt-5.5" };
+    const persisted = {
+      contextThreshold: 0.1,
+      source: "override" as const,
+      reason: "persisted deferred threshold debt",
+      specificity: 0,
+      freshTailCount: 16,
+    };
+    const liveOverride = resolver.resolve({ runtime });
+
+    expect(resolver.couldAnyRuleProduce({ runtime, persisted })).toBe(true);
+    expect(liveOverride).toMatchObject({
+      contextThreshold: 0.2,
+      source: "override",
+      freshTailCount: 8,
+    });
+    const result = reconcilePersistedContextThreshold({
+      persisted,
+      live: liveOverride,
+      anyRuleCouldProducePersisted: resolver.couldAnyRuleProduce({ runtime, persisted }),
+    });
+    expect(result.resolved).toBe(liveOverride);
+    expect(result.supersededStalePersisted).toBe(true);
+  });
+
   it("supersedes a persisted global that diverges from the configured global", () => {
     const persisted = {
       contextThreshold: 0.02,

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -258,20 +258,89 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     );
   });
 
-  it("maintain() supersedes a persisted override threshold no remaining rule could produce", async () => {
-    // Debt recorded by a since-removed 0.02 override experiment. An unrelated
-    // override rule is still configured and plausibly matches a metadata-less
-    // drain, but it produces a different threshold: rule presence alone must
-    // not keep the stale 0.02 alive when no current rule can produce it.
+  it("maintain() keeps a producible persisted override and fills unrecorded sizing from live config", async () => {
+    // Legacy debt row: only the 0.1 override threshold was recorded (the row
+    // predates the sizing columns). The producing rule is still configured,
+    // so the persisted value is kept and the drain fills the unrecorded
+    // sizing from the live resolution. The persisted reason string proves the
+    // kept object is the persisted one, not a fresh live resolution.
     const engine = createEngineWithConfig({
       contextThreshold: 0.75,
       contextThresholdOverrides: [
         {
           match: { modelContextWindowMax: 250_000 },
-          contextThreshold: 0.4,
+          contextThreshold: 0.1,
+          freshTailCount: 16,
+          leafChunkTokens: 12000,
         },
       ],
     });
+    const sessionId = "maintain-deferred-kept-persisted-fills-sizing";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
+      contextThreshold: 0.1,
+      contextThresholdSource: "override",
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-kept-persisted-fills-sizing-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
+        modelContextWindow: 200_000,
+      },
+    });
+
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.1,
+          source: "override",
+          reason: "persisted deferred threshold debt",
+          freshTailCount: 16,
+          leafChunkTokens: 12000,
+        }),
+      }),
+    );
+  });
+
+  it("maintain() supersedes a persisted override threshold no remaining rule could produce", async () => {
+    // Debt recorded by a since-removed 0.02 override experiment. An unrelated
+    // override rule is still configured and plausibly matches a metadata-less
+    // drain, but it produces a different threshold: rule presence alone must
+    // not keep the stale 0.02 alive when no current rule can produce it.
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const engine = createEngineWithDeps(
+      {
+        contextThreshold: 0.75,
+        contextThresholdOverrides: [
+          {
+            match: { modelContextWindowMax: 250_000 },
+            contextThreshold: 0.4,
+          },
+        ],
+      },
+      { log },
+    );
     const sessionId = "maintain-deferred-stale-persisted-unrelated-rule";
     const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
       sessionKey: undefined,
@@ -318,6 +387,13 @@ describe("LcmContextEngine maintain and assemble budget", () => {
         }),
       }),
     );
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "maintain: stale persisted context threshold superseded by live config",
+      ),
+    );
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("persistedThreshold=0.02"));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("liveThreshold=0.75"));
   });
 
   it("maintain() supersedes a persisted global threshold that diverges from live config", async () => {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -258,6 +258,68 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     );
   });
 
+  it("maintain() supersedes a persisted override threshold no remaining rule could produce", async () => {
+    // Debt recorded by a since-removed 0.02 override experiment. An unrelated
+    // override rule is still configured and plausibly matches a metadata-less
+    // drain, but it produces a different threshold: rule presence alone must
+    // not keep the stale 0.02 alive when no current rule can produce it.
+    const engine = createEngineWithConfig({
+      contextThreshold: 0.75,
+      contextThresholdOverrides: [
+        {
+          match: { modelContextWindowMax: 250_000 },
+          contextThreshold: 0.4,
+        },
+      ],
+    });
+    const sessionId = "maintain-deferred-stale-persisted-unrelated-rule";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
+      contextThreshold: 0.02,
+      contextThresholdSource: "override",
+      contextFreshTailCount: 16,
+      contextLeafChunkTokens: 12000,
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath(
+        "maintain-deferred-stale-persisted-unrelated-rule-maintain",
+      ),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
+      },
+    });
+
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.75,
+          source: "global",
+        }),
+      }),
+    );
+  });
+
   it("maintain() supersedes a persisted global threshold that diverges from live config", async () => {
     // The global contextThreshold was lowered for an experiment, debt was
     // recorded at 0.02, then the config was reverted to 0.75: the drain must

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -205,6 +205,110 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(maintenanceResult.changed).toBe(true);
   });
 
+  it("maintain() supersedes a stale persisted override threshold when no live rule could match", async () => {
+    // Debt recorded while a since-removed low-threshold override experiment
+    // was active; live config has no override rules left, so the persisted
+    // 0.02 provably no longer originates from config and must not be honoured.
+    const engine = createEngineWithConfig({
+      contextThreshold: 0.75,
+    });
+    const sessionId = "maintain-deferred-stale-persisted-override";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
+      contextThreshold: 0.02,
+      contextThresholdSource: "override",
+      contextFreshTailCount: 16,
+      contextLeafChunkTokens: 12000,
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-stale-persisted-override-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
+      },
+    });
+
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.75,
+          source: "global",
+        }),
+      }),
+    );
+  });
+
+  it("maintain() supersedes a persisted global threshold that diverges from live config", async () => {
+    // The global contextThreshold was lowered for an experiment, debt was
+    // recorded at 0.02, then the config was reverted to 0.75: the drain must
+    // follow the reverted config instead of wedging on the stale row.
+    const engine = createEngineWithConfig({
+      contextThreshold: 0.75,
+    });
+    const sessionId = "maintain-deferred-stale-persisted-global";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 500_000,
+      currentTokenCount: 80_000,
+      contextThreshold: 0.02,
+      contextThresholdSource: "global",
+    });
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeCompactionCoreSpy = vi.spyOn(
+      privateEngine,
+      "executeCompactionCore",
+    ).mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-deferred-stale-persisted-global-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 500_000,
+        currentTokenCount: 80_000,
+      },
+    });
+
+    expect(executeCompactionCoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextThresholdOverride: expect.objectContaining({
+          contextThreshold: 0.75,
+          source: "global",
+        }),
+      }),
+    );
+  });
+
   it("maintain() clears stale legacy non-threshold debt when threshold no longer applies", async () => {
     const engine = createEngine();
     const sessionId = "maintain-legacy-leaf-debt-cleared";


### PR DESCRIPTION
## Problem

[#942](https://github.com/Martian-Engineering/lossless-claw/issues/942): the deferred-compaction drain resolves its context threshold from the value persisted on the `conversation_compaction_maintenance` row and prefers it unconditionally over live config. A threshold recorded during a since-reverted config experiment therefore outlives the revert: the row survives restarts, config edits, and `/reset`, and no doctor cleaner targets it.

Observed twice on a production fleet: a `0.02` threshold recorded during a short-lived low-threshold experiment survived the config revert to `0.75`. Every subsequent drain targeted roughly 20k tokens, below the session's roughly 24k irreducible runtime overhead, so compaction could never reach the target and aborted with `stored_compaction_exhausted_but_live_context_still_exceeds_target` on every attempt until the conversation was manually reset.

## Fix

The persistence exists for a good reason (per the existing code comment, a background drain may lack the runtime model metadata that originally selected an override, and re-resolving could silently flip the compaction decision), so this change does not simply prefer live config. `reconcilePersistedContextThreshold` draws the trust boundary instead:

- A persisted `override` threshold stays authoritative while any configured rule could still match this context with absent runtime metadata treated as satisfiable (`couldAnyRuleMatch`, a wildcard variant of the rule matcher; a known session key remains decisive). When no configured rule could possibly produce it, the persisted value is provably stale and the live resolution wins.
- A persisted `global` threshold needs no runtime metadata, so live config is authoritative: it is superseded when the configured global diverges or a live rule now matches this context. An equal persisted global is kept unchanged.
- Every supersession logs an `[lcm] maintain:` info line carrying both the persisted and live values.

Existing behavior is otherwise preserved, including the fresh-tail and leaf-chunk fallback fills for older rows written before those columns existed.

## Tests

- Two engine integration regressions, red-proofed against the previous behavior (both fail without the fix): a stale persisted override with no remaining configured rules, and a stale persisted global after a config revert, both now drain at the live `0.75`.
- Unit coverage for the `couldAnyRuleMatch` wildcard semantics (absent window or model metadata counts as satisfiable, a known session key is decisive) and the full reconcile matrix (override kept while a rule is still plausible, equal global kept, divergent global and live-override supersessions).
- Full suite green: 107 files, 1917 tests; typecheck and build clean.

## Notes

- No changeset included; flagging that for a maintainer call. The change affects drain behavior only for rows whose persisted threshold provably cannot originate from current config.
