### PR TITLE
fix(reconcile): adopt oldest match for repeated same-body recovery turns

### DIFF
--- a/.changeset/repeated-same-body-recovery.md
+++ b/.changeset/repeated-same-body-recovery.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Prevent repeated same-body recovery turns from replaying duplicate bare transcript rows by adopting the oldest matching decorated runtime row during transcript reconciliation.

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1219,10 +1219,15 @@ export class TranscriptReconciler {
    * Stamp a brand-new transcript entry id onto a recently-persisted,
    * still-unstamped user runtime row that is the DECORATED face of the same
    * turn (its recognized metadata wrapper reduces to the exact bare
-   * model-facing body). When that body matches exactly one candidate, keeps the
-   * decorated row and anchors it instead of importing the bare transcript copy
-   * as a duplicate. Bounded to the flush-lag tail window and fails closed on
-   * ambiguous repeated bodies so legacy or unrelated rows are never mis-adopted.
+   * model-facing body). Keeps the decorated row and anchors it instead of
+   * importing the bare transcript copy as a duplicate. Bounded to the
+   * flush-lag tail window; rows whose reduced body differs are never
+   * mis-adopted. When several candidates reduce to the same body, the oldest
+   * takes the stamp: byte-identical reduced bodies are interchangeable
+   * provenance carriers, and each restamp removes its row from the next
+   * call's unstamped candidate set, so repeated identical turns converge one
+   * adoption per transcript entry instead of importing the bare body as a
+   * persisted duplicate that would replay on every later turn.
    */
   private async adoptDecorationInvariantEntryId(params: {
     conversationId: number;
@@ -1237,7 +1242,7 @@ export class TranscriptReconciler {
     const matches = candidates.filter((candidate) =>
       openClawInboundBodiesMatch(candidate.content, params.bareContent),
     );
-    if (matches.length !== 1) {
+    if (matches.length === 0) {
       return false;
     }
     return this.host.conversationStore.restampTranscriptEntryId(

--- a/test/placeholder-recovery-double-write.test.ts
+++ b/test/placeholder-recovery-double-write.test.ts
@@ -253,7 +253,13 @@ describe("placeholder-checkpoint recovery double-write", () => {
     expect(userRows.map((message) => message.content)).toEqual([differentDecoratedBody, "ok"]);
   });
 
-  it("does not adopt when multiple decorated rows reduce to the same bare body", async () => {
+  it("adopts the oldest unstamped row when multiple decorated rows reduce to the same bare body", async () => {
+    // Same-body multiplicity is not ambiguity: every candidate reduces to the
+    // exact bare body, so any of them is a correct provenance carrier for the
+    // entry. The earlier fail-closed refusal made the bare transcript copy
+    // import as an extra persisted row — a duplicate replayed on every later
+    // turn, which is the worse failure for a store whose contract is
+    // no-duplicates. Adoption now anchors the oldest unstamped match.
     const engine = createEngineWithDeps(
       {},
       { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
@@ -304,8 +310,91 @@ describe("placeholder-checkpoint recovery double-write", () => {
     expect(userRows.map((message) => message.content)).toEqual([
       decoratedRoomEvent("ok"),
       decoratedRoomEvent("ok"),
-      "ok",
     ]);
+    // The stamp landed on the OLDEST match (deterministic), leaving exactly
+    // the newer row in the unstamped pool.
+    const unstamped = await engine
+      .getConversationStore()
+      .listRecentUnstampedMessagesByRole(conversation!.conversationId, "user", 8);
+    expect(unstamped).toHaveLength(1);
+    expect(unstamped[0].messageId).toBe(userRows[1].messageId);
+  });
+
+  it("adopts every repeated same-body turn without importing bare duplicates on recovery", async () => {
+    // A user sends the same short reply twice; both turns are persisted
+    // decorated+unstamped by the live ingest, then a restart-class recovery
+    // replays the transcript holding BOTH bare entries. Each adoption removes
+    // its row from the next call's unstamped candidate set, so oldest-first
+    // adoption converges one stamp per transcript entry.
+    const engine = createEngineWithDeps(
+      {},
+      { log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+    );
+    const sessionId = "repeated-identical-turns";
+    const sessionKey = "agent:agent-one:telegram:repeated-identical-turns";
+
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("ok") }),
+    });
+    await engine.ingest({
+      sessionId,
+      sessionKey,
+      message: makeMessage({ role: "user", content: decoratedRoomEvent("ok") }),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationForSession({ sessionId, sessionKey });
+    expect(conversation).not.toBeNull();
+
+    const sessionFile = createSessionFilePath("repeated-identical-turns");
+    const sessionManager = SessionManager.open(sessionFile);
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "ok" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "assistant", content: "first reply" }));
+    appendSessionMessage(sessionManager, makeMessage({ role: "user", content: "ok" }));
+    appendSessionMessage(
+      sessionManager,
+      makeMessage({ role: "assistant", content: "second reply" }),
+    );
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation!.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    // Both turns keep exactly their decorated rows — no bare "ok" imports.
+    const userRows = stored.filter((message) => message.role === "user");
+    expect(userRows.map((message) => message.content)).toEqual([
+      decoratedRoomEvent("ok"),
+      decoratedRoomEvent("ok"),
+    ]);
+    // Every repeated turn took a stamp: the unstamped pool drained fully.
+    const unstamped = await engine
+      .getConversationStore()
+      .listRecentUnstampedMessagesByRole(conversation!.conversationId, "user", 8);
+    expect(unstamped).toHaveLength(0);
+    // The genuinely-new assistant replies still import (no over-suppression).
+    expect(
+      stored
+        .filter((message) => message.role === "assistant")
+        .map((message) => message.content),
+    ).toEqual(["first reply", "second reply"]);
   });
 
   it("does not apply inbound-decoration adoption to assistant rows", async () => {


### PR DESCRIPTION
## Problem

`adoptDecorationInvariantEntryId` fails closed when more than one recently persisted, still unstamped decorated user row reduces to the same bare body:

```ts
if (matches.length !== 1) {
  return false;
}
```

When a user sends the same short reply twice (two "ok" turns) and a restart-class recovery (placeholder or checkpoint-missing) later replays the transcript, adoption refuses both candidates, and each bare transcript copy is imported as an additional persisted user row. The store then carries a duplicate of a message it already holds, replayed into context on every subsequent turn. Two persisted rows are outside the runtime-vs-persisted metadata-face collapse, so nothing downstream removes them.

The multiplicity refusal was introduced in [d163ed6's sibling hardening round, commit d897771](https://github.com/Martian-Engineering/lossless-claw/commit/d897771) on [#935](https://github.com/Martian-Engineering/lossless-claw/pull/935).

## Why adopting the oldest match is safe

The refusal protects against stamping the wrong row, but the candidates here are byte-identical after reduction: `openClawInboundBodiesMatch` already guarantees every match reduces to the exact bare body. Interchangeable bodies are interchangeable provenance carriers, so there is no wrong choice, only a deterministic one. Rows whose reduced body differs are untouched (the filter is unchanged).

Adopting the oldest match also converges under repetition: each restamp removes that row from the next call's unstamped candidate set, so N identical turns recovered from a transcript holding N bare entries end with N stamped rows and zero imports.

The previous behavior traded a non-existent mis-stamp risk for a guaranteed persisted duplicate, which is the worse failure for a store whose contract is no duplicates.

## Tests

`test/placeholder-recovery-double-write.test.ts`:

- Re-derived the multiplicity cell: two same-body decorated rows plus one bare transcript entry now end as two rows with the oldest stamped, instead of the previously pinned three-row outcome (the bare duplicate import asserted as expected).
- New cell: two identical turns recovered from a transcript carrying both bare entries end with both rows stamped, zero bare imports, and both assistant replies imported (no over-suppression).

Both cells fail on the previous code with the predicted duplicate imports. Full suite: 1906 passing.

No changeset included (external contribution); flagging for a maintainer to add one if this qualifies as a user-facing patch.

## Validation

- `npm run build` clean
- `npx tsc --noEmit` clean
- Focused Vitest: `test/placeholder-recovery-double-write.test.ts` passes 7/7; the two new cells fail on the previous code with the predicted duplicate imports and pass with the fix
- Full suite green (1906 tests, 107 files)
- GitHub checks green on the current head
