### PR TITLE
Add maxDatabaseBytes config and size-based auto-pruning

### DIFF
--- a/.changeset/db-size-cap.md
+++ b/.changeset/db-size-cap.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": minor
+---
+
+Add `maxDatabaseBytes` config option to auto-prune oldest archived conversations during `maintain()`, and add `/lossless prune` slash command for manual age-based and size-based pruning with optional orphaned large file cleanup.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -278,6 +278,10 @@
       "label": "Prune HEARTBEAT_OK",
       "help": "Retroactively delete HEARTBEAT_OK turn cycles from LCM storage"
     },
+    "maxDatabaseBytes": {
+      "label": "Max Database Size (bytes)",
+      "help": "Auto-prune oldest archived conversations when DB exceeds this byte limit. 0 = unlimited."
+    },
     "transcriptGcEnabled": {
       "label": "Transcript GC",
       "help": "Enable transcript rewrite GC during maintain(); disabled by default"
@@ -624,6 +628,10 @@
       },
       "pruneHeartbeatOk": {
         "type": "boolean"
+      },
+      "maxDatabaseBytes": {
+        "type": "number",
+        "minimum": 0
       },
       "transcriptGcEnabled": {
         "type": "boolean"

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -173,6 +173,8 @@ export type LcmConfig = {
   timezone: string;
   /** When true, retroactively delete HEARTBEAT_OK turn cycles from LCM storage. */
   pruneHeartbeatOk: boolean;
+  /** When > 0, maintain() auto-prunes the oldest archived conversations to keep the DB under this byte limit. 0 = unlimited. */
+  maxDatabaseBytes: number;
   /** When true, maintain() may rewrite transcript entries for transcript GC. */
   transcriptGcEnabled: boolean;
   /** When true, requests low reasoning from the model for summarization calls. */
@@ -788,6 +790,10 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_PRUNE_HEARTBEAT_OK !== undefined
           ? env.LCM_PRUNE_HEARTBEAT_OK === "true"
           : toBool(pc.pruneHeartbeatOk) ?? false,
+      maxDatabaseBytes:
+        toPositiveInteger(parseFiniteInt(env.LCM_MAX_DATABASE_BYTES))
+          ?? toPositiveInteger(toNumber(pc.maxDatabaseBytes))
+          ?? 0,
       transcriptGcEnabled:
         env.LCM_TRANSCRIPT_GC_ENABLED !== undefined
           ? env.LCM_TRANSCRIPT_GC_ENABLED === "true"

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -84,6 +84,7 @@ import { describeAssembledPrefixChange, formatOverflowDiagnosticsForLog, shouldL
 import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResult, buildForkBoundedLiveFallback, clampMessagesToSerializedBudget, forkBoundedLiveSuffixAppendLogLevel, resolveDeferredAssemblyPressure } from "./assemble-fallback.js";
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
+import { getDatabaseSizeBytes, pruneArchivedConversationsToFitSize } from "./prune.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
 import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
@@ -305,6 +306,7 @@ export class LcmContextEngine implements ContextEngine {
    * readLeafPathMessages() call can be skipped entirely.
    */
   private lastFullReadFileState = new Map<number, { size: number; mtimeMs: number }>();
+  private lastAutoPruneAt = 0;
 
   // ── Circuit breaker + summary spend guard ───────────────────────────────
   private readonly compactionGuards: CompactionGuards;
@@ -2694,6 +2696,30 @@ export class LcmContextEngine implements ContextEngine {
       { operationName: "maintain", context: sessionLabel },
     );
     await runRuntimeAutoRotate();
+
+    if (this.config.maxDatabaseBytes > 0) {
+      const AUTO_PRUNE_INTERVAL_MS = 5 * 60 * 1000;
+      if (Date.now() - this.lastAutoPruneAt >= AUTO_PRUNE_INTERVAL_MS) {
+        this.lastAutoPruneAt = Date.now();
+        try {
+          const { deleted } = pruneArchivedConversationsToFitSize(
+            this.db,
+            this.config.maxDatabaseBytes,
+            { largeFilesDir: this.config.largeFilesDir },
+          );
+          if (deleted > 0) {
+            this.deps.log.info(
+              `[lcm] auto-prune: deleted ${deleted} archived conversation(s) to stay under maxDatabaseBytes=${this.config.maxDatabaseBytes}`,
+            );
+          }
+        } catch (err) {
+          this.deps.log.warn(
+            `[lcm] auto-prune: failed: ${String(err)}`,
+          );
+        }
+      }
+    }
+
     return result;
   }
   private async ingestSingle(params: {

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -19,6 +19,7 @@ import type {
 import { applyScopedDoctorRepair } from "./lcm-doctor-apply.js";
 import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
 import { describeLogError } from "../lcm-log.js";
+import { getDatabaseSizeBytes, parseDuration, pruneArchivedConversationsToFitSize, pruneConversations } from "../prune.js";
 import { listConfiguredAgentIds } from "./openclaw-agent-ids.js";
 import {
   applyDoctorCleaners,
@@ -108,6 +109,7 @@ type ParsedLcmCommand =
   | { kind: "status" }
   | { kind: "backup" }
   | { kind: "rotate" }
+  | { kind: "prune"; apply: boolean; maxAge?: string; maxBytes?: number; vacuum: boolean }
   | { kind: "focus_status" }
   | { kind: "focus_generate"; prompt: string }
   | { kind: "refocus" }
@@ -629,6 +631,55 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
             kind: "help",
             error: `\`${VISIBLE_COMMAND} rotate\` does not accept extra arguments.`,
           };
+    case "prune": {
+      let apply = false;
+      let maxAge: string | undefined;
+      let maxBytes: number | undefined;
+      let vacuum = false;
+      for (const token of rest) {
+        const lower = token.toLowerCase();
+        if (lower === "confirm") {
+          apply = true;
+        } else if (lower === "vacuum") {
+          vacuum = true;
+        } else if (lower.startsWith("age=")) {
+          maxAge = lower.slice(4);
+        } else if (lower.startsWith("size=")) {
+          const raw = lower.slice(5);
+          const mbMatch = raw.match(/^(\d+(?:\.\d+)?)\s*mb$/i);
+          const gbMatch = raw.match(/^(\d+(?:\.\d+)?)\s*gb$/i);
+          if (mbMatch) {
+            const mb = Number(mbMatch[1]);
+            if (Number.isFinite(mb) && mb > 0) {
+              maxBytes = Math.floor(mb * 1024 * 1024);
+            }
+          } else if (gbMatch) {
+            const gb = Number(gbMatch[1]);
+            if (Number.isFinite(gb) && gb > 0) {
+              maxBytes = Math.floor(gb * 1024 * 1024 * 1024);
+            }
+          } else {
+            // No suffix — interpret as MB.
+            const numeric = Number(raw);
+            if (Number.isFinite(numeric) && numeric > 0) {
+              maxBytes = Math.floor(numeric * 1024 * 1024);
+            }
+          }
+          if (maxBytes == null) {
+            return {
+              kind: "help",
+              error: `Invalid size format '${raw}'. Expected: size=500mb or size=1gb.`,
+            };
+          }
+        } else {
+          return {
+            kind: "help",
+            error: `Unknown prune option \`${token}\`. Supported: \`confirm\`, \`vacuum\`, \`age=<duration>\` (e.g. age=90d), \`size=<mb|gb>\` (e.g. size=500mb, size=1gb).`,
+          };
+        }
+      }
+      return { kind: "prune", apply, maxAge, maxBytes, vacuum };
+    }
     case "doctor":
       if (rest.length === 0) {
         return { kind: "doctor", apply: false };
@@ -676,7 +727,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
     default:
       return {
         kind: "help",
-        error: `Unknown subcommand \`${head}\`. Supported: status, focus, refocus, unfocus, backup, rotate, doctor, doctor clean, doctor apply, help.`,
+        error: `Unknown subcommand \`${head}\`. Supported: status, focus, refocus, unfocus, backup, rotate, prune, doctor, doctor clean, doctor apply, help.`,
       };
   }
 }
@@ -1314,6 +1365,22 @@ function buildHelpText(error?: string): string {
         "Compact the current session transcript while preserving the same LCM conversation and live session identity.",
       ),
       buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} prune age=<duration>`),
+        "Dry-run: list conversations older than a threshold (e.g. age=90d, age=3m, age=1y).",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} prune confirm age=90d vacuum`),
+        "Delete conversations older than the threshold and optionally VACUUM.",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} prune size=<mb|gb>`),
+        "Dry-run: show what would be deleted to fit DB under a size cap (e.g. size=500mb, size=1gb).",
+      ),
+      buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} prune confirm size=500mb vacuum`),
+        "Delete oldest archived conversations to fit under the size cap (also supports size=1gb).",
+      ),
+      buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} focus <prompt>`),
         "Generate an active focus brief with a delegated recall sub-agent.",
       ),
@@ -1377,6 +1444,109 @@ function buildDoctorCleanerExampleLine(params: {
   const sessionKey = params.sessionKey ? formatCommand(truncateMiddle(params.sessionKey, 44)) : "missing";
   const preview = params.firstMessagePreview ? ` · first: ${JSON.stringify(params.firstMessagePreview)}` : "";
   return `conv ${formatNumber(params.conversationId)} · session key ${sessionKey} · messages ${formatNumber(params.messageCount)}${preview}`;
+}
+
+async function buildPruneText(params: {
+  ctx: PluginCommandContext;
+  db: DatabaseSync;
+  config: LcmConfig;
+  maxAge?: string;
+  maxBytes?: number;
+  vacuum: boolean;
+  confirm: boolean;
+}): Promise<string> {
+  const dbSize = getDatabaseSizeBytes(params.db);
+  const dbSizeMb = (dbSize / (1024 * 1024)).toFixed(1);
+
+  // Age-based pruning (dry run unless confirm)
+  if (params.maxAge) {
+    const days = parseDuration(params.maxAge);
+    if (days == null) {
+      return `Invalid duration \`${params.maxAge}\`. Expected e.g. \`30d\`, \`3m\`, \`1y\`.`;
+    }
+    if (!params.confirm) {
+      const result = pruneConversations(params.db, { before: params.maxAge });
+      if (result.candidates.length === 0) {
+        return [
+          `Dry-run: no conversations found older than \`${params.maxAge}\` (cutoff: ${result.cutoffDate}).`,
+          `Current DB size: ${dbSizeMb} MB.`,
+        ].join("\n");
+      }
+      return [
+        `Dry-run: ${result.candidates.length} conversation(s) match age > \`${params.maxAge}\` (cutoff: ${result.cutoffDate}).`,
+        result.candidates.length <= 20
+          ? result.candidates.map(
+              (c) =>
+                `  conv ${c.conversationId} · ${c.sessionKey ?? "no key"} · ${c.messageCount} msgs · latest ${c.latestMessageAt}`,
+            ).join("\n")
+          : `  (${result.candidates.length} candidates, showing first 20)`,
+        `\nRun \`/lossless prune confirm age=${params.maxAge}${params.vacuum ? " vacuum" : ""}\` to delete.`,
+        `Current DB size: ${dbSizeMb} MB.`,
+      ].join("\n");
+    }
+    const result = pruneConversations(params.db, {
+      before: params.maxAge,
+      confirm: true,
+      vacuum: params.vacuum,
+    });
+    return [
+      `Deleted ${result.deleted} conversation(s) older than \`${params.maxAge}\`.`,
+      result.vacuumed ? "VACUUM completed." : "",
+      `Current DB size: ${dbSizeMb} MB.`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  // Size-based pruning
+  const targetBytes = params.maxBytes ?? params.config.maxDatabaseBytes;
+  if (targetBytes <= 0) {
+    return [
+      `No size target configured. Set \`maxDatabaseBytes\` in plugin config or use \`size=<mb|gb>\`.`,
+      `Current DB size: ${dbSizeMb} MB.`,
+      `\nAge-based example: \`/lossless prune age=90d\` (dry-run)`,
+      `Age + confirm: \`/lossless prune confirm age=90d vacuum\``,
+      `Size-based example: \`/lossless prune size=500mb\` (dry-run, will prune oldest archived to fit)`,
+      `Size + confirm: \`/lossless prune confirm size=500mb vacuum\``,
+    ].join("\n");
+  }
+
+  const maxBytes = targetBytes;
+  const maxBytesMb = (maxBytes / (1024 * 1024)).toFixed(0);
+
+  if (!params.confirm) {
+    const archivedCount = (
+      params.db.prepare(
+        "SELECT COUNT(*) AS cnt FROM conversations WHERE active = 0 AND archived_at IS NOT NULL",
+      ).get() as { cnt: number }
+    ).cnt;
+    return [
+      `Dry-run: would delete oldest archived conversations to stay under ${maxBytesMb} MB.`,
+      `Current DB size: ${dbSizeMb} MB.`,
+      `Archived conversations available: ${archivedCount}.`,
+      `\nRun \`/lossless prune confirm size=${maxBytesMb}mb${params.vacuum ? " vacuum" : ""}\` to execute.`,
+    ].join("\n");
+  }
+
+  const result = pruneArchivedConversationsToFitSize(params.db, maxBytes, {
+    largeFilesDir: params.config.largeFilesDir,
+  });
+
+  if (params.vacuum && result.deleted > 0) {
+    params.db.exec("VACUUM");
+    params.db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+  }
+
+  const newSizeMb = (getDatabaseSizeBytes(params.db) / (1024 * 1024)).toFixed(1);
+  return [
+    result.deleted > 0
+      ? `Deleted ${result.deleted} archived conversation(s). Freed ~${((dbSize - getDatabaseSizeBytes(params.db)) / (1024 * 1024)).toFixed(1)} MB.`
+      : "No archived conversations to prune (DB is already under the target size).",
+    params.vacuum ? "VACUUM completed." : "",
+    `Current DB size: ${newSizeMb} MB.`,
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 async function buildStatusText(params: {
@@ -3340,6 +3510,18 @@ export function createLcmCommand(params: {
               config: params.config,
               deps: params.deps,
               getLcm: params.getLcm,
+            }),
+          };
+        case "prune":
+          return {
+            text: await buildPruneText({
+              ctx,
+              db: await getDb(),
+              config: params.config,
+              maxAge: parsed.maxAge,
+              maxBytes: parsed.maxBytes,
+              vacuum: parsed.vacuum,
+              confirm: parsed.apply,
             }),
           };
         case "focus_status":

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -6,6 +6,8 @@
  * to clean up messages, summaries, context_items, and other dependent rows.
  */
 import type { DatabaseSync } from "node:sqlite";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
 
 // ── Duration parsing ────────────────────────────────────────────────────────
 
@@ -389,4 +391,118 @@ export function pruneConversations(
     vacuumed,
     cutoffDate,
   };
+}
+
+// ── Size-based pruning helpers ──────────────────────────────────────────────
+
+export type PruneSizeResult = {
+  deleted: number;
+  deletedBytes: number;
+};
+
+/**
+ * Return the current database file size in bytes using SQLite page stats.
+ */
+export function getDatabaseSizeBytes(db: DatabaseSync): number {
+  const pageCount = (
+    db.prepare("PRAGMA page_count").get() as { page_count: number }
+  ).page_count;
+  const pageSize = (
+    db.prepare("PRAGMA page_size").get() as { page_size: number }
+  ).page_size;
+  return pageCount * pageSize;
+}
+
+/**
+ * Delete the oldest archived conversations (active=0) until the database
+ * size drops below maxBytes (or no archived conversations remain).
+ *
+ * Each conversation is deleted in its own transaction.  The caller should
+ * call VACUUM separately if desired (VACUUM is expensive and may block
+ * concurrent writers).
+ *
+ * @param largeFilesDir  When provided, the on-disk large-file directories
+ *                       for deleted conversations are removed.
+ */
+export function pruneArchivedConversationsToFitSize(
+  db: DatabaseSync,
+  maxBytes: number,
+  options?: {
+    batchSize?: number;
+    largeFilesDir?: string;
+  },
+): PruneSizeResult {
+  let deleted = 0;
+  let deletedBytes = 0;
+  const batchSize = Math.min(
+    options?.batchSize && options.batchSize > 0 ? Math.floor(options.batchSize) : 10,
+    100,
+  );
+
+  const currentSize = getDatabaseSizeBytes(db);
+  if (currentSize <= maxBytes) {
+    return { deleted: 0, deletedBytes: 0 };
+  }
+
+  const beforeSize = currentSize;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const sizeNow = getDatabaseSizeBytes(db);
+    if (sizeNow <= maxBytes) {
+      break;
+    }
+
+    const rows = db
+      .prepare(
+        `SELECT conversation_id FROM conversations
+         WHERE active = 0 AND archived_at IS NOT NULL
+         ORDER BY archived_at ASC
+         LIMIT ?`,
+      )
+      .all(batchSize) as { conversation_id: number }[];
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    const ids = rows.map((r) => r.conversation_id);
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      if (options?.largeFilesDir) {
+        for (const id of ids) {
+          try {
+            rmSync(join(options.largeFilesDir, String(id)), { recursive: true, force: true });
+          } catch (err) {
+            // ENOENT: directory never existed or was already cleaned — fine.
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+              console.warn(
+                `prune: failed to remove large files directory for conversation ${id}:`,
+                (err as Error).message ?? err,
+              );
+            }
+          }
+        }
+      }
+
+      const placeholder = ids.map(() => "?").join(",");
+      const deletedConversations = Number(
+        db
+          .prepare(`DELETE FROM conversations WHERE conversation_id IN (${placeholder})`)
+          .run(...ids).changes ?? 0,
+      );
+
+      db.exec("COMMIT");
+      deleted += deletedConversations;
+    } catch {
+      db.exec("ROLLBACK");
+      break;
+    }
+
+    const newSize = getDatabaseSizeBytes(db);
+    deletedBytes = Math.max(0, beforeSize - newSize);
+  }
+
+  return { deleted, deletedBytes };
 }

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -37,6 +37,7 @@ const BASE_CONFIG: LcmConfig = {
   summaryTimeoutMs: 60_000,
   timezone: "UTC",
   pruneHeartbeatOk: false,
+  maxDatabaseBytes: 0,
   transcriptGcEnabled: false,
   enableSummaryThinking: true,
   proactiveThresholdCompactionMode: "deferred",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -81,6 +81,7 @@ export function createTestConfig(
     summaryTimeoutMs: 60_000,
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    maxDatabaseBytes: 0,
     transcriptGcEnabled: false,
     enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -4681,6 +4681,79 @@ describe("lcm command helpers", () => {
     });
   });
 
+  it("parses size= with mb, gb, and bare-numeric suffixes", () => {
+    // mb suffix
+    expect(__testing.parseLcmCommand("prune size=500mb")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: 500 * 1024 * 1024,
+      vacuum: false,
+    });
+    // gb suffix
+    expect(__testing.parseLcmCommand("prune size=1gb")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: 1 * 1024 * 1024 * 1024,
+      vacuum: false,
+    });
+    // gb with fractional value
+    expect(__testing.parseLcmCommand("prune size=1.5gb")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: Math.floor(1.5 * 1024 * 1024 * 1024),
+      vacuum: false,
+    });
+    // No suffix — interpreted as MB
+    expect(__testing.parseLcmCommand("prune size=500")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: 500 * 1024 * 1024,
+      vacuum: false,
+    });
+    // Case insensitive
+    expect(__testing.parseLcmCommand("prune size=100MB")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: 100 * 1024 * 1024,
+      vacuum: false,
+    });
+    expect(__testing.parseLcmCommand("prune size=1GB")).toEqual({
+      kind: "prune",
+      apply: false,
+      maxAge: undefined,
+      maxBytes: 1 * 1024 * 1024 * 1024,
+      vacuum: false,
+    });
+  });
+
+  it("returns a specific help error for invalid size= values", () => {
+    // Non-numeric
+    expect(__testing.parseLcmCommand("prune size=abc")).toEqual({
+      kind: "help",
+      error: "Invalid size format 'abc'. Expected: size=500mb or size=1gb.",
+    });
+    // Zero
+    expect(__testing.parseLcmCommand("prune size=0mb")).toEqual({
+      kind: "help",
+      error: "Invalid size format '0mb'. Expected: size=500mb or size=1gb.",
+    });
+    // Negative
+    expect(__testing.parseLcmCommand("prune size=-5mb")).toEqual({
+      kind: "help",
+      error: "Invalid size format '-5mb'. Expected: size=500mb or size=1gb.",
+    });
+    // Unknown suffix
+    expect(__testing.parseLcmCommand("prune size=500tb")).toEqual({
+      kind: "help",
+      error: "Invalid size format '500tb'. Expected: size=500mb or size=1gb.",
+    });
+  });
+
   it("treats only the canonical engine id and empty slot state as selected", () => {
     expect(__testing.resolvePluginSelected({})).toBe(true);
     expect(

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -54,6 +54,7 @@ function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
     summaryTimeoutMs: 60000,
     timezone: "UTC",
     pruneHeartbeatOk: false,
+    maxDatabaseBytes: 0,
     transcriptGcEnabled: false,
     enableSummaryThinking: true,
     proactiveThresholdCompactionMode: "deferred",

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -7,7 +7,7 @@ import { getLcmDbFeatures } from "../src/db/features.js";
 import { createLcmDatabaseConnection, closeLcmConnection } from "../src/db/connection.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
-import { parseDuration, pruneConversations } from "../src/prune.js";
+import { parseDuration, pruneConversations, getDatabaseSizeBytes, pruneArchivedConversationsToFitSize } from "../src/prune.js";
 
 function createPruneFixture() {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-prune-"));
@@ -456,5 +456,102 @@ describe("pruneConversations", () => {
 
     // 90 days before June 1 is March 3
     expect(result.cutoffDate).toContain("2025-03-03");
+  });
+});
+
+describe("getDatabaseSizeBytes", () => {
+  it("returns a positive number for a non-empty database", () => {
+    const { db } = createPruneFixture();
+    const size = getDatabaseSizeBytes(db);
+    expect(typeof size).toBe("number");
+    expect(size).toBeGreaterThan(0);
+  });
+});
+
+describe("pruneArchivedConversationsToFitSize", () => {
+  it("returns zero deleted when DB is under the size limit", () => {
+    const { db } = createPruneFixture();
+    const size = getDatabaseSizeBytes(db);
+    const result = pruneArchivedConversationsToFitSize(db, size * 2);
+    expect(result.deleted).toBe(0);
+  });
+
+  it("deletes archived conversations to fit under target size", () => {
+    const { db } = createPruneFixture();
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key, active, archived_at, archive_cause, created_at, updated_at)
+       VALUES (?, ?, 0, datetime('now'), 'session-end', datetime('now'), datetime('now'))`,
+    ).run("prune-size-test", "agent:main:test-prune-size");
+
+    const result = pruneArchivedConversationsToFitSize(db, 1);
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("cleans up orphaned large file directories when largeFilesDir is set", () => {
+    const { db, tempDir } = createPruneFixture();
+    const largeFilesDir = join(tempDir, "lcm-files");
+    mkdirSync(largeFilesDir, { recursive: true });
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key, active, archived_at, archive_cause, created_at, updated_at)
+       VALUES (?, ?, 0, datetime('now'), 'session-end', datetime('now'), datetime('now'))`,
+    ).run("prune-largefile-test", "agent:main:test-prune-largefile");
+
+    const convRow = db
+      .prepare(`SELECT conversation_id FROM conversations WHERE session_id = ?`)
+      .get("prune-largefile-test") as { conversation_id: number };
+    const convId = convRow.conversation_id;
+
+    const convDir = join(largeFilesDir, String(convId));
+    mkdirSync(convDir, { recursive: true });
+    writeFileSync(join(convDir, "test.txt"), "hello");
+
+    pruneArchivedConversationsToFitSize(db, 1, { largeFilesDir });
+
+    const stillExists = existsSync(convDir);
+    expect(stillExists).toBe(false);
+  });
+
+  it("rolls back the transaction when the DB delete fails", () => {
+    const { db } = createPruneFixture();
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key, active, archived_at, archive_cause, created_at, updated_at)
+       VALUES (?, ?, 0, datetime('now'), 'session-end', datetime('now'), datetime('now'))`,
+    ).run("rollback-test", "agent:main:test-rollback");
+
+    // Install a trigger that prevents deletion — this causes the DELETE to fail
+    // inside the transaction, triggering the ROLLBACK path.
+    db.exec(
+      `CREATE TEMP TRIGGER test_prevent_prune BEFORE DELETE ON conversations
+       BEGIN
+         SELECT RAISE(ABORT, 'test: forced rollback');
+       END`,
+    );
+
+    const result = pruneArchivedConversationsToFitSize(db, 1);
+
+    // The trigger prevented deletion, so no conversations should be deleted.
+    expect(result.deleted).toBe(0);
+
+    // Clean up the trigger and verify the row still exists.
+    db.exec("DROP TRIGGER IF EXISTS temp.test_prevent_prune");
+    const remaining = db
+      .prepare("SELECT COUNT(*) AS cnt FROM conversations WHERE session_id = ?")
+      .get("rollback-test") as { cnt: number };
+    expect(remaining.cnt).toBe(1);
+  });
+
+  it("returns zero deleted when all conversations are active (no archived)", () => {
+    const { db } = createPruneFixture();
+
+    db.prepare(
+      `INSERT INTO conversations (session_id, session_key, active, created_at, updated_at)
+       VALUES (?, ?, 1, datetime('now'), datetime('now'))`,
+    ).run("active-only", "agent:main:test-active-only");
+
+    const result = pruneArchivedConversationsToFitSize(db, 1);
+    expect(result.deleted).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

The LCM SQLite database grows without bound. While codebase has `pruneConversations()` for age-based deletion of old conversations, it has never been automatically triggered and had no slash-command interface. There is also no size-based upper bound — the DB can grow until the disk is full.

## Solution

### New config option: `maxDatabaseBytes`
- Type: `number`, default `0` (unlimited)
- Env override: `LCM_MAX_DATABASE_BYTES`
- When set, `maintain()` checks DB size every 5 min and prunes oldest archived conversations

### Size-driven pruning (`src/prune.ts`)
- `getDatabaseSizeBytes()` — PRAGMA-based DB size
- `pruneArchivedConversationsToFitSize()` — deletes oldest archived (active=0) conversations until under cap. Each batch in its own transaction. Optionally cleans up orphaned large-file directories (best-effort).

### Auto-pruning in `maintain()` (`src/engine.ts`)
- Per-instance throttle at 5-minute intervals
- Logs result; errors are caught and warned without disrupting maintain()

### `/lossless prune` slash command
- `size=500mb` / `size=1gb` — dry-run shows what would be deleted
- `confirm size=500mb vacuum` — execute + VACUUM
- Invalid formats get specific error feedback

## Design Decisions

- **Only archived conversations (active=0)**: Respects lossless principle — never touches active data
- **Size-based over age-based**: Adapts to actual storage pressure; no arbitrary age threshold needed
- **5-minute throttle (per engine instance)**: Balances responsiveness with overhead; concurrent attempts are safely handled by SQLite's BEGIN IMMEDIATE
- **Best-effort orphan file cleanup**: Removes `largeFilesDir/<conversationId>/` directories; ENOENT is silently skipped, other errors logged but don't block DB cleanup

## Files Changed

| File | +/- | Purpose |
|------|-----|---------|
| `src/prune.ts` | +128 | `getDatabaseSizeBytes()`, `pruneArchivedConversationsToFitSize()` |
| `src/engine.ts` | +26 | Auto-pruning throttle + maintain() integration |
| `src/plugin/lcm-command.ts` | +186 | `/lossless prune` size= command with mb/gb support |
| `src/db/config.ts` | +6 | `maxDatabaseBytes` type + resolution |
| `openclaw.plugin.json` | +8 | Config schema + UI hints |
| `.changeset/db-size-cap.md` | +5 | Changeset |
| `test/prune.test.ts` | +114 | 6 new tests (size pruning, rollback, active protection, large file cleanup) |
| `test/lcm-command.test.ts` | +57 | size= parsing boundary tests |
| `test/helpers.ts`, `test/expansion.test.ts`, `test/lcm-log.test.ts` | +3 | `maxDatabaseBytes: 0` default in fixtures |

## Testing

- `npm run typecheck` — 0 errors
- `npx vitest run test/prune.test.ts` — 24/24 passed
- `npx vitest run test/lcm-command.test.ts` — all passed

## Migration

- **Backward compatible** — `maxDatabaseBytes` defaults to `0` (unlimited), preserving existing behavior
- No schema changes, no API changes
- Rollback: set `maxDatabaseBytes` to `0` or remove from config
