### PR TITLE
fix(engine): declare accepted OpenClaw host parameters

### DIFF
--- a/.changeset/accepted-host-params.md
+++ b/.changeset/accepted-host-params.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Declare the OpenClaw host parameters accepted by the context engine and report the package version in engine metadata.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { open, stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import packageJson from "../package.json" with { type: "json" };
 import type {
   ContextEngine,
   ContextEngineControlCapabilities,
@@ -383,7 +384,8 @@ export class LcmContextEngine implements ContextEngine {
     this.info = {
       id: "lossless-claw",
       name: "Lossless Context Management Engine",
-      version: "0.1.0",
+      version: packageJson.version,
+      acceptedHostParams: ["sessionKey", "prompt", "runtimeContext"],
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
       hostRequirements: {

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -98,6 +98,7 @@ export type ContextEngineInfo = {
   id: string;
   name: string;
   version: string;
+  acceptedHostParams?: string[];
   ownsCompaction?: boolean;
   turnMaintenanceMode?: "background" | "inline" | string;
   hostRequirements?: Partial<Record<ContextEngineOperation, ContextEngineHostRequirements>>;

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
+import packageJson from "../package.json" with { type: "json" };
 import { createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
@@ -35,6 +36,16 @@ describe("LcmContextEngine metadata", () => {
   it("reports the registered lossless-claw engine id", () => {
     const engine = createEngine();
     expect(engine.info.id).toBe("lossless-claw");
+  });
+
+  it("reports its package version and accepted OpenClaw host parameters", () => {
+    const engine = createEngine();
+    expect(engine.info.version).toBe(packageJson.version);
+    expect(engine.info.acceptedHostParams).toEqual([
+      "sessionKey",
+      "prompt",
+      "runtimeContext",
+    ]);
   });
 
   it("advertises ownsCompaction capability", () => {


### PR DESCRIPTION
## Why

I recently removed OpenClaw's LosslessClaw-specific validator-error retry shim in [openclaw/openclaw#115872](https://github.com/openclaw/openclaw/pull/115872). The replacement contract lets context engines declare the host-added lifecycle parameters they accept through `info.acceptedHostParams`.

Engines without that declaration receive the legacy pre-`sessionKey` parameter set through 2026-08-12. After that compatibility window, undeclared engines receive the full host parameter set. Declaring LosslessClaw's contract now keeps its behavior explicit and independent of that cutoff.

## What changed

- Declare `sessionKey`, `prompt`, and `runtimeContext` in `info.acceptedHostParams`. I verified this list against the engine's lifecycle parameter shapes; LosslessClaw does not consume `runtimeSettings` or `sessionTarget`.
- Report the actual package version in `info.version` instead of the stale `0.1.0` literal. This field is engine-version metadata, not a protocol version.
- Add focused regression coverage and a patch changeset.

The lifecycle boundary has no strict runtime object validator and already ignores additional host-side properties, so no validation relaxation was necessary.

## Proof

- `npm test` — 109 files, 1,964 tests passed
- `npm run typecheck`
- `npm run build`

## Related

OpenClaw-side removal of the legacy host-param default, gated on this PR: https://github.com/openclaw/openclaw/pull/115948
