### PR TITLE
fix: validate stable release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.15.1
 
+<!-- release-rollback-version: 0.15.0 -->
+
 ### Patch Changes
 
 - [#1046](https://github.com/Martian-Engineering/lossless-claw/pull/1046) [`e7b69cf`](https://github.com/Martian-Engineering/lossless-claw/commit/e7b69cf0614f3c567503c084ce7ff5edca8907c1) Thanks [@steipete](https://github.com/steipete)! - Declare the OpenClaw host parameters accepted by the context engine and report the package version in engine metadata.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,11 +39,18 @@ make sure a maintainer gets a `.changeset/*.md` file onto `main`.
 
 1. Merge releasable PRs to `main`
 2. Let the `Version Packages` workflow open or update the release PR
-3. Review the generated version bump and `CHANGELOG.md`
-4. Merge the release PR to `main`
-5. Manually trigger the `Publish Package` workflow on the merged release commit
-6. Approve the workflow if a protected GitHub Environment is configured
-7. Let the workflow:
+3. Add exactly one `<!-- release-rollback-version: X.Y.Z -->` marker to the
+   generated changelog section, where `X.Y.Z` is the current npm `latest`
+   version
+4. Run `npm install --package-lock-only` and verify `package.json`, the root
+   lockfile version, and the lockfile root package version all match
+5. Approve the bot-authored release PR's GitHub Actions runs, then wait for
+   exact-head CI and review gates to pass
+6. Review the generated version bump and `CHANGELOG.md`
+7. Merge the release PR to `main`
+8. Manually trigger the `Publish Package` workflow on the merged release commit
+9. Approve the workflow if a protected GitHub Environment is configured
+10. Let the workflow:
    - install dependencies
    - run tests
    - publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "0.14.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/test/release-channel.test.ts
+++ b/test/release-channel.test.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const script = fileURLToPath(
   new URL("../scripts/release-channel.mjs", import.meta.url),
 );
@@ -154,5 +156,31 @@ Stable notes.
     expect(result.stderr).toContain(
       "Expected exactly one valid rollback marker for 0.14.0-beta.0",
     );
+  });
+});
+
+describe("repository release metadata", () => {
+  const packageJson = JSON.parse(
+    readFileSync(`${repositoryRoot}/package.json`, "utf8"),
+  );
+  const packageLock = JSON.parse(
+    readFileSync(`${repositoryRoot}/package-lock.json`, "utf8"),
+  );
+
+  it("keeps one valid rollback marker for the current package version", () => {
+    const changelog = readFileSync(`${repositoryRoot}/CHANGELOG.md`, "utf8");
+    const result = runWithInput(
+      changelog,
+      "--read-rollback",
+      packageJson.version,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+
+  it("keeps package and lockfile root versions aligned", () => {
+    expect(packageLock.version).toBe(packageJson.version);
+    expect(packageLock.packages[""].version).toBe(packageJson.version);
   });
 });


### PR DESCRIPTION
## What
Repair the blocked 0.15.1 release metadata and add pre-merge regression coverage for rollback markers and lockfile version alignment.

## Why
The publish workflow correctly rejected 0.15.1 because its generated changelog section lacked the rollback marker required to bind the release to npm latest. The release PR also carried stale root lockfile versions, and ordinary CI did not validate either repository state.

## Changes
- Add 0.15.1 rollback marker
- Align lockfile root versions
- Test current repository release metadata
- Document stable release PR gates

## Testing
- `npx vitest run test/release-channel.test.ts`
- `npm run release:verify`
- 109 test files and 1,966 tests passed
- Autoreview clean after live npm verification

No changeset: this PR repairs the already-versioned 0.15.1 release commit; creating another version entry would move the release target.