### PR TITLE
feat(tui): add MiniMax summarization provider

### DIFF
--- a/.changeset/minimax-tui-provider.md
+++ b/.changeset/minimax-tui-provider.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add MiniMax API-key support to standalone TUI summarization with global and China endpoints and `MiniMax-M3` model inference.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -289,6 +289,17 @@ lcm-tui doctor --all
 
 Use `--provider openai-codex` when you want ChatGPT Plus/Pro OAuth from the Codex CLI. Keep `--provider openai` for direct OpenAI-compatible HTTP calls with a raw `OPENAI_API_KEY`, including custom `--base-url` proxies.
 
+#### MiniMax regional endpoints
+
+Set `MINIMAX_API_KEY`, then select `--provider minimax` for the global endpoint or `--provider minimax-cn` for the China endpoint. Both provider IDs default to `MiniMax-M3` and use the Anthropic-compatible Messages API:
+
+| Provider ID | Default base URL |
+|-------------|------------------|
+| `minimax` | `https://api.minimax.io/anthropic` |
+| `minimax-cn` | `https://api.minimaxi.com/anthropic` |
+
+`--base-url`, `LCM_TUI_SUMMARY_BASE_URL`, and configured provider `baseUrl` values continue to override these defaults.
+
 ### `lcm-tui repair`
 
 Finds and fixes corrupted summaries (those containing the `[LCM fallback summary]` marker from failed summarization attempts).

--- a/tui/README.md
+++ b/tui/README.md
@@ -75,6 +75,8 @@ The TUI reads directly from the LCM SQLite database (`~/.openclaw/lcm.db`) and s
 
 Doctor, repair, rewrite, and backfill compaction operations all accept `--provider`, `--model`, and `--base-url`, and they also honor `LCM_TUI_SUMMARY_PROVIDER`, `LCM_TUI_SUMMARY_MODEL`, and `LCM_TUI_SUMMARY_BASE_URL` before falling back to the legacy `LCM_SUMMARY_*` settings. By default, repair/rewrite/backfill use Anthropic (`claude-sonnet-4-20250514`), while doctor keeps its lighter default (`claude-haiku-4-5`).
 
+MiniMax API-key calls use `--provider minimax` for the global endpoint or `--provider minimax-cn` for the China endpoint. Both read `MINIMAX_API_KEY` and default to `MiniMax-M3`.
+
 ## License
 
 Part of the [Lossless Claw](https://github.com/Martian-Engineering/lossless-claw) monorepo.

--- a/tui/base_url_test.go
+++ b/tui/base_url_test.go
@@ -47,6 +47,17 @@ func TestResolveProviderBaseURLFallsBackToProviderDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveProviderBaseURLMiniMaxRegionalDefaults(t *testing.T) {
+	paths := appDataPaths{}
+
+	if got := resolveProviderBaseURL(paths, miniMaxProviderID, ""); got != defaultMiniMaxBaseURL {
+		t.Fatalf("expected global MiniMax default %q, got %q", defaultMiniMaxBaseURL, got)
+	}
+	if got := resolveProviderBaseURL(paths, miniMaxCNProviderID, ""); got != defaultMiniMaxCNBaseURL {
+		t.Fatalf("expected China MiniMax default %q, got %q", defaultMiniMaxCNBaseURL, got)
+	}
+}
+
 func TestResolveInteractiveRewriteProviderModelUsesTUISummaryBaseURL(t *testing.T) {
 	t.Setenv("LCM_TUI_SUMMARY_PROVIDER", "openai")
 	t.Setenv("LCM_TUI_SUMMARY_MODEL", "gpt-5.3-codex")

--- a/tui/llm_client_test.go
+++ b/tui/llm_client_test.go
@@ -44,6 +44,91 @@ func TestResolveSummaryProviderModel(t *testing.T) {
 	}
 }
 
+func TestResolveSummaryProviderModelMiniMax(t *testing.T) {
+	provider, model := resolveSummaryProviderModel("", miniMaxModel)
+	if provider != miniMaxProviderID {
+		t.Fatalf("expected provider %q, got %q", miniMaxProviderID, provider)
+	}
+	if model != miniMaxModel {
+		t.Fatalf("expected model %q, got %q", miniMaxModel, model)
+	}
+
+	provider, model = resolveSummaryProviderModel(miniMaxCNProviderID, "")
+	if provider != miniMaxCNProviderID || model != miniMaxModel {
+		t.Fatalf("expected %s/%s, got %s/%s", miniMaxCNProviderID, miniMaxModel, provider, model)
+	}
+}
+
+func TestResolveProviderAPIKeyMiniMaxEnv(t *testing.T) {
+	t.Setenv("MINIMAX_API_KEY", "test-minimax-key-123456")
+
+	key, err := resolveProviderAPIKey(appDataPaths{}, miniMaxProviderID)
+	if err != nil {
+		t.Fatalf("resolveProviderAPIKey returned error: %v", err)
+	}
+	if key != "test-minimax-key-123456" {
+		t.Fatalf("unexpected API key: %q", key)
+	}
+}
+
+func TestSummarizeMiniMaxRegionalEndpoints(t *testing.T) {
+	tests := []struct {
+		provider string
+		baseURL  string
+	}{
+		{provider: miniMaxProviderID, baseURL: defaultMiniMaxBaseURL},
+		{provider: miniMaxCNProviderID, baseURL: defaultMiniMaxCNBaseURL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			client := &anthropicClient{
+				provider: tt.provider,
+				apiKey:   "test-minimax-key-123456",
+				model:    miniMaxModel,
+				http: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					expectedURL := tt.baseURL + "/v1/messages"
+					if req.URL.String() != expectedURL {
+						t.Fatalf("expected URL %s, got %s", expectedURL, req.URL.String())
+					}
+					if got := req.Header.Get("Authorization"); got != "Bearer test-minimax-key-123456" {
+						t.Fatalf("unexpected authorization header: %q", got)
+					}
+					if got := req.Header.Get("anthropic-version"); got != anthropicVersion {
+						t.Fatalf("unexpected API version header: %q", got)
+					}
+
+					var payload anthropicRequest
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode request: %v", err)
+					}
+					if payload.Model != miniMaxModel || payload.MaxTokens != 200 {
+						t.Fatalf("unexpected request model/token budget: %#v", payload)
+					}
+					if len(payload.Messages) != 1 || payload.Messages[0].Role != "user" || payload.Messages[0].Content != "prompt" {
+						t.Fatalf("unexpected request messages: %#v", payload.Messages)
+					}
+
+					return jsonResponse(200, `{
+						"content":[
+							{"type":"thinking","thinking":"internal reasoning"},
+							{"type":"text","text":"MiniMax summary."}
+						]
+					}`), nil
+				})},
+			}
+
+			summary, err := client.summarize(context.Background(), "prompt", 200)
+			if err != nil {
+				t.Fatalf("summarize returned error: %v", err)
+			}
+			if summary != "MiniMax summary." {
+				t.Fatalf("unexpected summary: %q", summary)
+			}
+		})
+	}
+}
+
 func TestExtractOpenAISummaryFromOutputAndReasoningBlocks(t *testing.T) {
 	body := []byte(`{
 		"id":"resp_1",

--- a/tui/llm_client_test.go
+++ b/tui/llm_client_test.go
@@ -105,6 +105,9 @@ func TestSummarizeMiniMaxRegionalEndpoints(t *testing.T) {
 					if payload.Model != miniMaxModel || payload.MaxTokens != 200 {
 						t.Fatalf("unexpected request model/token budget: %#v", payload)
 					}
+					if payload.Temperature == nil || *payload.Temperature != 0 {
+						t.Fatalf("expected deterministic temperature 0, got %#v", payload.Temperature)
+					}
 					if len(payload.Messages) != 1 || payload.Messages[0].Role != "user" || payload.Messages[0].Content != "prompt" {
 						t.Fatalf("unexpected request messages: %#v", payload.Messages)
 					}
@@ -598,6 +601,13 @@ func TestSummarizeAnthropicRegularKeyHitsDirectAPI(t *testing.T) {
 			capturedURL = req.URL.String()
 			if got := req.Header.Get("x-api-key"); got != "sk-ant-api03-regular-key" {
 				t.Fatalf("expected x-api-key header, got %q", got)
+			}
+			var payload anthropicRequest
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if payload.Temperature == nil || *payload.Temperature != 0 {
+				t.Fatalf("expected deterministic temperature 0, got %#v", payload.Temperature)
 			}
 			return jsonResponse(200, `{
 				"content":[{"type":"text","text":"Direct API response."}]

--- a/tui/repair.go
+++ b/tui/repair.go
@@ -115,7 +115,7 @@ type anthropicClient struct {
 type anthropicRequest struct {
 	Model       string                    `json:"model"`
 	MaxTokens   int                       `json:"max_tokens"`
-	Temperature float64                   `json:"temperature,omitempty"`
+	Temperature *float64                  `json:"temperature,omitempty"`
 	Messages    []anthropicRequestMessage `json:"messages"`
 }
 
@@ -990,7 +990,7 @@ func (c *anthropicClient) summarizeAnthropic(ctx context.Context, model, prompt 
 	reqBody := anthropicRequest{
 		Model:       model,
 		MaxTokens:   targetTokens,
-		Temperature: 0,
+		Temperature: zeroTemperature(),
 		Messages: []anthropicRequestMessage{
 			{Role: "user", Content: prompt},
 		},
@@ -1060,8 +1060,9 @@ func (c *anthropicClient) summarizeAnthropic(ctx context.Context, model, prompt 
 
 func (c *anthropicClient) summarizeMiniMax(ctx context.Context, model, prompt string, targetTokens int) (string, error) {
 	reqBody := anthropicRequest{
-		Model:     model,
-		MaxTokens: targetTokens,
+		Model:       model,
+		MaxTokens:   targetTokens,
+		Temperature: zeroTemperature(),
 		Messages: []anthropicRequestMessage{
 			{Role: "user", Content: prompt},
 		},
@@ -1120,6 +1121,11 @@ func (c *anthropicClient) summarizeMiniMax(ctx context.Context, model, prompt st
 		)
 	}
 	return result, nil
+}
+
+func zeroTemperature() *float64 {
+	value := 0.0
+	return &value
 }
 
 // summarizeViaCLI delegates to the `claude` CLI binary when an OAuth/setup-token

--- a/tui/repair.go
+++ b/tui/repair.go
@@ -28,11 +28,16 @@ const (
 	defaultLLMProvider     = "anthropic"
 	anthropicModel         = "claude-sonnet-4-20250514"
 	anthropicVersion       = "2023-06-01"
+	miniMaxProviderID      = "minimax"
+	miniMaxCNProviderID    = "minimax-cn"
+	miniMaxModel           = "MiniMax-M3"
 	openAIResponsesModel   = "gpt-5.3-codex"
 	condensedTargetTokens  = 2000
 	defaultHTTPTimeout     = 180 * time.Second
 
 	defaultAnthropicBaseURL = "https://api.anthropic.com"
+	defaultMiniMaxBaseURL   = "https://api.minimax.io/anthropic"
+	defaultMiniMaxCNBaseURL = "https://api.minimaxi.com/anthropic"
 	defaultOpenAIBaseURL    = "https://api.openai.com"
 )
 
@@ -972,6 +977,8 @@ func (c *anthropicClient) summarize(ctx context.Context, prompt string, targetTo
 	switch provider {
 	case "anthropic":
 		return c.summarizeAnthropic(ctx, model, prompt, targetTokens)
+	case miniMaxProviderID, miniMaxCNProviderID:
+		return c.summarizeMiniMax(ctx, model, prompt, targetTokens)
 	case "openai", "openai-codex", "github-copilot":
 		return c.summarizeOpenAI(ctx, model, prompt, targetTokens)
 	default:
@@ -1044,6 +1051,70 @@ func (c *anthropicClient) summarizeAnthropic(ctx context.Context, model, prompt 
 	if result == "" {
 		return "", fmt.Errorf(
 			"empty summary after normalization (provider=anthropic model=%s block_types=%s)",
+			model,
+			formatBlockTypes(blockTypes),
+		)
+	}
+	return result, nil
+}
+
+func (c *anthropicClient) summarizeMiniMax(ctx context.Context, model, prompt string, targetTokens int) (string, error) {
+	reqBody := anthropicRequest{
+		Model:     model,
+		MaxTokens: targetTokens,
+		Messages: []anthropicRequestMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal MiniMax request: %w", err)
+	}
+
+	baseURL := c.baseURL
+	if baseURL == "" {
+		baseURL = defaultMiniMaxBaseURLForProvider(c.provider)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		resolveProviderEndpointURL(baseURL, "/v1/messages"),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return "", fmt.Errorf("build MiniMax request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("call MiniMax API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read MiniMax response: %w", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		var apiErr anthropicErrorEnvelope
+		if json.Unmarshal(body, &apiErr) == nil && strings.TrimSpace(apiErr.Error.Message) != "" {
+			return "", fmt.Errorf("MiniMax API %d %s: %s", resp.StatusCode, apiErr.Error.Type, apiErr.Error.Message)
+		}
+		return "", fmt.Errorf("MiniMax API %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	result, blockTypes, err := extractMiniMaxSummary(body)
+	if err != nil {
+		return "", err
+	}
+	if result == "" {
+		return "", fmt.Errorf(
+			"empty summary after normalization (provider=%s model=%s block_types=%s)",
+			normalizeProviderID(c.provider),
 			model,
 			formatBlockTypes(blockTypes),
 		)
@@ -1320,9 +1391,17 @@ func (c *anthropicClient) summarizeOpenAI(ctx context.Context, model, prompt str
 }
 
 func extractAnthropicSummary(body []byte) (string, []string, error) {
+	return extractMessagesSummary("Anthropic", body)
+}
+
+func extractMiniMaxSummary(body []byte) (string, []string, error) {
+	return extractMessagesSummary("MiniMax", body)
+}
+
+func extractMessagesSummary(apiName string, body []byte) (string, []string, error) {
 	var parsed anthropicResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return "", nil, fmt.Errorf("decode Anthropic response: %w", err)
+		return "", nil, fmt.Errorf("decode %s response: %w", apiName, err)
 	}
 
 	chunks := make([]string, 0, len(parsed.Content))
@@ -1479,9 +1558,12 @@ func resolveSummaryProviderModel(providerHint, modelHint string) (string, string
 	model := strings.TrimSpace(modelHint)
 
 	if model == "" {
-		if provider == "openai" || provider == "openai-codex" || provider == "github-copilot" {
+		switch provider {
+		case miniMaxProviderID, miniMaxCNProviderID:
+			model = miniMaxModel
+		case "openai", "openai-codex", "github-copilot":
 			model = openAIResponsesModel
-		} else {
+		default:
 			model = anthropicModel
 		}
 	}
@@ -1510,6 +1592,8 @@ func normalizeProviderID(provider string) string {
 func inferProviderFromModel(model string) string {
 	lower := strings.ToLower(strings.TrimSpace(model))
 	switch {
+	case strings.HasPrefix(lower, miniMaxProviderID+"-"):
+		return miniMaxProviderID
 	case strings.HasPrefix(lower, "claude"):
 		return "anthropic"
 	case strings.HasPrefix(lower, "gpt-"),
@@ -1672,6 +1756,8 @@ func providerAPIEnvCandidates(provider string) []string {
 	switch normalizeProviderID(provider) {
 	case "anthropic":
 		return []string{"ANTHROPIC_API_KEY"}
+	case miniMaxProviderID, miniMaxCNProviderID:
+		return []string{"MINIMAX_API_KEY"}
 	case "openai", "openai-codex":
 		return []string{"OPENAI_API_KEY"}
 	case "github-copilot":
@@ -1747,11 +1833,20 @@ func resolveProviderBaseURL(paths appDataPaths, provider, flagOverride string) s
 	}
 
 	switch normalizedProvider {
+	case miniMaxProviderID, miniMaxCNProviderID:
+		return defaultMiniMaxBaseURLForProvider(normalizedProvider)
 	case "openai", "openai-codex", "github-copilot":
 		return defaultOpenAIBaseURL
 	default:
 		return defaultAnthropicBaseURL
 	}
+}
+
+func defaultMiniMaxBaseURLForProvider(provider string) string {
+	if normalizeProviderID(provider) == miniMaxCNProviderID {
+		return defaultMiniMaxCNBaseURL
+	}
+	return defaultMiniMaxBaseURL
 }
 
 // resolveProviderEndpointURL accepts either API-root base URLs or versioned /v1 URLs.


### PR DESCRIPTION
Reason: Add MiniMax support to standalone TUI summarization.

## Changes

- Add `minimax` and `minimax-cn` provider dispatch for the standalone TUI.
- Default both regions to `MiniMax-M3` with their regional Messages API endpoints and Bearer authentication.
- Resolve `MINIMAX_API_KEY`, normalize text responses, ignore thinking blocks, and document the regional provider IDs.
- Add focused request, endpoint, model inference, API key, and base URL coverage plus a patch changeset.

## Checks

- `go -C tui test -run 'MiniMax' -count=1`
- `go -C tui test ./... -skip '^TestResolveOpenclawStateDirFallsBackOnWhitespaceOnly$'`
- `go -C tui vet ./...`
- `go -C tui build ./...`
- `gofmt -l tui` (clean)

## Baseline

- `go -C tui test ./...` still fails `TestResolveOpenclawStateDirFallsBackOnWhitespaceOnly`; the failing source and test files are unchanged from `origin/main`.
