### PR TITLE
fix(assembler): preserve reasoning replay integrity across DB assembly

### DIFF
--- a/.changeset/preserve-thinking-identity.md
+++ b/.changeset/preserve-thinking-identity.md
@@ -1,0 +1,15 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve reasoning replay integrity for DB-assembled assistant messages.
+Ingestion now records the assistant message's model identity
+(`provider`/`api`/`model`/`responseModel`) in part metadata, and assembly
+re-attaches it so the host's model-bound thinking replay policy can
+recognize same-model history instead of downgrading replayed thinking
+blocks to plain text. Assembly keeps the host's `reasoning_content`
+sentinel thinking signature (it marks reasoning-native replay and is not
+a provider-issued signature), keeps provider-issued signatures only when
+a stored model identity is present so the host replay policy stays in
+charge, and continues to strip signatures from legacy rows without
+stored identity so cross-provider replay cannot send foreign signatures.

--- a/.changeset/preserve-thinking-identity.md
+++ b/.changeset/preserve-thinking-identity.md
@@ -3,13 +3,32 @@
 ---
 
 Preserve reasoning replay integrity for DB-assembled assistant messages.
+
 Ingestion now records the assistant message's model identity
-(`provider`/`api`/`model`/`responseModel`) in part metadata, and assembly
-re-attaches it so the host's model-bound thinking replay policy can
-recognize same-model history instead of downgrading replayed thinking
-blocks to plain text. Assembly keeps the host's `reasoning_content`
-sentinel thinking signature (it marks reasoning-native replay and is not
-a provider-issued signature), keeps provider-issued signatures only when
-a stored model identity is present so the host replay policy stays in
-charge, and continues to strip signatures from legacy rows without
-stored identity so cross-provider replay cannot send foreign signatures.
+(`provider`/`api`/`model`/`responseModel`) in ordinal-0 part metadata, and
+assembly re-attaches it so the host's model-bound thinking replay policy can
+recognize same-model history instead of downgrading replayed thinking blocks
+to plain text.
+
+Assembly applies a three-way `thinkingSignature` gate:
+
+1. **Sentinel `"reasoning_content"`** — the host's cross-provider reasoning-
+   native replay marker, not a provider-issued signature. Preserved only when
+   the assembled message carries stored model identity; dropped from legacy
+   rows without identity so the host's `transformMessages` doesn't downgrade
+   it to response-channel text (the contamination this patch fixes).
+
+2. **Provider-issued signatures** — kept only when a stored model identity
+   survives to the assembled message (the host's `transformMessages` then
+   applies its own same-model replay policy). The identity gate is decided at
+   message level (identity lives on ordinal-0 metadata, but signature-bearing
+   blocks may sit at any ordinal).
+
+3. **Legacy rows without identity** — keep the historical strip (#365) for
+   provider-issued signatures; sentinel blocks are dropped entirely.
+
+Comparison paths that treat part metadata as message identity
+(`createLosslessMessageSignature`, `externalizedReplayMetadataMatches`) now
+strip model-identity keys before comparing, so rows persisted before the
+upgrade still match their post-upgrade live/assembled representations for
+replay-prefix detection and live-coverage fork-anchor matching.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -583,8 +583,23 @@ function toRuntimeRole(
   return "user"; // user | system
 }
 
-/** @internal Exported for testing only. */
-export function blockFromPart(part: MessagePartRecord): unknown {
+/**
+ * Reconstruct a runtime content block from a stored message part.
+ *
+ * `messageHasStoredModelIdentity` is the message-level gate for preserving
+ * provider-issued thinking signatures (the host's transformMessages then
+ * applies its own same-model replay policy). Identity is persisted on
+ * ordinal-0 metadata only, so callers that reconstruct a whole message pass
+ * the message-level decision in; callers default to the per-part check so a
+ * standalone part still behaves correctly.
+ *
+ * @internal Exported for testing only.
+ */
+export function blockFromPart(
+  part: MessagePartRecord,
+  messageHasStoredModelIdentity?: boolean,
+): unknown {
+  const hasModelIdentity = messageHasStoredModelIdentity ?? hasStoredModelIdentity(part);
   const metadata = getPartMetadata(part);
   if (metadata.raw && typeof metadata.raw === "object") {
     // If this is an OpenClaw-normalised OpenAI reasoning block, restore the original
@@ -607,18 +622,29 @@ export function blockFromPart(part: MessagePartRecord): unknown {
       // "reasoning_content" is OpenClaw's cross-provider sentinel signature
       // (provider-stream stamps it for reasoning_content-native endpoints and
       // the Anthropic client recognizes it), not a provider-issued signature.
-      // Preserving it keeps reasoning-native replay working; stripping it
-      // downgrades the block to plain text on replay, which corrupts
-      // reasoning-native models (e.g. Kimi K3 response-channel contamination).
+      // Preserving it keeps reasoning-native replay working when the assembled
+      // message also carries model identity (the host's transformMessages then
+      // treats the block as same-model and keeps the sentinel, which the
+      // Anthropic client drops from outgoing requests).
+      //
+      // Legacy rows without stored identity: drop the block entirely. The
+      // host's transformMessages would treat it as cross-model (missing
+      // identity → downgrade to text), which lands reasoning in the response
+      // channel of the chat template — exactly the contamination this patch
+      // fixes. Dropping mirrors what the host does to sentinel blocks without
+      // identity and avoids polluting the response channel for existing
+      // sessions that still have pre-upgrade rows.
       if (rawRecord.thinkingSignature === "reasoning_content") {
-        return rawRecord;
+        return hasModelIdentity ? rawRecord : null;
       }
       // Provider-issued signatures are kept only when the stored model
       // identity survives to the assembled message (the host's
       // transformMessages then applies its own same-model replay policy).
-      // Legacy rows without identity keep the historical strip so foreign
-      // signatures cannot leak across a provider switch (#365).
-      if (hasStoredModelIdentity(part)) {
+      // Identity lives on ordinal-0 metadata, so the gate is decided at
+      // message level and passed in; per-part check is the single-block
+      // fallback. Legacy rows without identity keep the historical strip so
+      // foreign signatures cannot leak across a provider switch (#365).
+      if (hasModelIdentity) {
         return rawRecord;
       }
       const { thinkingSignature: _thinkingSignature, ...cleaned } = rawRecord;
@@ -743,7 +769,26 @@ export function contentFromParts(
     return fallbackContent;
   }
 
-  const blocks = contentParts.map(blockFromPart);
+  // Message-level signature-preservation gate: a signature-bearing thinking
+  // block may sit at any ordinal, but identity is persisted on ordinal-0
+  // metadata, so the decision must see the whole part set.
+  const messageHasStoredModelIdentity =
+    role === "assistant" && pickModelIdentity(parts) !== undefined;
+  const blocks = contentParts
+    .map((part) => blockFromPart(part, messageHasStoredModelIdentity))
+    .filter((block): block is NonNullable<typeof block> => block != null);
+  if (blocks.length === 0) {
+    // All content blocks were dropped (e.g. legacy sentinel-only thinking
+    // blocks without stored identity). Fall back to stored content like the
+    // no-parts branch above.
+    if (role === "assistant") {
+      return fallbackContent ? [{ type: "text", text: fallbackContent }] : [];
+    }
+    if (role === "toolResult") {
+      return [{ type: "text", text: fallbackContent }];
+    }
+    return fallbackContent;
+  }
   if (
     role === "user" &&
     blocks.length === 1 &&

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -306,6 +306,56 @@ function getOriginalRole(parts: MessagePartRecord[]): string | null {
   return null;
 }
 
+type StoredModelIdentity = {
+  provider?: string;
+  api?: string;
+  model?: string;
+  responseModel?: string;
+};
+
+/** Read the assistant model identity persisted by buildMessageParts (if any). */
+function pickModelIdentity(parts: MessagePartRecord[]): StoredModelIdentity | undefined {
+  for (const part of parts) {
+    const decoded = parseJson(part.metadata);
+    if (!decoded || typeof decoded !== "object") {
+      continue;
+    }
+    const record = decoded as {
+      modelProvider?: unknown;
+      modelApi?: unknown;
+      modelId?: unknown;
+      responseModelId?: unknown;
+    };
+    const identity: StoredModelIdentity = {};
+    if (typeof record.modelProvider === "string" && record.modelProvider.length > 0) {
+      identity.provider = record.modelProvider;
+    }
+    if (typeof record.modelApi === "string" && record.modelApi.length > 0) {
+      identity.api = record.modelApi;
+    }
+    if (typeof record.modelId === "string" && record.modelId.length > 0) {
+      identity.model = record.modelId;
+    }
+    if (typeof record.responseModelId === "string" && record.responseModelId.length > 0) {
+      identity.responseModel = record.responseModelId;
+    }
+    if (
+      identity.provider !== undefined ||
+      identity.api !== undefined ||
+      identity.model !== undefined ||
+      identity.responseModel !== undefined
+    ) {
+      return identity;
+    }
+  }
+  return undefined;
+}
+
+/** True when the part's message-level metadata carries a stored model identity. */
+function hasStoredModelIdentity(part: MessagePartRecord): boolean {
+  return pickModelIdentity([part]) !== undefined;
+}
+
 function getPartMetadata(part: MessagePartRecord): {
   originalRole?: string;
   rawType?: string;
@@ -554,6 +604,23 @@ export function blockFromPart(part: MessagePartRecord): unknown {
       rawType === "thinking" &&
       typeof rawRecord.thinkingSignature === "string"
     ) {
+      // "reasoning_content" is OpenClaw's cross-provider sentinel signature
+      // (provider-stream stamps it for reasoning_content-native endpoints and
+      // the Anthropic client recognizes it), not a provider-issued signature.
+      // Preserving it keeps reasoning-native replay working; stripping it
+      // downgrades the block to plain text on replay, which corrupts
+      // reasoning-native models (e.g. Kimi K3 response-channel contamination).
+      if (rawRecord.thinkingSignature === "reasoning_content") {
+        return rawRecord;
+      }
+      // Provider-issued signatures are kept only when the stored model
+      // identity survives to the assembled message (the host's
+      // transformMessages then applies its own same-model replay policy).
+      // Legacy rows without identity keep the historical strip so foreign
+      // signatures cannot leak across a provider switch (#365).
+      if (hasStoredModelIdentity(part)) {
+        return rawRecord;
+      }
       const { thinkingSignature: _thinkingSignature, ...cleaned } = rawRecord;
       return cleaned;
     }
@@ -1768,6 +1835,7 @@ export class ContextAssembler {
     const content = contentFromParts(parts, role, msg.content);
     const topLevelAssistantReasoning =
       role === "assistant" ? pickTopLevelAssistantReasoning(parts) : {};
+    const modelIdentity = role === "assistant" ? pickModelIdentity(parts) : undefined;
     const contentText =
       typeof content === "string" ? content : (JSON.stringify(content) ?? msg.content);
     const topLevelReasoningText = Object.values(topLevelAssistantReasoning).join("\n");
@@ -1804,6 +1872,7 @@ export class ContextAssembler {
           ? ({
               role,
               content,
+              ...(modelIdentity ?? {}),
               ...topLevelAssistantReasoning,
               usage: {
                 input: 0,

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -339,11 +339,15 @@ function pickModelIdentity(parts: MessagePartRecord[]): StoredModelIdentity | un
     if (typeof record.responseModelId === "string" && record.responseModelId.length > 0) {
       identity.responseModel = record.responseModelId;
     }
+    // Mirror the ingest-side gate (extractModelIdentityMetadata): the host's
+    // same-model check needs provider+api+model all present. A partial
+    // identity must not qualify — it would preserve signatures the host then
+    // treats as cross-model (downgrade to text → response-channel
+    // contamination). responseModel remains supplemental.
     if (
-      identity.provider !== undefined ||
-      identity.api !== undefined ||
-      identity.model !== undefined ||
-      identity.responseModel !== undefined
+      identity.provider !== undefined &&
+      identity.api !== undefined &&
+      identity.model !== undefined
     ) {
       return identity;
     }

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -463,6 +463,28 @@ export function buildMessageParts(params: {
   const topLevelReasoning = extractTopLevelReasoningContent(role, topLevel);
   const rawPayloadExternalized = safeBoolean(topLevel.rawPayloadExternalized);
   const externalizedFileId = safeString(topLevel.externalizedFileId);
+  // Assistant model identity (provider/api/model/responseModel). Persisted in
+  // part metadata so assembly can reconstruct messages that survive the host's
+  // model-bound thinking-replay checks (OpenClaw transformMessages treats a
+  // missing identity as a cross-model switch and downgrades thinking blocks to
+  // plain text, which corrupts reasoning-native models like Kimi K3).
+  const modelIdentityMetadata = (() => {
+    if (role !== "assistant") {
+      return undefined;
+    }
+    const identity = {
+      modelProvider: safeString(topLevel.provider),
+      modelApi: safeString(topLevel.api),
+      modelId: safeString(topLevel.model),
+      responseModelId: safeString(topLevel.responseModel),
+    };
+    return identity.modelProvider !== undefined ||
+      identity.modelApi !== undefined ||
+      identity.modelId !== undefined ||
+      identity.responseModelId !== undefined
+      ? identity
+      : undefined;
+  })();
   const externalizedFileIds = Array.isArray(topLevel.externalizedFileIds)
     ? topLevel.externalizedFileIds.filter((fileId): fileId is string => typeof fileId === "string")
     : undefined;
@@ -515,6 +537,7 @@ export function buildMessageParts(params: {
         textContent: message.content,
         metadata: toJson({
           originalRole: role,
+          ...(modelIdentityMetadata ?? {}),
           toolCallId: topLevelToolCallId,
           toolName: topLevelToolName,
           isError: topLevelIsError,
@@ -556,6 +579,7 @@ export function buildMessageParts(params: {
       textContent: null,
       metadata: toJson({
         originalRole: role,
+        ...(modelIdentityMetadata ?? {}),
         rawType: topLevelReasoning.field,
         ...topLevelReasoningMetadata(topLevelReasoning, true),
       }),
@@ -609,6 +633,7 @@ export function buildMessageParts(params: {
             : (safeString(metadataRecord?.tool_output) ?? null),
       metadata: toJson({
         originalRole: role,
+        ...(ordinal === 0 ? (modelIdentityMetadata ?? {}) : {}),
         toolCallId: topLevelToolCallId,
         toolName: topLevelToolName,
         isError: topLevelIsError,

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -82,6 +82,115 @@ export const REPLAY_CRITICAL_RAW_TYPES: ReadonlySet<string> = new Set([
 
 export const RAW_PAYLOAD_EXTERNALIZATION_REASON = "large_raw_message";
 
+/**
+ * Part-metadata keys that persist the assistant message's model identity
+ * (written by buildMessageParts on ordinal-0 parts). Identity is replay-
+ * affinity data, not message identity: any comparison path that treats
+ * metadata as identity (replay detection, live-coverage signatures, dedup)
+ * must strip these keys so rows persisted before identity stamping still
+ * match the post-upgrade representation of the same logical message.
+ */
+export const MODEL_IDENTITY_METADATA_KEYS = [
+  "modelProvider",
+  "modelApi",
+  "modelId",
+  "responseModelId",
+] as const;
+
+/**
+ * Remove model-identity keys from a serialized part-metadata JSON object.
+ *
+ * Returns the input byte-identical when no identity keys are present, so
+ * pre-upgrade rows keep their exact stored serialization. When keys are
+ * present, deleting them restores the pre-identity key order (buildMessageParts
+ * splices identity keys immediately after `originalRole`), so the stripped
+ * form of a post-upgrade serialization is byte-identical to the pre-upgrade
+ * serialization of the same message.
+ */
+export function stripModelIdentityFromMetadataJson(
+  metadata: string | null | undefined,
+): string | null {
+  if (typeof metadata !== "string" || metadata.length === 0) {
+    return metadata == null ? null : metadata;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata);
+  } catch {
+    return metadata;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return metadata;
+  }
+  const record = parsed as Record<string, unknown>;
+  if (!MODEL_IDENTITY_METADATA_KEYS.some((key) => key in record)) {
+    return metadata;
+  }
+  for (const key of MODEL_IDENTITY_METADATA_KEYS) {
+    delete record[key];
+  }
+  return JSON.stringify(record);
+}
+
+/**
+ * Strip model-identity keys from every `"metadata":"..."` value embedded in an
+ * already-serialized parts-signature payload, without re-serializing the
+ * surrounding content. This preserves byte-exact metadata equality across the
+ * pre/post-upgrade boundary inside comparison blobs like
+ * createLosslessMessageSignature output.
+ */
+export function stripModelIdentityFromSerializedPartsSignature(serialized: string): string {
+  const metadataPattern = /"metadata":"((?:[^"\\]|\\.)*)"/g;
+  return serialized.replace(metadataPattern, (whole, escaped: string) => {
+    let metadata: string;
+    try {
+      metadata = JSON.parse(`"${escaped}"`) as string;
+    } catch {
+      return whole;
+    }
+    const stripped = stripModelIdentityFromMetadataJson(metadata);
+    if (stripped == null || stripped === metadata) {
+      return whole;
+    }
+    return `"metadata":${JSON.stringify(stripped)}`;
+  });
+}
+
+/**
+ * Read the assistant model identity carried at message (top) level on an
+ * incoming AgentMessage (`provider`/`api`/`model`/`responseModel`). Shared by
+ * buildMessageParts (persistence) and normalizeMessageContentForStorage
+ * (message-level signature-preservation gate).
+ */
+export function extractModelIdentityMetadata(
+  message: AgentMessage,
+):
+  | {
+      modelProvider?: string;
+      modelApi?: string;
+      modelId?: string;
+      responseModelId?: string;
+    }
+  | undefined {
+  const role = typeof message.role === "string" ? message.role : "unknown";
+  if (role !== "assistant") {
+    return undefined;
+  }
+  const topLevel = message as unknown as Record<string, unknown>;
+  const identity = {
+    modelProvider: safeString(topLevel.provider),
+    modelApi: safeString(topLevel.api),
+    modelId: safeString(topLevel.model),
+    responseModelId: safeString(topLevel.responseModel),
+  };
+  return identity.modelProvider !== undefined ||
+    identity.modelApi !== undefined ||
+    identity.modelId !== undefined ||
+    identity.responseModelId !== undefined
+    ? identity
+    : undefined;
+}
+
 export function looksLikeJsonPayload(value: string): boolean {
   if (typeof value !== "string") return false;
   const trimmed = value.trim();
@@ -432,7 +541,24 @@ export function normalizeMessageContentForStorage(params: {
     return fallbackContent;
   }
 
-  const blocks = parts.map(blockFromPart);
+  // Resolve the signature-preservation gate at message level: identity is
+  // persisted on ordinal-0 metadata only, but a signature-bearing thinking
+  // block may sit at any ordinal. Using the incoming message's top-level
+  // identity mirrors contentFromParts' message-level decision so blocks at
+  // any ordinal see the same verdict.
+  const messageHasStoredModelIdentity = extractModelIdentityMetadata(message) !== undefined;
+  const blocks = parts
+    .map((part) => blockFromPart(part, messageHasStoredModelIdentity))
+    .filter((block): block is NonNullable<typeof block> => block != null);
+  if (blocks.length === 0) {
+    if (role === "assistant") {
+      return fallbackContent ? [{ type: "text", text: fallbackContent }] : [];
+    }
+    if (role === "toolResult") {
+      return [{ type: "text", text: fallbackContent }];
+    }
+    return fallbackContent;
+  }
   if (role === "user" && blocks.length === 1 && isTextBlock(blocks[0])) {
     return blocks[0].text;
   }
@@ -468,23 +594,7 @@ export function buildMessageParts(params: {
   // model-bound thinking-replay checks (OpenClaw transformMessages treats a
   // missing identity as a cross-model switch and downgrades thinking blocks to
   // plain text, which corrupts reasoning-native models like Kimi K3).
-  const modelIdentityMetadata = (() => {
-    if (role !== "assistant") {
-      return undefined;
-    }
-    const identity = {
-      modelProvider: safeString(topLevel.provider),
-      modelApi: safeString(topLevel.api),
-      modelId: safeString(topLevel.model),
-      responseModelId: safeString(topLevel.responseModel),
-    };
-    return identity.modelProvider !== undefined ||
-      identity.modelApi !== undefined ||
-      identity.modelId !== undefined ||
-      identity.responseModelId !== undefined
-      ? identity
-      : undefined;
-  })();
+  const modelIdentityMetadata = extractModelIdentityMetadata(message);
   const externalizedFileIds = Array.isArray(topLevel.externalizedFileIds)
     ? topLevel.externalizedFileIds.filter((fileId): fileId is string => typeof fileId === "string")
     : undefined;

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -133,30 +133,6 @@ export function stripModelIdentityFromMetadataJson(
 }
 
 /**
- * Strip model-identity keys from every `"metadata":"..."` value embedded in an
- * already-serialized parts-signature payload, without re-serializing the
- * surrounding content. This preserves byte-exact metadata equality across the
- * pre/post-upgrade boundary inside comparison blobs like
- * createLosslessMessageSignature output.
- */
-export function stripModelIdentityFromSerializedPartsSignature(serialized: string): string {
-  const metadataPattern = /"metadata":"((?:[^"\\]|\\.)*)"/g;
-  return serialized.replace(metadataPattern, (whole, escaped: string) => {
-    let metadata: string;
-    try {
-      metadata = JSON.parse(`"${escaped}"`) as string;
-    } catch {
-      return whole;
-    }
-    const stripped = stripModelIdentityFromMetadataJson(metadata);
-    if (stripped == null || stripped === metadata) {
-      return whole;
-    }
-    return `"metadata":${JSON.stringify(stripped)}`;
-  });
-}
-
-/**
  * Read the assistant model identity carried at message (top) level on an
  * incoming AgentMessage (`provider`/`api`/`model`/`responseModel`). Shared by
  * buildMessageParts (persistence) and normalizeMessageContentForStorage

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -183,10 +183,16 @@ export function extractModelIdentityMetadata(
     modelId: safeString(topLevel.model),
     responseModelId: safeString(topLevel.responseModel),
   };
-  return identity.modelProvider !== undefined ||
-    identity.modelApi !== undefined ||
-    identity.modelId !== undefined ||
-    identity.responseModelId !== undefined
+  // The host's same-model replay check (transformMessages) requires
+  // `provider`, `api`, and `model` to ALL match; `responseModel` is
+  // supplemental and never consulted by that predicate. Treat an identity as
+  // stored only when the three host-required fields are present — a partial
+  // identity (e.g. responseModel alone) would preserve a sentinel signature
+  // that the host later classifies as cross-model and downgrades to response
+  // text, reintroducing the contamination this gate exists to prevent.
+  return identity.modelProvider !== undefined &&
+    identity.modelApi !== undefined &&
+    identity.modelId !== undefined
     ? identity
     : undefined;
 }

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -3,7 +3,12 @@
  *
  * Extracted from engine.ts (Phase 1 of the engine decomposition).
  */
-import { buildMessageParts, toStoredMessage, type StoredMessage } from "./message-content.js";
+import {
+  buildMessageParts,
+  stripModelIdentityFromSerializedPartsSignature,
+  toStoredMessage,
+  type StoredMessage,
+} from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import type { CreateMessagePartInput } from "./store/conversation-store.js";
@@ -52,20 +57,27 @@ export function createLosslessMessageSignature(message: AgentMessage): string {
     fallbackContent: stored.content,
   });
 
-  return JSON.stringify({
-    role: stored.role,
-    content: stored.content,
-    parts: parts.map((part) => ({
-      partType: part.partType,
-      ordinal: part.ordinal,
-      textContent: part.textContent ?? null,
-      toolCallId: part.toolCallId ?? null,
-      toolName: part.toolName ?? null,
-      toolInput: part.toolInput ?? null,
-      toolOutput: part.toolOutput ?? null,
-      metadata: part.metadata ?? null,
-    })),
-  });
+  // Strip model-identity metadata from the serialized payload: identity is
+  // replay affinity, not message identity. Rows persisted before identity
+  // stamping and live/assembled representations produced after the upgrade
+  // must keep comparing equal for replay-prefix detection across the
+  // pre/post-upgrade boundary.
+  return stripModelIdentityFromSerializedPartsSignature(
+    JSON.stringify({
+      role: stored.role,
+      content: stored.content,
+      parts: parts.map((part) => ({
+        partType: part.partType,
+        ordinal: part.ordinal,
+        textContent: part.textContent ?? null,
+        toolCallId: part.toolCallId ?? null,
+        toolName: part.toolName ?? null,
+        toolInput: part.toolInput ?? null,
+        toolOutput: part.toolOutput ?? null,
+        metadata: part.metadata ?? null,
+      })),
+    }),
+  );
 }
 
 export function hashAgentMessageForAssemblyProtection(message: AgentMessage): string {

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -73,9 +73,53 @@ export function createLosslessMessageSignature(message: AgentMessage): string {
       toolName: part.toolName ?? null,
       toolInput: part.toolInput ?? null,
       toolOutput: part.toolOutput ?? null,
-      metadata: stripModelIdentityFromMetadataJson(part.metadata ?? null),
+      metadata: canonicalizePartMetadataForMessageSignature(part.metadata ?? null),
     })),
   });
+}
+
+/** Keep OpenAI encrypted-reasoning payloads as message identity. */
+function isOpenAiReasoningSignature(signature: string): boolean {
+  if (!signature.startsWith("{")) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(signature) as { type?: unknown; id?: unknown };
+    return parsed.type === "reasoning" && typeof parsed.id === "string";
+  } catch {
+    return false;
+  }
+}
+
+/** Remove replay affinity while retaining content-bearing metadata. */
+function canonicalizePartMetadataForMessageSignature(metadata: string | null): string | null {
+  const identityStripped = stripModelIdentityFromMetadataJson(metadata);
+  if (!identityStripped) {
+    return identityStripped;
+  }
+  try {
+    const parsed = JSON.parse(identityStripped) as { raw?: unknown };
+    if (!parsed.raw || typeof parsed.raw !== "object" || Array.isArray(parsed.raw)) {
+      return identityStripped;
+    }
+    const raw = parsed.raw as Record<string, unknown>;
+    const signature = raw.thinkingSignature;
+    // Empty opaque signatures can carry the only replayable payload. Keep
+    // those exact; non-empty thinking text supplies the comparison identity.
+    if (
+      raw.type !== "thinking" ||
+      typeof signature !== "string" ||
+      isOpenAiReasoningSignature(signature) ||
+      (signature !== "reasoning_content" &&
+        (typeof raw.thinking !== "string" || raw.thinking.length === 0))
+    ) {
+      return identityStripped;
+    }
+    const { thinkingSignature: _thinkingSignature, ...canonicalRaw } = raw;
+    return JSON.stringify({ ...parsed, raw: canonicalRaw });
+  } catch {
+    return identityStripped;
+  }
 }
 
 export function hashAgentMessageForAssemblyProtection(message: AgentMessage): string {
@@ -91,7 +135,9 @@ export function createLiveCoverageSignature(message: AgentMessage): string {
   if (
     (stored.role === "user" || stored.role === "system" || stored.role === "assistant") &&
     stored.content.length > 0 &&
-    isCanonicalTextOnlyMessage(message, stored.content)
+    (isCanonicalTextOnlyMessage(message, stored.content) ||
+      (stored.role === "assistant" &&
+        isCanonicalTextWithReasoningContent(message, stored.content)))
   ) {
     return JSON.stringify({
       kind: "canonical-text",
@@ -107,6 +153,51 @@ export function createLiveCoverageSignature(message: AgentMessage): string {
     return canonicalToolTextSignature;
   }
   return createLosslessMessageSignature(message);
+}
+
+/** Match post-upgrade sentinel replay to legacy assembly, which drops that block. */
+function isCanonicalTextWithReasoningContent(
+  message: AgentMessage,
+  fallbackContent: string,
+): boolean {
+  const parts = buildMessageParts({
+    sessionId: "live-coverage-signature",
+    message,
+    fallbackContent,
+  });
+  let removedSentinel = false;
+  const visibleParts = parts.filter((part) => {
+    if (part.partType !== "reasoning") {
+      return true;
+    }
+    if (!part.metadata) {
+      return true;
+    }
+    try {
+      const parsed = JSON.parse(part.metadata) as { raw?: unknown };
+      const raw = parsed.raw as Record<string, unknown> | undefined;
+      const isSentinel =
+        raw?.type === "thinking" && raw.thinkingSignature === "reasoning_content";
+      removedSentinel ||= isSentinel;
+      return !isSentinel;
+    } catch {
+      return true;
+    }
+  });
+  return removedSentinel && hasCanonicalTextPart(visibleParts, fallbackContent);
+}
+
+/** True when the parts contain exactly one plain text representation. */
+function hasCanonicalTextPart(parts: CreateMessagePartInput[], fallbackContent: string): boolean {
+  const part = parts[0];
+  return parts.length === 1 && part !== undefined && (
+    part.partType === "text" &&
+    (part.textContent ?? "") === fallbackContent &&
+    part.toolCallId == null &&
+    part.toolName == null &&
+    part.toolInput == null &&
+    part.toolOutput == null
+  );
 }
 
 export function normalizeToolNameForCoverage(toolName: string | null | undefined): string | null {
@@ -159,18 +250,7 @@ export function isCanonicalTextOnlyMessage(message: AgentMessage, fallbackConten
     message,
     fallbackContent,
   });
-  if (parts.length !== 1) {
-    return false;
-  }
-  const part = parts[0] as CreateMessagePartInput;
-  return (
-    part.partType === "text" &&
-    (part.textContent ?? "") === fallbackContent &&
-    part.toolCallId == null &&
-    part.toolName == null &&
-    part.toolInput == null &&
-    part.toolOutput == null
-  );
+  return hasCanonicalTextPart(parts, fallbackContent);
 }
 
 export function messagesHaveSameLiveCoverageSignature(left: AgentMessage, right: AgentMessage): boolean {

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -5,7 +5,7 @@
  */
 import {
   buildMessageParts,
-  stripModelIdentityFromSerializedPartsSignature,
+  stripModelIdentityFromMetadataJson,
   toStoredMessage,
   type StoredMessage,
 } from "./message-content.js";
@@ -62,22 +62,20 @@ export function createLosslessMessageSignature(message: AgentMessage): string {
   // stamping and live/assembled representations produced after the upgrade
   // must keep comparing equal for replay-prefix detection across the
   // pre/post-upgrade boundary.
-  return stripModelIdentityFromSerializedPartsSignature(
-    JSON.stringify({
-      role: stored.role,
-      content: stored.content,
-      parts: parts.map((part) => ({
-        partType: part.partType,
-        ordinal: part.ordinal,
-        textContent: part.textContent ?? null,
-        toolCallId: part.toolCallId ?? null,
-        toolName: part.toolName ?? null,
-        toolInput: part.toolInput ?? null,
-        toolOutput: part.toolOutput ?? null,
-        metadata: part.metadata ?? null,
-      })),
-    }),
-  );
+  return JSON.stringify({
+    role: stored.role,
+    content: stored.content,
+    parts: parts.map((part) => ({
+      partType: part.partType,
+      ordinal: part.ordinal,
+      textContent: part.textContent ?? null,
+      toolCallId: part.toolCallId ?? null,
+      toolName: part.toolName ?? null,
+      toolInput: part.toolInput ?? null,
+      toolOutput: part.toolOutput ?? null,
+      metadata: stripModelIdentityFromMetadataJson(part.metadata ?? null),
+    })),
+  });
 }
 
 export function hashAgentMessageForAssemblyProtection(message: AgentMessage): string {

--- a/src/replay-metadata.ts
+++ b/src/replay-metadata.ts
@@ -3,7 +3,10 @@
  *
  * Extracted from engine.ts (Phase 1 of the engine decomposition).
  */
-import { extractStructuredText } from "./message-content.js";
+import {
+  extractStructuredText,
+  stripModelIdentityFromMetadataJson,
+} from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
 import { getTranscriptEntryId, readLeafPathMessages } from "./transcript.js";
 import { asRecord, safeString, toJson } from "./value-utils.js";
@@ -228,8 +231,15 @@ export function externalizedReplayMetadataMatches(
   let persistedParsed: unknown;
   let incomingParsed: unknown;
   try {
-    persistedParsed = persistedMetadata ? JSON.parse(persistedMetadata) : undefined;
-    incomingParsed = incomingMetadata ? JSON.parse(incomingMetadata) : undefined;
+    // Model identity is replay affinity, not message identity: strip it so a
+    // row persisted before identity stamping still matches the post-upgrade
+    // representation of the same logical message (PR #1053).
+    persistedParsed = persistedMetadata
+      ? JSON.parse(stripModelIdentityFromMetadataJson(persistedMetadata) ?? "null")
+      : undefined;
+    incomingParsed = incomingMetadata
+      ? JSON.parse(stripModelIdentityFromMetadataJson(incomingMetadata) ?? "null")
+      : undefined;
   } catch {
     return false;
   }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -25,6 +25,7 @@ import {
   buildMessageParts,
   isLikelyInjectedDeliveryOnlyTranscript,
   isLikelyInjectedMetadataPreambleRecord,
+  stripModelIdentityFromMetadataJson,
   toStoredMessage,
   type StoredMessage,
 } from "./message-content.js";
@@ -1573,7 +1574,15 @@ export class TranscriptReconciler {
           const rows = rawBlockSignatureStmt.all(messageId) as Array<{ metadata: string | null }>;
           if (
             rows.length === parts.length &&
-            rows.every((row, index) => row.metadata === (parts[index]?.metadata ?? null))
+            rows.every(
+              (row, index) =>
+                // Strip model-identity keys before comparing: pre-upgrade rows
+                // lack them while replayed parts now carry them on ordinal-0.
+                // Raw byte-equality would treat the same turn as new and
+                // ingest it again across the upgrade boundary.
+                stripModelIdentityFromMetadataJson(row.metadata) ===
+                stripModelIdentityFromMetadataJson(parts[index]?.metadata ?? null),
+            )
           ) {
             alreadyPersisted = true;
             break;

--- a/test/assembler-blocks.test.ts
+++ b/test/assembler-blocks.test.ts
@@ -433,6 +433,52 @@ describe("blockFromPart", () => {
     expect(block).not.toHaveProperty("thinkingSignature");
   });
 
+  it("preserves the reasoning_content sentinel thinkingSignature", () => {
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "native reasoning replay text",
+      metadata: JSON.stringify({
+        raw: {
+          type: "thinking",
+          thinking: "native reasoning replay text",
+          thinkingSignature: "reasoning_content",
+        },
+      }),
+    });
+    const block = blockFromPart(part) as Record<string, unknown>;
+
+    expect(block).toEqual({
+      type: "thinking",
+      thinking: "native reasoning replay text",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
+  it("preserves provider thinkingSignature when stored model identity exists", () => {
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "same-model thinking text",
+      metadata: JSON.stringify({
+        originalRole: "assistant",
+        modelProvider: "anthropic",
+        modelApi: "anthropic-messages",
+        modelId: "claude-opus-4-6",
+        raw: {
+          type: "thinking",
+          thinking: "same-model thinking text",
+          thinkingSignature: "anthropic-signature-payload",
+        },
+      }),
+    });
+    const block = blockFromPart(part) as Record<string, unknown>;
+
+    expect(block).toEqual({
+      type: "thinking",
+      thinking: "same-model thinking text",
+      thinkingSignature: "anthropic-signature-payload",
+    });
+  });
+
   it("routes tool result parts correctly", () => {
     const part = makePart({
       partType: "tool",

--- a/test/assembler-blocks.test.ts
+++ b/test/assembler-blocks.test.ts
@@ -3,6 +3,7 @@ import {
   toolCallBlockFromPart,
   toolResultBlockFromPart,
   blockFromPart,
+  contentFromParts,
   tokenizeText,
   scoreRelevance,
 } from "../src/assembler.js";
@@ -433,11 +434,15 @@ describe("blockFromPart", () => {
     expect(block).not.toHaveProperty("thinkingSignature");
   });
 
-  it("preserves the reasoning_content sentinel thinkingSignature", () => {
+  it("preserves the reasoning_content sentinel when model identity exists", () => {
     const part = makePart({
       partType: "reasoning",
       textContent: "native reasoning replay text",
       metadata: JSON.stringify({
+        originalRole: "assistant",
+        modelProvider: "moonshot",
+        modelApi: "openai-completions",
+        modelId: "kimi-k3",
         raw: {
           type: "thinking",
           thinking: "native reasoning replay text",
@@ -452,6 +457,25 @@ describe("blockFromPart", () => {
       thinking: "native reasoning replay text",
       thinkingSignature: "reasoning_content",
     });
+  });
+
+  it("drops reasoning_content sentinel when no stored model identity (legacy rows)", () => {
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "legacy native reasoning text",
+      metadata: JSON.stringify({
+        raw: {
+          type: "thinking",
+          thinking: "legacy native reasoning text",
+          thinkingSignature: "reasoning_content",
+        },
+      }),
+    });
+    const block = blockFromPart(part);
+
+    // Legacy rows without identity: sentinel is dropped (null) so the host's
+    // transformMessages doesn't downgrade it to response-channel text.
+    expect(block).toBeNull();
   });
 
   it("preserves provider thinkingSignature when stored model identity exists", () => {
@@ -476,6 +500,32 @@ describe("blockFromPart", () => {
       type: "thinking",
       thinking: "same-model thinking text",
       thinkingSignature: "anthropic-signature-payload",
+    });
+  });
+
+  it("preserves provider sig on non-ordinal-0 thinking block when message-level identity exists", () => {
+    // Regression: identity is stored on ordinal-0 metadata only, but a
+    // signature-bearing thinking block may sit at any ordinal. The
+    // message-level gate must pass the identity decision to all blocks.
+    const part = makePart({
+      partType: "reasoning",
+      textContent: "thinking at ordinal 1",
+      metadata: JSON.stringify({
+        originalRole: "assistant",
+        raw: {
+          type: "thinking",
+          thinking: "thinking at ordinal 1",
+          thinkingSignature: "anthropic-sig-for-ordinal-1",
+        },
+      }),
+    });
+    // No identity on THIS part, but the message-level gate says identity exists.
+    const block = blockFromPart(part, true) as Record<string, unknown>;
+
+    expect(block).toEqual({
+      type: "thinking",
+      thinking: "thinking at ordinal 1",
+      thinkingSignature: "anthropic-sig-for-ordinal-1",
     });
   });
 
@@ -660,6 +710,90 @@ describe("blockFromPart", () => {
     const block = blockFromPart(part) as Record<string, unknown>;
 
     expect(block.id).toBe("toolu_lcm_test-part-1");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// contentFromParts (message-level identity gating)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("contentFromParts", () => {
+  it("preserves provider thinkingSignature on ordinal-1 block via message-level identity", () => {
+    // Identity is on ordinal-0 (text), thinking block is ordinal-1.
+    const parts: MessagePartRecord[] = [
+      {
+        partId: "p0",
+        messageId: 1,
+        sessionId: "s1",
+        partType: "text",
+        ordinal: 0,
+        textContent: "visible answer",
+        toolCallId: null,
+        toolName: null,
+        toolInput: null,
+        toolOutput: null,
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          modelProvider: "anthropic",
+          modelApi: "anthropic-messages",
+          modelId: "claude-opus-4-6",
+        }),
+      },
+      {
+        partId: "p1",
+        messageId: 1,
+        sessionId: "s1",
+        partType: "reasoning",
+        ordinal: 1,
+        textContent: "thinking at ordinal 1",
+        toolCallId: null,
+        toolName: null,
+        toolInput: null,
+        toolOutput: null,
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          raw: {
+            type: "thinking",
+            thinking: "thinking at ordinal 1",
+            thinkingSignature: "anthropic-sig-ordinal-1",
+          },
+        }),
+      },
+    ];
+    const content = contentFromParts(parts, "assistant", "fallback") as Array<Record<string, unknown>>;
+    expect(content.length).toBe(2);
+    expect(content[1]).toEqual({
+      type: "thinking",
+      thinking: "thinking at ordinal 1",
+      thinkingSignature: "anthropic-sig-ordinal-1",
+    });
+  });
+
+  it("drops legacy sentinel-only thinking block without identity", () => {
+    const parts: MessagePartRecord[] = [
+      {
+        partId: "p0",
+        messageId: 1,
+        sessionId: "s1",
+        partType: "reasoning",
+        ordinal: 0,
+        textContent: "legacy reasoning",
+        toolCallId: null,
+        toolName: null,
+        toolInput: null,
+        toolOutput: null,
+        metadata: JSON.stringify({
+          raw: {
+            type: "thinking",
+            thinking: "legacy reasoning",
+            thinkingSignature: "reasoning_content",
+          },
+        }),
+      },
+    ];
+    const content = contentFromParts(parts, "assistant", "fallback");
+    // Block dropped (no identity), falls back to stored content.
+    expect(content).toEqual([{ type: "text", text: "fallback" }]);
   });
 });
 

--- a/test/assembler-blocks.test.ts
+++ b/test/assembler-blocks.test.ts
@@ -795,6 +795,70 @@ describe("contentFromParts", () => {
     // Block dropped (no identity), falls back to stored content.
     expect(content).toEqual([{ type: "text", text: "fallback" }]);
   });
+
+  it("treats partial stored identity (responseModel only) as no identity: sentinel dropped", () => {
+    // Host same-model check needs provider+api+model; responseModel alone
+    // must not qualify, otherwise the sentinel survives assembly but the host
+    // later downgrades it to response-channel text.
+    const parts: MessagePartRecord[] = [
+      {
+        partId: "p0",
+        messageId: 1,
+        sessionId: "s1",
+        partType: "reasoning",
+        ordinal: 0,
+        textContent: "partial identity reasoning",
+        toolCallId: null,
+        toolName: null,
+        toolInput: null,
+        toolOutput: null,
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          responseModelId: "kimi-k3",
+          raw: {
+            type: "thinking",
+            thinking: "partial identity reasoning",
+            thinkingSignature: "reasoning_content",
+          },
+        }),
+      },
+    ];
+    const content = contentFromParts(parts, "assistant", "fallback");
+    expect(content).toEqual([{ type: "text", text: "fallback" }]);
+  });
+
+  it("strips provider signature when stored identity is partial (api missing)", () => {
+    const parts: MessagePartRecord[] = [
+      {
+        partId: "p0",
+        messageId: 1,
+        sessionId: "s1",
+        partType: "reasoning",
+        ordinal: 0,
+        textContent: "reasoning",
+        toolCallId: null,
+        toolName: null,
+        toolInput: null,
+        toolOutput: null,
+        metadata: JSON.stringify({
+          originalRole: "assistant",
+          modelProvider: "anthropic",
+          modelId: "claude-opus-4-6",
+          raw: {
+            type: "thinking",
+            thinking: "reasoning",
+            thinkingSignature: "real-provider-sig",
+          },
+        }),
+      },
+    ];
+    const content = contentFromParts(parts, "assistant", "fallback") as Array<
+      Record<string, unknown>
+    >;
+    expect(content.length).toBe(1);
+    expect(content[0]).toMatchObject({ type: "thinking", thinking: "reasoning" });
+    expect(content[0]).not.toHaveProperty("thinkingSignature");
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/test/lcm-integration-model-identity.test.ts
+++ b/test/lcm-integration-model-identity.test.ts
@@ -1,0 +1,170 @@
+/**
+ * End-to-end round-trip: ingest (buildMessageParts) → assemble → assert
+ * model identity and sentinel thinkingSignature survive the DB round-trip.
+ *
+ * Style: mirrors test/lcm-integration-assemble.test.ts (mock stores + real
+ * ContextAssembler) to verify the full persistence→reassembly path without
+ * heavy LcmContextEngine scaffolding.
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import { ContextAssembler } from "../src/assembler.js";
+import { buildMessageParts } from "../src/message-content.js";
+import {
+  createMockConversationStore,
+  createMockSummaryStore,
+  wireStores,
+  CONV_ID,
+} from "./integration-helpers.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { MessagePartRecord } from "../src/store/conversation-store.js";
+
+describe("LCM integration: model identity round-trip", () => {
+  let convStore: ReturnType<typeof createMockConversationStore>;
+  let sumStore: ReturnType<typeof createMockSummaryStore>;
+  let assembler: ContextAssembler;
+
+  beforeEach(() => {
+    convStore = createMockConversationStore();
+    sumStore = createMockSummaryStore();
+    wireStores(convStore, sumStore);
+    assembler = new ContextAssembler(convStore as any, sumStore as any);
+  });
+
+  it("preserves model identity and sentinel thinkingSignature through ingest→assemble", async () => {
+    // 1. Simulate a live assistant message with model identity + sentinel sig.
+    const liveMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning text", thinkingSignature: "reasoning_content" },
+        { type: "text", text: "visible answer" },
+      ],
+      provider: "moonshot",
+      api: "openai-completions",
+      model: "kimi-k3",
+      responseModel: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    // 2. Ingest: buildMessageParts → store parts.
+    await convStore.createConversation({ sessionId: "session-1" });
+    const msg = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 1,
+      role: "assistant",
+      content: "visible answer",
+      tokenCount: 10,
+    });
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message: liveMessage,
+      fallbackContent: "visible answer",
+    });
+    const partRecords: MessagePartRecord[] = parts.map((part, index) => ({
+      partId: `part-${index}`,
+      messageId: msg.messageId,
+      sessionId: part.sessionId,
+      partType: part.partType,
+      ordinal: part.ordinal,
+      textContent: part.textContent ?? null,
+      toolCallId: part.toolCallId ?? null,
+      toolName: part.toolName ?? null,
+      toolInput: part.toolInput ?? null,
+      toolOutput: part.toolOutput ?? null,
+      metadata: part.metadata ?? null,
+    }));
+    await convStore.createMessageParts(
+      msg.messageId,
+      partRecords.map((p) => ({
+        sessionId: p.sessionId,
+        partType: p.partType,
+        ordinal: p.ordinal,
+        textContent: p.textContent,
+        toolCallId: p.toolCallId,
+        toolName: p.toolName,
+        toolInput: p.toolInput,
+        toolOutput: p.toolOutput,
+        metadata: p.metadata,
+      })),
+    );
+    await sumStore.appendContextMessage(CONV_ID, msg.messageId);
+
+    // 3. Assemble with a generous budget.
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+    });
+
+    expect(result.messages).toHaveLength(1);
+    const assembled = result.messages[0] as Record<string, unknown>;
+
+    // 4. Assert model identity survived.
+    expect(assembled.provider).toBe("moonshot");
+    expect(assembled.api).toBe("openai-completions");
+    expect(assembled.model).toBe("kimi-k3");
+    expect(assembled.responseModel).toBe("kimi-k3");
+
+    // 5. Assert sentinel thinkingSignature survived on the thinking block.
+    const content = assembled.content as Array<Record<string, unknown>>;
+    const thinkingBlock = content.find((b) => b.type === "thinking");
+    expect(thinkingBlock).toBeDefined();
+    expect(thinkingBlock!.thinkingSignature).toBe("reasoning_content");
+    expect(thinkingBlock!.thinking).toBe("reasoning text");
+  });
+
+  it("drops legacy sentinel thinking blocks without stored identity", async () => {
+    // Simulate a pre-upgrade row: sentinel sig but no identity metadata.
+    await convStore.createConversation({ sessionId: "session-1" });
+    const msg = await convStore.createMessage({
+      conversationId: CONV_ID,
+      seq: 1,
+      role: "assistant",
+      content: "",
+      tokenCount: 10,
+    });
+    const legacyPart: MessagePartRecord = {
+      partId: "part-0",
+      messageId: msg.messageId,
+      sessionId: "session-1",
+      partType: "reasoning",
+      ordinal: 0,
+      textContent: "legacy reasoning",
+      toolCallId: null,
+      toolName: null,
+      toolInput: null,
+      toolOutput: null,
+      metadata: JSON.stringify({
+        originalRole: "assistant",
+        raw: {
+          type: "thinking",
+          thinking: "legacy reasoning",
+          thinkingSignature: "reasoning_content",
+        },
+      }),
+    };
+    await convStore.createMessageParts(msg.messageId, [
+      {
+        sessionId: legacyPart.sessionId,
+        partType: legacyPart.partType,
+        ordinal: legacyPart.ordinal,
+        textContent: legacyPart.textContent,
+        toolCallId: legacyPart.toolCallId,
+        toolName: legacyPart.toolName,
+        toolInput: legacyPart.toolInput,
+        toolOutput: legacyPart.toolOutput,
+        metadata: legacyPart.metadata,
+      },
+    ]);
+    await sumStore.appendContextMessage(CONV_ID, msg.messageId);
+
+    const result = await assembler.assemble({
+      conversationId: CONV_ID,
+      tokenBudget: 100_000,
+    });
+
+    // The sentinel-only thinking block is dropped (no identity → null →
+    // filtered). With no other content, the message is empty and the
+    // assembler drops it entirely — correct behavior, since the alternative
+    // (preserving the block) would let the host downgrade it to
+    // response-channel text.
+    expect(result.messages).toHaveLength(0);
+  });
+});

--- a/test/message-content-model-identity.test.ts
+++ b/test/message-content-model-identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { buildMessageParts } from "../src/message-content.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+
+function partMetadata(part: { metadata: string | null }): Record<string, unknown> {
+  return JSON.parse(part.metadata ?? "{}") as Record<string, unknown>;
+}
+
+describe("buildMessageParts model identity persistence", () => {
+  it("stores assistant provider/api/model/responseModel in ordinal-0 part metadata", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning text", thinkingSignature: "reasoning_content" },
+        { type: "text", text: "visible answer" },
+      ],
+      provider: "xiaomi",
+      api: "anthropic-messages",
+      model: "kimi-k3",
+      responseModel: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "visible answer",
+    });
+
+    expect(parts.length).toBe(2);
+    expect(partMetadata(parts[0]!)).toMatchObject({
+      modelProvider: "xiaomi",
+      modelApi: "anthropic-messages",
+      modelId: "kimi-k3",
+      responseModelId: "kimi-k3",
+    });
+    const laterMetadata = partMetadata(parts[1]!);
+    expect(laterMetadata).not.toHaveProperty("modelProvider");
+    expect(laterMetadata).not.toHaveProperty("modelId");
+  });
+
+  it("stores identity for string-content assistant messages", () => {
+    const message = {
+      role: "assistant",
+      content: "plain text reply",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-opus-4-6",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "plain text reply",
+    });
+
+    expect(parts.length).toBe(1);
+    expect(partMetadata(parts[0]!)).toMatchObject({
+      modelProvider: "anthropic",
+      modelApi: "anthropic-messages",
+      modelId: "claude-opus-4-6",
+    });
+    expect(partMetadata(parts[0]!)).not.toHaveProperty("responseModelId");
+  });
+
+  it("does not store identity fields for non-assistant messages", () => {
+    const message = {
+      role: "user",
+      content: "hello",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "hello",
+    });
+
+    expect(parts.length).toBe(1);
+    const metadata = partMetadata(parts[0]!);
+    expect(metadata).not.toHaveProperty("modelProvider");
+    expect(metadata).not.toHaveProperty("modelApi");
+    expect(metadata).not.toHaveProperty("modelId");
+  });
+
+  it("omits identity keys entirely when the assistant message carries none", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "legacy shape" }],
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "legacy shape",
+    });
+
+    expect(parts.length).toBe(1);
+    const metadata = partMetadata(parts[0]!);
+    expect(metadata).not.toHaveProperty("modelProvider");
+    expect(metadata).not.toHaveProperty("modelApi");
+    expect(metadata).not.toHaveProperty("modelId");
+    expect(metadata).not.toHaveProperty("responseModelId");
+  });
+});

--- a/test/message-content-model-identity.test.ts
+++ b/test/message-content-model-identity.test.ts
@@ -103,3 +103,69 @@ describe("buildMessageParts model identity persistence", () => {
     expect(metadata).not.toHaveProperty("responseModelId");
   });
 });
+
+describe("partial identity gating (host requires provider+api+model)", () => {
+  it("does not store identity when only responseModel is present", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning", thinkingSignature: "reasoning_content" },
+        { type: "text", text: "answer" },
+      ],
+      responseModel: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "answer",
+    });
+
+    const metadata = partMetadata(parts[0]!);
+    expect(metadata).not.toHaveProperty("modelProvider");
+    expect(metadata).not.toHaveProperty("modelApi");
+    expect(metadata).not.toHaveProperty("modelId");
+    expect(metadata).not.toHaveProperty("responseModelId");
+  });
+
+  it("does not store identity when api is missing (host same-model check would fail)", () => {
+    const message = {
+      role: "assistant",
+      content: "text",
+      provider: "xiaomi",
+      model: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "text",
+    });
+
+    const metadata = partMetadata(parts[0]!);
+    expect(metadata).not.toHaveProperty("modelProvider");
+    expect(metadata).not.toHaveProperty("modelId");
+  });
+
+  it("stores identity when provider+api+model are all present without responseModel", () => {
+    const message = {
+      role: "assistant",
+      content: "text",
+      provider: "xiaomi",
+      api: "anthropic-messages",
+      model: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    const parts = buildMessageParts({
+      sessionId: "session-1",
+      message,
+      fallbackContent: "text",
+    });
+
+    expect(partMetadata(parts[0]!)).toMatchObject({
+      modelProvider: "xiaomi",
+      modelApi: "anthropic-messages",
+      modelId: "kimi-k3",
+    });
+  });
+});

--- a/test/message-content-model-identity.test.ts
+++ b/test/message-content-model-identity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildMessageParts } from "../src/message-content.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 
-function partMetadata(part: { metadata: string | null }): Record<string, unknown> {
+function partMetadata(part: { metadata?: string | null }): Record<string, unknown> {
   return JSON.parse(part.metadata ?? "{}") as Record<string, unknown>;
 }
 

--- a/test/message-signatures.test.ts
+++ b/test/message-signatures.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createBootstrapEntryHash } from "../src/message-signatures.js";
+import { createBootstrapEntryHash, createLosslessMessageSignature } from "../src/message-signatures.js";
+import { stripModelIdentityFromMetadataJson } from "../src/message-content.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
 
 describe("message bootstrap signatures", () => {
   it("canonicalizes OpenClaw inbound metadata for user bootstrap hashes", () => {
@@ -12,6 +14,51 @@ describe("message bootstrap signatures", () => {
     expect(createBootstrapEntryHash({ role: "assistant", content: first, tokenCount: 1 })).not.toBe(
       createBootstrapEntryHash({ role: "assistant", content: second, tokenCount: 1 }),
     );
+  });
+});
+
+describe("createLosslessMessageSignature upgrade parity", () => {
+  // Pre-upgrade rows have no identity metadata; post-upgrade live messages do.
+  // createLosslessMessageSignature must produce the same signature for both
+  // so replay-prefix detection and live-coverage matching still work across
+  // the upgrade boundary.
+  it("strips model identity metadata so pre/post-upgrade signatures match", () => {
+    const preUpgrade = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+    } as unknown as AgentMessage;
+    const postUpgrade = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-opus-4-6",
+    } as unknown as AgentMessage;
+    expect(createLosslessMessageSignature(preUpgrade)).toBe(
+      createLosslessMessageSignature(postUpgrade),
+    );
+  });
+});
+
+describe("stripModelIdentityFromMetadataJson", () => {
+  it("returns input byte-identical when no identity keys present", () => {
+    const metadata = JSON.stringify({ originalRole: "assistant", toolCallId: "c1" });
+    expect(stripModelIdentityFromMetadataJson(metadata)).toBe(metadata);
+  });
+  it("returns null for null/undefined input", () => {
+    expect(stripModelIdentityFromMetadataJson(null)).toBe(null);
+    expect(stripModelIdentityFromMetadataJson(undefined)).toBe(null);
+  });
+  it("strips identity keys and preserves remaining key order", () => {
+    const withIdentity = JSON.stringify({
+      originalRole: "assistant",
+      modelProvider: "anthropic",
+      modelApi: "anthropic-messages",
+      modelId: "claude-opus-4-6",
+      toolCallId: "c1",
+    });
+    const stripped = stripModelIdentityFromMetadataJson(withIdentity);
+    expect(stripped).toBe(JSON.stringify({ originalRole: "assistant", toolCallId: "c1" }));
   });
 });
 

--- a/test/message-signatures.test.ts
+++ b/test/message-signatures.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createBootstrapEntryHash, createLosslessMessageSignature } from "../src/message-signatures.js";
+import {
+  createBootstrapEntryHash,
+  createLiveCoverageSignature,
+  createLosslessMessageSignature,
+} from "../src/message-signatures.js";
 import { stripModelIdentityFromMetadataJson } from "../src/message-content.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
 
@@ -36,6 +40,83 @@ describe("createLosslessMessageSignature upgrade parity", () => {
     } as unknown as AgentMessage;
     expect(createLosslessMessageSignature(preUpgrade)).toBe(
       createLosslessMessageSignature(postUpgrade),
+    );
+  });
+
+  it("strips provider replay signatures so legacy assembled thinking still matches", () => {
+    const legacyAssembled = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning" },
+        { type: "text", text: "answer" },
+      ],
+    } as unknown as AgentMessage;
+    const postUpgrade = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning", thinkingSignature: "provider-signature" },
+        { type: "text", text: "answer" },
+      ],
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-opus-4-6",
+    } as unknown as AgentMessage;
+
+    expect(createLosslessMessageSignature(legacyAssembled)).toBe(
+      createLosslessMessageSignature(postUpgrade),
+    );
+  });
+
+  it("keeps OpenAI encrypted reasoning payloads in message identity", () => {
+    const messageWithSignature = (id: string) =>
+      ({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: JSON.stringify({ type: "reasoning", id }),
+          },
+        ],
+      }) as unknown as AgentMessage;
+
+    expect(createLosslessMessageSignature(messageWithSignature("rs_1"))).not.toBe(
+      createLosslessMessageSignature(messageWithSignature("rs_2")),
+    );
+  });
+
+  it("keeps opaque signatures when no thinking text can identify the block", () => {
+    const messageWithSignature = (thinkingSignature: string) =>
+      ({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "", thinkingSignature }],
+      }) as unknown as AgentMessage;
+
+    expect(createLosslessMessageSignature(messageWithSignature("opaque-1"))).not.toBe(
+      createLosslessMessageSignature(messageWithSignature("opaque-2")),
+    );
+  });
+});
+
+describe("createLiveCoverageSignature upgrade parity", () => {
+  it("matches legacy text-only assembly to live text plus reasoning_content", () => {
+    const legacyAssembled = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+    } as unknown as AgentMessage;
+    const postUpgrade = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "reasoning", thinkingSignature: "reasoning_content" },
+        { type: "text", text: "answer" },
+      ],
+      provider: "moonshot",
+      api: "openai-completions",
+      model: "kimi-k3",
+    } as unknown as AgentMessage;
+
+    expect(createLiveCoverageSignature(legacyAssembled)).toBe(
+      createLiveCoverageSignature(postUpgrade),
     );
   });
 });


### PR DESCRIPTION
## Problem

DB-assembled assistant messages drop two attributes that live transcript messages carry:

1. **Model identity** (`provider` / `api` / `model` / `responseModel`) — `messages`/`message_parts` never stored it, so assembled messages come back identity-less.
2. **Thinking signature** — since #784 (fixing #365), assembly strips `thinkingSignature` from every DB-sourced thinking block unconditionally.

The host's model-bound thinking replay policy (`transformMessages`) treats a missing identity as a cross-model switch (`isSameModel = false`) and downgrades every replayed thinking block to a plain `text` block.

For ordinary Anthropic models this is mostly cosmetic. For **reasoning-native models served through an Anthropic-compatible path** (e.g. Kimi K3 behind a translation proxy, or any endpoint using the host's `reasoning_content` sentinel convention), it is corrupting: the downgraded thinking lands in the *response channel* of the chat template on replay. The model sees its own past reasoning as visible assistant output, imitates that shape, and starts leaking raw reasoning (and invented channel markers) into user-facing replies as sessions grow. We traced multi-day production incidents (task abandonment mid-turn, reasoning-as-reply, fake channel markers) to exactly this replay path.

`"reasoning_content"` is not a provider-issued signature: the host's provider stream layer stamps it for reasoning-native endpoints, and the host's Anthropic client explicitly recognizes it (drops those blocks from outgoing requests instead of replaying a forged signature). Stripping it in LCM breaks that contract; nothing about #365 requires removing it.

## Fix

Three coordinated changes, biased toward keeping the host's replay policy in charge instead of LCM making replay decisions:

- **Ingestion** (`buildMessageParts`): persist the assistant message's `provider` / `api` / `model` / `responseModel` in ordinal-0 part metadata (`modelProvider` / `modelApi` / `modelId` / `responseModelId`). Pure JSON metadata, no schema migration.
- **Assembly** (`blockFromPart`): three-way signature handling, gated on **message-level** model identity (identity lives on ordinal-0, but signature-bearing blocks may sit at any ordinal) —
  - `thinkingSignature === "reasoning_content"` **with** stored identity → preserved (host sentinel, both sides understand it);
  - `thinkingSignature === "reasoning_content"` **without** stored identity → **dropped** (legacy rows: host would downgrade to response-channel text — the contamination this patch fixes);
  - real provider signature **with** stored model identity → preserved, so the host's same-model replay policy decides;
  - legacy rows **without** stored identity → keep the existing strip (#365 stays fixed; no behavior change for existing databases).
- **Assembly** (`resolveMessageItem`): re-attach the stored identity to assembled assistant messages so the host's `isSameModel` check sees the original route.

### Hardening (review-driven)

Autoreview on the initial commit (c70027e) surfaced three findings, all addressed in commit 4d698d1:

1. **P1 — Ordinal gating**: `hasStoredModelIdentity(part)` checked only the signature-bearing part, but identity is stored on ordinal-0. A thinking block at ordinal 1+ lost its sig even though `pickModelIdentity(parts)` restored identity at message level. **Fix**: `blockFromPart` now accepts a `messageHasStoredModelIdentity` param; `contentFromParts` and `normalizeMessageContentForStorage` compute it from the full part set (or live message top-level fields) and pass it to every block.

2. **P1 — Legacy sentinel rows**: pre-upgrade rows with sentinel `"reasoning_content"` and no identity were always preserved, but the host treats missing identity as cross-model → downgrades to text → contamination persists for existing sessions. **Fix**: sentinel blocks without identity are dropped entirely (return `null`), mirroring what the host does to sentinel blocks without identity. Callers filter null blocks and fall back to stored content when all blocks are dropped.

3. **P2 — Comparison-path parity**: `createLosslessMessageSignature` and `externalizedReplayMetadataMatches` include part metadata in their serialized comparison forms. Post-upgrade live/assembled representations carry identity keys that pre-upgrade DB rows lack, breaking replay-prefix detection and live-coverage fork-anchor matching across the upgrade boundary. **Fix**: both paths now strip model-identity keys before comparing, so pre/post-upgrade representations of the same logical message compare equal.

## Behavior matrix

| Row | Signature | Stored identity | Before | After |
|---|---|---|---|---|
| legacy (pre-upgrade) | provider-issued | ✗ | strip | strip (unchanged) |
| legacy (pre-upgrade) | `reasoning_content` sentinel | ✗ | strip → text downgrade | **drop** (no response-channel contamination) |
| new | `reasoning_content` sentinel | ✓ | strip → text downgrade | preserve → host handles natively |
| new | provider-issued | ✓ | strip → text downgrade | preserve → host same-model policy decides |
| new | provider-issued | ✗ | strip | strip (unchanged) |
| any | none | — | as-is | as-is |

## Testing

- Updated sentinel test to reflect identity-gated preservation.
- Added legacy-sentinel-drop test (unit + integration).
- Added ordinal-gating regression test (`blockFromPart` + `contentFromParts`).
- Added `createLosslessMessageSignature` upgrade-parity test.
- Added `stripModelIdentityFromMetadataJson` unit tests.
- Added end-to-end ingest→assemble round-trip test (`lcm-integration-model-identity.test.ts`).
- Fixed pre-existing test type error in `partMetadata` helper.
- Full suite: 2000/2000 green; `tsc --noEmit` clean.

## Notes

- No schema migration; identity rides existing part `metadata` JSON (same pattern as `topLevelReasoning*` metadata).
- No config surface change (`openclaw.plugin.json` / `docs/configuration.md` untouched).
- `peerDependencies` unchanged (`openclaw >=2026.5.28`): no new plugin API used; the feature is inert on older hosts (they never stamp the sentinel, so no identity → no preservation → existing strip behavior).
- Changeset included (`patch`).
- Host compatibility: works with hosts that predate the sentinel convention too (worst case the host strips/ignores signatures itself, which is exactly the pre-PR status quo).
