### PR TITLE
fix(ingest): preserve tool pairing for empty-content tool results

### DIFF
--- a/.changeset/fix-empty-content-tool-result-parts.md
+++ b/.changeset/fix-empty-content-tool-result-parts.md
@@ -1,0 +1,19 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix tool-result pairing loss when a tool returns empty content. Tools like
+OpenClaw's `update_plan` (and any third-party tool) that return
+`{content: [], details: {...}}` produced zero `message_parts` rows on ingest,
+losing the top-level `toolCallId`/`toolName`/`isError` pairing identity. On
+assembly, the zero-part `role=tool` row was demoted to `role="assistant"` with
+empty content and dropped by the empty-content filter, causing
+`sanitizeToolUseResultPairing` to insert a synthetic "missing tool result"
+error on every assemble while the call sat in the context window — the model
+read its own plan calls as "failed" and retried in a loop. The fix emits one
+identity-carrying fallback part in `buildMessageParts()` when a tool-result
+message's content is an empty array, so assembly can reconstruct the
+`toolResult` with the correct `toolCallId`. A canonical empty-tool-result
+coverage signature is added to `message-signatures.ts` so live-coverage dedup
+recognizes the live, DB-round-trip, and assembled representations of the same
+logical result as identical.

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -627,6 +627,50 @@ export function buildMessageParts(params: {
     });
   }
 
+  // Empty-content tool-result fallback (issue #992): a tool result message
+  // whose content is an empty array (e.g. OpenClaw `update_plan` shape
+  // `{content: [], details: {...}}`) produces zero parts above, which loses
+  // the top-level pairing identity (toolCallId/toolName/isError live only in
+  // part metadata). Downstream, a zero-part role=tool row can no longer be
+  // rehydrated as a toolResult — it is demoted to assistant, filtered as
+  // empty, and `sanitizeToolUseResultPairing` then injects a synthetic
+  // "missing tool result" error on every assemble while the call is in the
+  // context window. Persist one fallback part that carries the pairing
+  // identity so assembly can reconstruct the toolResult. Role-gated (not
+  // id-gated): pre-existing routing in blockFromPart treats a metadata-less
+  // "tool" part as a toolCall, so only tool/toolResult roles may land here —
+  // an id-bearing assistant/user message would otherwise be misassembled as
+  // a phantom call. User and assistant empty content intentionally stays
+  // part-less (the empty-content filter and the empty-assistant skip are
+  // desired behavior). Callid-less tool rows keep today's demote-to-assistant
+  // assembly path.
+  if (
+    message.content.length === 0 &&
+    (role === "tool" || role === "toolResult") &&
+    !rawPayloadExternalized
+  ) {
+    parts.push({
+      sessionId,
+      partType: "tool",
+      ordinal: 0,
+      textContent: " ",
+      toolCallId: topLevelToolCallId ?? null,
+      toolName: topLevelToolName ?? null,
+      metadata: toJson({
+        // Always identify as "toolResult" so blockFromPart routes through
+        // toolResultBlockFromPart (not toolCallBlockFromPart which would
+        // emit a phantom toolCall block). The raw role may be "tool" but
+        // the logical shape is a tool RESULT.
+        originalRole: "toolResult",
+        rawType: "tool_result",
+        toolCallId: topLevelToolCallId,
+        toolName: topLevelToolName,
+        isError: topLevelIsError,
+        emptyContentFallback: true,
+      }),
+    });
+  }
+
   return parts;
 }
 

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -96,6 +96,13 @@ export function createLiveCoverageSignature(message: AgentMessage): string {
   if (canonicalToolTextSignature) {
     return canonicalToolTextSignature;
   }
+  const canonicalEmptyToolResultSignature = createCanonicalEmptyToolResultCoverageSignature(
+    message,
+    stored.content,
+  );
+  if (canonicalEmptyToolResultSignature) {
+    return canonicalEmptyToolResultSignature;
+  }
   return createLosslessMessageSignature(message);
 }
 
@@ -141,6 +148,164 @@ export function createCanonicalToolTextCoverageSignature(
     toolCallId: part.toolCallId ?? extractToolResultIdForPairing(message) ?? null,
     toolName: normalizeToolNameForCoverage(part.toolName),
   });
+}
+
+/**
+ * Canonical coverage identity for a tool-result message whose effective text
+ * is EMPTY. The empty-content ingest fallback (issue #992) persists a single
+ * identity-carrying "tool" part for `{content: [], details: …}` shapes, and
+ * assembly rehydrates that part into a `{type:"tool_result", output:" "}`
+ * block — the same logical result then appears under three raw shapes (live
+ * empty content, live single tool_result block, assembled block), each of
+ * which would otherwise hash to a different lossless parts-JSON and be
+ * double-emitted side by side by live-coverage dedup. Canonicalize all three
+ * onto the same key: (role, toolCallId) — toolName is intentionally omitted
+ * because it may be present on the DB round-trip representation and absent
+ * on the live transcript block, while toolCallId is the unique pairing identity.
+ */
+export function createCanonicalEmptyToolResultCoverageSignature(
+  message: AgentMessage,
+  fallbackContent: string,
+): string | undefined {
+  const stored = toStoredMessage(message);
+  if (stored.role !== "tool") {
+    return undefined;
+  }
+  const parts = buildMessageParts({
+    sessionId: "live-empty-tool-coverage-signature",
+    message,
+    fallbackContent,
+  });
+  if (parts.length !== 1) {
+    return undefined;
+  }
+  const part = parts[0] as CreateMessagePartInput;
+  if (part.partType !== "tool" || part.toolInput != null) {
+    return undefined;
+  }
+  // Effective text must be empty: the fallback sentinel " " or an output
+  // column holding only whitespace — never a real payload.
+  if (!isEffectivelyEmptyToolResultPart(part, fallbackContent)) {
+    return undefined;
+  }
+  if (!isToolResultShapedPart(part)) {
+    return undefined;
+  }
+  const toolCallId = part.toolCallId ?? extractToolResultIdForPairing(message) ?? null;
+  if (!toolCallId) {
+    // Identity-less results cannot be canonicalized without collision risk:
+    // two distinct id-less results would otherwise map to the same key and
+    // one side could be silently swallowed by coverage dedup.
+    return undefined;
+  }
+  // toolName is intentionally omitted from the key: the same logical result
+  // may appear with a top-level toolName (DB round-trip) or without one
+  // (live transcript block only), and toolCallId is the unique pairing
+  // identity — two results with the same toolCallId ARE the same result.
+  return JSON.stringify({
+    kind: "canonical-empty-tool-result",
+    role: stored.role,
+    toolCallId,
+  });
+}
+
+function isEffectivelyEmptyToolResultPart(
+  part: CreateMessagePartInput,
+  fallbackContent: string,
+): boolean {
+  if (fallbackContent.trim() !== "") {
+    return false;
+  }
+  const textContentEmpty = (part.textContent ?? "").trim() === "";
+  if (!textContentEmpty) {
+    return false;
+  }
+  const toolOutput = part.toolOutput;
+  if (toolOutput != null) {
+    // toolOutput may be a JSON-quoted string (e.g. '" "').
+    try {
+      const parsed: unknown = JSON.parse(toolOutput);
+      if (typeof parsed === "string") {
+        if (parsed.trim() !== "") {
+          return false;
+        }
+      } else {
+        // Non-string toolOutput means there is a real payload.
+        return false;
+      }
+    } catch {
+      if (toolOutput.trim() !== "") {
+        return false;
+      }
+    }
+  }
+  // Check metadata.raw for a content-bearing tool_result block. A part with
+  // null textContent and null toolOutput may still carry a real payload in
+  // metadata.raw.content (e.g. {type:"tool_result", content:[{type:"text",
+  // text:"real output"}]}). Declaring such a part "empty" would canonicalize
+  // it by call ID alone and let coverage dedup suppress a richer live
+  // representation.
+  let metadata: Record<string, unknown> | null = null;
+  try {
+    metadata = part.metadata ? (JSON.parse(part.metadata) as Record<string, unknown>) : null;
+  } catch {
+    return true;
+  }
+  if (!metadata) {
+    return true;
+  }
+  const raw = metadata.raw;
+  if (!raw || typeof raw !== "object") {
+    return true;
+  }
+  const rawRecord = raw as Record<string, unknown>;
+  // Check raw.content and raw.output for any payload.
+  if (rawRecord.content != null) {
+    return false;
+  }
+  if (rawRecord.output != null && String(rawRecord.output).trim() !== "") {
+    return false;
+  }
+  return true;
+}
+
+function isToolResultShapedPart(part: CreateMessagePartInput): boolean {
+  let metadata: Record<string, unknown> | null = null;
+  try {
+    metadata = part.metadata ? (JSON.parse(part.metadata) as Record<string, unknown>) : null;
+  } catch {
+    return false;
+  }
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  if (metadata.emptyContentFallback === true) {
+    return true;
+  }
+  const originalRole = metadata.originalRole;
+  if (originalRole !== "toolResult" && originalRole !== "tool") {
+    return false;
+  }
+  const rawType = metadata.rawType;
+  if (
+    rawType === "tool_result" ||
+    rawType === "toolResult" ||
+    rawType === "function_call_output"
+  ) {
+    return true;
+  }
+  const raw = metadata.raw;
+  if (raw && typeof raw === "object") {
+    const rawBlockType = (raw as { type?: unknown }).type;
+    if (
+      rawBlockType === "tool_result" ||
+      rawBlockType === "toolResult" ||
+      rawBlockType === "function_call_output"
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function isCanonicalTextOnlyMessage(message: AgentMessage, fallbackContent: string): boolean {

--- a/test/empty-content-tool-result-parts.test.ts
+++ b/test/empty-content-tool-result-parts.test.ts
@@ -1,0 +1,167 @@
+// Empty-content tool-result ingest fallback (issue #992 follow-up).
+//
+// Production RCA: OpenClaw's `update_plan` tool (and any third-party tool that
+// follows the same `{content: [], details: {...}}` result shape) returns a
+// toolResult whose content is an EMPTY array. Before this fix:
+//   1. Ingest `buildMessageParts()` ran the per-block loop zero times and
+//      persisted ZERO message_parts; the top-level toolCallId/toolName/isError
+//      only ever live inside part metadata, so pairing identity was lost.
+//   2. Assembly `resolveMessageItem` could not recover a toolCallId from a
+//      zero-part row and demoted role=tool to role="assistant" with [] content.
+//   3. `isEmptyMessageContent` dropped the demoted message entirely.
+//   4. `sanitizeToolUseResultPairing` then saw the assistant toolCall with no
+//      result and inserted the synthetic "missing tool result" error on every
+//      assemble while the call sat in the context window — the model read its
+//      plan calls as FAILED and retried in a loop.
+import { afterEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ContextAssembler } from "../src/assembler.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { cleanupEngineTestState, createEngine } from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+const MISSING_RESULT_MARKER = "[lossless-claw] missing tool result";
+
+function makeUpdatePlanCall(): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: "call_plan_1",
+        name: "update_plan",
+        arguments: { plan: [{ step: "reproduce", status: "in_progress" }] },
+      },
+    ],
+  } as AgentMessage;
+}
+
+function makeEmptyPlanResult(): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_plan_1",
+    toolName: "update_plan",
+    content: [],
+    details: { plan: [{ step: "reproduce", status: "in_progress" }] },
+  } as unknown as AgentMessage;
+}
+
+describe("empty-content toolResult ingest fallback (issue #992)", () => {
+  it("assembles a paired toolResult instead of a synthetic missing-result error", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    await engine.ingest({ sessionId, message: makeEmptyPlanResult() });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]!.role).toBe("tool");
+    // The stored text fallback is empty — the tool genuinely returned no text.
+    expect(stored[1]!.content).toBe("");
+
+    // Ingest must persist one fallback part carrying the pairing identity.
+    const parts = await engine
+      .getConversationStore()
+      .getMessageParts(stored[1]!.messageId);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("tool");
+    expect(parts[0]!.toolCallId).toBe("call_plan_1");
+    expect(parts[0]!.toolName).toBe("update_plan");
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+    });
+
+    // The empty result must NOT be demoted to assistant and dropped; both the
+    // call and its result survive assembly.
+    expect(assembled.messages).toHaveLength(2);
+    const resultMessage = assembled.messages[1] as {
+      role: string;
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: unknown;
+    };
+    expect(resultMessage.role).toBe("toolResult");
+    expect(resultMessage.toolCallId).toBe("call_plan_1");
+    expect(resultMessage.toolName).toBe("update_plan");
+    expect(resultMessage.isError).not.toBe(true);
+    // Effective tool output is an empty string — never a missing-result error.
+    expect(JSON.stringify(resultMessage.content)).not.toContain(MISSING_RESULT_MARKER);
+  });
+
+  it("never inserts the synthetic error while the call is inside the context window", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    await engine.ingest({ sessionId, message: makeEmptyPlanResult() });
+    // Follow-up turns keep the pair inside the fresh tail on every assemble.
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "next step?" } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+
+    for (let i = 0; i < 3; i++) {
+      const assembled = await assembler.assemble({
+        conversationId: conversation!.conversationId,
+        tokenBudget: 100_000,
+      });
+      const serialized = JSON.stringify(assembled.messages);
+      expect(serialized).not.toContain(MISSING_RESULT_MARKER);
+      const results = assembled.messages.filter(
+        (m) => m.role === "toolResult" && (m as { toolCallId?: string }).toolCallId === "call_plan_1",
+      );
+      expect(results).toHaveLength(1);
+    }
+  });
+
+  it("keeps legacy zero-part rows no worse than today (demote + drop, no crash)", async () => {
+    // Rows persisted BEFORE this fix have role=tool, content='', zero parts.
+    // There is no pairing identity left to recover — out of scope to repair —
+    // but assembly must keep handling them exactly as it does today.
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    // Fabricate the legacy shape by ingesting a string-content tool result and
+    // then deleting its parts — do this because a pre-fix row is precisely
+    // "role=tool, empty content, zero parts".
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_plan_1",
+        toolName: "update_plan",
+        content: "",
+      } as unknown as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+    });
+    // Must resolve to a finite message list without throwing.
+    expect(Array.isArray(assembled.messages)).toBe(true);
+    expect(assembled.messages.length).toBeGreaterThan(0);
+  });
+});

--- a/test/message-content-empty-tool-result.test.ts
+++ b/test/message-content-empty-tool-result.test.ts
@@ -1,0 +1,288 @@
+// buildMessageParts empty-content tool-result fallback — unit coverage.
+//
+// Complements the ingest→assemble regression in
+// test/empty-content-tool-result-parts.test.ts with focused unit checks:
+//   - exactly which empty-array shapes gain the fallback part (role-gated)
+//   - pairing identity / isError preserved in metadata
+//   - the fallback part routes through toolResultBlockFromPart (never raw
+//     passthrough → a phantom toolCall block)
+//   - createLiveCoverageSignature is stable across the live transcript shape
+//     and the assembled DB round-trip shape (prevents double-emitting the
+//     live message next to the assembled row)
+//   - unchanged behavior for ≥1-part shapes and empty user/assistant shapes
+import { describe, expect, it } from "vitest";
+import {
+  blockFromPart,
+  contentFromParts,
+  isEmptyMessageContent,
+} from "../src/assembler.js";
+import {
+  buildMessageParts,
+  normalizeMessageContentForStorage,
+  toSyntheticMessagePartRecord,
+} from "../src/message-content.js";
+import { createLiveCoverageSignature } from "../src/message-signatures.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+
+function makeEmptyResult(overrides: Record<string, unknown> = {}): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    toolName: "update_plan",
+    content: [],
+    ...overrides,
+  } as unknown as AgentMessage;
+}
+
+function partsOf(message: AgentMessage, fallbackContent = "") {
+  return buildMessageParts({ sessionId: "test", message, fallbackContent });
+}
+
+describe("buildMessageParts empty-content tool-result fallback", () => {
+  it("emits one fallback part carrying pairing identity", () => {
+    const parts = partsOf(makeEmptyResult());
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({
+      partType: "tool",
+      ordinal: 0,
+      textContent: " ",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+    });
+    const metadata = JSON.parse(parts[0]!.metadata!);
+    expect(metadata).toMatchObject({
+      originalRole: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      emptyContentFallback: true,
+    });
+  });
+
+  it("preserves top-level isError in fallback metadata", () => {
+    const parts = partsOf(makeEmptyResult({ isError: true }));
+    expect(parts).toHaveLength(1);
+    const metadata = JSON.parse(parts[0]!.metadata!);
+    expect(metadata.isError).toBe(true);
+    const pickIsError = JSON.parse(parts[0]!.metadata!) as { isError?: boolean };
+    expect(pickIsError.isError).toBe(true);
+  });
+
+  it("handles the raw 'tool' role shape", () => {
+    const parts = partsOf({
+      role: "tool",
+      toolCallId: "call_t",
+      toolName: "some_tool",
+      content: [],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.toolCallId).toBe("call_t");
+    // The fallback always identifies as toolResult so blockFromPart routes
+    // through toolResultBlockFromPart (not toolCallBlockFromPart).
+    expect(JSON.parse(parts[0]!.metadata!)).toMatchObject({
+      originalRole: "toolResult",
+      rawType: "tool_result",
+      emptyContentFallback: true,
+    });
+  });
+
+  it("handles callid-less tool rows without crashing (assembly still demotes)", () => {
+    const parts = partsOf({ role: "tool", content: [] } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.toolCallId).toBeNull();
+    expect(parts[0]!.toolName).toBeNull();
+  });
+
+  it("does NOT create parts for genuinely empty assistant messages", () => {
+    expect(partsOf({ role: "assistant", content: [] } as AgentMessage)).toHaveLength(0);
+  });
+
+  it("does NOT create parts for empty user messages", () => {
+    expect(partsOf({ role: "user", content: [] } as AgentMessage)).toHaveLength(0);
+  });
+
+  it("does NOT latch onto an id-bearing non-tool message (no phantom toolCalls)", () => {
+    // A hypothetical assistant message with empty content and a top-level id
+    // must not become a "tool" part: blockFromPart would otherwise emit a
+    // phantom toolCall block in the assembled transcript.
+    const parts = partsOf({
+      role: "assistant",
+      id: "some-id",
+      content: [],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(0);
+  });
+
+  it("keeps assistant content=[] + reasoning_content unchanged (reasoning part only)", () => {
+    const parts = partsOf({
+      role: "assistant",
+      content: [],
+      reasoning_content: "internal thinking",
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("reasoning");
+  });
+
+  it("leaves string-content tool results untouched (no fallback part)", () => {
+    const parts = partsOf(
+      {
+        role: "toolResult",
+        toolCallId: "call_s",
+        content: "Plan updated",
+      } as unknown as AgentMessage,
+      "Plan updated",
+    );
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("text");
+    expect(parts[0]!.textContent).toBe("Plan updated");
+    expect(JSON.parse(parts[0]!.metadata!).emptyContentFallback).toBeUndefined();
+  });
+
+  it("leaves non-empty block-array tool results untouched", () => {
+    const parts = partsOf({
+      role: "toolResult",
+      toolCallId: "call_b",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_b",
+          content: [{ type: "text", text: "output text" }],
+        },
+      ],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(JSON.parse(parts[0]!.metadata!).emptyContentFallback).toBeUndefined();
+  });
+});
+
+describe("fallback part assembly routing", () => {
+  it("routes through toolResultBlockFromPart via originalRole metadata", () => {
+    const records = partsOf(makeEmptyResult()).map((part) =>
+      toSyntheticMessagePartRecord(part, 1),
+    );
+    const block = blockFromPart(records[0]!) as Record<string, unknown>;
+    // tool_result shape — NOT a toolCall/function_call phantom.
+    expect(block.type).toBe("tool_result");
+    expect(block.tool_use_id).toBe("call_1");
+    expect(block.name).toBe("update_plan");
+    expect(block.output).toBe(" ");
+    expect(block.id).toBeUndefined();
+    expect(block.call_id).toBeUndefined();
+    expect(JSON.stringify(block)).not.toContain("emptyContentFallback");
+  });
+
+  it("contentFromParts yields a serializable toolResult content (Anthropic + OpenAI)", () => {
+    const records = partsOf(makeEmptyResult()).map((part) =>
+      toSyntheticMessagePartRecord(part, 1),
+    );
+    const content = contentFromParts(records, "toolResult", "");
+    expect(Array.isArray(content)).toBe(true);
+    const blocks = content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("tool_result");
+    expect(blocks[0]!.tool_use_id).toBe("call_1");
+    // JSON round-trip: no undefined/functions.
+    expect(JSON.parse(JSON.stringify(blocks[0]))).toEqual(blocks[0]);
+    // Survives the universal empty-content filter.
+    expect(isEmptyMessageContent({ role: "toolResult", content })).toBe(false);
+  });
+
+  it("normalizeMessageContentForStorage keeps the tool_result block shape", () => {
+    const normalized = normalizeMessageContentForStorage({
+      message: makeEmptyResult(),
+      fallbackContent: "",
+    });
+    expect(Array.isArray(normalized)).toBe(true);
+    const blocks = normalized as Array<Record<string, unknown>>;
+    expect(blocks[0]!.type).toBe("tool_result");
+    expect(blocks[0]!.tool_use_id).toBe("call_1");
+  });
+});
+
+describe("live-coverage signature stability across DB round-trip", () => {
+  it("live empty-content result matches its assembled reconstruction (no id)", () => {
+    const liveMessage = makeEmptyResult();
+    const assembled = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveMessage)).toBe(
+      createLiveCoverageSignature(assembled),
+    );
+  });
+
+  it("live empty-content result with tool_use_id block id matches assembly", () => {
+    // The live shape carries the tool_result block with tool_use_id but may
+    // lack a top-level toolName. The assembled shape has toolName filled in
+    // from part metadata. Both have the same toolCallId, so the canonical
+    // empty-tool-result signature keys on (role, toolCallId) only — toolName
+    // is intentionally omitted because it may be present on one
+    // representation and absent on the other.
+    const liveIded = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "tool_result", tool_use_id: "call_1", output: "" }],
+    } as unknown as AgentMessage;
+    const assembled = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveIded)).toBe(
+      createLiveCoverageSignature(assembled),
+    );
+  });
+
+  it("live empty-content result with NO call id does not signature-collide with an ided row", () => {
+    // The id-less result falls back to the full lossless signature (which
+    // includes parts metadata) while the ided result canonicalizes to
+    // canonical-empty-tool-result — they cannot collide.
+    const liveNoId = {
+      role: "toolResult",
+      content: [{ type: "tool_result", output: "" }],
+    } as unknown as AgentMessage;
+    const assembledWithId = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveNoId)).not.toBe(
+      createLiveCoverageSignature(assembledWithId),
+    );
+  });
+
+  it("does NOT canonicalize a tool_result block with real content as empty (autoreview P1)", () => {
+    // A tool_result block whose structured text extraction is empty (because
+    // extractStructuredText skips tool blocks) but whose raw.content carries
+    // a real text payload must NOT be canonicalized as an empty result —
+    // otherwise coverage dedup would suppress the live representation.
+    const liveWithContent = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_1",
+          content: [{ type: "text", text: "real output" }],
+        },
+      ],
+    } as unknown as AgentMessage;
+    const emptyResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [],
+    } as unknown as AgentMessage;
+    // The content-bearing message must NOT match the empty result's signature.
+    expect(createLiveCoverageSignature(liveWithContent)).not.toBe(
+      createLiveCoverageSignature(emptyResult),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Tools that return `{content: [], details: {...}}` (e.g. OpenClaw's `update_plan`, formerly `structured_output` and `agents-wait`, and any third-party tool) trigger a 5-step failure chain:

1. **Ingest** `buildMessageParts()` (`src/message-content.ts`): toolResult message with `content=[]` → ordinal loop runs zero times → **0 parts persisted**. Top-level `toolCallId`/`toolName`/`isError` only ever live inside part metadata → all lost. (messages row: `role=tool, content='', 0 parts`.)
2. **Assembly** `resolveMessageItem` (`src/assembler.ts` ~1810-1835): `role=tool` + 0 parts → `pickToolCallId()` returns `undefined` → demoted to `role:"assistant"` with `content: []`.
3. `isEmptyMessageContent` filter drops the demoted message entirely.
4. `sanitizeToolUseResultPairing` (`src/transcript-repair.ts`) sees the assistant's `toolCall` with no matching result → inserts `[lossless-claw] missing tool result…` synthetic error **every assemble** while the call is in the context window.
5. Model sees plan calls as "failed" → retry loops, corrupted context.

## Production evidence

~100% of `update_plan` results since April orphaned:

| Month | Orphaned | Total |
|-------|----------|-------|
| Apr   | 573      | 720   |
| May   | 605      | 619   |
| Jun   | 444      | 453   |
| Jul   | 69       | 70    |

Live repro on v0.15.1: conv 468, msg 472198 (call) / 472199 (role=tool, clen=0, 0 parts) → synthetic error.

## Why #993 didn't close the hole

Issue #992 was closed by PR #993 (`27cda30`) which dedups real-vs-synthetic results at **repair time** — but the **ingest hole** (zero parts persisted for empty-content results) was untouched at HEAD. The dedup only helps when a real result eventually arrives; for tools that genuinely return empty content, no real result ever exists.

## Relation to OpenClaw #116916

OpenClaw fixed `update_plan` itself (commit `87d5cb9f674`, PR #116916 — returns `textResult("Plan updated")`). They also fixed `structured_output` + `agents-wait`, confirming this is a class of tools. However, LCM must stay robust: any current/future/third-party tool returning empty content hits the same chain, and hosts running older OpenClaw keep emitting empty-content results.

## Fix design

**`buildMessageParts()` (`src/message-content.ts`):** when a `tool`/`toolResult` message's content is an empty array and no parts were produced, emit ONE fallback part:
- `partType: "tool"`, `ordinal: 0`
- `toolCallId`/`toolName` from top-level message fields
- `textContent: " "` (single space — keeps the fallback out of blank-content filter paths; effective tool output is still the empty string)
- `metadata`: `{originalRole, toolCallId, toolName, isError, emptyContentFallback: true}`

**Role-gated, not id-gated:** `blockFromPart` treats a metadata-less `"tool"` part as a `toolCall`, so only `tool`/`toolResult` roles may land here — an id-bearing `assistant`/`user` message would otherwise be misassembled as a phantom call.

**`message-signatures.ts`:** `createCanonicalEmptyToolResultCoverageSignature` canonicalizes the coverage identity for empty-content tool results to `(role, toolCallId)` — `toolName` is intentionally omitted because it may be present on the DB round-trip representation and absent on the live transcript block, while `toolCallId` is the unique pairing identity. This prevents live-coverage dedup from double-emitting the same logical result.

## Behavior matrix

| Message shape | Before | After |
|--------------|--------|-------|
| `toolResult` + `content: []` + `toolCallId` | 0 parts → demote → drop → synthetic error | 1 fallback part → `role=toolResult` preserved, no synthetic error |
| `toolResult` + `content: []` + no `toolCallId` | 0 parts → demote → drop | 1 fallback part (no id) → demote to assistant (same as today) |
| `toolResult` + `content: "text"` | 1 text part (unchanged) | 1 text part (unchanged) |
| `toolResult` + `content: [{type:"tool_result",...}]` | 1+ tool parts (unchanged) | 1+ tool parts (unchanged) |
| `assistant` + `content: []` | 0 parts → empty-assistant skip (intended) | 0 parts → empty-assistant skip (unchanged) |
| `assistant` + `content: []` + `reasoning_content` | 1 reasoning part (unchanged) | 1 reasoning part (unchanged) |
| `user` + `content: []` | 0 parts → dropped (intended) | 0 parts → dropped (unchanged) |

## Audit results

- **a. Signatures:** `createLosslessMessageSignature` now includes the fallback part → new signatures for empty-content tool messages. `createCanonicalEmptyToolResultCoverageSignature` ensures live-coverage signatures match across live/DB/assembly representations. Transcript-reconciler replay-prefix detection uses `createLosslessMessageSignature` on bootstrap candidates; since empty-content tool messages are `isBootstrapReplayCandidateMessage` (role=tool), old persisted rows (0 parts) and new live messages (1 fallback part) would produce different signatures — but this only affects bootstrap replay detection across an upgrade boundary, which is safe: a mismatch means the guard fails to detect a replay (false negative), not a false positive drop. The canonical coverage signature handles the within-process live-vs-assembly case.
- **b. `live-coverage.ts`:** `normalizeLiveMessageForAssemblyReconciliation` calls `buildMessageParts` → `contentFromParts`. With the fallback part, this now produces a `tool_result` block instead of empty content, consistent with the assembled shape.
- **c. `transcript-repair.ts`:** With the fallback part, `pickToolCallId` returns the correct id → `resolveMessageItem` sets `role=toolResult` → `sanitizeToolUseResultPairing` finds the matching result → **no synthetic error inserted**. The #993 real-result-preferred dedup (`shouldUseCandidateToolResult`) still works because the fallback part produces a non-synthetic `toolResult` message.
- **d. `engine.ts` ingest (~2911):** `buildMessageParts` is called after all interceptors. The empty-content check is inside `buildMessageParts` itself — no count/emptiness assumptions at the call site.
- **e. Externalization:** The `!rawPayloadExternalized` guard prevents the fallback from firing on raw-payload-externalized messages. The fallback part's `textContent: " "` is well under any large-file threshold. `interceptLargeToolResults` only processes array content (non-empty check via `!Array.isArray` returns null for `[]`), so no externalization triggered.

## Test coverage

- `test/empty-content-tool-result-parts.test.ts` (3 tests): ingest→assemble round-trip (paired toolResult, no synthetic error), repeated assemble stability, legacy zero-part rows no worse than today.
- `test/message-content-empty-tool-result.test.ts` (16 tests): fallback part emission (toolResult empty, tool role, callid-less, isError preserved), role-gating (assistant/user NOT affected, id-bearing assistant NOT latched), block routing (toolResultBlockFromPart, serializable content), live-coverage signature stability (live vs assembled match, id-less no collision), normalizeMessageContentForStorage shape.

Full suite: `npx vitest run --dir test` → 113 files, 2003 tests passed. `npx tsc --noEmit` → clean.

## Notes

- Trivial merge adjacency with PR #1053 (`fix/preserve-thinking-identity`, same file `message-content.ts` different concern) may exist — the hunks are in different functions.
- Legacy DB rows (already stored with 0 parts) are out of scope for repair — they keep today's demote-to-assistant behavior. A future migration could backfill fallback parts, but that is not included here.

Refs #992.