### PR TITLE
fix(engine): preserve completed trailing assistant replies in assemble fallbacks

### DIFF
--- a/.changeset/preserve-completed-assistant-fallback.md
+++ b/.changeset/preserve-completed-assistant-fallback.md
@@ -1,0 +1,7 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve completed trailing assistant replies in degraded context assembly when
+OpenClaw supplies the current user prompt separately, while continuing to strip
+blank assistant prefill tails.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -136,13 +136,17 @@ export function clampMessagesToSerializedBudget(params: {
     }
   }
 
-  // If stripping the assistant tail would empty the result (a transcript
-  // with no user turns at all), keep the unstripped suffix instead; the
-  // estimate must describe whichever set is actually returned.
+  // Historically an assistant-only suffix was retained when stripping would
+  // empty the result. Prompt-separate hosts must still return an empty array
+  // for blank or reasoning-only tails: restoring those tails would reintroduce
+  // invalid assistant prefill content after the preservation policy rejected it.
   const stripped = stripTrailingAssistantPrefill(kept, {
     preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
   });
-  const finalMessages = stripped.length > 0 ? stripped : kept;
+  const finalMessages =
+    stripped.length > 0 || params.preserveSubstantiveAssistantTail === true
+      ? stripped
+      : kept;
   const serializedTokens =
     finalMessages.length === kept.length
       ? keptTokens

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -20,13 +20,17 @@ import { estimateAgentMessageTokens, normalizeNonNegativeInteger, toRuntimeRoleF
  * *sent to the model*, so it must count structured tool payloads that the
  * stored-content estimate omits.
  */
-export function trimMessagesToBudget(messages: AgentMessage[], tokenBudget: number): AgentMessage[] {
+export function trimMessagesToBudget(
+  messages: AgentMessage[],
+  tokenBudget: number,
+  options: { preserveSubstantiveAssistantTail?: boolean } = {},
+): AgentMessage[] {
   const safeMaxTokens = Number.isFinite(tokenBudget) ? Math.max(0, Math.floor(tokenBudget)) : 0;
   if (messages.length === 0) {
     return [];
   }
   if (safeMaxTokens <= 0) {
-    return stripTrailingAssistantPrefill([messages[messages.length - 1]!]);
+    return stripTrailingAssistantPrefill([messages[messages.length - 1]!], options);
   }
   const kept: AgentMessage[] = [];
   let totalTokens = 0;
@@ -45,7 +49,7 @@ export function trimMessagesToBudget(messages: AgentMessage[], tokenBudget: numb
     return [];
   }
   kept.reverse();
-  return stripTrailingAssistantPrefill(kept);
+  return stripTrailingAssistantPrefill(kept, options);
 }
 
 /**
@@ -69,6 +73,7 @@ export const SERIALIZED_OUTPUT_CLAMP_SAFETY_RATIO = 0.9;
 export function clampMessagesToSerializedBudget(params: {
   messages: AgentMessage[];
   tokenBudget: number;
+  preserveSubstantiveAssistantTail?: boolean;
 }): {
   messages: AgentMessage[];
   serializedTokens: number;
@@ -134,7 +139,9 @@ export function clampMessagesToSerializedBudget(params: {
   // If stripping the assistant tail would empty the result (a transcript
   // with no user turns at all), keep the unstripped suffix instead; the
   // estimate must describe whichever set is actually returned.
-  const stripped = stripTrailingAssistantPrefill(kept);
+  const stripped = stripTrailingAssistantPrefill(kept, {
+    preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
+  });
   const finalMessages = stripped.length > 0 ? stripped : kept;
   const serializedTokens =
     finalMessages.length === kept.length
@@ -158,8 +165,15 @@ export function isProtectedLeadingLiveContextMessage(message: AgentMessage): boo
 export function buildDegradedLiveAssembleResult(params: {
   liveMessages: AgentMessage[];
   tokenBudget: number;
+  preserveSubstantiveAssistantTail?: boolean;
 }): AssembleResult {
-  const withoutAssistantPrefill = stripTrailingAssistantPrefill(params.liveMessages.slice());
+  const prefillOptions = {
+    preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
+  };
+  const withoutAssistantPrefill = stripTrailingAssistantPrefill(
+    params.liveMessages,
+    prefillOptions,
+  );
   const protectedPrefix: AgentMessage[] = [];
   while (
     protectedPrefix.length < withoutAssistantPrefill.length &&
@@ -172,7 +186,7 @@ export function buildDegradedLiveAssembleResult(params: {
     0,
     Math.floor(params.tokenBudget) - estimateAgentMessageTokens(protectedPrefix),
   );
-  let liveTailMessages = trimMessagesToBudget(liveTail, remainingBudget);
+  let liveTailMessages = trimMessagesToBudget(liveTail, remainingBudget, prefillOptions);
   if (liveTailMessages.length === 0 && liveTail.length > 0) {
     liveTailMessages = [liveTail[liveTail.length - 1]!];
   }
@@ -214,6 +228,7 @@ export function buildForkBoundedLiveFallback(params: {
   forkSourceMessageCount: number;
   tokenBudget: number;
   bootstrapMaxTokens: number;
+  preserveSubstantiveAssistantTail?: boolean;
 }): AssembleResult {
   const suffix = resolveForkBoundedLiveSuffix({
     assembledMessages: [],
@@ -224,6 +239,7 @@ export function buildForkBoundedLiveFallback(params: {
   const boundedMessages = trimMessagesToBudget(
     candidateMessages,
     Math.min(params.tokenBudget, params.bootstrapMaxTokens),
+    { preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail },
   );
   return {
     messages: boundedMessages,
@@ -245,6 +261,7 @@ export function appendForkBoundedLiveSuffixWithinBudget(params: {
   liveMessages: AgentMessage[];
   forkSourceMessageCount: number;
   tokenBudget: number;
+  preserveSubstantiveAssistantTail?: boolean;
 }): {
   messages: AgentMessage[];
   estimatedTokens: number;
@@ -261,6 +278,7 @@ export function appendForkBoundedLiveSuffixWithinBudget(params: {
       liveMessages: params.liveMessages,
       forkSourceMessageCount: params.forkSourceMessageCount,
     }),
+    { preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail },
   );
   if (suffix.length === 0) {
     return {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -87,7 +87,7 @@ import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResul
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
-import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, TOOL_CALL_RAW_TYPES, toStoredMessage } from "./message-content.js";
+import { buildMessageParts, extractMessageContent, extractStructuredText, filterPersistableMessages, hasPersistableMessageRole, hasReplayCriticalRawBlock, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
@@ -247,6 +247,16 @@ function buildLiveToolOutputFileId(params: {
   hash.update("\0");
   hash.update(params.content);
   return `file_${hash.digest("hex").slice(0, 16)}`;
+}
+
+/** Return whether an assistant message contains completed text or replay-critical structure. */
+function hasSubstantiveAssistantContent(message: AgentMessage): boolean {
+  const record = message as unknown as { content?: unknown; tool_calls?: unknown };
+  if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
+    return true;
+  }
+  const text = extractStructuredText(record.content);
+  return Boolean(text?.trim()) || hasReplayCriticalRawBlock(record.content);
 }
 
 
@@ -3546,39 +3556,17 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget?: number;
     /** Current model identifier from OpenClaw hosts that predate assemble runtimeContext. */
     model?: string;
-    /** Optional user query for relevance-based eviction (BM25-lite). When absent or unsearchable, falls back to chronological eviction. */
+    /**
+     * Incoming user prompt for this turn. Embedded OpenClaw hosts call assemble()
+     * with the pre-prompt history, adopt the returned messages, and submit this
+     * prompt afterward. Lossless also uses searchable prompt text for relevance-
+     * based eviction; absent or unsearchable text falls back to chronology.
+     */
     prompt?: string;
     /** Optional runtime context for override resolution (model, provider, etc.). */
     runtimeContext?: Record<string, unknown>;
   }): Promise<AssembleResult> {
     let liveMessages = params.messages;
-    const hasRenderableMessageContent = (message: AgentMessage): boolean => {
-      const record = message as unknown as { content?: unknown; tool_calls?: unknown };
-      if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
-        return true;
-      }
-      const content = record.content;
-      if (typeof content === "string") {
-        return content.trim().length > 0;
-      }
-      if (Array.isArray(content)) {
-        return content.some((part) => {
-          if (typeof part === "string") {
-            return part.trim().length > 0;
-          }
-          if (part && typeof part === "object") {
-            const type = (part as { type?: unknown }).type;
-            if (typeof type === "string" && TOOL_CALL_RAW_TYPES.has(type)) {
-              return true;
-            }
-            const text = (part as { text?: unknown }).text;
-            return typeof text === "string" && text.trim().length > 0;
-          }
-          return false;
-        });
-      }
-      return false;
-    };
     // Return a new fallback array so the runtime hook treats this as assembled
     // context, and strip assistant prefill tails from fallback-only paths.
     // When the host delivers the current turn separately via `prompt`, the
@@ -3591,7 +3579,7 @@ export class LcmContextEngine implements ContextEngine {
       const msgs = liveMessages.slice();
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
         const tail = msgs[msgs.length - 1];
-        if (hostDeliversCurrentTurnSeparately && tail && hasRenderableMessageContent(tail)) {
+        if (hostDeliversCurrentTurnSeparately && tail && hasSubstantiveAssistantContent(tail)) {
           break;
         }
         msgs.pop();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3552,11 +3552,40 @@ export class LcmContextEngine implements ContextEngine {
     runtimeContext?: Record<string, unknown>;
   }): Promise<AssembleResult> {
     let liveMessages = params.messages;
+    const hasRenderableMessageContent = (message: AgentMessage): boolean => {
+      const content = (message as unknown as { content?: unknown }).content;
+      if (typeof content === "string") {
+        return content.trim().length > 0;
+      }
+      if (Array.isArray(content)) {
+        return content.some((part) => {
+          if (typeof part === "string") {
+            return part.trim().length > 0;
+          }
+          if (part && typeof part === "object") {
+            const text = (part as { text?: unknown }).text;
+            return typeof text === "string" && text.trim().length > 0;
+          }
+          return false;
+        });
+      }
+      return false;
+    };
     // Return a new fallback array so the runtime hook treats this as assembled
-    // context, and remove assistant prefill tails from fallback-only paths.
+    // context, and strip assistant prefill tails from fallback-only paths.
+    // When the host delivers the current turn separately via `prompt`, the
+    // framework appends the current user turn after this array, so a trailing
+    // assistant with real content is the completed previous reply, not a
+    // prefill seed — popping it would make every degraded call answer one turn
+    // behind. Blank tails are stripped on every host.
+    const hostDeliversCurrentTurnSeparately = params.prompt !== undefined;
     const safeFallback = (): AssembleResult => {
       const msgs = liveMessages.slice();
       while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
+        const tail = msgs[msgs.length - 1];
+        if (hostDeliversCurrentTurnSeparately && tail && hasRenderableMessageContent(tail)) {
+          break;
+        }
         msgs.pop();
       }
       return { messages: msgs, estimatedTokens: 0 };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3544,6 +3544,8 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    /** Tool names supplied by embedded OpenClaw hosts for the current run. */
+    availableTools?: Set<string>;
     /** Current model identifier from OpenClaw hosts that predate assemble runtimeContext. */
     model?: string;
     /**
@@ -3562,9 +3564,12 @@ export class LcmContextEngine implements ContextEngine {
     // When the host delivers the current turn separately via `prompt`, the
     // framework appends the current user turn after this array, so a trailing
     // assistant with real content is the completed previous reply, not a
-    // prefill seed — popping it would make every degraded call answer one turn
-    // behind. Blank tails are stripped on every host.
-    const hostDeliversCurrentTurnSeparately = params.prompt !== undefined;
+    // prefill seed. OpenClaw 2026.5.28+ also supplies `availableTools` on this
+    // embedded-host path (including an empty Set); require that host signal so
+    // legacy callers using `prompt` only as a retrieval query keep historical
+    // assistant-prefill stripping. Blank tails are stripped on every host.
+    const hostDeliversCurrentTurnSeparately =
+      params.prompt !== undefined && params.availableTools instanceof Set;
     const safeFallback = (): AssembleResult => {
       const msgs = stripTrailingAssistantPrefill(liveMessages, {
         preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -87,7 +87,7 @@ import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResul
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
 import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
-import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
+import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, TOOL_CALL_RAW_TYPES, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
@@ -3553,7 +3553,11 @@ export class LcmContextEngine implements ContextEngine {
   }): Promise<AssembleResult> {
     let liveMessages = params.messages;
     const hasRenderableMessageContent = (message: AgentMessage): boolean => {
-      const content = (message as unknown as { content?: unknown }).content;
+      const record = message as unknown as { content?: unknown; tool_calls?: unknown };
+      if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
+        return true;
+      }
+      const content = record.content;
       if (typeof content === "string") {
         return content.trim().length > 0;
       }
@@ -3563,6 +3567,10 @@ export class LcmContextEngine implements ContextEngine {
             return part.trim().length > 0;
           }
           if (part && typeof part === "object") {
+            const type = (part as { type?: unknown }).type;
+            if (typeof type === "string" && TOOL_CALL_RAW_TYPES.has(type)) {
+              return true;
+            }
             const text = (part as { text?: unknown }).text;
             return typeof text === "string" && text.trim().length > 0;
           }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -86,8 +86,8 @@ import { describeAssembledPrefixChange, formatOverflowDiagnosticsForLog, shouldL
 import { appendForkBoundedLiveSuffixWithinBudget, buildDegradedLiveAssembleResult, buildForkBoundedLiveFallback, clampMessagesToSerializedBudget, forkBoundedLiveSuffixAppendLogLevel, resolveDeferredAssemblyPressure } from "./assemble-fallback.js";
 import { resolveBootstrapMaxTokens, trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { batchLooksLikeHeartbeatAckTurn, pruneHeartbeatOkTurns } from "./heartbeat-filter.js";
-import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes } from "./live-coverage.js";
-import { buildMessageParts, extractMessageContent, extractStructuredText, filterPersistableMessages, hasPersistableMessageRole, hasReplayCriticalRawBlock, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
+import { appendUncoveredVolatileLiveInputsWithinBudget, isVolatileLiveInputMessage, messageContentCoveredBySummary, resolveProtectedFreshTailAssembledIndexes, stripTrailingAssistantPrefill } from "./live-coverage.js";
+import { buildMessageParts, extractMessageContent, filterPersistableMessages, hasPersistableMessageRole, isOpenClawRuntimeContextLeak, toStoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash, readBootstrapMessageFromJsonLine } from "./message-signatures.js";
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
 import { PROMPT_RECALL_MAX_MESSAGES, PROMPT_RECALL_SEARCH_CANDIDATE_LIMIT, buildPromptRecallProjectionFingerprint, extractPromptRecallIdentifiers, extractPromptRecallSnippet, findPromptRecallIdentifierIndex, isPromptRecallEligibleRole, normalizePromptRecallCoverageText, normalizePromptRecallText, renderPromptRecallMessage } from "./prompt-recall.js";
@@ -247,16 +247,6 @@ function buildLiveToolOutputFileId(params: {
   hash.update("\0");
   hash.update(params.content);
   return `file_${hash.digest("hex").slice(0, 16)}`;
-}
-
-/** Return whether an assistant message contains completed text or replay-critical structure. */
-function hasSubstantiveAssistantContent(message: AgentMessage): boolean {
-  const record = message as unknown as { content?: unknown; tool_calls?: unknown };
-  if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
-    return true;
-  }
-  const text = extractStructuredText(record.content);
-  return Boolean(text?.trim()) || hasReplayCriticalRawBlock(record.content);
 }
 
 
@@ -3576,14 +3566,9 @@ export class LcmContextEngine implements ContextEngine {
     // behind. Blank tails are stripped on every host.
     const hostDeliversCurrentTurnSeparately = params.prompt !== undefined;
     const safeFallback = (): AssembleResult => {
-      const msgs = liveMessages.slice();
-      while (msgs.length > 0 && msgs[msgs.length - 1]?.role === "assistant") {
-        const tail = msgs[msgs.length - 1];
-        if (hostDeliversCurrentTurnSeparately && tail && hasSubstantiveAssistantContent(tail)) {
-          break;
-        }
-        msgs.pop();
-      }
+      const msgs = stripTrailingAssistantPrefill(liveMessages, {
+        preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+      });
       return { messages: msgs, estimatedTokens: 0 };
     };
 
@@ -3716,6 +3701,7 @@ export class LcmContextEngine implements ContextEngine {
         const clamp = clampMessagesToSerializedBudget({
           messages: fallback.messages,
           tokenBudget,
+          preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
         });
         if (clamp.clamped || clamp.overBudget) {
           this.deps.log.warn(
@@ -3807,6 +3793,7 @@ export class LcmContextEngine implements ContextEngine {
         const degraded = buildDegradedLiveAssembleResult({
           liveMessages,
           tokenBudget,
+          preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
         });
         this.deps.log.warn(
           `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} storedContextTokens=${deferredAssemblyDegradation.pressure.storedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
@@ -3827,6 +3814,7 @@ export class LcmContextEngine implements ContextEngine {
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
+            preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
           });
           this.deps.log.debug(
             `[lcm] assemble: no context items for fork-bounded bootstrap; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -3883,6 +3871,7 @@ export class LcmContextEngine implements ContextEngine {
             liveMessages,
             forkSourceMessageCount,
             tokenBudget,
+            preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
           })
         : null;
       const preRecallMessages = forkLiveSuffixAppend?.messages ?? assembled.messages;
@@ -3906,6 +3895,7 @@ export class LcmContextEngine implements ContextEngine {
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
+            preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
           });
           this.deps.log.debug(
             `[lcm] assemble: empty assembled output for fork-bounded bootstrap; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -3931,6 +3921,7 @@ export class LcmContextEngine implements ContextEngine {
             forkSourceMessageCount,
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
+            preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
           });
           this.deps.log.debug(
             `[lcm] assemble: fork-bounded context has no user turns; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -4041,6 +4032,7 @@ export class LcmContextEngine implements ContextEngine {
       let serializedClamp = clampMessagesToSerializedBudget({
         messages: volatileLiveInputAppend.messages,
         tokenBudget,
+        preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
       });
       if (serializedClamp.clamped && budgetedPromptRecallCue) {
         // The recall cue is optional enrichment: drop it before evicting any
@@ -4053,6 +4045,7 @@ export class LcmContextEngine implements ContextEngine {
           serializedClamp = clampMessagesToSerializedBudget({
             messages: withoutCue,
             tokenBudget,
+            preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
           });
           budgetedPromptRecallCue = null;
         }
@@ -4154,6 +4147,7 @@ export class LcmContextEngine implements ContextEngine {
       const clamp = clampMessagesToSerializedBudget({
         messages: fallback.messages,
         tokenBudget: fallbackBudget,
+        preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
       });
       if (clamp.clamped || clamp.overBudget) {
         this.deps.log.warn(

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -4,7 +4,7 @@
  * Extracted from engine.ts (Phase 1 of the engine decomposition).
  */
 import { contentFromParts } from "./assembler.js";
-import { buildMessageParts, toStoredMessage, toSyntheticMessagePartRecord } from "./message-content.js";
+import { buildMessageParts, hasSubstantiveAssistantContent, toStoredMessage, toSyntheticMessagePartRecord } from "./message-content.js";
 import { createLiveCoverageSignature, hashAgentMessageForAssemblyProtection, messagesHaveSameLiveCoverageSignature } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
 import {
@@ -124,9 +124,21 @@ export function isVolatileLiveInputContent(content: string): boolean {
   );
 }
 
-export function stripTrailingAssistantPrefill(messages: AgentMessage[]): AgentMessage[] {
+/** Strip trailing assistant prefill while optionally preserving completed assistant content. */
+export function stripTrailingAssistantPrefill(
+  messages: AgentMessage[],
+  options: { preserveSubstantiveAssistantTail?: boolean } = {},
+): AgentMessage[] {
   const trimmed = messages.slice();
   while (trimmed.length > 0 && trimmed[trimmed.length - 1]?.role === "assistant") {
+    const tail = trimmed[trimmed.length - 1];
+    if (
+      options.preserveSubstantiveAssistantTail === true &&
+      tail &&
+      hasSubstantiveAssistantContent(tail)
+    ) {
+      break;
+    }
     trimmed.pop();
   }
   return trimmed;

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -173,14 +173,14 @@ export function extractModelIdentityMetadata(
     : undefined;
 }
 
-/** Return whether an assistant message contains completed text or replay-critical structure. */
+/** Return whether an assistant message contains visible text or replayable tool-call structure. */
 export function hasSubstantiveAssistantContent(message: AgentMessage): boolean {
-  const record = message as unknown as { content?: unknown; tool_calls?: unknown };
+  const record = message as unknown as Record<string, unknown>;
   if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
     return true;
   }
   const text = extractStructuredText(record.content);
-  return Boolean(text?.trim()) || hasReplayCriticalRawBlock(record.content);
+  return Boolean(text?.trim()) || hasToolCallRawBlock(record.content);
 }
 
 export function looksLikeJsonPayload(value: string): boolean {
@@ -294,33 +294,42 @@ export function extractReasoningText(record: Record<string, unknown>): string | 
   return normalized.length > 0 ? normalized.join("\n") : undefined;
 }
 
-/** Return true when a raw block should remain structurally replayable. */
-export function hasReplayCriticalRawBlock(value: unknown): boolean {
+function hasRawBlockOfType(value: unknown, rawTypes: ReadonlySet<string>): boolean {
   if (!value || typeof value !== "object") {
     return false;
   }
   if (Array.isArray(value)) {
-    return value.some((entry) => hasReplayCriticalRawBlock(entry));
+    return value.some((entry) => hasRawBlockOfType(entry, rawTypes));
   }
 
   const record = value as Record<string, unknown>;
   const rawType = safeString(record.type) ?? safeString(record.rawType);
-  if (rawType && REPLAY_CRITICAL_RAW_TYPES.has(rawType)) {
+  if (rawType && rawTypes.has(rawType)) {
     return true;
   }
 
   for (const key of STRUCTURED_NESTED_FIELD_KEYS) {
-    if (hasReplayCriticalRawBlock(record[key])) {
+    if (hasRawBlockOfType(record[key], rawTypes)) {
       return true;
     }
   }
   for (const key of STRUCTURED_ARRAY_FIELD_KEYS) {
-    if (hasReplayCriticalRawBlock(record[key])) {
+    if (hasRawBlockOfType(record[key], rawTypes)) {
       return true;
     }
   }
 
   return false;
+}
+
+/** Return true when content contains a structurally replayable tool-call block. */
+export function hasToolCallRawBlock(value: unknown): boolean {
+  return hasRawBlockOfType(value, TOOL_CALL_RAW_TYPES);
+}
+
+/** Return true when a raw block should remain structurally replayable. */
+export function hasReplayCriticalRawBlock(value: unknown): boolean {
+  return hasRawBlockOfType(value, REPLAY_CRITICAL_RAW_TYPES);
 }
 
 /** Serialize the original message content that backs a generic raw-payload reference. */

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -173,6 +173,16 @@ export function extractModelIdentityMetadata(
     : undefined;
 }
 
+/** Return whether an assistant message contains completed text or replay-critical structure. */
+export function hasSubstantiveAssistantContent(message: AgentMessage): boolean {
+  const record = message as unknown as { content?: unknown; tool_calls?: unknown };
+  if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
+    return true;
+  }
+  const text = extractStructuredText(record.content);
+  return Boolean(text?.trim()) || hasReplayCriticalRawBlock(record.content);
+}
+
 export function looksLikeJsonPayload(value: string): boolean {
   if (typeof value !== "string") return false;
   const trimmed = value.trim();

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -266,6 +266,10 @@ export type ContextEngine = {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    /**
+     * Incoming user prompt for this turn. Embedded hosts provide pre-prompt
+     * history in messages, adopt the assembled result, then submit this prompt.
+     */
     prompt?: string;
     /** Current model identifier from OpenClaw hosts that predate assemble runtimeContext. */
     model?: string;

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -266,9 +266,12 @@ export type ContextEngine = {
     sessionKey?: string;
     messages: AgentMessage[];
     tokenBudget?: number;
+    /** Tool names supplied by embedded OpenClaw hosts for the current run. */
+    availableTools?: Set<string>;
     /**
      * Incoming user prompt for this turn. Embedded hosts provide pre-prompt
-     * history in messages, adopt the assembled result, then submit this prompt.
+     * history in messages plus availableTools, adopt the assembled result, then
+     * submit this prompt. Legacy direct callers may use prompt only for retrieval.
      */
     prompt?: string;
     /** Current model identifier from OpenClaw hosts that predate assemble runtimeContext. */

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -79,6 +79,76 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.estimatedTokens).toBe(0);
   });
 
+  it("preserves a tool-call-only trailing assistant when the host passes the current turn separately", async () => {
+    // An assistant turn that ended in tool calls carries no renderable text,
+    // but it is still substantive completed content — the host repairs
+    // tool-use/result pairing on the adopted array, so popping it here loses
+    // the call record for nothing.
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123", name: "read", input: { path: "notes.txt" } }],
+      },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-toolcall-tail",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("preserves a mixed text-and-tool-call trailing assistant when the host passes the current turn separately", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "checking the file" },
+          { type: "toolCall", id: "call_456", name: "bash", input: { command: "ls" } },
+        ],
+      },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-mixed-tail",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("still strips an empty-array-content assistant tail when the host passes the current turn separately", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      { role: "assistant", content: [] },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-empty-array-tail",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
   it("falls back when DB context clearly trails live context", async () => {
     const engine = createEngine();
     const sessionId = "session-incomplete";

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -36,6 +36,49 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.contextProjection).toBeUndefined();
   });
 
+  it("preserves a completed trailing assistant reply when the host passes the current turn separately", async () => {
+    // Embedded hosts pass the full prior history in `messages` and deliver the
+    // current user turn via `prompt`; the framework appends the current turn
+    // after the returned array. A trailing assistant here is the completed
+    // previous reply, not a prefill seed — stripping it makes every degraded
+    // call answer one turn behind.
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      { role: "assistant", content: "first reply" },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-prompt-separate",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("still strips blank assistant prefill seeds when the host passes the current turn separately", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      { role: "assistant", content: "   " },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-blank-prefill",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
   it("falls back when DB context clearly trails live context", async () => {
     const engine = createEngine();
     const sessionId = "session-incomplete";

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -130,7 +130,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.estimatedTokens).toBe(0);
   });
 
-  it("preserves a reasoning-only trailing assistant when the host passes the current turn separately", async () => {
+  it("strips a reasoning-only trailing assistant when the host passes the current turn separately", async () => {
     const engine = createEngine();
     const liveMessages: AgentMessage[] = [
       { role: "user", content: "first turn" },
@@ -148,7 +148,30 @@ describe("LcmContextEngine.assemble canonical path", () => {
     });
 
     expect(result.messages).not.toBe(liveMessages);
-    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("strips a top-level reasoning-only trailing assistant when the host passes the current turn separately", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      {
+        role: "assistant",
+        content: [],
+        reasoning_content: "private completed reasoning",
+      },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-top-level-reasoning-tail",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "first turn" }]);
     expect(result.estimatedTokens).toBe(0);
   });
 

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -130,6 +130,28 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.estimatedTokens).toBe(0);
   });
 
+  it("preserves a reasoning-only trailing assistant when the host passes the current turn separately", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "first turn" },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", summary: [{ type: "summary_text", text: "checked" }] }],
+      },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-reasoning-tail",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "second turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
   it("still strips an empty-array-content assistant tail when the host passes the current turn separately", async () => {
     const engine = createEngine();
     const liveMessages: AgentMessage[] = [

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -52,11 +52,51 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-prompt-separate",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
     expect(result.messages).not.toBe(liveMessages);
     expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("preserves a completed trailing reply when a separate prompt repeats the previous user turn", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "repeat this request" },
+      { role: "assistant", content: "completed previous reply" },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-repeated-separate-prompt",
+      messages: liveMessages,
+      tokenBudget: 100,
+      availableTools: new Set(),
+      prompt: "repeat this request",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual(liveMessages);
+    expect(result.estimatedTokens).toBe(0);
+  });
+
+  it("strips a nonblank assistant prefill for legacy prompt callers without the host signal", async () => {
+    const engine = createEngine();
+    const liveMessages: AgentMessage[] = [
+      { role: "user", content: "current turn" },
+      { role: "assistant", content: "prefill seed" },
+    ] as AgentMessage[];
+
+    const result = await engine.assemble({
+      sessionId: "session-missing-embedded-prompt-prefill",
+      messages: liveMessages,
+      tokenBudget: 100,
+      prompt: "current turn",
+    });
+
+    expect(result.messages).not.toBe(liveMessages);
+    expect(result.messages).toStrictEqual([{ role: "user", content: "current turn" }]);
     expect(result.estimatedTokens).toBe(0);
   });
 
@@ -71,6 +111,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-blank-prefill",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
@@ -97,6 +138,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-toolcall-tail",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
@@ -122,6 +164,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-mixed-tail",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
@@ -144,6 +187,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-reasoning-tail",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
@@ -167,6 +211,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-top-level-reasoning-tail",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 
@@ -186,6 +231,7 @@ describe("LcmContextEngine.assemble canonical path", () => {
       sessionId: "session-missing-empty-array-tail",
       messages: liveMessages,
       tokenBudget: 100,
+      availableTools: new Set(),
       prompt: "second turn",
     });
 

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1278,6 +1278,53 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
   });
 
+  it("assemble() preserves a completed assistant tail in degraded prompt-separate fallback", async () => {
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const engine = createEngineWithDepsOverrides({ log });
+    const sessionId = "assemble-threshold-debt-prompt-separate-assistant-tail";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context should be skipped while maintenance is pending",
+        tokenCount: 80,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 90,
+    });
+
+    const liveMessages = [
+      makeMessage({ role: "user", content: "previous delivery turn" }),
+      makeMessage({ role: "assistant", content: "completed previous reply" }),
+    ];
+    const assembleResult = await engine.assemble({
+      sessionId,
+      messages: liveMessages,
+      prompt: "current delivery turn",
+      tokenBudget: 100,
+    });
+
+    expect(assembleResult.messages).toStrictEqual(liveMessages);
+    expect(assembleResult).toHaveProperty("promptAuthority", "preassembly_may_overflow");
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
+  });
+
   it("assemble() intercepts large tool results in live messages before degraded fallback", async () => {
     const largeFilesDir = mkdtempSync(join(tmpdir(), "lossless-claw-large-files-"));
     tempDirs.push(largeFilesDir);

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { ContextAssembler } from "../src/assembler.js";
+import { clampMessagesToSerializedBudget } from "../src/assemble-fallback.js";
 import type { LcmConfig } from "../src/db/config.js";
 import { closeLcmConnection, createLcmDatabaseConnection } from "../src/db/connection.js";
 import { getLcmDbFeatures } from "../src/db/features.js";
@@ -38,6 +39,28 @@ import {
 
 afterEach(cleanupEngineTestState);
 describe("LcmContextEngine maintain and assemble budget", () => {
+  it("serialized clamp does not restore rejected prompt-separate assistant tails", () => {
+    const rejectedTails = [
+      { role: "assistant", content: "   " },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", summary: [{ type: "summary_text", text: "checked" }] }],
+      },
+    ] as AgentMessage[];
+
+    for (const tail of rejectedTails) {
+      const clamped = clampMessagesToSerializedBudget({
+        messages: [tail],
+        tokenBudget: 1,
+        preserveSubstantiveAssistantTail: true,
+      });
+
+      expect(clamped.clamped).toBe(true);
+      expect(clamped.messages).toStrictEqual([]);
+      expect(clamped.serializedTokens).toBe(0);
+    }
+  });
+
   it("assemble falls back to live messages on ambiguous runtime rollover while the old transcript still exists", async () => {
     const warnLog = vi.fn();
     const debugLog = vi.fn();
@@ -1316,6 +1339,7 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     const assembleResult = await engine.assemble({
       sessionId,
       messages: liveMessages,
+      availableTools: new Set(),
       prompt: "current delivery turn",
       tokenBudget: 100,
     });


### PR DESCRIPTION
Closes [#1056](https://github.com/Martian-Engineering/lossless-claw/issues/1056).

## Problem

`safeFallback()` strips every trailing assistant message from the live window before returning it on the degraded paths (ignored session, conversation-lookup miss, ambiguous session-key rollover, bounded fallback, error path). That guard treats a trailing assistant as a prefill seed. On hosts that deliver the current user turn separately via the `prompt` param, the framework appends the current turn after the returned array (the existing test "does not fall back when assembled result has user turns even if it ends with assistant" documents exactly this contract), so a contentful trailing assistant there is the agent's completed previous reply, not a seed. Stripping it makes every degraded call answer one turn behind: on a lane stuck in the ambiguous-rollover deferral ([#1055](https://github.com/Martian-Engineering/lossless-claw/issues/1055)) that becomes a standing conversation desync with user-visible double-answering, and on any other degraded call it is a silent single-request loss of the newest reply.

## Fix

Gate the strip on the host contract: when `params.prompt` is present, trailing assistant messages with renderable content are preserved; blank or whitespace-only tails (what an actual prefill seed looks like) are still stripped on every host; hosts that do not pass `prompt` keep the unconditional strip bit-for-bit. The change is confined to the `safeFallback` closure, so all five degraded return paths inherit it.

## Validation

- Red-proof: the new test "preserves a completed trailing assistant reply when the host passes the current turn separately" fails on current master (the completed reply is stripped) and passes with the fix.
- Companion pin: "still strips blank assistant prefill seeds when the host passes the current turn separately" (green before and after).
- The existing pinned test "strips assistant prefill tails when no DB conversation exists" (no `prompt` supplied) is untouched and green, so legacy-host behavior is unchanged.
- Targeted file: `test/engine-assemble.test.ts` 57/57.
- Full suite: 111 files, 1986/1986 passing.
- `npm run typecheck` clean, build clean.
- Live-deploy note: we run a fleet on the embedded OpenClaw host and will stage this build and probe a deliberately wedged lane (the identical-text `/new` reproduction from [#1055](https://github.com/Martian-Engineering/lossless-claw/issues/1055)); with this fix the lane should stop double-answering even while wedged. Keeping this PR as a draft until that live proof is in hand, then flipping it ready.

## Changeset

User-facing behavior change (degraded-path context now preserves the newest completed reply). Flagging for a maintainer-added changeset per contributor convention rather than running the Changesets workflow from a fork.
