### PR TITLE
fix(session-rollover): accept host-minted /new replacement transcripts (sibling-header instant correlation)

### DIFF
--- a/.changeset/host-minted-reset-replacement.md
+++ b/.changeset/host-minted-reset-replacement.md
@@ -1,0 +1,8 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Recover ingestion after `/new` when the replacement transcript repeats
+persisted content by correlating the host-minted reset archive and session
+header timestamps. Transcripts without matching reset evidence continue to
+fail closed.

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -125,13 +125,14 @@ export type AmbiguousSessionKeyRuntimeRollover = {
    */
   hasDeliberateRolloverEvidence: boolean;
   /**
-   * True when the new transcript's session-header creation instant follows
-   * the newest `.reset.` sibling's archive instant within
+   * True when the new transcript's header id matches the current runtime
+   * session and its creation instant follows the newest `.reset.` sibling
+   * archive instant within
    * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS` (on top of the
-   * deliberate-rollover evidence above): the new transcript is the
-   * host-minted replacement for exactly this /new, so the freshness gate may
-   * bypass the identity-overlap scan. Missing either artifact leaves this
-   * false and behavior unchanged (fail closed).
+   * deliberate-rollover evidence above): the new transcript is bound to the
+   * host's current session for this /new, so the freshness gate may bypass the
+   * identity-overlap scan. Missing or mismatched evidence leaves this false
+   * and behavior unchanged (fail closed).
    */
   hostMintedResetReplacement: boolean;
 };
@@ -299,22 +300,23 @@ export class SessionRolloverDetector {
   }
 
   /**
-   * True when the new transcript's session-header creation instant follows
-   * the newest `.reset.` sibling's archive instant within
-   * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS`. Both artifacts are minted
-   * by the same host-side /new operation, so their ordered proximity proves
-   * the new transcript is the host's replacement for exactly that reset; a
-   * foreign transcript reusing a stale sessionKey carries a header instant
-   * unrelated to the reset instant and cannot satisfy the correlation. Requires the
-   * deliberate-rollover evidence pair and both instants; anything missing
-   * yields false (fail closed).
+   * True when the new transcript's header id matches the current runtime
+   * session and its creation instant follows the newest `.reset.` sibling's
+   * archive instant within `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS`.
+   * OpenClaw mints the header id from that runtime session id, so the identity
+   * match binds the candidate file to the current host session while the
+   * ordered timestamps bind it to the reset window. Requires the deliberate
+   * rollover evidence pair, matching identity, and both instants; anything
+   * missing yields false (fail closed).
    */
   private async isHostMintedResetReplacementTranscript(params: {
     hasDeliberateRolloverEvidence: boolean;
+    sessionId: string;
     trackedSessionFile: string;
     sessionFile?: string;
   }): Promise<boolean> {
-    if (!params.hasDeliberateRolloverEvidence || !params.sessionFile) {
+    const sessionId = params.sessionId.trim();
+    if (!params.hasDeliberateRolloverEvidence || !sessionId || !params.sessionFile) {
       return false;
     }
     const resetArchivedAt = await this.latestResetArchivedTranscriptSiblingInstant(
@@ -324,7 +326,7 @@ export class SessionRolloverDetector {
       return false;
     }
     const header = await readTranscriptHeader(params.sessionFile);
-    if (!header.sessionHeaderCreatedAt) {
+    if (header.sessionHeaderId !== sessionId || !header.sessionHeaderCreatedAt) {
       return false;
     }
     const headerCreatedAt = Date.parse(header.sessionHeaderCreatedAt);
@@ -525,6 +527,7 @@ export class SessionRolloverDetector {
 
     const hostMintedResetReplacement = await this.isHostMintedResetReplacementTranscript({
       hasDeliberateRolloverEvidence,
+      sessionId: params.sessionId,
       trackedSessionFile,
       sessionFile: params.sessionFile,
     });

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -68,9 +68,14 @@ function isTrivialRolloverOverlapContent(content: string): boolean {
  * Max distance between an archive sibling's `.reset.<ts>` instant and the new
  * transcript's session-header `timestamp` for the pair to count as one
  * host-minted /new operation. Both artifacts are minted by the same host
- * handler (measured 0-1 ms apart on a live rotation); the allowance absorbs
- * slow disks and busy hosts while staying far below any plausible
- * foreign-transcript coincidence.
+ * handler within one /new (measured 0-1 ms apart on a live rotation); the
+ * allowance absorbs slow disks, busy hosts, and stalls between the archive
+ * rename and the header write while staying far below any plausible
+ * foreign-transcript coincidence. The window is also not the only defense: a
+ * transcript inside it must still carry Lossless's own /new marker
+ * (`softResetPrunedAt`) plus the `.reset.` sibling, and the per-entry
+ * timestamp gates (`candidate-missing-timestamp`,
+ * `candidate-entries-predate-last-persisted`) run ahead of the bypass.
  */
 const HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS = 30_000;
 
@@ -84,12 +89,15 @@ const AMBIGUOUS_ROLLOVER_FROZEN_RESTATEMENT_INFO_EVERY = 25;
 /**
  * Parse the `<ts>` tail of a host archive name (`${file}.reset.<ts>`). The
  * host mints ISO-8601 with the time separators replaced by dashes
- * (`2026-08-01T08-25-10.924Z`); a plain ISO tail is accepted too. Returns
- * epoch ms, or null when the tail does not parse (callers fail closed).
+ * (`2026-08-01T08-25-10.924Z`); a plain ISO tail is accepted too. A tail
+ * without a time component (e.g. a bare date, which `Date.parse` would
+ * happily read as midnight) is rejected: it cannot pin the archive to an
+ * instant precisely enough to correlate. Returns epoch ms, or null when the
+ * tail does not parse (callers fail closed).
  */
 function parseResetArchiveSuffixInstant(suffix: string): number | null {
   const trimmed = suffix.trim();
-  if (!trimmed) {
+  if (!/T\d{2}/.test(trimmed)) {
     return null;
   }
   const candidates = [trimmed, trimmed.replace(/T(\d{2})-(\d{2})-(\d{2})/, "T$1:$2:$3")];

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -15,7 +15,7 @@ import { createBootstrapEntryHash, messageIdentity } from "./message-signatures.
 import type { AgentMessage } from "./openclaw-bridge.js";
 import { isIsolatedCronSessionKey } from "./session-patterns.js";
 import type { ArchiveCause, ConversationStore } from "./store/conversation-store.js";
-import { getTranscriptEntryMeta } from "./transcript.js";
+import { getTranscriptEntryMeta, readTranscriptHeader } from "./transcript.js";
 import { isMissingFileError } from "./value-utils.js";
 import type { SummaryStore } from "./store/summary-store.js";
 import type { LcmDependencies } from "./types.js";
@@ -64,6 +64,44 @@ function isTrivialRolloverOverlapContent(content: string): boolean {
   return content.trim().length <= TRIVIAL_ROLLOVER_OVERLAP_CONTENT_MAX_LENGTH;
 }
 
+/**
+ * Max distance between an archive sibling's `.reset.<ts>` instant and the new
+ * transcript's session-header `timestamp` for the pair to count as one
+ * host-minted /new operation. Both artifacts are minted by the same host
+ * handler (measured 0-1 ms apart on a live rotation); the allowance absorbs
+ * slow disks and busy hosts while staying far below any plausible
+ * foreign-transcript coincidence.
+ */
+const HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS = 30_000;
+
+/**
+ * A still-frozen lane restates its once-only WARN at debug on every turn;
+ * every Nth restatement is re-emitted at info so a long-lived freeze stays
+ * visible in default log levels instead of going silent after one WARN.
+ */
+const AMBIGUOUS_ROLLOVER_FROZEN_RESTATEMENT_INFO_EVERY = 25;
+
+/**
+ * Parse the `<ts>` tail of a host archive name (`${file}.reset.<ts>`). The
+ * host mints ISO-8601 with the time separators replaced by dashes
+ * (`2026-08-01T08-25-10.924Z`); a plain ISO tail is accepted too. Returns
+ * epoch ms, or null when the tail does not parse (callers fail closed).
+ */
+function parseResetArchiveSuffixInstant(suffix: string): number | null {
+  const trimmed = suffix.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const candidates = [trimmed, trimmed.replace(/T(\d{2})-(\d{2})-(\d{2})/, "T$1:$2:$3")];
+  for (const candidate of candidates) {
+    const parsed = Date.parse(candidate);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
 export type AmbiguousSessionKeyRuntimeRollover = {
   conversationId: number;
   activeSessionId: string;
@@ -78,6 +116,16 @@ export type AmbiguousSessionKeyRuntimeRollover = {
    * `TRIVIAL_ROLLOVER_OVERLAP_CONTENT_MAX_LENGTH` above.
    */
   hasDeliberateRolloverEvidence: boolean;
+  /**
+   * True when the newest `.reset.` sibling's archive instant and the new
+   * transcript's session-header creation instant agree within
+   * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS` (on top of the
+   * deliberate-rollover evidence above): the new transcript is the
+   * host-minted replacement for exactly this /new, so the freshness gate may
+   * bypass the identity-overlap scan. Missing either artifact leaves this
+   * false and behavior unchanged (fail closed).
+   */
+  hostMintedResetReplacement: boolean;
 };
 
 /**
@@ -141,7 +189,10 @@ export class SessionRolloverDetector {
    * gets evicted just re-warns once more on its next call, which is harmless
    * noise, so plain size-capped FIFO is enough; no LRU needed.
    */
-  private readonly warnedAmbiguousRolloverGenerations = new Map<string, string>();
+  private readonly warnedAmbiguousRolloverGenerations = new Map<
+    string,
+    { reason: string; restatements: number }
+  >();
   private static readonly WARNED_AMBIGUOUS_ROLLOVER_GENERATIONS_CAP = 500;
 
   constructor(
@@ -200,6 +251,80 @@ export class SessionRolloverDetector {
       params.softResetPrunedAt !== null &&
       params.softResetPrunedAt !== undefined &&
       (await this.hasResetArchivedTranscriptSibling(params.trackedSessionFile))
+    );
+  }
+
+  /**
+   * Archive instant of the NEWEST `.reset.<ts>` sibling beside a tracked
+   * transcript, parsed from the suffix the host mints. Null when no sibling
+   * exists or no suffix parses; callers must fail closed on null.
+   */
+  private async latestResetArchivedTranscriptSiblingInstant(
+    trackedFile: string,
+  ): Promise<number | null> {
+    const prefix = basename(trackedFile);
+    if (!prefix) {
+      return null;
+    }
+    const resetPrefix = `${prefix}.reset.`;
+    let latest: number | null = null;
+    try {
+      const entries = await readdir(dirname(trackedFile));
+      for (const entry of entries) {
+        if (!entry.startsWith(resetPrefix)) {
+          continue;
+        }
+        const instant = parseResetArchiveSuffixInstant(entry.slice(resetPrefix.length));
+        if (instant !== null && (latest === null || instant > latest)) {
+          latest = instant;
+        }
+      }
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        this.deps.log.warn(
+          `[lcm] could not scan archived transcript sibling instants dir=${dirname(trackedFile)} file=${prefix} error=${describeLogError(err)}`,
+        );
+      }
+      return null;
+    }
+    return latest;
+  }
+
+  /**
+   * True when the new transcript's session-header creation instant and the
+   * newest `.reset.` sibling's archive instant agree within
+   * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS`. Both artifacts are minted
+   * by the same host-side /new operation, so their agreement proves the new
+   * transcript is the host's replacement for exactly that reset; a foreign
+   * transcript reusing a stale sessionKey carries a header instant unrelated
+   * to the reset instant and cannot satisfy the correlation. Requires the
+   * deliberate-rollover evidence pair and both instants; anything missing
+   * yields false (fail closed).
+   */
+  private async isHostMintedResetReplacementTranscript(params: {
+    hasDeliberateRolloverEvidence: boolean;
+    trackedSessionFile: string;
+    sessionFile?: string;
+  }): Promise<boolean> {
+    if (!params.hasDeliberateRolloverEvidence || !params.sessionFile) {
+      return false;
+    }
+    const resetArchivedAt = await this.latestResetArchivedTranscriptSiblingInstant(
+      params.trackedSessionFile,
+    );
+    if (resetArchivedAt === null) {
+      return false;
+    }
+    const header = await readTranscriptHeader(params.sessionFile);
+    if (!header.sessionHeaderCreatedAt) {
+      return false;
+    }
+    const headerCreatedAt = Date.parse(header.sessionHeaderCreatedAt);
+    if (!Number.isFinite(headerCreatedAt) || headerCreatedAt <= 0) {
+      return false;
+    }
+    return (
+      Math.abs(headerCreatedAt - resetArchivedAt) <= HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS
     );
   }
 
@@ -391,12 +516,19 @@ export class SessionRolloverDetector {
       }
     }
 
+    const hostMintedResetReplacement = await this.isHostMintedResetReplacementTranscript({
+      hasDeliberateRolloverEvidence,
+      trackedSessionFile,
+      sessionFile: params.sessionFile,
+    });
+
     return {
       conversationId: activeByKey.conversationId,
       activeSessionId: activeByKey.sessionId,
       sessionKey: normalizedSessionKey,
       trackedSessionFile,
       hasDeliberateRolloverEvidence,
+      hostMintedResetReplacement,
     };
   }
 
@@ -445,11 +577,23 @@ export class SessionRolloverDetector {
      * isolated-cron rollover) keep the unmodified, fully fail-closed check.
      */
     hasDeliberateRolloverEvidence?: boolean;
+    /**
+     * True when sibling + header instants prove the transcript is the
+     * host-minted replacement for exactly this /new (see
+     * `isHostMintedResetReplacementTranscript`): the identity-overlap scan is
+     * bypassed, because a same-text re-send across the user's own reset is
+     * the same user's traffic, not a foreign transcript reusing the key. The
+     * per-entry timestamp gates still apply. Defaults to false so every
+     * caller without the proof keeps the unmodified fail-closed check.
+     */
+    hasHostMintedResetReplacementEvidence?: boolean;
   }): Promise<{
     fresh: boolean;
     reason: string;
     lastPersistedAt: Date | null;
     firstCandidateAt: number | null;
+    /** Trimmed length of the overlapping content on an identity-overlap verdict. */
+    overlapContentLength?: number;
   }> {
     if (isLikelyInjectedDeliveryOnlyTranscript(params.candidateMessages)) {
       return {
@@ -506,6 +650,22 @@ export class SessionRolloverDetector {
       return {
         fresh: false,
         reason: "candidate-entries-predate-last-persisted",
+        lastPersistedAt: lastPersisted.createdAt,
+        firstCandidateAt,
+      };
+    }
+
+    if (params.hasHostMintedResetReplacementEvidence) {
+      // The archive sibling's reset instant and the new transcript's session
+      // header instant were minted by the same host-side /new and agree
+      // within tolerance: this transcript IS the host's replacement for
+      // exactly that reset. Overlapping content across the boundary is the
+      // same user's traffic (the natural "reset, then re-send" pattern), so
+      // the content-overlap scan below is bypassed; the timestamp gates
+      // above still hold.
+      return {
+        fresh: true,
+        reason: "fresh-host-minted-reset-replacement-transcript",
         lastPersistedAt: lastPersisted.createdAt,
         firstCandidateAt,
       };
@@ -591,6 +751,7 @@ export class SessionRolloverDetector {
           reason: "identity-overlap-with-persisted-history",
           lastPersistedAt: lastPersisted.createdAt,
           firstCandidateAt,
+          overlapContentLength: stored.content.trim().length,
         };
       }
     }
@@ -636,6 +797,7 @@ export class SessionRolloverDetector {
         conversationId: params.rollover.conversationId,
         candidateMessages: params.candidateMessages,
         hasDeliberateRolloverEvidence: params.rollover.hasDeliberateRolloverEvidence,
+        hasHostMintedResetReplacementEvidence: params.rollover.hostMintedResetReplacement,
       });
     } catch (err) {
       this.deps.log.warn(
@@ -645,7 +807,7 @@ export class SessionRolloverDetector {
     }
     if (!verdict.fresh) {
       const preserveExpected = isTransientAmbiguousRolloverFreshness(verdict.reason);
-      const message = `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"}`;
+      const message = `[lcm] ${params.phase}: ambiguous rollover not provably fresh conversation=${params.rollover.conversationId} sessionKey=${params.rollover.sessionKey} freshness=${verdict.reason} lastPersistedAt=${verdict.lastPersistedAt?.toISOString() ?? "none"} firstCandidateAt=${verdict.firstCandidateAt !== null ? new Date(verdict.firstCandidateAt).toISOString() : "none"} candidateMessages=${params.candidateMessages.length} overlapContentLength=${verdict.overlapContentLength ?? "none"}`;
       if (preserveExpected) {
         this.deps.log.info(message);
         return { rebound: false, preserveExpected, alreadyWarned: false };
@@ -653,12 +815,22 @@ export class SessionRolloverDetector {
       // Once-only WARN: a genuine freeze re-derives identically on every
       // subsequent call (nothing about a failed attempt mutates state), so
       // only the first occurrence of a given (generation, reason) pair
-      // warns; repeats log at debug. A reason change for the same
-      // generation is a materially different situation and warns again.
+      // warns; repeats log at debug, with every Nth restatement re-emitted
+      // at info so a long-frozen lane stays visible at default log levels.
+      // A reason change for the same generation is a materially different
+      // situation and warns again.
       const generationKey = this.ambiguousRolloverGenerationKey(params.rollover, params.sessionId);
-      const alreadyWarned = this.warnedAmbiguousRolloverGenerations.get(generationKey) === verdict.reason;
-      if (alreadyWarned) {
-        this.deps.log.debug(message);
+      const warnedEntry = this.warnedAmbiguousRolloverGenerations.get(generationKey);
+      const alreadyWarned = warnedEntry?.reason === verdict.reason;
+      if (alreadyWarned && warnedEntry) {
+        warnedEntry.restatements += 1;
+        if (warnedEntry.restatements % AMBIGUOUS_ROLLOVER_FROZEN_RESTATEMENT_INFO_EVERY === 0) {
+          this.deps.log.info(
+            `${message} restatements=${warnedEntry.restatements} (lane still frozen; ingest suspended until the next /new)`,
+          );
+        } else {
+          this.deps.log.debug(message);
+        }
       } else {
         this.deps.log.warn(message);
         if (
@@ -671,7 +843,10 @@ export class SessionRolloverDetector {
             this.warnedAmbiguousRolloverGenerations.delete(oldest);
           }
         }
-        this.warnedAmbiguousRolloverGenerations.set(generationKey, verdict.reason);
+        this.warnedAmbiguousRolloverGenerations.set(generationKey, {
+          reason: verdict.reason,
+          restatements: 0,
+        });
       }
       return { rebound: false, preserveExpected, alreadyWarned };
     }

--- a/src/session-rollover.ts
+++ b/src/session-rollover.ts
@@ -65,14 +65,14 @@ function isTrivialRolloverOverlapContent(content: string): boolean {
 }
 
 /**
- * Max distance between an archive sibling's `.reset.<ts>` instant and the new
+ * Max delay from an archive sibling's `.reset.<ts>` instant to the new
  * transcript's session-header `timestamp` for the pair to count as one
- * host-minted /new operation. Both artifacts are minted by the same host
- * handler within one /new (measured 0-1 ms apart on a live rotation); the
- * allowance absorbs slow disks, busy hosts, and stalls between the archive
- * rename and the header write while staying far below any plausible
- * foreign-transcript coincidence. The window is also not the only defense: a
- * transcript inside it must still carry Lossless's own /new marker
+ * host-minted /new operation. Both artifacts are minted in that order by the
+ * same host handler within one /new (measured 0-1 ms apart on a live
+ * rotation); the allowance absorbs slow disks, busy hosts, and stalls between
+ * the archive rename and the header write while staying far below any
+ * plausible foreign-transcript coincidence. The window is also not the only
+ * defense: a transcript inside it must still carry Lossless's own /new marker
  * (`softResetPrunedAt`) plus the `.reset.` sibling, and the per-entry
  * timestamp gates (`candidate-missing-timestamp`,
  * `candidate-entries-predate-last-persisted`) run ahead of the bypass.
@@ -125,8 +125,8 @@ export type AmbiguousSessionKeyRuntimeRollover = {
    */
   hasDeliberateRolloverEvidence: boolean;
   /**
-   * True when the newest `.reset.` sibling's archive instant and the new
-   * transcript's session-header creation instant agree within
+   * True when the new transcript's session-header creation instant follows
+   * the newest `.reset.` sibling's archive instant within
    * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS` (on top of the
    * deliberate-rollover evidence above): the new transcript is the
    * host-minted replacement for exactly this /new, so the freshness gate may
@@ -299,13 +299,13 @@ export class SessionRolloverDetector {
   }
 
   /**
-   * True when the new transcript's session-header creation instant and the
-   * newest `.reset.` sibling's archive instant agree within
+   * True when the new transcript's session-header creation instant follows
+   * the newest `.reset.` sibling's archive instant within
    * `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS`. Both artifacts are minted
-   * by the same host-side /new operation, so their agreement proves the new
-   * transcript is the host's replacement for exactly that reset; a foreign
-   * transcript reusing a stale sessionKey carries a header instant unrelated
-   * to the reset instant and cannot satisfy the correlation. Requires the
+   * by the same host-side /new operation, so their ordered proximity proves
+   * the new transcript is the host's replacement for exactly that reset; a
+   * foreign transcript reusing a stale sessionKey carries a header instant
+   * unrelated to the reset instant and cannot satisfy the correlation. Requires the
    * deliberate-rollover evidence pair and both instants; anything missing
    * yields false (fail closed).
    */
@@ -331,9 +331,8 @@ export class SessionRolloverDetector {
     if (!Number.isFinite(headerCreatedAt) || headerCreatedAt <= 0) {
       return false;
     }
-    return (
-      Math.abs(headerCreatedAt - resetArchivedAt) <= HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS
-    );
+    const headerDelayMs = headerCreatedAt - resetArchivedAt;
+    return headerDelayMs >= 0 && headerDelayMs <= HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS;
   }
 
   /**

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -105,6 +105,8 @@ export type TranscriptHeader = {
   /** Stable id from the leading `{type:"session", id}` line; null when absent. */
   sessionHeaderId: string | null;
   parentSession: string | null;
+  /** ISO creation instant from the header's `timestamp` field; null when absent. */
+  sessionHeaderCreatedAt: string | null;
 };
 
 /**
@@ -114,7 +116,11 @@ export type TranscriptHeader = {
  * of inferring them from path/size heuristics.
  */
 export async function readTranscriptHeader(sessionFile: string): Promise<TranscriptHeader> {
-  const empty: TranscriptHeader = { sessionHeaderId: null, parentSession: null };
+  const empty: TranscriptHeader = {
+    sessionHeaderId: null,
+    parentSession: null,
+    sessionHeaderCreatedAt: null,
+  };
   try {
     const stream = createReadStream(sessionFile, { encoding: "utf8" });
     const lines = createInterface({
@@ -132,6 +138,7 @@ export async function readTranscriptHeader(sessionFile: string): Promise<Transcr
             type?: unknown;
             id?: unknown;
             parentSession?: unknown;
+            timestamp?: unknown;
           };
           if (parsed.type !== "session") {
             return empty;
@@ -139,6 +146,7 @@ export async function readTranscriptHeader(sessionFile: string): Promise<Transcr
           return {
             sessionHeaderId: normalizeEnvelopeString(parsed.id),
             parentSession: normalizeEnvelopeString(parsed.parentSession),
+            sessionHeaderCreatedAt: normalizeEnvelopeString(parsed.timestamp),
           };
         } catch {
           return empty;

--- a/test/rebind-loglevel.test.ts
+++ b/test/rebind-loglevel.test.ts
@@ -18,6 +18,7 @@ const ROLLOVER: AmbiguousSessionKeyRuntimeRollover = {
   sessionKey: "agent:main:main",
   trackedSessionFile: "/tmp/old-transcript.jsonl",
   hasDeliberateRolloverEvidence: false,
+  hostMintedResetReplacement: false,
 };
 
 const NEW_SESSION_ID = "new-session";

--- a/test/rollover-warn-memo-cap.test.ts
+++ b/test/rollover-warn-memo-cap.test.ts
@@ -25,6 +25,7 @@ function baseRollover(sessionKey: string): AmbiguousSessionKeyRuntimeRollover {
     sessionKey,
     trackedSessionFile: "/tmp/old-transcript.jsonl",
     hasDeliberateRolloverEvidence: false,
+    hostMintedResetReplacement: false,
   };
 }
 

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -90,6 +90,8 @@ function makeMessage(role: string, content: string, timestamp: number): AgentMes
 function writeRolledTranscript(params: {
   name: string;
   entries: Array<{ role: string; text: string; timestamp: number }>;
+  /** When set, prepend a host-shaped `{type:"session"}` header line with this creation instant. */
+  sessionHeaderTimestampMs?: number;
 }): string {
   const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-sibling-roll-"));
   tempDirs.push(tempDir);
@@ -111,7 +113,18 @@ function writeRolledTranscript(params: {
     parentId = id;
     return line;
   });
-  writeFileSync(file, `${lines.join("\n")}\n`);
+  const headerLines =
+    params.sessionHeaderTimestampMs === undefined
+      ? []
+      : [
+          JSON.stringify({
+            type: "session",
+            version: 3,
+            id: params.name,
+            timestamp: new Date(params.sessionHeaderTimestampMs).toISOString(),
+          }),
+        ];
+  writeFileSync(file, `${[...headerLines, ...lines].join("\n")}\n`);
   return file;
 }
 
@@ -233,6 +246,18 @@ async function seedSummaryBearingLane(
  */
 function archiveTrackedFile(trackedFile: string, kind: "reset" | "deleted"): void {
   renameSync(trackedFile, `${trackedFile}.${kind}.2026-06-29T120000-000Z`);
+}
+
+/**
+ * Host-shaped archive rename carrying a REAL parseable instant, exactly as the
+ * live host mints it: ISO-8601 with the time separators dashed
+ * (`2026-08-01T08-25-10.924Z`).
+ */
+function archiveTrackedFileAtInstant(trackedFile: string, instantMs: number): void {
+  renameSync(
+    trackedFile,
+    `${trackedFile}.reset.${new Date(instantMs).toISOString().replace(/:/g, "-")}`,
+  );
 }
 
 describe("/new soft-reset carry-forward via archive-sibling probe", () => {
@@ -495,5 +520,162 @@ describe("/new soft-reset carry-forward via archive-sibling probe", () => {
     const rebound = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
     expect(rebound?.conversationId).toBe(lane.conversationId);
     expect(rebound?.sessionId).toBe(NEW_SESSION_ID);
+  });
+});
+
+describe("host-minted reset replacement (timestamp-correlated /new)", () => {
+  it("rebinds despite substantial same-text overlap when the sibling and header instants correlate", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    // The host archives the old transcript and mints the new session file in
+    // one /new operation: sibling instant and header instant 1 ms apart.
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const newSessionFile = writeRolledTranscript({
+      name: NEW_SESSION_ID,
+      sessionHeaderTimestampMs: resetInstant + 1,
+      entries: [
+        // Byte-identical, substantial re-send of a persisted line: exactly the
+        // shape that fails closed without the host-minted correlation (see the
+        // foreign reused-key test above).
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("ambiguous rollover not provably fresh"),
+    );
+    const active = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(active?.conversationId).toBe(lane.conversationId);
+    expect(active?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("still fails closed when the header instant is outside the correlation tolerance", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const overlapText = "lane turn 10 about the deployment plan";
+    const foreignFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-late-header`,
+      // Ten minutes past the reset instant: not the host-minted replacement.
+      sessionHeaderTimestampMs: resetInstant + 10 * 60_000,
+      entries: [{ role: "user", text: overlapText, timestamp: Date.now() + 60_000 }],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: foreignFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`overlapContentLength=${overlapText.length}`),
+    );
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.conversationId).toBe(lane.conversationId);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("fails closed when the new transcript has no session header even with a parseable sibling instant", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    archiveTrackedFileAtInstant(lane.trackedFile, Date.now());
+    const headerlessFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-headerless`,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: headerlessFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("fails closed when the sibling archive suffix does not parse", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    // Sibling present (deliberate-rollover evidence holds) but its suffix is
+    // not a parseable instant, so no correlation is possible.
+    archiveTrackedFile(lane.trackedFile, "reset");
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-unparseable-sibling`,
+      sessionHeaderTimestampMs: Date.now(),
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 });

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -567,6 +567,122 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     const active = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
     expect(active?.conversationId).toBe(lane.conversationId);
     expect(active?.sessionId).toBe(NEW_SESSION_ID);
+
+    // The rebind is the carry-forward path: the retained depth-2 summary
+    // survives, same as the plain sibling-rebind case above.
+    const carried = await engine.getSummaryStore().getContextItems(lane.conversationId);
+    expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
+  });
+
+  it("accepts a header instant 29s past the reset instant (inside the correlation tolerance)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-tolerance-inside`,
+      sessionHeaderTimestampMs: resetInstant + 29_000,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    const active = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(active?.sessionId).toBe(NEW_SESSION_ID);
+  });
+
+  it("fails closed at 31s past the reset instant (outside the correlation tolerance)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-tolerance-outside`,
+      sessionHeaderTimestampMs: resetInstant + 31_000,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
+  it("fails closed when the sibling archive suffix is date-only (no time component)", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    // A bare date would Date.parse as midnight; a header minted near that
+    // midnight must still not correlate, because a date-only tail cannot pin
+    // the archive to an instant.
+    const dateOnlyMidnight = Date.parse("2026-06-29");
+    renameSync(lane.trackedFile, `${lane.trackedFile}.reset.2026-06-29`);
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-date-only-sibling`,
+      sessionHeaderTimestampMs: dateOnlyMidnight + 5,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 
   it("still fails closed when the header instant is outside the correlation tolerance", async () => {

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -574,6 +574,45 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     expect(carried.map((item) => item.summaryId)).toContain("sum_d2");
   });
 
+  it("fails closed for an in-window transcript whose header id is not the current session", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const foreignSessionFile = writeRolledTranscript({
+      name: "foreign-session-created-in-window",
+      sessionHeaderTimestampMs: resetInstant + 1,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: foreignSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
   it("accepts a header instant 29s past the reset instant (inside the correlation tolerance)", async () => {
     const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
     const lane = await seedSummaryBearingLane(engine, db);
@@ -586,7 +625,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     const resetInstant = Date.now();
     archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
     const newSessionFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-tolerance-inside`,
+      name: NEW_SESSION_ID,
       sessionHeaderTimestampMs: resetInstant + 29_000,
       entries: [
         {
@@ -622,7 +661,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     const resetInstant = Date.now();
     archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
     const newSessionFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-tolerance-outside`,
+      name: NEW_SESSION_ID,
       sessionHeaderTimestampMs: resetInstant + 31_000,
       entries: [
         {
@@ -658,7 +697,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     const resetInstant = Date.now();
     archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
     const newSessionFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-header-before-reset`,
+      name: NEW_SESSION_ID,
       // The host archives first and then writes the replacement header. Even
       // a nearby pre-reset header cannot identify this /new replacement.
       sessionHeaderTimestampMs: resetInstant - 1,
@@ -702,7 +741,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     const dateOnlyMidnight = Date.parse("2026-06-29");
     renameSync(lane.trackedFile, `${lane.trackedFile}.reset.2026-06-29`);
     const newSessionFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-date-only-sibling`,
+      name: NEW_SESSION_ID,
       sessionHeaderTimestampMs: dateOnlyMidnight + 5,
       entries: [
         {
@@ -739,7 +778,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
     const overlapText = "lane turn 10 about the deployment plan";
     const foreignFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-late-header`,
+      name: NEW_SESSION_ID,
       // Ten minutes past the reset instant: not the host-minted replacement.
       sessionHeaderTimestampMs: resetInstant + 10 * 60_000,
       entries: [{ role: "user", text: overlapText, timestamp: Date.now() + 60_000 }],
@@ -812,7 +851,7 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     // not a parseable instant, so no correlation is possible.
     archiveTrackedFile(lane.trackedFile, "reset");
     const newSessionFile = writeRolledTranscript({
-      name: `${NEW_SESSION_ID}-unparseable-sibling`,
+      name: NEW_SESSION_ID,
       sessionHeaderTimestampMs: Date.now(),
       entries: [
         {

--- a/test/soft-reset-new-sibling-rebind.test.ts
+++ b/test/soft-reset-new-sibling-rebind.test.ts
@@ -646,6 +646,47 @@ describe("host-minted reset replacement (timestamp-correlated /new)", () => {
     expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
   });
 
+  it("fails closed when the header instant predates the reset archive", async () => {
+    const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
+    const lane = await seedSummaryBearingLane(engine, db);
+    await engine.handleBeforeReset({
+      reason: "new",
+      sessionId: OLD_SESSION_ID,
+      sessionKey: SESSION_KEY,
+    });
+
+    const resetInstant = Date.now();
+    archiveTrackedFileAtInstant(lane.trackedFile, resetInstant);
+    const newSessionFile = writeRolledTranscript({
+      name: `${NEW_SESSION_ID}-header-before-reset`,
+      // The host archives first and then writes the replacement header. Even
+      // a nearby pre-reset header cannot identify this /new replacement.
+      sessionHeaderTimestampMs: resetInstant - 1,
+      entries: [
+        {
+          role: "user",
+          text: "lane turn 10 about the deployment plan",
+          timestamp: Date.now() + 60_000,
+        },
+      ],
+    });
+
+    await engine.bootstrap({
+      sessionId: NEW_SESSION_ID,
+      sessionKey: SESSION_KEY,
+      sessionFile: newSessionFile,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("freshness=identity-overlap-with-persisted-history"),
+    );
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("resolved by fresh-transcript rebind"),
+    );
+    const conversation = await engine.getConversationStore().getConversationBySessionKey(SESSION_KEY);
+    expect(conversation?.sessionId).toBe(OLD_SESSION_ID);
+  });
+
   it("fails closed when the sibling archive suffix is date-only (no time component)", async () => {
     const { engine, log, db } = createEngine({ newSessionRetainDepth: 2 });
     const lane = await seedSummaryBearingLane(engine, db);


### PR DESCRIPTION
Closes [#1055](https://github.com/Martian-Engineering/lossless-claw/issues/1055).

## Problem

The ambiguous-rollover freshness gate fails closed on any substantial identity overlap with recent persisted history, and the verdict re-derives identically on every turn because the overlapping entry never leaves the new transcript. One same-text re-send across `/new` (the natural "reset, then re-send my question" pattern) therefore wedges the lane's ingest until the next `/new`, near-silently. Full trace, live reproduction, and downstream consequences are in [#1055](https://github.com/Martian-Engineering/lossless-claw/issues/1055).

## Fix

Correlate two independently host-minted instants: the archive sibling's `.reset.<ts>` tail and the new transcript's `{"type":"session"}` header `timestamp`. Both are minted by the same host-side `/new` operation (measured 0-1 ms apart on a live rotation), so their agreement within a conservative tolerance (30 s, `HOST_MINTED_RESET_REPLACEMENT_TOLERANCE_MS`) proves the new transcript is the host's replacement for exactly that reset, and overlapping content across the boundary is the same user's traffic. The freshness gate then accepts the rebind with a new verdict reason, `fresh-host-minted-reset-replacement-transcript`, bypassing only the content-overlap scan.

The defense the docstring describes is preserved and sharpened. A foreign transcript reusing a stale sessionKey carries a header instant unrelated to the reset instant and cannot satisfy the correlation. The bypass additionally requires all of: Lossless's own `/new` marker (`softResetPrunedAt`), the archive sibling, a parseable sibling instant, and a parseable header instant; missing any of them keeps today's behavior bit-for-bit. The per-entry timestamp gates (`candidate-missing-timestamp`, `candidate-entries-predate-last-persisted`) still run ahead of the bypass.

Wiring: `TranscriptHeader` gains `sessionHeaderCreatedAt` (parsed from the header's `timestamp` field); the detector computes `hostMintedResetReplacement` inside `findAmbiguousSessionKeyRuntimeRollover` (both tier-2 resolving callers already pass `sessionFile`, so no caller changes); `evaluateAmbiguousRolloverFreshness` takes the evidence as an opt-in flag that defaults to false, so the isolated-cron path is untouched.

Observability (the second half of the issue): the not-provably-fresh WARN now carries `candidateMessages` and `overlapContentLength`, and a still-frozen lane re-emits the suppressed restatement at INFO every 25th occurrence instead of going debug-silent forever after the once-only WARN.

## Validation

- Red-proof: the new test "rebinds despite substantial same-text overlap when the sibling and header instants correlate" fails on current master (the lane freezes) and passes with the fix; the tolerance test also red-proves the WARN enrichment (2 failed on master, both green after).
- New fail-closed pins, all keeping the freeze: header instant outside tolerance; headerless new transcript despite a parseable sibling instant; unparseable sibling suffix.
- Existing pinned tests unchanged and green: the foreign reused-key transcript with a sibling (`test/soft-reset-new-sibling-rebind.test.ts`) and the trivial-content boundary (`rollover-identity-scope.test.ts`). Existing fixtures emit no session header, so they exercise the unmodified fail-closed path by construction.
- Targeted file: `test/soft-reset-new-sibling-rebind.test.ts` 10/10.
- Full suite: 111 files, 1988/1988 passing. `npm run typecheck` clean, build clean.
- Live-deploy note: we run a fleet on the embedded OpenClaw host and will stage this build and re-run the identical-text `/new` probe that reproduced [#1055](https://github.com/Martian-Engineering/lossless-claw/issues/1055) on 2026-08-01, expecting acceptance via the new verdict reason instead of the wedge. Keeping this PR as a draft until that live proof is in hand.

## Notes for review

- Tolerance: 0-1 ms measured on one rotation on one host; 30 s is deliberately generous for slow disks and busy hosts while staying far below any plausible foreign-transcript coincidence. Happy to tune.
- The archive-suffix parser accepts the host's dashed-time shape (`2026-08-01T08-25-10.924Z`, verified live) plus plain ISO; anything else yields null and fails closed.

## Changeset

User-facing behavior change (a same-text re-send across `/new` no longer freezes the lane). Flagging for a maintainer-added changeset per contributor convention rather than running the Changesets workflow from a fork.
