### PR TITLE
ci: add ClawHub package publishing

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,32 @@
+name: Publish to ClawHub
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Validate the ClawHub package without publishing
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  dry-run:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || inputs.dry_run
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
+    with:
+      dry_run: true
+
+  publish:
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
+    with:
+      dry_run: false

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -17,16 +17,60 @@ jobs:
       actions: read
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
     with:
       dry_run: true
 
-  publish:
+  release-preflight:
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout selected release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Verify npm release identity
+        run: |
+          set -euo pipefail
+
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          expected_tag="v$version"
+
+          if [ "$GITHUB_REF_TYPE" != "tag" ] || [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+            echo "Select release tag $expected_tag, not $GITHUB_REF"
+            exit 1
+          fi
+
+          source_sha="$(git rev-parse HEAD)"
+          if [ "$source_sha" != "$GITHUB_SHA" ]; then
+            echo "Checked out $source_sha, expected selected commit $GITHUB_SHA"
+            exit 1
+          fi
+
+          npm_state="$(npm view "$package_name@$version" version gitHead --json)"
+          published_version="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.version || "")' "$npm_state")"
+          published_sha="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.gitHead || "")' "$npm_state")"
+
+          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$GITHUB_SHA" ]; then
+            echo "npm identity does not match $expected_tag at $GITHUB_SHA"
+            exit 1
+          fi
+
+  publish:
+    needs: release-preflight
+    concurrency:
+      group: clawhub-publish
+      cancel-in-progress: false
     permissions:
       actions: read
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.23.1
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
     with:
       dry_run: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,6 +72,11 @@ When configuring npm trusted publishing, register the GitHub workflow using the 
 
 The publish workflow is intentionally manual. Release issuance should stay deliberate even after trusted publishing is enabled.
 
+## ClawHub releases
+
+The `Publish to ClawHub` workflow defaults to a dry run. Set `dry_run` to
+`false` to publish the version in `package.json`.
+
 ## Beta releases
 
 Use a Changesets prerelease when `main` needs broader testing before a stable release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,8 +74,18 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 
 ## ClawHub releases
 
-The `Publish to ClawHub` workflow defaults to a dry run. Set `dry_run` to
-`false` to publish the version in `package.json`.
+Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
+manually run `Publish to ClawHub` from that exact tag with `dry_run` set to
+`false`.
+
+The workflow refuses to publish unless the selected tag, `package.json`
+version, npm version, npm `gitHead`, and selected commit all identify the same
+release. Real ClawHub publishes are serialized.
+
+ClawHub trusted publishing is configured for
+`.github/workflows/clawhub-publish.yml`; no long-lived repository token is
+required. Deleting that trusted-publisher configuration disables future
+publishes.
 
 ## Beta releases
 

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const workflow = readFileSync(
+  `${repositoryRoot}/.github/workflows/clawhub-publish.yml`,
+  "utf8",
+);
+const releasing = readFileSync(`${repositoryRoot}/RELEASING.md`, "utf8");
+const clawhubWorkflowCommit =
+  "a230d962db64019462c2c8ee400755eb92169908";
+
+describe("ClawHub publish workflow", () => {
+  it("pins every reusable workflow call to the reviewed commit", () => {
+    const refs = Array.from(
+      workflow.matchAll(
+        /openclaw\/clawhub\/.github\/workflows\/package-publish\.yml@([^\s]+)/g,
+      ),
+      (match) => match[1],
+    );
+
+    expect(refs).toEqual([clawhubWorkflowCommit, clawhubWorkflowCommit]);
+  });
+
+  it("requires the selected release tag to match the npm commit", () => {
+    expect(workflow).toContain("release-preflight:");
+    expect(workflow).toContain('GITHUB_REF_TYPE" != "tag"');
+    expect(workflow).toContain('GITHUB_REF_NAME" != "$expected_tag"');
+    expect(workflow).toContain(
+      'npm view "$package_name@$version" version gitHead --json',
+    );
+    expect(workflow).toContain('published_sha" != "$GITHUB_SHA"');
+    expect(workflow).toMatch(/publish:\n\s+needs: release-preflight/);
+  });
+
+  it("serializes real publishes without cancelling an active release", () => {
+    expect(workflow).toMatch(
+      /publish:\n(?:.|\n)*?concurrency:\n\s+group: clawhub-publish\n\s+cancel-in-progress: false/,
+    );
+  });
+
+  it("documents npm-first publication from the matching release tag", () => {
+    expect(releasing).toContain("Publish to npm first");
+    expect(releasing).toContain("matching `vX.Y.Z` tag");
+    expect(releasing).toContain("npm `gitHead`");
+  });
+});


### PR DESCRIPTION
## Summary

- add the official ClawHub reusable package-publish workflow, pinned to `v0.23.1`
- run non-mutating validation on same-repository pull requests
- default manual runs to dry-run mode and publish through the configured trusted GitHub workflow
- document the short release path

## Validation

- `actionlint .github/workflows/clawhub-publish.yml`
- `git diff --check`
- [live reusable-workflow dry run](https://github.com/Patrick-Erichsen/lossless-claw/actions/runs/30723291294): exact head `da3195536d7721dbc52e6533b53d63dae9366ddb`; passed plugin validation for `@martian-engineering/lossless-claw@0.15.1` (20 files, 76,064 bytes)
- first release published from upstream commit `8ac47205d2598c0875b5efde93cb836a15986439`
- trusted publisher configured for `Martian-Engineering/lossless-claw` and `clawhub-publish.yml`
