### PR TITLE
fix: delegated expansion cannot collect replies on current OpenClaw beta

### DIFF
--- a/.changeset/runtime-subagent-session-messages.md
+++ b/.changeset/runtime-subagent-session-messages.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Use OpenClaw's supported `subagent.getSessionMessages()` runtime method when collecting delegated expansion replies, restoring `lcm_expand_query` compatibility with current OpenClaw beta releases.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1465,7 +1465,7 @@ function createLcmDependencies(
             timeoutMs: (params.params?.timeoutMs as number) ?? params.timeoutMs,
           });
         case "sessions.get":
-          return sub.getSession({
+          return sub.getSessionMessages({
             sessionKey: String(params.params?.key ?? ""),
             limit: params.params?.limit as number | undefined,
           });

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -9,6 +9,7 @@ import { closeLcmConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { clearAllSharedInit } from "../src/plugin/shared-init.js";
 import { resetStartupBannerLogsForTests } from "../src/startup-banner-log.js";
+import { runDelegatedExpansionLoop } from "../src/tools/lcm-expand-tool.delegation.js";
 
 const buildMemorySystemPromptAdditionMock = vi.hoisted(() => vi.fn());
 
@@ -72,7 +73,7 @@ function buildApi(
       subagent: {
         run: vi.fn(),
         waitForRun: vi.fn(),
-        getSession: vi.fn(),
+        getSessionMessages: vi.fn(),
         deleteSession: vi.fn(),
       },
       ...(options?.includeRuntimeLlm === false
@@ -815,6 +816,66 @@ describe("lcm plugin registration", () => {
 
     expect(deleteSession).toHaveBeenCalledWith({
       sessionKey: "agent:main:subagent:delegated-expansion",
+      deleteTranscript: true,
+    });
+  });
+
+  it("collects delegated expansion replies through getSessionMessages", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const { api, getFactory } = buildApi({ enabled: true, dbPath });
+    const run = api.runtime.subagent.run as ReturnType<typeof vi.fn>;
+    const waitForRun = api.runtime.subagent.waitForRun as ReturnType<typeof vi.fn>;
+    const getSessionMessages = api.runtime.subagent.getSessionMessages as ReturnType<typeof vi.fn>;
+    const deleteSession = api.runtime.subagent.deleteSession as ReturnType<typeof vi.fn>;
+    run.mockResolvedValue({ runId: "run-delegated-expansion" });
+    waitForRun.mockResolvedValue({ status: "ok" });
+    getSessionMessages.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                summary: "Delegated answer collected.",
+                citedIds: ["sum_1059"],
+                followUpSummaryIds: [],
+                totalTokens: 42,
+                truncated: false,
+              }),
+            },
+          ],
+        },
+      ],
+    });
+
+    lcmPlugin.register(api);
+    const engine = getFactory()!() as {
+      deps?: Parameters<typeof runDelegatedExpansionLoop>[0]["deps"];
+    };
+
+    const result = await runDelegatedExpansionLoop({
+      deps: engine.deps!,
+      requesterSessionKey: "agent:main:main",
+      conversationId: 1059,
+      summaryIds: ["sum_1059"],
+      includeMessages: false,
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      citedIds: ["sum_1059"],
+    });
+    expect(result.text).toContain("Delegated answer collected.");
+    expect(result.text).toContain("sum_1059");
+    expect(getSessionMessages).toHaveBeenCalledWith({
+      sessionKey: expect.stringMatching(/^agent:main:subagent:/),
+      limit: 80,
+    });
+    expect(deleteSession).toHaveBeenCalledWith({
+      sessionKey: expect.stringMatching(/^agent:main:subagent:/),
       deleteTranscript: true,
     });
   });


### PR DESCRIPTION
Closes #1059

## What Problem This Solves

Fixes an issue where `lcm_expand_query` delegated expansions could complete successfully but fail to return their answer and citations on current OpenClaw beta hosts.

## Why This Change Was Made

OpenClaw removed the deprecated `api.runtime.subagent.getSession()` alias while retaining `getSessionMessages()`. This changes the Lossless Claw gateway adapter to use the supported method and adds regression coverage through the real delegated expansion path. The change is limited to issue #1059; the separate fallback and rollover fixes in #1057 and #1058 remain out of scope.

## User Impact

Delegated expansion replies are collected again on current OpenClaw beta releases instead of being reported as `DELEGATED_EXPANSION_REPLY_MISSING`. The regression fixture exposes only `run`, `waitForRun`, `getSessionMessages`, and `deleteSession`, matching the current runtime contract.

## Evidence

- `npm test -- --run test/plugin-config-registration.test.ts` — 49 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm test` — 111 test files and 1,985 tests passed
