### PR TITLE
fix(ingest): stop recurrent tool-call ids from silently dropping tool results

### DIFF
--- a/.changeset/fix-empty-content-tool-result-parts.md
+++ b/.changeset/fix-empty-content-tool-result-parts.md
@@ -17,3 +17,16 @@ message's content is an empty array, so assembly can reconstruct the
 coverage signature is added to `message-signatures.ts` so live-coverage dedup
 recognizes the live, DB-round-trip, and assembled representations of the same
 logical result as identical.
+
+Additionally fixes stable-event-key dedup dropping legitimate tool results
+when tool-call ids are model-authored and recurrent (Kimi K3 `name:N`
+counters like `exec:101`, reused across turns and even minutes). The
+`ingestSingle` stable-event short-circuit treated `tool-result:<toolCallId>`
+as conversation-globally unique, so every later reuse of a recurrent id was
+silently skipped — calls persisted while their results vanished, and
+assembly inserted synthetic "missing tool result" errors. `stable_event_key`
+is now derived only from provably provider-unique tool-call id formats
+(Anthropic `toolu_…`, OpenAI `call_…`); all other id shapes fall back to the
+content/adjacency-bound dedup paths (preferring possible duplicates over data
+loss). A colliding stable-key INSERT is degraded to a NULL-key persist with
+a warning instead of being rejected by the partial unique index.

--- a/.changeset/fix-empty-content-tool-result-parts.md
+++ b/.changeset/fix-empty-content-tool-result-parts.md
@@ -44,6 +44,7 @@ canonical empty/tool-text coverage signatures are now restricted to
 provider-unique ids (recurrent ids fall back to the full lossless signature,
 so an older occurrence can never prove coverage of a newer one), and the
 empty-content fallback rehydrates as a provider-valid whitespace text block
-while persisting the structured `details` payload in part metadata.
+while preserving structured `details` in part metadata. Oversized `details`
+payloads are externalized with a durable file reference instead of truncated.
 
 Co-Authored-By: Cha <cha@jetd.one> via OpenClaw

--- a/.changeset/fix-empty-content-tool-result-parts.md
+++ b/.changeset/fix-empty-content-tool-result-parts.md
@@ -1,0 +1,19 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix tool-result pairing loss when a tool returns empty content. Tools like
+OpenClaw's `update_plan` (and any third-party tool) that return
+`{content: [], details: {...}}` produced zero `message_parts` rows on ingest,
+losing the top-level `toolCallId`/`toolName`/`isError` pairing identity. On
+assembly, the zero-part `role=tool` row was demoted to `role="assistant"` with
+empty content and dropped by the empty-content filter, causing
+`sanitizeToolUseResultPairing` to insert a synthetic "missing tool result"
+error on every assemble while the call sat in the context window — the model
+read its own plan calls as "failed" and retried in a loop. The fix emits one
+identity-carrying fallback part in `buildMessageParts()` when a tool-result
+message's content is an empty array, so assembly can reconstruct the
+`toolResult` with the correct `toolCallId`. A canonical empty-tool-result
+coverage signature is added to `message-signatures.ts` so live-coverage dedup
+recognizes the live, DB-round-trip, and assembled representations of the same
+logical result as identical.

--- a/.changeset/fix-empty-content-tool-result-parts.md
+++ b/.changeset/fix-empty-content-tool-result-parts.md
@@ -30,3 +30,20 @@ is now derived only from provably provider-unique tool-call id formats
 content/adjacency-bound dedup paths (preferring possible duplicates over data
 loss). A colliding stable-key INSERT is degraded to a NULL-key persist with
 a warning instead of being rejected by the partial unique index.
+
+The same recurrent-id root cause had three more edges, fixed together:
+transcript repair pairing now dedups assistant tool_use blocks by
+(id, payload-fingerprint) of a PENDING call instead of by conversation-global
+id — byte-identical repeats while a result is outstanding are store
+double-writes (keep-first), while legitimate recurrent-id reuses, including
+identical-argument repeats with their own later results ("pwd" twice), are
+distinct occurrences that survive. Deferred-result lookup no longer crosses
+the next surviving same-id occurrence, so results pair with the newest
+pending occurrence instead of being stolen by the first call. The
+canonical empty/tool-text coverage signatures are now restricted to
+provider-unique ids (recurrent ids fall back to the full lossless signature,
+so an older occurrence can never prove coverage of a newer one), and the
+empty-content fallback rehydrates as a provider-valid whitespace text block
+while persisting the structured `details` payload in part metadata.
+
+Co-Authored-By: Cha <cha@jetd.one> via OpenClaw

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,10 +239,21 @@ The `messages` table carries a `stable_event_key` column (TEXT, nullable)
 indexed by a partial unique index `(conversation_id, stable_event_key)
 WHERE stable_event_key IS NOT NULL`. The key is computed at
 `ingestSingle` time from a message's `responseId` or a single
-`toolCallId` and acts as a third identity axis alongside
-`transcript_entry_id` and `identity_hash`. Aggregate tool-result messages
-and messages without either stable identifier continue to use the
-existing identity-hash and redaction-aware deduplication. When a message
-with a key that is already present for the conversation is ingested, the
-duplicate is rejected before any side effects (large-file interception,
-parts, context items) so the originally-persisted row stays canonical.
+PROVIDER-UNIQUE `toolCallId` (Anthropic `toolu_…`, OpenAI `call_…`; see
+`isProviderUniqueToolCallId`) and acts as a third identity axis alongside
+`transcript_entry_id` and `identity_hash`.
+
+Model-authored tool-call ids (Kimi K3 style `name:N` counters such as
+`exec:101`) recur across turns and are only adjacency-unique; they NEVER
+produce a stable key. Such messages fall back to the existing
+identity-hash and redaction-aware deduplication, which may duplicate a
+redacted twin but never loses an event — preferring duplicate emission
+(recoverable by repair-time dedup) over dropped ingestion. Aggregate
+tool-result messages and messages without either stable identifier use
+the same fallback. When a message with a key that is already present for
+the conversation is ingested, the duplicate is rejected before any side
+effects (large-file interception, parts, context items) so the
+originally-persisted row stays canonical. Should a key conflict ever
+slip past that pre-check at INSERT time (provider id reuse), the store
+persists the row with a NULL stable key and reports the conflict instead
+of losing data.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -513,21 +513,29 @@ To switch back to OpenClaw's legacy context engine instead:
 ## Stable event identity deduplication
 
 Lossless-claw persists a `stable_event_key` on messages that carry a
-`responseId` or tool call id. This prevents duplicate ingestion when the
-same semantic event arrives in two different content representations
-(typical case: the JSONL transcript is redacted by
+`responseId` or a provider-unique tool call id. This prevents duplicate
+ingestion when the same semantic event arrives in two different content
+representations (typical case: the JSONL transcript is redacted by
 `logging.redactPatterns` while the live `afterTurn` batch is not). The key
 is derived from the message as follows, in order:
 
 1. assistant messages with `responseId` (or `response_id`):
    `assistant-response:<responseId>`.
-2. tool / toolResult messages that represent exactly one tool call id:
+2. tool / toolResult messages that represent exactly one tool call id
+   whose format is provider-issued and therefore conversation-globally
+   unique (Anthropic `toolu_…`, OpenAI `call_…`):
    `tool-result:<toolCallId>`.
-3. Otherwise, including aggregate tool-result messages: no key is
-   persisted, and the row falls back to the existing content-based
-   deduplication.
+3. Otherwise, including aggregate tool-result messages and ALL
+   model-authored counter-pattern ids (Kimi K3 `name:N` such as
+   `exec:101`, `read:92`, `web_search:45`): no key is persisted, and the
+   row falls back to the existing content-based deduplication.
+   Model-authored ids recur across turns and are only adjacency-unique —
+   treating them as global event identities silently drops distinct
+   events sharing the id, so the fallback deliberately prefers possible
+   duplicates over data loss.
 
-A partial unique index on `(conversation_id, stable_event_key)` ensures
-that two rows in the same conversation can never share a key. The
+A partial unique index on `(conversation_id, stable_event_key)` enforces
+one row per key per conversation; a collision at insert time persists the
+row with a NULL key (and logs a warning) rather than rejecting it. The
 mechanism is independent of `logging.redactPatterns` and requires no user
 configuration.

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -313,6 +313,7 @@ function getPartMetadata(part: MessagePartRecord): {
   topLevelReasoningField?: string;
   topLevelReasoningContent?: string;
   topLevelReasoningOnly?: boolean;
+  emptyContentFallback?: boolean;
 } {
   const decoded = parseJson(part.metadata);
   if (!decoded || typeof decoded !== "object") {
@@ -326,6 +327,7 @@ function getPartMetadata(part: MessagePartRecord): {
     topLevelReasoningField?: unknown;
     topLevelReasoningContent?: unknown;
     topLevelReasoningOnly?: unknown;
+    emptyContentFallback?: unknown;
   };
   return {
     originalRole:
@@ -351,6 +353,7 @@ function getPartMetadata(part: MessagePartRecord): {
       typeof record.topLevelReasoningOnly === "boolean"
         ? record.topLevelReasoningOnly
         : undefined,
+    emptyContentFallback: record.emptyContentFallback === true,
   };
 }
 
@@ -607,6 +610,16 @@ export function blockFromPart(part: MessagePartRecord): unknown {
     return reasoningBlockFromPart(part, metadata.rawType);
   }
   if (part.partType === "tool") {
+    if (metadata.emptyContentFallback === true) {
+      // #992 identity carrier: pair via the surrounding message's top-level
+      // toolCallId (set from the part), but emit a plain text block —
+      // provider adapters only accept text/image blocks inside toolResult
+      // message content; a nested tool_result block without a valid id would
+      // be dropped or rejected downstream. Whitespace text keeps the block
+      // effectively-empty for coverage canonicalization while surviving the
+      // empty-content filter (toolResult role is not blank-filtered).
+      return { type: "text", text: part.textContent ?? " " };
+    }
     if (metadata.originalRole === "toolResult" || metadata.rawType === "function_call_output") {
       return toolResultBlockFromPart(
         part,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -434,6 +434,11 @@ export class LcmContextEngine implements ContextEngine {
       fts5Available: this.fts5Available,
       replayFloodThresholdExternal: this.config.replayFloodThresholdExternal,
       replayFloodThresholdInternal: this.config.replayFloodThresholdInternal,
+      onStableEventKeyConflict: ({ conversationId, stableEventKey }) => {
+        this.deps.log.warn(
+          `[lcm] stable-event-key unique conflict conversation=${conversationId} key=${stableEventKey} — provider/mode id uniqueness violated; row persisted without stable key`,
+        );
+      },
     });
     this.summaryStore = new SummaryStore(this.db, { fts5Available: this.fts5Available });
     this.largeFileInterceptor = new LargeFileInterceptor(
@@ -2768,9 +2773,20 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     // Stable event identity short-circuit: when the message carries a stable
-    // event key (responseId / toolCallId) that the conversation already holds,
-    // this is the same event under a different (likely redacted) content
-    // representation. Skip the duplicate insert before any side effects.
+    // event key (assistant responseId, or a PROVABLY PROVIDER-UNIQUE
+    // toolCallId — see stable-event-key.ts) that the conversation already
+    // holds, this is the same event under a different (likely redacted)
+    // content representation. Skip the duplicate insert before any side
+    // effects.
+    //
+    // Ordering matters (P1 rawId anchoring): the unique transcript-entry-id
+    // check above runs first because an entry id is per-line unique and is
+    // the authoritative replay anchor. The stable key below is only ever
+    // derived from event-unique identifiers, so an existing key is same-event
+    // proof even for fresh transcript entry ids. Model-authored recurrent
+    // toolCallIds (e.g. Kimi `exec:101`) never produce a key — they fall
+    // through to the content/adjacency-bound dedup paths, which prefer
+    // duplicate emission over dropped ingestion.
     const stableEventKey = extractStableEventKey(message);
     if (
       stableEventKey &&

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2787,18 +2787,46 @@ export class LcmContextEngine implements ContextEngine {
     // toolCallIds (e.g. Kimi `exec:101`) never produce a key — they fall
     // through to the content/adjacency-bound dedup paths, which prefer
     // duplicate emission over dropped ingestion.
+    //
+    // A fresh-transcript-entry TOOL RESULT colliding with an existing stable
+    // key is a NEW event recycled into a provider-unique FORMAT by a
+    // model/provider-compat layer — the entry-id check above already proved
+    // freshness, and no documented same-event tool-result import regenerates
+    // entry ids (the #1040 aborted/redacted-twin fault chain was
+    // assistant-responseId only). Persist it WITHOUT the stable key (conflict
+    // path) instead of silently skipping the result — ingested=false would
+    // repeat the #194379 disaster for id-recycling providers.
     const stableEventKey = extractStableEventKey(message);
-    if (
-      stableEventKey &&
-      (await this.conversationStore.hasMessageByStableEventKey(
-        conversationId,
-        stableEventKey,
-      ))
-    ) {
+    const stableEventKeyConflict = stableEventKey
+      ? await this.conversationStore.hasMessageByStableEventKey(
+          conversationId,
+          stableEventKey,
+        )
+      : false;
+    // A fresh-transcript-entry TOOL RESULT colliding with an existing stable
+    // key is a NEW event recycled into a provider-unique FORMAT by a
+    // model/provider-compat layer — the entry-id check above already proved
+    // freshness, and no documented same-event tool-result import regenerates
+    // entry ids (the #1040 aborted/redacted-twin fault chain was
+    // assistant-responseId only). Persist it WITHOUT the stable key (conflict
+    // path) instead of silently skipping the result — ingested=false would
+    // repeat the #194379 disaster for id-recycling providers.
+    const stableEventKeyToolResultOverride = Boolean(
+      stableEventKeyConflict &&
+        transcriptEntryId &&
+        stableEventKey?.startsWith("tool-result:"),
+    );
+    if (stableEventKeyConflict && !stableEventKeyToolResultOverride) {
       this.deps.log.debug(
         `[lcm] ingestSingle: stable-event duplicate skipped role=${stored.role} key=${stableEventKey} conversation=${conversationId}`,
       );
       return { ingested: false };
+    }
+    const stableEventKeyForInsert = stableEventKeyToolResultOverride ? null : stableEventKey;
+    if (stableEventKeyToolResultOverride) {
+      this.deps.log.warn(
+        `[lcm] ingestSingle: tool-result stable-event key recycled for a fresh transcript entry — persisted WITHOUT stable key role=${stored.role} key=${stableEventKey} entry=${transcriptEntryId} conversation=${conversationId}`,
+      );
     }
 
     // Delivery-mirror dedup: OpenClaw writes two entries per assistant turn —
@@ -2918,7 +2946,7 @@ export class LcmContextEngine implements ContextEngine {
       content: stored.content,
       tokenCount: stored.tokenCount,
       transcriptEntryId,
-      stableEventKey,
+      stableEventKey: stableEventKeyForInsert,
       createdAt,
       skipReplayTimestampFloodGuard,
     });

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -24,13 +24,16 @@ import {
 import {
   extractStructuredText,
   hasReplayCriticalRawBlock,
+  MAX_INLINE_TOOL_RESULT_DETAILS_BYTES,
   RAW_PAYLOAD_EXTERNALIZATION_REASON,
   serializeRawPayloadContent,
   type StoredMessage,
 } from "./message-content.js";
 import { resolveLiveToolResultExternalization } from "./read-tool-recovery.js";
 import { buildExternalizedToolResultBlock } from "./tool-result-blocks.js";
-import { asRecord, safeBoolean, safeString } from "./value-utils.js";
+import { asRecord, safeBoolean, safeString, toJson } from "./value-utils.js";
+
+const LARGE_TOOL_RESULT_DETAILS_EXTERNALIZATION_REASON = "large_tool_result_details";
 
 /** Resolves the optional model-backed summarizer used for large-file exploration summaries. */
 export type LargeFileTextSummarizerResolver = (params?: {
@@ -800,6 +803,56 @@ export class LargeFileInterceptor {
     const topLevelIsError =
       safeBoolean(topLevel.isError) ??
       safeBoolean(topLevel.is_error);
+
+    // Empty tool results can carry their entire structured payload in the
+    // top-level `details` field. Externalize oversized details here because
+    // the content-block loop below has nothing to inspect and the generic raw
+    // payload interceptor intentionally skips tool roles.
+    if (params.message.content.length === 0 && topLevel.details !== undefined) {
+      const serializedDetails = toJson(topLevel.details);
+      const serializedDetailsBytes = Buffer.byteLength(serializedDetails, "utf8");
+      if (
+        serializedDetails.length > 0 &&
+        (estimateTokens(serializedDetails) >= threshold ||
+          serializedDetailsBytes > MAX_INLINE_TOOL_RESULT_DETAILS_BYTES)
+      ) {
+        const toolName = topLevelToolName ?? "tool-result";
+        const detailsToolName = `${toolName}-details`;
+        const externalized = await this.externalizeLargeTextPayload({
+          conversationId: params.conversationId,
+          content: serializedDetails,
+          fileId: params.getFileId?.({
+            content: serializedDetails,
+            toolName: detailsToolName,
+            callId: topLevelToolCallId,
+          }),
+          fileName: `${detailsToolName}.json`,
+          mimeType: "application/json",
+          formatReference: ({ fileId, byteSize, summary }) =>
+            formatToolOutputReference({
+              fileId,
+              toolName: detailsToolName,
+              byteSize,
+              summary,
+            }),
+        });
+        return {
+          rewrittenMessage: {
+            ...params.message,
+            details: {
+              externalizedFileId: externalized.fileId,
+              originalByteSize: externalized.byteSize,
+              externalizationReason: LARGE_TOOL_RESULT_DETAILS_EXTERNALIZATION_REASON,
+              reference: externalized.reference,
+            },
+            externalizedFileId: externalized.fileId,
+            originalByteSize: externalized.byteSize,
+            externalizationReason: LARGE_TOOL_RESULT_DETAILS_EXTERNALIZATION_REASON,
+          } as AgentMessage,
+          fileIds: [externalized.fileId],
+        };
+      }
+    }
 
     for (const item of params.message.content) {
       if (!item || typeof item !== "object" || Array.isArray(item)) {

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -155,6 +155,7 @@ export function normalizeLiveMessageForAssemblyReconciliation(message: AgentMess
           sessionId: "live-reconciliation",
           message,
           fallbackContent: stored.content,
+          allowOversizedInlineDetailsForAnalysis: true,
         }).map((part) => toSyntheticMessagePartRecord(part, 0))
       : [];
   const content = contentFromParts(parts, runtimeRole, stored.content);

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -636,19 +636,66 @@ export function buildMessageParts(params: {
   // empty, and `sanitizeToolUseResultPairing` then injects a synthetic
   // "missing tool result" error on every assemble while the call is in the
   // context window. Persist one fallback part that carries the pairing
-  // identity so assembly can reconstruct the toolResult. Role-gated (not
-  // id-gated): pre-existing routing in blockFromPart treats a metadata-less
-  // "tool" part as a toolCall, so only tool/toolResult roles may land here —
-  // an id-bearing assistant/user message would otherwise be misassembled as
-  // a phantom call. User and assistant empty content intentionally stays
-  // part-less (the empty-content filter and the empty-assistant skip are
-  // desired behavior). Callid-less tool rows keep today's demote-to-assistant
-  // assembly path.
+  // identity so assembly can reconstruct the toolResult.
+  //
+  // The OpenClaw `details` payload (the motivating `update_plan` case is
+  // `{content: [], details: {...}}`) is persisted in part metadata — the
+  // lossless layer must not discard structured payload data just because the
+  // text content is empty. Oversized payloads are summarized instead of
+  // dropped silently.
+  //
+  // Gated on BOTH role and a non-empty pairing id: pre-existing routing in
+  // blockFromPart treats a metadata-less "tool" part as a toolCall, so only
+  // tool/toolResult roles may land here — an id-bearing assistant/user message
+  // would otherwise be misassembled as a phantom call. And without a
+  // toolCallId the rehydrated row demotes to assistant but now carries a
+  // tool_result block with no tool_use_id — malformed provider input — so
+  // ID-less rows keep the legacy zero-part path (demote to assistant with
+  // empty content, dropped by the empty-content filter). User and assistant
+  // empty content intentionally stays part-less (the empty-content filter and
+  // the empty-assistant skip are desired behavior).
   if (
     message.content.length === 0 &&
     (role === "tool" || role === "toolResult") &&
+    typeof topLevelToolCallId === "string" &&
+    topLevelToolCallId.length > 0 &&
     !rawPayloadExternalized
   ) {
+    // Structured payload capture (P3: lossless layer must not discard data).
+    // `details` rides the top-level message — e.g. update_plan's
+    // `{content: [], details: {...}}` — so persist it in part metadata even
+    // though the rehydrated provider-facing block stays a whitespace text
+    // block (adapters only accept text/image in toolResult content).
+    const details = (message as { details?: unknown }).details;
+    let detailsEntry: Record<string, unknown> = {};
+    if (details !== undefined) {
+      // Persist intact up to a bound: empty content gives
+      // interceptLargeToolResults nothing to externalize and raw-payload
+      // externalization skips tool roles, so an unbounded details blob both
+      // violates the lossless invariant in the other direction (if trimmed
+      // without evidence elsewhere) and bypasses payload-size controls (if
+      // kept whole) — plus it is reparsed at EVERY assemble. Normal empty
+      // results (update_plan-scale payloads are KBs) stay intact; an
+      // oversized blob keeps byteSize + head preview + a LOUD ingest warning
+      // (P3's "disappear without audible complaint" rationale: the invariant
+      // breach is at least evidence-bearing and audible, unlike silent loss).
+      const EMPTY_FALLBACK_DETAILS_MAX_BYTES = 65536;
+      const serialized = toJson(details);
+      const serializedBytes = Buffer.byteLength(serialized ?? "", "utf8");
+      if (serializedBytes <= EMPTY_FALLBACK_DETAILS_MAX_BYTES) {
+        detailsEntry = { details };
+      } else {
+        console.warn(
+          `[lcm] empty-content tool result details payload ${serializedBytes}B exceeds ${EMPTY_FALLBACK_DETAILS_MAX_BYTES}B cap (toolCallId=${topLevelToolCallId}); byteSize + preview preserved in part metadata`,
+        );
+        detailsEntry = {
+          detailsOversize: {
+            byteSize: serializedBytes,
+            preview: (serialized ?? "").slice(0, 2048),
+          },
+        };
+      }
+    }
     parts.push({
       sessionId,
       partType: "tool",
@@ -657,16 +704,16 @@ export function buildMessageParts(params: {
       toolCallId: topLevelToolCallId ?? null,
       toolName: topLevelToolName ?? null,
       metadata: toJson({
-        // Always identify as "toolResult" so blockFromPart routes through
-        // toolResultBlockFromPart (not toolCallBlockFromPart which would
-        // emit a phantom toolCall block). The raw role may be "tool" but
-        // the logical shape is a tool RESULT.
+        // Always identify as "toolResult" (the raw role may be "tool" but
+        // the logical shape is a tool RESULT); the emptyContentFallback flag
+        // routes rehydration to a provider-valid text block.
         originalRole: "toolResult",
         rawType: "tool_result",
         toolCallId: topLevelToolCallId,
         toolName: topLevelToolName,
         isError: topLevelIsError,
         emptyContentFallback: true,
+        ...detailsEntry,
       }),
     });
   }

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -627,6 +627,50 @@ export function buildMessageParts(params: {
     });
   }
 
+  // Empty-content tool-result fallback (issue #992): a tool result message
+  // whose content is an empty array (e.g. OpenClaw `update_plan` shape
+  // `{content: [], details: {...}}`) produces zero parts above, which loses
+  // the top-level pairing identity (toolCallId/toolName/isError live only in
+  // part metadata). Downstream, a zero-part role=tool row can no longer be
+  // rehydrated as a toolResult — it is demoted to assistant, filtered as
+  // empty, and `sanitizeToolUseResultPairing` then injects a synthetic
+  // "missing tool result" error on every assemble while the call is in the
+  // context window. Persist one fallback part that carries the pairing
+  // identity so assembly can reconstruct the toolResult. Role-gated (not
+  // id-gated): pre-existing routing in blockFromPart treats a metadata-less
+  // "tool" part as a toolCall, so only tool/toolResult roles may land here —
+  // an id-bearing assistant/user message would otherwise be misassembled as
+  // a phantom call. User and assistant empty content intentionally stays
+  // part-less (the empty-content filter and the empty-assistant skip are
+  // desired behavior). Callid-less tool rows keep today's demote-to-assistant
+  // assembly path.
+  if (
+    message.content.length === 0 &&
+    (role === "tool" || role === "toolResult") &&
+    !rawPayloadExternalized
+  ) {
+    parts.push({
+      sessionId,
+      partType: "tool",
+      ordinal: 0,
+      textContent: " ",
+      toolCallId: topLevelToolCallId ?? null,
+      toolName: topLevelToolName ?? null,
+      metadata: toJson({
+        // Always identify as "toolResult" so blockFromPart routes through
+        // toolResultBlockFromPart (not toolCallBlockFromPart which would
+        // emit a phantom toolCall block). The raw role may be "tool" but
+        // the logical shape is a tool RESULT.
+        originalRole: "toolResult",
+        rawType: "tool_result",
+        toolCallId: topLevelToolCallId,
+        toolName: topLevelToolName,
+        isError: topLevelIsError,
+        emptyContentFallback: true,
+      }),
+    });
+  }
+
   return parts;
 }
 

--- a/src/message-content.ts
+++ b/src/message-content.ts
@@ -11,6 +11,8 @@ import { estimateContentTokensForRole, toRuntimeRoleForTokenEstimate } from "./t
 import { safeBoolean, safeString, toJson } from "./value-utils.js";
 import { join } from "node:path";
 
+export const MAX_INLINE_TOOL_RESULT_DETAILS_BYTES = 65_536;
+
 export function appendTextValue(value: unknown, out: string[]): void {
   if (typeof value === "string") {
     out.push(value);
@@ -420,6 +422,7 @@ export function normalizeMessageContentForStorage(params: {
     sessionId: "storage-estimate",
     message,
     fallbackContent,
+    allowOversizedInlineDetailsForAnalysis: true,
   }).map((part) => toSyntheticMessagePartRecord(part, 0));
 
   if (parts.length === 0) {
@@ -443,6 +446,7 @@ export function buildMessageParts(params: {
   sessionId: string;
   message: AgentMessage;
   fallbackContent: string;
+  allowOversizedInlineDetailsForAnalysis?: boolean;
 }): import("./store/conversation-store.js").CreateMessagePartInput[] {
   const { sessionId, message, fallbackContent } = params;
   const role = typeof message.role === "string" ? message.role : "unknown";
@@ -639,10 +643,8 @@ export function buildMessageParts(params: {
   // identity so assembly can reconstruct the toolResult.
   //
   // The OpenClaw `details` payload (the motivating `update_plan` case is
-  // `{content: [], details: {...}}`) is persisted in part metadata — the
-  // lossless layer must not discard structured payload data just because the
-  // text content is empty. Oversized payloads are summarized instead of
-  // dropped silently.
+  // `{content: [], details: {...}}`) is preserved in part metadata, either
+  // inline or as the externalized reference prepared by LargeFileInterceptor.
   //
   // Gated on BOTH role and a non-empty pairing id: pre-existing routing in
   // blockFromPart treats a metadata-less "tool" part as a toolCall, so only
@@ -663,38 +665,23 @@ export function buildMessageParts(params: {
   ) {
     // Structured payload capture (P3: lossless layer must not discard data).
     // `details` rides the top-level message — e.g. update_plan's
-    // `{content: [], details: {...}}` — so persist it in part metadata even
-    // though the rehydrated provider-facing block stays a whitespace text
-    // block (adapters only accept text/image in toolResult content).
+    // `{content: [], details: {...}}` — so preserve it (or its externalized
+    // reference) even though the rehydrated provider-facing block stays a
+    // whitespace text block (adapters only accept text/image there).
     const details = (message as { details?: unknown }).details;
     let detailsEntry: Record<string, unknown> = {};
     if (details !== undefined) {
-      // Persist intact up to a bound: empty content gives
-      // interceptLargeToolResults nothing to externalize and raw-payload
-      // externalization skips tool roles, so an unbounded details blob both
-      // violates the lossless invariant in the other direction (if trimmed
-      // without evidence elsewhere) and bypasses payload-size controls (if
-      // kept whole) — plus it is reparsed at EVERY assemble. Normal empty
-      // results (update_plan-scale payloads are KBs) stay intact; an
-      // oversized blob keeps byteSize + head preview + a LOUD ingest warning
-      // (P3's "disappear without audible complaint" rationale: the invariant
-      // breach is at least evidence-bearing and audible, unlike silent loss).
-      const EMPTY_FALLBACK_DETAILS_MAX_BYTES = 65536;
-      const serialized = toJson(details);
-      const serializedBytes = Buffer.byteLength(serialized ?? "", "utf8");
-      if (serializedBytes <= EMPTY_FALLBACK_DETAILS_MAX_BYTES) {
-        detailsEntry = { details };
-      } else {
-        console.warn(
-          `[lcm] empty-content tool result details payload ${serializedBytes}B exceeds ${EMPTY_FALLBACK_DETAILS_MAX_BYTES}B cap (toolCallId=${topLevelToolCallId}); byteSize + preview preserved in part metadata`,
+      const serializedDetails = toJson(details);
+      const detailsBytes = Buffer.byteLength(serializedDetails, "utf8");
+      if (
+        detailsBytes > MAX_INLINE_TOOL_RESULT_DETAILS_BYTES &&
+        !params.allowOversizedInlineDetailsForAnalysis
+      ) {
+        throw new Error(
+          `Oversized empty tool-result details must be externalized before persistence (toolCallId=${topLevelToolCallId}, bytes=${detailsBytes})`,
         );
-        detailsEntry = {
-          detailsOversize: {
-            byteSize: serializedBytes,
-            preview: (serialized ?? "").slice(0, 2048),
-          },
-        };
       }
+      detailsEntry = { details };
     }
     parts.push({
       sessionId,
@@ -713,6 +700,9 @@ export function buildMessageParts(params: {
         toolName: topLevelToolName,
         isError: topLevelIsError,
         emptyContentFallback: true,
+        externalizedFileId,
+        originalByteSize,
+        externalizationReason,
         ...detailsEntry,
       }),
     });

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -6,10 +6,11 @@
 import { buildMessageParts, toStoredMessage, type StoredMessage } from "./message-content.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
 import { canonicalizeOpenClawInboundMetadataIdentityContent } from "./openclaw-inbound-metadata.js";
+import { isProviderUniqueToolCallId } from "./stable-event-key.js";
 import type { CreateMessagePartInput } from "./store/conversation-store.js";
 import { extractToolResultIdForPairing } from "./tool-pairing.js";
 import { extractBootstrapMessageCandidate } from "./transcript.js";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 export function createBootstrapEntryHash(message: StoredMessage | null): string | null {
   if (!message) {
@@ -103,6 +104,23 @@ export function createLiveCoverageSignature(message: AgentMessage): string {
   if (canonicalEmptyToolResultSignature) {
     return canonicalEmptyToolResultSignature;
   }
+  if (stored.role === "tool") {
+    const pairingId = extractToolResultIdForPairing(message);
+    if (pairingId && !isProviderUniqueToolCallId(pairingId)) {
+      // Recurrent model-authored ids: the lossless signature contains no
+      // occurrence identity, so two distinct events with identical content
+      // ("(no output)") sign equal and a coverage consumer can elide a REAL
+      // newer occurrence against an older assembled one. Without provenance
+      // there is no in-message occurrence discriminator, so refuse to let
+      // these events anchor coverage at all: double-emit is recoverable by
+      // repair-time dedup; a sliced-away live event is not (P3).
+      return JSON.stringify({
+        kind: "recurrent-tool-event",
+        toolCallId: pairingId,
+        nonce: randomUUID(),
+      });
+    }
+  }
   return createLosslessMessageSignature(message);
 }
 
@@ -141,11 +159,19 @@ export function createCanonicalToolTextCoverageSignature(
   ) {
     return undefined;
   }
+  const toolCallId = part.toolCallId ?? extractToolResultIdForPairing(message) ?? null;
+  if (toolCallId && !isProviderUniqueToolCallId(toolCallId)) {
+    // Model-authored recurrent ids (Kimi K3 `name:N`) are not event-unique:
+    // equal content + equal id across DISTINCT events would collapse their
+    // coverage signatures and let an older occurrence prove coverage of a
+    // newer one. Fall back to the full lossless signature instead.
+    return undefined;
+  }
   return JSON.stringify({
     kind: "canonical-tool-text",
     role: stored.role,
     content: fallbackContent,
-    toolCallId: part.toolCallId ?? extractToolResultIdForPairing(message) ?? null,
+    toolCallId,
     toolName: normalizeToolNameForCoverage(part.toolName),
   });
 }
@@ -180,28 +206,62 @@ export function createCanonicalEmptyToolResultCoverageSignature(
     return undefined;
   }
   const part = parts[0] as CreateMessagePartInput;
-  if (part.partType !== "tool" || part.toolInput != null) {
-    return undefined;
-  }
-  // Effective text must be empty: the fallback sentinel " " or an output
-  // column holding only whitespace — never a real payload.
-  if (!isEffectivelyEmptyToolResultPart(part, fallbackContent)) {
-    return undefined;
-  }
-  if (!isToolResultShapedPart(part)) {
+  // Two rehydrations of the same logical empty result are valid: the legacy
+  // "tool" part (pre-#1054-round-2 DB rows, plus single-tool_result-block
+  // live shapes) and the provider-facing plain text part the empty-content
+  // fallback now assembles into. Reject anything else.
+  if (part.toolInput != null) {
     return undefined;
   }
   const toolCallId = part.toolCallId ?? extractToolResultIdForPairing(message) ?? null;
+  if (part.partType === "text") {
+    // Whitespace-only text on a tool-result message: the text-block
+    // rehydration of the empty-content fallback (#992). After a DB round-trip
+    // the reconstructed part may carry metadata.originalRole:"toolResult"
+    // with rawType:"text" (no longer tool-shaped), so gate on the message
+    // role + whitespace content instead of tool-part shape.
+    if ((part.textContent ?? "").trim() !== "") {
+      return undefined;
+    }
+    if (stored.role !== "tool" && stored.role !== "toolResult") {
+      return undefined;
+    }
+    if (!toolCallId) {
+      return undefined;
+    }
+  } else if (part.partType === "tool") {
+    // Effective text must be empty: the fallback sentinel " " or an output
+    // column holding only whitespace — never a real payload.
+    if (!isEffectivelyEmptyToolResultPart(part, fallbackContent)) {
+      return undefined;
+    }
+    if (!isToolResultShapedPart(part)) {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
   if (!toolCallId) {
     // Identity-less results cannot be canonicalized without collision risk:
     // two distinct id-less results would otherwise map to the same key and
     // one side could be silently swallowed by coverage dedup.
     return undefined;
   }
+  if (!isProviderUniqueToolCallId(toolCallId)) {
+    // Model-authored ids (Kimi K3 `name:N` counters) recur across turns, so
+    // (role, toolCallId) does NOT identify an event: an id-less content match
+    // here would let coverage consumers (e.g. resolveForkBoundedLiveSuffix)
+    // treat an OLDER occurrence as proof a NEWER occurrence is covered and
+    // slice real events out of the request. Restrict the canonical shortcut
+    // to provider-unique ids; everything else keeps the full lossless
+    // signature, preferring a possible double-emit over a silent suppression.
+    return undefined;
+  }
   // toolName is intentionally omitted from the key: the same logical result
   // may appear with a top-level toolName (DB round-trip) or without one
-  // (live transcript block only), and toolCallId is the unique pairing
-  // identity — two results with the same toolCallId ARE the same result.
+  // (live transcript block only), and a provider-unique toolCallId is then
+  // an event-unique pairing identity — two results with the same provider-
+  // unique toolCallId ARE the same event.
   return JSON.stringify({
     kind: "canonical-empty-tool-result",
     role: stored.role,

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -51,6 +51,7 @@ export function createLosslessMessageSignature(message: AgentMessage): string {
     sessionId: "lossless-message-signature",
     message,
     fallbackContent: stored.content,
+    allowOversizedInlineDetailsForAnalysis: true,
   });
 
   return JSON.stringify({
@@ -146,6 +147,7 @@ export function createCanonicalToolTextCoverageSignature(
     sessionId: "live-tool-coverage-signature",
     message,
     fallbackContent,
+    allowOversizedInlineDetailsForAnalysis: true,
   });
   if (parts.length !== 1) {
     return undefined;
@@ -201,6 +203,7 @@ export function createCanonicalEmptyToolResultCoverageSignature(
     sessionId: "live-empty-tool-coverage-signature",
     message,
     fallbackContent,
+    allowOversizedInlineDetailsForAnalysis: true,
   });
   if (parts.length !== 1) {
     return undefined;
@@ -319,8 +322,14 @@ function isEffectivelyEmptyToolResultPart(
     return true;
   }
   const rawRecord = raw as Record<string, unknown>;
-  // Check raw.content and raw.output for any payload.
-  if (rawRecord.content != null) {
+  // Empty string/array content is another provider representation of an
+  // empty result. Preserve every other non-null shape conservatively so real
+  // structured payloads cannot be canonicalized away by call id alone.
+  const rawContent = rawRecord.content;
+  const rawContentIsEmpty =
+    (typeof rawContent === "string" && rawContent.trim() === "") ||
+    (Array.isArray(rawContent) && rawContent.length === 0);
+  if (rawContent != null && !rawContentIsEmpty) {
     return false;
   }
   if (rawRecord.output != null && String(rawRecord.output).trim() !== "") {
@@ -373,6 +382,7 @@ export function isCanonicalTextOnlyMessage(message: AgentMessage, fallbackConten
     sessionId: "live-coverage-signature",
     message,
     fallbackContent,
+    allowOversizedInlineDetailsForAnalysis: true,
   });
   if (parts.length !== 1) {
     return false;

--- a/src/message-signatures.ts
+++ b/src/message-signatures.ts
@@ -96,6 +96,13 @@ export function createLiveCoverageSignature(message: AgentMessage): string {
   if (canonicalToolTextSignature) {
     return canonicalToolTextSignature;
   }
+  const canonicalEmptyToolResultSignature = createCanonicalEmptyToolResultCoverageSignature(
+    message,
+    stored.content,
+  );
+  if (canonicalEmptyToolResultSignature) {
+    return canonicalEmptyToolResultSignature;
+  }
   return createLosslessMessageSignature(message);
 }
 
@@ -141,6 +148,164 @@ export function createCanonicalToolTextCoverageSignature(
     toolCallId: part.toolCallId ?? extractToolResultIdForPairing(message) ?? null,
     toolName: normalizeToolNameForCoverage(part.toolName),
   });
+}
+
+/**
+ * Canonical coverage identity for a tool-result message whose effective text
+ * is EMPTY. The empty-content ingest fallback (issue #992) persists a single
+ * identity-carrying "tool" part for `{content: [], details: …}` shapes, and
+ * assembly rehydrates that part into a `{type:"tool_result", output:" "}`
+ * block — the same logical result then appears under three raw shapes (live
+ * empty content, live single tool_result block, assembled block), each of
+ * which would otherwise hash to a different lossless parts-JSON and be
+ * double-emitted side by side by live-coverage dedup. Canonicalize all three
+ * onto the same key: (role, toolCallId) — toolName is intentionally omitted
+ * because it may be present on the DB round-trip representation and absent
+ * on the live transcript block, while toolCallId is the unique pairing identity.
+ */
+export function createCanonicalEmptyToolResultCoverageSignature(
+  message: AgentMessage,
+  fallbackContent: string,
+): string | undefined {
+  const stored = toStoredMessage(message);
+  if (stored.role !== "tool") {
+    return undefined;
+  }
+  const parts = buildMessageParts({
+    sessionId: "live-empty-tool-coverage-signature",
+    message,
+    fallbackContent,
+  });
+  if (parts.length !== 1) {
+    return undefined;
+  }
+  const part = parts[0] as CreateMessagePartInput;
+  if (part.partType !== "tool" || part.toolInput != null) {
+    return undefined;
+  }
+  // Effective text must be empty: the fallback sentinel " " or an output
+  // column holding only whitespace — never a real payload.
+  if (!isEffectivelyEmptyToolResultPart(part, fallbackContent)) {
+    return undefined;
+  }
+  if (!isToolResultShapedPart(part)) {
+    return undefined;
+  }
+  const toolCallId = part.toolCallId ?? extractToolResultIdForPairing(message) ?? null;
+  if (!toolCallId) {
+    // Identity-less results cannot be canonicalized without collision risk:
+    // two distinct id-less results would otherwise map to the same key and
+    // one side could be silently swallowed by coverage dedup.
+    return undefined;
+  }
+  // toolName is intentionally omitted from the key: the same logical result
+  // may appear with a top-level toolName (DB round-trip) or without one
+  // (live transcript block only), and toolCallId is the unique pairing
+  // identity — two results with the same toolCallId ARE the same result.
+  return JSON.stringify({
+    kind: "canonical-empty-tool-result",
+    role: stored.role,
+    toolCallId,
+  });
+}
+
+function isEffectivelyEmptyToolResultPart(
+  part: CreateMessagePartInput,
+  fallbackContent: string,
+): boolean {
+  if (fallbackContent.trim() !== "") {
+    return false;
+  }
+  const textContentEmpty = (part.textContent ?? "").trim() === "";
+  if (!textContentEmpty) {
+    return false;
+  }
+  const toolOutput = part.toolOutput;
+  if (toolOutput != null) {
+    // toolOutput may be a JSON-quoted string (e.g. '" "').
+    try {
+      const parsed: unknown = JSON.parse(toolOutput);
+      if (typeof parsed === "string") {
+        if (parsed.trim() !== "") {
+          return false;
+        }
+      } else {
+        // Non-string toolOutput means there is a real payload.
+        return false;
+      }
+    } catch {
+      if (toolOutput.trim() !== "") {
+        return false;
+      }
+    }
+  }
+  // Check metadata.raw for a content-bearing tool_result block. A part with
+  // null textContent and null toolOutput may still carry a real payload in
+  // metadata.raw.content (e.g. {type:"tool_result", content:[{type:"text",
+  // text:"real output"}]}). Declaring such a part "empty" would canonicalize
+  // it by call ID alone and let coverage dedup suppress a richer live
+  // representation.
+  let metadata: Record<string, unknown> | null = null;
+  try {
+    metadata = part.metadata ? (JSON.parse(part.metadata) as Record<string, unknown>) : null;
+  } catch {
+    return true;
+  }
+  if (!metadata) {
+    return true;
+  }
+  const raw = metadata.raw;
+  if (!raw || typeof raw !== "object") {
+    return true;
+  }
+  const rawRecord = raw as Record<string, unknown>;
+  // Check raw.content and raw.output for any payload.
+  if (rawRecord.content != null) {
+    return false;
+  }
+  if (rawRecord.output != null && String(rawRecord.output).trim() !== "") {
+    return false;
+  }
+  return true;
+}
+
+function isToolResultShapedPart(part: CreateMessagePartInput): boolean {
+  let metadata: Record<string, unknown> | null = null;
+  try {
+    metadata = part.metadata ? (JSON.parse(part.metadata) as Record<string, unknown>) : null;
+  } catch {
+    return false;
+  }
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  if (metadata.emptyContentFallback === true) {
+    return true;
+  }
+  const originalRole = metadata.originalRole;
+  if (originalRole !== "toolResult" && originalRole !== "tool") {
+    return false;
+  }
+  const rawType = metadata.rawType;
+  if (
+    rawType === "tool_result" ||
+    rawType === "toolResult" ||
+    rawType === "function_call_output"
+  ) {
+    return true;
+  }
+  const raw = metadata.raw;
+  if (raw && typeof raw === "object") {
+    const rawBlockType = (raw as { type?: unknown }).type;
+    if (
+      rawBlockType === "tool_result" ||
+      rawBlockType === "toolResult" ||
+      rawBlockType === "function_call_output"
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function isCanonicalTextOnlyMessage(message: AgentMessage, fallbackContent: string): boolean {

--- a/src/migrate-sessions.ts
+++ b/src/migrate-sessions.ts
@@ -5,6 +5,8 @@ import { homedir } from "node:os";
 import { DatabaseSync } from "node:sqlite";
 import { closeLcmConnection, createLcmDatabaseConnection } from "./db/connection.js";
 import { runLcmMigrations } from "./db/migration.js";
+import { resolveLcmConfig } from "./db/config.js";
+import { LargeFileInterceptor } from "./large-file-interceptor.js";
 import { buildMessageParts, filterPersistableMessages, toStoredMessage, type StoredMessage } from "./message-content.js";
 import { createBootstrapEntryHash } from "./message-signatures.js";
 import type { AgentMessage } from "./openclaw-bridge.js";
@@ -305,6 +307,7 @@ async function importPreparedFile(
   db: DatabaseSync,
   conversationStore: ConversationStore,
   summaryStore: SummaryStore,
+  largeFileInterceptor: LargeFileInterceptor,
   prepared: PreparedSessionFile,
 ): Promise<MigrationFileResult> {
   const importable = toImportableMessages(prepared.messages);
@@ -375,12 +378,30 @@ async function importPreparedFile(
     const createdMessages: MessageRecord[] = [];
     let nextSeq = (await conversationStore.getMaxSeq(conversation.conversationId)) + 1;
     for (const entry of toImport) {
+      let messageForParts = entry.message;
+      let storedForPersistence = entry.stored;
+      const rawContent = "content" in entry.message ? entry.message.content : undefined;
+      if (
+        entry.stored.role === "tool" &&
+        Array.isArray(rawContent) &&
+        rawContent.length === 0 &&
+        (entry.message as { details?: unknown }).details !== undefined
+      ) {
+        const intercepted = await largeFileInterceptor.interceptLargeToolResults({
+          conversationId: conversation.conversationId,
+          message: entry.message,
+        });
+        if (intercepted) {
+          messageForParts = intercepted.rewrittenMessage;
+          storedForPersistence = toStoredMessage(messageForParts);
+        }
+      }
       const message = await conversationStore.createMessage({
         conversationId: conversation.conversationId,
         seq: nextSeq,
-        role: entry.stored.role,
-        content: entry.stored.content,
-        tokenCount: entry.stored.tokenCount,
+        role: storedForPersistence.role,
+        content: storedForPersistence.content,
+        tokenCount: storedForPersistence.tokenCount,
         transcriptEntryId: entry.transcriptEntryId,
         createdAt: resolveTranscriptMessageCreatedAt(entry.message),
         skipReplayTimestampFloodGuard: true,
@@ -390,8 +411,8 @@ async function importPreparedFile(
         message.messageId,
         buildMessageParts({
           sessionId: prepared.sessionId,
-          message: entry.message,
-          fallbackContent: entry.stored.content,
+          message: messageForParts,
+          fallbackContent: storedForPersistence.content,
         }),
       );
       createdMessages.push(message);
@@ -488,6 +509,17 @@ export async function runSessionMigration(
     runLcmMigrations(db);
     const conversationStore = new ConversationStore(db);
     const summaryStore = new SummaryStore(db);
+    const migrationConfig = resolveLcmConfig({
+      ...process.env,
+      OPENCLAW_STATE_DIR: stateDir,
+      LCM_DATABASE_PATH: dbPath,
+      LCM_LARGE_FILES_DIR: join(stateDir, "lcm-files"),
+    });
+    const largeFileInterceptor = new LargeFileInterceptor(
+      migrationConfig,
+      summaryStore,
+      async () => undefined,
+    );
     const results: MigrationFileResult[] = [];
     for (const file of prepared) {
       if (!isPreparedSessionFile(file)) {
@@ -495,7 +527,15 @@ export async function runSessionMigration(
         continue;
       }
       try {
-        results.push(await importPreparedFile(db, conversationStore, summaryStore, file));
+        results.push(
+          await importPreparedFile(
+            db,
+            conversationStore,
+            summaryStore,
+            largeFileInterceptor,
+            file,
+          ),
+        );
       } catch (error) {
         results.push({
           file: file.file,

--- a/src/stable-event-key.ts
+++ b/src/stable-event-key.ts
@@ -3,12 +3,40 @@ import { extractSingleToolResultIdForPairing } from "./tool-pairing.js";
 import { safeString } from "./value-utils.js";
 
 /**
+ * Tool-call id shapes that are PROVABLY unique per event: minted by the
+ * provider/transport, never authored by the model. Only these may be used as
+ * conversation-global stable event keys.
+ *
+ *   - `toolu_…`  Anthropic tool_use ids (also Bedrock-hosted Anthropic).
+ *   - `call_…`   OpenAI chat/responses tool-call ids.
+ *
+ * Everything else — most importantly model-authored counter patterns such
+ * as Kimi K3's `name:N` ids (`exec:101`, `read:92`, `web_search:45`) — is
+ * deliberately excluded. Model-authored ids are only ADJACENCY-unique: the
+ * same id recurs across turns (K3 cycles through the same counters within
+ * the hour), so treating them as global event identities classifies
+ * DISTINCT events as duplicates and silently drops their tool results at
+ * ingest time (2026-08-02 incident: all recurrent-id tool results skipped
+ * by the stable-event short-circuit while their calls persisted, leaving
+ * the assembler to synthesize "missing tool result" errors). Non-listed
+ * formats return null here and fall back to the content/adjacency/rawId
+ * bound dedup paths, which may duplicate a redacted twin but never lose an
+ * event (repair-time dedup handles the duplicates).
+ */
+const PROVIDER_UNIQUE_TOOL_CALL_ID_PATTERN = /^(?:toolu_|call_)[A-Za-z0-9]{12,}$/;
+
+export function isProviderUniqueToolCallId(toolCallId: string): boolean {
+  return PROVIDER_UNIQUE_TOOL_CALL_ID_PATTERN.test(toolCallId);
+}
+
+/**
  * Extracts a message identity that remains stable across transcript and
  * runtime representations.
  *
- * Assistant response ids take priority, followed by tool call ids. Messages
- * without either identifier return `null` and use the existing content-based
- * and redaction-aware deduplication paths.
+ * Assistant response ids take priority, followed by tool call ids that are
+ * provably provider-unique (see PROVIDER_UNIQUE_TOOL_CALL_ID_PATTERN).
+ * Messages without such an identifier return `null` and use the existing
+ * content-based and redaction-aware deduplication paths.
  */
 export function extractStableEventKey(message: AgentMessage): string | null {
   const role = message.role;
@@ -24,7 +52,7 @@ export function extractStableEventKey(message: AgentMessage): string | null {
 
   if (role === "tool" || role === "toolResult") {
     const toolCallId = extractSingleToolResultIdForPairing(message);
-    if (toolCallId) {
+    if (toolCallId && isProviderUniqueToolCallId(toolCallId)) {
       return `tool-result:${toolCallId}`;
     }
   }

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -383,6 +383,10 @@ export class ConversationStore {
   private readonly fts5Available: boolean;
   private readonly replayFloodThresholdExternal: number;
   private readonly replayFloodThresholdInternal: number;
+  private readonly onStableEventKeyConflict?: (info: {
+    conversationId: ConversationId;
+    stableEventKey: string;
+  }) => void;
 
   constructor(
     private db: DatabaseSync,
@@ -400,11 +404,22 @@ export class ConversationStore {
        * calls returning identical results within the same SQLite-second).
        */
       replayFloodThresholdInternal?: number;
+      /**
+       * Invoked when a stable-event-key insert collides with the partial
+       * unique index and the row is re-inserted without its stable key. The
+       * hook exists so operators see the invariant violation; the row is
+       * always persisted (lossless over idempotency).
+       */
+      onStableEventKeyConflict?: (info: {
+        conversationId: ConversationId;
+        stableEventKey: string;
+      }) => void;
     },
   ) {
     this.fts5Available = options?.fts5Available ?? true;
     this.replayFloodThresholdExternal = options?.replayFloodThresholdExternal ?? 3;
     this.replayFloodThresholdInternal = options?.replayFloodThresholdInternal ?? 32;
+    this.onStableEventKeyConflict = options?.onStableEventKeyConflict;
   }
 
   // ── Transaction helpers ──────────────────────────────────────────────────
@@ -688,30 +703,64 @@ export class ConversationStore {
 
   // ── Message operations ────────────────────────────────────────────────────
 
+  /**
+   * Insert a message row, degrading the stable event key to NULL on a unique
+   * index conflict instead of losing the row. A conflict means the
+   * "provider-unique" toolCallId/responseId assumption was violated (a
+   * provider reused an id, or a model-augmented id slipped past the format
+   * gate); persisting without the key keeps the data and only weakens later
+   * dedup, the safe failure direction for a lossless store.
+   */
+  private runMessageInsert(prepared: PreparedMessageInsert): number {
+    const runWith = (stableEventKey: string | null): number => {
+      const result = this.db
+        .prepare(
+          `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, transcript_entry_id, stable_event_key, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          prepared.conversationId,
+          prepared.seq,
+          prepared.role,
+          prepared.content,
+          prepared.tokenCount,
+          prepared.identityHash,
+          prepared.transcriptEntryId ?? null,
+          stableEventKey,
+          prepared.createdAt,
+        );
+      return Number(result.lastInsertRowid);
+    };
+    if (prepared.stableEventKey == null) {
+      return runWith(null);
+    }
+    try {
+      return runWith(prepared.stableEventKey);
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        /UNIQUE constraint failed|SQLITE_CONSTRAINT_UNIQUE/i.test(err.message) &&
+        err.message.includes("stable_event_key")
+      ) {
+        const stableEventKey = prepared.stableEventKey;
+        const messageId = runWith(null);
+        this.onStableEventKeyConflict?.({
+          conversationId: prepared.conversationId,
+          stableEventKey,
+        });
+        return messageId;
+      }
+      throw err;
+    }
+  }
+
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
     const prepared = this.prepareMessageInsert(input);
     if (!prepared.skipReplayTimestampFloodGuard) {
       this.assertNoReplayTimestampFlood([prepared]);
     }
 
-    const result = this.db
-      .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, transcript_entry_id, stable_event_key, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        prepared.conversationId,
-        prepared.seq,
-        prepared.role,
-        prepared.content,
-        prepared.tokenCount,
-        prepared.identityHash,
-        prepared.transcriptEntryId ?? null,
-        prepared.stableEventKey,
-        prepared.createdAt,
-      );
-
-    const messageId = Number(result.lastInsertRowid);
+    const messageId = this.runMessageInsert(prepared);
 
     this.indexMessageForFullText(messageId, input.content);
 
@@ -735,10 +784,6 @@ export class ConversationStore {
       preparedInputs.filter((input) => !input.skipReplayTimestampFloodGuard),
     );
 
-    const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, transcript_entry_id, stable_event_key, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    );
     const selectStmt = this.db.prepare(
       `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content, transcript_entry_id
        FROM messages WHERE message_id = ?`,
@@ -746,19 +791,7 @@ export class ConversationStore {
 
     const records: MessageRecord[] = [];
     for (const input of preparedInputs) {
-      const result = insertStmt.run(
-        input.conversationId,
-        input.seq,
-        input.role,
-        input.content,
-        input.tokenCount,
-        input.identityHash,
-        input.transcriptEntryId ?? null,
-        input.stableEventKey,
-        input.createdAt,
-      );
-
-      const messageId = Number(result.lastInsertRowid);
+      const messageId = this.runMessageInsert(input);
       this.indexMessageForFullText(messageId, input.content);
       const row = selectStmt.get(messageId) as unknown as MessageRow;
       records.push(toMessageRecord(row));

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -1269,6 +1269,7 @@ export class TranscriptReconciler {
         sessionId: params.sessionId,
         message,
         fallbackContent: stored.content,
+        allowOversizedInlineDetailsForAnalysis: true,
       });
       for (const part of parts) {
         for (const rawId of extractRawIdsFromPartMetadata(part.metadata)) {
@@ -1425,6 +1426,7 @@ export class TranscriptReconciler {
         sessionId: params.sessionId,
         message,
         fallbackContent: stored.content,
+        allowOversizedInlineDetailsForAnalysis: true,
       });
       for (const part of parts) {
         const partRawBlockIds = extractRawBlockIdsFromPartMetadata(part.metadata);

--- a/src/transcript-repair.ts
+++ b/src/transcript-repair.ts
@@ -194,29 +194,59 @@ function isEmptyAfterToolUseDrop(content: unknown): boolean {
 }
 
 /**
+ * Fingerprint one tool_use block for occurrence-scoped duplicate detection.
+ * Model-authored ids (Kimi K3 `name:N`) legitimately recur across turns; two
+ * tool_use blocks share an EVENT only when id AND payload match (the store
+ * double-write case). Same id with different arguments is a new occurrence.
+ */
+function fingerprintToolUseBlock(block: unknown): string {
+  try {
+    return JSON.stringify(block);
+  } catch {
+    return String(block);
+  }
+}
+
+/**
  * Remove duplicate assistant `tool_use` blocks during assembly.
  *
  * The Anthropic Messages API rejects a turn containing two assistant tool_use
  * blocks that share an id. Duplicate-ingest can place the same tool_use id on
- * more than one assistant message. This filters tool_use blocks whose id has
- * already been emitted earlier in the assembled transcript (keep-first), while
- * preserving every other block (text, distinct tool calls).
+ * more than one assistant message. This filters tool_use blocks whose id AND
+ * payload fingerprint were already emitted (keep-first), while preserving
+ * every other block (text, distinct tool calls) — including a legitimate
+ * reuse of a recurrent model-authored id with different arguments.
  *
- * - record:false leaves surviving ids out of the seen set. Used for
- *   error/aborted turns, which are non-pairable and must not "claim" an id that
- *   a later valid turn legitimately reuses.
- * - dropAll:true strips every tool_use block regardless of the seen set. Also
+ * - `pendingToolUses` maps each id to the block fingerprints of its calls
+ *   that are still awaiting a result. Identity is (id, fingerprint) of a
+ *   pending call, never the bare id — recurrent `name:N` ids (Kimi K3)
+ *   recur across turns as distinct events, and a fingerprint is retired as
+ *   soon as its call pairs, so even identical repeats survive once paired.
+ * - record:false leaves surviving fingerprints out of the seen map. Used for
+ *   error/aborted turns, which are non-pairable and must not "claim" an id
+ *   that a later valid turn legitimately reuses.
+ * - dropAll:true strips every tool_use block regardless of the seen map. Also
  *   used for error/aborted turns, whose tool_use blocks may be incomplete.
  */
+/** Registered (kept) fingerprints per tool-call id from one filter pass. */
+export type KeptToolUseFingerprints = Map<string, string[]>;
+
 function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
   msg: T,
-  seenToolUseIds: Set<string>,
-  options: { dropAll?: boolean; record?: boolean } = {}
-): { message: T; dropped: DroppedToolUse[] } {
-  const { dropAll = false, record = true } = options;
+  pendingToolUses: Map<string, Set<string>>,
+  consumedToolUses: Map<string, Set<string>>,
+  options: { dropAll?: boolean; record?: boolean; consumedReuses?: ReadonlySet<string> } = {}
+): { message: T; dropped: DroppedToolUse[]; keptFingerprints: KeptToolUseFingerprints } {
+  const { dropAll = false, record = true, consumedReuses } = options;
+  const keptFingerprints: KeptToolUseFingerprints = new Map();
+  // One assistant turn may NEVER emit two tool-call blocks with the same id
+  // (strict providers reject same-id calls within a turn). Recurrent ids are
+  // only reusable across turns — collapse same-id repeats here keep-first,
+  // regardless of argument fingerprints.
+  const keptIdsInThisMessage = new Set<string>();
   const content = msg.content;
   if (!Array.isArray(content)) {
-    return { message: msg, dropped: [] };
+    return { message: msg, dropped: [], keptFingerprints };
   }
   const dropped: DroppedToolUse[] = [];
   const kept: unknown[] = [];
@@ -232,7 +262,27 @@ function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
       const isToolUse =
         !!id && typeof rec.type === "string" && TOOL_CALL_TYPES.has(rec.type);
       if (isToolUse && id) {
-        if (dropAll || seenToolUseIds.has(id)) {
+        if (keptIdsInThisMessage.has(id) && !dropAll) {
+          dropped.push({
+            id,
+            name: typeof rec.name === "string" ? rec.name : undefined,
+            reason: "duplicate",
+          });
+          continue;
+        }
+        const fingerprint = fingerprintToolUseBlock(block);
+        // A byte-identical repeat of a STILL-PENDING call is a store
+        // double-write (keep-first drop). A repeat of an already-paired
+        // (consumed) call is a legitimate fresh occurrence — e.g. `pwd` run
+        // twice with the same recurrent id — UNLESS there is no pairable
+        // later result for it, in which case it collapses as the double-write
+        // remnant. The caller precomputes which consumed ids have a pairable
+        // later result (consumedReuses).
+        if (
+          dropAll ||
+          pendingToolUses.get(id)?.has(fingerprint) ||
+          (consumedToolUses.get(id)?.has(fingerprint) && !consumedReuses?.has(id))
+        ) {
           dropped.push({
             id,
             name: typeof rec.name === "string" ? rec.name : undefined,
@@ -240,17 +290,42 @@ function filterAssistantToolUseBlocks<T extends AgentMessageLike>(
           });
           continue;
         }
+        const keptList = keptFingerprints.get(id);
+        keptIdsInThisMessage.add(id);
+        if (keptList) {
+          keptList.push(fingerprint);
+        } else {
+          keptFingerprints.set(id, [fingerprint]);
+        }
         if (record) {
-          seenToolUseIds.add(id);
+          const fingerprints = pendingToolUses.get(id);
+          if (fingerprints) {
+            fingerprints.add(fingerprint);
+          } else {
+            pendingToolUses.set(id, new Set([fingerprint]));
+          }
         }
       }
     }
     kept.push(block);
   }
   if (dropped.length === 0) {
-    return { message: msg, dropped };
+    return { message: msg, dropped, keptFingerprints };
   }
-  return { message: { ...msg, content: kept } as T, dropped };
+  return { message: { ...msg, content: kept } as T, dropped, keptFingerprints };
+}
+
+
+/** Deep-copy the seen-fingerprint registry for preview passes so speculative
+ * registrations never leak into the real pairing state. */
+function copyToolUseFingerprints(
+  source: Map<string, Set<string>>,
+): Map<string, Set<string>> {
+  const copy = new Map<string, Set<string>>();
+  for (const [id, fingerprints] of source) {
+    copy.set(id, new Set(fingerprints));
+  }
+  return copy;
 }
 
 // -- Repair logic (from session-transcript-repair.ts) --
@@ -307,17 +382,37 @@ function makeMissingToolResult(params: {
  * calls are not immediately followed by matching tool results. This function:
  * - Moves matching toolResult messages directly after their assistant toolCall turn
  * - Inserts synthetic error toolResults for missing IDs
- * - Drops duplicate toolResults for the same ID
+ * - Drops duplicate toolResults (an id emitted while no identical call is
+ *   awaiting its result)
  * - Drops orphaned toolResults with no matching tool call
+ *
+ * Pairing is OCCURRENCE-SCOPED, never global-id. Tool-call ids are authored by
+ * the model and recur across turns (Kimi K3 `name:N` counters), so an id is
+ * treated as a duplicate only while an identical earlier call still awaits its
+ * result; each paired id becomes reusable again immediately.
  */
 export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
   messages: T[],
   log?: WarnLogger
 ): T[] {
   const out: T[] = [];
-  const seenToolResultIds = new Set<string>();
-  const toolResultPositions = new Map<string, number>();
-  const seenToolUseIds = new Set<string>();
+  // Occurrence-scoped pairing state. Tool-call ids are authored by the model
+  // and recur across turns (Kimi K3 `name:N` counters), so duplication is
+  // (id, payload-fingerprint) of a PENDING (result-not-yet-paired) call,
+  // never a conversation-global id: a legitimate reuse — including a repeat
+  // with identical arguments after the first was paired — is a new
+  // occurrence and survives; a byte-identical repeat while the first still
+  // awaits its result is a store double-write and drops keep-first.
+  const pendingToolUses = new Map<string, Set<string>>();
+  // Fingerprints of calls whose occurrence already completed (paired or
+  // synthesized). A repeat of a consumed fingerprint is a fresh occurrence
+  // only when a pairable result still exists for it later in the transcript;
+  // otherwise it is a store double-write remnant of the completed event.
+  const consumedToolUses = new Map<string, Set<string>>();
+  // Per id, the out-indexes of every emitted result, in emission order. A
+  // later real result may replace the LATEST synthetic placeholder for its id
+  // (backfill repair); positions of earlier real results stay frozen.
+  const emittedResultPositions = new Map<string, number[]>();
   const movedToolResultIndexes = new Set<number>();
   let droppedDuplicateCount = 0;
   let droppedDuplicateAssistantToolUseCount = 0;
@@ -336,23 +431,29 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     }
   };
 
+  const replaceLatestSyntheticResult = (id: string, candidate: T): boolean => {
+    const positions = emittedResultPositions.get(id);
+    if (!positions || positions.length === 0) {
+      return false;
+    }
+    const latestIndex = positions[positions.length - 1] as number;
+    const existing = out[latestIndex];
+    if (existing && shouldUseCandidateToolResult(existing, candidate)) {
+      out[latestIndex] = candidate;
+      return true;
+    }
+    return false;
+  };
+
   const pushToolResult = (msg: T) => {
     const id = extractToolResultId(msg);
-    if (id && seenToolResultIds.has(id)) {
-      const existingIndex = toolResultPositions.get(id);
-      if (existingIndex !== undefined) {
-        const existing = out[existingIndex];
-        if (existing && shouldUseCandidateToolResult(existing, msg)) {
-          out[existingIndex] = msg;
-        }
-      }
-      droppedDuplicateCount += 1;
-      changed = true;
-      return;
-    }
     if (id) {
-      seenToolResultIds.add(id);
-      toolResultPositions.set(id, out.length);
+      const positions = emittedResultPositions.get(id);
+      if (positions) {
+        positions.push(out.length);
+      } else {
+        emittedResultPositions.set(id, [out.length]);
+      }
     }
     out.push(msg);
   };
@@ -372,6 +473,13 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       if (role !== "toolResult") {
         out.push(msg);
       } else {
+        const orphanId = extractToolResultId(msg);
+        // A late real result may still upgrade the latest synthetic
+        // placeholder emitted earlier for its id (backfill repair).
+        if (orphanId && replaceLatestSyntheticResult(orphanId, msg)) {
+          changed = true;
+          continue;
+        }
         droppedOrphanCount += 1;
         changed = true;
       }
@@ -384,16 +492,54 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     }
 
     // Drop duplicate assistant tool_use blocks (keep-first). Two assistant
-    // tool_use blocks sharing an id cause the Anthropic API to reject the turn.
+    // tool_use blocks sharing an id cause the Anthropic API to reject the turn;
+    // a duplicate is only a block identical to one still awaiting its result.
     const terminal = getTerminalStopReason(normalizedAssistant) !== null;
+    const consumedReuses = new Set<string>();
+    if (!terminal) {
+      const msgBlocks = Array.isArray(normalizedAssistant.content)
+        ? (normalizedAssistant.content as unknown[])
+        : [];
+      for (const block of msgBlocks) {
+        if (!block || typeof block !== "object") {
+          continue;
+        }
+        const rec = block as { type?: unknown; id?: unknown; call_id?: unknown };
+        const id = extractToolCallId(rec);
+        if (!id || typeof rec.type !== "string" || !TOOL_CALL_TYPES.has(rec.type)) {
+          continue;
+        }
+        const fingerprint = fingerprintToolUseBlock(block);
+        if (!consumedToolUses.get(id)?.has(fingerprint)) {
+          continue;
+        }
+        for (let ahead = i + 1; ahead < messages.length; ahead += 1) {
+          if (movedToolResultIndexes.has(ahead)) {
+            continue;
+          }
+          const nextResult = messages[ahead];
+          if (
+            nextResult &&
+            typeof nextResult === "object" &&
+            nextResult.role === "toolResult" &&
+            extractToolResultId(nextResult) === id
+          ) {
+            consumedReuses.add(id);
+            break;
+          }
+        }
+      }
+    }
     const deduped = filterAssistantToolUseBlocks(
       normalizedAssistant,
-      seenToolUseIds,
+      pendingToolUses,
+      consumedToolUses,
       // Error/aborted turns are non-pairable: strip their tool_use blocks and
       // do not let them claim an id a later valid turn may legitimately reuse.
-      terminal ? { dropAll: true, record: false } : {}
+      terminal ? { dropAll: true, record: false } : { consumedReuses }
     );
     const assistantMsg = deduped.message;
+    const keptFingerprints = deduped.keptFingerprints;
     if (deduped.dropped.length > 0) {
       changed = true;
       recordAssistantToolUseDrops(deduped.dropped);
@@ -422,6 +568,9 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
     const spanResultsById = new Map<string, T>();
     const remainder: T[] = [];
 
+    // Ids the breaking assistant turn survives with: results beyond that
+    // turn for these ids belong to the newer occurrence, not this span.
+    const boundaryClaimedIds = new Set<string>();
     let j = i + 1;
     for (; j < messages.length; j += 1) {
       const next = messages[j];
@@ -439,17 +588,38 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
         const nextTerminal = getTerminalStopReason(normalizedNext) !== null;
         const preview = filterAssistantToolUseBlocks(
           normalizedNext,
-          new Set(seenToolUseIds),
+          copyToolUseFingerprints(pendingToolUses),
+          copyToolUseFingerprints(consumedToolUses),
           nextTerminal ? { dropAll: true, record: false } : {}
         );
         const nextToolCalls = nextTerminal
           ? []
           : extractToolCallsFromAssistant(preview.message);
         if (nextToolCalls.length > 0) {
+          for (const call of nextToolCalls) {
+            if (toolCallIds.has(call.id)) {
+              boundaryClaimedIds.add(call.id);
+            }
+          }
           if (preview.dropped.length > 0) {
-            const lookaheadToolUseIds = new Set(seenToolUseIds);
-            for (const call of nextToolCalls) {
-              lookaheadToolUseIds.add(call.id);
+            const lookaheadToolUses = copyToolUseFingerprints(pendingToolUses);
+            for (const block of Array.isArray(preview.message.content)
+              ? (preview.message.content as unknown[])
+              : []) {
+              if (!block || typeof block !== "object") {
+                continue;
+              }
+              const rec = block as { type?: unknown; id?: unknown; call_id?: unknown };
+              const id = extractToolCallId(rec);
+              if (id && typeof rec.type === "string" && TOOL_CALL_TYPES.has(rec.type)) {
+                const fingerprint = fingerprintToolUseBlock(block);
+                const fingerprints = lookaheadToolUses.get(id);
+                if (fingerprints) {
+                  fingerprints.add(fingerprint);
+                } else {
+                  lookaheadToolUses.set(id, new Set([fingerprint]));
+                }
+              }
             }
             // The next assistant may mix stale duplicate calls from this span
             // with new calls. Keep that assistant for its own pass, but look
@@ -468,7 +638,8 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
                   getTerminalStopReason(normalizedCandidate) !== null;
                 const candidatePreview = filterAssistantToolUseBlocks(
                   normalizedCandidate,
-                  new Set(lookaheadToolUseIds),
+                  copyToolUseFingerprints(lookaheadToolUses),
+                  copyToolUseFingerprints(consumedToolUses),
                   candidateTerminal ? { dropAll: true, record: false } : {}
                 );
                 const candidateToolCalls = candidateTerminal
@@ -483,13 +654,10 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
                 continue;
               }
               const id = extractToolResultId(candidate);
-              if (!id || !toolCallIds.has(id)) {
-                continue;
-              }
-              movedToolResultIndexes.add(k);
-              if (seenToolResultIds.has(id)) {
-                droppedDuplicateCount += 1;
-                changed = true;
+              // The breaking assistant turn already survives with this id —
+              // any result for it beyond that turn belongs to the newer
+              // occurrence, never to this span.
+              if (!id || !toolCallIds.has(id) || boundaryClaimedIds.has(id)) {
                 continue;
               }
               const existing = spanResultsById.get(id);
@@ -497,13 +665,35 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
                 spanResultsById.set(id, candidate);
               }
               if (existing) {
+                // Not selected for THIS span: leave the index un-moved so the
+                // result can still pair a later occurrence of its id (a
+                // recurrent-id reuse), it is only a duplicate for this call.
                 droppedDuplicateCount += 1;
+                changed = true;
+                continue;
               }
+              movedToolResultIndexes.add(k);
               moved = true;
               changed = true;
             }
           }
           break;
+        }
+        if (preview.dropped.length > 0 && !nextTerminal) {
+          // Assistant whose dropped duplicate ids all belong to this span AND
+          // already have a collected in-span result: defer the WHOLE assistant
+          // (text and all) to its own main pass — after this span's pair
+          // retires the fingerprints its repeated call may legitimately
+          // survive as a new occurrence (`pwd` twice). Must not depend on the
+          // message emptying: a text-bearing identical repeat otherwise lost
+          // its second call/result pair entirely. Single-result transcripts
+          // fall through to the swallow path below (keep-first store-dup).
+          const droppedIdsDeferred = preview.dropped.every(
+            (drop) => toolCallIds.has(drop.id) && spanResultsById.has(drop.id),
+          );
+          if (droppedIdsDeferred) {
+            break;
+          }
         }
         if (preview.dropped.length > 0) {
           changed = true;
@@ -519,11 +709,6 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       if (nextRole === "toolResult") {
         const id = extractToolResultId(next);
         if (id && toolCallIds.has(id)) {
-          if (seenToolResultIds.has(id)) {
-            droppedDuplicateCount += 1;
-            changed = true;
-            continue;
-          }
           const existing = spanResultsById.get(id);
           if (shouldUseCandidateToolResult(existing, next)) {
             spanResultsById.set(id, next);
@@ -550,15 +735,44 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
         continue;
       }
       const candidate = messages[k];
-      if (!candidate || typeof candidate !== "object" || candidate.role !== "toolResult") {
+      if (!candidate || typeof candidate !== "object") {
+        continue;
+      }
+      if (candidate.role === "assistant") {
+        // Results cannot cross an occurrence boundary: the next assistant turn
+        // that SURVIVES with a same-id call starts a new pending occurrence of
+        // that id, and any result beyond it belongs to the newer occurrence.
+        // Without this bound `[call X(a), call X(b), result X]` would let the
+        // first call steal the second call's result and synthesize a false
+        // missing-result error for the second.
+        const normalizedCandidate = normalizeAssistantReasoningBlocks(candidate as T);
+        const boundaryPreview = filterAssistantToolUseBlocks(
+          normalizedCandidate,
+          copyToolUseFingerprints(pendingToolUses),
+          copyToolUseFingerprints(consumedToolUses),
+          getTerminalStopReason(normalizedCandidate) !== null
+            ? { dropAll: true, record: false }
+            : {}
+        );
+        const survivesBoundaryId = extractToolCallsFromAssistant(boundaryPreview.message).some(
+          (call) => toolCallIds.has(call.id),
+        );
+        if (survivesBoundaryId) {
+          break;
+        }
+        continue;
+      }
+      if (candidate.role !== "toolResult") {
         continue;
       }
       const id = extractToolResultId(candidate);
-      if (!id || !toolCallIds.has(id) || seenToolResultIds.has(id)) {
+      if (!id || !toolCallIds.has(id) || boundaryClaimedIds.has(id)) {
         continue;
       }
       const existing = laterResultsById.get(id);
-      if (shouldUseCandidateToolResult(existing?.message, candidate)) {
+      // Occurrence-ordered pairing: the NEAREST later result pairs this call;
+      // keep-first unless it upgrades a synthetic placeholder.
+      if (!existing || shouldUseCandidateToolResult(existing.message, candidate)) {
         laterResultsById.set(id, { message: candidate, index: k });
       }
     }
@@ -570,7 +784,15 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
       changed = true;
     }
 
+    const emittedCallIds = new Set<string>();
     for (const call of toolCalls) {
+      // One result per id per assistant turn, even if the turn carries
+      // multiple same-id blocks; pairing is by id, so a second same-id call
+      // here stays pending for a genuinely later result.
+      if (emittedCallIds.has(call.id)) {
+        continue;
+      }
+      emittedCallIds.add(call.id);
       let existing = spanResultsById.get(call.id);
       const later = laterResultsById.get(call.id);
       if (later && shouldUseCandidateToolResult(existing, later.message)) {
@@ -588,6 +810,25 @@ export function sanitizeToolUseResultPairing<T extends AgentMessageLike>(
         });
         changed = true;
         pushToolResult(missing as T);
+      }
+    }
+    // Occurrence completed (paired or synthesized): retire only the
+    // fingerprints THIS assistant registered for the emitted ids, so an
+    // identical later turn is a fresh occurrence while still-pending
+    // identical repeats from before the pair remain dedup candidates.
+    for (const id of emittedCallIds) {
+      const fingerprints = pendingToolUses.get(id);
+      for (const fingerprint of keptFingerprints.get(id) ?? []) {
+        fingerprints?.delete(fingerprint);
+        const consumed = consumedToolUses.get(id);
+        if (consumed) {
+          consumed.add(fingerprint);
+        } else {
+          consumedToolUses.set(id, new Set([fingerprint]));
+        }
+      }
+      if (fingerprints && fingerprints.size === 0) {
+        pendingToolUses.delete(id);
       }
     }
 

--- a/test/empty-content-tool-result-parts.test.ts
+++ b/test/empty-content-tool-result-parts.test.ts
@@ -15,9 +15,14 @@
 //      plan calls as FAILED and retried in a loop.
 import { afterEach, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { ContextAssembler } from "../src/assembler.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
-import { cleanupEngineTestState, createEngine } from "./helpers.js";
+import {
+  cleanupEngineTestState,
+  createEngine,
+  createEngineWithConfig,
+} from "./helpers.js";
 
 afterEach(cleanupEngineTestState);
 
@@ -133,6 +138,83 @@ describe("empty-content toolResult ingest fallback (issue #992)", () => {
       );
       expect(results).toHaveLength(1);
     }
+  });
+
+  it("externalizes oversized structured details without truncation", async () => {
+    const engine = createEngineWithConfig({ largeFileTokenThreshold: 100_000 });
+    const details = { payload: "oversized plan details\n".repeat(4_000) };
+    const result = {
+      ...makeEmptyPlanResult(),
+      details,
+    } as AgentMessage;
+    const sessionId = randomUUID();
+    await engine.ingest({ sessionId, message: result });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(1);
+    const parts = await engine
+      .getConversationStore()
+      .getMessageParts(stored[0]!.messageId);
+    expect(parts).toHaveLength(1);
+
+    const metadata = JSON.parse(parts[0]!.metadata!) as {
+      details?: { externalizedFileId?: string; reference?: string };
+      externalizedFileId?: string;
+      originalByteSize?: number;
+      externalizationReason?: string;
+    };
+    const fileId = metadata.externalizedFileId;
+    expect(fileId).toMatch(/^file_[a-f0-9]{16}$/);
+    expect(metadata).toMatchObject({
+      details: { externalizedFileId: fileId },
+      externalizedFileId: fileId,
+      originalByteSize: Buffer.byteLength(JSON.stringify(details), "utf8"),
+      externalizationReason: "large_tool_result_details",
+    });
+    expect(metadata.details?.reference).toContain(fileId);
+    expect(parts[0]!.metadata).not.toContain("oversized plan details");
+
+    const storedFile = await engine.getSummaryStore().getLargeFile(fileId!);
+    expect(storedFile).not.toBeNull();
+    expect(storedFile!.mimeType).toBe("application/json");
+    expect(readFileSync(storedFile!.storageUri, "utf8")).toBe(JSON.stringify(details));
+  });
+
+  it("reuses one externalized details file across repeated live assembly", async () => {
+    const engine = createEngineWithConfig({
+      largeFileTokenThreshold: 20,
+      stubLargeToolPayloads: true,
+    });
+    const sessionId = randomUUID();
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "seed" } as AgentMessage,
+    });
+    const liveMessages = [
+      makeUpdatePlanCall(),
+      {
+        ...makeEmptyPlanResult(),
+        details: { payload: "repeated live plan details\n".repeat(200) },
+      } as AgentMessage,
+    ];
+
+    await engine.assemble({ sessionId, messages: liveMessages, tokenBudget: 100_000 });
+    await engine.assemble({ sessionId, messages: liveMessages, tokenBudget: 100_000 });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const files = await engine
+      .getSummaryStore()
+      .getLargeFilesByConversation(conversation!.conversationId);
+    expect(files).toHaveLength(1);
   });
 
   it("keeps legacy zero-part rows no worse than today (demote + drop, no crash)", async () => {

--- a/test/empty-content-tool-result-parts.test.ts
+++ b/test/empty-content-tool-result-parts.test.ts
@@ -74,6 +74,10 @@ describe("empty-content toolResult ingest fallback (issue #992)", () => {
     expect(parts[0]!.partType).toBe("tool");
     expect(parts[0]!.toolCallId).toBe("call_plan_1");
     expect(parts[0]!.toolName).toBe("update_plan");
+    // The structured `details` payload is persisted in part metadata — the
+    // lossless layer must not discard it even though text content is empty.
+    const metadata = JSON.parse(parts[0]!.metadata!) as { details?: unknown };
+    expect(metadata.details).toEqual({ plan: [{ step: "reproduce", status: "in_progress" }] });
 
     const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
     const assembled = await assembler.assemble({
@@ -97,6 +101,9 @@ describe("empty-content toolResult ingest fallback (issue #992)", () => {
     expect(resultMessage.isError).not.toBe(true);
     // Effective tool output is an empty string — never a missing-result error.
     expect(JSON.stringify(resultMessage.content)).not.toContain(MISSING_RESULT_MARKER);
+    // Provider-facing content must be a valid text block: adapters only
+    // accept text/image blocks inside toolResult message content.
+    expect(resultMessage.content).toEqual([{ type: "text", text: " " }]);
   });
 
   it("never inserts the synthetic error while the call is inside the context window", async () => {
@@ -154,6 +161,16 @@ describe("empty-content toolResult ingest fallback (issue #992)", () => {
       .getConversationStore()
       .getMessages(conversation!.conversationId);
     expect(stored).toHaveLength(2);
+    // Fabricate the legacy shape: the string-content ingest above persisted a
+    // normal text part, so delete the parts row to reconstruct the pre-fix
+    // "role=tool, empty content, zero parts" shape exactly.
+    const db = (engine as unknown as {
+      db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } };
+    }).db;
+    db.prepare(`DELETE FROM message_parts WHERE message_id = ?`).run(stored[1]!.messageId);
+    expect(
+      await engine.getConversationStore().getMessageParts(stored[1]!.messageId),
+    ).toHaveLength(0);
 
     const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
     const assembled = await assembler.assemble({

--- a/test/empty-content-tool-result-parts.test.ts
+++ b/test/empty-content-tool-result-parts.test.ts
@@ -1,0 +1,167 @@
+// Empty-content tool-result ingest fallback (issue #992 follow-up).
+//
+// Production RCA: OpenClaw's `update_plan` tool (and any third-party tool that
+// follows the same `{content: [], details: {...}}` result shape) returns a
+// toolResult whose content is an EMPTY array. Before this fix:
+//   1. Ingest `buildMessageParts()` ran the per-block loop zero times and
+//      persisted ZERO message_parts; the top-level toolCallId/toolName/isError
+//      only ever live inside part metadata, so pairing identity was lost.
+//   2. Assembly `resolveMessageItem` could not recover a toolCallId from a
+//      zero-part row and demoted role=tool to role="assistant" with [] content.
+//   3. `isEmptyMessageContent` dropped the demoted message entirely.
+//   4. `sanitizeToolUseResultPairing` then saw the assistant toolCall with no
+//      result and inserted the synthetic "missing tool result" error on every
+//      assemble while the call sat in the context window — the model read its
+//      plan calls as FAILED and retried in a loop.
+import { afterEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { ContextAssembler } from "../src/assembler.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import { cleanupEngineTestState, createEngine } from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+const MISSING_RESULT_MARKER = "[lossless-claw] missing tool result";
+
+function makeUpdatePlanCall(): AgentMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: "call_plan_1",
+        name: "update_plan",
+        arguments: { plan: [{ step: "reproduce", status: "in_progress" }] },
+      },
+    ],
+  } as AgentMessage;
+}
+
+function makeEmptyPlanResult(): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_plan_1",
+    toolName: "update_plan",
+    content: [],
+    details: { plan: [{ step: "reproduce", status: "in_progress" }] },
+  } as unknown as AgentMessage;
+}
+
+describe("empty-content toolResult ingest fallback (issue #992)", () => {
+  it("assembles a paired toolResult instead of a synthetic missing-result error", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    await engine.ingest({ sessionId, message: makeEmptyPlanResult() });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]!.role).toBe("tool");
+    // The stored text fallback is empty — the tool genuinely returned no text.
+    expect(stored[1]!.content).toBe("");
+
+    // Ingest must persist one fallback part carrying the pairing identity.
+    const parts = await engine
+      .getConversationStore()
+      .getMessageParts(stored[1]!.messageId);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("tool");
+    expect(parts[0]!.toolCallId).toBe("call_plan_1");
+    expect(parts[0]!.toolName).toBe("update_plan");
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+    });
+
+    // The empty result must NOT be demoted to assistant and dropped; both the
+    // call and its result survive assembly.
+    expect(assembled.messages).toHaveLength(2);
+    const resultMessage = assembled.messages[1] as {
+      role: string;
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: unknown;
+    };
+    expect(resultMessage.role).toBe("toolResult");
+    expect(resultMessage.toolCallId).toBe("call_plan_1");
+    expect(resultMessage.toolName).toBe("update_plan");
+    expect(resultMessage.isError).not.toBe(true);
+    // Effective tool output is an empty string — never a missing-result error.
+    expect(JSON.stringify(resultMessage.content)).not.toContain(MISSING_RESULT_MARKER);
+  });
+
+  it("never inserts the synthetic error while the call is inside the context window", async () => {
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    await engine.ingest({ sessionId, message: makeEmptyPlanResult() });
+    // Follow-up turns keep the pair inside the fresh tail on every assemble.
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "next step?" } as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+
+    for (let i = 0; i < 3; i++) {
+      const assembled = await assembler.assemble({
+        conversationId: conversation!.conversationId,
+        tokenBudget: 100_000,
+      });
+      const serialized = JSON.stringify(assembled.messages);
+      expect(serialized).not.toContain(MISSING_RESULT_MARKER);
+      const results = assembled.messages.filter(
+        (m) => m.role === "toolResult" && (m as { toolCallId?: string }).toolCallId === "call_plan_1",
+      );
+      expect(results).toHaveLength(1);
+    }
+  });
+
+  it("keeps legacy zero-part rows no worse than today (demote + drop, no crash)", async () => {
+    // Rows persisted BEFORE this fix have role=tool, content='', zero parts.
+    // There is no pairing identity left to recover — out of scope to repair —
+    // but assembly must keep handling them exactly as it does today.
+    const engine = createEngine();
+    const sessionId = randomUUID();
+
+    await engine.ingest({ sessionId, message: makeUpdatePlanCall() });
+    // Fabricate the legacy shape by ingesting a string-content tool result and
+    // then deleting its parts — do this because a pre-fix row is precisely
+    // "role=tool, empty content, zero parts".
+    await engine.ingest({
+      sessionId,
+      message: {
+        role: "toolResult",
+        toolCallId: "call_plan_1",
+        toolName: "update_plan",
+        content: "",
+      } as unknown as AgentMessage,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const stored = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(stored).toHaveLength(2);
+
+    const assembler = new ContextAssembler(engine.getConversationStore(), engine.getSummaryStore());
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 100_000,
+    });
+    // Must resolve to a finite message list without throwing.
+    expect(Array.isArray(assembled.messages)).toBe(true);
+    expect(assembled.messages.length).toBeGreaterThan(0);
+  });
+});

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4897,10 +4897,13 @@ describe("LcmContextEngine afterTurn", () => {
     expect(rows[0]!.content).toBe("redacted by logging.redactPatterns");
   });
 
-  it("afterTurn dedupes tool/toolResult messages by toolCallId", async () => {
-    // The transcript imports a redacted toolResult message carrying
-    // toolCallId="call-001"; the runtime batch arrives with the same toolCallId
-    // but original content. The previously persisted redacted row stays canonical.
+  it("afterTurn dedupes tool/toolResult messages by provider-unique toolCallId", async () => {
+    // The transcript imports a redacted toolResult message carrying a
+    // provider-unique (Anthropic toolu_) toolCallId; the runtime batch
+    // arrives with the same toolCallId but original content. The previously
+    // persisted redacted row stays canonical. Model-authored recurrent ids
+    // (e.g. Kimi `exec:101`) are intentionally NOT deduped this way — see
+    // stable-event-key-recurrent-id.test.ts.
     const engine = createEngine();
     const sessionId = "after-turn-stable-event-tool-call-id";
     const sessionKey = "agent:main:stable-event-tool-call-id";
@@ -4909,7 +4912,7 @@ describe("LcmContextEngine afterTurn", () => {
       makeMessage({
         role: "toolResult",
         content: [{ type: "text", text: "redacted by logging.redactPatterns" }],
-        toolCallId: "call-001",
+        toolCallId: "toolu_01StableEventDedupeCase",
       }),
     ]);
     await engine.bootstrap({ sessionId, sessionKey, sessionFile });
@@ -4921,7 +4924,7 @@ describe("LcmContextEngine afterTurn", () => {
         makeMessage({
           role: "toolResult",
           content: "original unredacted tool result body",
-          toolCallId: "call-001",
+          toolCallId: "toolu_01StableEventDedupeCase",
         } as never),
       ],
       prePromptMessageCount: 0,

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -2411,7 +2411,7 @@ describe("LcmContextEngine.assemble maxAssemblyTokenBudget cap", () => {
 
     // Ingest a tool result that will be stored with toolName="unknown"
     // by the assembler (assembler fills missing tool names with "unknown").
-    const toolCallId = "call_nameless_tool";
+    const toolCallId = "call_AbCdEf012345";
     const toolOutput = "tool output without a real tool name must anchor correctly";
     await engine.ingest({
       sessionId,

--- a/test/message-content-empty-tool-result.test.ts
+++ b/test/message-content-empty-tool-result.test.ts
@@ -85,11 +85,13 @@ describe("buildMessageParts empty-content tool-result fallback", () => {
     });
   });
 
-  it("handles callid-less tool rows without crashing (assembly still demotes)", () => {
+  it("handles callid-less tool rows via the legacy zero-part path (assembly demotes)", () => {
+    // No pairing id: a fallback part would rehydrate into an assistant message
+    // carrying a tool_result block with no tool_use_id — malformed provider
+    // input. ID-less empty rows keep the legacy zero-part behavior (demote
+    // to assistant, dropped by the empty-content filter).
     const parts = partsOf({ role: "tool", content: [] } as unknown as AgentMessage);
-    expect(parts).toHaveLength(1);
-    expect(parts[0]!.toolCallId).toBeNull();
-    expect(parts[0]!.toolName).toBeNull();
+    expect(parts).toHaveLength(0);
   });
 
   it("does NOT create parts for genuinely empty assistant messages", () => {
@@ -155,16 +157,18 @@ describe("buildMessageParts empty-content tool-result fallback", () => {
 });
 
 describe("fallback part assembly routing", () => {
-  it("routes through toolResultBlockFromPart via originalRole metadata", () => {
+  it("rehydrates as a provider-valid text block via the fallback metadata", () => {
     const records = partsOf(makeEmptyResult()).map((part) =>
       toSyntheticMessagePartRecord(part, 1),
     );
     const block = blockFromPart(records[0]!) as Record<string, unknown>;
-    // tool_result shape — NOT a toolCall/function_call phantom.
-    expect(block.type).toBe("tool_result");
-    expect(block.tool_use_id).toBe("call_1");
-    expect(block.name).toBe("update_plan");
-    expect(block.output).toBe(" ");
+    // Provider adapters only accept text/image blocks inside toolResult
+    // message content — the fallback rehydrates as whitespace text; pairing
+    // identity lives on the surrounding message's top-level toolCallId (set
+    // from the part by resolveMessageItem), NOT a nested tool_result block.
+    expect(block.type).toBe("text");
+    expect(block.text).toBe(" ");
+    expect(block.tool_use_id).toBeUndefined();
     expect(block.id).toBeUndefined();
     expect(block.call_id).toBeUndefined();
     expect(JSON.stringify(block)).not.toContain("emptyContentFallback");
@@ -178,35 +182,40 @@ describe("fallback part assembly routing", () => {
     expect(Array.isArray(content)).toBe(true);
     const blocks = content as Array<Record<string, unknown>>;
     expect(blocks).toHaveLength(1);
-    expect(blocks[0]!.type).toBe("tool_result");
-    expect(blocks[0]!.tool_use_id).toBe("call_1");
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[0]!.text).toBe(" ");
     // JSON round-trip: no undefined/functions.
     expect(JSON.parse(JSON.stringify(blocks[0]))).toEqual(blocks[0]);
     // Survives the universal empty-content filter.
     expect(isEmptyMessageContent({ role: "toolResult", content })).toBe(false);
   });
 
-  it("normalizeMessageContentForStorage keeps the tool_result block shape", () => {
+  it("normalizeMessageContentForStorage keeps a text block shape", () => {
     const normalized = normalizeMessageContentForStorage({
       message: makeEmptyResult(),
       fallbackContent: "",
     });
     expect(Array.isArray(normalized)).toBe(true);
     const blocks = normalized as Array<Record<string, unknown>>;
-    expect(blocks[0]!.type).toBe("tool_result");
-    expect(blocks[0]!.tool_use_id).toBe("call_1");
+    expect(blocks[0]!.type).toBe("text");
+    expect(blocks[0]!.tool_use_id).toBeUndefined();
   });
 });
 
 describe("live-coverage signature stability across DB round-trip", () => {
-  it("live empty-content result matches its assembled reconstruction (no id)", () => {
-    const liveMessage = makeEmptyResult();
+  it("live empty-content result matches its assembled reconstruction", () => {
+    const liveMessage = makeEmptyResult({ toolCallId: "call_0123456789abcdef" });
     const assembled = {
       role: "toolResult",
-      toolCallId: "call_1",
+      toolCallId: "call_0123456789abcdef",
       toolName: "update_plan",
       content: [
-        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+        {
+          type: "tool_result",
+          name: "update_plan",
+          output: " ",
+          tool_use_id: "call_0123456789abcdef",
+        },
       ],
     } as unknown as AgentMessage;
     expect(createLiveCoverageSignature(liveMessage)).toBe(
@@ -217,26 +226,54 @@ describe("live-coverage signature stability across DB round-trip", () => {
   it("live empty-content result with tool_use_id block id matches assembly", () => {
     // The live shape carries the tool_result block with tool_use_id but may
     // lack a top-level toolName. The assembled shape has toolName filled in
-    // from part metadata. Both have the same toolCallId, so the canonical
-    // empty-tool-result signature keys on (role, toolCallId) only — toolName
-    // is intentionally omitted because it may be present on one
-    // representation and absent on the other.
+    // from part metadata. Both have the same provider-unique toolCallId, so
+    // the canonical empty-tool-result signature keys on (role, toolCallId)
+    // only — toolName is intentionally omitted because it may be present on
+    // one representation and absent on the other.
     const liveIded = {
       role: "toolResult",
-      toolCallId: "call_1",
-      content: [{ type: "tool_result", tool_use_id: "call_1", output: "" }],
+      toolCallId: "call_0123456789abcdef",
+      content: [{ type: "tool_result", tool_use_id: "call_0123456789abcdef", output: "" }],
     } as unknown as AgentMessage;
     const assembled = {
       role: "toolResult",
-      toolCallId: "call_1",
+      toolCallId: "call_0123456789abcdef",
       toolName: "update_plan",
       content: [
-        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+        {
+          type: "tool_result",
+          name: "update_plan",
+          output: " ",
+          tool_use_id: "call_0123456789abcdef",
+        },
       ],
     } as unknown as AgentMessage;
     expect(createLiveCoverageSignature(liveIded)).toBe(
       createLiveCoverageSignature(assembled),
     );
+  });
+
+  it("canonical empty-result signature refuses recurrent model-authored ids", () => {
+    // Kimi K3 `name:N` counters recur across turns: (role, toolCallId) does
+    // not identify an event, so recurrent ids must fall back to the full
+    // lossless signature (byte-shaped), distinct per representation.
+    const liveRecurrent = makeEmptyResult({ toolCallId: "update_plan:7" });
+    expect(createLiveCoverageSignature(liveRecurrent)).not.toContain(
+      "canonical-empty-tool-result",
+    );
+    const assembledRecurrent = {
+      role: "toolResult",
+      toolCallId: "update_plan:7",
+      content: [
+        { type: "tool_result", output: " ", tool_use_id: "update_plan:7" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(assembledRecurrent)).not.toContain(
+      "canonical-empty-tool-result",
+    );
+    expect(
+      createLiveCoverageSignature(makeEmptyResult({ toolCallId: "toolu_01CanonicalTestID" })),
+    ).toContain("canonical-empty-tool-result");
   });
 
   it("live empty-content result with NO call id does not signature-collide with an ided row", () => {

--- a/test/message-content-empty-tool-result.test.ts
+++ b/test/message-content-empty-tool-result.test.ts
@@ -39,6 +39,16 @@ function partsOf(message: AgentMessage, fallbackContent = "") {
 }
 
 describe("buildMessageParts empty-content tool-result fallback", () => {
+  it("rejects oversized details that were not externalized before persistence", () => {
+    const message = makeEmptyResult({
+      details: { payload: "x".repeat(65_537) },
+    });
+
+    expect(() => partsOf(message)).toThrow(
+      "Oversized empty tool-result details must be externalized before persistence",
+    );
+  });
+
   it("emits one fallback part carrying pairing identity", () => {
     const parts = partsOf(makeEmptyResult());
     expect(parts).toHaveLength(1);
@@ -249,6 +259,27 @@ describe("live-coverage signature stability across DB round-trip", () => {
       ],
     } as unknown as AgentMessage;
     expect(createLiveCoverageSignature(liveIded)).toBe(
+      createLiveCoverageSignature(assembled),
+    );
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["empty array", []],
+  ])("live tool_result block with %s content matches assembly", (_label, content) => {
+    const toolCallId = "call_0123456789abcdef";
+    const live = {
+      role: "toolResult",
+      toolCallId,
+      content: [{ type: "tool_result", tool_use_id: toolCallId, content }],
+    } as unknown as AgentMessage;
+    const assembled = {
+      role: "toolResult",
+      toolCallId,
+      content: [{ type: "text", text: " " }],
+    } as unknown as AgentMessage;
+
+    expect(createLiveCoverageSignature(live)).toBe(
       createLiveCoverageSignature(assembled),
     );
   });

--- a/test/message-content-empty-tool-result.test.ts
+++ b/test/message-content-empty-tool-result.test.ts
@@ -1,0 +1,288 @@
+// buildMessageParts empty-content tool-result fallback — unit coverage.
+//
+// Complements the ingest→assemble regression in
+// test/empty-content-tool-result-parts.test.ts with focused unit checks:
+//   - exactly which empty-array shapes gain the fallback part (role-gated)
+//   - pairing identity / isError preserved in metadata
+//   - the fallback part routes through toolResultBlockFromPart (never raw
+//     passthrough → a phantom toolCall block)
+//   - createLiveCoverageSignature is stable across the live transcript shape
+//     and the assembled DB round-trip shape (prevents double-emitting the
+//     live message next to the assembled row)
+//   - unchanged behavior for ≥1-part shapes and empty user/assistant shapes
+import { describe, expect, it } from "vitest";
+import {
+  blockFromPart,
+  contentFromParts,
+  isEmptyMessageContent,
+} from "../src/assembler.js";
+import {
+  buildMessageParts,
+  normalizeMessageContentForStorage,
+  toSyntheticMessagePartRecord,
+} from "../src/message-content.js";
+import { createLiveCoverageSignature } from "../src/message-signatures.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+
+function makeEmptyResult(overrides: Record<string, unknown> = {}): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    toolName: "update_plan",
+    content: [],
+    ...overrides,
+  } as unknown as AgentMessage;
+}
+
+function partsOf(message: AgentMessage, fallbackContent = "") {
+  return buildMessageParts({ sessionId: "test", message, fallbackContent });
+}
+
+describe("buildMessageParts empty-content tool-result fallback", () => {
+  it("emits one fallback part carrying pairing identity", () => {
+    const parts = partsOf(makeEmptyResult());
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({
+      partType: "tool",
+      ordinal: 0,
+      textContent: " ",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+    });
+    const metadata = JSON.parse(parts[0]!.metadata!);
+    expect(metadata).toMatchObject({
+      originalRole: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      emptyContentFallback: true,
+    });
+  });
+
+  it("preserves top-level isError in fallback metadata", () => {
+    const parts = partsOf(makeEmptyResult({ isError: true }));
+    expect(parts).toHaveLength(1);
+    const metadata = JSON.parse(parts[0]!.metadata!);
+    expect(metadata.isError).toBe(true);
+    const pickIsError = JSON.parse(parts[0]!.metadata!) as { isError?: boolean };
+    expect(pickIsError.isError).toBe(true);
+  });
+
+  it("handles the raw 'tool' role shape", () => {
+    const parts = partsOf({
+      role: "tool",
+      toolCallId: "call_t",
+      toolName: "some_tool",
+      content: [],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.toolCallId).toBe("call_t");
+    // The fallback always identifies as toolResult so blockFromPart routes
+    // through toolResultBlockFromPart (not toolCallBlockFromPart).
+    expect(JSON.parse(parts[0]!.metadata!)).toMatchObject({
+      originalRole: "toolResult",
+      rawType: "tool_result",
+      emptyContentFallback: true,
+    });
+  });
+
+  it("handles callid-less tool rows without crashing (assembly still demotes)", () => {
+    const parts = partsOf({ role: "tool", content: [] } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.toolCallId).toBeNull();
+    expect(parts[0]!.toolName).toBeNull();
+  });
+
+  it("does NOT create parts for genuinely empty assistant messages", () => {
+    expect(partsOf({ role: "assistant", content: [] } as AgentMessage)).toHaveLength(0);
+  });
+
+  it("does NOT create parts for empty user messages", () => {
+    expect(partsOf({ role: "user", content: [] } as AgentMessage)).toHaveLength(0);
+  });
+
+  it("does NOT latch onto an id-bearing non-tool message (no phantom toolCalls)", () => {
+    // A hypothetical assistant message with empty content and a top-level id
+    // must not become a "tool" part: blockFromPart would otherwise emit a
+    // phantom toolCall block in the assembled transcript.
+    const parts = partsOf({
+      role: "assistant",
+      id: "some-id",
+      content: [],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(0);
+  });
+
+  it("keeps assistant content=[] + reasoning_content unchanged (reasoning part only)", () => {
+    const parts = partsOf({
+      role: "assistant",
+      content: [],
+      reasoning_content: "internal thinking",
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("reasoning");
+  });
+
+  it("leaves string-content tool results untouched (no fallback part)", () => {
+    const parts = partsOf(
+      {
+        role: "toolResult",
+        toolCallId: "call_s",
+        content: "Plan updated",
+      } as unknown as AgentMessage,
+      "Plan updated",
+    );
+    expect(parts).toHaveLength(1);
+    expect(parts[0]!.partType).toBe("text");
+    expect(parts[0]!.textContent).toBe("Plan updated");
+    expect(JSON.parse(parts[0]!.metadata!).emptyContentFallback).toBeUndefined();
+  });
+
+  it("leaves non-empty block-array tool results untouched", () => {
+    const parts = partsOf({
+      role: "toolResult",
+      toolCallId: "call_b",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_b",
+          content: [{ type: "text", text: "output text" }],
+        },
+      ],
+    } as unknown as AgentMessage);
+    expect(parts).toHaveLength(1);
+    expect(JSON.parse(parts[0]!.metadata!).emptyContentFallback).toBeUndefined();
+  });
+});
+
+describe("fallback part assembly routing", () => {
+  it("routes through toolResultBlockFromPart via originalRole metadata", () => {
+    const records = partsOf(makeEmptyResult()).map((part) =>
+      toSyntheticMessagePartRecord(part, 1),
+    );
+    const block = blockFromPart(records[0]!) as Record<string, unknown>;
+    // tool_result shape — NOT a toolCall/function_call phantom.
+    expect(block.type).toBe("tool_result");
+    expect(block.tool_use_id).toBe("call_1");
+    expect(block.name).toBe("update_plan");
+    expect(block.output).toBe(" ");
+    expect(block.id).toBeUndefined();
+    expect(block.call_id).toBeUndefined();
+    expect(JSON.stringify(block)).not.toContain("emptyContentFallback");
+  });
+
+  it("contentFromParts yields a serializable toolResult content (Anthropic + OpenAI)", () => {
+    const records = partsOf(makeEmptyResult()).map((part) =>
+      toSyntheticMessagePartRecord(part, 1),
+    );
+    const content = contentFromParts(records, "toolResult", "");
+    expect(Array.isArray(content)).toBe(true);
+    const blocks = content as Array<Record<string, unknown>>;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("tool_result");
+    expect(blocks[0]!.tool_use_id).toBe("call_1");
+    // JSON round-trip: no undefined/functions.
+    expect(JSON.parse(JSON.stringify(blocks[0]))).toEqual(blocks[0]);
+    // Survives the universal empty-content filter.
+    expect(isEmptyMessageContent({ role: "toolResult", content })).toBe(false);
+  });
+
+  it("normalizeMessageContentForStorage keeps the tool_result block shape", () => {
+    const normalized = normalizeMessageContentForStorage({
+      message: makeEmptyResult(),
+      fallbackContent: "",
+    });
+    expect(Array.isArray(normalized)).toBe(true);
+    const blocks = normalized as Array<Record<string, unknown>>;
+    expect(blocks[0]!.type).toBe("tool_result");
+    expect(blocks[0]!.tool_use_id).toBe("call_1");
+  });
+});
+
+describe("live-coverage signature stability across DB round-trip", () => {
+  it("live empty-content result matches its assembled reconstruction (no id)", () => {
+    const liveMessage = makeEmptyResult();
+    const assembled = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveMessage)).toBe(
+      createLiveCoverageSignature(assembled),
+    );
+  });
+
+  it("live empty-content result with tool_use_id block id matches assembly", () => {
+    // The live shape carries the tool_result block with tool_use_id but may
+    // lack a top-level toolName. The assembled shape has toolName filled in
+    // from part metadata. Both have the same toolCallId, so the canonical
+    // empty-tool-result signature keys on (role, toolCallId) only — toolName
+    // is intentionally omitted because it may be present on one
+    // representation and absent on the other.
+    const liveIded = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "tool_result", tool_use_id: "call_1", output: "" }],
+    } as unknown as AgentMessage;
+    const assembled = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "update_plan",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveIded)).toBe(
+      createLiveCoverageSignature(assembled),
+    );
+  });
+
+  it("live empty-content result with NO call id does not signature-collide with an ided row", () => {
+    // The id-less result falls back to the full lossless signature (which
+    // includes parts metadata) while the ided result canonicalizes to
+    // canonical-empty-tool-result — they cannot collide.
+    const liveNoId = {
+      role: "toolResult",
+      content: [{ type: "tool_result", output: "" }],
+    } as unknown as AgentMessage;
+    const assembledWithId = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [
+        { type: "tool_result", name: "update_plan", output: " ", tool_use_id: "call_1" },
+      ],
+    } as unknown as AgentMessage;
+    expect(createLiveCoverageSignature(liveNoId)).not.toBe(
+      createLiveCoverageSignature(assembledWithId),
+    );
+  });
+
+  it("does NOT canonicalize a tool_result block with real content as empty (autoreview P1)", () => {
+    // A tool_result block whose structured text extraction is empty (because
+    // extractStructuredText skips tool blocks) but whose raw.content carries
+    // a real text payload must NOT be canonicalized as an empty result —
+    // otherwise coverage dedup would suppress the live representation.
+    const liveWithContent = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "call_1",
+          content: [{ type: "text", text: "real output" }],
+        },
+      ],
+    } as unknown as AgentMessage;
+    const emptyResult = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [],
+    } as unknown as AgentMessage;
+    // The content-bearing message must NOT match the empty result's signature.
+    expect(createLiveCoverageSignature(liveWithContent)).not.toBe(
+      createLiveCoverageSignature(emptyResult),
+    );
+  });
+});

--- a/test/migrate-sessions.test.ts
+++ b/test/migrate-sessions.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, appendFileSync, readFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -168,6 +168,56 @@ describe("runSessionMigration", () => {
       });
     } finally {
       closeLcmConnection(db);
+    }
+  });
+
+  it("externalizes oversized empty tool-result details during migration", async () => {
+    const root = tempRoot();
+    const details = { payload: "migrated details\n".repeat(5_000) };
+    writeAgentSession(root, "session-details.jsonl", [
+      sessionHeader("session-details"),
+      {
+        type: "message",
+        id: "m1",
+        parentId: null,
+        timestamp: "2026-06-10T00:00:00.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call_migration_details",
+          toolName: "update_plan",
+          content: [],
+          details,
+        },
+      },
+    ]);
+    const dbPath = migratedDb(root);
+
+    const result = await runSessionMigration({ dbPath, stateDir: root, apply: true });
+
+    expect(result.files[0]).toMatchObject({ status: "imported", importedMessages: 1 });
+    const migrated = openMigratedDb(dbPath);
+    try {
+      const conversation = await migrated.conversationStore.getConversationForSession({
+        sessionId: "session-details",
+      });
+      expect(conversation).not.toBeNull();
+      const files = await migrated.summaryStore.getLargeFilesByConversation(
+        conversation!.conversationId,
+      );
+      expect(files).toHaveLength(1);
+      expect(files[0]!.mimeType).toBe("application/json");
+      expect(readFileSync(files[0]!.storageUri, "utf8")).toBe(JSON.stringify(details));
+
+      const messages = await migrated.conversationStore.getMessages(conversation!.conversationId);
+      const parts = await migrated.conversationStore.getMessageParts(messages[0]!.messageId);
+      const metadata = JSON.parse(parts[0]!.metadata!) as Record<string, unknown>;
+      expect(metadata).toMatchObject({
+        externalizedFileId: files[0]!.fileId,
+        externalizationReason: "large_tool_result_details",
+      });
+      expect(parts[0]!.metadata).not.toContain("migrated details");
+    } finally {
+      closeLcmConnection(migrated.db);
     }
   });
 

--- a/test/stable-event-key-conflict.test.ts
+++ b/test/stable-event-key-conflict.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Store-level backstop: a stable-event-key unique index conflict must never
+ * lose the row (P3 — prefer duplicate emission over dropped ingestion). The
+ * colliding row is persisted with stable_event_key NULL and the conflict hook
+ * fires so operators see the violated uniqueness invariant.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import {
+  cleanupEngineTestState,
+  createEngineWithDepsOverrides,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+describe("ConversationStore stable-event-key conflict degradation", () => {
+  it("persists the colliding row with a NULL stable key and notifies the conflict hook", async () => {
+    const warn = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    const conversationStore: ConversationStore = engine.getConversationStore();
+    const conversation = await conversationStore.getOrCreateConversation("stable-key-conflict");
+
+    const first = await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "tool",
+      content: "first result",
+      tokenCount: 1,
+      stableEventKey: "tool-result:call_conflictTest001",
+      skipReplayTimestampFloodGuard: true,
+    });
+    expect(first).toBeTruthy();
+
+    // A second row with a different event body but the same stable key — the
+    // "provider-unique" assumption was violated upstream. The row must
+    // persist anyway.
+    const second = await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 1,
+      role: "tool",
+      content: "second result",
+      tokenCount: 1,
+      stableEventKey: "tool-result:call_conflictTest001",
+      skipReplayTimestampFloodGuard: true,
+    });
+    expect(second.messageId).not.toBe(first.messageId);
+
+    const rows = await conversationStore.getMessages(conversation.conversationId);
+    expect(rows.map((row) => row.content)).toEqual(["first result", "second result"]);
+    expect(
+      warn.mock.calls.some((call) => String(call[0]).includes("stable-event-key unique conflict")),
+    ).toBe(true);
+  });
+
+  it("bulk insert path persists colliding rows too", async () => {
+    const engine = createEngineWithDepsOverrides({
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const conversationStore = engine.getConversationStore();
+    const conversation = await conversationStore.getOrCreateConversation("stable-key-conflict-bulk");
+
+    const created = await conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "tool",
+        content: "first bulk",
+        tokenCount: 1,
+        stableEventKey: "tool-result:call_bulkConflict001",
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "tool",
+        content: "second bulk",
+        tokenCount: 1,
+        stableEventKey: "tool-result:call_bulkConflict001",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    expect(created.length).toBe(2);
+    const rows = await conversationStore.getMessages(conversation.conversationId);
+    expect(rows.map((row) => row.content)).toEqual(["first bulk", "second bulk"]);
+  });
+});

--- a/test/stable-event-key-recurrent-id.test.ts
+++ b/test/stable-event-key-recurrent-id.test.ts
@@ -173,14 +173,15 @@ describe("recurrent model-authored toolCallIds (K3 pattern)", () => {
     expect(rows[0]!.content).toBe("redacted by logging.redactPatterns");
   });
 
-  it("assembly after recurrent-id ingestion inserts no synthetic missing-tool-result errors", async () => {
+  it("assembly preserves every recurrent-id call/result occurrence (occurrence-scoped pairing)", async () => {
     const engine = createEngine();
     const sessionId = "k3-recurrent-id-assembly";
     const sessionFile = createSessionFilePath("k3-recurrent-id-assembly");
     writeLeafTranscriptMessages(sessionFile, []);
     await engine.bootstrap({ sessionId, sessionFile });
 
-    for (const command of ["ls /tmp/a", "ls /tmp/b", "ls /tmp/c"]) {
+    const commands = ["ls /tmp/a", "ls /tmp/b", "ls /tmp/c"];
+    for (const command of commands) {
       await engine.ingest({ sessionId, message: makeMessage({ role: "user", content: `run ${command}` }) });
       await engine.ingest({ sessionId, message: assistantToolCall("exec:101", command) });
       await engine.ingest({ sessionId, message: toolResult("exec:101") });
@@ -197,5 +198,21 @@ describe("recurrent model-authored toolCallIds (K3 pattern)", () => {
     });
     const payload = JSON.stringify(assembled.messages);
     expect(payload).not.toContain("missing tool result");
+
+    // All three occurrences must survive: three tool_use blocks with distinct
+    // arguments and three results, not just the first pair.
+    const toolUseBlocks = assembled.messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? (message.content as Array<Record<string, unknown>>).filter(
+            (block) => block && block.type === "tool_use",
+          )
+        : [],
+    );
+    const resultMessages = assembled.messages.filter(
+      (message) => message.role === "toolResult",
+    );
+    expect(toolUseBlocks.length).toBe(commands.length);
+    expect(toolUseBlocks.map((block) => (block.input as { command: string }).command)).toEqual(commands);
+    expect(resultMessages.length).toBe(commands.length);
   });
 });

--- a/test/stable-event-key-recurrent-id.test.ts
+++ b/test/stable-event-key-recurrent-id.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression repro: recurrent model-authored tool-call ids (Kimi K3 style
+ * `name:N`, e.g. `exec:101`) must never be treated as globally unique event
+ * identities. After PR #1040/8ac4720 the stable-event-key short-circuit in
+ * ingestSingle skipped every tool result whose toolCallId had been persisted
+ * before — on a model that recycles the same ~30 ids each hour this silently
+ * dropped nearly all tool results (2026-08-02 incident, conversation 476).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { ContextAssembler } from "../src/assembler.js";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import {
+  appendSessionMessage,
+  cleanupEngineTestState,
+  createEngine,
+  createSessionFilePath,
+  makeMessage,
+  writeLeafTranscriptMessages,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+const NO_OUTPUT = "(no output)";
+
+function assistantToolCall(id: string, command: string): AgentMessage {
+  return makeMessage({
+    role: "assistant",
+    content: [{ type: "tool_use", id, name: "exec", input: { command } }],
+  });
+}
+
+function toolResult(id: string): AgentMessage {
+  return makeMessage({
+    role: "toolResult",
+    toolCallId: id,
+    content: [{ type: "text", text: NO_OUTPUT }],
+  });
+}
+
+describe("recurrent model-authored toolCallIds (K3 pattern)", () => {
+  it("persists every tool result when the same recurrent toolCallId repeats with identical content", async () => {
+    const engine = createEngine();
+    const sessionId = "k3-recurrent-id-repro";
+
+    // Three K3 turns reusing exec:101 with byte-identical "(no output)"
+    // results — the exact pattern from the live incident.
+    for (const command of ["ls /tmp/a", "ls /tmp/b", "ls /tmp/c"]) {
+      await engine.ingest({ sessionId, message: makeMessage({ role: "user", content: `run ${command}` }) });
+      await engine.ingest({ sessionId, message: assistantToolCall("exec:101", command) });
+      await engine.ingest({ sessionId, message: toolResult("exec:101") });
+    }
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const rows = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const results = rows.filter((row) => row.role === "tool");
+    expect(results.length).toBe(3);
+    expect(results.every((row) => row.content === NO_OUTPUT)).toBe(true);
+  });
+
+  it("persists transcript-imported results even when a same-toolCallId row already exists", async () => {
+    // The incident shape: a previous occurrence of recurrent id exec:101 is
+    // already persisted AND stamped with its transcript entry id; a later
+    // DISTINCT transcript entry (new unique rawId, same model-authored id,
+    // same "(no output)" body) must still import. Pre-fix the stable-event
+    // short-circuit dropped it; the partial unique index then made the loss
+    // unrecoverable.
+    const engine = createEngine();
+    const sessionId = "k3-recurrent-id-transcript-import";
+    const sessionKey = "agent:main:k3-recurrent-id-transcript-import";
+    const sessionFile = createSessionFilePath("k3-recurrent-id-transcript-import");
+
+    writeLeafTranscriptMessages(sessionFile, []);
+    const sm = SessionManager.open(sessionFile);
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run ls /tmp/a" }));
+    appendSessionMessage(sm, assistantToolCall("exec:101", "ls /tmp/a"));
+    appendSessionMessage(sm, toolResult("exec:101"));
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    // A later turn reuses the recurrent id: same id, same result body, new
+    // transcript entry id.
+    appendSessionMessage(sm, makeMessage({ role: "user", content: "run ls /tmp/b" }));
+    appendSessionMessage(sm, assistantToolCall("exec:101", "ls /tmp/b"));
+    appendSessionMessage(sm, toolResult("exec:101"));
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const rows = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const results = rows.filter((row) => row.role === "tool");
+    expect(results.length).toBe(2);
+    expect(results.every((row) => row.content === NO_OUTPUT)).toBe(true);
+  });
+
+  it("persists constant-content results from upstream OpenClaw (update_plan 'Plan updated'), even with repeated ids", async () => {
+    // Upstream OpenClaw 87d5cb9f674 makes update_plan / agents-wait return a
+    // CONSTANT result string. Combined with recurrent model-authored ids this
+    // is the permanent collision class: content and toolCallId both
+    // non-discriminating. Every event must still persist.
+    const engine = createEngine();
+    const sessionId = "k3-constant-content-results";
+
+    for (let turn = 0; turn < 4; turn += 1) {
+      await engine.ingest({ sessionId, message: makeMessage({ role: "user", content: `turn ${turn}` }) });
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({
+          role: "assistant",
+          content: [{ type: "tool_use", id: "update_plan:7", name: "update_plan", input: { plan: [`step ${turn}`] } }],
+        }),
+      });
+      await engine.ingest({
+        sessionId,
+        message: makeMessage({
+          role: "tool",
+          toolCallId: "update_plan:7",
+          content: "Plan updated",
+        }),
+      });
+    }
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const rows = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    const results = rows.filter((row) => row.role === "tool");
+    expect(results.length).toBe(4);
+    expect(results.every((row) => row.content === "Plan updated")).toBe(true);
+  });
+
+  it("still dedupes redacted twins carrying provider-unique tool ids (original #1040 behavior)", async () => {
+    const engine = createEngine();
+    const sessionId = "unique-id-redacted-twin";
+    const sessionKey = "agent:main:unique-id-redacted-twin";
+    const sessionFile = createSessionFilePath("unique-id-redacted-twin");
+
+    writeLeafTranscriptMessages(sessionFile, [
+      makeMessage({
+        role: "toolResult",
+        content: [{ type: "text", text: "redacted by logging.redactPatterns" }],
+        toolCallId: "toolu_01Y9u9D2Vrv7VdWeLPvHUfwU",
+      }),
+    ]);
+    await engine.bootstrap({ sessionId, sessionKey, sessionFile });
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [
+        makeMessage({
+          role: "toolResult",
+          content: "original unredacted tool result body",
+          toolCallId: "toolu_01Y9u9D2Vrv7VdWeLPvHUfwU",
+        } as never),
+      ],
+      prePromptMessageCount: 0,
+      tokenBudget: 4096,
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const rows = await engine.getConversationStore().getMessages(conversation!.conversationId);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.content).toBe("redacted by logging.redactPatterns");
+  });
+
+  it("assembly after recurrent-id ingestion inserts no synthetic missing-tool-result errors", async () => {
+    const engine = createEngine();
+    const sessionId = "k3-recurrent-id-assembly";
+    const sessionFile = createSessionFilePath("k3-recurrent-id-assembly");
+    writeLeafTranscriptMessages(sessionFile, []);
+    await engine.bootstrap({ sessionId, sessionFile });
+
+    for (const command of ["ls /tmp/a", "ls /tmp/b", "ls /tmp/c"]) {
+      await engine.ingest({ sessionId, message: makeMessage({ role: "user", content: `run ${command}` }) });
+      await engine.ingest({ sessionId, message: assistantToolCall("exec:101", command) });
+      await engine.ingest({ sessionId, message: toolResult("exec:101") });
+    }
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    const assembler = new ContextAssembler(
+      engine.getConversationStore(),
+      engine.getSummaryStore(),
+    );
+    const assembled = await assembler.assemble({
+      conversationId: conversation!.conversationId,
+      tokenBudget: 64_000,
+    });
+    const payload = JSON.stringify(assembled.messages);
+    expect(payload).not.toContain("missing tool result");
+  });
+});

--- a/test/stable-event-key.test.ts
+++ b/test/stable-event-key.test.ts
@@ -20,35 +20,63 @@ describe("extractStableEventKey", () => {
     expect(key).toBe("assistant-response:r-2");
   });
 
-  it("returns a tool-result key for tool/toolResult messages with toolCallId", () => {
+  it("returns a tool-result key for provider-unique toolCallIds", () => {
     expect(
-      extractStableEventKey({ role: "tool", content: "ok", toolCallId: "call-1" } as never),
-    ).toBe("tool-result:call-1");
+      extractStableEventKey({
+        role: "tool",
+        content: "ok",
+        toolCallId: "toolu_01Y9u9D2Vrv7VdWeLPvHUfwU",
+      } as never),
+    ).toBe("tool-result:toolu_01Y9u9D2Vrv7VdWeLPvHUfwU");
     expect(
       extractStableEventKey({
         role: "toolResult",
         content: "ok",
-        toolCallId: "call-1",
+        toolCallId: "call_9WAWztsl7y7GR4dDUMm9eUAr",
       } as never),
-    ).toBe("tool-result:call-1");
+    ).toBe("tool-result:call_9WAWztsl7y7GR4dDUMm9eUAr");
   });
 
-  it("returns a tool-result key using toolUseId fallback for tool messages", () => {
+  it("returns null for recurrent model-authored counter ids (Kimi K3 name:N pattern)", () => {
+    // These ids recur across turns; using them as global stable keys silently
+    // drops DISTINCT events (2026-08-02 incident). They must fall back to the
+    // content/adjacency-bound dedup paths instead.
+    expect(
+      extractStableEventKey({ role: "tool", content: "(no output)", toolCallId: "exec:101" } as never),
+    ).toBeNull();
+    expect(
+      extractStableEventKey({ role: "toolResult", content: "ok", toolCallId: "read:92" } as never),
+    ).toBeNull();
+    expect(
+      extractStableEventKey({ role: "tool", content: "ok", toolCallId: "web_search:45" } as never),
+    ).toBeNull();
+  });
+
+  it("returns null for unproven short or dash-shaped tool ids", () => {
+    expect(
+      extractStableEventKey({ role: "tool", content: "ok", toolCallId: "call-001" } as never),
+    ).toBeNull();
+    expect(
+      extractStableEventKey({ role: "tool", content: "ok", toolCallId: "call_1" } as never),
+    ).toBeNull();
+  });
+
+  it("returns a tool-result key using toolUseId fallback for tool messages when provider-unique", () => {
     const key = extractStableEventKey({
       role: "tool",
       content: "ok",
-      toolUseId: "call-x",
+      toolUseId: "toolu_01XkkPwLiXaNDMNmTGgNzma4",
     } as never);
-    expect(key).toBe("tool-result:call-x");
+    expect(key).toBe("tool-result:toolu_01XkkPwLiXaNDMNmTGgNzma4");
   });
 
-  it("returns a tool-result key when top-level and block ids agree", () => {
+  it("returns a tool-result key when top-level and block ids agree and are provider-unique", () => {
     const key = extractStableEventKey({
       role: "toolResult",
-      toolCallId: "call-1",
-      content: [{ type: "tool_result", tool_use_id: "call-1", output: "ok" }],
+      toolCallId: "toolu_01Xe9eNfegbyW44MtSfQHnJF",
+      content: [{ type: "tool_result", tool_use_id: "toolu_01Xe9eNfegbyW44MtSfQHnJF", output: "ok" }],
     } as never);
-    expect(key).toBe("tool-result:call-1");
+    expect(key).toBe("tool-result:toolu_01Xe9eNfegbyW44MtSfQHnJF");
   });
 
   it("returns null for aggregate tool-result messages", () => {

--- a/test/transcript-repair.test.ts
+++ b/test/transcript-repair.test.ts
@@ -282,19 +282,27 @@ describe("sanitizeToolUseResultPairing", () => {
   const toolResultIds = (messages: Msg[]): string[] =>
     messages.filter((m) => m.role === "toolResult" && m.toolCallId).map((m) => m.toolCallId as string);
 
-  it("drops a duplicate assistant tool_use id repeated across two messages", () => {
+  it("drops a byte-identical assistant tool_use repeat while the first call is still pending", () => {
+    // A pending (not-yet-paired) call repeated byte-identically is a store
+    // double-write; the later identical block drops keep-first. Repeats that
+    // arrive with their own later result are distinct occurrences — see the
+    // recurrent-id occurrence semantics suite below.
     const out = sanitizeToolUseResultPairing<Msg>([
       { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
-      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "out-1" }] },
       { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
-      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "out-2" }] },
+      { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "out-1" }] },
     ]);
 
     expect(assistantToolUseIds(out)).toEqual(["X"]);
     expect(toolResultIds(out)).toEqual(["X"]);
   });
 
-  it("keeps a distinct tool_use in a later message while dropping the duplicate block", () => {
+  it("keeps a repeated id as a fresh occurrence when a pairable later result exists", () => {
+    // Occurrence-scoped pairing: the second X call reuses an id whose first
+    // occurrence already paired, and a second X result exists for it — the
+    // same shape as `pwd` run twice or a store double-write. Prefer emitting
+    // both occurrences (recoverable by repair-time dedup) over dropping a
+    // possibly-genuine event.
     const out = sanitizeToolUseResultPairing<Msg>([
       { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
       { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "x" }] },
@@ -309,8 +317,8 @@ describe("sanitizeToolUseResultPairing", () => {
       { role: "toolResult", toolCallId: "Y", content: [{ type: "text", text: "y" }] },
     ]);
 
-    expect(assistantToolUseIds(out).sort()).toEqual(["X", "Y"]);
-    expect(toolResultIds(out).sort()).toEqual(["X", "Y"]);
+    expect(assistantToolUseIds(out).sort()).toEqual(["X", "X", "Y"]);
+    expect(toolResultIds(out).sort()).toEqual(["X", "X", "Y"]);
   });
 
   it("moves a delayed real result before a mixed duplicate and new tool_use turn", () => {
@@ -466,9 +474,8 @@ describe("sanitizeToolUseResultPairing", () => {
     sanitizeToolUseResultPairing<Msg>(
       [
         { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
-        { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "a" }] },
         { role: "assistant", content: [{ type: "toolCall", id: "X", name: "bash" }] },
-        { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "b" }] },
+        { role: "toolResult", toolCallId: "X", content: [{ type: "text", text: "a" }] },
       ],
       { warn: (m) => warnings.push(m) }
     );
@@ -490,4 +497,96 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(warnings[0]).not.toContain("duplicate");
   });
 
+});
+
+describe("sanitizeToolUseResultPairing recurrent-id occurrence semantics", () => {
+  type Msg = {
+    role: string;
+    content?: unknown;
+    toolCallId?: string;
+    toolUseId?: string;
+    toolName?: string;
+    stopReason?: string;
+    stop_reason?: string;
+    isError?: boolean;
+  };
+
+  it("keeps identical-args repeats with their own results (`pwd` twice)", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "exec:7", name: "exec", arguments: { command: "pwd" } }] },
+      { role: "toolResult", toolCallId: "exec:7", content: [{ type: "text", text: "/home/jet" }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "exec:7", name: "exec", arguments: { command: "pwd" } }] },
+      { role: "toolResult", toolCallId: "exec:7", content: [{ type: "text", text: "/home/jet" }] },
+    ]);
+    expect(out.filter((m) => m.role === "assistant").length).toBe(2);
+    expect(out.filter((m) => m.role === "toolResult").length).toBe(2);
+    expect(JSON.stringify(out)).not.toContain("missing tool result");
+  });
+
+  it("does not let an earlier call steal a result past the next same-id occurrence", () => {
+    // [call X(a), call X(b), result X]: the result belongs to the newest
+    // pending occurrence; the first call gets a synthetic placeholder instead
+    // of stealing the second call's result.
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "exec:9", name: "exec", arguments: { command: "ls /tmp/a" } }] },
+      { role: "assistant", content: [{ type: "toolCall", id: "exec:9", name: "exec", arguments: { command: "ls /tmp/b" } }] },
+      { role: "toolResult", toolCallId: "exec:9", content: [{ type: "text", text: "real-for-b" }] },
+    ]);
+    const resultContents = out
+      .filter((m) => m.role === "toolResult")
+      .map((m) => JSON.stringify(m.content));
+    const realIndex = out.findIndex(
+      (m) => m.role === "toolResult" && JSON.stringify(m.content).includes("real-for-b"),
+    );
+    const callBIndex = out.findIndex(
+      (m) => m.role === "assistant" && JSON.stringify(m.content).includes("ls /tmp/b"),
+    );
+    expect(resultContents.length).toBe(2);
+    expect(callBIndex).toBeGreaterThanOrEqual(0);
+    expect(realIndex).toBe(callBIndex + 1);
+    // The first call gets the synthetic placeholder, never the second call's
+    // real result.
+    expect(resultContents[0]).toContain("missing tool result");
+    expect(resultContents[1]).toContain("real-for-b");
+  });
+
+  it("reprocesses text-bearing identical recurrent calls instead of swallowing them", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      { role: "assistant", content: [{ type: "toolCall", id: "exec:11", name: "exec", arguments: { command: "pwd" } }] },
+      { role: "toolResult", toolCallId: "exec:11", content: [{ type: "text", text: "/home/jet" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "again:" },
+          { type: "toolCall", id: "exec:11", name: "exec", arguments: { command: "pwd" } },
+        ],
+      },
+      { role: "toolResult", toolCallId: "exec:11", content: [{ type: "text", text: "/home/jet" }] },
+    ]);
+    const texts = JSON.stringify(out);
+    expect(out.filter((m) => m.role === "assistant").length).toBe(2);
+    expect(out.filter((m) => m.role === "toolResult").length).toBe(2);
+    expect(texts).toContain("again:");
+    expect(texts).not.toContain("missing tool result");
+  });
+
+  it("collapses same-id tool calls within a single assistant turn (keep-first)", () => {
+    const out = sanitizeToolUseResultPairing<Msg>([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "exec:13", name: "exec", arguments: { command: "ls a" } },
+          { type: "toolCall", id: "exec:13", name: "exec", arguments: { command: "ls b" } },
+        ],
+      },
+      { role: "toolResult", toolCallId: "exec:13", content: [{ type: "text", text: "ok" }] },
+    ]);
+    const calls = out
+      .filter((m) => m.role === "assistant")
+      .flatMap((m) => (Array.isArray(m.content) ? (m.content as Array<{ type?: string }>) : []))
+      .filter((b) => b && typeof b.type === "string" && b.type === "toolCall");
+    expect(calls.length).toBe(1);
+    expect(out.filter((m) => m.role === "toolResult").length).toBe(1);
+    expect(JSON.stringify(out)).not.toContain("missing tool result");
+  });
 });


### PR DESCRIPTION
Supersedes #1054 — this branch carries #1054's `#992` empty-content fix plus the actual root cause found while investigating a production data-loss incident.

## Incident

A production conversation (Kimi K3 served through an SGLang Anthropic-compatible adapter) progressively lost tool results until the assembled transcript was mostly `[lossless-claw] missing tool result …` synthetic errors, and the model began reasoning against its own broken history.

Hourly `assistant : tool` message counts in the affected conversation:

| window | assistant | tool |
|---|---|---|
| 07-31 20:xx | 74 | 69 |
| 08-01 23:xx | 94 | 44 |
| 08-02 00:xx | 103 | 7 |

The session JSONL contained every tool result — only the LCM DB was missing them.

## Root cause — stable-event-key assumes globally unique tool-call ids

`extractStableEventKey()` (#1040) returned `tool-result:${toolCallId}` for **any** tool result, and `ingestSingle()` treats an existing stable key as proof that the event was already ingested.

That holds for provider-minted ids (`toolu_…`, `call_…`). It does **not** hold for model-authored ids: Kimi K3 emits `exec:101`, `read:92`, `web_search:45` counters that recur across turns (observed counting *down* 105→94 over ~17 minutes; `exec:101` reused 3× within 9 minutes). Once the first result for an id is stored, every later **distinct** result reusing that id is skipped.

The skip fires on both intake routes — runtime `ingest` **and** transcript-reconcile import, which carries a unique transcript entry id that *proves* a new event. Reconcile could therefore never backfill the loss.

The partial unique index `messages_stable_event_key_unique` baked the assumption into the schema: a correct persist of a repeated id would have thrown at INSERT time.

## Fix

**1. `fix(ingest)` — empty-content tool results (#992)** _(unchanged from #1054)_
`{content: [], details: {…}}` shapes (OpenClaw `update_plan`, any third-party tool) produced zero parts, lost the top-level pairing identity, and triggered a synthetic missing-result error on every assemble. Now persists one identity-carrying fallback part.

**2. `fix(stable-event-key)` — provider-unique scoping** ← the bleed-stopper
- keys derive only from provably unique shapes `/^(?:toolu_|call_)[A-Za-z0-9]{12,}$/`; everything else returns `null` and falls back to content/adjacency/rawId dedup, which prefers a duplicate over a drop
- `runMessageInsert()` degrades a stable-key UNIQUE conflict to `stable_event_key = NULL` plus a warn hook instead of failing or dropping — **a row is never lost**
- assistant `responseId` keys unchanged

**3. `fix(pairing)` — occurrence-scoped pairing and coverage**
- a fresh transcript-entry-id colliding with an existing key is persisted as a new event without a key (+ loud warn)
- `(id, fingerprint)` pending entries retire on pairing, so running `pwd` twice survives as two occurrences
- the delayed-result scan stops at the next surviving call reusing the same id, so `[call X(a), call X(b), result X]` binds to the newest occurrence
- same-id repeats *within a single assistant turn* still collapse keep-first (strict providers reject same-id calls in one turn)
- the empty-content fallback rehydrates as a provider-valid text block rather than a nested `tool_result` block
- recurrent ids no longer take the canonical/lossless coverage shortcut: identical content at distinct occurrences could cross-match and elide a real newer event, so they emit an unmatchable nonce'd signature (a double-emit is recoverable, an elision is not)
- the structured `details` payload is persisted intact rather than as a byte-size stub

## Why an allowlist instead of smarter content hashing

OpenClaw's 87d5cb9f674 makes `update_plan` return a constant `"Plan updated"`. Content and id then both stop discriminating, so any content-based identity collapses. Trusting only ids whose uniqueness the *provider* guarantees stays robust; a regression test covers 4× `"Plan updated"` under one repeated id.

## Compatibility

- #365 (foreign thinking signatures) unaffected
- #1040's redacted-twin double-persist protection still holds for provider-unique ids; for recurrent ids the pre-#1040 status quo returns and repair-time dedup (#993) handles it — deliberate, per "prefer a duplicate over a silent drop"
- no schema migration

## Tests

`tsc --noEmit` clean; `vitest run` **2018 passing across 115 files**. New coverage: recurrent-id ingest/reconcile repro (fails pre-fix on both intake routes), stable-key conflict degradation, occurrence semantics (`pwd` twice, next-reuse binding), empty-content/`details` persistence, provider-unique coverage gating.
