### PR TITLE
fix(lcm_grep): report a missing pattern instead of throwing

### DIFF
--- a/.changeset/lcm-grep-missing-pattern.md
+++ b/.changeset/lcm-grep-missing-pattern.md
@@ -1,0 +1,11 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix `lcm_grep` throwing `Cannot read properties of undefined (reading
+'trim')` when a model omits or misnames the `pattern` argument. Hosts pass
+model-supplied tool arguments through without schema validation, so the
+call died with an uncatchable TypeError before any query ran. The tool now
+returns a tool error naming the expected field, including the `query` vs
+`pattern` difference against `lcm_expand` and `lcm_expand_query`, so the
+agent can correct the call and retry.

--- a/src/tools/lcm-grep-tool.ts
+++ b/src/tools/lcm-grep-tool.ts
@@ -181,7 +181,16 @@ export function createLcmGrepTool(input: {
       const timezone = lcm.timezone;
 
       const p = params as Record<string, unknown>;
-      const pattern = (p.pattern as string).trim();
+      // Hosts pass model-supplied arguments through without schema validation, so a
+      // missing or misnamed `pattern` reaches us as undefined. Report it as a tool
+      // error the model can act on instead of throwing a TypeError it cannot.
+      const pattern = typeof p.pattern === "string" ? p.pattern.trim() : "";
+      if (!pattern) {
+        return jsonResult({
+          error:
+            'Missing required `pattern`. Pass the search text as `pattern` (a regular expression when mode is "regex", an FTS5 query when mode is "full_text"). Note that lcm_expand and lcm_expand_query use `query`, but lcm_grep uses `pattern`.',
+        });
+      }
       const mode = (p.mode as "regex" | "full_text") ?? "regex";
       const scope = (p.scope as "messages" | "summaries" | "both" | "files") ?? "both";
       const fileIds = Array.isArray(p.fileIds)

--- a/test/lcm-tools.test.ts
+++ b/test/lcm-tools.test.ts
@@ -208,6 +208,34 @@ describe("LCM tools session scoping", () => {
     expect((result.details as { error?: string }).error).toContain('mode: "regex"');
   });
 
+  it("lcm_grep reports a missing pattern instead of throwing", async () => {
+    const retrieval = {
+      grep: vi.fn(async () => ({
+        messages: [],
+        summaries: [],
+        totalMatches: 0,
+      })),
+      expand: vi.fn(),
+      describe: vi.fn(),
+    };
+
+    const tool = createLcmGrepTool({
+      deps: makeDeps(),
+      lcm: buildLcmEngine({ retrieval, conversationId: 42 }) as never,
+      sessionId: "session-1",
+    });
+    // Hosts forward model-supplied arguments unvalidated, so the omitted
+    // required parameter has to surface as a tool error, not a TypeError.
+    const result = await tool.execute("call-missing-pattern", {
+      mode: "full_text",
+      allConversations: true,
+      sort: "recency",
+    });
+
+    expect(retrieval.grep).not.toHaveBeenCalled();
+    expect((result.details as { error?: string }).error).toContain("Missing required `pattern`");
+  });
+
   it("lcm_grep still forwards regex alternation in regex mode", async () => {
     const retrieval = {
       grep: vi.fn(async () => ({


### PR DESCRIPTION
## What problem this solves

`lcm_grep` throws an uncatchable `TypeError` when the model omits or misnames the `pattern` argument:

```
Cannot read properties of undefined (reading 'trim')
```

`src/tools/lcm-grep-tool.ts` reads the parameter as `(p.pattern as string).trim()`. The cast is a compile-time assertion only — hosts pass model-supplied tool arguments through without schema validation, so a missing `pattern` arrives as `undefined` and the call dies before any query runs.

Because the failure is a thrown TypeError rather than a tool result, the agent gets nothing it can act on. There is no message naming the missing field, so the model has no basis for a corrected retry — the tool call is a dead end.

This is not hypothetical: it is the most likely malformed call in practice, because the sibling tools `lcm_expand` and `lcm_expand_query` take `query` while `lcm_grep` takes `pattern`. A model that has just used one of those reaches for `query` and gets a crash instead of a correction.

## Why this change was made

Read the parameter defensively and return a tool error that names the expected field and the `query`/`pattern` difference, so the model can fix the call itself:

```ts
const pattern = typeof p.pattern === "string" ? p.pattern.trim() : "";
if (!pattern) {
  return jsonResult({ error: "Missing required `pattern`. …" });
}
```

An empty or whitespace-only `pattern` takes the same path — it was previously accepted and produced a meaningless query.

This is independent of PR #952 and reproduces on current `main`. `git log -S` traces the unchecked cast back to the initial scaffold (`3be0da9`); it has never been guarded.

Only `pattern` is changed. The other parameters (`mode`, `scope`, `fileIds`, …) already have `??` defaults or `Array.isArray` guards, so they degrade rather than throw.

## User impact

A model that calls `lcm_grep` without `pattern` — most commonly by passing `query` instead — now receives an actionable tool error and can retry correctly, rather than hitting a hard TypeError that ends the tool call.

No behavior change for well-formed calls.

## Evidence

- New regression test in `test/lcm-tools.test.ts`: a `lcm_grep` call with no `pattern` returns the tool error and never reaches `retrieval.grep`. Empty and whitespace-only patterns take the same branch but are not separately asserted.
- `npx vitest run --dir test` on a clean checkout of this branch: **111 files, 1985 tests, all passing**.
- `npx tsc --noEmit`: clean.
- Reproduced live against lossless-claw running under OpenClaw 2026.7.2-beta.7 before the fix; the corrected call succeeds after it.
