### PR TITLE
fix(dedup): anchor the metadata-face collapse on fresh transcript provenance

### DIFF
--- a/.changeset/provenance-anchored-collapse.md
+++ b/.changeset/provenance-anchored-collapse.md
@@ -1,0 +1,8 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Collapse the decorated end-of-turn face of an inbound message onto its bare
+transcript row when that row was ingested by the same turn's own reconcile,
+removing the per-turn double-write on decorated channels. Rows from earlier
+turns, however recent, and provenance-less rows never anchor a collapse.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -43,10 +43,30 @@ type StoredIncomingMatch =
   | "unproven-externalized"
   | "redacted";
 type CoveredStoredIncomingMatch = StoredIncomingMatch | "decorated";
-type AlignmentMatch = CoveredStoredIncomingMatch | "unanchored-inbound";
+type AlignmentMatch = CoveredStoredIncomingMatch | "unanchored-inbound" | "provenanced-inbound";
+
+/**
+ * True when a persisted row is host-proven (transcript provenance) AND was
+ * inserted during the current afterTurn's own transcript reconcile: its
+ * message_id lies above the conversation's newest message id captured just
+ * before that reconcile ran. Session writes are queue-serialized and
+ * message_id is insertion-ordered, so rows above the floor are exactly this
+ * turn's transcript ingests. Provenance authenticates the persisted row; the
+ * floor ties the incoming decorated face to that very ingest rather than to
+ * any older row, however recent. Either condition missing (including callers
+ * that pass no floor) keeps the match weak: it may support alignment but
+ * never anchors a collapse.
+ */
+function persistedRowIsCurrentTurnIngest(
+  record: Pick<MessageRecord, "transcriptEntryId" | "messageId">,
+  sameTurnIngestFloor: number | undefined,
+): boolean {
+  if (record.transcriptEntryId == null) return false;
+  return sameTurnIngestFloor !== undefined && record.messageId > sameTurnIngestFloor;
+}
 
 function isStrongReplayAnchor(match: AlignmentMatch | undefined): boolean {
-  return match === "exact" || match === "decorated";
+  return match === "exact" || match === "decorated" || match === "provenanced-inbound";
 }
 
 function redactedMatchesHaveAdjacentAnchor(matches: readonly AlignmentMatch[]): boolean {
@@ -244,6 +264,7 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
+    sameTurnIngestFloor?: number,
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -310,10 +331,19 @@ export class BatchDeduplicator {
               { allowUntimestampedInboundBodyMatch: true },
             )
           ) {
-            // Stored provenance qualifies this as alignment support, but it
-            // authenticates only the persisted row. Another exact/timestamp
-            // anchor must still prove the runtime batch is a replay.
-            matches.push("unanchored-inbound");
+            // Stored provenance authenticates only the persisted row. When
+            // that row was ingested by THIS turn's own reconcile (above the
+            // pre-reconcile floor), the incoming decorated face is the
+            // end-of-turn copy of that very ingest (the store double-write)
+            // and anchors the collapse. Any older row, however recent, stays
+            // weak and needs an independent exact/timestamp anchor, so an
+            // echo or replay of an earlier turn duplicates instead of
+            // trimming.
+            matches.push(
+              persistedRowIsCurrentTurnIngest(tailMessages[i]!, sameTurnIngestFloor)
+                ? "provenanced-inbound"
+                : "unanchored-inbound",
+            );
             continue;
           }
           aligned = false;
@@ -369,6 +399,7 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
+    sameTurnIngestFloor?: number,
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -391,6 +422,7 @@ export class BatchDeduplicator {
     }
     return this.deduplicateAfterTurnBatch(sessionId, sessionKey, batch, {
       oversizedNoOverlap: "ingest",
+      sameTurnIngestFloor,
     });
   }
 
@@ -418,7 +450,7 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
-    options?: { oversizedNoOverlap?: "ingest" | "skip" },
+    options?: { oversizedNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -472,6 +504,18 @@ export class BatchDeduplicator {
           lastDbMessage.content,
           batchAtBoundary.role,
           batchAtBoundary.content,
+          {
+            // Heuristic routes may collapse only against a row this turn's
+            // own reconcile ingested (see persistedRowIsCurrentTurnIngest).
+            allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
+              lastDbMessage,
+              options?.sameTurnIngestFloor,
+            ),
+            allowUntimestampedInboundBodyMatch: persistedRowIsCurrentTurnIngest(
+              lastDbMessage,
+              options?.sameTurnIngestFloor,
+            ),
+          },
         ) &&
           !(await this.messagesDifferOnlyByHostRedaction(
             lastDbMessage,
@@ -488,7 +532,7 @@ export class BatchDeduplicator {
           rawPayloadContents,
           storedMessageCount,
           "prefix-mismatch",
-          { onNoOverlap: "ingest" },
+          { onNoOverlap: "ingest", sameTurnIngestFloor: options?.sameTurnIngestFloor },
         );
       }
     }
@@ -533,6 +577,16 @@ export class BatchDeduplicator {
             storedMessages[i]!.content,
             storedBatch[i]!.role,
             storedBatch[i]!.content,
+            {
+              allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
+                storedMessages[i]!,
+                options?.sameTurnIngestFloor,
+              ),
+              allowUntimestampedInboundBodyMatch: persistedRowIsCurrentTurnIngest(
+                storedMessages[i]!,
+                options?.sameTurnIngestFloor,
+              ),
+            },
           )
         ) {
           return batch;
@@ -563,7 +617,7 @@ export class BatchDeduplicator {
     rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
     lastDbIdentityHash: string,
-    options?: { oversizedNoOverlap?: "ingest" | "skip" },
+    options?: { oversizedNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
   ): Promise<AgentMessage[]> {
     const lastBatchHash = batchHashes[batchHashes.length - 1]!;
 
@@ -577,7 +631,7 @@ export class BatchDeduplicator {
       );
       if (tailMessages.length === batch.length && tailHashes.length === batch.length) {
         let tailMatch = true;
-        const matches: CoveredStoredIncomingMatch[] = [];
+        const matches: AlignmentMatch[] = [];
         for (let i = 0; i < batch.length; i++) {
           const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
             tailMessages[i]!,
@@ -586,6 +640,7 @@ export class BatchDeduplicator {
             batchHashes[i]!,
             tailHashes[i]!,
             rawPayloadContents[i],
+            options?.sameTurnIngestFloor,
           );
           if (!match || match === "unproven-externalized") {
             tailMatch = false;
@@ -615,7 +670,10 @@ export class BatchDeduplicator {
       rawPayloadContents,
       storedMessageCount,
       "oversized",
-      { onNoOverlap: options?.oversizedNoOverlap ?? "ingest" },
+      {
+        onNoOverlap: options?.oversizedNoOverlap ?? "ingest",
+        sameTurnIngestFloor: options?.sameTurnIngestFloor,
+      },
     );
   }
 
@@ -632,7 +690,7 @@ export class BatchDeduplicator {
     rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
     context: string,
-    options?: { onNoOverlap?: "ingest" | "skip" },
+    options?: { onNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
   ): Promise<AgentMessage[]> {
     const allRecentHashes = await this.conversationStore.getRecentMessageIdentityHashes(
       conversationId,
@@ -656,6 +714,7 @@ export class BatchDeduplicator {
         batchHashes[k]!,
         lastStoredHash,
         rawPayloadContents[k],
+        options?.sameTurnIngestFloor,
       );
       if (lastMatch === "unproven-externalized") {
         ambiguousWeakOverlap = true;
@@ -666,7 +725,7 @@ export class BatchDeduplicator {
       const matchLen = Math.min(k + 1, allRecentHashes.length);
       const startDb = allRecentHashes.length - matchLen;
       let suffixMatch = true;
-      const matches: CoveredStoredIncomingMatch[] = [];
+      const matches: AlignmentMatch[] = [];
       for (let j = 0; j < matchLen; j++) {
         const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
           allStored[startDb + j]!,
@@ -675,6 +734,7 @@ export class BatchDeduplicator {
           batchHashes[k - matchLen + 1 + j]!,
           allRecentHashes[startDb + j]!,
           rawPayloadContents[k - matchLen + 1 + j],
+          options?.sameTurnIngestFloor,
         );
         if (match === "unproven-externalized") {
           ambiguousWeakOverlap = true;
@@ -742,7 +802,8 @@ export class BatchDeduplicator {
     incomingHash: string,
     storedHash: string,
     incomingRawPayloadContent?: string | null,
-  ): Promise<CoveredStoredIncomingMatch | null> {
+    sameTurnIngestFloor?: number,
+  ): Promise<CoveredStoredIncomingMatch | "provenanced-inbound" | null> {
     const match = await this.matchStoredMessageToIncoming(
       storedMessage,
       incoming,
@@ -760,9 +821,32 @@ export class BatchDeduplicator {
         storedMessage.content,
         incoming.role,
         incoming.content,
+        {
+          allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
+            storedMessage,
+            sameTurnIngestFloor,
+          ),
+        },
       )
     ) {
       return "decorated";
+    }
+    // Body equality after metadata stripping: collapse strength requires the
+    // persisted row's transcript provenance AND that this turn's own
+    // reconcile inserted it (above the pre-reconcile floor). The match alone
+    // never anchors: metadata blocks are user-forgeable, and any older proven
+    // row may face an echo of an earlier turn.
+    if (
+      persistedRowIsCurrentTurnIngest(storedMessage, sameTurnIngestFloor) &&
+      this.runtimeRowCoversPersistedFrontierRow(
+        storedMessage.role,
+        storedMessage.content,
+        incoming.role,
+        incoming.content,
+        { allowUntimestampedInboundBodyMatch: true },
+      )
+    ) {
+      return "provenanced-inbound";
     }
     return null;
   }

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -48,25 +48,23 @@ type AlignmentMatch = CoveredStoredIncomingMatch | "unanchored-inbound" | "prove
 /**
  * True when a persisted row may anchor the same-turn metadata-face collapse.
  * Three conditions, all required: the row is host-proven (transcript
- * provenance), it was inserted during the current afterTurn's own transcript
- * reconcile (message_id above the pre-reconcile floor; session writes are
- * queue-serialized and message_id is insertion-ordered), and it is the
- * conversation's newest user row after that reconcile. The last condition is
- * what turns the floor from an insertion watermark into same-turn
- * provenance: a reconcile that backfills older transcript history (catch-up
- * import, first reconcile with floor 0) puts historical rows above the floor
- * too, but on the transcript-covered route the turn's own inbound is always
- * the newest user row, so a backfilled row can never anchor. Any condition
- * missing (including callers that pass no floor) keeps the match weak: it
- * may support alignment but never anchors a collapse.
+ * provenance), its message id is in the set the current afterTurn's own
+ * transcript reconcile reported as inserted (ground truth from the insert
+ * sites, not an insertion-order inference), and it is the conversation's
+ * newest user row after that reconcile. Membership ties the anchor to this
+ * very reconcile's writes; the newest-user condition ties it to the turn's
+ * own inbound, so a historical row a catch-up reconcile backfilled in the
+ * same pass can never anchor while a newer user row exists. Any condition
+ * missing (including callers that pass no set) keeps the match weak: it may
+ * support alignment but never anchors a collapse.
  */
 function persistedRowAnchorsSameTurnCollapse(
   record: Pick<MessageRecord, "transcriptEntryId" | "messageId">,
-  sameTurnIngestFloor: number | undefined,
+  sameTurnInsertedIds: ReadonlySet<number> | undefined,
   newestUserMessageId: number | undefined,
 ): boolean {
   if (record.transcriptEntryId == null) return false;
-  if (sameTurnIngestFloor === undefined || record.messageId <= sameTurnIngestFloor) return false;
+  if (!sameTurnInsertedIds || !sameTurnInsertedIds.has(record.messageId)) return false;
   return newestUserMessageId !== undefined && record.messageId === newestUserMessageId;
 }
 
@@ -298,7 +296,7 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
-    sameTurnIngestFloor?: number,
+    sameTurnInsertedIds?: ReadonlySet<number>,
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -317,7 +315,7 @@ export class BatchDeduplicator {
     // newest user row IS this turn's inbound. Only that row may anchor the
     // metadata-face collapse (see persistedRowAnchorsSameTurnCollapse).
     const newestUserMessageId =
-      sameTurnIngestFloor === undefined
+      sameTurnInsertedIds === undefined || sameTurnInsertedIds.size === 0
         ? undefined
         : (await this.conversationStore.getLastMessageWithRole(conversationId, "user"))
             ?.messageId;
@@ -375,19 +373,18 @@ export class BatchDeduplicator {
             )
           ) {
             // Stored provenance authenticates only the persisted row. When
-            // that row was ingested by THIS turn's own reconcile (above the
-            // pre-reconcile floor) AND is the conversation's newest user row,
-            // the incoming decorated face is the end-of-turn copy of that
-            // very ingest (the store double-write) and anchors the collapse
-            // of its own row. Any other row — older, backfilled by a
-            // catch-up reconcile, or shadowed by a newer user row — stays
-            // weak and needs an independent exact/timestamp anchor, so an
-            // echo or replay of an earlier turn duplicates instead of
-            // trimming.
+            // that row is among the ids THIS turn's own reconcile inserted
+            // AND is the conversation's newest user row, the incoming
+            // decorated face is the end-of-turn copy of that very ingest
+            // (the store double-write) and anchors the collapse of its own
+            // row. Any other row — older, backfilled by a catch-up reconcile
+            // in the same pass, or shadowed by a newer user row — stays weak
+            // and needs an independent exact/timestamp anchor, so an echo or
+            // replay of an earlier turn duplicates instead of trimming.
             matches.push(
               persistedRowAnchorsSameTurnCollapse(
                 tailMessages[i]!,
-                sameTurnIngestFloor,
+                sameTurnInsertedIds,
                 newestUserMessageId,
               )
                 ? "provenanced-inbound"

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -46,35 +46,69 @@ type CoveredStoredIncomingMatch = StoredIncomingMatch | "decorated";
 type AlignmentMatch = CoveredStoredIncomingMatch | "unanchored-inbound" | "provenanced-inbound";
 
 /**
- * True when a persisted row is host-proven (transcript provenance) AND was
- * inserted during the current afterTurn's own transcript reconcile: its
- * message_id lies above the conversation's newest message id captured just
- * before that reconcile ran. Session writes are queue-serialized and
- * message_id is insertion-ordered, so rows above the floor are exactly this
- * turn's transcript ingests. Provenance authenticates the persisted row; the
- * floor ties the incoming decorated face to that very ingest rather than to
- * any older row, however recent. Either condition missing (including callers
- * that pass no floor) keeps the match weak: it may support alignment but
- * never anchors a collapse.
+ * True when a persisted row may anchor the same-turn metadata-face collapse.
+ * Three conditions, all required: the row is host-proven (transcript
+ * provenance), it was inserted during the current afterTurn's own transcript
+ * reconcile (message_id above the pre-reconcile floor; session writes are
+ * queue-serialized and message_id is insertion-ordered), and it is the
+ * conversation's newest user row after that reconcile. The last condition is
+ * what turns the floor from an insertion watermark into same-turn
+ * provenance: a reconcile that backfills older transcript history (catch-up
+ * import, first reconcile with floor 0) puts historical rows above the floor
+ * too, but on the transcript-covered route the turn's own inbound is always
+ * the newest user row, so a backfilled row can never anchor. Any condition
+ * missing (including callers that pass no floor) keeps the match weak: it
+ * may support alignment but never anchors a collapse.
  */
-function persistedRowIsCurrentTurnIngest(
+function persistedRowAnchorsSameTurnCollapse(
   record: Pick<MessageRecord, "transcriptEntryId" | "messageId">,
   sameTurnIngestFloor: number | undefined,
+  newestUserMessageId: number | undefined,
 ): boolean {
   if (record.transcriptEntryId == null) return false;
-  return sameTurnIngestFloor !== undefined && record.messageId > sameTurnIngestFloor;
+  if (sameTurnIngestFloor === undefined || record.messageId <= sameTurnIngestFloor) return false;
+  return newestUserMessageId !== undefined && record.messageId === newestUserMessageId;
 }
 
-function isStrongReplayAnchor(match: AlignmentMatch | undefined): boolean {
-  return match === "exact" || match === "decorated" || match === "provenanced-inbound";
+/**
+ * Anchors that may vouch for rows beyond their own: exact identity or the
+ * strict structural decoration gate. "provenanced-inbound" is deliberately
+ * absent — its proof (body equality under the same-turn floor) authenticates
+ * only its own row, so it never carries a neighboring redacted or otherwise
+ * weak match into a trim.
+ */
+function isIndependentReplayAnchor(match: AlignmentMatch | undefined): boolean {
+  return match === "exact" || match === "decorated";
 }
 
 function redactedMatchesHaveAdjacentAnchor(matches: readonly AlignmentMatch[]): boolean {
   return matches.every(
     (match, index) =>
       match !== "redacted" ||
-      isStrongReplayAnchor(matches[index - 1]) ||
-      isStrongReplayAnchor(matches[index + 1]),
+      isIndependentReplayAnchor(matches[index - 1]) ||
+      isIndependentReplayAnchor(matches[index + 1]),
+  );
+}
+
+/**
+ * Trim decision for the covered-frontier alignment. Either an independent
+ * anchor (exact/decorated) proves the suffix under the pre-existing contract
+ * (with redacted rows needing an independent neighbor), or every row is
+ * self-proven — exact, decorated, or a provenanced-inbound row whose own
+ * same-turn ingest authenticates it. A provenanced-inbound match never
+ * extends its authority to any other row: a suffix that still contains an
+ * unanchored or redacted row alongside only provenanced-inbound strength is
+ * left untrimmed.
+ */
+function alignedSuffixIsAnchored(matches: readonly AlignmentMatch[]): boolean {
+  if (matches.some(isIndependentReplayAnchor)) {
+    return redactedMatchesHaveAdjacentAnchor(matches);
+  }
+  return (
+    matches.length > 0 &&
+    matches.every(
+      (match) => match === "provenanced-inbound" || isIndependentReplayAnchor(match),
+    )
   );
 }
 
@@ -278,6 +312,15 @@ export class BatchDeduplicator {
     const storedBatch = batch.map((message) => toStoredMessage(message));
     const batchHashes = computeBatchIdentityHashes(storedBatch);
     const rawPayloadContents = computeBatchRawPayloadContents(batch, storedBatch);
+    // Resolved once, after this turn's reconcile has already run: on the
+    // covered route the reconcile read the transcript to its frontier, so the
+    // newest user row IS this turn's inbound. Only that row may anchor the
+    // metadata-face collapse (see persistedRowAnchorsSameTurnCollapse).
+    const newestUserMessageId =
+      sameTurnIngestFloor === undefined
+        ? undefined
+        : (await this.conversationStore.getLastMessageWithRole(conversationId, "user"))
+            ?.messageId;
     const tail = await this.conversationStore.getLastMessages(conversationId, batch.length);
     const tailHashes = await this.conversationStore.getRecentMessageIdentityHashes(
       conversationId,
@@ -333,14 +376,20 @@ export class BatchDeduplicator {
           ) {
             // Stored provenance authenticates only the persisted row. When
             // that row was ingested by THIS turn's own reconcile (above the
-            // pre-reconcile floor), the incoming decorated face is the
-            // end-of-turn copy of that very ingest (the store double-write)
-            // and anchors the collapse. Any older row, however recent, stays
+            // pre-reconcile floor) AND is the conversation's newest user row,
+            // the incoming decorated face is the end-of-turn copy of that
+            // very ingest (the store double-write) and anchors the collapse
+            // of its own row. Any other row — older, backfilled by a
+            // catch-up reconcile, or shadowed by a newer user row — stays
             // weak and needs an independent exact/timestamp anchor, so an
             // echo or replay of an earlier turn duplicates instead of
             // trimming.
             matches.push(
-              persistedRowIsCurrentTurnIngest(tailMessages[i]!, sameTurnIngestFloor)
+              persistedRowAnchorsSameTurnCollapse(
+                tailMessages[i]!,
+                sameTurnIngestFloor,
+                newestUserMessageId,
+              )
                 ? "provenanced-inbound"
                 : "unanchored-inbound",
             );
@@ -352,13 +401,10 @@ export class BatchDeduplicator {
         matches.push(match);
       }
       // Externalized-only matches are ambiguous in the same way as suffix
-      // fallback anchors: they may be a replay or a legitimate repeated upload.
-      // Trim only when at least one matched message still has exact identity.
-      if (
-        aligned &&
-        matches.some(isStrongReplayAnchor) &&
-        redactedMatchesHaveAdjacentAnchor(matches)
-      ) {
+      // fallback anchors: they may be a replay or a legitimate repeated
+      // upload. Trim only under an independent anchor, or when every row in
+      // the suffix proves itself (see alignedSuffixIsAnchored).
+      if (aligned && alignedSuffixIsAnchored(matches)) {
         return batch.slice(k);
       }
     }
@@ -399,7 +445,6 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
-    sameTurnIngestFloor?: number,
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -422,7 +467,6 @@ export class BatchDeduplicator {
     }
     return this.deduplicateAfterTurnBatch(sessionId, sessionKey, batch, {
       oversizedNoOverlap: "ingest",
-      sameTurnIngestFloor,
     });
   }
 
@@ -450,7 +494,7 @@ export class BatchDeduplicator {
     sessionId: string,
     sessionKey: string | undefined,
     batch: AgentMessage[],
-    options?: { oversizedNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
+    options?: { oversizedNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
     if (batch.length === 0) return batch;
 
@@ -504,18 +548,6 @@ export class BatchDeduplicator {
           lastDbMessage.content,
           batchAtBoundary.role,
           batchAtBoundary.content,
-          {
-            // Heuristic routes may collapse only against a row this turn's
-            // own reconcile ingested (see persistedRowIsCurrentTurnIngest).
-            allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
-              lastDbMessage,
-              options?.sameTurnIngestFloor,
-            ),
-            allowUntimestampedInboundBodyMatch: persistedRowIsCurrentTurnIngest(
-              lastDbMessage,
-              options?.sameTurnIngestFloor,
-            ),
-          },
         ) &&
           !(await this.messagesDifferOnlyByHostRedaction(
             lastDbMessage,
@@ -532,7 +564,7 @@ export class BatchDeduplicator {
           rawPayloadContents,
           storedMessageCount,
           "prefix-mismatch",
-          { onNoOverlap: "ingest", sameTurnIngestFloor: options?.sameTurnIngestFloor },
+          { onNoOverlap: "ingest" },
         );
       }
     }
@@ -577,16 +609,6 @@ export class BatchDeduplicator {
             storedMessages[i]!.content,
             storedBatch[i]!.role,
             storedBatch[i]!.content,
-            {
-              allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
-                storedMessages[i]!,
-                options?.sameTurnIngestFloor,
-              ),
-              allowUntimestampedInboundBodyMatch: persistedRowIsCurrentTurnIngest(
-                storedMessages[i]!,
-                options?.sameTurnIngestFloor,
-              ),
-            },
           )
         ) {
           return batch;
@@ -617,7 +639,7 @@ export class BatchDeduplicator {
     rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
     lastDbIdentityHash: string,
-    options?: { oversizedNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
+    options?: { oversizedNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
     const lastBatchHash = batchHashes[batchHashes.length - 1]!;
 
@@ -631,7 +653,7 @@ export class BatchDeduplicator {
       );
       if (tailMessages.length === batch.length && tailHashes.length === batch.length) {
         let tailMatch = true;
-        const matches: AlignmentMatch[] = [];
+        const matches: CoveredStoredIncomingMatch[] = [];
         for (let i = 0; i < batch.length; i++) {
           const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
             tailMessages[i]!,
@@ -640,7 +662,6 @@ export class BatchDeduplicator {
             batchHashes[i]!,
             tailHashes[i]!,
             rawPayloadContents[i],
-            options?.sameTurnIngestFloor,
           );
           if (!match || match === "unproven-externalized") {
             tailMatch = false;
@@ -670,10 +691,7 @@ export class BatchDeduplicator {
       rawPayloadContents,
       storedMessageCount,
       "oversized",
-      {
-        onNoOverlap: options?.oversizedNoOverlap ?? "ingest",
-        sameTurnIngestFloor: options?.sameTurnIngestFloor,
-      },
+      { onNoOverlap: options?.oversizedNoOverlap ?? "ingest" },
     );
   }
 
@@ -690,7 +708,7 @@ export class BatchDeduplicator {
     rawPayloadContents: Array<string | null>,
     storedMessageCount: number,
     context: string,
-    options?: { onNoOverlap?: "ingest" | "skip"; sameTurnIngestFloor?: number },
+    options?: { onNoOverlap?: "ingest" | "skip" },
   ): Promise<AgentMessage[]> {
     const allRecentHashes = await this.conversationStore.getRecentMessageIdentityHashes(
       conversationId,
@@ -714,7 +732,6 @@ export class BatchDeduplicator {
         batchHashes[k]!,
         lastStoredHash,
         rawPayloadContents[k],
-        options?.sameTurnIngestFloor,
       );
       if (lastMatch === "unproven-externalized") {
         ambiguousWeakOverlap = true;
@@ -725,7 +742,7 @@ export class BatchDeduplicator {
       const matchLen = Math.min(k + 1, allRecentHashes.length);
       const startDb = allRecentHashes.length - matchLen;
       let suffixMatch = true;
-      const matches: AlignmentMatch[] = [];
+      const matches: CoveredStoredIncomingMatch[] = [];
       for (let j = 0; j < matchLen; j++) {
         const match = await this.matchStoredMessageToIncomingOrDecoratedCoverage(
           allStored[startDb + j]!,
@@ -734,7 +751,6 @@ export class BatchDeduplicator {
           batchHashes[k - matchLen + 1 + j]!,
           allRecentHashes[startDb + j]!,
           rawPayloadContents[k - matchLen + 1 + j],
-          options?.sameTurnIngestFloor,
         );
         if (match === "unproven-externalized") {
           ambiguousWeakOverlap = true;
@@ -747,7 +763,7 @@ export class BatchDeduplicator {
         }
         matches.push(match);
       }
-      const exactAnchor = matches.some(isStrongReplayAnchor);
+      const exactAnchor = matches.some(isIndependentReplayAnchor);
       const redactionAnchored = redactedMatchesHaveAdjacentAnchor(matches);
       const newSlice = batch.slice(k + 1);
       // Outside the transcript-covered path, an externalized-only anchor is
@@ -802,8 +818,7 @@ export class BatchDeduplicator {
     incomingHash: string,
     storedHash: string,
     incomingRawPayloadContent?: string | null,
-    sameTurnIngestFloor?: number,
-  ): Promise<CoveredStoredIncomingMatch | "provenanced-inbound" | null> {
+  ): Promise<CoveredStoredIncomingMatch | null> {
     const match = await this.matchStoredMessageToIncoming(
       storedMessage,
       incoming,
@@ -821,32 +836,9 @@ export class BatchDeduplicator {
         storedMessage.content,
         incoming.role,
         incoming.content,
-        {
-          allowCollapsedSpaceRunMatch: persistedRowIsCurrentTurnIngest(
-            storedMessage,
-            sameTurnIngestFloor,
-          ),
-        },
       )
     ) {
       return "decorated";
-    }
-    // Body equality after metadata stripping: collapse strength requires the
-    // persisted row's transcript provenance AND that this turn's own
-    // reconcile inserted it (above the pre-reconcile floor). The match alone
-    // never anchors: metadata blocks are user-forgeable, and any older proven
-    // row may face an echo of an earlier turn.
-    if (
-      persistedRowIsCurrentTurnIngest(storedMessage, sameTurnIngestFloor) &&
-      this.runtimeRowCoversPersistedFrontierRow(
-        storedMessage.role,
-        storedMessage.content,
-        incoming.role,
-        incoming.content,
-        { allowUntimestampedInboundBodyMatch: true },
-      )
-    ) {
-      return "provenanced-inbound";
     }
     return null;
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3057,11 +3057,14 @@ export class LcmContextEngine implements ContextEngine {
       params.messages.slice(params.prePromptMessageCount),
     );
     // Capture the conversation's newest message id BEFORE the transcript
-    // reconcile below runs: rows above this floor are exactly the ingests of
-    // THIS turn's reconcile (session writes are queue-serialized), which is
-    // what lets the deduplicator collapse the decorated end-of-turn face onto
-    // the same turn's bare transcript row while never trimming against any
-    // older row. Undefined on lookup failure = the strong collapse stays off.
+    // reconcile below runs: rows above this floor are the ingests of THIS
+    // turn's reconcile (session writes are queue-serialized). Only the
+    // transcript-covered alignment consumes it — covered means the reconcile
+    // read the transcript to its frontier, so the newest user row is this
+    // turn's own inbound and the decorated end-of-turn face may collapse
+    // onto exactly that ingest. Routes without that proof (degraded
+    // checkpoint, heuristic, oversized) never strong-collapse and keep the
+    // pair. Undefined on lookup failure = the strong collapse stays off.
     let sameTurnIngestFloor: number | undefined;
     try {
       const preReconcileConversation = await this.conversationStore.getConversationForSession({
@@ -3143,7 +3146,6 @@ export class LcmContextEngine implements ContextEngine {
           params.sessionId,
           params.sessionKey,
           newMessages,
-          sameTurnIngestFloor,
         );
       if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
         this.deps.log.debug(
@@ -3173,7 +3175,6 @@ export class LcmContextEngine implements ContextEngine {
         newMessages,
         {
           oversizedNoOverlap: "ingest",
-          sameTurnIngestFloor,
         },
       );
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3056,6 +3056,28 @@ export class LcmContextEngine implements ContextEngine {
     const newMessages = filterPersistableMessages(
       params.messages.slice(params.prePromptMessageCount),
     );
+    // Capture the conversation's newest message id BEFORE the transcript
+    // reconcile below runs: rows above this floor are exactly the ingests of
+    // THIS turn's reconcile (session writes are queue-serialized), which is
+    // what lets the deduplicator collapse the decorated end-of-turn face onto
+    // the same turn's bare transcript row while never trimming against any
+    // older row. Undefined on lookup failure = the strong collapse stays off.
+    let sameTurnIngestFloor: number | undefined;
+    try {
+      const preReconcileConversation = await this.conversationStore.getConversationForSession({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      });
+      sameTurnIngestFloor = preReconcileConversation
+        ? ((
+            await this.conversationStore.getLastMessage(
+              preReconcileConversation.conversationId,
+            )
+          )?.messageId ?? 0)
+        : 0;
+    } catch {
+      sameTurnIngestFloor = undefined;
+    }
     let transcriptReconcileResult: TranscriptReconcileResult = {
       importedMessages: 0,
       blockedByImportCap: false,
@@ -3121,6 +3143,7 @@ export class LcmContextEngine implements ContextEngine {
           params.sessionId,
           params.sessionKey,
           newMessages,
+          sameTurnIngestFloor,
         );
       if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
         this.deps.log.debug(
@@ -3136,6 +3159,7 @@ export class LcmContextEngine implements ContextEngine {
         params.sessionId,
         params.sessionKey,
         newMessages,
+        sameTurnIngestFloor,
       );
       if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
         this.deps.log.debug(
@@ -3149,6 +3173,7 @@ export class LcmContextEngine implements ContextEngine {
         newMessages,
         {
           oversizedNoOverlap: "ingest",
+          sameTurnIngestFloor,
         },
       );
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2921,7 +2921,7 @@ export class LcmContextEngine implements ContextEngine {
     // Append to context items so assembler can see it
     await this.summaryStore.appendContextMessage(conversationId, msgRecord.messageId);
 
-    return { ingested: true };
+    return { ingested: true, messageId: msgRecord.messageId };
   }
 
   async ingest(params: {
@@ -3056,33 +3056,6 @@ export class LcmContextEngine implements ContextEngine {
     const newMessages = filterPersistableMessages(
       params.messages.slice(params.prePromptMessageCount),
     );
-    // Capture the conversation's maximum message id BEFORE the transcript
-    // reconcile below runs: rows above this floor were inserted by THIS
-    // turn's reconcile (session writes are queue-serialized and message_id
-    // is insertion-ordered). MAX(message_id) rather than the logical tail's
-    // id: a writer that backfills rows out of seq order leaves the tail's id
-    // below newer insertions, and a watermark that misses them would let a
-    // pre-existing row pose as this turn's ingest. Only the
-    // transcript-covered alignment consumes the floor — covered means the
-    // reconcile read the transcript to its frontier, so the newest user row
-    // is this turn's own inbound and the decorated end-of-turn face may
-    // collapse onto exactly that ingest. Routes without that proof (degraded
-    // checkpoint, heuristic, oversized) never strong-collapse and keep the
-    // pair. Undefined on lookup failure = the strong collapse stays off.
-    let sameTurnIngestFloor: number | undefined;
-    try {
-      const preReconcileConversation = await this.conversationStore.getConversationForSession({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-      });
-      sameTurnIngestFloor = preReconcileConversation
-        ? ((await this.conversationStore.getMaxMessageId(
-            preReconcileConversation.conversationId,
-          )) ?? 0)
-        : 0;
-    } catch {
-      sameTurnIngestFloor = undefined;
-    }
     let transcriptReconcileResult: TranscriptReconcileResult = {
       importedMessages: 0,
       blockedByImportCap: false,
@@ -3158,12 +3131,17 @@ export class LcmContextEngine implements ContextEngine {
       // The transcript reconcile read the file to its frontier, so the DB
       // tail is exact — use precise alignment instead of the heuristic
       // dedup stack, and persist only what the transcript flush has not
-      // delivered yet.
+      // delivered yet. The reconcile reports the exact message ids it
+      // inserted this turn; only those rows may anchor the metadata-face
+      // collapse (ground truth, not an insertion-order inference). An empty
+      // or absent set keeps the strong collapse off.
       dedupedNewMessages = await this.batchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier(
         params.sessionId,
         params.sessionKey,
         newMessages,
-        sameTurnIngestFloor,
+        transcriptReconcileResult.insertedMessageIds?.length
+          ? new Set(transcriptReconcileResult.insertedMessageIds)
+          : undefined,
       );
       if (newMessages.length > 0 && dedupedNewMessages.length < newMessages.length) {
         this.deps.log.debug(

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3056,13 +3056,17 @@ export class LcmContextEngine implements ContextEngine {
     const newMessages = filterPersistableMessages(
       params.messages.slice(params.prePromptMessageCount),
     );
-    // Capture the conversation's newest message id BEFORE the transcript
-    // reconcile below runs: rows above this floor are the ingests of THIS
-    // turn's reconcile (session writes are queue-serialized). Only the
-    // transcript-covered alignment consumes it — covered means the reconcile
-    // read the transcript to its frontier, so the newest user row is this
-    // turn's own inbound and the decorated end-of-turn face may collapse
-    // onto exactly that ingest. Routes without that proof (degraded
+    // Capture the conversation's maximum message id BEFORE the transcript
+    // reconcile below runs: rows above this floor were inserted by THIS
+    // turn's reconcile (session writes are queue-serialized and message_id
+    // is insertion-ordered). MAX(message_id) rather than the logical tail's
+    // id: a writer that backfills rows out of seq order leaves the tail's id
+    // below newer insertions, and a watermark that misses them would let a
+    // pre-existing row pose as this turn's ingest. Only the
+    // transcript-covered alignment consumes the floor — covered means the
+    // reconcile read the transcript to its frontier, so the newest user row
+    // is this turn's own inbound and the decorated end-of-turn face may
+    // collapse onto exactly that ingest. Routes without that proof (degraded
     // checkpoint, heuristic, oversized) never strong-collapse and keep the
     // pair. Undefined on lookup failure = the strong collapse stays off.
     let sameTurnIngestFloor: number | undefined;
@@ -3072,11 +3076,9 @@ export class LcmContextEngine implements ContextEngine {
         sessionKey: params.sessionKey,
       });
       sameTurnIngestFloor = preReconcileConversation
-        ? ((
-            await this.conversationStore.getLastMessage(
-              preReconcileConversation.conversationId,
-            )
-          )?.messageId ?? 0)
+        ? ((await this.conversationStore.getMaxMessageId(
+            preReconcileConversation.conversationId,
+          )) ?? 0)
         : 0;
     } catch {
       sameTurnIngestFloor = undefined;

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -81,6 +81,8 @@ export type ContextEngineMaintenanceRuntimeContext = Record<string, unknown> & {
 
 export type IngestResult = {
   ingested: boolean;
+  /** Set when ingested: the persisted row's message id. */
+  messageId?: number;
 };
 
 export type IngestBatchResult = {

--- a/src/reconcile-plan.ts
+++ b/src/reconcile-plan.ts
@@ -107,6 +107,13 @@ export type TranscriptReconcileResult = {
   importedMessages: number;
   hasOverlap: boolean;
   /**
+   * message_ids of the rows THIS reconcile inserted, in insertion order.
+   * Ground truth for the same-turn metadata-face collapse: only a row whose
+   * id appears here may anchor it. Absent or empty when nothing was
+   * inserted, which keeps the strong collapse off.
+   */
+  insertedMessageIds?: number[];
+  /**
    * True only when the transcript file was actually read to its frontier and
    * reconciled into the DB this call (or proven already reconciled). When
    * true, the transcript is the single persistence source for the turn and

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -110,10 +110,10 @@ export type MessageRecord = {
    * Transcript provenance: non-null only when the row was imported from a
    * transcript envelope written by the host's own flush — a marker a user
    * cannot forge. Dedup uses it, together with proof that the row is the
-   * current turn's own transcript ingest (above the pre-reconcile message-id
-   * floor and the conversation's newest user row), to decide whether a
-   * metadata-body match against this row may anchor a collapse; provenance
-   * alone only supports alignment.
+   * current turn's own transcript ingest (its id in the set the reconcile
+   * reported as inserted, and the conversation's newest user row), to decide
+   * whether a metadata-body match against this row may anchor a collapse;
+   * provenance alone only supports alignment.
    */
   transcriptEntryId: string | null;
   /** Allowlisted OpenClaw sender identity, or null for legacy/direct messages. */
@@ -843,19 +843,6 @@ export class ConversationStore {
       .get(conversationId) as unknown as MessageRow | undefined;
 
     return row ? toMessageRecord(row) : null;
-  }
-
-  /**
-   * True insertion watermark for a conversation: the maximum message_id ever
-   * inserted, independent of seq ordering. getLastMessage follows the
-   * logical tail (seq), which can sit below the newest insertion when a
-   * writer backfills rows out of sequence; watermark semantics must not.
-   */
-  async getMaxMessageId(conversationId: ConversationId): Promise<number | null> {
-    const row = this.db
-      .prepare(`SELECT MAX(message_id) AS max_id FROM messages WHERE conversation_id = ?`)
-      .get(conversationId) as { max_id: number | null } | undefined;
-    return row?.max_id ?? null;
   }
 
   async getLastMessageWithRole(

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -109,9 +109,9 @@ export type MessageRecord = {
   /**
    * Transcript provenance: non-null only when the row was imported from a
    * transcript envelope written by the host's own flush — a marker a user
-   * cannot forge. Covered-frontier dedup requires it before a metadata-body
-   * match may support alignment; an independent replay anchor is still
-   * required before collapse.
+   * cannot forge. Dedup uses it, together with same-turn freshness of the
+   * row, to decide whether a metadata-body match against this row may anchor
+   * a collapse; provenance alone only supports alignment.
    */
   transcriptEntryId: string | null;
   /** Allowlisted OpenClaw sender identity, or null for legacy/direct messages. */

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -845,6 +845,19 @@ export class ConversationStore {
     return row ? toMessageRecord(row) : null;
   }
 
+  /**
+   * True insertion watermark for a conversation: the maximum message_id ever
+   * inserted, independent of seq ordering. getLastMessage follows the
+   * logical tail (seq), which can sit below the newest insertion when a
+   * writer backfills rows out of sequence; watermark semantics must not.
+   */
+  async getMaxMessageId(conversationId: ConversationId): Promise<number | null> {
+    const row = this.db
+      .prepare(`SELECT MAX(message_id) AS max_id FROM messages WHERE conversation_id = ?`)
+      .get(conversationId) as { max_id: number | null } | undefined;
+    return row?.max_id ?? null;
+  }
+
   async getLastMessageWithRole(
     conversationId: ConversationId,
     role: string,

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -851,7 +851,7 @@ export class ConversationStore {
   ): Promise<MessageRecord | null> {
     const row = this.db
       .prepare(
-        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content, transcript_entry_id
+        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content, transcript_entry_id, openclaw_sender_metadata
        FROM messages
        WHERE conversation_id = ? AND role = ?
        ORDER BY seq DESC

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -109,9 +109,11 @@ export type MessageRecord = {
   /**
    * Transcript provenance: non-null only when the row was imported from a
    * transcript envelope written by the host's own flush — a marker a user
-   * cannot forge. Dedup uses it, together with same-turn freshness of the
-   * row, to decide whether a metadata-body match against this row may anchor
-   * a collapse; provenance alone only supports alignment.
+   * cannot forge. Dedup uses it, together with proof that the row is the
+   * current turn's own transcript ingest (above the pre-reconcile message-id
+   * floor and the conversation's newest user row), to decide whether a
+   * metadata-body match against this row may anchor a collapse; provenance
+   * alone only supports alignment.
    */
   transcriptEntryId: string | null;
   /** Allowlisted OpenClaw sender identity, or null for legacy/direct messages. */
@@ -839,6 +841,23 @@ export class ConversationStore {
        LIMIT 1`,
       )
       .get(conversationId) as unknown as MessageRow | undefined;
+
+    return row ? toMessageRecord(row) : null;
+  }
+
+  async getLastMessageWithRole(
+    conversationId: ConversationId,
+    role: string,
+  ): Promise<MessageRecord | null> {
+    const row = this.db
+      .prepare(
+        `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content, transcript_entry_id
+       FROM messages
+       WHERE conversation_id = ? AND role = ?
+       ORDER BY seq DESC
+       LIMIT 1`,
+      )
+      .get(conversationId, role) as unknown as MessageRow | undefined;
 
     return row ? toMessageRecord(row) : null;
   }

--- a/src/transcript-reconciler.ts
+++ b/src/transcript-reconciler.ts
@@ -427,6 +427,7 @@ export class TranscriptReconciler {
 
     const replayTwinIndex = this.buildReplayTwinIndex(historicalMessages);
     let importedMessages = 0;
+    const insertedMessageIds: number[] = [];
     let adoptedMessages = 0;
     let restampedMessages = 0;
     let replayTwinsSkipped = 0;
@@ -486,6 +487,7 @@ export class TranscriptReconciler {
       if (result.ingested) {
         importedMessages += 1;
         cappedImportProgress += 1;
+        if (result.messageId !== undefined) insertedMessageIds.push(result.messageId);
       }
     }
 
@@ -497,10 +499,11 @@ export class TranscriptReconciler {
         blockedByImportCap: true,
         blockedReason: "import-cap",
         importedMessages,
+        insertedMessageIds,
         hasOverlap: true,
       };
     }
-    return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+    return { blockedByImportCap: false, importedMessages, insertedMessageIds, hasOverlap: true };
   }
 
   /**
@@ -873,7 +876,7 @@ export class TranscriptReconciler {
       );
     }
 
-    const importedMessages = await this.ingestBatch({
+    const { importedMessages, insertedMessageIds } = await this.ingestBatch({
       sessionId,
       sessionKey: params.sessionKey,
       messages: importableTail,
@@ -888,6 +891,7 @@ export class TranscriptReconciler {
         blockedByImportCap: true,
         blockedReason: "import-cap",
         importedMessages,
+        insertedMessageIds,
         hasOverlap: true,
       };
     }
@@ -895,7 +899,7 @@ export class TranscriptReconciler {
     this.host.deps.log.debug(
       `[lcm] reconcileSessionTail: slow path for ${sessionContext} duration=${formatDurationMs(Date.now() - startedAt)} historicalMessages=${historicalMessages.length} anchorIndex=${anchorIndex} missingTail=${missingTail.length} importedMessages=${importedMessages}`,
     );
-    return { blockedByImportCap: false, importedMessages, hasOverlap: true };
+    return { blockedByImportCap: false, importedMessages, insertedMessageIds, hasOverlap: true };
   }
 
   /**
@@ -914,6 +918,7 @@ export class TranscriptReconciler {
     const existingCount = await this.host.conversationStore.getMessageCount(params.conversationId);
     if (existingCount === 0) {
       let importedMessages = 0;
+      const insertedMessageIds: number[] = [];
       for (const message of params.historicalMessages) {
         const result = await this.host.ingestSingle({
           sessionId: params.sessionId,
@@ -924,6 +929,7 @@ export class TranscriptReconciler {
         });
         if (result.ingested) {
           importedMessages += 1;
+          if (result.messageId !== undefined) insertedMessageIds.push(result.messageId);
         }
       }
       await this.host.conversationStore.markConversationBootstrapped(params.conversationId);
@@ -934,6 +940,7 @@ export class TranscriptReconciler {
       });
       return {
         importedMessages,
+        insertedMessageIds,
         blockedByImportCap: false,
         hasOverlap: true,
         transcriptCovered: importedMessages > 0,
@@ -1132,6 +1139,7 @@ export class TranscriptReconciler {
         .filter((id): id is string => id !== null),
     );
     let importedMessages = 0;
+    const insertedMessageIds: number[] = [];
     let adoptedMessages = 0;
     for (const message of noAnchorImportMessages) {
       const entryId = getTranscriptEntryId(message);
@@ -1197,6 +1205,7 @@ export class TranscriptReconciler {
       });
       if (result.ingested) {
         importedMessages += 1;
+        if (result.messageId !== undefined) insertedMessageIds.push(result.messageId);
       }
     }
     // A fresh-ambiguous-rollover rebind imports the rolled transcript as a new
@@ -1216,6 +1225,7 @@ export class TranscriptReconciler {
         blockedByImportCap: true,
         blockedReason: "import-cap",
         importedMessages,
+        insertedMessageIds,
         hasOverlap: adoptedMessages > 0,
       };
     }
@@ -1223,7 +1233,12 @@ export class TranscriptReconciler {
     // host re-issued ids for messages we already hold), so report the
     // overlap — the caller then refreshes the checkpoint instead of
     // re-entering this path every turn.
-    return { blockedByImportCap: false, importedMessages, hasOverlap: adoptedMessages > 0 };
+    return {
+      blockedByImportCap: false,
+      importedMessages,
+      insertedMessageIds,
+      hasOverlap: adoptedMessages > 0,
+    };
   }
 
   /**
@@ -1783,9 +1798,10 @@ export class TranscriptReconciler {
   }
 
   /**
-   * Ingest a reconciled batch in order, returning how many rows persisted.
-   * Indexes below `replayGuardExemptPrefixLength` skip the replay-timestamp
-   * flood guard (transcript-proven history); pass Infinity to exempt all.
+   * Ingest a reconciled batch in order, returning how many rows persisted
+   * and their message ids. Indexes below `replayGuardExemptPrefixLength`
+   * skip the replay-timestamp flood guard (transcript-proven history); pass
+   * Infinity to exempt all.
    */
   private async ingestBatch(params: {
     sessionId: string;
@@ -1798,8 +1814,9 @@ export class TranscriptReconciler {
     replayTwinConversationId?: number;
     replayTwinSessionFile?: string;
     onReplayTwinSkipped?: () => void;
-  }): Promise<number> {
+  }): Promise<{ importedMessages: number; insertedMessageIds: number[] }> {
     let importedMessages = 0;
+    const insertedMessageIds: number[] = [];
     // Tier 2 full-tail index, built lazily at most once per batch: only a Tier-1
     // store hit (a persisted same-identity, same-second row) justifies the full
     // leaf-path re-read.
@@ -1846,9 +1863,10 @@ export class TranscriptReconciler {
       });
       if (result.ingested) {
         importedMessages += 1;
+        if (result.messageId !== undefined) insertedMessageIds.push(result.messageId);
       }
     }
-    return importedMessages;
+    return { importedMessages, insertedMessageIds };
   }
 
   /**
@@ -1951,7 +1969,7 @@ export class TranscriptReconciler {
         );
         return { importedMessages: 0, blockedByImportCap: true, hasOverlap: false };
       }
-      const importedMessages = await this.ingestBatch({
+      const { importedMessages, insertedMessageIds } = await this.ingestBatch({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         messages: bootstrapMessages,
@@ -1976,6 +1994,7 @@ export class TranscriptReconciler {
       }
       return {
         importedMessages,
+        insertedMessageIds,
         blockedByImportCap: bootstrapMessages.length < historicalMessages.length,
         hasOverlap: true,
         transcriptCovered: true,
@@ -2089,7 +2108,7 @@ export class TranscriptReconciler {
         });
         if (!appendOnlyOverlapsPersisted) {
           let replayTwinsSkipped = 0;
-          const importedMessages = await this.ingestBatch({
+          const { importedMessages, insertedMessageIds } = await this.ingestBatch({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             messages: replayFilteredMessages,
@@ -2114,6 +2133,7 @@ export class TranscriptReconciler {
           }
           return {
             importedMessages,
+            insertedMessageIds,
             blockedByImportCap: false,
             hasOverlap: true,
             transcriptCovered: true,

--- a/test/engine-ingest.test.ts
+++ b/test/engine-ingest.test.ts
@@ -1534,7 +1534,7 @@ describe("LcmContextEngine.ingest content extraction", () => {
         message: makeMessage({ role: "user", content: "keep LCM active" }),
       });
 
-      expect(ingested).toEqual({ ingested: true });
+      expect(ingested).toEqual({ ingested: true, messageId: expect.any(Number) });
 
       const result = await engine.maintain({
         sessionId,
@@ -1622,8 +1622,8 @@ describe("LcmContextEngine.ingest content extraction", () => {
     releaseFirstCreate();
 
     await expect(Promise.all([firstIngest, secondIngest])).resolves.toEqual([
-      { ingested: true },
-      { ingested: true },
+      { ingested: true, messageId: expect.any(Number) },
+      { ingested: true, messageId: expect.any(Number) },
     ]);
 
     const conversation = await store.getConversationBySessionKey(sessionKey);

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -189,7 +189,7 @@ describe("LcmContextEngine ignored sessions", () => {
     });
 
     expect(ignored).toEqual({ ingested: false });
-    expect(included).toEqual({ ingested: true });
+    expect(included).toEqual({ ingested: true, messageId: expect.any(Number) });
     expect(
       await engine.getConversationStore().getConversationBySessionId(ignoredSessionId),
     ).toBeNull();
@@ -732,7 +732,7 @@ describe("LcmContextEngine stateless sessions", () => {
 
     expect(ingested).toEqual({ ingested: false });
     expect(batched).toEqual({ ingestedCount: 0 });
-    expect(included).toEqual({ ingested: true });
+    expect(included).toEqual({ ingested: true, messageId: expect.any(Number) });
 
     const conversation = await engine
       .getConversationStore()
@@ -754,7 +754,7 @@ describe("LcmContextEngine stateless sessions", () => {
       sessionKey,
       message: makeMessage({ role: "user", content: "ping" }),
     });
-    expect(userResult).toEqual({ ingested: true });
+    expect(userResult).toEqual({ ingested: true, messageId: expect.any(Number) });
 
     // Ingest an error assistant message with empty content array
     const errorResult = await engine.ingest({
@@ -814,7 +814,7 @@ describe("LcmContextEngine stateless sessions", () => {
       sessionKey,
       message: makeMessage({ role: "assistant", content: "pong" }),
     });
-    expect(normalResult).toEqual({ ingested: true });
+    expect(normalResult).toEqual({ ingested: true, messageId: expect.any(Number) });
 
     // An error assistant with actual content should still be ingested
     const errorWithContentResult = await engine.ingest({
@@ -827,7 +827,7 @@ describe("LcmContextEngine stateless sessions", () => {
         timestamp: Date.now(),
       } as AgentMessage,
     });
-    expect(errorWithContentResult).toEqual({ ingested: true });
+    expect(errorWithContentResult).toEqual({ ingested: true, messageId: expect.any(Number) });
 
     // Verify only the 3 valid messages were stored despite rejected empty error turns.
     const conversation = await engine
@@ -1436,7 +1436,7 @@ describe("LcmContextEngine connection lifecycle", () => {
         sessionId,
         message: makeMessage({ role: "assistant", content: "second" }),
       }),
-    ).resolves.toEqual({ ingested: true });
+    ).resolves.toEqual({ ingested: true, messageId: expect.any(Number) });
   });
 });
 

--- a/test/metadata-face-double-write.test.ts
+++ b/test/metadata-face-double-write.test.ts
@@ -438,6 +438,97 @@ describe("covered-frontier same-turn anchor", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("captures a true insertion watermark: an out-of-order backfilled row above the logical tail's id never anchors", async () => {
+    // Insertion order deliberately diverges from seq order: the assistant
+    // tail row (seq 1) is inserted FIRST, the user row (seq 0) SECOND, so
+    // the user row carries the higher message_id while the logical tail's
+    // id sits below it. A floor read from the tail row's id would report
+    // this pre-existing user row as above-floor; MAX(message_id) reports it
+    // below, which is the semantics the collapse predicate documents. The
+    // end-to-end shape stays a keep either way (the tail window never pairs
+    // a lone face with a row below the logical tail), so this pins the
+    // watermark contract and the keep direction against future window
+    // changes rather than a live reproduction.
+    const engine = quietEngine();
+    const sessionId = "metadata-face-out-of-order";
+    const sessionKey = "agent:main:metadata-face-out-of-order";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey });
+
+    const assistantRows = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "assistant",
+        content: "previous exact reply",
+        tokenCount: 3,
+        transcriptEntryId: "ooo-entry-0002",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    const userRows = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BARE,
+        tokenCount: 12,
+        transcriptEntryId: "ooo-entry-0001",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    // The divergence this test exists for: the seq-0 user row was inserted
+    // after the seq-1 tail row and carries the higher message_id, so the
+    // logical tail's id under-reports the insertion frontier while
+    // MAX(message_id) captures it.
+    expect(userRows[0]!.messageId).toBeGreaterThan(assistantRows[0]!.messageId);
+    const tailRow = await engine
+      .getConversationStore()
+      .getLastMessage(conversation.conversationId);
+    const watermark = await engine
+      .getConversationStore()
+      .getMaxMessageId(conversation.conversationId);
+    expect(tailRow!.messageId).toBe(assistantRows[0]!.messageId);
+    expect(watermark).toBe(userRows[0]!.messageId);
+    expect(watermark!).toBeGreaterThan(tailRow!.messageId);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [
+        userRows[0]!.messageId,
+        assistantRows[0]!.messageId,
+      ]);
+
+    const sessionFile = createSessionFilePath("metadata-face-out-of-order");
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: BARE },
+      { role: "assistant", content: "previous exact reply" },
+    ]);
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: sessionFile,
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      lastProcessedEntryHash: null,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      messages: [makeMessage({ role: "user", content: decorated(BARE) })],
+      prePromptMessageCount: 0,
+      tokenBudget: 4_096,
+    });
+
+    const stored = await engine.getConversationStore().getMessages(conversation.conversationId);
+    const bareRows = stored.filter((m) => m.role === "user" && m.content.includes(BARE));
+    expect(bareRows).toHaveLength(2);
+    expect(bareRows.some((m) => m.content === BARE)).toBe(true);
+    expect(bareRows.some((m) => m.content !== BARE)).toBe(true);
+  });
+
   it("keeps the pair when no floor is available (lookup failure disables the strong collapse)", async () => {
     const engine = quietEngine();
     const sessionId = "metadata-face-no-floor";

--- a/test/metadata-face-double-write.test.ts
+++ b/test/metadata-face-double-write.test.ts
@@ -5,11 +5,13 @@
 // AgentMessage carries the DECORATED face ("Conversation info (untrusted
 // metadata)" block + body). Their identity_hashes differ, so identity dedup
 // cannot see the pair; the metadata-body match must collapse it. Collapse
-// strength requires BOTH persisted transcript provenance (host-written row)
-// AND that the row was ingested by the CURRENT turn's own reconcile (its
-// message_id above the pre-reconcile floor the engine captures). Any older
-// row, however recent, and any provenance-less row stays weak and duplicates
-// instead of trimming, so an echo of an earlier turn is never eaten.
+// strength exists only on the transcript-covered route and requires the
+// persisted row to be host-proven (transcript provenance), ingested by the
+// CURRENT turn's own reconcile (message_id above the pre-reconcile floor the
+// engine captures), AND the conversation's newest user row — a backfilled
+// historical row imported by the same reconcile never anchors. Any other
+// row, and any provenance-less row, stays weak and duplicates instead of
+// trimming; the degraded and oversized routes never strong-collapse at all.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LcmContextEngine } from "../src/engine.js";
 import {
@@ -166,8 +168,8 @@ describe("metadata-face covered-path double-write", () => {
     });
 
     // The persisted row was seeded moments ago, yet the transcript is
-    // unavailable this turn: nothing was ingested by THIS turn's reconcile,
-    // so the row sits below the same-turn floor and the match stays weak. A
+    // unavailable this turn: the degraded route runs without same-turn
+    // ingest proof and never strong-collapses, so the match stays weak. A
     // rapid repeated body (same text within seconds) takes exactly this
     // shape, and the pair duplicates instead of eating the new turn.
     const userRows = (
@@ -343,4 +345,128 @@ describe("metadata-face covered-path double-write", () => {
     expect(userRows.some((m) => m.content === BARE)).toBe(true);
   });
 
+});
+
+describe("covered-frontier same-turn anchor", () => {
+  it("never anchors on a backfilled above-floor row: an older user row imported by the same reconcile stays weak and the batch is kept", async () => {
+    // Catch-up reconcile shape: floor 0 (first reconcile of the
+    // conversation), several host-proven rows imported by the same
+    // reconcile, among them an OLD user row whose body a decorated runtime
+    // face repeats. The insertion watermark alone would call that row
+    // same-turn; the newest-user-row condition refuses it, and its
+    // provenanced sibling never extends strength to the refused neighbor.
+    const engine = quietEngine();
+    const sessionId = "metadata-face-backfill";
+    const sessionKey = "agent:main:metadata-face-backfill";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey });
+
+    const bulk = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BARE,
+        tokenCount: 12,
+        transcriptEntryId: "backfill-entry-0001",
+        skipReplayTimestampFloodGuard: true,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "user",
+        content: DIFFERENT,
+        tokenCount: 8,
+        transcriptEntryId: "backfill-entry-0002",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, bulk.map((m) => m.messageId));
+
+    const result = await engine
+      .getBatchDeduplicator()
+      .alignRuntimeBatchAgainstCoveredFrontier(
+        sessionId,
+        sessionKey,
+        [
+          makeMessage({ role: "user", content: decorated(BARE) }),
+          makeMessage({ role: "user", content: decorated(DIFFERENT) }),
+        ],
+        0,
+      );
+
+    // The BARE-bodied face matched a row that is above the floor but not the
+    // newest user row (a backfill), so nothing in the suffix may trim.
+    expect(result).toHaveLength(2);
+  });
+
+  it("collapses a lone decorated face onto exactly its own same-turn ingest (above floor and the newest user row)", async () => {
+    const engine = quietEngine();
+    const sessionId = "metadata-face-own-ingest";
+    const sessionKey = "agent:main:metadata-face-own-ingest";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey });
+
+    const bulk = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BARE,
+        tokenCount: 12,
+        transcriptEntryId: "own-ingest-entry-0001",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, bulk.map((m) => m.messageId));
+
+    const result = await engine
+      .getBatchDeduplicator()
+      .alignRuntimeBatchAgainstCoveredFrontier(
+        sessionId,
+        sessionKey,
+        [makeMessage({ role: "user", content: decorated(BARE) })],
+        0,
+      );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps the pair when no floor is available (lookup failure disables the strong collapse)", async () => {
+    const engine = quietEngine();
+    const sessionId = "metadata-face-no-floor";
+    const sessionKey = "agent:main:metadata-face-no-floor";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey });
+
+    const bulk = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: BARE,
+        tokenCount: 12,
+        transcriptEntryId: "no-floor-entry-0001",
+        skipReplayTimestampFloodGuard: true,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, bulk.map((m) => m.messageId));
+
+    const result = await engine
+      .getBatchDeduplicator()
+      .alignRuntimeBatchAgainstCoveredFrontier(sessionId, sessionKey, [
+        makeMessage({ role: "user", content: decorated(BARE) }),
+      ]);
+
+    expect(result).toHaveLength(1);
+  });
 });

--- a/test/metadata-face-double-write.test.ts
+++ b/test/metadata-face-double-write.test.ts
@@ -6,12 +6,12 @@
 // metadata)" block + body). Their identity_hashes differ, so identity dedup
 // cannot see the pair; the metadata-body match must collapse it. Collapse
 // strength exists only on the transcript-covered route and requires the
-// persisted row to be host-proven (transcript provenance), ingested by the
-// CURRENT turn's own reconcile (message_id above the pre-reconcile floor the
-// engine captures), AND the conversation's newest user row — a backfilled
-// historical row imported by the same reconcile never anchors. Any other
-// row, and any provenance-less row, stays weak and duplicates instead of
-// trimming; the degraded and oversized routes never strong-collapse at all.
+// persisted row to be host-proven (transcript provenance), among the exact
+// message ids the CURRENT turn's own reconcile reported as inserted, AND
+// the conversation's newest user row — a backfilled historical row imported
+// by the same reconcile never anchors while a newer user row exists. Any
+// other row, and any provenance-less row, stays weak and duplicates instead
+// of trimming; the degraded and oversized routes never strong-collapse.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LcmContextEngine } from "../src/engine.js";
 import {
@@ -348,13 +348,13 @@ describe("metadata-face covered-path double-write", () => {
 });
 
 describe("covered-frontier same-turn anchor", () => {
-  it("never anchors on a backfilled above-floor row: an older user row imported by the same reconcile stays weak and the batch is kept", async () => {
-    // Catch-up reconcile shape: floor 0 (first reconcile of the
-    // conversation), several host-proven rows imported by the same
-    // reconcile, among them an OLD user row whose body a decorated runtime
-    // face repeats. The insertion watermark alone would call that row
-    // same-turn; the newest-user-row condition refuses it, and its
-    // provenanced sibling never extends strength to the refused neighbor.
+  it("never anchors on a backfilled row: an older user row imported by the same reconcile stays weak and the batch is kept", async () => {
+    // Catch-up reconcile shape: several host-proven rows imported by the
+    // same reconcile (both ids in this turn's inserted set), among them an
+    // OLD user row whose body a decorated runtime face repeats. Set
+    // membership alone would call that row same-turn; the newest-user-row
+    // condition refuses it, and its provenanced sibling never extends
+    // strength to the refused neighbor.
     const engine = quietEngine();
     const sessionId = "metadata-face-backfill";
     const sessionKey = "agent:main:metadata-face-backfill";
@@ -395,7 +395,7 @@ describe("covered-frontier same-turn anchor", () => {
           makeMessage({ role: "user", content: decorated(BARE) }),
           makeMessage({ role: "user", content: decorated(DIFFERENT) }),
         ],
-        0,
+        new Set(bulk.map((m) => m.messageId)),
       );
 
     // The BARE-bodied face matched a row that is above the floor but not the
@@ -403,7 +403,7 @@ describe("covered-frontier same-turn anchor", () => {
     expect(result).toHaveLength(2);
   });
 
-  it("collapses a lone decorated face onto exactly its own same-turn ingest (above floor and the newest user row)", async () => {
+  it("collapses a lone decorated face onto exactly its own same-turn ingest (in the inserted set and the newest user row)", async () => {
     const engine = quietEngine();
     const sessionId = "metadata-face-own-ingest";
     const sessionKey = "agent:main:metadata-face-own-ingest";
@@ -432,23 +432,19 @@ describe("covered-frontier same-turn anchor", () => {
         sessionId,
         sessionKey,
         [makeMessage({ role: "user", content: decorated(BARE) })],
-        0,
+        new Set([bulk[0]!.messageId]),
       );
 
     expect(result).toHaveLength(0);
   });
 
-  it("captures a true insertion watermark: an out-of-order backfilled row above the logical tail's id never anchors", async () => {
+  it("keeps the pair when rows were inserted out of seq order before this turn (pre-existing rows are never in the inserted set)", async () => {
     // Insertion order deliberately diverges from seq order: the assistant
     // tail row (seq 1) is inserted FIRST, the user row (seq 0) SECOND, so
     // the user row carries the higher message_id while the logical tail's
-    // id sits below it. A floor read from the tail row's id would report
-    // this pre-existing user row as above-floor; MAX(message_id) reports it
-    // below, which is the semantics the collapse predicate documents. The
-    // end-to-end shape stays a keep either way (the tail window never pairs
-    // a lone face with a row below the logical tail), so this pins the
-    // watermark contract and the keep direction against future window
-    // changes rather than a live reproduction.
+    // id sits below it. Both rows predate this turn, so neither appears in
+    // the reconcile's inserted-id set and no watermark inference can
+    // misclassify them; the pair is kept.
     const engine = quietEngine();
     const sessionId = "metadata-face-out-of-order";
     const sessionKey = "agent:main:metadata-face-out-of-order";
@@ -479,19 +475,8 @@ describe("covered-frontier same-turn anchor", () => {
       },
     ]);
     // The divergence this test exists for: the seq-0 user row was inserted
-    // after the seq-1 tail row and carries the higher message_id, so the
-    // logical tail's id under-reports the insertion frontier while
-    // MAX(message_id) captures it.
+    // after the seq-1 tail row and carries the higher message_id.
     expect(userRows[0]!.messageId).toBeGreaterThan(assistantRows[0]!.messageId);
-    const tailRow = await engine
-      .getConversationStore()
-      .getLastMessage(conversation.conversationId);
-    const watermark = await engine
-      .getConversationStore()
-      .getMaxMessageId(conversation.conversationId);
-    expect(tailRow!.messageId).toBe(assistantRows[0]!.messageId);
-    expect(watermark).toBe(userRows[0]!.messageId);
-    expect(watermark!).toBeGreaterThan(tailRow!.messageId);
     await engine
       .getSummaryStore()
       .appendContextMessages(conversation.conversationId, [

--- a/test/metadata-face-double-write.test.ts
+++ b/test/metadata-face-double-write.test.ts
@@ -4,11 +4,12 @@
 // persists the BARE body (with a transcript_entry_id), while the runtime
 // AgentMessage carries the DECORATED face ("Conversation info (untrusted
 // metadata)" block + body). Their identity_hashes differ, so identity dedup
-// cannot see the pair; the metadata-body match must collapse it. Anchoring
-// The covered-frontier path requires both persisted transcript provenance and
-// an independent exact/timestamp replay anchor. Heuristic degraded and
-// oversized routes cannot prove that an incoming face belongs to that row, so
-// they preserve both faces (duplicates over deletion).
+// cannot see the pair; the metadata-body match must collapse it. Collapse
+// strength requires BOTH persisted transcript provenance (host-written row)
+// AND that the row was ingested by the CURRENT turn's own reconcile (its
+// message_id above the pre-reconcile floor the engine captures). Any older
+// row, however recent, and any provenance-less row stays weak and duplicates
+// instead of trimming, so an echo of an earlier turn is never eaten.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LcmContextEngine } from "../src/engine.js";
 import {
@@ -121,7 +122,7 @@ describe("metadata-face covered-path double-write", () => {
     ).toBe(true);
   });
 
-  it("keeps the decorated turn on the degraded route even when the persisted row is transcript-proven", async () => {
+  it("keeps the pair on the degraded route even for a transcript-proven row created moments ago (not this turn's ingest; covers the rapid repeated-body case)", async () => {
     const engine = quietEngine();
     const sessionId = "metadata-face-degraded-double-write";
     const sessionKey = "agent:main:metadata-face-degraded-double-write";
@@ -164,6 +165,11 @@ describe("metadata-face covered-path double-write", () => {
       tokenBudget: 4_096,
     });
 
+    // The persisted row was seeded moments ago, yet the transcript is
+    // unavailable this turn: nothing was ingested by THIS turn's reconcile,
+    // so the row sits below the same-turn floor and the match stays weak. A
+    // rapid repeated body (same text within seconds) takes exactly this
+    // shape, and the pair duplicates instead of eating the new turn.
     const userRows = (
       await engine.getConversationStore().getMessages(conversation.conversationId)
     ).filter((m) => m.role === "user" && m.content.includes(BARE));
@@ -172,7 +178,7 @@ describe("metadata-face covered-path double-write", () => {
     expect(userRows.some((m) => m.content !== BARE)).toBe(true);
   });
 
-  it("keeps the decorated turn on the oversized-suffix route even when the persisted row is transcript-proven", async () => {
+  it("keeps the pair on the oversized-suffix route even for a transcript-proven row created moments ago (not this turn's ingest)", async () => {
     const engine = quietEngine();
     const sessionId = "metadata-face-oversized-double-write";
     const sessionKey = "agent:main:metadata-face-oversized-double-write";
@@ -336,4 +342,5 @@ describe("metadata-face covered-path double-write", () => {
     expect(userRows).toHaveLength(2);
     expect(userRows.some((m) => m.content === BARE)).toBe(true);
   });
+
 });

--- a/test/transcript-entry-id.test.ts
+++ b/test/transcript-entry-id.test.ts
@@ -415,7 +415,7 @@ describe("afterTurn covered-frontier alignment", () => {
     expect(messages.map((message) => message.content)).toEqual(["nice! thank you!"]);
   });
 
-  it("keeps a conv-info-only runtime copy without a sibling anchor", async () => {
+  it("collapses a conv-info-only runtime copy onto the same turn's own transcript ingest without a sibling anchor", async () => {
     const sessionFile = createSessionFilePath("decorated-convinfo-repeat");
     const header = JSON.stringify({
       type: "session",
@@ -453,12 +453,12 @@ describe("afterTurn covered-frontier alignment", () => {
       .getConversationStore()
       .getConversationForSession({ sessionId });
     const messages = await engine.getConversationStore().getMessages(conversation!.conversationId);
-    // The bare row is transcript-proven, but that authenticates only the
-    // stored row. It does not prove this incoming metadata face belongs to the
-    // same entry, so without another exact/timestamp anchor both rows survive.
+    // The bare row is transcript-proven AND same-turn fresh: the host ingested
+    // it from its own transcript moments ago, so the incoming metadata face is
+    // this turn's end-of-turn copy (the store double-write), not an echo of an
+    // older turn. Fresh provenance anchors the collapse; the bare face wins.
     expect(messages.map((message) => message.content)).toEqual([
       "Hey there! hows it going?",
-      decorated,
     ]);
   });
 


### PR DESCRIPTION
## Problem

[#1050](https://github.com/Martian-Engineering/lossless-claw/issues/1050): since [`1307b950a`](https://github.com/Martian-Engineering/lossless-claw/pull/1042/commits/1307b950aea9f8f11c44f48022e5e633d30126fc), every inbound turn on decorated channels (Slack DMs and similar) stores twice: the bare transcript-anchored row, then the decorated end-of-turn face as a second row. With the see-through rendering from [#1036](https://github.com/Martian-Engineering/lossless-claw/pull/1036), both faces replay into every later prompt and each turn compounds one duplicate for the life of the conversation. The commit is unreleased so far (0.15.1 predates it); the next release would ship it.

## The design tension, and how this resolves it

[`1307b950a`](https://github.com/Martian-Engineering/lossless-claw/pull/1042/commits/1307b950aea9f8f11c44f48022e5e633d30126fc)'s rationale stands: a metadata-body match alone must never anchor a collapse, and stored transcript provenance authenticates only the persisted row, not the claim that the incoming face is a replay of it. The problem is that the end-of-turn pair structurally never has the exact or timestamp anchor the commit now requires, so the double-write is guaranteed.

This PR adds the missing link as ground truth rather than a heuristic. Each transcript import path now reports the exact message ids it inserted, and the reconcile result carries them to afterTurn. Collapse strength then exists only on the transcript-covered route (the one route that proves this turn's inbound was actually ingested, because the reconcile read the transcript to its frontier) and requires the persisted row to satisfy all three of:

1. transcript provenance (host-written row),
2. its `message_id` in the set THIS turn's reconcile reported as inserted (collected at the insert sites themselves, so no insertion-order or seq property needs to be inferred),
3. being the conversation's newest user row after the reconcile.

Condition 2 ties the anchor to this very reconcile's writes (per review, replacing the earlier watermark inference entirely); condition 3 ties it to the turn's own inbound: a historical row a catch-up reconcile backfilled in the same pass is in the inserted set too, but on the covered route the turn's own inbound is always the newest user row, so the backfilled row never anchors while a newer user row exists (per review). The strength is also local to the matched row: a `provenanced-inbound` match authenticates only itself, never a neighboring redacted or otherwise unanchored match (per review). Concretely:

* The double-write pair always qualifies: the bare row is ingested by this very turn's reconcile as the newest user row, and the decorated face arrives in the same afterTurn.
* Any older or backfilled row never qualifies. A repeated body seconds later, an echo, a replay, or a catch-up import faces a row that fails condition 2 or 3, stays weak, and duplicates instead of trimming (the loss-safe direction is preserved).
* Routes without the covered proof (degraded checkpoint, heuristic boundary/full-cover, oversized, suffix) never strong-collapse and keep the pair.
* An aligned suffix trims only under the pre-existing independent anchor contract (exact/decorated, with redacted rows requiring an independent neighbor), or when every row in it proves itself. A suffix containing an unanchored row alongside only `provenanced-inbound` strength is left untrimmed.
* Provenance-less rows keep the existing behavior: never collapse on a metadata-body match.

No wall-clock heuristics are involved; the correlation is the row-insertion order under the per-session queue plus the newest-user-row identity, which is the "correlate the rows to the same transcript entry/turn" shape suggested in review.

## What changed

* `src/transcript-reconciler.ts` and `src/openclaw-bridge.ts`: `ingestSingle` reports the persisted row's message id; every import path (entry-id tail, batch/slow path, append-only fast path, afterTurn bootstrap, fresh-rollover import, no-anchor epoch import) collects the ids it inserted into `insertedMessageIds` on the reconcile result.
* `src/engine.ts`: afterTurn passes that set to the covered-frontier alignment only (absent or empty keeps the strong collapse off). Import-capped reconciles need no special handling: `blockedByImportCap` already makes the turn unsafe-to-advance and afterTurn skips persistence entirely.
* `src/batch-dedup.ts`: `persistedRowAnchorsSameTurnCollapse(record, floor, newestUserMessageId)` implements the three-condition rule; `alignedSuffixIsAnchored` implements the trim decision (independent anchor contract, or every row self-proven); `redactedMatchesHaveAdjacentAnchor` accepts only exact/decorated neighbors. The heuristic, oversized, checkpoint, and suffix routes are reverted to their previous behavior (keep the pair).
* `src/store/conversation-store.ts`: `getLastMessageWithRole` (newest user row lookup), provenance docstring updated to the three-condition rule.
* `.changeset/provenance-anchored-collapse.md`: patch changeset (review ask).
* Deliberately untouched: the recap-strip gate in `openclaw-inbound-metadata.ts` from the same commit (unrelated mechanism, interacts with identity canonicalization).

## Tests

* Red against current main, green here: `collapses a conv-info-only runtime copy onto the same turn's own transcript ingest without a sibling anchor` (`test/transcript-entry-id.test.ts`), a real afterTurn whose reconcile ingests the bare row, then collapses the decorated face; this is the live pair's exact route and reproduces the #1050 double-write on main. Plus the arm-level positive `collapses a lone decorated face onto exactly its own same-turn ingest`, also red against main.
* Red against the previous head of this branch, green here: `never anchors on a backfilled above-floor row` pins the review finding (an older user row imported by the same reconcile, above the floor, must stay weak; the prior head wrongly trimmed it).
* Pins kept or added for the loss-safe direction: the degraded and oversized routes keep the pair even for a transcript-proven row created moments ago (rapid repeated-body case), the missing-floor case keeps the pair, the fail-closed different-body case, and the no-provenance case.

## Validation

* `npm run typecheck` clean, `npm run build` clean.
* Red-proof matrix run both ways: with `src/` from current main, exactly the two positive collapse tests fail (the double-write reproducing); with `src/` from the previous head, exactly the backfill test fails (the false anchor reproducing); with this branch all pass. Full suite: 113 files, 2035/2035 passing (two pre-existing exact-shape pins on the ingest result updated for the new `messageId` field).
* Live deploy: running on our OpenClaw fleet (deployed 2026-08-04). Six ordinary decorated Slack turns each persisted exactly one user row on this fix lineage (the [`1307b950a`](https://github.com/Martian-Engineering/lossless-claw/pull/1042/commits/1307b950aea9f8f11c44f48022e5e633d30126fc) build stores bare plus decorated pairs for the same shape), and a byte-identical message re-sent 12 minutes later was correctly kept as a genuine new turn. The current form is under continued live observation.

Closes [#1050](https://github.com/Martian-Engineering/lossless-claw/issues/1050).
