### PR TITLE
ci: publish ClawHub releases from historical tags

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing npm and GitHub release tag to publish
+        required: true
+        type: string
       dry_run:
         description: Validate the ClawHub package without publishing
         required: true
@@ -12,7 +16,7 @@ on:
 
 jobs:
   dry-run:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || inputs.dry_run
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read
@@ -23,17 +27,22 @@ jobs:
       dry_run: true
 
   release-preflight:
-    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      source_sha: ${{ steps.identity.outputs.source_sha }}
     steps:
       - name: Checkout selected release
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_tag }}
 
       - name: Verify npm release identity
+        id: identity
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -41,14 +50,16 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           expected_tag="v$version"
 
-          if [ "$GITHUB_REF_TYPE" != "tag" ] || [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
-            echo "Select release tag $expected_tag, not $GITHUB_REF"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Select release tag $expected_tag, not $RELEASE_TAG"
             exit 1
           fi
 
           source_sha="$(git rev-parse HEAD)"
-          if [ "$source_sha" != "$GITHUB_SHA" ]; then
-            echo "Checked out $source_sha, expected selected commit $GITHUB_SHA"
+          git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          if [ "$source_sha" != "$tag_sha" ]; then
+            echo "Checked out $source_sha, expected $RELEASE_TAG at $tag_sha"
             exit 1
           fi
 
@@ -56,13 +67,31 @@ jobs:
           published_version="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.version || "")' "$npm_state")"
           published_sha="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.gitHead || "")' "$npm_state")"
 
-          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$GITHUB_SHA" ]; then
-            echo "npm identity does not match $expected_tag at $GITHUB_SHA"
+          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$source_sha" ]; then
+            echo "npm identity does not match $expected_tag at $source_sha"
             exit 1
           fi
 
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+  release-dry-run:
+    needs: release-preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
+    with:
+      source: ${{ github.repository }}
+      ref: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: refs/tags/${{ inputs.release_tag }}
+      dry_run: true
+
   publish:
     needs: release-preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
     concurrency:
       group: clawhub-publish
       cancel-in-progress: false
@@ -73,4 +102,7 @@ jobs:
     # openclaw/clawhub package-publish.yml v0.23.1
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
     with:
+      source: ${{ github.repository }}
+      ref: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: refs/tags/${{ inputs.release_tag }}
       dry_run: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,12 +75,15 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 ## ClawHub releases
 
 Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
-manually run `Publish to ClawHub` from that exact tag with `dry_run` set to
-`false`.
+manually run `Publish to ClawHub` from the default branch with `release_tag`
+set to that tag. Run once with `dry_run` set to `true`, review the validation,
+then run again with `dry_run` set to `false`.
 
 The workflow refuses to publish unless the selected tag, `package.json`
-version, npm version, npm `gitHead`, and selected commit all identify the same
-release. Real ClawHub publishes are serialized.
+version, npm version, npm `gitHead`, and the tag's immutable commit all identify
+the same release. Real ClawHub publishes are serialized. Selecting the default
+branch allows releases whose tags predate this workflow to be published without
+moving those tags or weakening the npm commit check.
 
 ClawHub trusted publishing is configured for
 `.github/workflows/clawhub-publish.yml`; no long-lived repository token is

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -20,18 +20,38 @@ describe("ClawHub publish workflow", () => {
       (match) => match[1],
     );
 
-    expect(refs).toEqual([clawhubWorkflowCommit, clawhubWorkflowCommit]);
+    expect(refs).toEqual([
+      clawhubWorkflowCommit,
+      clawhubWorkflowCommit,
+      clawhubWorkflowCommit,
+    ]);
   });
 
-  it("requires the selected release tag to match the npm commit", () => {
+  it("resolves the requested release tag to the npm commit", () => {
+    expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("release-preflight:");
-    expect(workflow).toContain('GITHUB_REF_TYPE" != "tag"');
-    expect(workflow).toContain('GITHUB_REF_NAME" != "$expected_tag"');
+    expect(workflow).toContain("ref: ${{ inputs.release_tag }}");
+    expect(workflow).toContain(
+      'git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"',
+    );
+    expect(workflow).toContain(
+      'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
+    );
+    expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
     );
-    expect(workflow).toContain('published_sha" != "$GITHUB_SHA"');
-    expect(workflow).toMatch(/publish:\n\s+needs: release-preflight/);
+    expect(workflow).toContain('published_sha" != "$source_sha"');
+    expect(workflow).toContain('echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"');
+  });
+
+  it("binds manual validation and publication to the verified commit", () => {
+    expect(workflow).toMatch(
+      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+    );
+    expect(workflow).toMatch(
+      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+    );
   });
 
   it("serializes real publishes without cancelling an active release", () => {


### PR DESCRIPTION
## What

Allow the manual ClawHub workflow to publish an npm release whose tag predates the caller workflow. The workflow resolves a required `release_tag` input and passes its verified commit to the pinned ClawHub reusable workflow.

## Why

`v1.0.0-beta.0` resolves to the same commit as npm `gitHead`, but GitHub cannot dispatch the ClawHub workflow from that tag because the workflow file was added afterward. Dispatching from the default branch with an explicit release tag preserves the npm commit check without moving the tag.

## Changes

- Require a manual `release_tag` input
- Verify tag, package, and npm identities
- Bind dry runs to the verified commit
- Bind publication to the verified commit
- Document the default-branch dispatch flow

## Testing

- `npm test -- --run test/clawhub-publish-workflow.test.ts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/clawhub-publish.yml`
- Real preflight against `v1.0.0-beta.0`
- `npm run release:verify`

All checks pass. Release verification covers 114 test files and 2,037 tests.

No Changeset is required because this changes release tooling and documentation without changing the npm package behavior.
