### PR TITLE
fix(context-engine): commit accepted turns durably

### DIFF
--- a/.changeset/durable-turn-advancement.md
+++ b/.changeset/durable-turn-advancement.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Persist accepted OpenClaw turns with an atomic idempotency ledger so host retries cannot duplicate or partially advance LosslessClaw context.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STA
 
 > **Compatibility:** `lossless-claw` requires OpenClaw `2026.7.2-beta.2` or newer. That beta is the first published build with the branch-safe visible transcript projection used to bootstrap SQLite-backed sessions; stable `2026.7.1` does not provide it. If you cannot use a beta or upgrade OpenClaw, stay on a `lossless-claw` release compatible with your installed OpenClaw version.
 
+On OpenClaw hosts that advertise the durable context-engine turn contract,
+LosslessClaw declares current-turn transcript fencing and commits each accepted
+turn through an atomic idempotency ledger. Older supported hosts continue to use
+the existing `afterTurn` compatibility path.
+
 > **Breaking upgrade:** Before upgrading, remove `transcriptGcEnabled` and `autoRotateSessionFiles` from `plugins.entries.lossless-claw.config`. OpenClaw rejects keys that are absent from the plugin manifest, so either removed key prevents Lossless Claw from loading.
 
 ### Install the plugin

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1412,6 +1412,17 @@ export function runLcmMigrations(
       PRIMARY KEY (step_name, algorithm_version)
     );
 
+    CREATE TABLE IF NOT EXISTS turn_advancements (
+      advancement_key TEXT PRIMARY KEY,
+      payload_hash TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_key TEXT,
+      admission_entry_id TEXT NOT NULL,
+      terminal_entry_id TEXT NOT NULL,
+      message_count INTEGER NOT NULL,
+      committed_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     -- Indexes
     CREATE INDEX IF NOT EXISTS messages_conv_seq_idx ON messages (conversation_id, seq);
     CREATE INDEX IF NOT EXISTS message_anchor_trust_conv_state_idx
@@ -1446,6 +1457,8 @@ export function runLcmMigrations(
       ON focus_briefs (conversation_id, status, created_at);
     CREATE INDEX IF NOT EXISTS focus_brief_sources_summary_idx
       ON focus_brief_sources (summary_id);
+    CREATE INDEX IF NOT EXISTS turn_advancements_session_idx
+      ON turn_advancements (session_id, committed_at);
 
     -- Speed up summary_messages lookups by message_id (PK is summary_id,message_id)
     CREATE INDEX IF NOT EXISTS summary_messages_message_idx ON summary_messages (message_id);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3805,14 +3805,21 @@ export class LcmContextEngine implements ContextEngine {
   /**
    * Persist one host-accepted transcript turn and its advancement receipt in
    * the same SQLite transaction. The host may safely retry after losing the
-   * response; a reused key with a different payload fails closed.
+   * response; a reused key with a different payload fails closed. Sessions
+   * configured to skip LCM writes acknowledge the turn as an idempotent no-op.
    */
   async commitTurn(params: CommitTurnParams): Promise<{ status: "committed" | "duplicate" }> {
     assertValidTurnAdvancement(params);
-    this.ensureMigrated();
-    const payloadHash = buildTurnAdvancementPayloadHash(params);
     const sessionId = params.admission.sessionId;
     const sessionKey = params.admission.sessionKey;
+    if (
+      this.shouldIgnoreSession({ sessionId, sessionKey }) ||
+      this.isStatelessSession(sessionKey)
+    ) {
+      return { status: "committed" };
+    }
+    this.ensureMigrated();
+    const payloadHash = buildTurnAdvancementPayloadHash(params);
 
     return this.withSessionQueue(
       this.resolveSessionQueueKey(sessionId, sessionKey),

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -180,7 +180,7 @@ function buildTurnAdvancementPayloadHash(params: CommitTurnParams): string {
   const canonicalPayload = canonicalizeTurnPayload({
     admission: params.admission,
     isHeartbeat: params.isHeartbeat === true,
-    messages: params.messages,
+    messages: params.messages.slice(params.prePromptMessageCount),
     prePromptMessageCount: params.prePromptMessageCount,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -149,6 +149,17 @@ type CommitTurnParams = {
   isHeartbeat?: boolean;
 };
 
+type PostTurnCompactionParams = {
+  phase: "afterTurn" | "commitTurn";
+  sessionId: string;
+  sessionKey?: string;
+  sessionFile?: string;
+  tokenBudget?: number;
+  currentTokenCount?: number;
+  runtimeContext?: Record<string, unknown>;
+  legacyCompactionParams?: Record<string, unknown>;
+};
+
 /** JSON.stringify semantics with stable object-key ordering for retry identity. */
 function canonicalizeTurnPayload(value: unknown): unknown {
   if (Array.isArray(value)) {
@@ -207,7 +218,8 @@ function assertValidTurnAdvancement(params: CommitTurnParams): void {
     params.prePromptMessageCount < 0 ||
     params.prePromptMessageCount > params.messages.length ||
     params.prePromptMessageCount !== admission.activeMessagePosition ||
-    terminal.activeMessagePosition < admission.activeMessagePosition
+    terminal.activeMessagePosition < admission.activeMessagePosition ||
+    terminal.activeMessagePosition !== params.messages.length - 1
   ) {
     throw new Error("turn advancement transcript range is invalid");
   }
@@ -3802,6 +3814,223 @@ export class LcmContextEngine implements ContextEngine {
     );
   }
 
+  /** Evaluate and schedule the compaction work shared by both turn commit paths. */
+  private async evaluatePostTurnCompaction(
+    params: PostTurnCompactionParams,
+  ): Promise<number | undefined> {
+    const sessionLabel = formatSessionLabel(params.sessionId, params.sessionKey);
+    const legacyParams = asRecord(params.runtimeContext) ?? asRecord(params.legacyCompactionParams);
+    const defaultTokenBudget = 128_000;
+    const resolvedTokenBudget = this.resolveTokenBudget({
+      tokenBudget: params.tokenBudget,
+      runtimeContext: params.runtimeContext,
+      legacyParams,
+    });
+    const tokenBudget = this.applyAssemblyBudgetCap(resolvedTokenBudget ?? defaultTokenBudget);
+    if (resolvedTokenBudget === undefined) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: tokenBudget not provided; using default ${defaultTokenBudget}`,
+      );
+    }
+
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
+    const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
+      (
+        (legacyParams ?? {}) as {
+          currentTokenCount?: unknown;
+        }
+      ).currentTokenCount,
+    );
+    const observedCurrentTokenCount = runtimePromptTokens ?? suppliedCurrentTokenCount;
+    if (runtimePromptTokens !== undefined) {
+      this.deps.log.debug(
+        `[lcm] ${params.phase}: using runtime prompt token count currentTokenCount=${runtimePromptTokens}`,
+      );
+    }
+    if (!conversation) {
+      this.deps.log.debug(
+        `[lcm] ${params.phase}: conversation lookup missed ${sessionLabel}`,
+      );
+      return undefined;
+    }
+
+    const recordCompactionRetry = async (
+      reason: string,
+      diagnostics?: {
+        projectedTokenCount?: number;
+        rawTokensOutsideTail?: number;
+        contextThreshold?: ResolvedContextThreshold;
+      },
+    ): Promise<void> => {
+      try {
+        await this.telemetryRecorder.recordDeferredCompactionDebt({
+          conversationId: conversation.conversationId,
+          reason,
+          tokenBudget,
+          currentTokenCount: observedCurrentTokenCount,
+          projectedTokenCount: diagnostics?.projectedTokenCount,
+          rawTokensOutsideTail: diagnostics?.rawTokensOutsideTail,
+          contextThreshold: diagnostics?.contextThreshold,
+        });
+      } catch (err) {
+        this.deps.log.warn(
+          `[lcm] ${params.phase}: failed to persist deferred compaction retry for ${sessionLabel}: ${describeLogError(err)}`,
+        );
+      }
+    };
+    let deferredCompactionDrain:
+      | {
+          reason: string;
+          tokenBudget: number;
+          currentTokenCount?: number;
+        }
+      | null = null;
+    let pendingSummaryPreparationDrain:
+      | {
+          reason: string;
+          tokenBudget: number;
+          currentTokenCount?: number;
+        }
+      | null = null;
+
+    try {
+      await this.telemetryRecorder.updateCompactionTelemetry({
+        conversationId: conversation.conversationId,
+        runtimeContext: legacyParams,
+        tokenBudget,
+      });
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: compaction telemetry update failed: ${describeLogError(err)}`,
+      );
+    }
+
+    try {
+      const resolvedContextThreshold = this.contextThresholdResolver.resolve({
+        sessionKey: params.sessionKey,
+        runtime: readRuntimeModelContext(
+          asRecord(params.runtimeContext),
+          asRecord(params.legacyCompactionParams),
+        ),
+      });
+      const thresholdDecision = await this.compaction.evaluate(
+        conversation.conversationId,
+        tokenBudget,
+        observedCurrentTokenCount,
+        {
+          contextThreshold: resolvedContextThreshold.contextThreshold,
+          ...(resolvedContextThreshold.freshTailCount !== undefined
+            ? { freshTailCount: resolvedContextThreshold.freshTailCount }
+            : {}),
+        },
+      );
+      this.logContextThresholdSelection({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget,
+        thresholdTokens: thresholdDecision.threshold,
+        resolved: resolvedContextThreshold,
+        phase: params.phase,
+      });
+      const thresholdDiagnostics = {
+        projectedTokenCount: thresholdDecision.projectedTokens,
+        rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+        contextThreshold: resolvedContextThreshold,
+      };
+      const canCompactInline =
+        this.config.proactiveThresholdCompactionMode === "inline" &&
+        params.sessionFile !== undefined;
+      if (canCompactInline) {
+        if (thresholdDecision.shouldCompact) {
+          const compactResult = await this.compact({
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile!,
+            tokenBudget,
+            currentTokenCount: observedCurrentTokenCount,
+            compactionTarget: "threshold",
+            contextThresholdOverride: resolvedContextThreshold,
+            legacyParams,
+          });
+          if (!compactResult.ok) {
+            await recordCompactionRetry("threshold", thresholdDiagnostics);
+          }
+        }
+      } else if (thresholdDecision.shouldCompact) {
+        await this.telemetryRecorder.recordDeferredCompactionDebt({
+          conversationId: conversation.conversationId,
+          reason: "threshold",
+          tokenBudget,
+          currentTokenCount: observedCurrentTokenCount,
+          projectedTokenCount: thresholdDecision.projectedTokens,
+          rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
+          contextThreshold: resolvedContextThreshold,
+        });
+        deferredCompactionDrain = {
+          tokenBudget,
+          currentTokenCount: observedCurrentTokenCount,
+          reason: "threshold",
+        };
+        this.scheduleThresholdPublicationOpportunity({
+          conversationId: conversation.conversationId,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          tokenBudget,
+          currentTokenCount: observedCurrentTokenCount,
+          reason: "threshold",
+        });
+      }
+      if (!thresholdDecision.shouldCompact) {
+        const leafDecision = await this.compaction.evaluateLeafTrigger(
+          conversation.conversationId,
+          this.config.leafChunkTokens,
+        );
+        this.deps.log.debug(
+          `[lcm] pending-summary-prep: selected phase=${params.phase} conversation=${conversation.conversationId} ${sessionLabel} rawTokensOutsideTail=${leafDecision.rawTokensOutsideTail} threshold=${leafDecision.threshold} shouldPrepare=${leafDecision.shouldCompact}`,
+        );
+        if (leafDecision.shouldCompact) {
+          pendingSummaryPreparationDrain = {
+            tokenBudget,
+            currentTokenCount: observedCurrentTokenCount,
+            reason: "leaf-prep",
+          };
+        }
+      }
+    } catch (err) {
+      this.deps.log.warn(
+        `[lcm] ${params.phase}: compaction policy check failed for ${sessionLabel}: ${describeLogError(err)}`,
+      );
+    }
+
+    if (deferredCompactionDrain) {
+      this.scheduleDeferredCompactionDebtDrain({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget: deferredCompactionDrain.tokenBudget,
+        currentTokenCount: deferredCompactionDrain.currentTokenCount,
+        reason: deferredCompactionDrain.reason,
+      });
+    }
+    if (pendingSummaryPreparationDrain) {
+      this.schedulePendingSummaryPreparationDrain({
+        conversationId: conversation.conversationId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        tokenBudget: pendingSummaryPreparationDrain.tokenBudget,
+        currentTokenCount: pendingSummaryPreparationDrain.currentTokenCount,
+        reason: pendingSummaryPreparationDrain.reason,
+      });
+    }
+    return conversation.conversationId;
+  }
+
   /**
    * Persist one host-accepted transcript turn and its advancement receipt in
    * the same SQLite transaction. The host may safely retry after losing the
@@ -3821,7 +4050,7 @@ export class LcmContextEngine implements ContextEngine {
     this.ensureMigrated();
     const payloadHash = buildTurnAdvancementPayloadHash(params);
 
-    return this.withSessionQueue(
+    const result = await this.withSessionQueue(
       this.resolveSessionQueueKey(sessionId, sessionKey),
       async () =>
         this.conversationStore.withTransaction(async () => {
@@ -3884,6 +4113,15 @@ export class LcmContextEngine implements ContextEngine {
         context: `session=${sessionId} sessionKey=${sessionKey} advancementKey=${params.advancementKey}`,
       },
     );
+    const runtimeLimits = asRecord(asRecord(params.runtimeSettings)?.limits);
+    await this.evaluatePostTurnCompaction({
+      phase: "commitTurn",
+      sessionId,
+      sessionKey,
+      tokenBudget: this.normalizeObservedTokenCount(runtimeLimits?.promptTokenBudget),
+      runtimeContext: params.runtimeContext,
+    });
+    return result;
   }
 
   async afterTurn(params: {
@@ -4094,216 +4332,22 @@ export class LcmContextEngine implements ContextEngine {
       }
     }
 
-    const legacyParams = asRecord(params.runtimeContext) ?? asRecord(params.legacyCompactionParams);
-    const DEFAULT_AFTER_TURN_TOKEN_BUDGET = 128_000;
-    const resolvedTokenBudget = this.resolveTokenBudget({
-      tokenBudget: params.tokenBudget,
-      runtimeContext: params.runtimeContext,
-      legacyParams,
-    });
-    const tokenBudget = this.applyAssemblyBudgetCap(resolvedTokenBudget ?? DEFAULT_AFTER_TURN_TOKEN_BUDGET);
-    if (resolvedTokenBudget === undefined) {
-      this.deps.log.warn(
-        `[lcm] afterTurn: tokenBudget not provided; using default ${DEFAULT_AFTER_TURN_TOKEN_BUDGET}`,
-      );
-    }
-
-    const conversation = await this.conversationStore.getConversationForSession({
+    const conversationId = await this.evaluatePostTurnCompaction({
+      phase: "afterTurn",
       sessionId,
       sessionKey,
+      sessionFile: params.sessionFile,
+      tokenBudget: params.tokenBudget,
+      currentTokenCount: params.currentTokenCount,
+      runtimeContext: params.runtimeContext,
+      legacyCompactionParams: params.legacyCompactionParams,
     });
-    const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
-    const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
-      params.currentTokenCount ??
-      (
-        (legacyParams ?? {}) as {
-          currentTokenCount?: unknown;
-        }
-      ).currentTokenCount,
-    );
-    const observedCurrentTokenCount = runtimePromptTokens ?? suppliedCurrentTokenCount;
-    if (runtimePromptTokens !== undefined) {
-      this.deps.log.debug(
-        `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens}`,
-      );
-    }
-    if (!conversation) {
-      this.deps.log.debug(
-        `[lcm] afterTurn: conversation lookup missed ${sessionLabel} ingestBatch=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
-      );
+    if (conversationId === undefined) {
       return;
-    }
-    const recordAfterTurnCompactionRetry = async (
-      reason: string,
-      diagnostics?: {
-        projectedTokenCount?: number;
-        rawTokensOutsideTail?: number;
-        contextThreshold?: ResolvedContextThreshold;
-      },
-    ): Promise<void> => {
-      try {
-        await this.telemetryRecorder.recordDeferredCompactionDebt({
-          conversationId: conversation.conversationId,
-          reason,
-          tokenBudget,
-          currentTokenCount: observedCurrentTokenCount,
-          projectedTokenCount: diagnostics?.projectedTokenCount,
-          rawTokensOutsideTail: diagnostics?.rawTokensOutsideTail,
-          contextThreshold: diagnostics?.contextThreshold,
-        });
-      } catch (err) {
-        this.deps.log.warn(
-          `[lcm] afterTurn: failed to persist deferred compaction retry for ${sessionLabel}: ${describeLogError(err)}`,
-        );
-      }
-    };
-    let deferredCompactionDrain:
-      | {
-          reason: string;
-          tokenBudget: number;
-          currentTokenCount?: number;
-        }
-      | null = null;
-    let pendingSummaryPreparationDrain:
-      | {
-          reason: string;
-          tokenBudget: number;
-          currentTokenCount?: number;
-        }
-      | null = null;
-
-    try {
-      await this.telemetryRecorder.updateCompactionTelemetry({
-        conversationId: conversation.conversationId,
-        runtimeContext: legacyParams,
-        tokenBudget,
-      });
-    } catch (err) {
-      this.deps.log.warn(
-        `[lcm] afterTurn: compaction telemetry update failed: ${describeLogError(err)}`,
-      );
-    }
-
-    try {
-      const resolvedContextThreshold = this.contextThresholdResolver.resolve({
-        sessionKey,
-        runtime: readRuntimeModelContext(
-          asRecord(params.runtimeContext),
-          asRecord(params.legacyCompactionParams),
-        ),
-      });
-      const thresholdDecision = await this.compaction.evaluate(
-        conversation.conversationId,
-        tokenBudget,
-        observedCurrentTokenCount,
-        {
-          contextThreshold: resolvedContextThreshold.contextThreshold,
-          ...(resolvedContextThreshold.freshTailCount !== undefined
-            ? { freshTailCount: resolvedContextThreshold.freshTailCount }
-            : {}),
-        },
-      );
-      this.logContextThresholdSelection({
-        conversationId: conversation.conversationId,
-        sessionId,
-        sessionKey,
-        tokenBudget,
-        thresholdTokens: thresholdDecision.threshold,
-        resolved: resolvedContextThreshold,
-        phase: "afterTurn",
-      });
-      const thresholdDiagnostics = {
-        projectedTokenCount: thresholdDecision.projectedTokens,
-        rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
-        contextThreshold: resolvedContextThreshold,
-      };
-      if (this.config.proactiveThresholdCompactionMode === "inline") {
-        if (thresholdDecision.shouldCompact) {
-          const compactResult = await this.compact({
-            sessionId,
-            sessionKey,
-            sessionFile: params.sessionFile,
-            tokenBudget,
-            currentTokenCount: observedCurrentTokenCount,
-            compactionTarget: "threshold",
-            contextThresholdOverride: resolvedContextThreshold,
-            legacyParams,
-          });
-          if (!compactResult.ok) {
-            await recordAfterTurnCompactionRetry("threshold", thresholdDiagnostics);
-          }
-        }
-      } else if (thresholdDecision.shouldCompact) {
-        await this.telemetryRecorder.recordDeferredCompactionDebt({
-          conversationId: conversation.conversationId,
-          reason: "threshold",
-          tokenBudget,
-          currentTokenCount: observedCurrentTokenCount,
-          projectedTokenCount: thresholdDecision.projectedTokens,
-          rawTokensOutsideTail: thresholdDecision.rawTokensOutsideTail,
-          contextThreshold: resolvedContextThreshold,
-        });
-        deferredCompactionDrain = {
-          tokenBudget,
-          currentTokenCount: observedCurrentTokenCount,
-          reason: "threshold",
-        };
-        // Register this queue entry synchronously. A later foreground operation
-        // can enqueue behind it, but cannot extend the busy promise ahead of it.
-        this.scheduleThresholdPublicationOpportunity({
-          conversationId: conversation.conversationId,
-          sessionId,
-          sessionKey,
-          tokenBudget,
-          currentTokenCount: observedCurrentTokenCount,
-          reason: "threshold",
-        });
-      }
-      if (!thresholdDecision.shouldCompact) {
-        const leafDecision = await this.compaction.evaluateLeafTrigger(
-          conversation.conversationId,
-          this.config.leafChunkTokens,
-        );
-        this.deps.log.debug(
-          `[lcm] pending-summary-prep: selected phase=afterTurn conversation=${conversation.conversationId} ${sessionLabel} rawTokensOutsideTail=${leafDecision.rawTokensOutsideTail} threshold=${leafDecision.threshold} shouldPrepare=${leafDecision.shouldCompact}`,
-        );
-        if (leafDecision.shouldCompact) {
-          pendingSummaryPreparationDrain = {
-            tokenBudget,
-            currentTokenCount: observedCurrentTokenCount,
-            reason: "leaf-prep",
-          };
-        }
-      }
-    } catch (err) {
-      this.deps.log.warn(
-        `[lcm] afterTurn: compaction policy check failed for ${sessionLabel}: ${describeLogError(err)}`,
-      );
-    }
-
-    if (deferredCompactionDrain) {
-      this.scheduleDeferredCompactionDebtDrain({
-        conversationId: conversation.conversationId,
-        sessionId,
-        sessionKey,
-        tokenBudget: deferredCompactionDrain.tokenBudget,
-        currentTokenCount: deferredCompactionDrain.currentTokenCount,
-        reason: deferredCompactionDrain.reason,
-      });
-    }
-    if (pendingSummaryPreparationDrain) {
-      this.schedulePendingSummaryPreparationDrain({
-        conversationId: conversation.conversationId,
-        sessionId,
-        sessionKey,
-        tokenBudget: pendingSummaryPreparationDrain.tokenBudget,
-        currentTokenCount: pendingSummaryPreparationDrain.currentTokenCount,
-        reason: pendingSummaryPreparationDrain.reason,
-      });
     }
 
     this.deps.log.debug(
-      `[lcm] afterTurn: done conversation=${conversation.conversationId} ${sessionLabel} newMessages=${newMessages.length} dedupedMessages=${dedupedNewMessages.length} ingestedMessages=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
+      `[lcm] afterTurn: done conversation=${conversationId} ${sessionLabel} newMessages=${newMessages.length} dedupedMessages=${dedupedNewMessages.length} ingestedMessages=${ingestBatch.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
     );
   }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -19,6 +19,8 @@ import type {
   IngestResult,
   SubagentEndReason,
   SubagentSpawnPreparation,
+  TranscriptEntryAnchor,
+  TranscriptTurnAdmission,
 } from "./openclaw-bridge.js";
 import { ContextAssembler } from "./assembler.js";
 import { CompactionEngine, type CompactionConfig } from "./compaction.js";
@@ -132,6 +134,84 @@ const LOSSLESS_AGENT_RUN_CAPTURE_ONLY_HOST_CAPABILITIES: ContextEngineHostCapabi
   "maintain",
 ];
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
+
+type CommitTurnParams = {
+  advancementKey: string;
+  admission: TranscriptTurnAdmission;
+  terminal: TranscriptEntryAnchor;
+  messages: AgentMessage[];
+  prePromptMessageCount: number;
+  sessionId: string;
+  sessionKey?: string;
+  sessionTarget?: ContextEngineSessionTarget;
+  runtimeSettings?: Record<string, unknown>;
+  runtimeContext?: ContextEngineRuntimeContext;
+  isHeartbeat?: boolean;
+};
+
+/** JSON.stringify semantics with stable object-key ordering for retry identity. */
+function canonicalizeTurnPayload(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalizeTurnPayload(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalizeTurnPayload(entry)]),
+    );
+  }
+  return value;
+}
+
+function buildTurnAdvancementPayloadHash(params: CommitTurnParams): string {
+  const canonicalPayload = canonicalizeTurnPayload({
+    admission: params.admission,
+    isHeartbeat: params.isHeartbeat === true,
+    messages: params.messages,
+    prePromptMessageCount: params.prePromptMessageCount,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    terminal: params.terminal,
+  });
+  return createHash("sha256").update(JSON.stringify(canonicalPayload)).digest("hex");
+}
+
+function assertValidTurnAdvancement(params: CommitTurnParams): void {
+  const { admission, terminal } = params;
+  if (!params.advancementKey || params.advancementKey !== admission.logicalTurnId) {
+    throw new Error("turn advancement key does not match transcript admission");
+  }
+  if (
+    params.sessionId !== admission.sessionId ||
+    (params.sessionKey !== undefined && params.sessionKey !== admission.sessionKey) ||
+    terminal.agentId !== admission.agentId ||
+    terminal.sessionId !== admission.sessionId ||
+    terminal.sessionKey !== admission.sessionKey ||
+    terminal.storePath !== admission.storePath ||
+    terminal.generation !== admission.generation ||
+    params.sessionTarget?.agentId !== undefined &&
+      params.sessionTarget.agentId !== admission.agentId ||
+    params.sessionTarget?.sessionId !== undefined &&
+      params.sessionTarget.sessionId !== admission.sessionId ||
+    params.sessionTarget?.sessionKey !== undefined &&
+      params.sessionTarget.sessionKey !== admission.sessionKey ||
+    params.sessionTarget?.storePath !== undefined &&
+      params.sessionTarget.storePath !== admission.storePath
+  ) {
+    throw new Error("turn advancement transcript target changed after admission");
+  }
+  if (
+    !Number.isSafeInteger(params.prePromptMessageCount) ||
+    params.prePromptMessageCount < 0 ||
+    params.prePromptMessageCount > params.messages.length ||
+    params.prePromptMessageCount !== admission.activeMessagePosition ||
+    terminal.activeMessagePosition < admission.activeMessagePosition
+  ) {
+    throw new Error("turn advancement transcript range is invalid");
+  }
+}
 
 // Host-contract dependency: the deliberate-vs-incidental archive distinction
 // relies on OpenClaw emitting these exact reason strings only for genuine
@@ -500,6 +580,10 @@ export class LcmContextEngine implements ContextEngine {
       name: "Lossless Context Management Engine",
       version: packageJson.version,
       acceptedHostParams: ["sessionKey", "prompt", "runtimeContext"],
+      transcriptSemantics: {
+        currentTurnFence: "before-current-turn-entry-v1",
+        turnAdvancementIdempotency: "atomic-idempotent-v1",
+      },
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
       hostRequirements: {
@@ -3714,6 +3798,83 @@ export class LcmContextEngine implements ContextEngine {
           ...(params.sessionKey?.trim() ? [`sessionKey=${params.sessionKey.trim()}`] : []),
           `messages=${params.messages.length}`,
         ].join(" "),
+      },
+    );
+  }
+
+  /**
+   * Persist one host-accepted transcript turn and its advancement receipt in
+   * the same SQLite transaction. The host may safely retry after losing the
+   * response; a reused key with a different payload fails closed.
+   */
+  async commitTurn(params: CommitTurnParams): Promise<{ status: "committed" | "duplicate" }> {
+    assertValidTurnAdvancement(params);
+    this.ensureMigrated();
+    const payloadHash = buildTurnAdvancementPayloadHash(params);
+    const sessionId = params.admission.sessionId;
+    const sessionKey = params.admission.sessionKey;
+
+    return this.withSessionQueue(
+      this.resolveSessionQueueKey(sessionId, sessionKey),
+      async () =>
+        this.conversationStore.withTransaction(async () => {
+          const existing = this.db
+            .prepare(
+              `SELECT payload_hash
+               FROM turn_advancements
+               WHERE advancement_key = ?`,
+            )
+            .get(params.advancementKey) as { payload_hash: string } | undefined;
+          if (existing) {
+            if (existing.payload_hash !== payloadHash) {
+              throw new Error(
+                `context-engine advancement key collision: ${params.advancementKey}`,
+              );
+            }
+            return { status: "duplicate" as const };
+          }
+
+          let ingestedCount = 0;
+          const turnMessages = params.messages.slice(params.prePromptMessageCount);
+          for (const message of turnMessages) {
+            const result = await this.ingestSingle({
+              sessionId,
+              sessionKey,
+              message,
+              isHeartbeat: params.isHeartbeat === true,
+              createdAt: resolveTranscriptMessageCreatedAt(message),
+            });
+            if (result.ingested) {
+              ingestedCount += 1;
+            }
+          }
+
+          this.db
+            .prepare(
+              `INSERT INTO turn_advancements (
+                 advancement_key,
+                 payload_hash,
+                 session_id,
+                 session_key,
+                 admission_entry_id,
+                 terminal_entry_id,
+                 message_count
+               ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              params.advancementKey,
+              payloadHash,
+              sessionId,
+              sessionKey,
+              params.admission.entryId,
+              params.terminal.entryId,
+              ingestedCount,
+            );
+          return { status: "committed" as const };
+        }),
+      {
+        operationName: "commitTurn",
+        context: `session=${sessionId} sessionKey=${sessionKey} advancementKey=${params.advancementKey}`,
       },
     );
   }

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -96,6 +96,10 @@ export type ContextEngineInfo = {
   name: string;
   version: string;
   acceptedHostParams?: string[];
+  transcriptSemantics?: {
+    currentTurnFence?: "before-current-turn-entry-v1";
+    turnAdvancementIdempotency?: "atomic-idempotent-v1";
+  };
   ownsCompaction?: boolean;
   turnMaintenanceMode?: "background" | "inline" | string;
   hostRequirements?: Partial<Record<ContextEngineOperation, ContextEngineHostRequirements>>;
@@ -236,6 +240,27 @@ export type ContextEngineRuntimeContext = {
   [key: string]: unknown;
 };
 
+/** Immutable SQLite transcript identity supplied by OpenClaw. */
+export type TranscriptEntryAnchor = Readonly<{
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  generation: string;
+  entryId: string;
+  rawSeq: number;
+  effectiveParentId: string | null;
+  activeMessagePosition: number;
+  idempotencyKey?: string;
+}>;
+
+/** Current user row that owns one host-issued logical turn. */
+export type TranscriptTurnAdmission = TranscriptEntryAnchor &
+  Readonly<{
+    logicalTurnId: string;
+    role: "user";
+  }>;
+
 export type ContextEngine = {
   info: ContextEngineInfo;
   bootstrap(params: {
@@ -271,6 +296,19 @@ export type ContextEngine = {
     runtimeContext?: Record<string, unknown>;
     legacyCompactionParams?: Record<string, unknown>;
   }): Promise<void>;
+  commitTurn?(params: {
+    advancementKey: string;
+    admission: TranscriptTurnAdmission;
+    terminal: TranscriptEntryAnchor;
+    messages: AgentMessage[];
+    prePromptMessageCount: number;
+    sessionId: string;
+    sessionKey?: string;
+    sessionTarget?: ContextEngineSessionTarget;
+    runtimeSettings?: Record<string, unknown>;
+    runtimeContext?: ContextEngineRuntimeContext;
+    isHeartbeat?: boolean;
+  }): Promise<{ status: "committed" | "duplicate" }>;
   assemble(params: {
     sessionId: string;
     sessionKey?: string;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -180,6 +180,7 @@ class MemorySupplementContextEngine implements ContextEngine {
   readonly info: ContextEngine["info"];
   readonly ingestBatch: ContextEngine["ingestBatch"];
   readonly afterTurn: ContextEngine["afterTurn"];
+  readonly commitTurn: ContextEngine["commitTurn"];
   readonly prepareSubagentSpawn: ContextEngine["prepareSubagentSpawn"];
   readonly onSubagentEnded: ContextEngine["onSubagentEnded"];
   readonly maintain: ContextEngine["maintain"];
@@ -190,6 +191,7 @@ class MemorySupplementContextEngine implements ContextEngine {
   constructor(private readonly inner: ContextEngine) {
     const ingestBatch = inner.ingestBatch?.bind(inner);
     const afterTurn = inner.afterTurn?.bind(inner);
+    const commitTurn = inner.commitTurn?.bind(inner);
     const prepareSubagentSpawn = inner.prepareSubagentSpawn?.bind(inner);
     const onSubagentEnded = inner.onSubagentEnded?.bind(inner);
     const maintain = inner.maintain?.bind(inner);
@@ -199,6 +201,7 @@ class MemorySupplementContextEngine implements ContextEngine {
     this.info = inner.info;
     this.ingestBatch = ingestBatch ? (params) => ingestBatch(params) : undefined;
     this.afterTurn = afterTurn ? (params) => afterTurn(params) : undefined;
+    this.commitTurn = commitTurn ? (params) => commitTurn(params) : undefined;
     this.prepareSubagentSpawn = prepareSubagentSpawn
       ? (params) => prepareSubagentSpawn(params)
       : undefined;

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -161,6 +161,23 @@ describe("LcmContextEngine commitTurn", () => {
     ).toEqual({ count: 1 });
   });
 
+  it("ignores the uncommitted transcript prefix when identifying a retry", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.commitTurn(params);
+    params.messages[0] = makeMessage({
+      role: "assistant",
+      content: "refreshed visible prefix",
+      timestamp: 1_500,
+    });
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current answer",
+    ]);
+  });
+
   it("acknowledges excluded session turns without writing LCM state", async () => {
     const engine = createEngineWithConfig({
       ignoreSessionPatterns: ["agent:main:durable-turn-session"],

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeLcmConnection } from "../src/db/connection.js";
+import type {
+  ContextEngine,
+  TranscriptEntryAnchor,
+  TranscriptTurnAdmission,
+} from "../src/openclaw-bridge.js";
+import {
+  cleanupEngineTestState,
+  createEngine,
+  createEngineAtDatabasePath,
+  makeMessage,
+  tempDirs,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+function buildCommitTurnParams(overrides?: {
+  advancementKey?: string;
+  answer?: string;
+}): Parameters<NonNullable<ContextEngine["commitTurn"]>>[0] {
+  const sessionId = "durable-turn-session";
+  const sessionKey = "agent:main:durable-turn-session";
+  const storePath = "/tmp/openclaw-agent.sqlite";
+  const generation = "generation-1";
+  const advancementKey = overrides?.advancementKey ?? "logical-turn-1";
+  const admission: TranscriptTurnAdmission = {
+    activeMessagePosition: 1,
+    agentId: "main",
+    effectiveParentId: "prior-entry",
+    entryId: "user-entry",
+    generation,
+    logicalTurnId: advancementKey,
+    rawSeq: 2,
+    role: "user",
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+  const terminal: TranscriptEntryAnchor = {
+    activeMessagePosition: 2,
+    agentId: "main",
+    effectiveParentId: admission.entryId,
+    entryId: "assistant-entry",
+    generation,
+    rawSeq: 3,
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+  return {
+    advancementKey,
+    admission,
+    terminal,
+    messages: [
+      makeMessage({ role: "assistant", content: "prior persisted prefix", timestamp: 1_000 }),
+      makeMessage({ role: "user", content: "current question", timestamp: 2_000 }),
+      makeMessage({
+        role: "assistant",
+        content: overrides?.answer ?? "current answer",
+        timestamp: 3_000,
+      }),
+    ],
+    prePromptMessageCount: 1,
+    sessionId,
+    sessionKey,
+    sessionTarget: {
+      agentId: admission.agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    },
+  };
+}
+
+async function readStoredMessages(engine: ReturnType<typeof createEngine>) {
+  const conversation = await engine
+    .getConversationStore()
+    .getConversationBySessionId("durable-turn-session");
+  if (!conversation) {
+    return [];
+  }
+  return engine.getConversationStore().getMessages(conversation.conversationId);
+}
+
+function getEngineDatabase(engine: ReturnType<typeof createEngine>): DatabaseSync {
+  return (engine as unknown as { db: DatabaseSync }).db;
+}
+
+describe("LcmContextEngine commitTurn", () => {
+  it("declares the fenced atomic-idempotent transcript contract", () => {
+    const engine = createEngine();
+
+    expect(engine.info.transcriptSemantics).toEqual({
+      currentTurnFence: "before-current-turn-entry-v1",
+      turnAdvancementIdempotency: "atomic-idempotent-v1",
+    });
+  });
+
+  it("atomically commits only the accepted turn delta and its ledger receipt", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current answer",
+    ]);
+    const ledger = getEngineDatabase(engine)
+      .prepare(
+        `SELECT advancement_key, session_id, session_key, admission_entry_id,
+                terminal_entry_id, message_count, length(payload_hash) AS hash_length
+         FROM turn_advancements`,
+      )
+      .get() as Record<string, unknown>;
+    expect(ledger).toMatchObject({
+      advancement_key: params.advancementKey,
+      session_id: params.sessionId,
+      session_key: params.sessionKey,
+      admission_entry_id: params.admission.entryId,
+      terminal_entry_id: params.terminal.entryId,
+      message_count: 2,
+      hash_length: 64,
+    });
+  });
+
+  it("returns duplicate without repeating message or context persistence", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+
+    expect(await readStoredMessages(engine)).toHaveLength(2);
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM context_items").get(),
+    ).toEqual({ count: 2 });
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
+    ).toEqual({ count: 1 });
+  });
+
+  it("fails closed when the same advancement key carries a different payload", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.commitTurn(params);
+
+    await expect(
+      engine.commitTurn(buildCommitTurnParams({ answer: "colliding answer" })),
+    ).rejects.toThrow(`context-engine advancement key collision: ${params.advancementKey}`);
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current answer",
+    ]);
+  });
+
+  it("rolls back messages, context, and ledger together when persistence fails", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      ingestSingle: (params: Record<string, unknown>) => Promise<{ ingested: boolean }>;
+    };
+    const originalIngest = privateEngine.ingestSingle.bind(privateEngine);
+    const ingestSpy = vi
+      .spyOn(privateEngine, "ingestSingle")
+      .mockImplementationOnce(async (params) => {
+        await originalIngest(params);
+        throw new Error("injected persistence failure");
+      });
+
+    await expect(engine.commitTurn(buildCommitTurnParams())).rejects.toThrow(
+      "injected persistence failure",
+    );
+    expect(await readStoredMessages(engine)).toHaveLength(0);
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM context_items").get(),
+    ).toEqual({ count: 0 });
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
+    ).toEqual({ count: 0 });
+
+    ingestSpy.mockRestore();
+    await expect(engine.commitTurn(buildCommitTurnParams())).resolves.toEqual({
+      status: "committed",
+    });
+    expect(await readStoredMessages(engine)).toHaveLength(2);
+  });
+
+  it("recognizes a committed advancement after the engine restarts", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claw-durable-turn-"));
+    tempDirs.push(tempDir);
+    const databasePath = join(tempDir, "lcm.db");
+    const firstEngine = createEngineAtDatabasePath(databasePath);
+    const params = buildCommitTurnParams();
+    await firstEngine.commitTurn(params);
+    closeLcmConnection(databasePath);
+
+    const restartedEngine = createEngineAtDatabasePath(databasePath);
+    await expect(restartedEngine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+    expect(await readStoredMessages(restartedEngine)).toHaveLength(2);
+  });
+});

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -13,6 +13,7 @@ import {
   cleanupEngineTestState,
   createEngine,
   createEngineAtDatabasePath,
+  createEngineWithConfig,
   makeMessage,
   tempDirs,
 } from "./helpers.js";
@@ -143,6 +144,43 @@ describe("LcmContextEngine commitTurn", () => {
     expect(
       getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
     ).toEqual({ count: 1 });
+  });
+
+  it("acknowledges excluded session turns without writing LCM state", async () => {
+    const engine = createEngineWithConfig({
+      ignoreSessionPatterns: ["agent:main:durable-turn-session"],
+    });
+    const params = buildCommitTurnParams();
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect(await readStoredMessages(engine)).toHaveLength(0);
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM context_items").get(),
+    ).toEqual({ count: 0 });
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
+    ).toEqual({ count: 0 });
+  });
+
+  it("acknowledges stateless session turns without writing LCM state", async () => {
+    const engine = createEngineWithConfig({
+      statelessSessionPatterns: ["agent:main:durable-turn-session"],
+      skipStatelessSessions: true,
+    });
+    const params = buildCommitTurnParams();
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect(await readStoredMessages(engine)).toHaveLength(0);
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM context_items").get(),
+    ).toEqual({ count: 0 });
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
+    ).toEqual({ count: 0 });
   });
 
   it("fails closed when the same advancement key carries a different payload", async () => {

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -130,6 +130,21 @@ describe("LcmContextEngine commitTurn", () => {
     });
   });
 
+  it("rejects a terminal anchor outside the supplied message range", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    params.messages = params.messages.slice(0, 2);
+
+    await expect(engine.commitTurn(params)).rejects.toThrow(
+      "turn advancement transcript range is invalid",
+    );
+
+    expect(await readStoredMessages(engine)).toHaveLength(0);
+    expect(
+      getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
+    ).toEqual({ count: 0 });
+  });
+
   it("returns duplicate without repeating message or context persistence", async () => {
     const engine = createEngine();
     const params = buildCommitTurnParams();
@@ -181,6 +196,32 @@ describe("LcmContextEngine commitTurn", () => {
     expect(
       getEngineDatabase(engine).prepare("SELECT count(*) AS count FROM turn_advancements").get(),
     ).toEqual({ count: 0 });
+  });
+
+  it("records deferred compaction debt after a durable turn commit", async () => {
+    const engine = createEngineWithConfig({
+      proactiveThresholdCompactionMode: "inline",
+    });
+    const params = buildCommitTurnParams();
+    params.runtimeContext = {
+      currentTokenCount: 1_000,
+      tokenBudget: 100,
+    };
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(params.sessionId);
+    expect(conversation).not.toBeNull();
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation!.conversationId);
+    expect(maintenance).toMatchObject({
+      currentTokenCount: 1_000,
+      reason: "threshold",
+      tokenBudget: 100,
+    });
   });
 
   it("fails closed when the same advancement key carries a different payload", async () => {

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -46,6 +46,10 @@ describe("LcmContextEngine metadata", () => {
       "prompt",
       "runtimeContext",
     ]);
+    expect(engine.info.transcriptSemantics).toEqual({
+      currentTurnFence: "before-current-turn-entry-v1",
+      turnAdvancementIdempotency: "atomic-idempotent-v1",
+    });
   });
 
   it("advertises ownsCompaction capability", () => {

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -383,6 +383,7 @@ describe("lcm plugin registration", () => {
 
     const engine = factory!() as {
       afterTurn?: unknown;
+      commitTurn?: unknown;
       maintain?: unknown;
       dispose?: unknown;
       assemble: (params: {
@@ -393,6 +394,7 @@ describe("lcm plugin registration", () => {
       }) => Promise<{ systemPromptAddition?: string }>;
     };
     expect(engine.afterTurn).toBeTypeOf("function");
+    expect(engine.commitTurn).toBeTypeOf("function");
     expect(engine.maintain).toBeTypeOf("function");
     expect(engine.dispose).toBeTypeOf("function");
     const result = await engine.assemble({


### PR DESCRIPTION
## What Problem This Solves

On hosts that use OpenClaw's durable context-engine turn contract, an accepted
turn needs an explicit, retry-safe acknowledgement from Lossless Claw. The
existing `afterTurn` compatibility path cannot prove that the exact admitted
transcript range and its LCM messages advanced together. A process or plugin
failure can therefore leave the host unsure whether retrying will duplicate or
partially persist the turn.

## Why This Change Was Made

- Declare the `before-current-turn-entry-v1` fence and
  `atomic-idempotent-v1` advancement semantics.
- Add `commitTurn`, validating the logical turn id, transcript target,
  generation, and admitted-to-terminal message range before persistence.
- Persist the accepted turn delta and a `turn_advancements` receipt in one
  SQLite transaction.
- Return `duplicate` for a retried key with an identical canonical payload,
  while failing closed if the same key is reused with different content.
- Keep the existing `afterTurn` path for older supported hosts.

## User Impact

Accepted turns are committed exactly once even when the host retries after a
lost response or restart. Failed persistence rolls back the messages, context,
and ledger receipt together instead of leaving partial LCM state.

A patch changeset is included.

## Evidence

- `env -u OPENCLAW_HOME -u OPENCLAW_STATE_DIR -u OPENCLAW_CONFIG_PATH npm run release:verify`
  - TypeScript typecheck passed.
  - Plugin, migration CLI, and LCM CLI builds passed.
  - 1,773/1,773 Vitest tests passed.
  - Go TUI tests passed.
  - npm package dry-run passed.
- New regression coverage proves atomic commit, harmless identical retries,
  collision rejection, transaction rollback, and duplicate recognition after
  engine restart.
- The built artifact has also been exercised on five OCM-managed OpenClaw
  gateways. Native channel turns advanced their Lossless stores without
  fallback, including preserved large pre-existing stores.
