### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "@martian-engineering/lossless-claw": "0.15.1"
   },
   "changesets": [
+    "durable-turn-advancement",
     "legacy-bootstrap-diagnostics",
     "minimax-tui-provider",
     "pending-summary-projection-pressure",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @martian-engineering/lossless-claw
 
+## 1.0.0-beta.1
+
+<!-- release-rollback-version: 0.15.1 -->
+
+### Patch Changes
+
+- [#1070](https://github.com/Martian-Engineering/lossless-claw/pull/1070) [`267f006`](https://github.com/Martian-Engineering/lossless-claw/commit/267f00696fd8266d57dc223ccaa91c20d9f871e6) Thanks [@hannesrudolph](https://github.com/hannesrudolph)! - Persist accepted OpenClaw turns with an atomic idempotency ledger so host retries cannot duplicate or partially advance LosslessClaw context.
+
 ## 1.0.0-beta.0
 
 <!-- release-rollback-version: 0.15.1 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Version `@martian-engineering/lossless-claw` as `1.0.0-beta.1` and generate the prerelease changelog entry for the durable context-engine turn commit.

## Why

The `next/1.0` branch contains one change after `1.0.0-beta.0`. This release makes that change available through npm's `beta` channel while preserving `0.15.1` as the stable rollback version.

## Changes

- Bump package version to `1.0.0-beta.1`
- Consume the durable-turn changeset
- Add beta changelog and rollback marker
- Synchronize root lockfile versions

## Testing

- `npm run release:verify`
  - Typecheck, builds, and 1,778 Vitest tests passed
  - Local TUI test could not start because Go is unavailable
- `npm pack --dry-run`
  - Package contents and beta version verified
- Autoreview
  - No actionable findings
