### PR TITLE
fix: avoid double-counting compaction pressure

### DIFF
--- a/.changeset/fair-wolves-avoid-double-counting.md
+++ b/.changeset/fair-wolves-avoid-double-counting.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Avoid premature threshold compaction by treating raw messages outside the fresh tail as diagnostic and preparation data instead of adding them again to prompt pressure already represented by stored and observed token counts.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -29,7 +29,7 @@ export interface CompactionDecision {
   observedTokens?: number;
   /** Raw message tokens outside the protected fresh tail, when live prompt pressure is known. */
   rawTokensOutsideTail?: number;
-  /** Projected prompt pressure after adding unsummarized raw backlog to observed tokens. */
+  /** Larger of persisted and runtime-observed prompt pressure, when observation is available. */
   projectedTokens?: number;
   currentTokens: number;
   threshold: number;
@@ -716,9 +716,8 @@ export class CompactionEngine {
       liveTokens > 0
         ? await this.countRawTokensOutsideFreshTail(conversationId, options?.freshTailCount)
         : undefined;
-    const projectedTokens =
-      liveTokens > 0 ? liveTokens + (rawTokensOutsideTail ?? 0) : undefined;
-    const currentTokens = Math.max(storedTokens, projectedTokens ?? liveTokens);
+    const projectedTokens = liveTokens > 0 ? Math.max(storedTokens, liveTokens) : undefined;
+    const currentTokens = Math.max(storedTokens, liveTokens);
     const threshold = Math.floor(
       resolveContextThreshold(this.config, options?.contextThreshold) * tokenBudget,
     );

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -305,12 +305,12 @@ describe("LcmContextEngine afterTurn", () => {
     );
   });
 
-  it("afterTurn runs inline threshold compaction when projected raw backlog crosses threshold", async () => {
+  it("afterTurn does not run inline threshold compaction for double-counted raw backlog", async () => {
     const engine = createEngineWithConfig({
       proactiveThresholdCompactionMode: "inline",
       freshTailCount: 1,
     });
-    const sessionId = "after-turn-inline-projected-raw-backlog-threshold";
+    const sessionId = "after-turn-inline-double-counted-raw-backlog";
     await seedBacklogContext(engine, sessionId, [100, 100, 100]);
     const compactSpy = vi.spyOn(engine, "compact").mockResolvedValue({
       ok: true,
@@ -320,21 +320,14 @@ describe("LcmContextEngine afterTurn", () => {
 
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("after-turn-inline-projected-raw-backlog-threshold"),
+      sessionFile: createSessionFilePath("after-turn-inline-double-counted-raw-backlog"),
       messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
       prePromptMessageCount: 0,
       tokenBudget: 600,
       runtimeContext: { currentTokenCount: 300 },
     });
 
-    expect(compactSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId,
-        tokenBudget: 600,
-        currentTokenCount: 300,
-        compactionTarget: "threshold",
-      }),
-    );
+    expect(compactSpy).not.toHaveBeenCalled();
     const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
     expect(conversation).not.toBeNull();
     await expect(
@@ -342,7 +335,7 @@ describe("LcmContextEngine afterTurn", () => {
     ).resolves.toBeLessThan(450);
   });
 
-  it("afterTurn records deferred threshold debt when projected raw backlog crosses threshold", async () => {
+  it("afterTurn does not record deferred threshold debt for double-counted raw backlog", async () => {
     const debugLog = vi.fn();
     const engine = createEngineWithDeps(
       { freshTailCount: 1 },
@@ -350,7 +343,7 @@ describe("LcmContextEngine afterTurn", () => {
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: debugLog },
       },
     );
-    const sessionId = "after-turn-deferred-projected-raw-backlog-threshold";
+    const sessionId = "after-turn-deferred-double-counted-raw-backlog";
     const privateEngine = engine as unknown as {
       scheduleDeferredCompactionDebtDrain: (params: unknown) => void;
     };
@@ -362,7 +355,7 @@ describe("LcmContextEngine afterTurn", () => {
 
     await engine.afterTurn({
       sessionId,
-      sessionFile: createSessionFilePath("after-turn-deferred-projected-raw-backlog-threshold"),
+      sessionFile: createSessionFilePath("after-turn-deferred-double-counted-raw-backlog"),
       messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
       prePromptMessageCount: 0,
       tokenBudget: 600,
@@ -375,33 +368,15 @@ describe("LcmContextEngine afterTurn", () => {
       .getCompactionMaintenanceStore()
       .getConversationCompactionMaintenance(conversation!.conversationId);
     expect(compactSpy).not.toHaveBeenCalled();
-    expect(scheduleSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId,
-        tokenBudget: 600,
-        currentTokenCount: 300,
-        reason: "threshold",
-      }),
-    );
-    expect(maintenance).toMatchObject({
-      pending: true,
-      running: false,
-      reason: "threshold",
-      tokenBudget: 600,
-      currentTokenCount: 300,
-      projectedTokenCount: expect.any(Number),
-      rawTokensOutsideTail: expect.any(Number),
-    });
+    expect(scheduleSpy).not.toHaveBeenCalled();
+    expect(maintenance).toBeNull();
     await expect(
       engine.getSummaryStore().getContextTokenCount(conversation!.conversationId),
     ).resolves.toBeLessThan(450);
     const deferredDebtLog = debugLog.mock.calls
       .map((call) => String(call[0]))
       .find((message) => message.includes("deferred compaction debt recorded"));
-    expect(deferredDebtLog).toContain("projectedTokenCount=");
-    expect(deferredDebtLog).not.toContain("projectedTokenCount=null");
-    expect(deferredDebtLog).toContain("rawTokensOutsideTail=");
-    expect(deferredDebtLog).not.toContain("rawTokensOutsideTail=null");
+    expect(deferredDebtLog).toBeUndefined();
   });
 
   it("afterTurn ignores raw leaf pressure below the context threshold", async () => {
@@ -4439,7 +4414,7 @@ describe("LcmContextEngine afterTurn", () => {
     expect(maintenance?.running).toBe(false);
   });
 
-  it("afterTurn refreshes threshold debt while retry backoff is active without compacting", async () => {
+  it("afterTurn leaves threshold debt backoff unchanged when pressure is below threshold", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-31T12:30:00.000Z"));
     try {
@@ -4486,7 +4461,7 @@ describe("LcmContextEngine afterTurn", () => {
         .getCompactionMaintenanceStore()
         .getConversationCompactionMaintenance(conversation!.conversationId);
       expect(compactSpy).not.toHaveBeenCalled();
-      expect(scheduleSpy).toHaveBeenCalled();
+      expect(scheduleSpy).not.toHaveBeenCalled();
       expect(after?.pending).toBe(true);
       expect(after?.running).toBe(false);
       expect(after?.nextAttemptAfter?.toISOString()).toBe(

--- a/test/lcm-integration-compaction.test.ts
+++ b/test/lcm-integration-compaction.test.ts
@@ -2075,7 +2075,7 @@ describe("LCM integration: compaction", () => {
     });
   });
 
-  it("evaluate compacts when observed tokens plus raw backlog exceed the threshold", async () => {
+  it("evaluate does not add raw backlog to an observed projection count", async () => {
     const backlogEngine = new CompactionEngine(convStore as any, sumStore as any, {
       ...defaultCompactionConfig,
       freshTailCount: 1,
@@ -2087,13 +2087,13 @@ describe("LCM integration: compaction", () => {
 
     const decision = await backlogEngine.evaluate(CONV_ID, 600, 300);
     expect(decision).toMatchObject({
-      shouldCompact: true,
-      reason: "threshold",
+      shouldCompact: false,
+      reason: "none",
       storedTokens: 300,
       observedTokens: 300,
       rawTokensOutsideTail: 200,
-      projectedTokens: 500,
-      currentTokens: 500,
+      projectedTokens: 300,
+      currentTokens: 300,
       threshold: 450,
     });
   });


### PR DESCRIPTION
## What

Prevent threshold compaction from adding raw messages outside the fresh tail to token pressure that is already represented by stored and host-observed prompt counts.

## Why

`evaluate()` could double-count a raw backlog and trigger premature compaction while both stored and live context remained below the configured threshold. This caused unnecessary summarization work and reduced active raw context early.

Closes #1063.

## Changes

- Use maximum stored/live threshold pressure
- Retain raw-backlog diagnostic data
- Cover inline and deferred decisions
- Add a patch changeset

## Testing

- `npx vitest run test/lcm-integration-compaction.test.ts test/engine-after-turn.test.ts -t 'evaluate does not add raw backlog to an observed projection count|afterTurn does not run inline threshold compaction for double-counted raw backlog|afterTurn does not record deferred threshold debt for double-counted raw backlog'` — 3 passed
- `npx vitest run test/lcm-integration-compaction.test.ts test/engine-after-turn.test.ts` — 125 passed
- `npm run typecheck` — passed
- `npm test` — 114 files, 2,037 tests passed
- `npm run build` — passed
- `npx changeset status --since origin/main` — patch bump detected
