### PR TITLE
fix: recover context engine after gateway restart

### DIFF
--- a/.changeset/restart-retained-context-engine.md
+++ b/.changeset/restart-retained-context-engine.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Reopen the SQLite-backed context engine when OpenClaw starts a new gateway lifecycle from a cached plugin registry, preventing fallback to the legacy engine after in-process restarts.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -2090,6 +2090,45 @@ const lcmPlugin = {
       reject?.(error);
     }
 
+    /** Clear connection-local state so a retained factory can initialize the next gateway. */
+    function resetInitializationState(): void {
+      initPromise = null;
+      initError = null;
+      resolveDeferredInit = null;
+      rejectDeferredInit = null;
+      startupMaintenanceStarted = false;
+      if (shared) {
+        shared.startupMaintenanceStarted = false;
+      }
+    }
+
+    /** Reopen the stopped engine when OpenClaw reuses this registration for a new gateway. */
+    function reinitializeAfterGatewayStop(): void {
+      if (!allowStartupMaintenance || !stopped) {
+        return;
+      }
+
+      // Leave recovery to a fresh plugin registration when one already owns this database path.
+      const activeShared = getSharedInit(normalizedDbPath);
+      if (activeShared && activeShared !== nextShared && !activeShared.stopped) {
+        return;
+      }
+
+      stopped = false;
+      nextShared.stopped = false;
+      try {
+        const nextEngine = initializeEngine();
+        initPromise = Promise.resolve(nextEngine);
+        setSharedInit(normalizedDbPath, nextShared);
+      } catch (error) {
+        const normalized = toInitError(error);
+        rejectDeferredEngine(normalized);
+        stopped = true;
+        nextShared.stopped = true;
+        deps.log.error(`[lcm] DB reinitialization after gateway restart failed: ${normalized.message}`);
+      }
+    }
+
     /** Return the initialized engine, waiting for deferred startup when the DB is lock-contended. */
     async function waitForEngine(): Promise<LcmContextEngine> {
       if (!allowStartupMaintenance) {
@@ -2176,6 +2215,8 @@ const lcmPlugin = {
       setSharedInit(normalizedDbPath, nextShared);
     }
 
+    api.on("gateway_start", reinitializeAfterGatewayStop);
+
     api.on("gateway_stop", async () => {
       stopped = true;
       nextShared.stopped = true;
@@ -2187,6 +2228,7 @@ const lcmPlugin = {
         database = null;
       }
       lcm = null;
+      resetInitializationState();
       removeSharedInit(normalizedDbPath);
     });
 

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1990,4 +1990,62 @@ describe("lcm plugin registration", () => {
     lcmPlugin.register(api2);
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("reopens the retained context-engine factory on the next gateway lifecycle", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, getFactory, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+
+    const retainedFactory = getFactory();
+    const gatewayStop = getHook("gateway_stop");
+    expect(retainedFactory).toBeTypeOf("function");
+    expect(gatewayStop).toBeTypeOf("function");
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+
+    await gatewayStop?.({}, {});
+
+    const gatewayStart = getHook("gateway_start");
+    expect(gatewayStart).toBeTypeOf("function");
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+    expect(api.registerContextEngine).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries retained-factory initialization after a failed gateway lifecycle", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const originalCreate = connectionModule.createLcmDatabaseConnection;
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    createSpy.mockImplementation((path: string) => {
+      if (createSpy.mock.calls.length === 2) {
+        throw new Error("database is locked");
+      }
+      return originalCreate(path);
+    });
+
+    const { api, getFactory, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+    const retainedFactory = getFactory();
+    const gatewayStop = getHook("gateway_stop");
+    const gatewayStart = getHook("gateway_start");
+
+    await gatewayStop?.({}, {});
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+    await expect(Promise.resolve(retainedFactory!())).rejects.toThrow(
+      "Database connection closed after gateway_stop",
+    );
+
+    await gatewayStop?.({}, {});
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+    expect(api.registerContextEngine).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## What

Reopens the SQLite-backed context engine when OpenClaw starts a new in-process gateway lifecycle from a cached plugin registry.

## Why

OpenClaw can retain the originally registered context-engine factory across gateway restarts. After `gateway_stop`, that factory remained permanently stopped, so the host silently quarantined it and fell back to the legacy engine. Fixes #1065.

## Changes

- Reinitialize retained context-engine factories
- Reset restart-scoped initialization state
- Preserve fresh-registration database ownership
- Cover restart success and retry recovery
- Add a patch changeset

## Testing

- `npx vitest run test/plugin-config-registration.test.ts` — 51 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm test` — 114 files, 2,039 tests passed
- `npm pack --dry-run` — passed
- `npm run release:verify` — TypeScript/build/Vitest passed; TUI step unavailable because Go is not installed