### PR TITLE
fix: bootstrap SQLite-backed sessions

### DIFF
--- a/.changeset/sqlite-bootstrap-projection-backport.md
+++ b/.changeset/sqlite-bootstrap-projection-backport.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Bootstrap SQLite-backed OpenClaw sessions through the host-owned visible transcript projection instead of treating storage markers and session keys as filesystem paths. File-backed hosts retain the existing JSONL bootstrap path.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STA
 
 > **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer for OpenClaw's `api.runtime.llm.complete` summarization capability. Releases that include context-engine memory supplement support require OpenClaw `2026.5.28` or newer for `buildMemorySystemPromptAddition`. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
 
+SQLite-backed OpenClaw sessions require the branch-safe visible transcript
+projection first published in OpenClaw `2026.7.2-beta.2`. Lossless detects that
+storage mode from the context-engine runtime context and reads the host-owned
+projection without treating session markers as file paths. File-backed stable
+hosts retain the JSONL bootstrap path and the `2026.5.28` package minimum. If
+your OpenClaw build does not expose the projection helper, remain on a
+file-backed OpenClaw release or select the `legacy` context engine.
+
 ### Install the plugin
 
 Use OpenClaw's plugin installer (recommended):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ When compaction creates a summary from a range of messages (or summaries), the s
 
 When OpenClaw processes a turn, it calls the context engine's lifecycle hooks:
 
-1. **bootstrap** — On session start, reconciles the JSONL session file with the LCM database. Imports any messages that exist in the file but not in LCM (crash recovery).
+1. **bootstrap** — On session start, reconciles the host-owned visible transcript with the LCM database. SQLite hosts provide a storage-neutral message projection; file-backed hosts use the JSONL session file. Messages present in the host transcript but missing from LCM are imported for crash recovery.
 2. **ingest** / **ingestBatch** — Persists new messages to the database and appends them to context_items.
 3. **afterTurn** — After the model responds, ingests new messages, then evaluates whether `contextThreshold` requires compaction.
 
@@ -203,14 +203,14 @@ This prevents a single large file paste from consuming the entire context window
 
 LCM handles crash recovery through **bootstrap reconciliation**:
 
-1. On session start, read the JSONL session file (OpenClaw's ground truth).
+1. On session start, read OpenClaw's visible transcript. SQLite hosts supply a branch-safe projection keyed by the runtime session target; file-backed hosts supply the JSONL session file.
 2. Compare against the LCM database.
 3. Find the most recent message that exists in both (the "anchor").
-4. Import any messages after the anchor that are in JSONL but not in LCM.
+4. Import any messages after the anchor that are in the host transcript but not in LCM. Stable transcript entry ids provide exact identity when the host supplies them.
 5. If an existing session key moves to a different transcript file and no anchor exists, treat the new file as a bounded transcript epoch and import its recoverable messages. The same flood cap used for tail reconciliation prevents large unrelated transcripts from being appended automatically.
 6. Advance the bootstrap checkpoint only after an overlap is found or a bounded epoch import succeeds. No-anchor reads that import nothing leave the old checkpoint in place so a later turn can retry.
 
-This handles the case where OpenClaw wrote messages to the session file but crashed before LCM could persist them.
+This handles the case where OpenClaw persisted transcript messages but crashed before LCM could persist them.
 
 For forked child sessions, LCM treats a host-copied parent JSONL branch as a
 first-time bootstrap source and imports only the newest messages that fit within

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,13 @@ runtime LLM completion. Fully capable native hosts still advertise and execute
 the full lifecycle, and Lossless retains compaction ownership for those runs.
 Subagent forks continue to require `thread-bootstrap-projection`.
 
+SQLite-backed session bootstrap uses OpenClaw's host-owned visible transcript
+projection, first published in OpenClaw `2026.7.2-beta.2`. The plugin selects
+that path only when the runtime reports SQLite transcript storage. File-backed
+hosts continue to use JSONL bootstrap, so the package-wide minimum remains
+OpenClaw `2026.5.28`. If a SQLite host does not expose the projection helper,
+upgrade OpenClaw or select the `legacy` context engine.
+
 The optional programmatic `status` / `doctor` / `rotate` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
 That host contract is not covered by the baseline plugin API version above. As

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10,6 +10,8 @@ import type {
   ContextEngineControlResult,
   ContextEngineInfo,
   ContextEngineHostCapability,
+  ContextEngineRuntimeContext,
+  ContextEngineSessionTarget,
   AssembleResult,
   BootstrapResult,
   CompactResult,
@@ -62,14 +64,18 @@ import { FocusBriefStore, type FocusBriefRecord } from "./store/focus-brief-stor
 import { buildToolCallInputMap } from "./tool-pairing.js";
 import { SummaryStore, type ContextItemRecord } from "./store/summary-store.js";
 import { createLcmSummarizeFromLegacyParams, FALLBACK_SUMMARY_MARKER, LcmProviderAuthError, LcmSummarySpendLimitError, type LcmSummarizeFn } from "./summarize.js";
-import type { LcmDependencies } from "./types.js";
+import type {
+  LcmDependencies,
+  SessionTranscriptReadTarget,
+  VisibleSessionTranscriptMessageEntry,
+} from "./types.js";
 import { estimateTokens } from "./estimate-tokens.js";
 import {
   buildDeterministicFallbackSummary,
   FALLBACK_DIRECTIVE_SUMMARY_MARKER,
   MIN_FALLBACK_MAX_TOKENS,
 } from "./summary-fallback.js";
-import { getTranscriptEntryId, readAppendedLeafPathMessages, readLastJsonlEntryBeforeOffset, readLeafPathMessages, readSessionParentSessionReference, resolveTranscriptMessageCreatedAt } from "./transcript.js";
+import { attachTranscriptEntryMeta, getTranscriptEntryId, readAppendedLeafPathMessages, readLastJsonlEntryBeforeOffset, readLeafPathMessages, readSessionParentSessionReference, resolveTranscriptMessageCreatedAt } from "./transcript.js";
 import { extractStableEventKey } from "./stable-event-key.js";
 import { type TranscriptReconcileResult } from "./reconcile-plan.js";
 import { checkpointIsPastTranscriptEof, TranscriptReconciler } from "./transcript-reconciler.js";
@@ -118,6 +124,64 @@ const LOSSLESS_AGENT_RUN_CAPTURE_ONLY_HOST_CAPABILITIES: ContextEngineHostCapabi
 ];
 const MAX_PREVIOUS_ASSEMBLED_SNAPSHOTS = 100;
 const FORK_BOUNDED_BOOTSTRAP_REASON = "fork-bounded bootstrap import";
+
+/** Normalize one optional runtime-supplied session identity field. */
+function normalizedTargetString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/** Return whether this lifecycle invocation uses OpenClaw-owned SQLite transcripts. */
+function usesSqliteTranscriptStorage(params: {
+  sessionTarget?: ContextEngineSessionTarget;
+  runtimeContext?: ContextEngineRuntimeContext;
+}): boolean {
+  const kind = normalizedTargetString(params.runtimeContext?.transcriptStorage?.kind);
+  if (kind) {
+    return kind.toLowerCase() === "sqlite";
+  }
+  const target = params.sessionTarget ?? params.runtimeContext?.sessionTarget;
+  return normalizedTargetString(target?.storePath)?.toLowerCase().endsWith(".sqlite") === true;
+}
+
+/** Resolve the storage-neutral identity expected by OpenClaw's transcript projection API. */
+function resolveSessionTranscriptReadTarget(params: {
+  sessionId: string;
+  sessionKey?: string;
+  sessionTarget?: ContextEngineSessionTarget;
+  runtimeContext?: ContextEngineRuntimeContext;
+}): SessionTranscriptReadTarget | undefined {
+  const target = params.sessionTarget ?? params.runtimeContext?.sessionTarget;
+  const sessionId = normalizedTargetString(target?.sessionId) ?? params.sessionId.trim();
+  const sessionKey =
+    normalizedTargetString(target?.sessionKey) ?? normalizedTargetString(params.sessionKey);
+  if (!sessionId || !sessionKey) {
+    return undefined;
+  }
+  const agentId = normalizedTargetString(target?.agentId);
+  const storePath = normalizedTargetString(target?.storePath);
+  const threadId =
+    typeof target?.threadId === "string" || typeof target?.threadId === "number"
+      ? target.threadId
+      : undefined;
+  return {
+    sessionId,
+    sessionKey,
+    ...(agentId ? { agentId } : {}),
+    ...(storePath ? { storePath } : {}),
+    ...(threadId !== undefined ? { threadId } : {}),
+  };
+}
+
+/** Attach the host-owned transcript identity to one projected message. */
+function messageFromVisibleTranscriptEntry(
+  entry: VisibleSessionTranscriptMessageEntry,
+): AgentMessage {
+  return attachTranscriptEntryMeta(entry.message, {
+    entryId: entry.entryId,
+    parentId: entry.parentId,
+    timestamp: entry.createdAt ?? null,
+  });
+}
 
 // Host-contract dependency: the deliberate-vs-incidental archive distinction
 // relies on OpenClaw emitting these exact reason strings only for genuine
@@ -1859,6 +1923,210 @@ export class LcmContextEngine implements ContextEngine {
     }
   }
 
+  /** Import a bounded projection into a conversation that has no persisted messages. */
+  private async importInitialVisibleTranscriptProjection(params: {
+    sessionId: string;
+    sessionKey?: string;
+    conversationId: number;
+    historicalMessages: AgentMessage[];
+    startedAt: number;
+    sessionLabel: string;
+  }): Promise<BootstrapResult> {
+    const bootstrapMessages = trimBootstrapMessagesToBudget(
+      params.historicalMessages,
+      resolveBootstrapMaxTokens(this.config),
+    );
+    if (bootstrapMessages.length === 0) {
+      await this.conversationStore.markConversationBootstrapped(params.conversationId);
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "no visible transcript messages in session",
+      };
+    }
+
+    let importedMessages = 0;
+    for (const message of bootstrapMessages) {
+      const ingestResult = await this.ingestSingle({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        message,
+        createdAt: resolveTranscriptMessageCreatedAt(message),
+        skipReplayTimestampFloodGuard: true,
+      });
+      if (ingestResult.ingested) {
+        importedMessages += 1;
+      }
+    }
+    await this.conversationStore.markConversationBootstrapped(params.conversationId);
+
+    if (this.config.pruneHeartbeatOk) {
+      const pruned = await pruneHeartbeatOkTurns(
+        this.conversationStore,
+        params.conversationId,
+      );
+      if (pruned > 0) {
+        this.deps.log.info(
+          `[lcm] bootstrap: pruned ${pruned} HEARTBEAT_OK messages from conversation ${params.conversationId}`,
+        );
+      }
+    }
+
+    this.deps.log.debug(
+      `[lcm] bootstrap: sqlite projection initial import conversation=${params.conversationId} ${params.sessionLabel} importedMessages=${importedMessages} sourceMessages=${params.historicalMessages.length} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+    );
+    return {
+      bootstrapped: importedMessages > 0,
+      importedMessages,
+    };
+  }
+
+  /** Reconcile one visible projection with an existing 0.15.x conversation. */
+  private async reconcileVisibleTranscriptProjection(params: {
+    sessionId: string;
+    sessionKey?: string;
+    conversation: ConversationRecord;
+    historicalMessages: AgentMessage[];
+    startedAt: number;
+    sessionLabel: string;
+  }): Promise<BootstrapResult> {
+    const conversationId = params.conversation.conversationId;
+    const bootstrapState = await this.summaryStore.getConversationBootstrapState(conversationId);
+    const isFirstBootstrap = !params.conversation.bootstrappedAt;
+    const firstBootstrapFrontierIsNonAnchoring =
+      !bootstrapState &&
+      isFirstBootstrap &&
+      (await this.transcriptReconciler.conversationFrontierIsEntirelyNonAnchoring(
+        conversationId,
+      ));
+    const reconcile = await this.transcriptReconciler.reconcileSessionTail({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      conversationId,
+      historicalMessages: params.historicalMessages,
+      checkpointEntryHash: bootstrapState?.lastProcessedEntryHash,
+      lastProcessedEntryId: bootstrapState?.lastProcessedEntryId,
+      allowNoAnchorImport: firstBootstrapFrontierIsNonAnchoring,
+      allowFullNonAnchoringFrontierImport: firstBootstrapFrontierIsNonAnchoring,
+      noAnchorImportReason: firstBootstrapFrontierIsNonAnchoring
+        ? "checkpoint-missing-recovery"
+        : undefined,
+    });
+    this.deps.log.debug(
+      `[lcm] bootstrap: sqlite projection reconcile finished conversation=${conversationId} ${params.sessionLabel} importedMessages=${reconcile.importedMessages} overlap=${reconcile.hasOverlap} blockedByImportCap=${reconcile.blockedByImportCap} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+    );
+
+    if (reconcile.blockedByImportCap) {
+      return {
+        bootstrapped: false,
+        importedMessages: reconcile.importedMessages,
+        reason:
+          reconcile.blockedReason === "cross-conversation-raw-id"
+            ? "reconcile duplicate raw ids"
+            : reconcile.blockedReason === "duplicate-transcript-replay"
+              ? "reconcile duplicate transcript replay"
+              : "reconcile import capped",
+      };
+    }
+    if (isFirstBootstrap && (reconcile.importedMessages > 0 || reconcile.hasOverlap)) {
+      await this.conversationStore.markConversationBootstrapped(conversationId);
+    }
+    if (reconcile.importedMessages > 0) {
+      return {
+        bootstrapped: true,
+        importedMessages: reconcile.importedMessages,
+        reason: "reconciled missing session messages",
+      };
+    }
+    if (params.conversation.bootstrappedAt) {
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "already bootstrapped",
+      };
+    }
+    return {
+      bootstrapped: false,
+      importedMessages: 0,
+      reason: reconcile.hasOverlap
+        ? "conversation already up to date"
+        : "conversation already has messages",
+    };
+  }
+
+  /** Bootstrap from OpenClaw's storage-neutral visible SQLite transcript projection. */
+  private async bootstrapFromVisibleTranscriptProjection(params: {
+    sessionId: string;
+    sessionKey?: string;
+    target: SessionTranscriptReadTarget;
+    startedAt: number;
+    sessionLabel: string;
+  }): Promise<BootstrapResult> {
+    const readVisibleSessionTranscriptMessageEntries =
+      this.deps.readVisibleSessionTranscriptMessageEntries;
+    if (!readVisibleSessionTranscriptMessageEntries) {
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "visible transcript projection unavailable",
+      };
+    }
+
+    const result = await this.withSessionQueue(
+      this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
+      async () =>
+        this.conversationStore.withTransaction(async () => {
+          const entries = await readVisibleSessionTranscriptMessageEntries(params.target);
+          const historicalMessages = entries.map(messageFromVisibleTranscriptEntry);
+          await this.sessionRolloverDetector.rotateIsolatedCronConversationIfRuntimeChanged({
+            phase: "bootstrap",
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            createReplacement: true,
+          });
+          const conversation = await this.conversationStore.getOrCreateConversation(params.sessionId, {
+            sessionKey: params.sessionKey,
+          });
+          const existingCount = await this.conversationStore.getMessageCount(
+            conversation.conversationId,
+          );
+          const bootstrapParams = {
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            historicalMessages,
+            startedAt: params.startedAt,
+            sessionLabel: params.sessionLabel,
+          };
+          return existingCount === 0
+            ? this.importInitialVisibleTranscriptProjection({
+                ...bootstrapParams,
+                conversationId: conversation.conversationId,
+              })
+            : this.reconcileVisibleTranscriptProjection({
+                ...bootstrapParams,
+                conversation,
+              });
+        }),
+      { operationName: "bootstrap", context: params.sessionLabel },
+    );
+
+    const conversation = await this.conversationStore.getConversationForSession({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    if (conversation) {
+      this.recordRecentBootstrapImport(
+        conversation.conversationId,
+        result.importedMessages,
+        result.reason ?? null,
+      );
+    }
+    this.deps.log.debug(
+      `[lcm] bootstrap: done ${params.sessionLabel} bootstrapped=${result.bootstrapped} importedMessages=${result.importedMessages} reason=${result.reason ?? "none"} duration=${formatDurationMs(Date.now() - params.startedAt)}`,
+    );
+    return result;
+  }
+
 
   // ── ContextEngine interface ─────────────────────────────────────────────
 
@@ -1866,17 +2134,25 @@ export class LcmContextEngine implements ContextEngine {
 
   async bootstrap(params: {
     sessionId: string;
-    sessionFile: string;
+    sessionFile?: string;
     sessionKey?: string;
+    sessionTarget?: ContextEngineSessionTarget;
+    runtimeContext?: ContextEngineRuntimeContext;
   }): Promise<BootstrapResult> {
-    if (this.shouldIgnoreSession({ sessionId: params.sessionId, sessionKey: params.sessionKey })) {
+    const sqliteTranscriptStorage = usesSqliteTranscriptStorage(params);
+    const transcriptReadTarget = sqliteTranscriptStorage
+      ? resolveSessionTranscriptReadTarget(params)
+      : undefined;
+    const sessionId = transcriptReadTarget?.sessionId ?? params.sessionId;
+    const sessionKey = transcriptReadTarget?.sessionKey ?? params.sessionKey;
+    if (this.shouldIgnoreSession({ sessionId, sessionKey })) {
       return {
         bootstrapped: false,
         importedMessages: 0,
         reason: "session excluded by pattern",
       };
     }
-    if (this.isStatelessSession(params.sessionKey)) {
+    if (this.isStatelessSession(sessionKey)) {
       return {
         bootstrapped: false,
         importedMessages: 0,
@@ -1885,11 +2161,35 @@ export class LcmContextEngine implements ContextEngine {
     }
     this.ensureMigrated();
     const startedAt = Date.now();
-    const sessionLabel = formatSessionLabel(params.sessionId, params.sessionKey);
-    const sessionFileStats = await stat(params.sessionFile);
+    const sessionLabel = formatSessionLabel(sessionId, sessionKey);
+    if (sqliteTranscriptStorage) {
+      if (!transcriptReadTarget) {
+        return {
+          bootstrapped: false,
+          importedMessages: 0,
+          reason: "visible transcript projection unavailable",
+        };
+      }
+      return this.bootstrapFromVisibleTranscriptProjection({
+        sessionId,
+        sessionKey,
+        target: transcriptReadTarget,
+        startedAt,
+        sessionLabel,
+      });
+    }
+    if (!params.sessionFile) {
+      return {
+        bootstrapped: false,
+        importedMessages: 0,
+        reason: "session file unavailable",
+      };
+    }
+    const sessionFile = params.sessionFile;
+    const sessionFileStats = await stat(sessionFile);
     const sessionFileSize = sessionFileStats.size;
     const sessionFileMtimeMs = Math.trunc(sessionFileStats.mtimeMs);
-    const parentSessionReference = await readSessionParentSessionReference(params.sessionFile);
+    const parentSessionReference = await readSessionParentSessionReference(sessionFile);
 
     const result = await this.withSessionQueue(
       this.resolveSessionQueueKey(params.sessionId, params.sessionKey),
@@ -1905,7 +2205,7 @@ export class LcmContextEngine implements ContextEngine {
           ): Promise<void> => {
             await this.transcriptReconciler.refreshBootstrapState({
               conversationId,
-              sessionFile: params.sessionFile,
+              sessionFile,
               fileStats: {
                 size: sessionFileSize,
                 mtimeMs: sessionFileMtimeMs,
@@ -1943,7 +2243,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionFile: params.sessionFile,
             });
           if (ambiguousRollover) {
-            preloadedHistoricalMessages = await readLeafPathMessages(params.sessionFile);
+            preloadedHistoricalMessages = await readLeafPathMessages(sessionFile);
             const activeBootstrapState =
               await this.summaryStore.getConversationBootstrapState(
                 ambiguousRollover.conversationId,
@@ -1972,7 +2272,7 @@ export class LcmContextEngine implements ContextEngine {
                   phase: "bootstrap",
                   rollover: ambiguousRollover,
                   sessionId: params.sessionId,
-                  sessionFile: params.sessionFile,
+                  sessionFile,
                   expected: rolloverResolution.preserveExpected,
                   alreadyWarned: rolloverResolution.alreadyWarned,
                 });
@@ -1986,7 +2286,7 @@ export class LcmContextEngine implements ContextEngine {
                 await this.transcriptReconciler.importFreshAmbiguousRolloverTranscript({
                   sessionId: params.sessionId,
                   sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
+                  sessionFile,
                   conversationId: ambiguousRollover.conversationId,
                   historicalMessages: preloadedHistoricalMessages,
                 });
@@ -2231,7 +2531,7 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           const historicalMessages =
-            preloadedHistoricalMessages ?? (await readLeafPathMessages(params.sessionFile));
+            preloadedHistoricalMessages ?? (await readLeafPathMessages(sessionFile));
           this.deps.log.debug(
             `[lcm] bootstrap: full transcript read conversation=${conversationId} ${sessionLabel} existingCount=${existingCount} historicalMessages=${historicalMessages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
           );

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -229,6 +229,25 @@ export type AgentMessage = {
   output?: unknown;
 };
 
+/** Storage-neutral session identity supplied by newer OpenClaw runtimes. */
+export type ContextEngineSessionTarget = {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  storePath?: string;
+  threadId?: string | number;
+};
+
+/** Runtime-owned storage details supplied to context-engine lifecycle hooks. */
+export type ContextEngineRuntimeContext = {
+  sessionTarget?: ContextEngineSessionTarget;
+  transcriptStorage?: {
+    kind?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
 export type ContextEngine = {
   info: ContextEngineInfo;
   bootstrap(params: {
@@ -236,6 +255,8 @@ export type ContextEngine = {
     sessionKey?: string;
     sessionFile?: string;
     messages?: AgentMessage[];
+    sessionTarget?: ContextEngineSessionTarget;
+    runtimeContext?: ContextEngineRuntimeContext;
   }): Promise<BootstrapResult>;
   ingest(params: {
     sessionId: string;

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -29,20 +29,33 @@ import { createLcmGrepTool } from "../tools/lcm-grep-tool.js";
 import { createLcmCommand } from "./lcm-command.js";
 import type {
   LcmDependencies,
+  SessionTranscriptReadTarget,
   RuntimeLlmCompleteFn,
   RuntimeLlmModelOverride,
   RuntimeCompactionDelegateFn,
   StartupSessionFileCandidate,
+  VisibleSessionTranscriptMessageEntry,
 } from "../types.js";
 import { listConfiguredAgentIds, normalizeAgentId } from "./openclaw-agent-ids.js";
 
 const MIN_CONTEXT_ENGINE_OPENCLAW_VERSION = "2026.5.28";
+const MIN_SQLITE_TRANSCRIPT_OPENCLAW_VERSION = "2026.7.2-beta.2";
 
 type PluginSdkCoreModule = {
   delegateCompactionToRuntime?: RuntimeCompactionDelegateFn;
 };
 
 let pluginSdkCoreImport: Promise<PluginSdkCoreModule | null> | undefined;
+
+type ReadVisibleSessionTranscriptMessageEntries = (
+  target: SessionTranscriptReadTarget,
+) => Promise<VisibleSessionTranscriptMessageEntry[]>;
+
+type SessionTranscriptRuntimeModule = {
+  readVisibleSessionTranscriptMessageEntries?: unknown;
+};
+
+let sessionTranscriptRuntimeImport: Promise<SessionTranscriptRuntimeModule | null> | undefined;
 
 type ContextEngineCapableOpenClawPluginApi = OpenClawPluginApi & {
   registerContextEngine: (id: string, factory: ContextEngineFactory) => void;
@@ -76,6 +89,37 @@ function loadPluginSdkCore(log: LcmDependencies["log"]): Promise<PluginSdkCoreMo
     return null;
   });
   return pluginSdkCoreImport;
+}
+
+/** Lazily load the optional SQLite transcript projection without raising the stable peer floor. */
+function loadSessionTranscriptRuntime(
+  log: LcmDependencies["log"],
+): Promise<SessionTranscriptRuntimeModule | null> {
+  sessionTranscriptRuntimeImport ??= (Function("specifier", "return import(specifier)") as (
+    specifier: string,
+  ) => Promise<SessionTranscriptRuntimeModule>)(
+    "openclaw/plugin-sdk/session-transcript-runtime",
+  ).catch((error: unknown) => {
+    log.debug(`[lcm] SQLite transcript projection unavailable: ${describeLogError(error)}`);
+    return null;
+  });
+  return sessionTranscriptRuntimeImport;
+}
+
+/** Create a late-bound reader for OpenClaw-owned visible SQLite transcript entries. */
+function createVisibleTranscriptReader(
+  log: LcmDependencies["log"],
+): ReadVisibleSessionTranscriptMessageEntries {
+  return async (target) => {
+    const runtime = await loadSessionTranscriptRuntime(log);
+    const reader = runtime?.readVisibleSessionTranscriptMessageEntries;
+    if (typeof reader !== "function") {
+      throw new Error(
+        `[lcm] SQLite transcript bootstrap requires OpenClaw >=${MIN_SQLITE_TRANSCRIPT_OPENCLAW_VERSION}.`,
+      );
+    }
+    return (reader as ReadVisibleSessionTranscriptMessageEntries)(target);
+  };
 }
 
 /** Create a late-bound delegate to OpenClaw's stock runtime compaction path. */
@@ -1657,6 +1701,7 @@ function createLcmDependencies(
 
       return candidates;
     },
+    readVisibleSessionTranscriptMessageEntries: createVisibleTranscriptReader(log),
     agentLaneSubagent: "subagent",
     log,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@
 
 import type { LcmConfig } from "./db/config.js";
 import type { LcmConfigDiagnostics } from "./db/config.js";
-import type { CompactResult } from "./openclaw-bridge.js";
+import type { AgentMessage, CompactResult } from "./openclaw-bridge.js";
 
 /**
  * Minimal LLM completion interface needed by LCM for summarization.
@@ -126,6 +126,26 @@ export type StartupSessionFileCandidate = {
   storePath?: string;
 };
 
+/** Storage-neutral OpenClaw session identity for transcript reads. */
+export type SessionTranscriptReadTarget = {
+  sessionId: string;
+  sessionKey: string;
+  agentId?: string;
+  storePath?: string;
+  threadId?: string | number;
+};
+
+/** Branch-safe visible message projection returned by OpenClaw's transcript runtime. */
+export type VisibleSessionTranscriptMessageEntry = {
+  entryId: string;
+  parentId: string | null;
+  seq: number;
+  message: AgentMessage;
+  role: AgentMessage["role"];
+  createdAt?: string;
+  idempotencyKey?: string;
+};
+
 /**
  * Dependencies injected into the LCM engine at registration time.
  * These replace all direct imports from OpenClaw core.
@@ -186,6 +206,11 @@ export interface LcmDependencies {
 
   /** List OpenClaw-indexed session files that startup recovery may enumerate. */
   listStartupSessionFileCandidates?: () => Promise<StartupSessionFileCandidate[]>;
+
+  /** Read OpenClaw-owned visible transcript entries for SQLite-backed sessions. */
+  readVisibleSessionTranscriptMessageEntries?: (
+    target: SessionTranscriptReadTarget,
+  ) => Promise<VisibleSessionTranscriptMessageEntry[]>;
 
   /** Agent lane constant for subagents */
   agentLaneSubagent: string;

--- a/test/sqlite-bootstrap-projection.test.ts
+++ b/test/sqlite-bootstrap-projection.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type { VisibleSessionTranscriptMessageEntry } from "../src/types.js";
+import {
+  cleanupEngineTestState,
+  createEngineWithDepsOverrides,
+  createSessionFilePath,
+  writeLeafTranscript,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+describe("LcmContextEngine.bootstrap SQLite transcript projection", () => {
+  it("ignores an opaque heartbeat session marker and reconciles visible entries by id", async () => {
+    const sessionId = "sqlite-heartbeat-session";
+    const sessionKey = "agent:main:main:heartbeat";
+    const visibleEntries: VisibleSessionTranscriptMessageEntry[] = [
+      {
+        entryId: "entry-user",
+        parentId: null,
+        seq: 1,
+        role: "user",
+        message: { role: "user", content: "sqlite user" } satisfies AgentMessage,
+        createdAt: "2026-07-20T12:00:00.000Z",
+      },
+      {
+        entryId: "entry-assistant",
+        parentId: "entry-user",
+        seq: 2,
+        role: "assistant",
+        message: { role: "assistant", content: "sqlite assistant" } satisfies AgentMessage,
+        createdAt: "2026-07-20T12:00:01.000Z",
+      },
+    ];
+    const readVisibleSessionTranscriptMessageEntries = vi.fn(async () => visibleEntries);
+    const engine = createEngineWithDepsOverrides({
+      readVisibleSessionTranscriptMessageEntries,
+    });
+    const runtimeContext = {
+      transcriptStorage: { kind: "sqlite" },
+      sessionTarget: {
+        agentId: "main",
+        sessionId,
+        sessionKey,
+        storePath: "/tmp/openclaw-agent.sqlite",
+      },
+    } as const;
+
+    const first = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: sessionKey,
+      runtimeContext,
+    });
+
+    expect(first).toMatchObject({ bootstrapped: true, importedMessages: 2 });
+    expect(readVisibleSessionTranscriptMessageEntries).toHaveBeenLastCalledWith({
+      agentId: "main",
+      sessionId,
+      sessionKey,
+      storePath: "/tmp/openclaw-agent.sqlite",
+    });
+
+    visibleEntries.push({
+      entryId: "entry-user-2",
+      parentId: "entry-assistant",
+      seq: 3,
+      role: "user",
+      message: { role: "user", content: "sqlite follow-up" } satisfies AgentMessage,
+      createdAt: "2026-07-20T12:00:02.000Z",
+    });
+    const second = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile: sessionKey,
+      runtimeContext,
+    });
+
+    expect(second).toMatchObject({ bootstrapped: true, importedMessages: 1 });
+    const conversation = await engine.getConversationStore().getConversationForSession({
+      sessionId,
+      sessionKey,
+    });
+    expect(conversation).not.toBeNull();
+    const messages = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(messages.map((message) => message.content)).toEqual([
+      "sqlite user",
+      "sqlite assistant",
+      "sqlite follow-up",
+    ]);
+  });
+
+  it("preserves JSONL bootstrap when the host does not report SQLite storage", async () => {
+    const sessionId = "jsonl-bootstrap-session";
+    const sessionKey = "agent:main:jsonl-bootstrap-session";
+    const sessionFile = createSessionFilePath(sessionId);
+    writeLeafTranscript(sessionFile, [
+      { role: "user", content: "jsonl user" },
+      { role: "assistant", content: "jsonl assistant" },
+    ]);
+    const readVisibleSessionTranscriptMessageEntries = vi.fn(async () => {
+      throw new Error("projection reader must not run for JSONL bootstrap");
+    });
+    const engine = createEngineWithDepsOverrides({
+      readVisibleSessionTranscriptMessageEntries,
+    });
+
+    const result = await engine.bootstrap({
+      sessionId,
+      sessionKey,
+      sessionFile,
+      runtimeContext: {
+        transcriptStorage: { kind: "jsonl" },
+        sessionTarget: {
+          sessionId,
+          sessionKey,
+          storePath: "/tmp/openclaw-agent.sqlite",
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ bootstrapped: true, importedMessages: 2 });
+    expect(readVisibleSessionTranscriptMessageEntries).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Backport SQLite-backed session bootstrap support from the 1.0 line to current main. The context engine now reads OpenClaw's host-owned visible transcript projection for SQLite sessions while retaining the existing JSONL bootstrap path for file-backed hosts.

## Why

OpenClaw 2026.7.2 beta can pass an opaque session locator such as `agent:main:main:heartbeat` where main expects a filesystem path. Calling `stat()` on that locator fails bootstrap, quarantines Lossless Claw for the process, and silently falls back to the legacy engine. Fixes #1017.

## Changes

- Read SQLite visible transcript projections
- Reconcile projected entries by stable ids
- Preserve explicit JSONL storage routing
- Document conditional beta compatibility
- Add focused bootstrap regressions
- Add a patch changeset

## Testing

- `npm run typecheck`
- `npx vitest run test/sqlite-bootstrap-projection.test.ts test/engine-bootstrap.test.ts test/engine-lifecycle.test.ts` (128 tests)
- `npm test` (115 files, 2,039 tests)
- `npm run build`
- `npm ci --package-lock-only --ignore-scripts`
- `npm pack --dry-run`
- Autoreview: clean after addressing JSONL routing precedence
