### PR TITLE
fix: bound 0.x OpenClaw compatibility

### DIFF
--- a/.changeset/openclaw-0x-compatibility-bound.md
+++ b/.changeset/openclaw-0x-compatibility-bound.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Bound the 0.x peer dependency to file-backed OpenClaw releases before 2026.7.2. SQLite-backed OpenClaw releases require Lossless Claw 1.0.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STA
 - Node.js 22+
 - An LLM provider configured in OpenClaw (used for summarization)
 
-> **Compatibility:** `lossless-claw@0.10.0` and newer require OpenClaw `2026.5.12` or newer for OpenClaw's `api.runtime.llm.complete` summarization capability. Releases that include context-engine memory supplement support require OpenClaw `2026.5.28` or newer for `buildMemorySystemPromptAddition`. If you cannot upgrade OpenClaw yet, stay on `lossless-claw@0.9.4` and remove `0.10.x`-only config such as `sweepMaxDepth`.
+> **Compatibility:** Lossless Claw 0.x supports file-backed OpenClaw from `2026.5.28` through `2026.7.1`. OpenClaw `2026.7.2` prereleases and later use SQLite-backed session storage and require Lossless Claw 1.0 from the `next/1.0` release line. If you cannot move to 1.0, remain on OpenClaw `2026.7.1` or select OpenClaw's `legacy` context engine. Lossless Claw `0.9.4` remains the fallback for OpenClaw versions older than `2026.5.28`.
 
 ### Install the plugin
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,9 +2,13 @@
 
 Lossless-claw reads plugin configuration from `plugins.entries.lossless-claw.config`.
 
-Lossless-claw requires OpenClaw `2026.5.28` or newer so the host can enforce
-context-engine runtime capabilities before an agent run starts. Agent runs need
-a native host that provides the full context-engine lifecycle: session bootstrap,
+Lossless Claw 0.x supports file-backed OpenClaw from `2026.5.28` through
+`2026.7.1`. OpenClaw `2026.7.2` prereleases and later use SQLite-backed session
+storage and require Lossless Claw 1.0 from the `next/1.0` release line. If you
+cannot move to 1.0, remain on OpenClaw `2026.7.1` or select OpenClaw's `legacy`
+context engine. The `2026.5.28` minimum lets the host enforce context-engine
+runtime capabilities before an agent run starts. Agent runs need a native host
+that provides the full context-engine lifecycle: session bootstrap,
 pre-prompt assembly, after-turn ingestion, maintenance, compaction, and runtime
 LLM completion. Native Codex and Pi embedded runs provide those capabilities;
 generic CLI harnesses such as `claude-cli` and `codex-cli` do not. If you must

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^4.1.9"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.5.28"
+        "openclaw": ">=2026.5.28 <2026.7.2-0"
       },
       "peerDependenciesMeta": {
         "openclaw": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vitest": "^4.1.9"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.28"
+    "openclaw": ">=2026.5.28 <2026.7.2-0"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -3,12 +3,14 @@ import { readFileSync } from "node:fs";
 import packageJson from "../package.json" with { type: "json" };
 
 describe("package OpenClaw compatibility metadata", () => {
-  it("declares the memory supplement context-engine minimum OpenClaw version without an upper bound", () => {
-    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.28");
+  it("bounds the 0.x line to file-backed OpenClaw while preserving its minimum contract", () => {
+    expect(packageJson.peerDependencies.openclaw).toBe(">=2026.5.28 <2026.7.2-0");
+    expect(packageJson.peerDependenciesMeta.openclaw.optional).toBe(true);
     expect(packageJson.openclaw.compat.pluginApi).toBe(">=2026.5.28");
     expect(packageJson.openclaw.compat.minGatewayVersion).toBe("2026.5.28");
     expect(packageJson.openclaw.compat.tested).toEqual(["2026.5.28"]);
     expect(packageJson.openclaw.build.openclawVersion).toBe("2026.5.28");
+    expect(packageJson.openclaw.compat).not.toHaveProperty("maxGatewayVersion");
   });
 
   it("publishes the TypeScript lcm executable", () => {


### PR DESCRIPTION
## What

Bound Lossless Claw 0.x to the file-backed OpenClaw release line with the optional peer range `>=2026.5.28 <2026.7.2-0`.

## Why

Lossless Claw 0.x bootstraps from JSONL session files. OpenClaw 2026.7.2 prereleases and later use SQLite-backed sessions, which require the Lossless Claw 1.0 architecture on `next/1.0`. The peer boundary prevents package managers and release tooling from treating those incompatible lines as supported.

Related to #1017. Supersedes #1074.

## Changes

- Bound the optional OpenClaw peer range
- Preserve the 2026.5.28 minimum contract
- Document the 0.x and 1.0 release lines
- Add metadata regression coverage
- Add a patch changeset

## Compatibility metadata

The `openclaw.compat` fields describe minimum plugin API and gateway capabilities and do not define a maximum-version field. They remain aligned at `2026.5.28`. The npm peer range carries the 0.x upper bound, and `peerDependenciesMeta.openclaw.optional` remains enabled.

## Testing

- `npx vitest run test/package-metadata.test.ts` (3 tests)
- `npm run typecheck`
- `npm test` (114 files, 2,037 tests)
- `npm run build`
- `npm ci --package-lock-only --ignore-scripts`
- `npm pack --dry-run`
- Plugin Inspector: pass, zero breakages
- Autoreview: clean
