### PR TITLE
fix(context-engine): accept turn-local durable commits

### DIFF
--- a/.changeset/turn-local-durable-commit.md
+++ b/.changeset/turn-local-durable-commit.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Accept OpenClaw's turn-local durable commit payload and preserve idempotent retries for beta.1 receipts after the host removes `prePromptMessageCount`.
+Accept the turn-local durable `commitTurn` payload defined by [OpenClaw PR 122149](https://github.com/openclaw/openclaw/pull/122149), and preserve idempotent retries for beta.1 receipts after the host removes `prePromptMessageCount`.

--- a/.changeset/turn-local-durable-commit.md
+++ b/.changeset/turn-local-durable-commit.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Accept OpenClaw's turn-local durable commit payload and preserve idempotent retries for beta.1 receipts after the host removes `prePromptMessageCount`.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -140,7 +140,6 @@ type CommitTurnParams = {
   admission: TranscriptTurnAdmission;
   terminal: TranscriptEntryAnchor;
   messages: AgentMessage[];
-  prePromptMessageCount: number;
   sessionId: string;
   sessionKey?: string;
   sessionTarget?: ContextEngineSessionTarget;
@@ -176,12 +175,18 @@ function canonicalizeTurnPayload(value: unknown): unknown {
   return value;
 }
 
-function buildTurnAdvancementPayloadHash(params: CommitTurnParams): string {
+/** Build the current receipt hash or the beta.1 hash needed for upgrade retries. */
+function buildTurnAdvancementPayloadHash(
+  params: CommitTurnParams,
+  legacyPrePromptMessageCount?: number,
+): string {
   const canonicalPayload = canonicalizeTurnPayload({
     admission: params.admission,
     isHeartbeat: params.isHeartbeat === true,
-    messages: params.messages.slice(params.prePromptMessageCount),
-    prePromptMessageCount: params.prePromptMessageCount,
+    messages: params.messages,
+    ...(legacyPrePromptMessageCount === undefined
+      ? {}
+      : { prePromptMessageCount: legacyPrePromptMessageCount }),
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     terminal: params.terminal,
@@ -214,12 +219,12 @@ function assertValidTurnAdvancement(params: CommitTurnParams): void {
     throw new Error("turn advancement transcript target changed after admission");
   }
   if (
-    !Number.isSafeInteger(params.prePromptMessageCount) ||
-    params.prePromptMessageCount < 0 ||
-    params.prePromptMessageCount > params.messages.length ||
-    params.prePromptMessageCount !== admission.activeMessagePosition ||
+    !Number.isSafeInteger(admission.activeMessagePosition) ||
+    admission.activeMessagePosition < 0 ||
+    !Number.isSafeInteger(terminal.activeMessagePosition) ||
     terminal.activeMessagePosition < admission.activeMessagePosition ||
-    terminal.activeMessagePosition !== params.messages.length - 1
+    params.messages.length !==
+      terminal.activeMessagePosition - admission.activeMessagePosition + 1
   ) {
     throw new Error("turn advancement transcript range is invalid");
   }
@@ -4062,7 +4067,11 @@ export class LcmContextEngine implements ContextEngine {
             )
             .get(params.advancementKey) as { payload_hash: string } | undefined;
           if (existing) {
-            if (existing.payload_hash !== payloadHash) {
+            if (
+              existing.payload_hash !== payloadHash &&
+              existing.payload_hash !==
+                buildTurnAdvancementPayloadHash(params, params.admission.activeMessagePosition)
+            ) {
               throw new Error(
                 `context-engine advancement key collision: ${params.advancementKey}`,
               );
@@ -4071,8 +4080,7 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           let ingestedCount = 0;
-          const turnMessages = params.messages.slice(params.prePromptMessageCount);
-          for (const message of turnMessages) {
+          for (const message of params.messages) {
             const result = await this.ingestSingle({
               sessionId,
               sessionKey,

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -301,7 +301,6 @@ export type ContextEngine = {
     admission: TranscriptTurnAdmission;
     terminal: TranscriptEntryAnchor;
     messages: AgentMessage[];
-    prePromptMessageCount: number;
     sessionId: string;
     sessionKey?: string;
     sessionTarget?: ContextEngineSessionTarget;

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -20,6 +20,10 @@ import {
 
 afterEach(cleanupEngineTestState);
 
+/** Receipt produced for the default fixture by lossless-claw 1.0.0-beta.1. */
+const BETA_1_RECEIPT_HASH =
+  "894ebf9d9233e5d8ceb3da959cac9a4bb2ebf422633e65cacb4750fdbb8c8dfb";
+
 function buildCommitTurnParams(overrides?: {
   advancementKey?: string;
   answer?: string;
@@ -30,7 +34,7 @@ function buildCommitTurnParams(overrides?: {
   const generation = "generation-1";
   const advancementKey = overrides?.advancementKey ?? "logical-turn-1";
   const admission: TranscriptTurnAdmission = {
-    activeMessagePosition: 1,
+    activeMessagePosition: 41,
     agentId: "main",
     effectiveParentId: "prior-entry",
     entryId: "user-entry",
@@ -43,7 +47,7 @@ function buildCommitTurnParams(overrides?: {
     storePath,
   };
   const terminal: TranscriptEntryAnchor = {
-    activeMessagePosition: 2,
+    activeMessagePosition: 42,
     agentId: "main",
     effectiveParentId: admission.entryId,
     entryId: "assistant-entry",
@@ -58,7 +62,6 @@ function buildCommitTurnParams(overrides?: {
     admission,
     terminal,
     messages: [
-      makeMessage({ role: "assistant", content: "prior persisted prefix", timestamp: 1_000 }),
       makeMessage({ role: "user", content: "current question", timestamp: 2_000 }),
       makeMessage({
         role: "assistant",
@@ -66,7 +69,6 @@ function buildCommitTurnParams(overrides?: {
         timestamp: 3_000,
       }),
     ],
-    prePromptMessageCount: 1,
     sessionId,
     sessionKey,
     sessionTarget: {
@@ -133,7 +135,7 @@ describe("LcmContextEngine commitTurn", () => {
   it("rejects a terminal anchor outside the supplied message range", async () => {
     const engine = createEngine();
     const params = buildCommitTurnParams();
-    params.messages = params.messages.slice(0, 2);
+    params.messages = params.messages.slice(0, 1);
 
     await expect(engine.commitTurn(params)).rejects.toThrow(
       "turn advancement transcript range is invalid",
@@ -161,17 +163,31 @@ describe("LcmContextEngine commitTurn", () => {
     ).toEqual({ count: 1 });
   });
 
-  it("ignores the uncommitted transcript prefix when identifying a retry", async () => {
+  it("recognizes a beta.1 receipt after the turn-local contract upgrade", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.commitTurn(params);
+    getEngineDatabase(engine)
+      .prepare("UPDATE turn_advancements SET payload_hash = ? WHERE advancement_key = ?")
+      .run(BETA_1_RECEIPT_HASH, params.advancementKey);
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+    expect(await readStoredMessages(engine)).toHaveLength(2);
+  });
+
+  it("includes the admitted user message in retry identity", async () => {
     const engine = createEngine();
     const params = buildCommitTurnParams();
     await engine.commitTurn(params);
     params.messages[0] = makeMessage({
-      role: "assistant",
-      content: "refreshed visible prefix",
+      role: "user",
+      content: "colliding question",
       timestamp: 1_500,
     });
 
-    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+    await expect(engine.commitTurn(params)).rejects.toThrow(
+      `context-engine advancement key collision: ${params.advancementKey}`,
+    );
     expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
       "current question",
       "current answer",


### PR DESCRIPTION
## What

Update LosslessClaw's durable `commitTurn` implementation to consume the inclusive turn-local message payload defined by [OpenClaw PR 122149](https://github.com/openclaw/openclaw/pull/122149). The legacy `afterTurn` full-prefix contract remains unchanged.

## Why

OpenClaw PR 122149 consolidates the unreleased durable callback into `commitTurn(...)` and removes `prePromptMessageCount`. LosslessClaw 1.0.0-beta.1 requires that field and rejects the turn-local payload before ingestion. OpenClaw merged the host change as `2f4dff74281211c56f4cde5d983ef294cd6c1ad3`.

Published OpenClaw builds continue through `afterTurn`, so this forward-compatible callback does not raise LosslessClaw's minimum host version.

## Changes

- Remove the durable prefix offset
- Validate the inclusive anchor span
- Hash and ingest the complete turn
- Preserve beta.1 receipt retries
- Add regression coverage and Changeset

## Testing

- `npm run typecheck` passed
- `npx vitest run test/engine-commit-turn.test.ts` passed 12 tests
- `npm test` passed 1,779 tests
- Thermonuclear maintainability review found no issues
- Autoreview found no actionable issues
- Exact-head GitHub CI passed all six checks
