### PR TITLE
chore: release 1.0.0-beta.2

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -21,6 +21,7 @@
     "strict-metadata-decoration-gate",
     "transcript-provenance-dedup",
     "trust-conversation-prompt-hook",
+    "turn-local-durable-commit",
     "verified-transcript-anchors"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @martian-engineering/lossless-claw
 
+## 1.0.0-beta.2
+
+<!-- release-rollback-version: 0.15.1 -->
+
+### Patch Changes
+
+- [#1077](https://github.com/Martian-Engineering/lossless-claw/pull/1077) [`d7d58ce`](https://github.com/Martian-Engineering/lossless-claw/commit/d7d58ce8bf78683d947d0582429c8ae51760da44) Thanks [@jalehman](https://github.com/jalehman)! - Accept the turn-local durable `commitTurn` payload defined by [OpenClaw PR 122149](https://github.com/openclaw/openclaw/pull/122149), and preserve idempotent retries for beta.1 receipts after the host removes `prePromptMessageCount`.
+
 ## 1.0.0-beta.1
 
 <!-- release-rollback-version: 0.15.1 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Prepare `@martian-engineering/lossless-claw@1.0.0-beta.2` for publication from `next/1.0`.

## Why

The beta adds LosslessClaw support for OpenClaw's turn-local durable `commitTurn` payload while preserving retry recognition for receipts written by beta.1. Published OpenClaw builds continue through the unchanged `afterTurn` path, and OpenClaw main uses the new callback contract.

## Changes

- Set package version to beta.2
- Record the consumed Changeset
- Add beta.2 release notes
- Pin rollback guidance to 0.15.1
- Synchronize root lockfile versions

## Testing

- `npm run release:verify`
- 1,779 JavaScript tests passed
- Go TUI tests passed
- npm package dry-run passed
- Autoreview found no actionable issues
