### PR TITLE
fix: skip lifecycle session end after gateway stop

### DIFF
--- a/.changeset/skip-stopped-lifecycle-session-end.md
+++ b/.changeset/skip-stopped-lifecycle-session-end.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip restart and shutdown `session_end` hooks before acquiring the context engine, preventing closed-database errors after `gateway_stop`.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -373,6 +373,11 @@ type SessionEndLifecycleEvent = {
   nextSessionKey?: string;
 };
 
+function isGatewayLifecycleSessionEndReason(reason?: string): boolean {
+  const normalizedReason = reason?.trim();
+  return normalizedReason === "restart" || normalizedReason === "shutdown";
+}
+
 const RUNTIME_LLM_PR_URL = "https://github.com/openclaw/openclaw/pull/64294";
 const AUTH_ERROR_TEXT_PATTERN =
   /\b401\b|unauthorized|unauthorised|invalid[_ -]?token|invalid[_ -]?api[_ -]?key|authentication failed|authorization failed|missing scope|insufficient scope|model\.request\b/i;
@@ -1684,6 +1689,9 @@ function wirePluginHandlers(
   }));
   api.on("session_end", async (event) => {
     const lifecycleEvent = event as SessionEndLifecycleEvent;
+    if (isGatewayLifecycleSessionEndReason(lifecycleEvent.reason)) {
+      return;
+    }
     await (await shared.waitForEngine()).handleSessionEnd({
       reason: lifecycleEvent.reason,
       sessionId: lifecycleEvent.sessionId,

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1991,6 +1991,66 @@ describe("lcm plugin registration", () => {
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["restart", "shutdown"])(
+    "does not acquire the stopped engine for session_end %s",
+    async (reason) => {
+      const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+      dbPaths.add(dbPath);
+
+      const { api, getHook } = buildApi({ enabled: true, dbPath });
+      lcmPlugin.register(api);
+
+      const gatewayStop = getHook("gateway_stop");
+      const sessionEnd = getHook("session_end");
+      expect(gatewayStop).toBeTypeOf("function");
+      expect(sessionEnd).toBeTypeOf("function");
+
+      await gatewayStop?.({}, {});
+
+      await expect(
+        sessionEnd?.(
+          {
+            reason: ` ${reason} `,
+            sessionId: "session-before-restart",
+            sessionKey: "agent:main:main",
+          },
+          {},
+        ),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("delegates ordinary session_end reasons to the context engine", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const handleSessionEnd = vi
+      .spyOn(LcmContextEngine.prototype, "handleSessionEnd")
+      .mockResolvedValue(undefined);
+
+    const { api, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+
+    const sessionEnd = getHook("session_end");
+    expect(sessionEnd).toBeTypeOf("function");
+
+    await sessionEnd?.(
+      {
+        reason: "deleted",
+        sessionId: "session-before-delete",
+        sessionKey: "agent:main:main",
+      },
+      {},
+    );
+
+    expect(handleSessionEnd).toHaveBeenCalledWith({
+      reason: "deleted",
+      sessionId: "session-before-delete",
+      sessionKey: "agent:main:main",
+      nextSessionId: undefined,
+      nextSessionKey: undefined,
+    });
+  });
+
   it("reopens the retained context-engine factory on the next gateway lifecycle", async () => {
     const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
     dbPaths.add(dbPath);


### PR DESCRIPTION
## Summary

- short-circuit normalized `restart` and `shutdown` `session_end` events in the plugin adapter before it acquires the context engine
- preserve the existing engine delegation for ordinary conversation-lifecycle reasons
- add hook-boundary regressions and a patch changeset

## Why

PR #657 correctly made `LcmContextEngine.handleSessionEnd()` ignore gateway lifecycle reasons. The plugin adapter still awaited `shared.waitForEngine()` before reaching that guard, however. After `gateway_stop` closes the database, OpenClaw's subsequent lifecycle `session_end` could therefore throw `Database connection closed after gateway_stop`.

This moves the same narrow lifecycle decision to the hook boundary, where it can prevent the stopped-engine acquisition.

Fixes #668.

## Verification

- `npx vitest run test/plugin-config-registration.test.ts` — 54/54 passed
- `npm run typecheck`
- `npm run build`
- `npm test` — 115 files, 2,052 tests passed
- `npm run test:tui`
- `git diff --check`

### Exact-head same-PID canary

Project 047 ran source commit `ea12d4f4ddf8c1ca77b8b8c3d6b3cf7e23e7d5f5` with OpenClaw `2026.7.2-beta.4` under `OPENCLAW_NO_RESPAWN=1` and an in-process `SIGUSR1` restart:

- source-built package integrity: `sha512-UUU2WXv+FxsqxJbZCMWKdsUftSuLlGyIIGajfqiQpvzXwEkmqzu6D04GRa4JFHrpJPHgJrc4KAkWz4LHlmF7QQ==`
- isolated image digest: `sha256:fad146e0446450169bff1867763690f0a5fb15990b4fb0440efb710d9446f009`
- same gateway PID assertion passed
- deterministic turns completed before and after restart
- `Database connection closed after gateway_stop` signature count: **0**

The separate `sqlite:` session-locator quarantine still reproduced after restart and remains outside this focused PR.

## Scope

This intentionally does not change session-locator handling, engine reopen behavior, or ordinary conversation lifecycle semantics.
