### PR TITLE
fix host-owned prompt accounting in threshold compaction

### DIFF
--- a/.changeset/fix-host-prompt-accounting.md
+++ b/.changeset/fix-host-prompt-accounting.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Separate typed host-owned prompt framing from Lossless compaction pressure and preserve stable thread-bootstrap projection metadata across managed degraded and fork-bounded fallbacks.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -170,6 +170,7 @@ export function isProtectedLeadingLiveContextMessage(message: AgentMessage): boo
   return role === "system" || role === "developer";
 }
 
+/** Build a budget-bounded live fallback that preserves the managed projection epoch. */
 export function buildDegradedLiveAssembleResult(params: {
   liveMessages: AgentMessage[];
   tokenBudget: number;
@@ -233,6 +234,7 @@ export function resolveDeferredAssemblyPressure(params: {
   };
 }
 
+/** Build a fork-local live suffix that preserves the managed projection epoch. */
 export function buildForkBoundedLiveFallback(params: {
   liveMessages: AgentMessage[];
   forkSourceMessageCount: number;

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -7,7 +7,11 @@ import { trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { estimateSerializedMessageTokens, estimateSerializedMessagesTokens } from "./estimate-tokens.js";
 import { resolveForkBoundedLiveSuffix, stripTrailingAssistantPrefill } from "./live-coverage.js";
 import { toStoredMessage } from "./message-content.js";
-import type { AgentMessage, AssembleResult } from "./openclaw-bridge.js";
+import type {
+  AgentMessage,
+  AssembleResult,
+  ContextEngineProjection,
+} from "./openclaw-bridge.js";
 import type { ConversationCompactionMaintenanceRecord } from "./store/compaction-maintenance-store.js";
 import { estimateAgentMessageTokens, normalizeNonNegativeInteger, toRuntimeRoleForTokenEstimate } from "./token-accounting.js";
 
@@ -170,6 +174,7 @@ export function buildDegradedLiveAssembleResult(params: {
   liveMessages: AgentMessage[];
   tokenBudget: number;
   preserveSubstantiveAssistantTail?: boolean;
+  contextProjection: ContextEngineProjection;
 }): AssembleResult {
   const prefillOptions = {
     preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
@@ -199,6 +204,7 @@ export function buildDegradedLiveAssembleResult(params: {
     messages,
     estimatedTokens: estimateAgentMessageTokens(messages),
     promptAuthority: "preassembly_may_overflow",
+    contextProjection: params.contextProjection,
   };
 }
 
@@ -233,6 +239,7 @@ export function buildForkBoundedLiveFallback(params: {
   tokenBudget: number;
   bootstrapMaxTokens: number;
   preserveSubstantiveAssistantTail?: boolean;
+  contextProjection: ContextEngineProjection;
 }): AssembleResult {
   const suffix = resolveForkBoundedLiveSuffix({
     assembledMessages: [],
@@ -248,6 +255,7 @@ export function buildForkBoundedLiveFallback(params: {
   return {
     messages: boundedMessages,
     estimatedTokens: estimateAgentMessageTokens(boundedMessages),
+    contextProjection: params.contextProjection,
   };
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -227,6 +227,12 @@ function buildFocusProjectionKey(brief?: FocusBriefRecord | null): string | null
   return hash.digest("hex").slice(0, 32);
 }
 
+/** Return whether a typed execution host owns prompt framing outside Lossless storage. */
+function hostOwnsPromptFraming(runtimeSettings?: ContextEngineRuntimeSettings): boolean {
+  const executionHostId = runtimeSettings?.executionHost?.id;
+  return typeof executionHostId === "string" && executionHostId.trim().length > 0;
+}
+
 
 const TRANSCRIPT_GC_BATCH_SIZE = 12;
 
@@ -390,7 +396,7 @@ export class LcmContextEngine implements ContextEngine {
       id: "lossless-claw",
       name: "Lossless Context Management Engine",
       version: packageJson.version,
-      acceptedHostParams: ["sessionKey", "prompt", "runtimeContext"],
+      acceptedHostParams: ["sessionKey", "prompt", "runtimeContext", "runtimeSettings"],
       ownsCompaction: migrationOk,
       turnMaintenanceMode: "background",
       hostRequirements: {
@@ -890,6 +896,9 @@ export class LcmContextEngine implements ContextEngine {
       const resolvedCurrentTokenCount = this.normalizeObservedTokenCount(
         params.currentTokenCount ?? maintenance.currentTokenCount ?? undefined,
       );
+      const compactableCurrentTokenCount = hostOwnsPromptFraming(params.runtimeSettings)
+        ? undefined
+        : resolvedCurrentTokenCount;
       const resolvedProjectedTokenCount = this.normalizeObservedTokenCount(
         maintenance.projectedTokenCount ?? undefined,
       );
@@ -948,7 +957,7 @@ export class LcmContextEngine implements ContextEngine {
         const thresholdDecision = await this.compaction.evaluate(
           params.conversationId,
           resolvedTokenBudget,
-          resolvedCurrentTokenCount,
+          compactableCurrentTokenCount,
           {
             contextThreshold: resolvedContextThreshold.contextThreshold,
             ...(resolvedContextThreshold.freshTailCount !== undefined
@@ -1216,7 +1225,8 @@ export class LcmContextEngine implements ContextEngine {
     // thread history. Lossless cannot compact any of that framing. Keep the
     // legacy observed-token behavior only for older/generic callers that do
     // not declare an execution host.
-    const hostOwnsPromptFraming = params.runtimeSettings?.executionHost.id !== undefined;
+    const promptFramingOwnedByHost = hostOwnsPromptFraming(params.runtimeSettings);
+    const compactableObservedTokens = promptFramingOwnedByHost ? undefined : observedTokens;
     // The resolved threshold is passed unconditionally: when no override rule
     // matches, the resolved value equals the global config.contextThreshold,
     // so the call is behavior-identical to omitting it.
@@ -1229,7 +1239,7 @@ export class LcmContextEngine implements ContextEngine {
     const decision = await this.compaction.evaluate(
       conversationId,
       tokenBudget,
-      hostOwnsPromptFraming ? undefined : observedTokens,
+      compactableObservedTokens,
       {
       contextThreshold: resolvedContextThreshold.contextThreshold,
       ...(resolvedContextThreshold.freshTailCount !== undefined
@@ -1262,14 +1272,13 @@ export class LcmContextEngine implements ContextEngine {
         ? Math.floor(decision.rawTokensOutsideTail)
         : undefined;
     const observedRuntimeOverhead =
-      !hostOwnsPromptFraming &&
-      params.compactionTarget === "threshold" && observedTokens !== undefined
-        ? Math.max(0, observedTokens - decisionStoredTokens)
+      params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+        ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
         : 0;
     const runtimeAdjustedSweepTargetTokens =
       observedRuntimeOverhead > 0 &&
-      observedTokens !== undefined &&
-      observedTokens > targetTokens
+      compactableObservedTokens !== undefined &&
+      compactableObservedTokens > targetTokens
         ? Math.max(1, targetTokens - observedRuntimeOverhead)
         : undefined;
     const projectedRawBacklogPressure =
@@ -1281,10 +1290,10 @@ export class LcmContextEngine implements ContextEngine {
       params.compactionTarget === "threshold"
         ? Math.max(
             decision.currentTokens,
-            hostOwnsPromptFraming ? 0 : (observedTokens ?? 0),
+            compactableObservedTokens ?? 0,
             decisionProjectedTokens ?? 0,
           )
-        : observedTokens;
+        : compactableObservedTokens;
     const liveContextStillExceedsTarget =
       thresholdPressureTokens !== undefined && thresholdPressureTokens >= targetTokens;
 
@@ -1299,7 +1308,7 @@ export class LcmContextEngine implements ContextEngine {
     });
 
     this.deps.log.info(
-      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} hostOwnsPromptFraming=${hostOwnsPromptFraming} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
+      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} hostOwnsPromptFraming=${promptFramingOwnedByHost} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
     );
 
     if (!forceCompaction && !decision.shouldCompact) {
@@ -1473,7 +1482,7 @@ export class LcmContextEngine implements ContextEngine {
       // session, and never fires on budget-stopped sweeps (more sweeps can
       // still make progress there).
       const thresholdSweepTranscriptWedge =
-        thresholdSweepExhaustedOverTarget && observedTokens !== undefined;
+        thresholdSweepExhaustedOverTarget && compactableObservedTokens !== undefined;
       const sweepOk =
         !sweepResult.authFailure &&
         (isUnderTargetAfterSweep || (sweepResult.actionTaken && !isThresholdSweep));
@@ -1494,7 +1503,7 @@ export class LcmContextEngine implements ContextEngine {
               : "live context still exceeds target";
       if (thresholdSweepTranscriptWedge) {
         this.deps.log.warn(
-          `[lcm] compact: transcript wedge detected conversation=${conversationId} ${sessionLabel} storedTokensAfter=${sweepTokensAfter ?? "none"} targetTokens=${targetTokens} observedTokens=${observedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} projectedTokensAfter=${projectedTokensAfterSweep ?? "none"} — stored compaction cannot reduce the live transcript; reset the session (/new) or re-bootstrap`,
+          `[lcm] compact: transcript wedge detected conversation=${conversationId} ${sessionLabel} storedTokensAfter=${sweepTokensAfter ?? "none"} targetTokens=${targetTokens} observedTokens=${compactableObservedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} projectedTokensAfter=${projectedTokensAfterSweep ?? "none"} — stored compaction cannot reduce the live transcript; reset the session (/new) or re-bootstrap`,
         );
       }
       let spendBackoffOpened = false;
@@ -1559,8 +1568,8 @@ export class LcmContextEngine implements ContextEngine {
     // compactUntilUnder does not bail with "already under target" while the
     // live context is actually overflowing.
     const effectiveCurrentTokens =
-      observedTokens !== undefined
-        ? observedTokens
+      compactableObservedTokens !== undefined
+        ? compactableObservedTokens
         : forceCompaction
           ? tokenBudget
           : undefined;
@@ -3314,6 +3323,9 @@ export class LcmContextEngine implements ContextEngine {
       ).currentTokenCount,
     );
     const observedCurrentTokenCount = runtimePromptTokens ?? suppliedCurrentTokenCount;
+    const compactableObservedTokenCount = hostOwnsPromptFraming(params.runtimeSettings)
+      ? undefined
+      : observedCurrentTokenCount;
     if (runtimePromptTokens !== undefined) {
       this.deps.log.debug(
         `[lcm] afterTurn: using runtime prompt token count currentTokenCount=${runtimePromptTokens}`,
@@ -3396,7 +3408,7 @@ export class LcmContextEngine implements ContextEngine {
       const thresholdDecision = await this.compaction.evaluate(
         conversation.conversationId,
         tokenBudget,
-        observedCurrentTokenCount,
+        compactableObservedTokenCount,
         {
           contextThreshold: resolvedContextThreshold.contextThreshold,
           ...(resolvedContextThreshold.freshTailCount !== undefined
@@ -3726,28 +3738,6 @@ export class LcmContextEngine implements ContextEngine {
           ? Math.floor(params.tokenBudget)
           : 128_000,
       );
-      // Bounded variant of safeFallback for paths where this engine manages
-      // the conversation but cannot produce assembled coverage. Returning the
-      // raw live transcript unbounded here is how an over-budget prompt
-      // reaches the model, so clamp it to the budget by serialized estimate.
-      const boundedLiveFallback = (reason: string): AssembleResult => {
-        const fallback = safeFallback();
-        const clamp = clampMessagesToSerializedBudget({
-          messages: fallback.messages,
-          tokenBudget,
-          preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
-        });
-        if (clamp.clamped || clamp.overBudget) {
-          this.deps.log.warn(
-            `[lcm] assemble: bounded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${reason} serializedTokensBefore=${clamp.serializedTokensBefore} serializedTokens=${clamp.serializedTokens} evictedMessages=${clamp.evictedMessages} tokenBudget=${tokenBudget} overBudget=${clamp.overBudget}`,
-          );
-        }
-        return {
-          messages: clamp.messages,
-          estimatedTokens: clamp.serializedTokens,
-          contextProjection,
-        };
-      };
       let storedContextTokens = await this.summaryStore.getContextTokenCount(
         conversation.conversationId,
       );
@@ -3783,6 +3773,7 @@ export class LcmContextEngine implements ContextEngine {
               sessionKey: params.sessionKey,
               tokenBudget,
               currentTokenCount: pressure.storedContextTokens,
+              runtimeSettings: params.runtimeSettings,
             });
           } catch (error) {
             this.deps.log.warn(
@@ -3838,6 +3829,28 @@ export class LcmContextEngine implements ContextEngine {
           contextItems,
           activeFocusBrief,
         ),
+      };
+      // Bounded variant of safeFallback for paths where this engine manages
+      // the conversation but cannot produce assembled coverage. Returning the
+      // raw live transcript unbounded here is how an over-budget prompt
+      // reaches the model, so clamp it to the budget by serialized estimate.
+      const boundedLiveFallback = (reason: string): AssembleResult => {
+        const fallback = safeFallback();
+        const clamp = clampMessagesToSerializedBudget({
+          messages: fallback.messages,
+          tokenBudget,
+          preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+        });
+        if (clamp.clamped || clamp.overBudget) {
+          this.deps.log.warn(
+            `[lcm] assemble: bounded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${reason} serializedTokensBefore=${clamp.serializedTokensBefore} serializedTokens=${clamp.serializedTokens} evictedMessages=${clamp.evictedMessages} tokenBudget=${tokenBudget} overBudget=${clamp.overBudget}`,
+          );
+        }
+        return {
+          messages: clamp.messages,
+          estimatedTokens: clamp.serializedTokens,
+          contextProjection,
+        };
       };
       if (deferredAssemblyDegradation) {
         const degraded = buildDegradedLiveAssembleResult({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10,6 +10,7 @@ import type {
   ContextEngineControlResult,
   ContextEngineInfo,
   ContextEngineHostCapability,
+  ContextEngineRuntimeSettings,
   AssembleResult,
   BootstrapResult,
   CompactResult,
@@ -154,6 +155,7 @@ type CompactionExecutionParams = {
   customInstructions?: string;
   /** OpenClaw runtime param name (preferred). */
   runtimeContext?: Record<string, unknown>;
+  runtimeSettings?: ContextEngineRuntimeSettings;
   /** Back-compat param name. */
   legacyParams?: Record<string, unknown>;
   /** Force compaction even if below threshold */
@@ -171,6 +173,7 @@ type DeferredCompactionDebtDrainParams = {
   sessionKey?: string;
   tokenBudget: number;
   currentTokenCount?: number;
+  runtimeSettings?: ContextEngineRuntimeSettings;
   reason: string;
 };
 
@@ -802,6 +805,7 @@ export class LcmContextEngine implements ContextEngine {
           sessionKey: params.sessionKey,
           tokenBudget: cappedTokenBudget,
           currentTokenCount: params.currentTokenCount,
+          runtimeSettings: params.runtimeSettings,
           legacyParams,
         });
         if (result) {
@@ -828,6 +832,7 @@ export class LcmContextEngine implements ContextEngine {
     tokenBudget: number;
     currentTokenCount?: number;
     runtimeContext?: ContextEngineMaintenanceRuntimeContext;
+    runtimeSettings?: ContextEngineRuntimeSettings;
     legacyParams?: Record<string, unknown>;
     /** When true, skip the backoff check — used by assemble emergency drain. */
     force?: boolean;
@@ -993,6 +998,7 @@ export class LcmContextEngine implements ContextEngine {
         compactionTarget: "threshold",
         contextThresholdOverride: resolvedContextThreshold,
         runtimeContext: params.runtimeContext,
+        runtimeSettings: params.runtimeSettings,
         legacyParams: params.legacyParams,
         force: params.force,
       });
@@ -1065,6 +1071,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionKey?: string;
     tokenBudget: number;
     currentTokenCount?: number;
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<{ exhausted: boolean }> {
     const sessionLabel = formatSessionLabel(params.sessionId, params.sessionKey);
     let drainResult = { exhausted: false };
@@ -1103,6 +1110,7 @@ export class LcmContextEngine implements ContextEngine {
           tokenBudget: cappedTokenBudget,
           currentTokenCount: normalizedCurrentTokenCount,
           legacyParams: deferredLegacyParams,
+          runtimeSettings: params.runtimeSettings,
           force: forceAllowed,
         });
         drainResult = { exhausted: result?.exhausted === true };
@@ -1203,6 +1211,12 @@ export class LcmContextEngine implements ContextEngine {
           }
         ).currentTokenCount,
     );
+    // A host-aware OpenClaw runtime reports the full provider prompt here,
+    // including system instructions, tool schemas, and (for Codex) native
+    // thread history. Lossless cannot compact any of that framing. Keep the
+    // legacy observed-token behavior only for older/generic callers that do
+    // not declare an execution host.
+    const hostOwnsPromptFraming = params.runtimeSettings?.executionHost.id !== undefined;
     // The resolved threshold is passed unconditionally: when no override rule
     // matches, the resolved value equals the global config.contextThreshold,
     // so the call is behavior-identical to omitting it.
@@ -1212,12 +1226,17 @@ export class LcmContextEngine implements ContextEngine {
         sessionKey: params.sessionKey,
         runtime: readRuntimeModelContext(asRecord(params.runtimeContext), asRecord(params.legacyParams)),
       });
-    const decision = await this.compaction.evaluate(conversationId, tokenBudget, observedTokens, {
+    const decision = await this.compaction.evaluate(
+      conversationId,
+      tokenBudget,
+      hostOwnsPromptFraming ? undefined : observedTokens,
+      {
       contextThreshold: resolvedContextThreshold.contextThreshold,
       ...(resolvedContextThreshold.freshTailCount !== undefined
         ? { freshTailCount: resolvedContextThreshold.freshTailCount }
         : {}),
-    });
+      },
+    );
     const targetTokens =
       params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
     // Codex can report a live prompt count that includes runtime framing,
@@ -1243,6 +1262,7 @@ export class LcmContextEngine implements ContextEngine {
         ? Math.floor(decision.rawTokensOutsideTail)
         : undefined;
     const observedRuntimeOverhead =
+      !hostOwnsPromptFraming &&
       params.compactionTarget === "threshold" && observedTokens !== undefined
         ? Math.max(0, observedTokens - decisionStoredTokens)
         : 0;
@@ -1261,7 +1281,7 @@ export class LcmContextEngine implements ContextEngine {
       params.compactionTarget === "threshold"
         ? Math.max(
             decision.currentTokens,
-            observedTokens ?? 0,
+            hostOwnsPromptFraming ? 0 : (observedTokens ?? 0),
             decisionProjectedTokens ?? 0,
           )
         : observedTokens;
@@ -1279,7 +1299,7 @@ export class LcmContextEngine implements ContextEngine {
     });
 
     this.deps.log.info(
-      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
+      `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} hostOwnsPromptFraming=${hostOwnsPromptFraming} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
     );
 
     if (!forceCompaction && !decision.shouldCompact) {
@@ -2488,6 +2508,7 @@ export class LcmContextEngine implements ContextEngine {
     sessionFile: string;
     sessionKey?: string;
     runtimeContext?: ContextEngineMaintenanceRuntimeContext;
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<ContextEngineMaintenanceResult> {
     const hostApprovedRuntimeMaintenance =
       params.runtimeContext?.allowDeferredCompactionExecution === true;
@@ -2567,6 +2588,7 @@ export class LcmContextEngine implements ContextEngine {
               tokenBudget: cappedTokenBudget,
               currentTokenCount: maintainCurrentTokenCount,
               runtimeContext: params.runtimeContext,
+              runtimeSettings: params.runtimeSettings,
               legacyParams: asRecord(params.runtimeContext),
             });
           }
@@ -3024,6 +3046,7 @@ export class LcmContextEngine implements ContextEngine {
     currentTokenCount?: number;
     /** OpenClaw runtime param name (preferred). */
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
     /** Back-compat param name. */
     legacyCompactionParams?: Record<string, unknown>;
   }): Promise<void> {
@@ -3406,6 +3429,7 @@ export class LcmContextEngine implements ContextEngine {
             compactionTarget: "threshold",
             contextThresholdOverride: resolvedContextThreshold,
             legacyParams,
+            runtimeSettings: params.runtimeSettings,
           });
           if (!compactResult.ok) {
             shouldRefreshBootstrapState = false;
@@ -3445,6 +3469,7 @@ export class LcmContextEngine implements ContextEngine {
         sessionKey: params.sessionKey,
         tokenBudget: deferredCompactionDrain.tokenBudget,
         currentTokenCount: deferredCompactionDrain.currentTokenCount,
+        runtimeSettings: params.runtimeSettings,
         reason: deferredCompactionDrain.reason,
       });
     }
@@ -3560,6 +3585,7 @@ export class LcmContextEngine implements ContextEngine {
     prompt?: string;
     /** Optional runtime context for override resolution (model, provider, etc.). */
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<AssembleResult> {
     let liveMessages = params.messages;
     // Return a new fallback array so the runtime hook treats this as assembled
@@ -3716,7 +3742,11 @@ export class LcmContextEngine implements ContextEngine {
             `[lcm] assemble: bounded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${reason} serializedTokensBefore=${clamp.serializedTokensBefore} serializedTokens=${clamp.serializedTokens} evictedMessages=${clamp.evictedMessages} tokenBudget=${tokenBudget} overBudget=${clamp.overBudget}`,
           );
         }
-        return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
+        return {
+          messages: clamp.messages,
+          estimatedTokens: clamp.serializedTokens,
+          contextProjection,
+        };
       };
       let storedContextTokens = await this.summaryStore.getContextTokenCount(
         conversation.conversationId,
@@ -3797,11 +3827,24 @@ export class LcmContextEngine implements ContextEngine {
           );
         }
       }
+      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+      const activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
+        conversation.conversationId,
+      );
+      const contextProjection = {
+        mode: "thread_bootstrap" as const,
+        epoch: buildContextEngineProjectionEpoch(
+          conversation.conversationId,
+          contextItems,
+          activeFocusBrief,
+        ),
+      };
       if (deferredAssemblyDegradation) {
         const degraded = buildDegradedLiveAssembleResult({
           liveMessages,
           tokenBudget,
           preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+          contextProjection,
         });
         this.deps.log.warn(
           `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} storedContextTokens=${deferredAssemblyDegradation.pressure.storedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
@@ -3814,7 +3857,6 @@ export class LcmContextEngine implements ContextEngine {
       );
       const forkBoundedBootstrap = bootstrapState?.forkBounded === true;
       const forkSourceMessageCount = bootstrapState?.forkSourceMessageCount ?? 0;
-      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
       if (contextItems.length === 0) {
         if (forkBoundedBootstrap) {
           const boundedFallback = buildForkBoundedLiveFallback({
@@ -3823,6 +3865,7 @@ export class LcmContextEngine implements ContextEngine {
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
             preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+            contextProjection,
           });
           this.deps.log.debug(
             `[lcm] assemble: no context items for fork-bounded bootstrap; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -3904,6 +3947,7 @@ export class LcmContextEngine implements ContextEngine {
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
             preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+            contextProjection,
           });
           this.deps.log.debug(
             `[lcm] assemble: empty assembled output for fork-bounded bootstrap; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} tokenBudget=${tokenBudget} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -3930,6 +3974,7 @@ export class LcmContextEngine implements ContextEngine {
             tokenBudget,
             bootstrapMaxTokens: resolveBootstrapMaxTokens(this.config),
             preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+            contextProjection,
           });
           this.deps.log.debug(
             `[lcm] assemble: fork-bounded context has no user turns; using bounded live suffix conversation=${conversation.conversationId} ${sessionLabel} outputMessages=${boundedFallback.messages.length} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -4072,14 +4117,7 @@ export class LcmContextEngine implements ContextEngine {
       const stubStatsLog = assembled.debug?.stubStats
         ? ` stubbed=${assembled.debug.stubStats.stubbedCount} tokensSaved=${assembled.debug.stubStats.tokensSaved}`
         : "";
-      const activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
-        conversation.conversationId,
-      );
-      const contextProjectionEpoch = buildContextEngineProjectionEpoch(
-        conversation.conversationId,
-        contextItems,
-        activeFocusBrief,
-      );
+      const contextProjectionEpoch = contextProjection.epoch;
       const contextProjectionFingerprint = budgetedPromptRecallCue
         ? buildPromptRecallProjectionFingerprint(budgetedPromptRecallCue.message)
         : undefined;
@@ -4205,6 +4243,7 @@ export class LcmContextEngine implements ContextEngine {
     customInstructions?: string;
     /** OpenClaw runtime param name (preferred). */
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
     /** Back-compat param name. */
     legacyParams?: Record<string, unknown>;
     /** Force compaction even if below threshold */
@@ -4266,6 +4305,7 @@ export class LcmContextEngine implements ContextEngine {
           contextThresholdOverride: params.contextThresholdOverride,
           customInstructions: params.customInstructions,
           runtimeContext: params.runtimeContext,
+          runtimeSettings: params.runtimeSettings,
           legacyParams: params.legacyParams,
           force: params.force,
         });

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -33,6 +33,7 @@ export type ContextEngineProjection = {
   fingerprint?: string;
 };
 
+/** Runtime ownership metadata projected by host-aware OpenClaw versions. */
 export type ContextEngineRuntimeSettings = {
   schemaVersion: 1;
   executionHost: {

--- a/src/openclaw-bridge.ts
+++ b/src/openclaw-bridge.ts
@@ -33,6 +33,15 @@ export type ContextEngineProjection = {
   fingerprint?: string;
 };
 
+export type ContextEngineRuntimeSettings = {
+  schemaVersion: 1;
+  executionHost: {
+    id: string | null;
+    label: string | null;
+  };
+  [key: string]: unknown;
+};
+
 export type AssembleResult = {
   messages: AgentMessage[];
   estimatedTokens: number;
@@ -243,6 +252,7 @@ export type ContextEngine = {
     sessionKey?: string;
     sessionFile?: string;
     messages?: AgentMessage[];
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<BootstrapResult>;
   ingest(params: {
     sessionId: string;
@@ -266,6 +276,7 @@ export type ContextEngine = {
     tokenBudget?: number;
     currentTokenCount?: number;
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
     legacyCompactionParams?: Record<string, unknown>;
   }): Promise<void>;
   assemble(params: {
@@ -285,6 +296,7 @@ export type ContextEngine = {
     model?: string;
     /** Optional runtime context for override resolution (model, provider, etc.). */
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<AssembleResult>;
   compact(params: {
     sessionId: string;
@@ -295,6 +307,7 @@ export type ContextEngine = {
     compactionTarget?: "budget" | "threshold";
     customInstructions?: string;
     runtimeContext?: Record<string, unknown>;
+    runtimeSettings?: ContextEngineRuntimeSettings;
     legacyParams?: Record<string, unknown>;
     force?: boolean;
   }): Promise<CompactResult>;
@@ -319,6 +332,7 @@ export type ContextEngine = {
     sessionFile: string;
     sessionKey?: string;
     runtimeContext?: ContextEngineMaintenanceRuntimeContext;
+    runtimeSettings?: ContextEngineRuntimeSettings;
   }): Promise<ContextEngineMaintenanceResult>;
   dispose?(): Promise<void>;
 };

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -823,6 +823,50 @@ describe("LcmContextEngine afterTurn", () => {
     });
   });
 
+  it("afterTurn excludes prompt counts owned by a typed execution host", async () => {
+    const engine = createEngine();
+    const sessionId = "after-turn-host-owned-prompt";
+    await seedBacklogContext(engine, sessionId, [100]);
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "none",
+      currentTokens: 100,
+      threshold: 22_500,
+    });
+
+    await engine.afterTurn({
+      sessionId,
+      sessionFile: createSessionFilePath("after-turn-host-owned-prompt"),
+      messages: [makeMessage({ role: "assistant", content: "fresh projected turn" })],
+      prePromptMessageCount: 0,
+      tokenBudget: 30_000,
+      currentTokenCount: 93_486,
+      runtimeSettings: {
+        schemaVersion: 1,
+        executionHost: {
+          id: "codex-app-server",
+          label: "Codex app-server harness",
+        },
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      30_000,
+      undefined,
+      expect.any(Object),
+    );
+  });
+
   it("afterTurn leaves live token pressure unset when runtimeContext.currentTokenCount is absent", async () => {
     const engine = createEngine();
     const sessionId = "after-turn-local-current-token-count-fallback";

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -270,6 +270,38 @@ describe("LcmContextEngine.assemble canonical path", () => {
     });
   });
 
+  it("marks a managed fork-bounded live suffix as a stable thread bootstrap", async () => {
+    const engine = createEngine();
+    const sessionId = "session-fork-bounded-projection";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getSummaryStore().upsertConversationBootstrapState({
+      conversationId: conversation.conversationId,
+      sessionFilePath: "/tmp/fork-bounded-projection.jsonl",
+      lastSeenSize: 0,
+      lastSeenMtimeMs: 0,
+      lastProcessedOffset: 0,
+      forkBounded: true,
+      forkSourceMessageCount: 1,
+    });
+
+    const result = await engine.assemble({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "parent history" }),
+        makeMessage({ role: "user", content: "child turn" }),
+      ],
+      tokenBudget: 256,
+    });
+
+    expect(result.messages.map((message) => message.content)).toEqual(["child turn"]);
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
+    });
+  });
+
   it("assembles context from DB when coverage exists", async () => {
     const engine = createEngine();
     const sessionId = "session-canonical";

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -264,7 +264,10 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).toStrictEqual(liveMessages);
     // Bounded fallback reports the real serialized estimate instead of 0.
     expect(result.estimatedTokens).toBeGreaterThan(0);
-    expect(result.contextProjection).toBeUndefined();
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:/),
+    });
   });
 
   it("assembles context from DB when coverage exists", async () => {

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -9,7 +9,11 @@ import { createLcmDatabaseConnection } from "../src/db/connection.js";
 import { LcmContextEngine } from "../src/engine.js";
 import { estimateTokens } from "../src/estimate-tokens.js";
 import { formatFileReference } from "../src/large-files.js";
-import type { AgentMessage } from "../src/openclaw-bridge.js";
+import type {
+  AgentMessage,
+  ContextEngine,
+  ContextEngineRuntimeSettings,
+} from "../src/openclaw-bridge.js";
 import { buildMessageIdentityHash } from "../src/store/message-identity.js";
 import { attachTranscriptEntryMeta } from "../src/transcript.js";
 import {
@@ -27,6 +31,40 @@ import {
 } from "./helpers.js";
 
 afterEach(cleanupEngineTestState);
+
+const OPENCLAW_HOST_PARAM_NAMES = new Set([
+  "sessionKey",
+  "prompt",
+  "runtimeSettings",
+  "sessionTarget",
+  "runtimeContext",
+]);
+
+/** Apply OpenClaw's accepted-host-parameter projection contract in integration tests. */
+function projectContextEngineHostParams(
+  engine: ContextEngine,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const accepted = engine.info.acceptedHostParams;
+  if (!accepted) return params;
+  return Object.fromEntries(
+    Object.entries(params).filter(
+      ([key]) => accepted.includes(key) || !OPENCLAW_HOST_PARAM_NAMES.has(key),
+    ),
+  );
+}
+
+/** Build the ownership metadata emitted by typed OpenClaw execution hosts. */
+function buildRuntimeSettings(executionHostId: string): ContextEngineRuntimeSettings {
+  return {
+    schemaVersion: 1,
+    executionHost: {
+      id: executionHostId,
+      label: "host-aware OpenClaw runtime",
+    },
+  };
+}
+
 describe("LcmContextEngine afterTurn dedup guard", () => {
   it("ingests all messages when no prior conversation exists (new session)", async () => {
     const infoLog = vi.fn();
@@ -3375,8 +3413,74 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
   });
 
   it.each(["codex-app-server", "openclaw-embedded"])(
-    "does not make threshold convergence impossible when %s owns excess prompt framing",
+    "excludes %s-owned prompt framing after OpenClaw host-param projection",
     async (executionHostId) => {
+      const engine = createEngine();
+      const privateEngine = engine as unknown as {
+        compaction: {
+          evaluate: (
+            conversationId: number,
+            tokenBudget: number,
+            observed?: number,
+          ) => Promise<unknown>;
+          compactFullSweep: (input: unknown) => Promise<unknown>;
+        };
+      };
+
+      const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+        shouldCompact: true,
+        reason: "threshold",
+        storedTokens: 36_047,
+        observedTokens: 93_486,
+        currentTokens: 36_047,
+        threshold: 22_500,
+      });
+      vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 36_047,
+        tokensAfter: 20_000,
+        condensed: false,
+      });
+
+      await engine.ingest({
+        sessionId: `host-owned-prompt-${executionHostId}`,
+        message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+      });
+
+      const runtimeSettings = buildRuntimeSettings(executionHostId);
+      const projectedParams = projectContextEngineHostParams(engine, {
+        sessionId: `host-owned-prompt-${executionHostId}`,
+        sessionFile: "/tmp/session.jsonl",
+        tokenBudget: 30_000,
+        currentTokenCount: 93_486,
+        compactionTarget: "threshold",
+        runtimeSettings,
+      });
+      expect(projectedParams.runtimeSettings).toBe(runtimeSettings);
+
+      const result = await engine.compact(
+        projectedParams as Parameters<typeof engine.compact>[0],
+      );
+
+      expect(evaluateSpy).toHaveBeenCalledWith(
+        expect.any(Number),
+        30_000,
+        undefined,
+        expect.any(Object),
+      );
+      expect(result).toMatchObject({
+        ok: true,
+        compacted: true,
+        reason: "compacted",
+        result: {
+          tokensAfter: 20_000,
+          details: { targetTokens: 22_500 },
+        },
+      });
+    },
+  );
+
+  it("treats incomplete runtime settings as Lossless-owned prompt framing", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
       compaction: {
@@ -3385,62 +3489,39 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
           tokenBudget: number,
           observed?: number,
         ) => Promise<unknown>;
-        compactFullSweep: (input: unknown) => Promise<unknown>;
       };
     };
-
     const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
-      shouldCompact: true,
-      reason: "threshold",
-      storedTokens: 36_047,
-      observedTokens: 93_486,
-      currentTokens: 36_047,
-      threshold: 22_500,
+      shouldCompact: false,
+      reason: "below_threshold",
+      storedTokens: 100,
+      observedTokens: 500,
+      currentTokens: 500,
+      threshold: 750,
     });
-    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
-      actionTaken: true,
-      tokensBefore: 36_047,
-      tokensAfter: 20_000,
-      condensed: false,
-    });
-
     await engine.ingest({
-      sessionId: "codex-native-history-overhead",
-      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+      sessionId: "incomplete-runtime-settings",
+      message: { role: "user", content: "preserve legacy host behavior" } as AgentMessage,
     });
 
-    const result = await engine.compact({
-      sessionId: "codex-native-history-overhead",
+    await engine.compact({
+      sessionId: "incomplete-runtime-settings",
       sessionFile: "/tmp/session.jsonl",
-      tokenBudget: 30_000,
-      currentTokenCount: 93_486,
+      tokenBudget: 1_000,
+      currentTokenCount: 500,
       compactionTarget: "threshold",
       runtimeSettings: {
-        schemaVersion: 1,
-        executionHost: {
-          id: executionHostId,
-          label: "host-aware OpenClaw runtime",
-        },
-      },
+        limits: { promptTokenBudget: 1_000 },
+      } as unknown as ContextEngineRuntimeSettings,
     });
 
-    expect(result.ok).toBe(true);
     expect(evaluateSpy).toHaveBeenCalledWith(
       expect.any(Number),
-      30_000,
-      undefined,
+      1_000,
+      500,
       expect.any(Object),
     );
-    expect(result.compacted).toBe(true);
-    expect(result.reason).toBe("compacted");
-    expect(result.result?.tokensAfter).toBe(20_000);
-    expect(result.result?.details).toEqual(
-      expect.objectContaining({
-        targetTokens: 22_500,
-      }),
-    );
-    },
-  );
+  });
 
   it("does not clear threshold pressure when persisted tokens are under target but runtime tokens remain over", async () => {
     const engine = createEngine();
@@ -3705,6 +3786,65 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     );
   });
 
+  it("does not treat typed host prompt framing as compactable during forced recovery", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: false,
+      reason: "below_threshold",
+      storedTokens: 21_452,
+      currentTokens: 21_452,
+      threshold: 22_500,
+    });
+    const compactUntilUnderSpy = vi
+      .spyOn(privateEngine.compaction, "compactUntilUnder")
+      .mockResolvedValue({
+        success: true,
+        rounds: 1,
+        finalTokens: 20_000,
+      });
+    await engine.ingest({
+      sessionId: "forced-host-owned-prompt",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "forced-host-owned-prompt",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 30_000,
+      currentTokenCount: 93_486,
+      force: true,
+      compactionTarget: "budget",
+      runtimeSettings: buildRuntimeSettings("codex-app-server"),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      30_000,
+      undefined,
+      expect.any(Object),
+    );
+    expect(compactUntilUnderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.any(Number),
+        tokenBudget: 30_000,
+        targetTokens: 30_000,
+        currentTokens: 30_000,
+        summarize: expect.any(Function),
+      }),
+    );
+  });
+
   it("uses tokenBudget as currentTokens for forced recovery when observed tokens are unavailable", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
@@ -3790,12 +3930,7 @@ describe("#639 Mode 2 deferred-compaction wedge (live context exceeds target, no
         rewrittenEntries: 0,
         reason: "compacted",
       });
-    const runtimeSettings = {
-      executionHost: {
-        id: "codex-app-server",
-        capabilities: ["thread-bootstrap-projection"],
-      },
-    };
+    const runtimeSettings = buildRuntimeSettings("codex-app-server");
 
     await privateEngine.drainDeferredCompactionDebtIfIdle({
       conversationId: conversation.conversationId,

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -3374,6 +3374,74 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     ).toBe(true);
   });
 
+  it.each(["codex-app-server", "openclaw-embedded"])(
+    "does not make threshold convergence impossible when %s owns excess prompt framing",
+    async (executionHostId) => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 36_047,
+      observedTokens: 93_486,
+      currentTokens: 36_047,
+      threshold: 22_500,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 36_047,
+      tokensAfter: 20_000,
+      condensed: false,
+    });
+
+    await engine.ingest({
+      sessionId: "codex-native-history-overhead",
+      message: { role: "user", content: "trigger threshold compact" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "codex-native-history-overhead",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 30_000,
+      currentTokenCount: 93_486,
+      compactionTarget: "threshold",
+      runtimeSettings: {
+        schemaVersion: 1,
+        executionHost: {
+          id: executionHostId,
+          label: "host-aware OpenClaw runtime",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      30_000,
+      undefined,
+      expect.any(Object),
+    );
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted");
+    expect(result.result?.tokensAfter).toBe(20_000);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({
+        targetTokens: 22_500,
+      }),
+    );
+    },
+  );
+
   it("does not clear threshold pressure when persisted tokens are under target but runtime tokens remain over", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {
@@ -3697,6 +3765,52 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
 });
 
 describe("#639 Mode 2 deferred-compaction wedge (live context exceeds target, no candidates)", () => {
+  it("preserves Codex host ownership through the background deferred-debt drain", async () => {
+    const engine = createEngine();
+    const sessionId = "codex-background-debt-runtime-settings";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 30_000,
+      currentTokenCount: 84_628,
+    });
+
+    const privateEngine = engine as unknown as {
+      drainDeferredCompactionDebtIfIdle: (params: unknown) => Promise<void>;
+      consumeDeferredCompactionDebt: (params: unknown) => Promise<unknown>;
+    };
+    const consumeSpy = vi
+      .spyOn(privateEngine, "consumeDeferredCompactionDebt")
+      .mockResolvedValue({
+        changed: true,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "compacted",
+      });
+    const runtimeSettings = {
+      executionHost: {
+        id: "codex-app-server",
+        capabilities: ["thread-bootstrap-projection"],
+      },
+    };
+
+    await privateEngine.drainDeferredCompactionDebtIfIdle({
+      conversationId: conversation.conversationId,
+      sessionId,
+      tokenBudget: 30_000,
+      currentTokenCount: 84_628,
+      runtimeSettings,
+      reason: "threshold",
+    });
+
+    expect(consumeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeSettings }),
+    );
+  });
+
   it("over-target threshold debt with no compactable candidates is exhaustion: debt clears, no retry thrash", async () => {
     const engine = createEngine();
     const sessionId = "wedge-639-mode2-exhaustion";

--- a/test/engine-lifecycle.test.ts
+++ b/test/engine-lifecycle.test.ts
@@ -45,6 +45,7 @@ describe("LcmContextEngine metadata", () => {
       "sessionKey",
       "prompt",
       "runtimeContext",
+      "runtimeSettings",
     ]);
   });
 

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1295,10 +1295,126 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       "promptAuthority",
       "preassembly_may_overflow",
     );
+    expect(assembleResult.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
+    });
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("[lcm] assemble: degraded live fallback"),
     );
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
+  });
+
+  it("keeps degraded projection epochs stable across live growth and rotates after summary changes", async () => {
+    const engine = createEngine();
+    const sessionId = "assemble-degraded-projection-epoch";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context while maintenance remains pending",
+        tokenCount: 80,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 90,
+    });
+
+    const first = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "first live turn" })],
+      tokenBudget: 100,
+    });
+    const afterLiveGrowth = await engine.assemble({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "first live turn" }),
+        makeMessage({ role: "assistant", content: "first live reply" }),
+        makeMessage({ role: "user", content: "second live turn" }),
+      ],
+      tokenBudget: 100,
+    });
+
+    expect(first.contextProjection?.mode).toBe("thread_bootstrap");
+    expect(afterLiveGrowth.contextProjection?.epoch).toBe(first.contextProjection?.epoch);
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_degraded_projection_epoch",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "Changed semantic prefix for the degraded projection.",
+      tokenCount: 10,
+      descendantCount: 0,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(conversation.conversationId, "sum_degraded_projection_epoch");
+
+    const afterSummary = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "third live turn" })],
+      tokenBudget: 100,
+    });
+    expect(afterSummary.contextProjection?.epoch).not.toBe(first.contextProjection?.epoch);
+  });
+
+  it("preserves host ownership through an assemble-time emergency debt drain", async () => {
+    const engine = createEngine();
+    const sessionId = "assemble-emergency-debt-runtime-settings";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context above the emergency budget",
+        tokenCount: 500,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 30,
+      currentTokenCount: 84_628,
+    });
+    const privateEngine = engine as unknown as {
+      maybeConsumeDeferredCompactionDebtForAssemble: (params: unknown) => Promise<unknown>;
+    };
+    const drainSpy = vi
+      .spyOn(privateEngine, "maybeConsumeDeferredCompactionDebtForAssemble")
+      .mockResolvedValue({ exhausted: false });
+    const runtimeSettings = {
+      schemaVersion: 1 as const,
+      executionHost: {
+        id: "codex-app-server",
+        label: "Codex app-server harness",
+      },
+    };
+
+    await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current delivery turn" })],
+      tokenBudget: 10,
+      runtimeSettings,
+    });
+
+    expect(drainSpy).toHaveBeenCalledWith(expect.objectContaining({ runtimeSettings }));
   });
 
   it("assemble() preserves a completed assistant tail in degraded prompt-separate fallback", async () => {

--- a/test/regression-codex-0151.test.ts
+++ b/test/regression-codex-0151.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDegradedLiveAssembleResult,
+  buildForkBoundedLiveFallback,
+} from "../src/assemble-fallback.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+
+const user = (content: string): AgentMessage => ({ role: "user", content }) as AgentMessage;
+
+describe("Codex 0.15.1 regression contracts", () => {
+  it("marks degraded live fallback as a thread bootstrap projection", () => {
+    const result = buildDegradedLiveAssembleResult({
+      liveMessages: [user("older"), user("newest")],
+      tokenBudget: 100,
+      contextProjection: {
+        mode: "thread_bootstrap",
+        epoch: "summary-prefix-v1:543:degraded",
+      },
+    });
+
+    // The host must suppress per-turn re-projection when a resumed native
+    // thread takes this fallback path.
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: "summary-prefix-v1:543:degraded",
+    });
+  });
+
+  it("marks fork-bounded fallback as a thread bootstrap projection", () => {
+    const result = buildForkBoundedLiveFallback({
+      liveMessages: [user("parent"), user("child turn")],
+      forkSourceMessageCount: 1,
+      tokenBudget: 100,
+      bootstrapMaxTokens: 100,
+      contextProjection: {
+        mode: "thread_bootstrap",
+        epoch: "summary-prefix-v1:543:fork",
+      },
+    });
+
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: "summary-prefix-v1:543:fork",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Treat Codex app-server's native prompt history as runtime-owned instead of Lossless-compactable pressure during threshold compaction.
- Preserve `thread_bootstrap` projection metadata through degraded and fork-bounded fallback paths so resumed native threads do not fall back to per-turn re-projection.
- Add regression coverage for the observed 93,486-token Codex / 36,047-token Lossless divergence and both fallback paths.

Fixes #1085.

## Why

Codex app-server owns a persistent native thread whose prompt can be much larger than Lossless's stored `context_items`. Lossless previously subtracted that host-owned difference from its own compaction target and then added it back during convergence checks. At the reported scale, the effective compactable target collapsed to one token and could never succeed, leaving permanent threshold debt and `compacted but still over target` loops.

Degraded fallback results also omitted projection metadata. The Codex harness consequently selected per-turn projection on a resumed native thread, amplifying native-history growth.

## Implementation

- Thread `runtimeSettings` through after-turn, maintenance, deferred-drain, and compact paths.
- When `executionHost.id === "codex-app-server"`, evaluate threshold pressure using Lossless-owned stored/projected context rather than the host's full native prompt count.
- Build one stable `thread_bootstrap` projection epoch early in assembly and attach it to every managed fallback result.
- Preserve current upstream behavior for hosts that do not own persistent native history.

## Verification

- `npm test`: 116 files, 2,052 tests passed
- `npx tsc --noEmit`
- `npm run build`
- `npm pack --dry-run`
- `git diff --check upstream/main...HEAD`

All verification was rerun after rebasing onto current `main` (`8f4f240`). No production database, OpenClaw configuration, or live gateway state was modified.

## Related OpenClaw context

- openclaw/openclaw#84662 documents native Codex history growth.
- The local incident showed Codex's 93,486-token prompt count entering Lossless maintenance 297 ms later while Lossless owned only 36,047 stored tokens.
