### PR TITLE
fix: recover 1.0 context engine across gateway restart

### DIFF
--- a/.changeset/restart-retained-context-engine.md
+++ b/.changeset/restart-retained-context-engine.md
@@ -2,4 +2,4 @@
 "@martian-engineering/lossless-claw": patch
 ---
 
-Reopen the SQLite-backed context engine when OpenClaw starts a new gateway lifecycle from a cached plugin registry, preventing fallback to the legacy engine after in-process restarts.
+Reopen the SQLite-backed context engine when OpenClaw starts a new gateway lifecycle from a cached plugin registry, preventing fallback to the legacy engine after in-process restarts and resolving the current host default model after config changes.

--- a/.changeset/restart-retained-context-engine.md
+++ b/.changeset/restart-retained-context-engine.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Reopen the SQLite-backed context engine when OpenClaw starts a new gateway lifecycle from a cached plugin registry, preventing fallback to the legacy engine after in-process restarts.

--- a/.changeset/skip-stopped-lifecycle-session-end.md
+++ b/.changeset/skip-stopped-lifecycle-session-end.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Skip restart and shutdown `session_end` hooks before acquiring the context engine, preventing closed-database errors after `gateway_stop`.

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -322,6 +322,11 @@ type SessionEndLifecycleEvent = {
   nextSessionKey?: string;
 };
 
+function isGatewayLifecycleSessionEndReason(reason?: string): boolean {
+  const normalizedReason = reason?.trim();
+  return normalizedReason === "restart" || normalizedReason === "shutdown";
+}
+
 const RUNTIME_LLM_PR_URL = "https://github.com/openclaw/openclaw/pull/64294";
 const AUTH_ERROR_TEXT_PATTERN =
   /\b401\b|unauthorized|unauthorised|invalid[_ -]?token|invalid[_ -]?api[_ -]?key|authentication failed|authorization failed|missing scope|insufficient scope|model\.request\b/i;
@@ -1496,6 +1501,9 @@ function wirePluginHandlers(
   }));
   api.on("session_end", async (event) => {
     const lifecycleEvent = event as SessionEndLifecycleEvent;
+    if (isGatewayLifecycleSessionEndReason(lifecycleEvent.reason)) {
+      return;
+    }
     await (await shared.waitForEngine()).handleSessionEnd({
       reason: lifecycleEvent.reason,
       sessionId: lifecycleEvent.sessionId,
@@ -1702,6 +1710,41 @@ const lcmPlugin = {
       reject?.(error);
     }
 
+    /** Clear connection-local state so a retained factory can initialize the next gateway. */
+    function resetInitializationState(): void {
+      initPromise = null;
+      initError = null;
+      resolveDeferredInit = null;
+      rejectDeferredInit = null;
+    }
+
+    /** Reopen the stopped engine when OpenClaw reuses this registration for a new gateway. */
+    function reinitializeAfterGatewayStop(): void {
+      if (!allowRuntimeDatabaseInit || !stopped) {
+        return;
+      }
+
+      // Leave recovery to a fresh plugin registration when one already owns this database path.
+      const activeShared = getSharedInit(normalizedDbPath);
+      if (activeShared && activeShared !== nextShared && !activeShared.stopped) {
+        return;
+      }
+
+      stopped = false;
+      nextShared.stopped = false;
+      try {
+        const nextEngine = initializeEngine();
+        initPromise = Promise.resolve(nextEngine);
+        setSharedInit(normalizedDbPath, nextShared);
+      } catch (error) {
+        const normalized = toInitError(error);
+        rejectDeferredEngine(normalized);
+        stopped = true;
+        nextShared.stopped = true;
+        deps.log.error(`[lcm] DB reinitialization after gateway restart failed: ${normalized.message}`);
+      }
+    }
+
     /** Return the initialized engine, waiting for deferred startup when the DB is lock-contended. */
     async function waitForEngine(): Promise<LcmContextEngine> {
       if (!allowRuntimeDatabaseInit) {
@@ -1786,6 +1829,8 @@ const lcmPlugin = {
       setSharedInit(normalizedDbPath, nextShared);
     }
 
+    api.on("gateway_start", reinitializeAfterGatewayStop);
+
     api.on("gateway_stop", async () => {
       stopped = true;
       nextShared.stopped = true;
@@ -1797,6 +1842,7 @@ const lcmPlugin = {
         database = null;
       }
       lcm = null;
+      resetInitializationState();
       removeSharedInit(normalizedDbPath);
     });
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -298,7 +298,6 @@ type PluginEnvSnapshot = {
   pluginSummaryModel: string;
   pluginSummaryProvider: string;
   openclawProvider: string;
-  openclawDefaultModel: string;
   agentDir: string;
   home: string;
   /** Active OpenClaw state directory — respects OPENCLAW_STATE_DIR for multi-profile hosts. */
@@ -425,7 +424,6 @@ function snapshotPluginEnv(env: NodeJS.ProcessEnv = process.env): PluginEnvSnaps
     pluginSummaryModel: "",
     pluginSummaryProvider: "",
     openclawProvider: env.OPENCLAW_PROVIDER?.trim() ?? "",
-    openclawDefaultModel: "",
     agentDir: env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim() || "",
     home: env.HOME?.trim() ?? "",
     stateDir: resolveOpenclawStateDir(env),
@@ -1242,7 +1240,6 @@ function createLcmDependencies(
   registrationConfig = resolveRegistrationConfig(api),
 ): LcmDependencies {
   const envSnapshot = snapshotPluginEnv();
-  envSnapshot.openclawDefaultModel = readDefaultModelFromConfig(registrationConfig.openClawConfig);
   const pluginConfig = registrationConfig.pluginConfig;
   const { config, diagnostics } = resolveLcmConfigWithDiagnostics(process.env, pluginConfig);
   const log = createLcmLogger(api, config);
@@ -1436,7 +1433,7 @@ function createLcmDependencies(
           : envSnapshot.lcmSummaryModel ||
             config.summaryModel ||
             explicitModelRef ||
-            envSnapshot.openclawDefaultModel
+            readDefaultModelFromConfig(loadEffectiveOpenClawConfig(api))
       ).trim();
       if (!raw) {
         throw new Error("No model configured for LCM summarization.");

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1296,4 +1296,122 @@ describe("lcm plugin registration", () => {
     lcmPlugin.register(api2);
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
+
+  it.each(["restart", "shutdown"])(
+    "does not acquire the stopped engine for session_end %s",
+    async (reason) => {
+      const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+      dbPaths.add(dbPath);
+
+      const { api, getHook } = buildApi({ enabled: true, dbPath });
+      lcmPlugin.register(api);
+
+      const gatewayStop = getHook("gateway_stop");
+      const sessionEnd = getHook("session_end");
+      expect(gatewayStop).toBeTypeOf("function");
+      expect(sessionEnd).toBeTypeOf("function");
+
+      await gatewayStop?.({}, {});
+
+      await expect(
+        sessionEnd?.(
+          {
+            reason: ` ${reason} `,
+            sessionId: "session-before-restart",
+            sessionKey: "agent:main:main",
+          },
+          {},
+        ),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("delegates ordinary session_end reasons to the context engine", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const handleSessionEnd = vi
+      .spyOn(LcmContextEngine.prototype, "handleSessionEnd")
+      .mockResolvedValue(undefined);
+
+    const { api, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+
+    const sessionEnd = getHook("session_end");
+    expect(sessionEnd).toBeTypeOf("function");
+
+    await sessionEnd?.(
+      {
+        reason: "deleted",
+        sessionId: "session-before-delete",
+        sessionKey: "agent:main:main",
+      },
+      {},
+    );
+
+    expect(handleSessionEnd).toHaveBeenCalledWith({
+      reason: "deleted",
+      sessionId: "session-before-delete",
+      sessionKey: "agent:main:main",
+      nextSessionId: undefined,
+      nextSessionKey: undefined,
+    });
+  });
+
+  it("reopens the retained context-engine factory on the next gateway lifecycle", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    const { api, getFactory, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+
+    const retainedFactory = getFactory();
+    const gatewayStop = getHook("gateway_stop");
+    expect(retainedFactory).toBeTypeOf("function");
+    expect(gatewayStop).toBeTypeOf("function");
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+
+    await gatewayStop?.({}, {});
+
+    const gatewayStart = getHook("gateway_start");
+    expect(gatewayStart).toBeTypeOf("function");
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+    expect(api.registerContextEngine).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries retained-factory initialization after a failed gateway lifecycle", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+
+    const originalCreate = connectionModule.createLcmDatabaseConnection;
+    const createSpy = vi.spyOn(connectionModule, "createLcmDatabaseConnection");
+    createSpy.mockImplementation((path: string) => {
+      if (createSpy.mock.calls.length === 2) {
+        throw new Error("database is locked");
+      }
+      return originalCreate(path);
+    });
+
+    const { api, getFactory, getHook } = buildApi({ enabled: true, dbPath });
+    lcmPlugin.register(api);
+    const retainedFactory = getFactory();
+    const gatewayStop = getHook("gateway_stop");
+    const gatewayStart = getHook("gateway_start");
+
+    await gatewayStop?.({}, {});
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+    await expect(Promise.resolve(retainedFactory!())).rejects.toThrow(
+      "Database connection closed after gateway_stop",
+    );
+
+    await gatewayStop?.({}, {});
+    await gatewayStart?.({ port: 3000 }, { port: 3000 });
+
+    await expect(Promise.resolve(retainedFactory!())).resolves.toBeDefined();
+    expect(api.registerContextEngine).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledTimes(3);
+  });
 });

--- a/test/plugin-config-registration.test.ts
+++ b/test/plugin-config-registration.test.ts
@@ -1382,6 +1382,40 @@ describe("lcm plugin registration", () => {
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes the OpenClaw default model for a retained factory restart", async () => {
+    const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
+    dbPaths.add(dbPath);
+    const runtimeConfig = {
+      agents: { defaults: { model: { primary: "openai/model-a" } } },
+    };
+    const { api, getFactory, getHook } = buildApi(
+      { enabled: true, databasePath: dbPath },
+      { runtimeConfig },
+    );
+    lcmPlugin.register(api);
+
+    const retainedFactory = getFactory();
+    const firstEngine = (await Promise.resolve(retainedFactory!())) as {
+      deps?: { resolveModel: (modelRef?: string, providerHint?: string) => unknown };
+    };
+    expect(firstEngine.deps?.resolveModel(undefined, undefined)).toEqual({
+      provider: "openai",
+      model: "model-a",
+    });
+
+    runtimeConfig.agents.defaults.model.primary = "anthropic/model-b";
+    await getHook("gateway_stop")?.({}, {});
+    await getHook("gateway_start")?.({ port: 3000 }, { port: 3000 });
+
+    const restartedEngine = (await Promise.resolve(retainedFactory!())) as {
+      deps?: { resolveModel: (modelRef?: string, providerHint?: string) => unknown };
+    };
+    expect(restartedEngine.deps?.resolveModel(undefined, undefined)).toEqual({
+      provider: "anthropic",
+      model: "model-b",
+    });
+  });
+
   it("retries retained-factory initialization after a failed gateway lifecycle", async () => {
     const dbPath = join(tmpdir(), `lossless-claw-${Date.now()}-${Math.random().toString(16)}.db`);
     dbPaths.add(dbPath);


### PR DESCRIPTION
Related: #1017, #1039, #1073, #1083

## What Problem This Solves

The SQLite-compatible `next/1.0` release line does not yet contain two gateway-lifecycle fixes that exist on `main`:

- a retained context-engine factory remains stopped after an in-process Gateway restart;
- restart/shutdown `session_end` delivery can try to acquire the engine after `gateway_stop` has closed its database.

Together these make same-process restart unreliable for Lossless Claw 1.0 even though the SQLite transcript projection itself is already present through #952.

OpenClaw beta.3 can also reuse that cached plugin registry when unrelated root config changes. Lossless Claw previously snapshotted `agents.defaults.model.primary` at registration, so a retained factory could continue resolving summaries against model A after the host changed to model B.

## Why This Change Was Made

This is a focused port of the lifecycle behavior from #1073 and #1083 to the branch that will actually ship SQLite-backed OpenClaw support:

- ignore only normalized `restart` and `shutdown` `session_end` reasons before acquiring the stopped engine;
- reopen a retained context-engine factory on the next `gateway_start`;
- preserve ownership when a fresh registration already owns the database path;
- leave a failed reinitialization retryable on a later gateway lifecycle;
- read the current validated host config only when resolving the OpenClaw default-model fallback.

The PR deliberately does not port #1039's filesystem-locator guards. `next/1.0` already uses OpenClaw's visible transcript projection from #952, while `main` remains the file-backed 0.x line. It also does not treat registration-time `api.pluginConfig` or `api.registrationMode` as mutable runtime state.

## User Impact

Lossless Claw 1.0 can keep its SQLite-backed context engine active across an OpenClaw in-process Gateway restart. Restart/shutdown cleanup no longer emits a closed-database lifecycle error, ordinary session-end reasons continue to reach the engine, and a retained registry follows a changed OpenClaw default model.

## Evidence

- Lifecycle failing-before regression: the focused registration suite produced four failures covering the closed-database restart/shutdown path and the retained stopped factory.
- Default-model failing-before regression: after model A → B across `gateway_stop` / retained `gateway_start`, the public parent still returned model A; the current head returns model B.
- Focused current-head suite: `test/plugin-config-registration.test.ts` — 48/48 passed.
- Full current-head lane: `npm run release:verify` — TypeScript, production build, 108 test files / 1,785 tests, Go TUI tests, and npm pack dry-run all passed.
- `git diff --check` passed.
- Exact release lifecycle canary on parent commit `4779736704124334c2e170fc541ba76c84d7dd25`:
  - OpenClaw `2026.8.1-beta.3` source `4dcfeeae708798200d6ad6f3c635db5d5fd045d5`, base image `sha256:75f253c85e27b4d4fe34447b7550380e00f1475027c3b79dca5ed58c376edcf7`.
  - Packed Lossless artifact SHA-256 `ba86649814e6e2c2c663e941d831feb9e5981c5a7e8398ee8ed27be51d3b7cf8`, candidate image `sha256:12be7f1f568753f3c48787eb7b4b22d981217651b443208eb99a1d1e2d1fa2e3`.
  - Candidate ran with no network, host mounts, Docker socket, SSH agent, production secrets, or production database; it used a synthetic migrated SQLite fixture.
  - Turn one persisted, `SIGUSR1` completed an in-process restart on the same Gateway PID, turn two persisted, database integrity passed before and after, and the failure-signature scan found no quarantine, legacy fallback, closed-database, or bootstrap-failure signature.
  - Messages increased from 0 to 6 in one conversation. CLI status passed; doctor transport succeeded but reported unavailable against the deliberately empty synthetic fixture.

An authenticated, read-only current-head review inspected both this diff and the exact beta.3 host cache/runtime-config implementation. Verdict: no P1/P2 findings; the prior stale-default-model P2 is closed, and the follow-up is the smallest behaviorally complete correction. Hosted CI and maintainer review remain required.

AI-assisted: yes. The branch, lifecycle ownership, failing-before regressions, full verification, beta.3 host behavior, and release canary were independently inspected before publication.
