### PR TITLE
fix: preserve lossless ingestion on stable line

### DIFF
--- a/.changeset/preserve-partial-overlap-turns.md
+++ b/.changeset/preserve-partial-overlap-turns.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve new `afterTurn` messages when an unaligned runtime batch only partially overlaps persisted history. Ambiguous mixed batches now ingest in full instead of repeatedly discarding genuine turns beside recurring control rows.

--- a/.changeset/preserve-recurrent-tool-results.md
+++ b/.changeset/preserve-recurrent-tool-results.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve distinct tool results when a model reuses tool-call IDs across turns. Only provider-minted IDs now participate in conversation-global event deduplication, and unexpected stable-key collisions retain the row without the conflicting key.

--- a/src/batch-dedup.ts
+++ b/src/batch-dedup.ts
@@ -168,9 +168,9 @@ export class BatchDeduplicator {
    *  - the transcript flush lagged mid-turn: a prefix of the batch aligns
    *    with the DB tail — ingest only the remainder;
    *  - no tail alignment: a batch with zero persisted-identity overlap is a
-   *    genuinely unflushed new turn (ingest all); any overlap means a stale
-   *    replay snapshot — fail closed, because a covered transcript read will
-   *    deliver anything real on the next turn idempotently.
+   *    genuinely unflushed new turn (ingest all); a fully persisted batch is
+   *    a replay (ingest none); partial overlap is ambiguous and fails open by
+   *    ingesting the full batch so repeated control rows cannot hide new data.
    */
   /**
    * A runtime batch row is covered by a persisted frontier row when their
@@ -345,16 +345,16 @@ export class BatchDeduplicator {
       storedBatch,
     );
     if (persistedIdentityOverlaps > 0) {
-      const overlapMessage = `[lcm] afterTurn: runtime batch does not align with the covered transcript frontier and overlaps persisted history (${persistedIdentityOverlaps}/${batch.length}); failing closed — the transcript reconcile delivers real messages next turn conversation=${conversationId}`;
-      // Full overlap (N === batch.length) means every row is already persisted, so
-      // failing closed drops nothing new: log at debug. A partial overlap still
-      // defers genuinely new rows to the reconcile and stays at warn.
       if (await this.batchIsFullyPersistedByMultiplicity(conversationId, storedBatch)) {
-        this.deps.log.debug(overlapMessage);
-      } else {
-        this.deps.log.warn(overlapMessage);
+        this.deps.log.debug(
+          `[lcm] afterTurn: runtime batch does not align with the covered transcript frontier but is fully persisted by multiplicity (${persistedIdentityOverlaps}/${batch.length}); skipping replay conversation=${conversationId}`,
+        );
+        return [];
       }
-      return [];
+      this.deps.log.warn(
+        `[lcm] afterTurn: runtime batch does not align with the covered transcript frontier and partially overlaps persisted history (${persistedIdentityOverlaps}/${batch.length}); ingesting full batch to preserve potentially new messages conversation=${conversationId}`,
+      );
+      return batch;
     }
     return batch;
   }
@@ -810,8 +810,7 @@ export class BatchDeduplicator {
     return overlaps;
   }
 
-  // Proves the debug-only case: every incoming occurrence has a distinct
-  // persisted occurrence, so fail-closed cannot be hiding a new duplicate row.
+  /** Return whether persisted multiplicity covers every incoming identity. */
   private async batchIsFullyPersistedByMultiplicity(
     conversationId: number,
     incomingBatch: StoredMessage[],

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -435,6 +435,11 @@ export class LcmContextEngine implements ContextEngine {
       fts5Available: this.fts5Available,
       replayFloodThresholdExternal: this.config.replayFloodThresholdExternal,
       replayFloodThresholdInternal: this.config.replayFloodThresholdInternal,
+      onStableEventKeyConflict: ({ conversationId, stableEventKey }) => {
+        this.deps.log.warn(
+          `[lcm] stable-event-key conflict conversation=${conversationId} key=${stableEventKey}; persisted row without stable key`,
+        );
+      },
     });
     this.summaryStore = new SummaryStore(this.db, { fts5Available: this.fts5Available });
     this.largeFileInterceptor = new LargeFileInterceptor(
@@ -2769,10 +2774,10 @@ export class LcmContextEngine implements ContextEngine {
       return { ingested: false };
     }
 
-    // Stable event identity short-circuit: when the message carries a stable
-    // event key (responseId / toolCallId) that the conversation already holds,
-    // this is the same event under a different (likely redacted) content
-    // representation. Skip the duplicate insert before any side effects.
+    // Stable event identity short-circuit: only provider-minted tool ids and
+    // assistant response ids can reach this path. Model-authored tool ids can
+    // recur across turns and deliberately fall through to occurrence-scoped
+    // ingestion so a later result is never discarded as a global duplicate.
     const stableEventKey = extractStableEventKey(message);
     if (
       stableEventKey &&

--- a/src/stable-event-key.ts
+++ b/src/stable-event-key.ts
@@ -2,13 +2,21 @@ import type { AgentMessage } from "./openclaw-bridge.js";
 import { extractSingleToolResultIdForPairing } from "./tool-pairing.js";
 import { safeString } from "./value-utils.js";
 
+/** Provider-minted tool-call ids that are unique for one tool event. */
+const PROVIDER_UNIQUE_TOOL_CALL_ID_PATTERN = /^(?:toolu_|call_)[A-Za-z0-9]{12,}$/;
+
+/** Return whether a tool-call id is safe as a conversation-global identity. */
+export function isProviderUniqueToolCallId(toolCallId: string): boolean {
+  return PROVIDER_UNIQUE_TOOL_CALL_ID_PATTERN.test(toolCallId);
+}
+
 /**
  * Extracts a message identity that remains stable across transcript and
  * runtime representations.
  *
- * Assistant response ids take priority, followed by tool call ids. Messages
- * without either identifier return `null` and use the existing content-based
- * and redaction-aware deduplication paths.
+ * Assistant response ids take priority, followed by provider-minted tool-call
+ * ids. Model-authored ids such as `exec:101` can recur across turns, so they
+ * return `null` and use occurrence-scoped ingestion instead of global dedup.
  */
 export function extractStableEventKey(message: AgentMessage): string | null {
   const role = message.role;
@@ -24,7 +32,7 @@ export function extractStableEventKey(message: AgentMessage): string | null {
 
   if (role === "tool" || role === "toolResult") {
     const toolCallId = extractSingleToolResultIdForPairing(message);
-    if (toolCallId) {
+    if (toolCallId && isProviderUniqueToolCallId(toolCallId)) {
       return `tool-result:${toolCallId}`;
     }
   }

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -54,9 +54,9 @@ export type CreateMessageInput = {
    */
   transcriptEntryId?: string | null;
   /**
-   * Cross-representation stable event identity (responseId / toolCallId) used
-   * to short-circuit duplicate ingestion when the transcript (often redacted)
-   * and the live runtime batch describe the same semantic event.
+   * Cross-representation stable event identity (responseId or provider-minted
+   * toolCallId) used to short-circuit duplicate ingestion when the transcript
+   * and live runtime batch describe the same semantic event.
    * Null/undefined preserves the existing behavior.
    */
   stableEventKey?: string | null;
@@ -395,6 +395,10 @@ export class ConversationStore {
   private readonly fts5Available: boolean;
   private readonly replayFloodThresholdExternal: number;
   private readonly replayFloodThresholdInternal: number;
+  private readonly onStableEventKeyConflict?: (info: {
+    conversationId: ConversationId;
+    stableEventKey: string;
+  }) => void;
 
   constructor(
     private db: DatabaseSync,
@@ -412,11 +416,17 @@ export class ConversationStore {
        * calls returning identical results within the same SQLite-second).
        */
       replayFloodThresholdInternal?: number;
+      /** Report when a colliding stable key must be dropped to preserve a row. */
+      onStableEventKeyConflict?: (info: {
+        conversationId: ConversationId;
+        stableEventKey: string;
+      }) => void;
     },
   ) {
     this.fts5Available = options?.fts5Available ?? true;
     this.replayFloodThresholdExternal = options?.replayFloodThresholdExternal ?? 3;
     this.replayFloodThresholdInternal = options?.replayFloodThresholdInternal ?? 32;
+    this.onStableEventKeyConflict = options?.onStableEventKeyConflict;
   }
 
   // ── Transaction helpers ──────────────────────────────────────────────────
@@ -700,31 +710,63 @@ export class ConversationStore {
 
   // ── Message operations ────────────────────────────────────────────────────
 
+  /**
+   * Insert one prepared row, retrying without its stable key when the unique
+   * identity assumption is violated. The row remains durable while later
+   * dedup becomes conservative, which is the lossless failure direction.
+   */
+  private runMessageInsert(prepared: PreparedMessageInsert): number {
+    const insert = (stableEventKey: string | null): number => {
+      const result = this.db
+        .prepare(
+          `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, openclaw_sender_metadata, transcript_entry_id, stable_event_key, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          prepared.conversationId,
+          prepared.seq,
+          prepared.role,
+          prepared.content,
+          prepared.tokenCount,
+          prepared.identityHash,
+          serializeOpenClawSenderMetadata(prepared.openClawSenderMetadata),
+          prepared.transcriptEntryId ?? null,
+          stableEventKey,
+          prepared.createdAt,
+        );
+      return Number(result.lastInsertRowid);
+    };
+
+    if (prepared.stableEventKey == null) {
+      return insert(null);
+    }
+    try {
+      return insert(prepared.stableEventKey);
+    } catch (error: unknown) {
+      const isStableKeyConflict =
+        error instanceof Error &&
+        /UNIQUE constraint failed|SQLITE_CONSTRAINT_UNIQUE/i.test(error.message) &&
+        error.message.includes("stable_event_key");
+      if (!isStableKeyConflict) {
+        throw error;
+      }
+
+      const messageId = insert(null);
+      this.onStableEventKeyConflict?.({
+        conversationId: prepared.conversationId,
+        stableEventKey: prepared.stableEventKey,
+      });
+      return messageId;
+    }
+  }
+
   async createMessage(input: CreateMessageInput): Promise<MessageRecord> {
     const prepared = this.prepareMessageInsert(input);
     if (!prepared.skipReplayTimestampFloodGuard) {
       this.assertNoReplayTimestampFlood([prepared]);
     }
 
-    const result = this.db
-      .prepare(
-        `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, openclaw_sender_metadata, transcript_entry_id, stable_event_key, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        prepared.conversationId,
-        prepared.seq,
-        prepared.role,
-        prepared.content,
-        prepared.tokenCount,
-        prepared.identityHash,
-        serializeOpenClawSenderMetadata(prepared.openClawSenderMetadata),
-        prepared.transcriptEntryId ?? null,
-        prepared.stableEventKey,
-        prepared.createdAt,
-      );
-
-    const messageId = Number(result.lastInsertRowid);
+    const messageId = this.runMessageInsert(prepared);
 
     this.indexMessageForFullText(messageId, input.content);
 
@@ -748,10 +790,6 @@ export class ConversationStore {
       preparedInputs.filter((input) => !input.skipReplayTimestampFloodGuard),
     );
 
-    const insertStmt = this.db.prepare(
-      `INSERT INTO messages (conversation_id, seq, role, content, token_count, identity_hash, openclaw_sender_metadata, transcript_entry_id, stable_event_key, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    );
     const selectStmt = this.db.prepare(
       `SELECT message_id, conversation_id, seq, role, content, token_count, created_at, large_content, transcript_entry_id, openclaw_sender_metadata
        FROM messages WHERE message_id = ?`,
@@ -759,20 +797,7 @@ export class ConversationStore {
 
     const records: MessageRecord[] = [];
     for (const input of preparedInputs) {
-      const result = insertStmt.run(
-        input.conversationId,
-        input.seq,
-        input.role,
-        input.content,
-        input.tokenCount,
-        input.identityHash,
-        serializeOpenClawSenderMetadata(input.openClawSenderMetadata),
-        input.transcriptEntryId ?? null,
-        input.stableEventKey,
-        input.createdAt,
-      );
-
-      const messageId = Number(result.lastInsertRowid);
+      const messageId = this.runMessageInsert(input);
       this.indexMessageForFullText(messageId, input.content);
       const row = selectStmt.get(messageId) as unknown as MessageRow;
       records.push(toMessageRecord(row));

--- a/test/batch-dedup-frontier-loglevel.test.ts
+++ b/test/batch-dedup-frontier-loglevel.test.ts
@@ -47,7 +47,7 @@ function makeDedup(
   return { dedup, log };
 }
 
-describe("batch-dedup frontier-overlap fail-closed log level", () => {
+describe("batch-dedup frontier-overlap policy", () => {
   it("logs at debug, not warn, when the runtime batch is fully covered (N==M)", async () => {
     const { dedup, log } = makeDedup([true, true], [
       { role: "user", content: "u1", count: 1 },
@@ -63,11 +63,11 @@ describe("batch-dedup frontier-overlap fail-closed log level", () => {
     expect(result).toEqual([]);
     expect(log.warn).not.toHaveBeenCalled();
     expect(log.debug).toHaveBeenCalledWith(
-      expect.stringContaining("overlaps persisted history (2/2)"),
+      expect.stringContaining("fully persisted by multiplicity (2/2)"),
     );
   });
 
-  it("keeps warn on partial overlap (N<M) so the suspicious mixed case stays visible", async () => {
+  it("fails open with a warning on partial overlap (N<M)", async () => {
     const { dedup, log } = makeDedup([true, true, false], [
       { role: "user", content: "u1", count: 1 },
       { role: "assistant", content: "a1", count: 1 },
@@ -80,14 +80,15 @@ describe("batch-dedup frontier-overlap fail-closed log level", () => {
 
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s2", undefined, batch);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(batch);
     expect(log.debug).not.toHaveBeenCalled();
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("overlaps persisted history (2/3)"),
+      expect.stringContaining("partially overlaps persisted history (2/3)"),
     );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("ingesting full batch"));
   });
 
-  it("keeps warn when duplicate incoming rows outnumber persisted occurrences", async () => {
+  it("fails open when duplicate incoming rows outnumber persisted occurrences", async () => {
     const { dedup, log } = makeDedup([true, true], [
       { role: "user", content: "repeat", count: 1 },
     ]);
@@ -98,10 +99,10 @@ describe("batch-dedup frontier-overlap fail-closed log level", () => {
 
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s2", undefined, batch);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual(batch);
     expect(log.debug).not.toHaveBeenCalled();
     expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("overlaps persisted history (2/2)"),
+      expect.stringContaining("partially overlaps persisted history (2/2)"),
     );
   });
 

--- a/test/batch-dedup.test.ts
+++ b/test/batch-dedup.test.ts
@@ -448,7 +448,11 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
       conversationId: 1,
       messages: [
         storedMessage("assistant", "prior exact reply", 1),
-        { ...storedMessage("user", bareContent, 2), seq: 1 },
+        {
+          ...storedMessage("user", bareContent, 2),
+          seq: 1,
+          transcriptEntryId: "covered-user-entry",
+        },
       ],
     });
     const batch = [
@@ -464,7 +468,7 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
     expect(result).toEqual([]);
   });
 
-  it("fails closed when persisted identity overlaps without frontier alignment", async () => {
+  it("fails open when persisted identity partially overlaps without frontier alignment", async () => {
     const dedup = makeDedup({
       conversationId: 1,
       messages: [storedMessage("user", "a"), storedMessage("assistant", "b")],
@@ -474,6 +478,33 @@ describe("BatchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier", () => {
       makeMessage({ role: "assistant", content: "new" }),
     ];
     const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier("s1", undefined, batch);
-    expect(result).toEqual([]);
+    expect(result).toEqual(batch);
+  });
+
+  it("preserves a new turn beside a high-multiplicity injected control row", async () => {
+    const control = "[OpenClaw heartbeat poll]";
+    const repeatedControls = Array.from({ length: 5 }, (_, index) => ({
+      ...storedMessage("user", control, index + 1),
+      seq: index,
+    }));
+    const dedup = makeDedup({
+      conversationId: 1,
+      messages: [
+        ...repeatedControls,
+        { ...storedMessage("assistant", "previous answer", 6), seq: 5 },
+      ],
+    });
+    const batch = [
+      makeMessage({ role: "user", content: control }),
+      makeMessage({ role: "user", content: "genuinely new user turn" }),
+    ];
+
+    const result = await dedup.alignRuntimeBatchAgainstCoveredFrontier(
+      "s1",
+      undefined,
+      batch,
+    );
+
+    expect(result).toEqual(batch);
   });
 });

--- a/test/engine-after-turn.test.ts
+++ b/test/engine-after-turn.test.ts
@@ -4874,7 +4874,7 @@ describe("LcmContextEngine afterTurn", () => {
 
   it("afterTurn dedupes tool/toolResult messages by toolCallId", async () => {
     // The transcript imports a redacted toolResult message carrying
-    // toolCallId="call-001"; the runtime batch arrives with the same toolCallId
+    // a provider-minted toolCallId; the runtime batch arrives with the same id
     // but original content. The previously persisted redacted row stays canonical.
     const engine = createEngine();
     const sessionId = "after-turn-stable-event-tool-call-id";
@@ -4884,7 +4884,7 @@ describe("LcmContextEngine afterTurn", () => {
       makeMessage({
         role: "toolResult",
         content: [{ type: "text", text: "redacted by logging.redactPatterns" }],
-        toolCallId: "call-001",
+        toolCallId: "call_123456789012",
       }),
     ]);
     await engine.bootstrap({ sessionId, sessionKey, sessionFile });
@@ -4896,7 +4896,7 @@ describe("LcmContextEngine afterTurn", () => {
         makeMessage({
           role: "toolResult",
           content: "original unredacted tool result body",
-          toolCallId: "call-001",
+          toolCallId: "call_123456789012",
         } as never),
       ],
       prePromptMessageCount: 0,

--- a/test/stable-event-key-conflict.test.ts
+++ b/test/stable-event-key-conflict.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupEngineTestState,
+  createEngineWithDepsOverrides,
+} from "./helpers.js";
+
+afterEach(cleanupEngineTestState);
+
+describe("stable event key conflict fallback", () => {
+  it("preserves recurrent model-authored tool results across ingests", async () => {
+    const engine = createEngineWithDepsOverrides({
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const sessionId = "recurrent-model-tool-id";
+    const toolResult = {
+      role: "toolResult" as const,
+      toolCallId: "exec:101",
+      content: "(no output)",
+    };
+
+    await engine.ingest({ sessionId, message: toolResult });
+    await engine.ingest({ sessionId, message: toolResult });
+
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    const rows = await engine
+      .getConversationStore()
+      .getMessages(conversation!.conversationId);
+    expect(rows.map((row) => row.content)).toEqual(["(no output)", "(no output)"]);
+  });
+
+  it("persists a colliding row without its stable key", async () => {
+    const warn = vi.fn();
+    const engine = createEngineWithDepsOverrides({
+      log: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    const store = engine.getConversationStore();
+    const conversation = await store.getOrCreateConversation("stable-key-conflict");
+    const sharedInput = {
+      conversationId: conversation.conversationId,
+      role: "tool" as const,
+      tokenCount: 1,
+      stableEventKey: "tool-result:call_123456789012",
+      skipReplayTimestampFloodGuard: true,
+    };
+
+    await store.createMessage({ ...sharedInput, seq: 0, content: "first result" });
+    await store.createMessage({ ...sharedInput, seq: 1, content: "second result" });
+
+    const rows = await store.getMessages(conversation.conversationId);
+    expect(rows.map((row) => row.content)).toEqual(["first result", "second result"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("stable-event-key conflict"));
+  });
+
+  it("preserves colliding rows in bulk inserts", async () => {
+    const engine = createEngineWithDepsOverrides({
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const store = engine.getConversationStore();
+    const conversation = await store.getOrCreateConversation("stable-key-conflict-bulk");
+    const sharedInput = {
+      conversationId: conversation.conversationId,
+      role: "tool" as const,
+      tokenCount: 1,
+      stableEventKey: "tool-result:call_abcdefghijkl",
+      skipReplayTimestampFloodGuard: true,
+    };
+
+    const rows = await store.createMessagesBulk([
+      { ...sharedInput, seq: 0, content: "first bulk result" },
+      { ...sharedInput, seq: 1, content: "second bulk result" },
+    ]);
+
+    expect(rows.map((row) => row.content)).toEqual([
+      "first bulk result",
+      "second bulk result",
+    ]);
+  });
+});

--- a/test/stable-event-key.test.ts
+++ b/test/stable-event-key.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractStableEventKey } from "../src/stable-event-key.js";
+import {
+  extractStableEventKey,
+  isProviderUniqueToolCallId,
+} from "../src/stable-event-key.js";
 
 describe("extractStableEventKey", () => {
   it("returns an assistant-response key for assistant messages with responseId", () => {
@@ -20,44 +23,46 @@ describe("extractStableEventKey", () => {
     expect(key).toBe("assistant-response:r-2");
   });
 
-  it("returns a tool-result key for tool/toolResult messages with toolCallId", () => {
+  it("returns a tool-result key for provider-minted toolCallIds", () => {
+    const toolCallId = "call_123456789012";
     expect(
-      extractStableEventKey({ role: "tool", content: "ok", toolCallId: "call-1" } as never),
-    ).toBe("tool-result:call-1");
+      extractStableEventKey({ role: "tool", content: "ok", toolCallId } as never),
+    ).toBe(`tool-result:${toolCallId}`);
     expect(
       extractStableEventKey({
         role: "toolResult",
         content: "ok",
-        toolCallId: "call-1",
+        toolCallId: "toolu_123456789012",
       } as never),
-    ).toBe("tool-result:call-1");
+    ).toBe("tool-result:toolu_123456789012");
   });
 
   it("returns a tool-result key using toolUseId fallback for tool messages", () => {
     const key = extractStableEventKey({
       role: "tool",
       content: "ok",
-      toolUseId: "call-x",
+      toolUseId: "call_abcdefghijkl",
     } as never);
-    expect(key).toBe("tool-result:call-x");
+    expect(key).toBe("tool-result:call_abcdefghijkl");
   });
 
   it("returns a tool-result key when top-level and block ids agree", () => {
+    const toolCallId = "call_123456789012";
     const key = extractStableEventKey({
       role: "toolResult",
-      toolCallId: "call-1",
-      content: [{ type: "tool_result", tool_use_id: "call-1", output: "ok" }],
+      toolCallId,
+      content: [{ type: "tool_result", tool_use_id: toolCallId, output: "ok" }],
     } as never);
-    expect(key).toBe("tool-result:call-1");
+    expect(key).toBe(`tool-result:${toolCallId}`);
   });
 
   it("returns null for aggregate tool-result messages", () => {
     const key = extractStableEventKey({
       role: "toolResult",
-      toolCallId: "call-1",
+      toolCallId: "call_123456789012",
       content: [
-        { type: "tool_result", tool_use_id: "call-1", output: "old" },
-        { type: "tool_result", tool_use_id: "call-2", output: "new" },
+        { type: "tool_result", tool_use_id: "call_123456789012", output: "old" },
+        { type: "tool_result", tool_use_id: "call_abcdefghijkl", output: "new" },
       ],
     } as never);
     expect(key).toBeNull();
@@ -66,10 +71,19 @@ describe("extractStableEventKey", () => {
   it("returns null when top-level and block tool ids conflict", () => {
     const key = extractStableEventKey({
       role: "toolResult",
-      toolCallId: "call-top",
-      content: [{ type: "tool_result", tool_use_id: "call-block", output: "ok" }],
+      toolCallId: "call_123456789012",
+      content: [{ type: "tool_result", tool_use_id: "call_abcdefghijkl", output: "ok" }],
     } as never);
     expect(key).toBeNull();
+  });
+
+  it("rejects recurrent model-authored tool ids as global identities", () => {
+    for (const toolCallId of ["exec:101", "update_plan:7", "call-1"]) {
+      expect(isProviderUniqueToolCallId(toolCallId)).toBe(false);
+      expect(
+        extractStableEventKey({ role: "toolResult", content: "same", toolCallId } as never),
+      ).toBeNull();
+    }
   });
 
   it("returns null for user message without responseId or toolCallId", () => {


### PR DESCRIPTION
## What

Ports the two loss-preserving ingestion fixes from `next/1.0` to the stable `main` line. The stable implementation retains its sender-metadata columns while matching the beta line's stable-key and batch-overlap behavior.

## Why

Model-authored tool-call IDs can recur across turns, so they cannot safely identify one conversation-global event. A partially overlapping runtime batch also does not prove that every incoming occurrence is already durable. The previous assumptions could discard a later tool result or a new message. Keeping the same policy on both release lines also reduces conflicts when `next/1.0` merges into `main`.

## Changes

- Restrict global tool identity to provider IDs
- Preserve colliding rows without stable keys
- Ingest ambiguous partially overlapping batches
- Retain multiplicity-proven replay elision
- Add stable-line regressions and changesets

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` (2,057 tests)
- `npx changeset status`
- `npm pack --dry-run`
- `autoreview --mode branch --base origin/main`
