### PR TITLE
ci: publish npm releases to ClawHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   id-token: write
 
@@ -206,3 +207,20 @@ jobs:
             release_args+=(--prerelease)
           fi
           gh release create "$tag" --repo "$GITHUB_REPOSITORY" "${release_args[@]}"
+
+      - name: Dispatch ClawHub publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: v${{ steps.package.outputs.version }}
+        run: |
+          jq -n \
+            --arg ref "$WORKFLOW_REF" \
+            --arg release_tag "$RELEASE_TAG" \
+            '{ref: $ref, inputs: {release_tag: $release_tag, dry_run: false}}' |
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/clawhub-publish.yml/dispatches" \
+              --input -

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,6 +57,7 @@ make sure a maintainer gets a `.changeset/*.md` file onto `main`.
    - create tag `vX.Y.Z`
    - create the GitHub release using the matching `CHANGELOG.md` section as the primary notes
    - prepend those notes ahead of GitHub's generated contributor and compare summary
+   - dispatch `Publish to ClawHub` for the same tag with `dry_run` set to `false`
 
 ## External setup required
 
@@ -74,10 +75,14 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 
 ## ClawHub releases
 
-Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
-manually run `Publish to ClawHub` from the default branch with `release_tag`
-set to that tag. Run once with `dry_run` set to `true`, review the validation,
-then run again with `dry_run` set to `false`.
+Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag
+and GitHub Release, it automatically dispatches `Publish to ClawHub` from the
+default branch with `release_tag` set to that tag and `dry_run` set to `false`.
+
+The standalone `Publish to ClawHub` workflow remains available for validation
+and recovery. Run it with `dry_run` set to `true` to validate a release without
+publishing, or rerun it with `dry_run` set to `false` if the automatic ClawHub
+workflow failed or was not dispatched.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -7,6 +7,10 @@ const workflow = readFileSync(
   `${repositoryRoot}/.github/workflows/clawhub-publish.yml`,
   "utf8",
 );
+const npmPublishWorkflow = readFileSync(
+  `${repositoryRoot}/.github/workflows/publish.yml`,
+  "utf8",
+);
 const releasing = readFileSync(`${repositoryRoot}/RELEASING.md`, "utf8");
 const clawhubWorkflowCommit =
   "a230d962db64019462c2c8ee400755eb92169908";
@@ -64,5 +68,26 @@ describe("ClawHub publish workflow", () => {
     expect(releasing).toContain("Publish to npm first");
     expect(releasing).toContain("matching `vX.Y.Z` tag");
     expect(releasing).toContain("npm `gitHead`");
+  });
+
+  it("dispatches a real ClawHub publish after the npm release completes", () => {
+    expect(npmPublishWorkflow).toMatch(
+      /permissions:\n(?:.|\n)*?actions: write/,
+    );
+    expect(npmPublishWorkflow).toContain(
+      "actions/workflows/clawhub-publish.yml/dispatches",
+    );
+    expect(npmPublishWorkflow).toContain(
+      "WORKFLOW_REF: ${{ github.event.repository.default_branch }}",
+    );
+    expect(npmPublishWorkflow).toContain(
+      'RELEASE_TAG: v${{ steps.package.outputs.version }}',
+    );
+    expect(npmPublishWorkflow).toContain(
+      "inputs: {release_tag: $release_tag, dry_run: false}",
+    );
+    expect(npmPublishWorkflow.indexOf("Create GitHub release")).toBeLessThan(
+      npmPublishWorkflow.indexOf("Dispatch ClawHub publish"),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- automatically dispatch the OIDC-trusted ClawHub workflow after npm, tag, and GitHub Release publication succeed
- pass the exact released tag and publish with `dry_run: false` from the default branch
- preserve the standalone ClawHub workflow for validation and recovery
- document the combined release flow

## Validation

- `npm test` (116 files, 2058 tests)
- `npm run typecheck`
- `actionlint`
- `git diff --check`

No Changeset: this only changes release automation and maintainer documentation.