### PR TITLE
fix: bind ClawHub publishing to release tags

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -56,6 +56,11 @@ jobs:
           fi
 
           source_sha="$(git rev-parse HEAD)"
+          if [ "$source_sha" != "$GITHUB_SHA" ]; then
+            echo "Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF"
+            exit 1
+          fi
+
           git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
           if [ "$source_sha" != "$tag_sha" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Dispatch ClawHub publish
         env:
           GH_TOKEN: ${{ github.token }}
-          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+          WORKFLOW_REF: v${{ steps.package.outputs.version }}
           RELEASE_TAG: v${{ steps.package.outputs.version }}
         run: |
           jq -n \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,19 +76,19 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 ## ClawHub releases
 
 Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag
-and GitHub Release, it automatically dispatches `Publish to ClawHub` from the
-default branch with `release_tag` set to that tag and `dry_run` set to `false`.
+and GitHub Release, it automatically dispatches `Publish to ClawHub` from that
+tag with `release_tag` set to the same tag and `dry_run` set to `false`.
 
 The standalone `Publish to ClawHub` workflow remains available for validation
-and recovery. Run it with `dry_run` set to `true` to validate a release without
-publishing, or rerun it with `dry_run` set to `false` if the automatic ClawHub
-workflow failed or was not dispatched.
+and recovery. Select the release tag as the workflow ref, set `release_tag` to
+the same tag, and use `dry_run` to choose validation or publication.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify
-the same release. Real ClawHub publishes are serialized. Selecting the default
-branch allows releases whose tags predate this workflow to be published without
-moving those tags or weakening the npm commit check.
+the same release. Real ClawHub publishes are serialized. Selecting the release
+tag for both the workflow ref and package source lets ClawHub verify that the
+trusted workflow commit matches the published package commit. Tags that predate
+this workflow cannot use OIDC trusted publishing.
 
 ClawHub trusted publishing is configured for
 `.github/workflows/clawhub-publish.yml`; no long-lived repository token is

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -41,6 +41,10 @@ describe("ClawHub publish workflow", () => {
     expect(workflow).toContain(
       'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
     );
+    expect(workflow).toContain('source_sha" != "$GITHUB_SHA"');
+    expect(workflow).toContain(
+      'Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF',
+    );
     expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
@@ -78,7 +82,7 @@ describe("ClawHub publish workflow", () => {
       "actions/workflows/clawhub-publish.yml/dispatches",
     );
     expect(npmPublishWorkflow).toContain(
-      "WORKFLOW_REF: ${{ github.event.repository.default_branch }}",
+      "WORKFLOW_REF: v${{ steps.package.outputs.version }}",
     );
     expect(npmPublishWorkflow).toContain(
       'RELEASE_TAG: v${{ steps.package.outputs.version }}',


### PR DESCRIPTION
## What

Dispatch the ClawHub publish workflow from the immutable release tag and reject manual runs whose workflow ref does not match the package source commit.

## Why

ClawHub trusted publishing binds the GitHub workflow run SHA to the package source commit. A live beta.2 smoke test authenticated successfully but failed because the workflow ran from `main` while publishing the beta tag commit.

## Changes

- Dispatch from the immutable release tag
- Reject mismatched manual workflow refs
- Document tag-bound recovery publishing
- Test workflow and source ref binding

## Testing

- `npm test -- test/clawhub-publish-workflow.test.ts`
- `npm run typecheck`
- Parsed both workflow files as YAML
- `git diff --check`
- Autoreview: no actionable findings

No Changeset: this changes release automation and maintainer documentation.
