### PR TITLE
ci: backport ClawHub publishing for beta.3

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: Existing npm and GitHub release tag to publish
+        required: true
+        type: string
       dry_run:
         description: Validate the ClawHub package without publishing
         required: true
@@ -12,7 +16,7 @@ on:
 
 jobs:
   dry-run:
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || inputs.dry_run
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read
@@ -23,17 +27,22 @@ jobs:
       dry_run: true
 
   release-preflight:
-    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      source_sha: ${{ steps.identity.outputs.source_sha }}
     steps:
       - name: Checkout selected release
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_tag }}
 
       - name: Verify npm release identity
+        id: identity
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
 
@@ -41,14 +50,16 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           expected_tag="v$version"
 
-          if [ "$GITHUB_REF_TYPE" != "tag" ] || [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
-            echo "Select release tag $expected_tag, not $GITHUB_REF"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Select release tag $expected_tag, not $RELEASE_TAG"
             exit 1
           fi
 
           source_sha="$(git rev-parse HEAD)"
-          if [ "$source_sha" != "$GITHUB_SHA" ]; then
-            echo "Checked out $source_sha, expected selected commit $GITHUB_SHA"
+          git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
+          if [ "$source_sha" != "$tag_sha" ]; then
+            echo "Checked out $source_sha, expected $RELEASE_TAG at $tag_sha"
             exit 1
           fi
 
@@ -56,13 +67,31 @@ jobs:
           published_version="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.version || "")' "$npm_state")"
           published_sha="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.gitHead || "")' "$npm_state")"
 
-          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$GITHUB_SHA" ]; then
-            echo "npm identity does not match $expected_tag at $GITHUB_SHA"
+          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$source_sha" ]; then
+            echo "npm identity does not match $expected_tag at $source_sha"
             exit 1
           fi
 
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
+  release-dry-run:
+    needs: release-preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
+    with:
+      source: ${{ github.repository }}
+      ref: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: refs/tags/${{ inputs.release_tag }}
+      dry_run: true
+
   publish:
     needs: release-preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
     concurrency:
       group: clawhub-publish
       cancel-in-progress: false
@@ -73,4 +102,7 @@ jobs:
     # openclaw/clawhub package-publish.yml v0.23.1
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
     with:
+      source: ${{ github.repository }}
+      ref: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: refs/tags/${{ inputs.release_tag }}
       dry_run: false

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -56,6 +56,11 @@ jobs:
           fi
 
           source_sha="$(git rev-parse HEAD)"
+          if [ "$source_sha" != "$GITHUB_SHA" ]; then
+            echo "Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF"
+            exit 1
+          fi
+
           git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
           if [ "$source_sha" != "$tag_sha" ]; then

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,76 @@
+name: Publish to ClawHub
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Validate the ClawHub package without publishing
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  dry-run:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || inputs.dry_run
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
+    with:
+      dry_run: true
+
+  release-preflight:
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout selected release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Verify npm release identity
+        run: |
+          set -euo pipefail
+
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          expected_tag="v$version"
+
+          if [ "$GITHUB_REF_TYPE" != "tag" ] || [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+            echo "Select release tag $expected_tag, not $GITHUB_REF"
+            exit 1
+          fi
+
+          source_sha="$(git rev-parse HEAD)"
+          if [ "$source_sha" != "$GITHUB_SHA" ]; then
+            echo "Checked out $source_sha, expected selected commit $GITHUB_SHA"
+            exit 1
+          fi
+
+          npm_state="$(npm view "$package_name@$version" version gitHead --json)"
+          published_version="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.version || "")' "$npm_state")"
+          published_sha="$(node -e 'const data=JSON.parse(process.argv[1]); process.stdout.write(data.gitHead || "")' "$npm_state")"
+
+          if [ "$published_version" != "$version" ] || [ "$published_sha" != "$GITHUB_SHA" ]; then
+            echo "npm identity does not match $expected_tag at $GITHUB_SHA"
+            exit 1
+          fi
+
+  publish:
+    needs: release-preflight
+    concurrency:
+      group: clawhub-publish
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    # openclaw/clawhub package-publish.yml v0.23.1
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
+    with:
+      dry_run: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Dispatch ClawHub publish
         env:
           GH_TOKEN: ${{ github.token }}
-          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+          WORKFLOW_REF: v${{ steps.package.outputs.version }}
           RELEASE_TAG: v${{ steps.package.outputs.version }}
         run: |
           jq -n \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   id-token: write
 
@@ -206,3 +207,20 @@ jobs:
             release_args+=(--prerelease)
           fi
           gh release create "$tag" --repo "$GITHUB_REPOSITORY" "${release_args[@]}"
+
+      - name: Dispatch ClawHub publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: v${{ steps.package.outputs.version }}
+        run: |
+          jq -n \
+            --arg ref "$WORKFLOW_REF" \
+            --arg release_tag "$RELEASE_TAG" \
+            '{ref: $ref, inputs: {release_tag: $release_tag, dry_run: false}}' |
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/clawhub-publish.yml/dispatches" \
+              --input -

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,19 +76,19 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 ## ClawHub releases
 
 Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag
-and GitHub Release, it automatically dispatches `Publish to ClawHub` from the
-default branch with `release_tag` set to that tag and `dry_run` set to `false`.
+and GitHub Release, it automatically dispatches `Publish to ClawHub` from that
+tag with `release_tag` set to the same tag and `dry_run` set to `false`.
 
 The standalone `Publish to ClawHub` workflow remains available for validation
-and recovery. Run it with `dry_run` set to `true` to validate a release without
-publishing, or rerun it with `dry_run` set to `false` if the automatic ClawHub
-workflow failed or was not dispatched.
+and recovery. Select the release tag as the workflow ref, set `release_tag` to
+the same tag, and use `dry_run` to choose validation or publication.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify
-the same release. Real ClawHub publishes are serialized. Selecting the default
-branch allows releases whose tags predate this workflow to be published without
-moving those tags or weakening the npm commit check.
+the same release. Real ClawHub publishes are serialized. Selecting the release
+tag for both the workflow ref and package source lets ClawHub verify that the
+trusted workflow commit matches the published package commit. Tags that predate
+this workflow cannot use OIDC trusted publishing.
 
 ClawHub trusted publishing is configured for
 `.github/workflows/clawhub-publish.yml`; no long-lived repository token is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,6 +57,7 @@ make sure a maintainer gets a `.changeset/*.md` file onto `main`.
    - create tag `vX.Y.Z`
    - create the GitHub release using the matching `CHANGELOG.md` section as the primary notes
    - prepend those notes ahead of GitHub's generated contributor and compare summary
+   - dispatch `Publish to ClawHub` for the same tag with `dry_run` set to `false`
 
 ## External setup required
 
@@ -74,10 +75,14 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 
 ## ClawHub releases
 
-Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
-manually run `Publish to ClawHub` from the default branch with `release_tag`
-set to that tag. Run once with `dry_run` set to `true`, review the validation,
-then run again with `dry_run` set to `false`.
+Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag
+and GitHub Release, it automatically dispatches `Publish to ClawHub` from the
+default branch with `release_tag` set to that tag and `dry_run` set to `false`.
+
+The standalone `Publish to ClawHub` workflow remains available for validation
+and recovery. Run it with `dry_run` set to `true` to validate a release without
+publishing, or rerun it with `dry_run` set to `false` if the automatic ClawHub
+workflow failed or was not dispatched.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,6 +72,21 @@ When configuring npm trusted publishing, register the GitHub workflow using the 
 
 The publish workflow is intentionally manual. Release issuance should stay deliberate even after trusted publishing is enabled.
 
+## ClawHub releases
+
+Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
+manually run `Publish to ClawHub` from that exact tag with `dry_run` set to
+`false`.
+
+The workflow refuses to publish unless the selected tag, `package.json`
+version, npm version, npm `gitHead`, and selected commit all identify the same
+release. Real ClawHub publishes are serialized.
+
+ClawHub trusted publishing is configured for
+`.github/workflows/clawhub-publish.yml`; no long-lived repository token is
+required. Deleting that trusted-publisher configuration disables future
+publishes.
+
 ## Beta releases
 
 Use a Changesets prerelease when `main` needs broader testing before a stable release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,12 +75,15 @@ The publish workflow is intentionally manual. Release issuance should stay delib
 ## ClawHub releases
 
 Publish to npm first. After the npm workflow creates the matching `vX.Y.Z` tag,
-manually run `Publish to ClawHub` from that exact tag with `dry_run` set to
-`false`.
+manually run `Publish to ClawHub` from the default branch with `release_tag`
+set to that tag. Run once with `dry_run` set to `true`, review the validation,
+then run again with `dry_run` set to `false`.
 
 The workflow refuses to publish unless the selected tag, `package.json`
-version, npm version, npm `gitHead`, and selected commit all identify the same
-release. Real ClawHub publishes are serialized.
+version, npm version, npm `gitHead`, and the tag's immutable commit all identify
+the same release. Real ClawHub publishes are serialized. Selecting the default
+branch allows releases whose tags predate this workflow to be published without
+moving those tags or weakening the npm commit check.
 
 ClawHub trusted publishing is configured for
 `.github/workflows/clawhub-publish.yml`; no long-lived repository token is

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -20,18 +20,38 @@ describe("ClawHub publish workflow", () => {
       (match) => match[1],
     );
 
-    expect(refs).toEqual([clawhubWorkflowCommit, clawhubWorkflowCommit]);
+    expect(refs).toEqual([
+      clawhubWorkflowCommit,
+      clawhubWorkflowCommit,
+      clawhubWorkflowCommit,
+    ]);
   });
 
-  it("requires the selected release tag to match the npm commit", () => {
+  it("resolves the requested release tag to the npm commit", () => {
+    expect(workflow).toContain("release_tag:");
     expect(workflow).toContain("release-preflight:");
-    expect(workflow).toContain('GITHUB_REF_TYPE" != "tag"');
-    expect(workflow).toContain('GITHUB_REF_NAME" != "$expected_tag"');
+    expect(workflow).toContain("ref: ${{ inputs.release_tag }}");
+    expect(workflow).toContain(
+      'git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"',
+    );
+    expect(workflow).toContain(
+      'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
+    );
+    expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
     );
-    expect(workflow).toContain('published_sha" != "$GITHUB_SHA"');
-    expect(workflow).toMatch(/publish:\n\s+needs: release-preflight/);
+    expect(workflow).toContain('published_sha" != "$source_sha"');
+    expect(workflow).toContain('echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"');
+  });
+
+  it("binds manual validation and publication to the verified commit", () => {
+    expect(workflow).toMatch(
+      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+    );
+    expect(workflow).toMatch(
+      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+    );
   });
 
   it("serializes real publishes without cancelling an active release", () => {

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -41,6 +41,10 @@ describe("ClawHub publish workflow", () => {
     expect(workflow).toContain(
       'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
     );
+    expect(workflow).toContain('source_sha" != "$GITHUB_SHA"');
+    expect(workflow).toContain(
+      'Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF',
+    );
     expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
@@ -78,7 +82,7 @@ describe("ClawHub publish workflow", () => {
       "actions/workflows/clawhub-publish.yml/dispatches",
     );
     expect(npmPublishWorkflow).toContain(
-      "WORKFLOW_REF: ${{ github.event.repository.default_branch }}",
+      "WORKFLOW_REF: v${{ steps.package.outputs.version }}",
     );
     expect(npmPublishWorkflow).toContain(
       'RELEASE_TAG: v${{ steps.package.outputs.version }}',

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -7,6 +7,10 @@ const workflow = readFileSync(
   `${repositoryRoot}/.github/workflows/clawhub-publish.yml`,
   "utf8",
 );
+const npmPublishWorkflow = readFileSync(
+  `${repositoryRoot}/.github/workflows/publish.yml`,
+  "utf8",
+);
 const releasing = readFileSync(`${repositoryRoot}/RELEASING.md`, "utf8");
 const clawhubWorkflowCommit =
   "a230d962db64019462c2c8ee400755eb92169908";
@@ -64,5 +68,26 @@ describe("ClawHub publish workflow", () => {
     expect(releasing).toContain("Publish to npm first");
     expect(releasing).toContain("matching `vX.Y.Z` tag");
     expect(releasing).toContain("npm `gitHead`");
+  });
+
+  it("dispatches a real ClawHub publish after the npm release completes", () => {
+    expect(npmPublishWorkflow).toMatch(
+      /permissions:\n(?:.|\n)*?actions: write/,
+    );
+    expect(npmPublishWorkflow).toContain(
+      "actions/workflows/clawhub-publish.yml/dispatches",
+    );
+    expect(npmPublishWorkflow).toContain(
+      "WORKFLOW_REF: ${{ github.event.repository.default_branch }}",
+    );
+    expect(npmPublishWorkflow).toContain(
+      'RELEASE_TAG: v${{ steps.package.outputs.version }}',
+    );
+    expect(npmPublishWorkflow).toContain(
+      "inputs: {release_tag: $release_tag, dry_run: false}",
+    );
+    expect(npmPublishWorkflow.indexOf("Create GitHub release")).toBeLessThan(
+      npmPublishWorkflow.indexOf("Dispatch ClawHub publish"),
+    );
   });
 });

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const workflow = readFileSync(
+  `${repositoryRoot}/.github/workflows/clawhub-publish.yml`,
+  "utf8",
+);
+const releasing = readFileSync(`${repositoryRoot}/RELEASING.md`, "utf8");
+const clawhubWorkflowCommit =
+  "a230d962db64019462c2c8ee400755eb92169908";
+
+describe("ClawHub publish workflow", () => {
+  it("pins every reusable workflow call to the reviewed commit", () => {
+    const refs = Array.from(
+      workflow.matchAll(
+        /openclaw\/clawhub\/.github\/workflows\/package-publish\.yml@([^\s]+)/g,
+      ),
+      (match) => match[1],
+    );
+
+    expect(refs).toEqual([clawhubWorkflowCommit, clawhubWorkflowCommit]);
+  });
+
+  it("requires the selected release tag to match the npm commit", () => {
+    expect(workflow).toContain("release-preflight:");
+    expect(workflow).toContain('GITHUB_REF_TYPE" != "tag"');
+    expect(workflow).toContain('GITHUB_REF_NAME" != "$expected_tag"');
+    expect(workflow).toContain(
+      'npm view "$package_name@$version" version gitHead --json',
+    );
+    expect(workflow).toContain('published_sha" != "$GITHUB_SHA"');
+    expect(workflow).toMatch(/publish:\n\s+needs: release-preflight/);
+  });
+
+  it("serializes real publishes without cancelling an active release", () => {
+    expect(workflow).toMatch(
+      /publish:\n(?:.|\n)*?concurrency:\n\s+group: clawhub-publish\n\s+cancel-in-progress: false/,
+    );
+  });
+
+  it("documents npm-first publication from the matching release tag", () => {
+    expect(releasing).toContain("Publish to npm first");
+    expect(releasing).toContain("matching `vX.Y.Z` tag");
+    expect(releasing).toContain("npm `gitHead`");
+  });
+});


### PR DESCRIPTION
## What

Backport the ClawHub publishing workflow, automatic npm-to-ClawHub dispatch, and release-tag OIDC binding to `next/1.0`.

## Why

The beta branch lacks the ClawHub workflow required in the immutable beta.3 tag. ClawHub trusted publishing also requires the workflow run SHA to match the package source commit, so the automatic dispatch must run from the release tag.

## Changes

- Add the ClawHub publish workflow
- Backport PR 1092 automatic dispatch
- Dispatch from the immutable release tag
- Reject mismatched manual workflow refs
- Add release workflow regression coverage

## Testing

- `npm test -- test/clawhub-publish-workflow.test.ts`
- `npm run typecheck`
- Parsed both workflow files as YAML
- `git diff --check`
- Autoreview finding rejected after GitHub returned `204 No Content` for the exact boolean-input REST payload

No Changeset: this backports release automation and maintainer documentation.
