### PR TITLE
chore: update beta.3 rollback marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0-beta.3
 
-<!-- release-rollback-version: 0.15.1 -->
+<!-- release-rollback-version: 0.15.2 -->
 
 ### Patch Changes
 


### PR DESCRIPTION
## What

Update the 1.0.0-beta.3 rollback marker to the newly published stable version, 0.15.2.

## Why

The stable patch release advanced while beta.3 was queued. The publish preflight correctly rejected the stale 0.15.1 marker before npm publication.

## Changes

- Point beta.3 rollback to 0.15.2

## Testing

- Parsed the beta.3 rollback marker
- Verified live npm dist-tags
- Ran autoreview with no findings