### PR TITLE
fix: publish npm releases through OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.19.0
+
       - name: Install dependencies
         run: npm ci
 
@@ -179,9 +182,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.preflight.outputs.npm_exists != 'true'
-        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --tag "${{ steps.package.outputs.npm_tag }}"
 
       - name: Create and push release tag
         if: steps.preflight.outputs.tag_exists != 'true'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,10 @@ Recommended external setup:
 
 When configuring npm trusted publishing, register the GitHub workflow using the exact workflow filename in this repo: `.github/workflows/publish.yml`.
 
+The workflow requests an OIDC identity token, installs an npm CLI with trusted
+publishing support, and publishes with provenance. It intentionally does not
+inject `NODE_AUTH_TOKEN` or use the legacy `NPM_TOKEN` repository secret.
+
 The publish workflow is intentionally manual. Release issuance should stay deliberate even after trusted publishing is enabled.
 
 ## ClawHub releases

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -115,4 +115,16 @@ describe("ClawHub publish workflow", () => {
       npmPublishWorkflow.indexOf("Dispatch ClawHub publish"),
     );
   });
+
+  it("publishes npm releases through the configured OIDC trust", () => {
+    expect(npmPublishWorkflow).toContain("id-token: write");
+    expect(npmPublishWorkflow).toContain(
+      "npm install --global npm@11.19.0",
+    );
+    expect(npmPublishWorkflow).toContain(
+      'npm publish --provenance --tag "${{ steps.package.outputs.npm_tag }}"',
+    );
+    expect(npmPublishWorkflow).not.toContain("NODE_AUTH_TOKEN");
+    expect(npmPublishWorkflow).not.toContain("secrets.NPM_TOKEN");
+  });
 });


### PR DESCRIPTION
## What

Publish npm releases through the package's configured GitHub Actions trusted publisher. The workflow installs npm 11.19.0, requests provenance, and does not inject a repository token.

## Why

The 0.15.3 release failed at `npm publish` because `publish.yml` supplied an expired `NPM_TOKEN`. npm Trusted Publishing already trusts this repository, workflow, and `npm-publish` environment, but the explicit token prevented the workflow from using that OIDC trust.

## Changes

- Install an OIDC-capable npm CLI
- Publish npm packages with provenance
- Remove long-lived token injection
- Add workflow regression coverage
- Document the OIDC credential path

## Testing

- `npx vitest run test/clawhub-publish-workflow.test.ts`
- `npm run typecheck`
- `npm run build`
- Autoreview: no actionable findings

No Changeset is required because this changes GitHub release infrastructure without changing the published package.