### PR TITLE
fix: backport release artifact publishing to beta

### DIFF
--- a/.changeset/clawhub-prebuilt-artifacts.md
+++ b/.changeset/clawhub-prebuilt-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Publish the built npm tarball through ClawHub so marketplace installs include the declared `dist/index.js` extension entrypoint.

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -15,7 +15,47 @@ on:
         type: boolean
 
 jobs:
+  pull-request-package:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Build package tarball
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          mkdir -p "$RUNNER_TEMP/clawhub-pr-package"
+          npm pack --pack-destination "$RUNNER_TEMP/clawhub-pr-package"
+
+          shopt -s nullglob
+          tarballs=("$RUNNER_TEMP/clawhub-pr-package"/*.tgz)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "Expected one package tarball, found ${#tarballs[@]}"
+            exit 1
+          fi
+          tar -tzf "${tarballs[0]}" | grep -Fx 'package/dist/index.js'
+
+      - name: Upload package tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-pr-package
+          path: ${{ runner.temp }}/clawhub-pr-package/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
   dry-run:
+    needs: pull-request-package
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
@@ -24,6 +64,7 @@ jobs:
     # openclaw/clawhub package-publish.yml v0.23.1
     uses: openclaw/clawhub/.github/workflows/package-publish.yml@a230d962db64019462c2c8ee400755eb92169908
     with:
+      package_artifact_name: clawhub-pr-package
       dry_run: true
 
   release-preflight:
@@ -79,6 +120,30 @@ jobs:
 
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
 
+      - name: Download exact npm package tarball
+        run: |
+          set -euo pipefail
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          mkdir -p "$RUNNER_TEMP/clawhub-release-package"
+          npm pack "$package_name@$version" --pack-destination "$RUNNER_TEMP/clawhub-release-package"
+
+          shopt -s nullglob
+          tarballs=("$RUNNER_TEMP/clawhub-release-package"/*.tgz)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "Expected one package tarball, found ${#tarballs[@]}"
+            exit 1
+          fi
+          tar -tzf "${tarballs[0]}" | grep -Fx 'package/dist/index.js'
+
+      - name: Upload exact npm package tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawhub-release-package
+          path: ${{ runner.temp }}/clawhub-release-package/*.tgz
+          if-no-files-found: error
+          retention-days: 1
+
   release-dry-run:
     needs: release-preflight
     if: github.event_name == 'workflow_dispatch' && inputs.dry_run
@@ -92,6 +157,7 @@ jobs:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: refs/tags/${{ inputs.release_tag }}
+      package_artifact_name: clawhub-release-package
       dry_run: true
 
   publish:
@@ -110,4 +176,5 @@ jobs:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: refs/tags/${{ inputs.release_tag }}
+      package_artifact_name: clawhub-release-package
       dry_run: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.19.0
+
       - name: Install dependencies
         run: npm ci
 
@@ -179,9 +182,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.preflight.outputs.npm_exists != 'true'
-        run: npm publish --tag "${{ steps.package.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --tag "${{ steps.package.outputs.npm_tag }}"
 
       - name: Create and push release tag
         if: steps.preflight.outputs.tag_exists != 'true'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -90,6 +90,13 @@ tag for both the workflow ref and package source lets ClawHub verify that the
 trusted workflow commit matches the published package commit. Tags that predate
 this workflow cannot use OIDC trusted publishing.
 
+After identity verification, the workflow downloads the exact published npm
+tarball and passes that prebuilt artifact to ClawHub. This keeps generated
+files such as `dist/index.js` identical between npm and ClawHub even though
+`dist/` is excluded from the source tag. Pull-request dry runs build and pack
+the checkout before ClawHub validation so they exercise the same artifact
+shape as a release.
+
 ClawHub trusted publishing is configured for
 `.github/workflows/clawhub-publish.yml`; no long-lived repository token is
 required. Deleting that trusted-publisher configuration disables future

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,10 @@ Recommended external setup:
 
 When configuring npm trusted publishing, register the GitHub workflow using the exact workflow filename in this repo: `.github/workflows/publish.yml`.
 
+The workflow requests an OIDC identity token, installs an npm CLI with trusted
+publishing support, and publishes with provenance. It intentionally does not
+inject `NODE_AUTH_TOKEN` or use the legacy `NPM_TOKEN` repository secret.
+
 The publish workflow is intentionally manual. Release issuance should stay deliberate even after trusted publishing is enabled.
 
 ## ClawHub releases

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -53,6 +53,26 @@ describe("ClawHub publish workflow", () => {
     expect(workflow).toContain('echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"');
   });
 
+  it("builds a prebuilt package for pull-request validation", () => {
+    expect(workflow).toMatch(
+      /pull-request-package:\n(?:.|\n)*?npm ci(?:.|\n)*?npm run build(?:.|\n)*?npm pack --pack-destination "\$RUNNER_TEMP\/clawhub-pr-package"/,
+    );
+    expect(workflow).toMatch(
+      /dry-run:\n\s+needs: pull-request-package(?:.|\n)*?package_artifact_name: clawhub-pr-package/,
+    );
+  });
+
+  it("publishes the exact npm tarball through ClawHub", () => {
+    expect(workflow).toContain(
+      'npm pack "$package_name@$version" --pack-destination "$RUNNER_TEMP/clawhub-release-package"',
+    );
+    expect(workflow.match(/package\/dist\/index\.js/g)).toHaveLength(2);
+    expect(workflow).toMatch(
+      /name: Upload exact npm package tarball(?:.|\n)*?name: clawhub-release-package/,
+    );
+    expect(workflow.match(/package_artifact_name: clawhub-release-package/g)).toHaveLength(2);
+  });
+
   it("binds manual validation and publication to the verified commit", () => {
     expect(workflow).toMatch(
       /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
@@ -72,6 +92,7 @@ describe("ClawHub publish workflow", () => {
     expect(releasing).toContain("Publish to npm first");
     expect(releasing).toContain("matching `vX.Y.Z` tag");
     expect(releasing).toContain("npm `gitHead`");
+    expect(releasing).toMatch(/exact published npm\s+tarball/);
   });
 
   it("dispatches a real ClawHub publish after the npm release completes", () => {

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -115,4 +115,16 @@ describe("ClawHub publish workflow", () => {
       npmPublishWorkflow.indexOf("Dispatch ClawHub publish"),
     );
   });
+
+  it("publishes npm releases through the configured OIDC trust", () => {
+    expect(npmPublishWorkflow).toContain("id-token: write");
+    expect(npmPublishWorkflow).toContain(
+      "npm install --global npm@11.19.0",
+    );
+    expect(npmPublishWorkflow).toContain(
+      'npm publish --provenance --tag "${{ steps.package.outputs.npm_tag }}"',
+    );
+    expect(npmPublishWorkflow).not.toContain("NODE_AUTH_TOKEN");
+    expect(npmPublishWorkflow).not.toContain("secrets.NPM_TOKEN");
+  });
 });


### PR DESCRIPTION
## What

Backport the stable release-artifact and npm OIDC fixes to the `next/1.0` beta line.

## Why

The beta.3 ClawHub package omitted `dist/index.js` because ClawHub repacked the source tag. The beta release workflow also retained the expired `NPM_TOKEN` path that blocked the first 0.15.3 publish attempt. Beta.4 needs both shared fixes before publication.

## Changes

- Pass prebuilt npm tarballs to ClawHub
- Verify `dist/index.js` before upload
- Publish npm releases through OIDC
- Add release workflow regression coverage
- Carry the patch Changeset into beta.4

## Testing

- `npx vitest run test/clawhub-publish-workflow.test.ts`
- `npm run typecheck`
- `npm run build`
- Autoreview: no actionable findings