### PR TITLE
chore: prepare 1.0.0-beta.4

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "@martian-engineering/lossless-claw": "0.15.1"
   },
   "changesets": [
+    "clawhub-prebuilt-artifacts",
     "durable-turn-advancement",
     "legacy-bootstrap-diagnostics",
     "minimax-tui-provider",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @martian-engineering/lossless-claw
 
+## 1.0.0-beta.4
+
+<!-- release-rollback-version: 0.15.3 -->
+
+### Patch Changes
+
+- [#1102](https://github.com/Martian-Engineering/lossless-claw/pull/1102) [`c686ad1`](https://github.com/Martian-Engineering/lossless-claw/commit/c686ad1371b3187096f9e167424506dad2533460) Thanks [@jalehman](https://github.com/jalehman)! - Publish the built npm tarball through ClawHub so marketplace installs include the declared `dist/index.js` extension entrypoint.
+
 ## 1.0.0-beta.3
 
 <!-- release-rollback-version: 0.15.2 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Prepare `@martian-engineering/lossless-claw@1.0.0-beta.4` from the reviewed `next/1.0` release-artifact fix.

## Why

Beta.3 is missing `dist/index.js` in its ClawHub artifact. Beta.4 consumes the prebuilt-artifact Changeset and publishes through the corrected npm OIDC path.

## Changes

- Advance package metadata to beta.4
- Consume the ClawHub artifact Changeset
- Record stable rollback version 0.15.3
- Refresh package-lock release metadata

## Testing

- `npm run release:verify`
  - Typecheck, build, and 1,805 tests pass
  - Local TUI step cannot run because Go is unavailable
- `npm ci --package-lock-only --ignore-scripts`
- `npm pack` contains 23 files and `dist/index.js`
- `npx vitest run test/package-metadata.test.ts test/clawhub-publish-workflow.test.ts test/release-channel.test.ts`
- Autoreview: no actionable findings