### PR TITLE
fix: add an audited close path for inactive compaction debt

### DIFF
--- a/.changeset/close-inactive-maintenance-debt.md
+++ b/.changeset/close-inactive-maintenance-debt.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add read-only inactive compaction-debt diagnostics and a backup-first, explicitly confirmed administrative close command that preserves recall data.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The native OpenClaw command surface provides in-session operations:
 - `/lossless backup` creates a timestamped backup of the current LCM SQLite database
 - `/lossless rotate` rewrites the active session transcript into a compact tail-preserving form without changing the live OpenClaw session identity or current LCM conversation
 - `/lossless doctor` scans for broken or truncated summaries
+- `/lossless doctor maintenance` reports active actionable compaction debt separately from inactive historical debt, grouped by reason, without writing
+- `/lossless doctor apply maintenance <conversation-id> confirm-inactive` administratively closes one eligible inactive debt row after creating a SQLite backup
 - `/lossless doctor apply` repairs broken summaries in the current conversation after the normal safety preflight
 - `/lossless doctor apply <conversation-id> confirm-offline` repairs a specific conversation after its active channel path has been paused or moved away; targeted repair is restricted to authorized OpenClaw command senders and always requires the explicit offline confirmation
 - `/lossless doctor clean` shows read-only high-confidence junk diagnostics for archived subagents and cron sessions under every configured OpenClaw agent id, plus NULL-key orphaned subagent runs
@@ -66,6 +68,8 @@ Supported native command examples:
 - `/lossless backup`
 - `/lossless rotate`
 - `/lossless doctor`
+- `/lossless doctor maintenance`
+- `/lossless doctor apply maintenance 42 confirm-inactive`
 - `/lossless doctor apply 42 confirm-offline`
 - `/lossless doctor clean`
 - `/lcm`
@@ -78,6 +82,8 @@ The package does not register these OpenClaw root subcommands:
 - `openclaw /lcm`
 
 The bundled skill focuses on configuration, diagnostics, architecture, and recall-tool usage. Its reference set lives under `skills/lossless-claw/references/`.
+
+Deferred compaction debt on an active conversation is actionable maintenance pressure. Debt on an archived or otherwise inactive conversation is historical: normal stable-session maintenance cannot select that conversation, so `/lossless doctor maintenance` reports it separately and shows a bounded set of recent examples. Closing historical debt requires the exact `confirm-inactive` token and a successful file-backed SQLite backup. The close records an `operator-ignored` resolution on the maintenance row only; it does not run compaction and does not delete or rewrite conversations, messages, summaries, or context items. If that conversation later receives a genuine new debt request, the prior administrative resolution is cleared and the row becomes pending again.
 
 ### Programmatic control
 

--- a/skills/lossless-claw/references/diagnostics.md
+++ b/skills/lossless-claw/references/diagnostics.md
@@ -79,6 +79,18 @@ Use this only after `/lossless doctor` identifies broken summaries. The command 
 
 Conversation ids are gateway-wide maintenance identifiers rather than sender ownership credentials. Only authorized OpenClaw command senders can invoke the command; before targeting an id, pause or move active delivery away from that conversation and verify the displayed session key is the intended lane.
 
+### `/lossless doctor maintenance`
+
+Use this read-only scan to separate active actionable compaction debt from inactive historical debt. It groups pending rows by active state and reason and shows only a bounded set of recent inactive examples. The scan does not run maintenance or change database state.
+
+Normal stable-session maintenance selects active conversations, so pending debt attached to an archived conversation can remain historical even though its recall data is still valuable. To close one eligible row, run:
+
+`/lossless doctor apply maintenance <conversation-id> confirm-inactive`
+
+The target must be inactive, pending, and not running. The confirmation token must be exactly `confirm-inactive`, and Lossless Claw must successfully create a backup of a file-backed SQLite database before changing the maintenance row. Active, running, missing, already-resolved, non-pending, and in-memory targets are read-only refusals; repeating a successful close performs no work and creates no additional backup.
+
+This is an administrative `operator-ignored` resolution, not successful compaction. It changes only the compaction-maintenance row and does not delete or rewrite conversations, messages, summaries, or context items. A later genuine debt request clears the resolution metadata and makes the row actionable again.
+
 ### `/lossless doctor clean`
 
 Use this when the user wants read-only diagnostics for high-confidence junk patterns before any cleanup.

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -222,6 +222,9 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
     (col) => col.name === "resolution_reason",
   );
   const hasResolvedAt = maintenanceColumns.some((col) => col.name === "resolved_at");
+  const hasMaintenanceRevision = maintenanceColumns.some(
+    (col) => col.name === "maintenance_revision",
+  );
 
   if (!hasProjectedTokenCount) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
@@ -254,6 +257,11 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   }
   if (!hasResolvedAt) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN resolved_at TEXT`);
+  }
+  if (!hasMaintenanceRevision) {
+    db.exec(
+      `ALTER TABLE conversation_compaction_maintenance ADD COLUMN maintenance_revision INTEGER NOT NULL DEFAULT 0`,
+    );
   }
 }
 
@@ -1328,6 +1336,7 @@ export function runLcmMigrations(
       next_attempt_after TEXT,
       resolution_reason TEXT,
       resolved_at TEXT,
+      maintenance_revision INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -218,6 +218,10 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   const hasContextLeafChunkTokens = maintenanceColumns.some(
     (col) => col.name === "context_leaf_chunk_tokens",
   );
+  const hasResolutionReason = maintenanceColumns.some(
+    (col) => col.name === "resolution_reason",
+  );
+  const hasResolvedAt = maintenanceColumns.some((col) => col.name === "resolved_at");
 
   if (!hasProjectedTokenCount) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN projected_token_count INTEGER`);
@@ -244,6 +248,12 @@ function ensureCompactionMaintenanceColumns(db: DatabaseSync): void {
   }
   if (!hasContextLeafChunkTokens) {
     db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN context_leaf_chunk_tokens INTEGER`);
+  }
+  if (!hasResolutionReason) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN resolution_reason TEXT`);
+  }
+  if (!hasResolvedAt) {
+    db.exec(`ALTER TABLE conversation_compaction_maintenance ADD COLUMN resolved_at TEXT`);
   }
 }
 
@@ -1316,6 +1326,8 @@ export function runLcmMigrations(
       context_leaf_chunk_tokens INTEGER,
       retry_attempts INTEGER NOT NULL DEFAULT 0,
       next_attempt_after TEXT,
+      resolution_reason TEXT,
+      resolved_at TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -38,6 +38,11 @@ import {
   type RolloverSplitCounts,
   type RolloverSplitExample,
 } from "./lcm-doctor-rollover-splits.js";
+import {
+  closeInactiveCompactionMaintenanceDebt,
+  scanCompactionMaintenanceDebt,
+  type InactiveMaintenanceCloseResult,
+} from "./lcm-doctor-maintenance.js";
 import { scanLcmVersionCopies, type LcmVersionDoctorScan } from "./lcm-version-doctor.js";
 import {
   CompactionMaintenanceStore,
@@ -113,6 +118,8 @@ type ParsedLcmCommand =
   | { kind: "refocus" }
   | { kind: "unfocus" }
   | { kind: "doctor"; apply: boolean; applyOptions?: DoctorApplyOptions }
+  | { kind: "doctor_maintenance"; apply: false }
+  | { kind: "doctor_maintenance"; apply: true; conversationId: number; confirmed: boolean }
   | { kind: "doctor_rollover_splits"; apply: boolean; applyOptions?: RolloverSplitApplyOptions }
   | { kind: "doctor_cleaners"; apply: boolean; filterId?: DoctorCleanerId; vacuum: boolean }
   | { kind: "help"; error?: string };
@@ -584,6 +591,32 @@ function parseRolloverSplitApplyArgs(tokens: string[]):
   };
 }
 
+function parseMaintenanceApplyArgs(tokens: string[]):
+  | { ok: true; conversationId: number; confirmed: boolean }
+  | { ok: false; error: string } {
+  const conversationId = Number(tokens[0]);
+  const validConversationId =
+    tokens[0] !== undefined &&
+    Number.isSafeInteger(conversationId) &&
+    conversationId > 0 &&
+    String(conversationId) === tokens[0];
+  const validConfirmation =
+    tokens.length === 1 ||
+    (tokens.length === 2 && tokens[1] === "confirm-inactive");
+  if (!validConversationId || !validConfirmation) {
+    return {
+      ok: false,
+      error:
+        `\`${VISIBLE_COMMAND} doctor apply maintenance\` requires a positive conversation id followed by optional exact \`confirm-inactive\`.`,
+    };
+  }
+  return {
+    ok: true,
+    conversationId,
+    confirmed: tokens.length === 2,
+  };
+}
+
 function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
   const raw = (rawArgs ?? "").trim();
   if (raw === "") {
@@ -639,6 +672,9 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       if (rest.length === 1 && rest[0]?.toLowerCase() === "rollover-splits") {
         return { kind: "doctor_rollover_splits", apply: false };
       }
+      if (rest.length === 1 && rest[0]?.toLowerCase() === "maintenance") {
+        return { kind: "doctor_maintenance", apply: false };
+      }
       if (rest[0]?.toLowerCase() === "clean" && rest[1]?.toLowerCase() === "apply") {
         const parsedApply = parseDoctorCleanerApplyArgs(rest.slice(2));
         return parsedApply.ok
@@ -660,6 +696,17 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
             }
           : { kind: "help", error: parsedApply.error };
       }
+      if (rest[0]?.toLowerCase() === "apply" && rest[1]?.toLowerCase() === "maintenance") {
+        const parsedApply = parseMaintenanceApplyArgs(rest.slice(2));
+        return parsedApply.ok
+          ? {
+              kind: "doctor_maintenance",
+              apply: true,
+              conversationId: parsedApply.conversationId,
+              confirmed: parsedApply.confirmed,
+            }
+          : { kind: "help", error: parsedApply.error };
+      }
       if (rest[0]?.toLowerCase() === "apply") {
         const parsedApply = parseDoctorApplyArgs(rest.slice(1));
         return parsedApply.ok
@@ -669,7 +716,7 @@ function parseLcmCommand(rawArgs: string | undefined): ParsedLcmCommand {
       return {
         kind: "help",
         error:
-          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, \`apply [confirm-offline]\` for current-conversation repair, or \`apply <conversation-id> confirm-offline\` for targeted repair.`,
+          `\`${VISIBLE_COMMAND} doctor\` accepts no arguments, \`maintenance\` for compaction-debt diagnostics, \`apply maintenance <conversation-id> confirm-inactive\` for audited inactive-debt closure, \`rollover-splits\` for global rollover diagnostics, \`apply rollover-splits [confirm]\` for backup-first split repair, \`clean\` for global high-confidence junk diagnostics, \`clean apply [filter-id] [vacuum]\` for cleanup, \`apply [confirm-offline]\` for current-conversation repair, or \`apply <conversation-id> confirm-offline\` for targeted repair.`,
       };
     case "help":
       return { kind: "help" };
@@ -1331,6 +1378,16 @@ function buildHelpText(error?: string): string {
       ),
       buildStatLine(formatCommand(`${VISIBLE_COMMAND} doctor`), "Scan for broken or truncated summaries."),
       buildStatLine(
+        formatCommand(`${VISIBLE_COMMAND} doctor maintenance`),
+        "Report active actionable and inactive historical compaction debt without writing.",
+      ),
+      buildStatLine(
+        formatCommand(
+          `${VISIBLE_COMMAND} doctor apply maintenance <conversation-id> confirm-inactive`,
+        ),
+        "Administratively close eligible inactive debt after creating a DB backup; recall data is preserved.",
+      ),
+      buildStatLine(
         formatCommand(`${VISIBLE_COMMAND} doctor rollover-splits`),
         "Report whole-DB fresh-transcript rollover split memory.",
       ),
@@ -1607,6 +1664,134 @@ async function buildDoctorText(params: {
     );
   }
 
+  return lines.join("\n");
+}
+
+function buildMaintenanceDoctorText(db: DatabaseSync): string {
+  const scan = scanCompactionMaintenanceDebt(db);
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🩺 Lossless Claw Maintenance Doctor",
+    "",
+    buildSection("📊 Pending compaction debt", [
+      buildStatLine("active actionable debt", formatNumber(scan.activeCount)),
+      buildStatLine("inactive historical debt", formatNumber(scan.inactiveCount)),
+      buildStatLine("mode", "read-only scan; no maintenance state changed"),
+    ]),
+  ];
+
+  if (scan.reasonCounts.length > 0) {
+    lines.push(
+      "",
+      buildSection(
+        "🧭 By state and reason",
+        scan.reasonCounts.map(
+          (entry) =>
+            `${entry.active ? "active" : "inactive"} / ${entry.reason}: ${formatNumber(entry.count)}`,
+        ),
+      ),
+    );
+  }
+
+  if (scan.inactiveExamples.length > 0) {
+    const examples = scan.inactiveExamples.map((example) => {
+      const sessionKey = example.sessionKey
+        ? formatCommand(truncateMiddle(example.sessionKey, 44))
+        : "missing";
+      const requestedAt = example.requestedAt?.toISOString() ?? "unknown";
+      return `conversation ${formatNumber(example.conversationId)} · ${example.reason} · requested ${requestedAt} · session key ${sessionKey}`;
+    });
+    if (scan.inactiveExamplesOmitted > 0) {
+      examples.push(`... ${formatNumber(scan.inactiveExamplesOmitted)} more inactive row(s)`);
+    }
+    lines.push("", buildSection("🧷 Inactive examples", examples));
+  }
+
+  if (scan.inactiveCount > 0) {
+    lines.push(
+      "",
+      buildSection("🛠️ Administrative close", [
+        `${formatCommand(`${VISIBLE_COMMAND} doctor apply maintenance <conversation-id> confirm-inactive`)} closes one eligible inactive debt row after creating a database backup.`,
+        "This records an operator-ignored resolution; it does not claim compaction completed and does not compact or delete recall data.",
+      ]),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function describeMaintenanceCloseRefusal(
+  result: Extract<InactiveMaintenanceCloseResult, { kind: "refused" }>,
+): string {
+  switch (result.reason) {
+    case "missing-confirmation":
+      return "The close requires exact `confirm-inactive`; no backup or write ran.";
+    case "active-conversation":
+      return "Refused because the conversation is active; active debt remains actionable.";
+    case "running":
+      return "Refused because maintenance is running; no maintenance state changed.";
+    case "conversation-not-found":
+      return "Refused because the conversation was not found; no maintenance state changed.";
+    case "already-resolved":
+      return "The maintenance debt is already resolved; no work performed and no backup created.";
+    case "not-pending":
+      return "Refused because the conversation has no pending maintenance debt; no work performed.";
+    case "backup-unavailable":
+      return "Refused because a successful backup requires a file-backed SQLite database.";
+    case "backup-failed":
+      return `Refused because the database backup failed: ${result.error ?? "unknown error"}`;
+    case "state-changed":
+      return "Refused because maintenance or conversation state changed before the guarded close; no maintenance row was changed.";
+    case "close-failed":
+      return `Refused because the guarded maintenance close failed: ${result.error ?? "unknown error"}`;
+  }
+}
+
+async function buildMaintenanceDoctorApplyText(params: {
+  db: DatabaseSync;
+  config: LcmConfig;
+  conversationId: number;
+  confirmed: boolean;
+}): Promise<string> {
+  const result = await closeInactiveCompactionMaintenanceDebt({
+    db: params.db,
+    databasePath: params.config.databasePath,
+    conversationId: params.conversationId,
+    confirmed: params.confirmed,
+  });
+  const lines = [
+    ...buildHeaderLines(),
+    "",
+    "🩺 Lossless Claw Maintenance Close",
+    "",
+  ];
+
+  if (result.kind === "refused") {
+    lines.push(
+      buildSection("⛔ Result", [
+        buildStatLine("status", "read-only refusal"),
+        buildStatLine("conversation", formatNumber(params.conversationId)),
+        buildStatLine("reason", describeMaintenanceCloseRefusal(result)),
+        ...(result.backupPath ? [buildStatLine("backup path", result.backupPath)] : []),
+      ]),
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    buildSection("✅ Result", [
+      buildStatLine("status", "administratively closed"),
+      buildStatLine("conversation", formatNumber(result.conversationId)),
+      buildStatLine("resolution", "operator-ignored"),
+      buildStatLine("resolved at", result.resolvedAt.toISOString()),
+      buildStatLine("backup path", result.backupPath),
+      buildStatLine(
+        "recall data",
+        "preserved; this did not compact or delete recall data",
+      ),
+    ]),
+  );
   return lines.join("\n");
 }
 
@@ -3395,6 +3580,17 @@ export function createLcmCommand(params: {
                   activeSourcePath: params.activeSourcePath,
                 }),
               };
+        case "doctor_maintenance":
+          return parsed.apply
+            ? {
+                text: await buildMaintenanceDoctorApplyText({
+                  db: await getDb(),
+                  config: params.config,
+                  conversationId: parsed.conversationId,
+                  confirmed: parsed.confirmed,
+                }),
+              }
+            : { text: buildMaintenanceDoctorText(await getDb()) };
         case "doctor_rollover_splits":
           return parsed.apply
             ? {

--- a/src/plugin/lcm-doctor-maintenance.ts
+++ b/src/plugin/lcm-doctor-maintenance.ts
@@ -23,6 +23,7 @@ type MaintenanceTargetRow = {
   pending: number | null;
   running: number | null;
   resolution_reason: string | null;
+  maintenance_revision: number | null;
 };
 
 export type MaintenanceDebtReasonCount = {
@@ -146,7 +147,8 @@ function loadMaintenanceTarget(
            conversations.active,
            maintenance.pending,
            maintenance.running,
-           maintenance.resolution_reason
+           maintenance.resolution_reason,
+           maintenance.maintenance_revision
          FROM conversations
          LEFT JOIN conversation_compaction_maintenance maintenance
            ON maintenance.conversation_id = conversations.conversation_id
@@ -178,9 +180,8 @@ export async function closeInactiveCompactionMaintenanceDebt(params: {
     return { kind: "refused", reason: "missing-confirmation" };
   }
 
-  const refusalReason = getTargetRefusalReason(
-    loadMaintenanceTarget(params.db, params.conversationId),
-  );
+  const target = loadMaintenanceTarget(params.db, params.conversationId);
+  const refusalReason = getTargetRefusalReason(target);
   if (refusalReason) {
     return { kind: "refused", reason: refusalReason };
   }
@@ -207,6 +208,7 @@ export async function closeInactiveCompactionMaintenanceDebt(params: {
   try {
     closed = await new CompactionMaintenanceStore(params.db).closeInactiveCompactionDebt({
       conversationId: params.conversationId,
+      expectedRevision: target?.maintenance_revision ?? 0,
       resolvedAt,
     });
   } catch (error) {

--- a/src/plugin/lcm-doctor-maintenance.ts
+++ b/src/plugin/lcm-doctor-maintenance.ts
@@ -1,0 +1,230 @@
+import type { DatabaseSync } from "node:sqlite";
+import { parseUtcTimestampOrNull } from "../store/parse-utc-timestamp.js";
+import { CompactionMaintenanceStore } from "../store/compaction-maintenance-store.js";
+import { createLcmDatabaseBackup } from "./lcm-db-backup.js";
+
+const INACTIVE_EXAMPLE_LIMIT = 5;
+
+type MaintenanceReasonCountRow = {
+  active: number;
+  reason: string;
+  count: number;
+};
+
+type InactiveMaintenanceExampleRow = {
+  conversation_id: number;
+  session_key: string | null;
+  reason: string;
+  requested_at: string | null;
+};
+
+type MaintenanceTargetRow = {
+  active: number;
+  pending: number | null;
+  running: number | null;
+  resolution_reason: string | null;
+};
+
+export type MaintenanceDebtReasonCount = {
+  active: boolean;
+  reason: string;
+  count: number;
+};
+
+export type InactiveMaintenanceDebtExample = {
+  conversationId: number;
+  sessionKey: string | null;
+  reason: string;
+  requestedAt: Date | null;
+};
+
+export type MaintenanceDebtScan = {
+  activeCount: number;
+  inactiveCount: number;
+  reasonCounts: MaintenanceDebtReasonCount[];
+  inactiveExamples: InactiveMaintenanceDebtExample[];
+  inactiveExamplesOmitted: number;
+};
+
+export type InactiveMaintenanceCloseResult =
+  | {
+      kind: "applied";
+      conversationId: number;
+      backupPath: string;
+      resolvedAt: Date;
+    }
+  | {
+      kind: "refused";
+      reason:
+        | "missing-confirmation"
+        | "active-conversation"
+        | "running"
+        | "conversation-not-found"
+        | "already-resolved"
+        | "not-pending"
+        | "backup-unavailable"
+        | "backup-failed"
+        | "state-changed"
+        | "close-failed";
+      backupPath?: string;
+      error?: string;
+    };
+
+/** Read-only global scan of pending compaction debt grouped by conversation activity. */
+export function scanCompactionMaintenanceDebt(
+  db: DatabaseSync,
+  options?: { inactiveExampleLimit?: number },
+): MaintenanceDebtScan {
+  const reasonRows = db
+    .prepare(
+      `SELECT
+         conversations.active,
+         COALESCE(NULLIF(TRIM(maintenance.reason), ''), 'reason unknown') AS reason,
+         COUNT(*) AS count
+       FROM conversation_compaction_maintenance maintenance
+       JOIN conversations
+         ON conversations.conversation_id = maintenance.conversation_id
+       WHERE maintenance.pending = 1
+       GROUP BY conversations.active, COALESCE(NULLIF(TRIM(maintenance.reason), ''), 'reason unknown')
+       ORDER BY conversations.active DESC, reason ASC`,
+    )
+    .all() as MaintenanceReasonCountRow[];
+  const requestedLimit = options?.inactiveExampleLimit ?? INACTIVE_EXAMPLE_LIMIT;
+  const inactiveExampleLimit = Number.isFinite(requestedLimit)
+    ? Math.max(0, Math.floor(requestedLimit))
+    : INACTIVE_EXAMPLE_LIMIT;
+  const inactiveRows = db
+    .prepare(
+      `SELECT
+         maintenance.conversation_id,
+         conversations.session_key,
+         COALESCE(NULLIF(TRIM(maintenance.reason), ''), 'reason unknown') AS reason,
+         maintenance.requested_at
+       FROM conversation_compaction_maintenance maintenance
+       JOIN conversations
+         ON conversations.conversation_id = maintenance.conversation_id
+       WHERE maintenance.pending = 1
+         AND conversations.active = 0
+       ORDER BY maintenance.requested_at DESC, maintenance.conversation_id DESC
+       LIMIT ?`,
+    )
+    .all(inactiveExampleLimit) as InactiveMaintenanceExampleRow[];
+  const reasonCounts = reasonRows.map((row) => ({
+    active: row.active === 1,
+    reason: row.reason,
+    count: row.count,
+  }));
+  const activeCount = reasonCounts
+    .filter((row) => row.active)
+    .reduce((total, row) => total + row.count, 0);
+  const inactiveCount = reasonCounts
+    .filter((row) => !row.active)
+    .reduce((total, row) => total + row.count, 0);
+
+  return {
+    activeCount,
+    inactiveCount,
+    reasonCounts,
+    inactiveExamples: inactiveRows.map((row) => ({
+      conversationId: row.conversation_id,
+      sessionKey: row.session_key,
+      reason: row.reason,
+      requestedAt: parseUtcTimestampOrNull(row.requested_at),
+    })),
+    inactiveExamplesOmitted: Math.max(0, inactiveCount - inactiveRows.length),
+  };
+}
+
+function loadMaintenanceTarget(
+  db: DatabaseSync,
+  conversationId: number,
+): MaintenanceTargetRow | null {
+  return (
+    (db
+      .prepare(
+        `SELECT
+           conversations.active,
+           maintenance.pending,
+           maintenance.running,
+           maintenance.resolution_reason
+         FROM conversations
+         LEFT JOIN conversation_compaction_maintenance maintenance
+           ON maintenance.conversation_id = conversations.conversation_id
+         WHERE conversations.conversation_id = ?`,
+      )
+      .get(conversationId) as MaintenanceTargetRow | undefined) ?? null
+  );
+}
+
+function getTargetRefusalReason(
+  target: MaintenanceTargetRow | null,
+): Extract<InactiveMaintenanceCloseResult, { kind: "refused" }>["reason"] | null {
+  if (!target) return "conversation-not-found";
+  if (target.active === 1) return "active-conversation";
+  if (target.running === 1) return "running";
+  if (target.pending === 1) return null;
+  if (target.resolution_reason === "operator-ignored") return "already-resolved";
+  return "not-pending";
+}
+
+/** Backup-first administrative close for one eligible inactive maintenance row. */
+export async function closeInactiveCompactionMaintenanceDebt(params: {
+  db: DatabaseSync;
+  databasePath: string;
+  conversationId: number;
+  confirmed: boolean;
+}): Promise<InactiveMaintenanceCloseResult> {
+  if (!params.confirmed) {
+    return { kind: "refused", reason: "missing-confirmation" };
+  }
+
+  const refusalReason = getTargetRefusalReason(
+    loadMaintenanceTarget(params.db, params.conversationId),
+  );
+  if (refusalReason) {
+    return { kind: "refused", reason: refusalReason };
+  }
+
+  let backupPath: string | null;
+  try {
+    backupPath = createLcmDatabaseBackup(params.db, {
+      databasePath: params.databasePath,
+      label: `maintenance-close-${params.conversationId}`,
+    });
+  } catch (error) {
+    return {
+      kind: "refused",
+      reason: "backup-failed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (!backupPath) {
+    return { kind: "refused", reason: "backup-unavailable" };
+  }
+
+  const resolvedAt = new Date();
+  let closed: boolean;
+  try {
+    closed = await new CompactionMaintenanceStore(params.db).closeInactiveCompactionDebt({
+      conversationId: params.conversationId,
+      resolvedAt,
+    });
+  } catch (error) {
+    return {
+      kind: "refused",
+      reason: "close-failed",
+      backupPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (!closed) {
+    return { kind: "refused", reason: "state-changed", backupPath };
+  }
+
+  return {
+    kind: "applied",
+    conversationId: params.conversationId,
+    backupPath,
+    resolvedAt,
+  };
+}

--- a/src/plugin/lcm-doctor-rollover-splits.ts
+++ b/src/plugin/lcm-doctor-rollover-splits.ts
@@ -528,6 +528,9 @@ function clearSourceStateAndMarkTarget(db: DatabaseSync, group: SafeGroup): void
        requested_at = datetime('now'),
        reason = excluded.reason,
        running = 0,
+       resolution_reason = NULL,
+       resolved_at = NULL,
+       maintenance_revision = conversation_compaction_maintenance.maintenance_revision + 1,
        updated_at = datetime('now')`,
   ).run(group.targetConversationId, ROLLOVER_SPLIT_MAINTENANCE_REASON);
 }

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -21,6 +21,8 @@ export type ConversationCompactionMaintenanceRecord = {
   contextLeafChunkTokens: number | null;
   retryAttempts: number;
   nextAttemptAfter: Date | null;
+  resolutionReason: "operator-ignored" | null;
+  resolvedAt: Date | null;
   updatedAt: Date;
 };
 
@@ -43,6 +45,8 @@ type ConversationCompactionMaintenanceRow = {
   context_leaf_chunk_tokens: number | null;
   retry_attempts: number;
   next_attempt_after: string | null;
+  resolution_reason: string | null;
+  resolved_at: string | null;
   updated_at: string;
 };
 
@@ -105,6 +109,8 @@ function toMaintenanceRecord(
         ? Math.max(0, Math.floor(row.retry_attempts))
         : 0,
     nextAttemptAfter: parseUtcTimestampOrNull(row.next_attempt_after),
+    resolutionReason: row.resolution_reason === "operator-ignored" ? row.resolution_reason : null,
+    resolvedAt: parseUtcTimestampOrNull(row.resolved_at),
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -163,6 +169,11 @@ function mergeMaintenanceRecord(
       patch.nextAttemptAfter !== undefined
         ? patch.nextAttemptAfter
         : existing?.nextAttemptAfter ?? null,
+    resolutionReason:
+      patch.resolutionReason !== undefined
+        ? patch.resolutionReason
+        : existing?.resolutionReason ?? null,
+    resolvedAt: patch.resolvedAt !== undefined ? patch.resolvedAt : existing?.resolvedAt ?? null,
     updatedAt: new Date(),
   };
 }
@@ -207,6 +218,8 @@ export class CompactionMaintenanceStore {
            context_leaf_chunk_tokens,
            retry_attempts,
            next_attempt_after,
+           resolution_reason,
+           resolved_at,
            updated_at
          FROM conversation_compaction_maintenance
          WHERE conversation_id = ?`,
@@ -239,8 +252,10 @@ export class CompactionMaintenanceStore {
            context_leaf_chunk_tokens,
            retry_attempts,
            next_attempt_after,
+           resolution_reason,
+           resolved_at,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -259,6 +274,8 @@ export class CompactionMaintenanceStore {
            context_leaf_chunk_tokens = excluded.context_leaf_chunk_tokens,
            retry_attempts = excluded.retry_attempts,
            next_attempt_after = excluded.next_attempt_after,
+           resolution_reason = excluded.resolution_reason,
+           resolved_at = excluded.resolved_at,
            updated_at = datetime('now')`,
       )
       .run(
@@ -280,6 +297,8 @@ export class CompactionMaintenanceStore {
         record.contextLeafChunkTokens ?? null,
         record.retryAttempts,
         record.nextAttemptAfter?.toISOString() ?? null,
+        record.resolutionReason,
+        record.resolvedAt?.toISOString() ?? null,
       );
   }
 
@@ -316,8 +335,37 @@ export class CompactionMaintenanceStore {
         contextThresholdSource: input.contextThresholdSource ?? null,
         contextFreshTailCount: input.contextFreshTailCount ?? null,
         contextLeafChunkTokens: input.contextLeafChunkTokens ?? null,
+        resolutionReason: null,
+        resolvedAt: null,
       }),
     );
+  }
+
+  /** Administratively close pending debt only when its conversation is inactive. */
+  async closeInactiveCompactionDebt(input: {
+    conversationId: number;
+    resolvedAt?: Date;
+  }): Promise<boolean> {
+    const result = this.db
+      .prepare(
+        `UPDATE conversation_compaction_maintenance
+         SET pending = 0,
+             running = 0,
+             resolution_reason = 'operator-ignored',
+             resolved_at = ?,
+             updated_at = datetime('now')
+         WHERE conversation_id = ?
+           AND pending = 1
+           AND running = 0
+           AND EXISTS (
+             SELECT 1
+             FROM conversations
+             WHERE conversations.conversation_id = conversation_compaction_maintenance.conversation_id
+               AND conversations.active = 0
+           )`,
+      )
+      .run((input.resolvedAt ?? new Date()).toISOString(), input.conversationId);
+    return Number(result.changes) === 1;
   }
 
   /** Mark deferred proactive compaction as actively running. */

--- a/src/store/compaction-maintenance-store.ts
+++ b/src/store/compaction-maintenance-store.ts
@@ -23,6 +23,7 @@ export type ConversationCompactionMaintenanceRecord = {
   nextAttemptAfter: Date | null;
   resolutionReason: "operator-ignored" | null;
   resolvedAt: Date | null;
+  maintenanceRevision: number;
   updatedAt: Date;
 };
 
@@ -47,6 +48,7 @@ type ConversationCompactionMaintenanceRow = {
   next_attempt_after: string | null;
   resolution_reason: string | null;
   resolved_at: string | null;
+  maintenance_revision: number;
   updated_at: string;
 };
 
@@ -111,6 +113,7 @@ function toMaintenanceRecord(
     nextAttemptAfter: parseUtcTimestampOrNull(row.next_attempt_after),
     resolutionReason: row.resolution_reason === "operator-ignored" ? row.resolution_reason : null,
     resolvedAt: parseUtcTimestampOrNull(row.resolved_at),
+    maintenanceRevision: Math.max(0, Math.floor(row.maintenance_revision)),
     updatedAt: parseUtcTimestampOrNull(row.updated_at) ?? new Date(0),
   };
 }
@@ -174,6 +177,10 @@ function mergeMaintenanceRecord(
         ? patch.resolutionReason
         : existing?.resolutionReason ?? null,
     resolvedAt: patch.resolvedAt !== undefined ? patch.resolvedAt : existing?.resolvedAt ?? null,
+    maintenanceRevision:
+      patch.maintenanceRevision !== undefined
+        ? Math.max(0, Math.floor(patch.maintenanceRevision))
+        : existing?.maintenanceRevision ?? 0,
     updatedAt: new Date(),
   };
 }
@@ -220,6 +227,7 @@ export class CompactionMaintenanceStore {
            next_attempt_after,
            resolution_reason,
            resolved_at,
+           maintenance_revision,
            updated_at
          FROM conversation_compaction_maintenance
          WHERE conversation_id = ?`,
@@ -254,8 +262,9 @@ export class CompactionMaintenanceStore {
            next_attempt_after,
            resolution_reason,
            resolved_at,
+           maintenance_revision,
            updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
          ON CONFLICT(conversation_id) DO UPDATE SET
            pending = excluded.pending,
            requested_at = excluded.requested_at,
@@ -276,6 +285,7 @@ export class CompactionMaintenanceStore {
            next_attempt_after = excluded.next_attempt_after,
            resolution_reason = excluded.resolution_reason,
            resolved_at = excluded.resolved_at,
+           maintenance_revision = conversation_compaction_maintenance.maintenance_revision + 1,
            updated_at = datetime('now')`,
       )
       .run(
@@ -299,6 +309,7 @@ export class CompactionMaintenanceStore {
         record.nextAttemptAfter?.toISOString() ?? null,
         record.resolutionReason,
         record.resolvedAt?.toISOString() ?? null,
+        record.maintenanceRevision,
       );
   }
 
@@ -344,6 +355,7 @@ export class CompactionMaintenanceStore {
   /** Administratively close pending debt only when its conversation is inactive. */
   async closeInactiveCompactionDebt(input: {
     conversationId: number;
+    expectedRevision: number;
     resolvedAt?: Date;
   }): Promise<boolean> {
     const result = this.db
@@ -353,8 +365,10 @@ export class CompactionMaintenanceStore {
              running = 0,
              resolution_reason = 'operator-ignored',
              resolved_at = ?,
+             maintenance_revision = maintenance_revision + 1,
              updated_at = datetime('now')
          WHERE conversation_id = ?
+           AND maintenance_revision = ?
            AND pending = 1
            AND running = 0
            AND EXISTS (
@@ -364,7 +378,11 @@ export class CompactionMaintenanceStore {
                AND conversations.active = 0
            )`,
       )
-      .run((input.resolvedAt ?? new Date()).toISOString(), input.conversationId);
+      .run(
+        (input.resolvedAt ?? new Date()).toISOString(),
+        input.conversationId,
+        input.expectedRevision,
+      );
     return Number(result.changes) === 1;
   }
 

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -250,16 +250,20 @@ describe("CompactionMaintenanceStore", () => {
       reason: "budget-trigger",
     });
     await conversationStore.archiveConversation(inactive.conversationId, "rollover-fallback");
+    const activeMaintenance = await store.getConversationCompactionMaintenance(active.conversationId);
+    const inactiveMaintenance = await store.getConversationCompactionMaintenance(inactive.conversationId);
 
     await expect(
       store.closeInactiveCompactionDebt({
         conversationId: active.conversationId,
+        expectedRevision: activeMaintenance!.maintenanceRevision,
         resolvedAt,
       }),
     ).resolves.toBe(false);
     await expect(
       store.closeInactiveCompactionDebt({
         conversationId: inactive.conversationId,
+        expectedRevision: inactiveMaintenance!.maintenanceRevision,
         resolvedAt,
       }),
     ).resolves.toBe(true);
@@ -275,6 +279,7 @@ describe("CompactionMaintenanceStore", () => {
     await expect(
       store.closeInactiveCompactionDebt({
         conversationId: inactive.conversationId,
+        expectedRevision: inactiveMaintenance!.maintenanceRevision,
         resolvedAt: new Date("2026-08-20T13:00:00.000Z"),
       }),
     ).resolves.toBe(false);
@@ -289,6 +294,49 @@ describe("CompactionMaintenanceStore", () => {
       reason: "fresh-threshold",
       resolutionReason: null,
       resolvedAt: null,
+    });
+  });
+
+  it("refuses a stale close after debt is refreshed with the same timestamp and reason", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-refreshed-session",
+      sessionKey: "agent:main:maintenance-store:refreshed",
+    });
+    const store = new CompactionMaintenanceStore(db);
+    const requestedAt = new Date("2026-08-20T12:00:00.000Z");
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      requestedAt,
+    });
+    await conversationStore.archiveConversation(conversation.conversationId, "rollover-fallback");
+    const staleRevision = (
+      await store.getConversationCompactionMaintenance(conversation.conversationId)
+    )!.maintenanceRevision;
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      requestedAt,
+    });
+
+    await expect(
+      store.closeInactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        expectedRevision: staleRevision,
+      }),
+    ).resolves.toBe(false);
+    expect(await store.getConversationCompactionMaintenance(conversation.conversationId)).toMatchObject({
+      pending: true,
+      running: false,
+      reason: "threshold",
+      resolutionReason: null,
+      resolvedAt: null,
+      maintenanceRevision: staleRevision + 1,
     });
   });
 
@@ -310,9 +358,13 @@ describe("CompactionMaintenanceStore", () => {
     db.prepare(
       `UPDATE conversation_compaction_maintenance SET running = 1 WHERE conversation_id = ?`,
     ).run(conversation.conversationId);
+    const maintenance = await store.getConversationCompactionMaintenance(conversation.conversationId);
 
     await expect(
-      store.closeInactiveCompactionDebt({ conversationId: conversation.conversationId }),
+      store.closeInactiveCompactionDebt({
+        conversationId: conversation.conversationId,
+        expectedRevision: maintenance!.maintenanceRevision,
+      }),
     ).resolves.toBe(false);
     expect(await store.getConversationCompactionMaintenance(conversation.conversationId)).toMatchObject({
       pending: true,

--- a/test/compaction-maintenance-store.test.ts
+++ b/test/compaction-maintenance-store.test.ts
@@ -225,4 +225,100 @@ describe("CompactionMaintenanceStore", () => {
     expect(record?.retryAttempts).toBe(0);
     expect(record?.nextAttemptAfter).toBeNull();
   });
+
+  it("closes only inactive pending debt and clears the resolution when fresh debt is requested", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const inactive = await conversationStore.createConversation({
+      sessionId: "maintenance-store-inactive-session",
+      sessionKey: "agent:main:maintenance-store:inactive",
+    });
+    const active = await conversationStore.createConversation({
+      sessionId: "maintenance-store-active-session",
+      sessionKey: "agent:main:maintenance-store:active",
+    });
+    const store = new CompactionMaintenanceStore(db);
+    const resolvedAt = new Date("2026-08-20T12:00:00.000Z");
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: inactive.conversationId,
+      reason: "threshold",
+    });
+    await store.requestProactiveCompactionDebt({
+      conversationId: active.conversationId,
+      reason: "budget-trigger",
+    });
+    await conversationStore.archiveConversation(inactive.conversationId, "rollover-fallback");
+
+    await expect(
+      store.closeInactiveCompactionDebt({
+        conversationId: active.conversationId,
+        resolvedAt,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      store.closeInactiveCompactionDebt({
+        conversationId: inactive.conversationId,
+        resolvedAt,
+      }),
+    ).resolves.toBe(true);
+
+    expect(await store.getConversationCompactionMaintenance(inactive.conversationId)).toMatchObject({
+      pending: false,
+      running: false,
+      reason: "threshold",
+      resolutionReason: "operator-ignored",
+      resolvedAt,
+    });
+
+    await expect(
+      store.closeInactiveCompactionDebt({
+        conversationId: inactive.conversationId,
+        resolvedAt: new Date("2026-08-20T13:00:00.000Z"),
+      }),
+    ).resolves.toBe(false);
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: inactive.conversationId,
+      reason: "fresh-threshold",
+    });
+    expect(await store.getConversationCompactionMaintenance(inactive.conversationId)).toMatchObject({
+      pending: true,
+      running: false,
+      reason: "fresh-threshold",
+      resolutionReason: null,
+      resolvedAt: null,
+    });
+  });
+
+  it("refuses to close a running inactive maintenance row", async () => {
+    const db = createTestDb();
+    const { fts5Available } = getLcmDbFeatures(db);
+    const conversationStore = new ConversationStore(db, { fts5Available });
+    const conversation = await conversationStore.createConversation({
+      sessionId: "maintenance-store-running-session",
+      sessionKey: "agent:main:maintenance-store:running",
+    });
+    const store = new CompactionMaintenanceStore(db);
+
+    await store.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+    await conversationStore.archiveConversation(conversation.conversationId, "rollover-fallback");
+    db.prepare(
+      `UPDATE conversation_compaction_maintenance SET running = 1 WHERE conversation_id = ?`,
+    ).run(conversation.conversationId);
+
+    await expect(
+      store.closeInactiveCompactionDebt({ conversationId: conversation.conversationId }),
+    ).resolves.toBe(false);
+    expect(await store.getConversationCompactionMaintenance(conversation.conversationId)).toMatchObject({
+      pending: true,
+      running: true,
+      resolutionReason: null,
+      resolvedAt: null,
+    });
+  });
 });

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -11,6 +11,7 @@ import { resolveLcmConfig } from "../src/db/config.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { FocusBriefStore } from "../src/store/focus-brief-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
+import { CompactionMaintenanceStore } from "../src/store/compaction-maintenance-store.js";
 import {
   LcmProgrammaticControlUnavailableError,
   createLcmCommand,
@@ -3612,6 +3613,279 @@ describe("lcm command", () => {
     expect(repaired?.content).not.toContain("[Truncated from 111 tokens]");
   });
 
+  it("reports active and inactive maintenance debt by reason without writing", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const maintenanceStore = new CompactionMaintenanceStore(fixture.db);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-active",
+      sessionKey: "agent:main:doctor-maintenance:active",
+    });
+    const inactiveThreshold = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-inactive-threshold",
+      sessionKey: "agent:main:doctor-maintenance:inactive-threshold",
+    });
+    const inactiveBudget = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-inactive-budget",
+      sessionKey: "agent:main:doctor-maintenance:inactive-budget",
+    });
+
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: active.conversationId,
+      reason: "threshold",
+    });
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: inactiveThreshold.conversationId,
+      reason: "threshold",
+    });
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: inactiveBudget.conversationId,
+      reason: "budget-trigger",
+    });
+    await fixture.conversationStore.archiveConversation(
+      inactiveThreshold.conversationId,
+      "rollover-fallback",
+    );
+    await fixture.conversationStore.archiveConversation(
+      inactiveBudget.conversationId,
+      "rollover-fallback",
+    );
+    for (let index = 0; index < 4; index += 1) {
+      const extra = await fixture.conversationStore.createConversation({
+        sessionId: `doctor-maintenance-inactive-extra-${index}`,
+        sessionKey: `agent:main:doctor-maintenance:inactive-extra-${index}`,
+      });
+      await maintenanceStore.requestProactiveCompactionDebt({
+        conversationId: extra.conversationId,
+        reason: "threshold",
+      });
+      await fixture.conversationStore.archiveConversation(extra.conversationId, "rollover-fallback");
+    }
+    const before = fixture.db
+      .prepare(`SELECT * FROM conversation_compaction_maintenance ORDER BY conversation_id`)
+      .all();
+
+    const result = await fixture.command.handler(createCommandContext("doctor maintenance"));
+
+    expect(result.text).toContain("active actionable debt: 1");
+    expect(result.text).toContain("inactive historical debt: 6");
+    expect(result.text).toContain("active / threshold: 1");
+    expect(result.text).toContain("inactive / threshold: 5");
+    expect(result.text).toContain("inactive / budget-trigger: 1");
+    expect(result.text.match(/conversation \d+/g)).toHaveLength(5);
+    expect(result.text).toContain("... 1 more inactive row(s)");
+    expect(result.text).toContain("read-only scan; no maintenance state changed");
+    expect(
+      fixture.db.prepare(`SELECT * FROM conversation_compaction_maintenance ORDER BY conversation_id`).all(),
+    ).toEqual(before);
+  });
+
+  it("closes inactive maintenance debt after exact confirmation and a backup without changing recall data", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const maintenanceStore = new CompactionMaintenanceStore(fixture.db);
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-apply",
+      sessionKey: "agent:main:doctor-maintenance:apply",
+    });
+    const message = await fixture.conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 0,
+      role: "user",
+      content: "valuable archived recall",
+      tokenCount: 4,
+    });
+    await fixture.summaryStore.insertSummary({
+      summaryId: "sum_doctor_maintenance_apply",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      content: "valuable summary",
+      tokenCount: 2,
+      sourceMessageTokenCount: 4,
+    });
+    await fixture.summaryStore.linkSummaryToMessages("sum_doctor_maintenance_apply", [message.messageId]);
+    await fixture.summaryStore.appendContextSummary(
+      conversation.conversationId,
+      "sum_doctor_maintenance_apply",
+    );
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+    await fixture.conversationStore.archiveConversation(conversation.conversationId, "rollover-fallback");
+    const countsBefore = fixture.db
+      .prepare(
+        `SELECT
+           (SELECT COUNT(*) FROM conversations) AS conversations,
+           (SELECT COUNT(*) FROM messages) AS messages,
+           (SELECT COUNT(*) FROM summaries) AS summaries,
+           (SELECT COUNT(*) FROM context_items) AS context_items`,
+      )
+      .get();
+
+    const missingConfirmation = await fixture.command.handler(
+      createCommandContext(`doctor apply maintenance ${conversation.conversationId}`),
+    );
+    expect(missingConfirmation.text).toContain("requires exact `confirm-inactive`");
+    expect(readdirSync(fixture.tempDir).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+
+    const applied = await fixture.command.handler(
+      createCommandContext(
+        `doctor apply maintenance ${conversation.conversationId} confirm-inactive`,
+      ),
+    );
+    const backupPath = applied.text.match(/backup path: (.+)/)?.[1]?.trim();
+    expect(applied.text).toContain("administratively closed");
+    expect(applied.text).toContain("did not compact or delete recall data");
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
+    expect(await maintenanceStore.getConversationCompactionMaintenance(conversation.conversationId)).toMatchObject({
+      pending: false,
+      running: false,
+      reason: "threshold",
+      resolutionReason: "operator-ignored",
+    });
+    expect(
+      fixture.db
+        .prepare(
+          `SELECT
+             (SELECT COUNT(*) FROM conversations) AS conversations,
+             (SELECT COUNT(*) FROM messages) AS messages,
+             (SELECT COUNT(*) FROM summaries) AS summaries,
+             (SELECT COUNT(*) FROM context_items) AS context_items`,
+        )
+        .get(),
+    ).toEqual(countsBefore);
+
+    const repeated = await fixture.command.handler(
+      createCommandContext(
+        `doctor apply maintenance ${conversation.conversationId} confirm-inactive`,
+      ),
+    );
+    expect(repeated.text).toContain("already resolved; no work performed");
+    expect(readdirSync(fixture.tempDir).filter((name) => name.endsWith(".bak"))).toHaveLength(1);
+  });
+
+  it("refuses active, running, unknown, and in-memory maintenance close targets without writes", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const maintenanceStore = new CompactionMaintenanceStore(fixture.db);
+    const active = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-refuse-active",
+      sessionKey: "agent:main:doctor-maintenance:refuse-active",
+    });
+    const running = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-refuse-running",
+      sessionKey: "agent:main:doctor-maintenance:refuse-running",
+    });
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: active.conversationId,
+      reason: "threshold",
+    });
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: running.conversationId,
+      reason: "threshold",
+    });
+    await fixture.conversationStore.archiveConversation(running.conversationId, "rollover-fallback");
+    fixture.db.prepare(
+      `UPDATE conversation_compaction_maintenance SET running = 1 WHERE conversation_id = ?`,
+    ).run(running.conversationId);
+    const before = fixture.db
+      .prepare(`SELECT * FROM conversation_compaction_maintenance ORDER BY conversation_id`)
+      .all();
+
+    const activeResult = await fixture.command.handler(
+      createCommandContext(`doctor apply maintenance ${active.conversationId} confirm-inactive`),
+    );
+    const runningResult = await fixture.command.handler(
+      createCommandContext(`doctor apply maintenance ${running.conversationId} confirm-inactive`),
+    );
+    const unknownResult = await fixture.command.handler(
+      createCommandContext("doctor apply maintenance 999999 confirm-inactive"),
+    );
+    expect(activeResult.text).toContain("conversation is active");
+    expect(runningResult.text).toContain("maintenance is running");
+    expect(unknownResult.text).toContain("conversation was not found");
+    expect(
+      fixture.db.prepare(`SELECT * FROM conversation_compaction_maintenance ORDER BY conversation_id`).all(),
+    ).toEqual(before);
+    expect(readdirSync(fixture.tempDir).filter((name) => name.endsWith(".bak"))).toHaveLength(0);
+
+    const memoryDb = new DatabaseSync(":memory:");
+    runLcmMigrations(memoryDb);
+    const memoryConversationStore = new ConversationStore(memoryDb, {
+      fts5Available: getLcmDbFeatures(memoryDb).fts5Available,
+    });
+    const memoryConversation = await memoryConversationStore.createConversation({
+      sessionId: "doctor-maintenance-memory",
+      sessionKey: "agent:main:doctor-maintenance:memory",
+    });
+    const memoryMaintenanceStore = new CompactionMaintenanceStore(memoryDb);
+    await memoryMaintenanceStore.requestProactiveCompactionDebt({
+      conversationId: memoryConversation.conversationId,
+      reason: "threshold",
+    });
+    await memoryConversationStore.archiveConversation(
+      memoryConversation.conversationId,
+      "rollover-fallback",
+    );
+    const memoryCommand = createLcmCommand({
+      db: memoryDb,
+      config: resolveLcmConfig({}, { dbPath: ":memory:" }),
+    });
+    try {
+      const memoryResult = await memoryCommand.handler(
+        createCommandContext(
+          `doctor apply maintenance ${memoryConversation.conversationId} confirm-inactive`,
+        ),
+      );
+      expect(memoryResult.text).toContain("file-backed SQLite database");
+      expect(await memoryMaintenanceStore.getConversationCompactionMaintenance(
+        memoryConversation.conversationId,
+      )).toMatchObject({ pending: true, resolutionReason: null });
+    } finally {
+      memoryDb.close();
+    }
+  });
+
+  it("reports a guarded maintenance close failure after preserving the backup", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+    const maintenanceStore = new CompactionMaintenanceStore(fixture.db);
+    const conversation = await fixture.conversationStore.createConversation({
+      sessionId: "doctor-maintenance-close-failure",
+      sessionKey: "agent:main:doctor-maintenance:close-failure",
+    });
+    await maintenanceStore.requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+    });
+    await fixture.conversationStore.archiveConversation(conversation.conversationId, "rollover-fallback");
+    vi.spyOn(
+      CompactionMaintenanceStore.prototype,
+      "closeInactiveCompactionDebt",
+    ).mockRejectedValueOnce(new Error("database is locked"));
+
+    const result = await fixture.command.handler(
+      createCommandContext(
+        `doctor apply maintenance ${conversation.conversationId} confirm-inactive`,
+      ),
+    );
+
+    expect(result.text).toContain("guarded maintenance close failed: database is locked");
+    const backupPath = result.text.match(/backup path: (.+)/)?.[1]?.trim();
+    expect(backupPath).toBeTruthy();
+    expect(existsSync(backupPath!)).toBe(true);
+    expect(await maintenanceStore.getConversationCompactionMaintenance(conversation.conversationId)).toMatchObject({
+      pending: true,
+      resolutionReason: null,
+    });
+  });
+
   it("creates a standalone database backup", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
@@ -4540,6 +4814,10 @@ describe("lcm command", () => {
     expect(result.text).toContain("⚠️ Unknown subcommand `rewrite`.");
     expect(result.text).toContain("`/lossless backup`");
     expect(result.text).toContain("`/lossless rotate`");
+    expect(result.text).toContain("`/lossless doctor maintenance`");
+    expect(result.text).toContain(
+      "`/lossless doctor apply maintenance <conversation-id> confirm-inactive`",
+    );
     expect(result.text).toContain("`/lossless help`");
     expect(result.text).toContain("`/lcm` is accepted as a shorter alias.");
   });
@@ -4678,6 +4956,32 @@ describe("lcm command helpers", () => {
       kind: "doctor_rollover_splits",
       apply: true,
       applyOptions: { confirm: true },
+    });
+    expect(__testing.parseLcmCommand("doctor maintenance")).toEqual({
+      kind: "doctor_maintenance",
+      apply: false,
+    });
+    expect(__testing.parseLcmCommand("doctor apply maintenance 42 confirm-inactive")).toEqual({
+      kind: "doctor_maintenance",
+      apply: true,
+      conversationId: 42,
+      confirmed: true,
+    });
+    expect(__testing.parseLcmCommand("doctor apply maintenance 42")).toEqual({
+      kind: "doctor_maintenance",
+      apply: true,
+      conversationId: 42,
+      confirmed: false,
+    });
+    expect(__testing.parseLcmCommand("doctor apply maintenance 42 CONFIRM-INACTIVE")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply maintenance` requires a positive conversation id followed by optional exact `confirm-inactive`.",
+    });
+    expect(__testing.parseLcmCommand("doctor apply maintenance nope confirm-inactive")).toEqual({
+      kind: "help",
+      error:
+        "`/lossless doctor apply maintenance` requires a positive conversation id followed by optional exact `confirm-inactive`.",
     });
   });
 

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -233,8 +233,11 @@ function insertRolloverStateRows(fixture: CommandFixture, sourceId: number, targ
       `INSERT INTO conversation_compaction_maintenance (
          conversation_id,
          pending,
-         reason
-       ) VALUES (?, 0, 'target-maintenance')`,
+         reason,
+         resolution_reason,
+         resolved_at,
+         maintenance_revision
+       ) VALUES (?, 0, 'target-maintenance', 'operator-ignored', '2026-06-17T00:00:00.000Z', 7)`,
     )
     .run(targetId);
 }
@@ -1984,15 +1987,25 @@ describe("lcm command", () => {
 
     const maintenance = fixture.db
       .prepare(
-        `SELECT pending, reason, running
+        `SELECT pending, reason, running, resolution_reason, resolved_at, maintenance_revision
          FROM conversation_compaction_maintenance
          WHERE conversation_id = ?`,
       )
-      .get(active.conversationId) as { pending: number; reason: string; running: number };
+      .get(active.conversationId) as {
+      pending: number;
+      reason: string;
+      running: number;
+      resolution_reason: string | null;
+      resolved_at: string | null;
+      maintenance_revision: number;
+    };
     expect(maintenance).toEqual({
       pending: 1,
       reason: "doctor-rollover-split-repair",
       running: 0,
+      resolution_reason: null,
+      resolved_at: null,
+      maintenance_revision: 8,
     });
 
     const ftsRows = fixture.db

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -252,10 +252,11 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(columns.some((column) => column.name === "context_leaf_chunk_tokens")).toBe(true);
     expect(columns.some((column) => column.name === "resolution_reason")).toBe(true);
     expect(columns.some((column) => column.name === "resolved_at")).toBe(true);
+    expect(columns.some((column) => column.name === "maintenance_revision")).toBe(true);
 
     const row = db
       .prepare(
-        `SELECT pending, requested_at, reason, running, last_started_at, last_finished_at, last_failure_summary, token_budget, current_token_count, retry_attempts, next_attempt_after, context_threshold, context_threshold_source, context_fresh_tail_count, context_leaf_chunk_tokens, resolution_reason, resolved_at
+        `SELECT pending, requested_at, reason, running, last_started_at, last_finished_at, last_failure_summary, token_budget, current_token_count, retry_attempts, next_attempt_after, context_threshold, context_threshold_source, context_fresh_tail_count, context_leaf_chunk_tokens, resolution_reason, resolved_at, maintenance_revision
          FROM conversation_compaction_maintenance
          WHERE conversation_id = 1`,
       )
@@ -277,6 +278,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       context_leaf_chunk_tokens: number | null;
       resolution_reason: string | null;
       resolved_at: string | null;
+      maintenance_revision: number;
     };
     expect(row).toEqual({
       pending: 1,
@@ -296,6 +298,7 @@ describe("runLcmMigrations summary depth backfill", () => {
       context_leaf_chunk_tokens: null,
       resolution_reason: null,
       resolved_at: null,
+      maintenance_revision: 0,
     });
     expect(
       db.prepare(`SELECT session_id, title FROM conversations WHERE conversation_id = 1`).get(),

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -181,7 +181,7 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(row.openclaw_sender_metadata).toBeNull();
   });
 
-  it("adds deferred compaction retry columns to legacy maintenance rows", () => {
+  it("adds deferred compaction retry and resolution columns without rewriting legacy maintenance rows", () => {
     const db = createTestDb("legacy-maintenance.db");
     db.exec(`
       CREATE TABLE conversations (
@@ -206,9 +206,10 @@ describe("runLcmMigrations summary depth backfill", () => {
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
     `);
-    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (?, ?)`).run(
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id, title) VALUES (?, ?, ?)`).run(
       1,
       "legacy-maintenance-session",
+      "valuable legacy conversation",
     );
     db.prepare(
       `INSERT INTO conversation_compaction_maintenance (
@@ -217,16 +218,20 @@ describe("runLcmMigrations summary depth backfill", () => {
          requested_at,
          reason,
          running,
+         last_started_at,
+         last_finished_at,
          last_failure_summary,
          token_budget,
          current_token_count
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       1,
       1,
       "2026-05-31T12:00:00.000Z",
       "threshold",
       0,
+      "2026-05-31T12:01:00.000Z",
+      "2026-05-31T12:02:00.000Z",
       "provider timeout",
       4096,
       3500,
@@ -245,16 +250,23 @@ describe("runLcmMigrations summary depth backfill", () => {
     expect(columns.some((column) => column.name === "context_threshold_source")).toBe(true);
     expect(columns.some((column) => column.name === "context_fresh_tail_count")).toBe(true);
     expect(columns.some((column) => column.name === "context_leaf_chunk_tokens")).toBe(true);
+    expect(columns.some((column) => column.name === "resolution_reason")).toBe(true);
+    expect(columns.some((column) => column.name === "resolved_at")).toBe(true);
 
     const row = db
       .prepare(
-        `SELECT pending, reason, token_budget, current_token_count, retry_attempts, next_attempt_after, context_threshold, context_threshold_source, context_fresh_tail_count, context_leaf_chunk_tokens
+        `SELECT pending, requested_at, reason, running, last_started_at, last_finished_at, last_failure_summary, token_budget, current_token_count, retry_attempts, next_attempt_after, context_threshold, context_threshold_source, context_fresh_tail_count, context_leaf_chunk_tokens, resolution_reason, resolved_at
          FROM conversation_compaction_maintenance
          WHERE conversation_id = 1`,
       )
       .get() as {
       pending: number;
+      requested_at: string;
       reason: string;
+      running: number;
+      last_started_at: string;
+      last_finished_at: string;
+      last_failure_summary: string;
       token_budget: number;
       current_token_count: number;
       retry_attempts: number;
@@ -263,10 +275,17 @@ describe("runLcmMigrations summary depth backfill", () => {
       context_threshold_source: string | null;
       context_fresh_tail_count: number | null;
       context_leaf_chunk_tokens: number | null;
+      resolution_reason: string | null;
+      resolved_at: string | null;
     };
     expect(row).toEqual({
       pending: 1,
+      requested_at: "2026-05-31T12:00:00.000Z",
       reason: "threshold",
+      running: 0,
+      last_started_at: "2026-05-31T12:01:00.000Z",
+      last_finished_at: "2026-05-31T12:02:00.000Z",
+      last_failure_summary: "provider timeout",
       token_budget: 4096,
       current_token_count: 3500,
       retry_attempts: 0,
@@ -275,6 +294,14 @@ describe("runLcmMigrations summary depth backfill", () => {
       context_threshold_source: null,
       context_fresh_tail_count: null,
       context_leaf_chunk_tokens: null,
+      resolution_reason: null,
+      resolved_at: null,
+    });
+    expect(
+      db.prepare(`SELECT session_id, title FROM conversations WHERE conversation_id = 1`).get(),
+    ).toEqual({
+      session_id: "legacy-maintenance-session",
+      title: "valuable legacy conversation",
     });
   });
 


### PR DESCRIPTION
## Why

Deferred compaction rows are resolved through `maintain()`, but that entrypoint first calls `getConversationForSession()`, whose stable-session lookups deliberately return active conversations only. Once a main conversation is archived, its pending row can therefore remain indefinitely even though repeated maintenance attempts report a benign completion and cannot reach the archived conversation. Current global status also combines active and inactive debt, leaving operators unable to distinguish live pressure from historical debt or resolve a recent, valuable archived conversation without deleting its recall data. The issue explicitly accepts a stale-inactive diagnostic plus an audited close operation as an operator-safe resolution.

## What

Add nullable maintenance-resolution metadata through the existing additive migration path, expose it on `CompactionMaintenanceStore`, clear it whenever new debt is requested, and add a conditional store operation that can close only a pending, non-running debt row whose conversation is inactive. Implement a production-used doctor module that scans pending maintenance joined to conversations, groups counts by active state and reason, shows bounded inactive examples, and applies a single-conversation `operator-ignored` resolution only after explicit `confirm-inactive` input and a successful file-backed SQLite backup. Wire the module into `/lossless doctor maintenance` and `/lossless doctor apply maintenance <conversation-id> confirm-inactive`, making no-match/repeated apply idempotent and reporting active, running, missing, or already-resolved targets as read-only refusals.

## Testing

- Migrating a legacy database adds the nullable resolution fields without changing existing pending/running flags, reasons, timestamps, or persisted conversation data.
- Requesting fresh debt after an operator-ignored resolution clears the prior resolution metadata and restores an actionable pending row.
- The read-only doctor scan groups pending rows by active/inactive state and reason, reports bounded inactive examples, and performs no writes.
- Applying the command to an inactive, pending, non-running conversation with the exact confirmation creates a backup, clears pending/running, records the operator-ignored reason and timestamp, and leaves conversation/message/summary/context counts unchanged.
- Missing confirmation, an active conversation, a running row, an unknown conversation, or an in-memory database refuses the apply without changing maintenance state; a repeated apply reports no work and does not create another backup.
- Command parsing, help text, and rendered output advertise the diagnostic and apply forms and clearly distinguish administrative closure from successful compaction.

Fixes #848
