### PR TITLE
fix(context-engine): preserve degraded projection bootstrap

### DIFF
--- a/.changeset/preserve-degraded-projection-bootstrap.md
+++ b/.changeset/preserve-degraded-projection-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Preserve stable `thread_bootstrap` projection metadata when a managed conversation uses bounded or degraded live fallback, preventing persistent Codex threads from appending the reconstructed transcript again on every turn while compaction maintenance is pending.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -7,7 +7,11 @@ import { trimBootstrapMessagesToBudget } from "./bootstrap-budget.js";
 import { estimateSerializedMessageTokens, estimateSerializedMessagesTokens } from "./estimate-tokens.js";
 import { resolveForkBoundedLiveSuffix, stripTrailingAssistantPrefill } from "./live-coverage.js";
 import { toStoredMessage } from "./message-content.js";
-import type { AgentMessage, AssembleResult } from "./openclaw-bridge.js";
+import type {
+  AgentMessage,
+  AssembleResult,
+  ContextEngineProjection,
+} from "./openclaw-bridge.js";
 import type { ConversationCompactionMaintenanceRecord } from "./store/compaction-maintenance-store.js";
 import { estimateAgentMessageTokens, normalizeNonNegativeInteger, toRuntimeRoleForTokenEstimate } from "./token-accounting.js";
 
@@ -171,6 +175,7 @@ export function buildDegradedLiveAssembleResult(params: {
   liveMessages: AgentMessage[];
   tokenBudget: number;
   preserveSubstantiveAssistantTail?: boolean;
+  contextProjection: ContextEngineProjection;
 }): AssembleResult {
   const prefillOptions = {
     preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
@@ -200,6 +205,7 @@ export function buildDegradedLiveAssembleResult(params: {
     messages,
     estimatedTokens: estimateAgentMessageTokens(messages),
     promptAuthority: "preassembly_may_overflow",
+    contextProjection: params.contextProjection,
   };
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4620,6 +4620,18 @@ export class LcmContextEngine implements ContextEngine {
           ? Math.floor(params.tokenBudget)
           : 128_000,
       );
+      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+      const activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
+        conversation.conversationId,
+      );
+      const contextProjection = {
+        mode: "thread_bootstrap" as const,
+        epoch: buildContextEngineProjectionEpoch(
+          conversation.conversationId,
+          contextItems,
+          activeFocusBrief,
+        ),
+      };
       // Bounded variant of safeFallback for paths where this engine manages
       // the conversation but cannot produce assembled coverage. Returning the
       // raw live transcript unbounded here is how an over-budget prompt
@@ -4636,7 +4648,11 @@ export class LcmContextEngine implements ContextEngine {
             `[lcm] assemble: bounded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${reason} serializedTokensBefore=${clamp.serializedTokensBefore} serializedTokens=${clamp.serializedTokens} evictedMessages=${clamp.evictedMessages} tokenBudget=${tokenBudget} overBudget=${clamp.overBudget}`,
           );
         }
-        return { messages: clamp.messages, estimatedTokens: clamp.serializedTokens };
+        return {
+          messages: clamp.messages,
+          estimatedTokens: clamp.serializedTokens,
+          contextProjection,
+        };
       };
       let storedContextTokens = await this.summaryStore.getContextTokenCount(
         conversation.conversationId,
@@ -4723,6 +4739,7 @@ export class LcmContextEngine implements ContextEngine {
           liveMessages,
           tokenBudget,
           preserveSubstantiveAssistantTail: hostDeliversCurrentTurnSeparately,
+          contextProjection,
         });
         this.deps.log.warn(
           `[lcm] assemble: degraded live fallback conversation=${conversation.conversationId} ${sessionLabel} reason=${deferredAssemblyDegradation.reason} storedContextTokens=${deferredAssemblyDegradation.pressure.storedContextTokens} projectedTokenCount=${deferredAssemblyDegradation.pressure.projectedTokenCount ?? "null"} tokenBudget=${tokenBudget} pressureThreshold=${Math.floor(tokenBudget * DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO)} outputMessages=${degraded.messages.length} estimatedTokens=${degraded.estimatedTokens}`,
@@ -4730,7 +4747,6 @@ export class LcmContextEngine implements ContextEngine {
         return degraded;
       }
 
-      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
       if (contextItems.length === 0) {
         this.deps.log.debug(
           `[lcm] assemble: no context items conversation=${conversation.conversationId} ${sessionLabel} duration=${formatDurationMs(Date.now() - startedAt)}`,
@@ -4913,14 +4929,7 @@ export class LcmContextEngine implements ContextEngine {
       const stubStatsLog = assembled.debug?.stubStats
         ? ` stubbed=${assembled.debug.stubStats.stubbedCount} tokensSaved=${assembled.debug.stubStats.tokensSaved}`
         : "";
-      const activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
-        conversation.conversationId,
-      );
-      const contextProjectionEpoch = buildContextEngineProjectionEpoch(
-        conversation.conversationId,
-        contextItems,
-        activeFocusBrief,
-      );
+      const contextProjectionEpoch = contextProjection.epoch;
       const contextProjectionFingerprint = budgetedPromptRecallCue
         ? buildPromptRecallProjectionFingerprint(budgetedPromptRecallCue.message)
         : undefined;
@@ -4972,8 +4981,7 @@ export class LcmContextEngine implements ContextEngine {
         messages: finalMessages,
         estimatedTokens: finalEstimatedTokens,
         contextProjection: {
-          mode: "thread_bootstrap",
-          epoch: contextProjectionEpoch,
+          ...contextProjection,
           ...(contextProjectionFingerprint ? { fingerprint: contextProjectionFingerprint } : {}),
         },
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4620,11 +4620,11 @@ export class LcmContextEngine implements ContextEngine {
           ? Math.floor(params.tokenBudget)
           : 128_000,
       );
-      const contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
-      const activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
+      let contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+      let activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
         conversation.conversationId,
       );
-      const contextProjection = {
+      let contextProjection = {
         mode: "thread_bootstrap" as const,
         epoch: buildContextEngineProjectionEpoch(
           conversation.conversationId,
@@ -4696,6 +4696,20 @@ export class LcmContextEngine implements ContextEngine {
               `[lcm] assemble: deferred compaction execution failed for ${sessionLabel}: ${describeLogError(error)}`,
             );
           }
+          // Emergency maintenance may replace the canonical context prefix.
+          // Refresh both projection inputs before returning any assemble path.
+          contextItems = await this.summaryStore.getContextItems(conversation.conversationId);
+          activeFocusBrief = await this.focusBriefStore.getActiveFocusBrief(
+            conversation.conversationId,
+          );
+          contextProjection = {
+            mode: "thread_bootstrap",
+            epoch: buildContextEngineProjectionEpoch(
+              conversation.conversationId,
+              contextItems,
+              activeFocusBrief,
+            ),
+          };
           storedContextTokens = await this.summaryStore.getContextTokenCount(
             conversation.conversationId,
           );

--- a/test/engine-assemble.test.ts
+++ b/test/engine-assemble.test.ts
@@ -264,7 +264,10 @@ describe("LcmContextEngine.assemble canonical path", () => {
     expect(result.messages).toStrictEqual(liveMessages);
     // Bounded fallback reports the real serialized estimate instead of 0.
     expect(result.estimatedTokens).toBeGreaterThan(0);
-    expect(result.contextProjection).toBeUndefined();
+    expect(result.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
+    });
   });
 
   it("assembles context from DB when coverage exists", async () => {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -2033,6 +2033,70 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=over-budget"));
   });
 
+  it("refreshes the projection epoch after emergency compaction replaces context", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const sessionId = "assemble-emergency-refreshes-projection";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const summaryStore = engine.getSummaryStore();
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context before emergency compaction",
+        tokenCount: 150,
+      },
+    ]);
+    await summaryStore.appendContextMessages(conversation.conversationId, [
+      storedMessage.messageId,
+    ]);
+
+    const beforeCompaction = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: storedMessage.content })],
+      tokenBudget: 1_000,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 150,
+    });
+    vi.spyOn(privateEngine, "executeCompactionCore").mockImplementation(async () => {
+      await summaryStore.insertSummary({
+        summaryId: "sum_emergency_projection_refresh",
+        conversationId: conversation.conversationId,
+        kind: "leaf",
+        depth: 0,
+        content: "Emergency compaction summary.",
+        tokenCount: 10,
+        descendantCount: 1,
+      });
+      await summaryStore.replaceContextRangeWithSummary({
+        conversationId: conversation.conversationId,
+        startOrdinal: 0,
+        endOrdinal: 0,
+        summaryId: "sum_emergency_projection_refresh",
+      });
+      return { ok: true, compacted: true, reason: "compacted" };
+    });
+
+    const afterCompaction = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "current emergency turn" })],
+      tokenBudget: 100,
+    });
+
+    expect(afterCompaction.contextProjection?.epoch).not.toBe(
+      beforeCompaction.contextProjection?.epoch,
+    );
+  });
+
   it("assemble() drains pending threshold debt when recorded runtime tokens are over budget", async () => {
     const engine = createEngine();
     const privateEngine = engine as unknown as {

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -1536,10 +1536,78 @@ describe("LcmContextEngine maintain and assemble budget", () => {
       "promptAuthority",
       "preassembly_may_overflow",
     );
+    expect(assembleResult.contextProjection).toEqual({
+      mode: "thread_bootstrap",
+      epoch: expect.stringMatching(/^summary-prefix-v1:\d+:[a-f0-9]{32}$/),
+    });
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("[lcm] assemble: degraded live fallback"),
     );
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("reason=near-budget"));
+  });
+
+  it("keeps degraded projection epochs stable across live growth and rotates after summary changes", async () => {
+    const engine = createEngine();
+    const sessionId = "assemble-degraded-projection-epoch";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    const [storedMessage] = await engine.getConversationStore().createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 0,
+        role: "user",
+        content: "stored context while maintenance remains pending",
+        tokenCount: 80,
+      },
+    ]);
+    await engine
+      .getSummaryStore()
+      .appendContextMessages(conversation.conversationId, [storedMessage.messageId]);
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 100,
+      currentTokenCount: 90,
+    });
+
+    const first = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "first live turn" })],
+      tokenBudget: 100,
+    });
+    const afterLiveGrowth = await engine.assemble({
+      sessionId,
+      messages: [
+        makeMessage({ role: "user", content: "first live turn" }),
+        makeMessage({ role: "assistant", content: "first live reply" }),
+        makeMessage({ role: "user", content: "second live turn" }),
+      ],
+      tokenBudget: 100,
+    });
+
+    expect(first.contextProjection?.mode).toBe("thread_bootstrap");
+    expect(afterLiveGrowth.contextProjection?.epoch).toBe(first.contextProjection?.epoch);
+
+    await engine.getSummaryStore().insertSummary({
+      summaryId: "sum_degraded_projection_epoch",
+      conversationId: conversation.conversationId,
+      kind: "leaf",
+      depth: 0,
+      content: "Changed semantic prefix for the degraded projection.",
+      tokenCount: 10,
+      descendantCount: 0,
+    });
+    await engine
+      .getSummaryStore()
+      .appendContextSummary(conversation.conversationId, "sum_degraded_projection_epoch");
+
+    const afterSummary = await engine.assemble({
+      sessionId,
+      messages: [makeMessage({ role: "user", content: "third live turn" })],
+      tokenBudget: 100,
+    });
+    expect(afterSummary.contextProjection?.epoch).not.toBe(first.contextProjection?.epoch);
   });
 
   it("assemble() preserves a completed assistant tail in degraded prompt-separate fallback", async () => {


### PR DESCRIPTION
## Summary

- Preserve stable thread_bootstrap projection metadata for managed bounded and degraded live fallbacks.
- Derive the fallback epoch from the same semantic context prefix used by normal assembly.
- Keep unmanaged and error-only safe fallbacks unchanged.
- Add regression coverage proving raw live growth keeps the epoch stable while summary changes rotate it.
- Add a patch changeset.

## Why

In 1.0.0-beta.4, degraded live fallback omits contextProjection. OpenClaw therefore interprets the result as per_turn on persistent Codex app-server sessions and appends the reconstructed transcript again on each turn while compaction debt remains pending.

This is a focused next/1.0 port of the projection behavior proposed in #1086. PR #1091 fixed host prompt accounting but did not preserve projection metadata on these fallback paths.

## Verification

- npx vitest run test/engine-assemble.test.ts test/engine-maintenance.test.ts: 108 passed
- TypeScript typecheck and build: passed
- JavaScript suite: 111 files, 1806 tests passed
- npm pack --dry-run: passed
- npm run plugin-inspector:ci: passed with zero live breakages
- GX10 live canary on an existing over-budget managed conversation:
  - first degraded turn selected thread_bootstrap and established the epoch binding
  - second degraded turn kept the same epoch, logged projected=false with matching-thread-bootstrap-binding, and reused the thread
  - second provider call needed 565 new input tokens and read 154368 cached tokens
- SQLite integrity checks remained clean after both canaries

The Go TUI portion of release:verify was not run locally because Go is not installed on the GX10; CI is expected to cover it.

Related: #1085, #1086, #1091
OpenClaw context: https://github.com/openclaw/openclaw/issues/125254 and https://github.com/openclaw/openclaw/pull/125324