### PR TITLE
fix: inherit default model for durable summary preparation

### DIFF
--- a/.changeset/inherit-durable-default-summary-model.md
+++ b/.changeset/inherit-durable-default-summary-model.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Inherit OpenClaw's effective default model during context-free durable `commitTurn` summary preparation when no Lossless summary override is configured. Automatic pending-summary work now retains raw context instead of persisting emergency truncations when no model-backed summarizer can be resolved.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -245,6 +245,7 @@ const HOST_SESSION_END_REASON_DELETED = "deleted";
 const HOST_SESSION_END_REASON_RESET = "reset";
 const CONTEXT_ENGINE_PROJECTION_EPOCH_VERSION = "summary-prefix-v1";
 const DEFERRED_ASSEMBLY_DEGRADED_PRESSURE_RATIO = 0.75;
+const PENDING_SUMMARY_MODEL_UNAVAILABLE_REASON = "pending summary model unavailable";
 /** Stop bypassing compaction backoff after repeated emergency failures. */
 const ASSEMBLE_FORCE_MAX_RETRY_ATTEMPTS = 3;
 type CompactionExecutionParams = {
@@ -1126,7 +1127,8 @@ export class LcmContextEngine implements ContextEngine {
       if (
         result.pending === true &&
         result.reason !== "pending summaries ready for publish" &&
-        result.reason !== "circuit breaker open"
+        result.reason !== "circuit breaker open" &&
+        result.reason !== PENDING_SUMMARY_MODEL_UNAVAILABLE_REASON
       ) {
         this.schedulePendingSummaryPreparationDrain(params);
       }
@@ -1215,11 +1217,14 @@ export class LcmContextEngine implements ContextEngine {
         nextMaintenance.nextAttemptAfter.getTime() > Date.now();
       const pendingSummariesReadyForPublish =
         result?.reason === "pending summaries ready for publish";
+      const pendingSummaryModelUnavailable =
+        result?.reason === PENDING_SUMMARY_MODEL_UNAVAILABLE_REASON;
       if (
         nextMaintenance?.pending &&
         !nextMaintenance.running &&
         !retryBackoffActive &&
-        !pendingSummariesReadyForPublish
+        !pendingSummariesReadyForPublish &&
+        !pendingSummaryModelUnavailable
       ) {
         const currentTokenCount =
           result?.changed === true && result.reason === "pending summaries published"
@@ -1572,6 +1577,9 @@ export class LcmContextEngine implements ContextEngine {
   }): Promise<CompactResult & { pending?: boolean }> {
     const breakerScope = this.resolveSessionQueueKey(params.sessionId, params.sessionKey);
     const publicationOnly = params.publishPolicy === "publish-ready-only";
+    const pendingManualCompaction =
+      (asRecord(params.runtimeContext) ?? asRecord(params.legacyParams))?.manualCompaction === true;
+    const allowEmergencyFallback = params.force === true || pendingManualCompaction;
     const resolvedSummarizer = publicationOnly ? {
       summarize: async () => {
         throw new Error("publication-only pending summary pass attempted model-backed preparation");
@@ -1585,7 +1593,20 @@ export class LcmContextEngine implements ContextEngine {
       }),
       customInstructions: params.customInstructions,
       breakerScope,
+      allowEmergencyFallback,
     });
+    if (
+      !publicationOnly &&
+      !allowEmergencyFallback &&
+      resolvedSummarizer.unavailable === true
+    ) {
+      return {
+        ok: false,
+        compacted: false,
+        pending: true,
+        reason: PENDING_SUMMARY_MODEL_UNAVAILABLE_REASON,
+      };
+    }
     if (!publicationOnly &&
       resolvedSummarizer.breakerKey &&
       this.compactionGuards.isCircuitBreakerOpen(resolvedSummarizer.breakerKey)
@@ -1603,8 +1624,6 @@ export class LcmContextEngine implements ContextEngine {
       kind: "compaction",
       scope: breakerScope,
     });
-    const pendingManualCompaction =
-      (asRecord(params.runtimeContext) ?? asRecord(params.legacyParams))?.manualCompaction === true;
     if (params.force === true || pendingManualCompaction) {
       const clearedBackoffUntil =
         this.compactionGuards.clearSummarySpendBackoff(summarySpendScopeKey);
@@ -2449,10 +2468,12 @@ export class LcmContextEngine implements ContextEngine {
     legacyParams?: Record<string, unknown>;
     customInstructions?: string;
     breakerScope: string;
+    allowEmergencyFallback?: boolean;
   }): Promise<{
     summarize: LcmSummarizeFn;
     summaryModel: string;
     breakerKey?: string;
+    unavailable?: boolean;
   }> {
     const lp = params.legacyParams ?? {};
     const breakerScope = params.breakerScope || "global";
@@ -2493,8 +2514,20 @@ export class LcmContextEngine implements ContextEngine {
       this.deps.log.error(`[lcm] resolveSummarize: createLcmSummarizeFromLegacyParams returned undefined`);
     } catch (err) {
       this.deps.log.error(
-        `[lcm] resolveSummarize failed, using emergency fallback: ${describeLogError(err)}`,
+        `[lcm] resolveSummarize failed${params.allowEmergencyFallback === false ? " with emergency fallback disabled" : ", using emergency fallback"}: ${describeLogError(err)}`,
       );
+    }
+    if (params.allowEmergencyFallback === false) {
+      this.deps.log.warn(
+        "[lcm] resolveSummarize: model-backed summarizer unavailable; emergency truncation disabled for automatic pending preparation",
+      );
+      return {
+        summarize: async () => {
+          throw new Error(PENDING_SUMMARY_MODEL_UNAVAILABLE_REASON);
+        },
+        summaryModel: "unavailable",
+        unavailable: true,
+      };
     }
     this.deps.log.error(`[lcm] resolveSummarize: FALLING BACK TO EMERGENCY TRUNCATION`);
     return {

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -1469,6 +1469,26 @@ function resolveSummaryCandidates(params: {
     }
   }
 
+  if (resolutionCandidates.every((candidate) => !candidate.modelRef)) {
+    try {
+      const resolved = params.deps.resolveModel(undefined, providerHint || undefined);
+      if (resolved.provider && resolved.model) {
+        resolvedCandidates.push({
+          levelName: "effective OpenClaw default model",
+          modelRef: "",
+          providerHint: providerHint || undefined,
+          hasExplicitProvider: false,
+          provider: resolved.provider,
+          model: resolved.model,
+        });
+      }
+    } catch (err) {
+      params.deps.log.error(
+        `[lcm] createLcmSummarize: resolveModel FAILED at effective OpenClaw default model: ${describeLogError(err)}`,
+      );
+    }
+  }
+
   return dedupeResolvedCandidates(resolvedCandidates);
 }
 

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -14,7 +14,9 @@ import {
   createEngine,
   createEngineAtDatabasePath,
   createEngineWithConfig,
+  createEngineWithDeps,
   makeMessage,
+  seedBacklogContext,
   tempDirs,
 } from "./helpers.js";
 
@@ -297,6 +299,96 @@ describe("LcmContextEngine commitTurn", () => {
       reason: "threshold",
       tokenBudget: 100,
     });
+  });
+
+  it("inherits the effective OpenClaw model during a context-free durable commit", async () => {
+    const complete = vi.fn(async (_input: unknown) => ({
+      content: [{ type: "text", text: "default-model summary" }],
+    }));
+    const resolveModel = vi.fn((modelRef?: string) => {
+      expect(modelRef).toBeUndefined();
+      return { provider: "openai-codex", model: "gpt-5.5" };
+    });
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 1,
+        leafChunkTokens: 120,
+        maxSweepIterations: 1,
+      },
+      { complete, resolveModel },
+    );
+    const params = buildCommitTurnParams({ advancementKey: "default-model-turn" });
+    await seedBacklogContext(engine, params.sessionId, [120, 120]);
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(params.sessionId);
+    expect(conversation).not.toBeNull();
+    await vi.waitFor(async () => {
+      expect(complete.mock.calls.length).toBeGreaterThan(0);
+      const batch = await engine
+        .getPendingSummaryStore()
+        .getActiveBatchForConversation(conversation!.conversationId);
+      expect(batch?.model).toBe("gpt-5.5");
+    });
+    expect(resolveModel).toHaveBeenCalledWith(undefined, undefined);
+    expect(complete.mock.calls[0]?.[0]).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+    });
+  });
+
+  it("retains raw pending work when a context-free durable commit cannot resolve a model", async () => {
+    const complete = vi.fn(async () => ({
+      content: [{ type: "text", text: "unexpected summary" }],
+    }));
+    const warn = vi.fn();
+    const engine = createEngineWithDeps(
+      {
+        freshTailCount: 1,
+        leafChunkTokens: 120,
+        maxSweepIterations: 1,
+      },
+      {
+        complete,
+        resolveModel: vi.fn(() => {
+          throw new Error("no model configured");
+        }),
+        log: {
+          info: vi.fn(),
+          warn,
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+    );
+    const params = buildCommitTurnParams({ advancementKey: "missing-model-turn" });
+    await seedBacklogContext(engine, params.sessionId, [120, 120]);
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "emergency truncation disabled for automatic pending preparation",
+        ),
+      );
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(params.sessionId);
+    expect(conversation).not.toBeNull();
+    await expect(
+      engine.getSummaryStore().getSummariesByConversation(conversation!.conversationId),
+    ).resolves.toHaveLength(0);
+    await expect(
+      engine
+        .getPendingSummaryStore()
+        .getActiveBatchForConversation(conversation!.conversationId),
+    ).resolves.toBeNull();
+    expect(complete).not.toHaveBeenCalled();
   });
 
   it("fails closed when the same advancement key carries a different payload", async () => {

--- a/test/summarize.test.ts
+++ b/test/summarize.test.ts
@@ -110,6 +110,34 @@ describe("createLcmSummarizeFromLegacyParams", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("resolves the effective OpenClaw default when no model candidate is supplied", async () => {
+    const deps = makeDeps({
+      resolveModel: vi.fn((modelRef?: string) => {
+        expect(modelRef).toBeUndefined();
+        return { provider: "openai-codex", model: "gpt-5.5" };
+      }),
+    });
+
+    const result = await createLcmSummarizeFromLegacyParams({
+      deps,
+      legacyParams: {},
+    });
+
+    expect(result?.model).toBe("gpt-5.5");
+    expect(vi.mocked(deps.resolveModel)).toHaveBeenCalledWith(undefined, undefined);
+
+    await result?.fn("default model summary source", false);
+    expect(vi.mocked(deps.complete)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      }),
+    );
+    expect(vi.mocked(deps.complete).mock.calls[0]?.[0]).not.toHaveProperty(
+      "runtimeModelOverride",
+    );
+  });
+
   it("plugin summaryProvider alone (no summaryModel) is ignored and falls back to legacy provider", async () => {
     const deps = makeDeps();
 


### PR DESCRIPTION
## What

Fix #1107 on the `next/1.0` SQLite context-engine line. Context-free durable `commitTurn(...)` processing now inherits OpenClaw's effective default model when Lossless has no explicit summary override. Automatic pending-summary preparation retains raw context when no model-backed summarizer is available.

## Why

OpenClaw's durable turn outbox invokes `commitTurn(...)` without `runtimeSettings` or `runtimeContext`. Lossless's candidate resolver skipped every empty model source and returned before calling the dependency resolver that reads OpenClaw's effective default. Pending-summary preparation then persisted deterministic emergency truncations as summary coverage.

## Changes

- Resolve the implicit OpenClaw default model
- Preserve explicit summary-model candidate precedence
- Retain raw context when models are unavailable
- Stop unavailable-model background rescheduling loops
- Add durable context-free commit regressions
- Add a patch Changeset

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` (111 files, 1,808 tests)
- Focused pending-maintenance suites (167 tests)
- `npm pack --dry-run`
- Thermonuclear review: no findings
- Autoreview: no accepted/actionable findings

`npm run test:tui` could not start because this machine does not have `go` installed.

Fixes #1107
