### PR TITLE
fix: publish empty-source pending coverage

### DIFF
--- a/.changeset/publish-empty-source-coverage.md
+++ b/.changeset/publish-empty-source-coverage.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Publish deterministic, raw-linked coverage for pending summary sources that sanitize empty, without retrying or calling the summary model, so later meaningful compaction work can continue and publish without an ordinal gap.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1796,7 +1796,9 @@ export class LcmContextEngine implements ContextEngine {
       }
       if (lastResult.status === "prepared") {
         preparedSteps += 1;
-        if (resolvedSummarizer.breakerKey) {
+        // Empty-source coverage is deterministic and makes no provider call,
+        // so it must not be recorded as a successful provider outcome.
+        if (!lastResult.emptySource && resolvedSummarizer.breakerKey) {
           this.compactionGuards.recordCompactionSuccess(resolvedSummarizer.breakerKey);
         }
       }

--- a/src/pending-summary-coordinator.ts
+++ b/src/pending-summary-coordinator.ts
@@ -15,7 +15,12 @@ import {
   type PendingSummaryPlannerSnapshotItem,
 } from "./pending-summary-planner.js";
 import { PendingSummaryPublisher } from "./pending-summary-publisher.js";
-import { PendingSummaryPreparationWorker } from "./pending-summary-worker.js";
+import {
+  PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+  PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+  PendingSummaryEmptySourceCoverage,
+  PendingSummaryPreparationWorker,
+} from "./pending-summary-worker.js";
 import type { ConversationStore, MessageRecord } from "./store/conversation-store.js";
 import {
   MAX_PENDING_NODE_RETRIES,
@@ -65,7 +70,7 @@ export type PendingCompactionPublishPolicy =
 export type PendingCompactionCoordinatorResult =
   | { status: "idle"; reason: string }
   | { status: "planned"; batchId: string; nodeCount: number }
-  | { status: "prepared"; batchId: string; nodeId: string }
+  | { status: "prepared"; batchId: string; nodeId: string; emptySource?: true }
   | { status: "ready"; batchId: string; reason: "pending summaries ready for publish" }
   | {
       status: "published";
@@ -222,7 +227,12 @@ export class PendingCompactionCoordinator {
     });
     const prepared = await worker.prepareOne({ conversationId: input.conversationId });
     if (prepared.status === "prepared") {
-      return { status: "prepared", batchId: batch.batchId, nodeId: prepared.nodeId };
+      return {
+        status: "prepared",
+        batchId: batch.batchId,
+        nodeId: prepared.nodeId,
+        ...(prepared.emptySource ? { emptySource: true } : {}),
+      };
     }
     if (prepared.status === "spend-limited") {
       return { status: "idle", reason: "summary spend backoff open" };
@@ -916,29 +926,48 @@ export class PendingCompactionCoordinator {
   private async loadSourceText(node: PendingSummaryNodeRecord): Promise<string> {
     if (node.kind === "leaf") {
       const messageLinks = await this.pendingSummaryStore.getNodeMessages(node.nodeId);
+      if (messageLinks.length === 0) {
+        throw new Error(`Pending leaf summary ${node.nodeId} has no linked source messages`);
+      }
       const chunks: string[] = [];
       for (const link of messageLinks) {
         const message = await this.conversationStore.getMessageById(link.messageId);
-        if (message) {
-          chunks.push(
-            await formatMessageForSummary(
-              this.conversationStore,
-              message,
-              this.config.stripInjectedContextTags,
-            ),
+        if (!message) {
+          throw new Error(
+            `Pending leaf summary ${node.nodeId} source message ${link.messageId} was not found`,
           );
         }
+        chunks.push(
+          await formatMessageForSummary(
+            this.conversationStore,
+            message,
+            this.config.stripInjectedContextTags,
+          ),
+        );
       }
-      return chunks.filter(Boolean).join("\n\n");
+      const sourceText = chunks.filter(Boolean).join("\n\n");
+      if (!sourceText.trim()) {
+        throw new PendingSummaryEmptySourceCoverage();
+      }
+      return sourceText;
     }
 
     const children = await this.pendingSummaryStore.getNodeChildren(node.nodeId);
+    if (children.length === 0) {
+      throw new Error(`Pending condensed summary ${node.nodeId} has no linked child summaries`);
+    }
     const chunks: string[] = [];
     for (const child of children) {
       if (child.childNodeId) {
         const pendingChild = await this.pendingSummaryStore.getNode(child.childNodeId);
         if (!pendingChild?.content) {
           throw new Error(`Pending child summary ${child.childNodeId} is not ready`);
+        }
+        if (
+          pendingChild.model === PENDING_EMPTY_SOURCE_COVERAGE_MODEL &&
+          pendingChild.content === PENDING_EMPTY_SOURCE_COVERAGE_CONTENT
+        ) {
+          continue;
         }
         chunks.push(pendingChild.content);
         continue;
@@ -948,9 +977,19 @@ export class PendingCompactionCoordinator {
         if (!canonicalChild) {
           throw new Error(`Canonical child summary ${child.childSummaryId} was not found`);
         }
+        if (
+          canonicalChild.model === PENDING_EMPTY_SOURCE_COVERAGE_MODEL &&
+          canonicalChild.content === PENDING_EMPTY_SOURCE_COVERAGE_CONTENT
+        ) {
+          continue;
+        }
         chunks.push(canonicalChild.content);
       }
     }
-    return chunks.filter(Boolean).join("\n\n");
+    const sourceText = chunks.filter(Boolean).join("\n\n");
+    if (!sourceText.trim()) {
+      throw new PendingSummaryEmptySourceCoverage();
+    }
+    return sourceText;
   }
 }

--- a/src/pending-summary-worker.ts
+++ b/src/pending-summary-worker.ts
@@ -1,5 +1,32 @@
 import type { PendingSummaryNodeRecord } from "./store/pending-summary-store.js";
 
+/**
+ * Deterministic summary payload used when safety sanitation removes an entire
+ * pending source. Canonical leaf lineage still links to every raw source
+ * message, so this marker closes the publish range without inventing content
+ * or discarding the lossless expansion path. Condensed marker nodes preserve
+ * those leaf links through their parent lineage.
+ */
+export const PENDING_EMPTY_SOURCE_COVERAGE_CONTENT =
+  "[Lossless Claw empty-source coverage marker: no summarizable text remained after safety sanitization; no model was called, and the raw source remains linked for retrieval.]";
+
+/** Summary provenance recorded for deterministic empty-source coverage. */
+export const PENDING_EMPTY_SOURCE_COVERAGE_MODEL = "lossless-claw/empty-source";
+
+/**
+ * Explicit signal from a source loader that lineage was verified but safety
+ * sanitation removed every summarizable byte.
+ *
+ * A plain empty string is not sufficient evidence: it can also indicate
+ * missing links or records and remains a retryable preparation failure.
+ */
+export class PendingSummaryEmptySourceCoverage extends Error {
+  constructor() {
+    super("pending summary source sanitized empty");
+    this.name = "PendingSummaryEmptySourceCoverage";
+  }
+}
+
 export type PendingSummaryPreparationStore = {
   claimNextPlannedNode(input: {
     conversationId: number;
@@ -13,6 +40,7 @@ export type PendingSummaryPreparationStore = {
     leaseExpiresAt: Date;
     content: string;
     tokenCount: number;
+    model?: string;
     readyAt?: Date;
   }): Promise<boolean>;
   markNodeFailed(input: {
@@ -42,7 +70,7 @@ export type PendingSummaryPreparationWorkerOptions = {
 
 export type PendingSummaryPreparationResult =
   | { status: "idle" }
-  | { status: "prepared"; nodeId: string }
+  | { status: "prepared"; nodeId: string; emptySource?: true }
   | { status: "spend-limited"; nodeId: string }
   | { status: "failed"; nodeId: string; failureSummary: string; authFailure?: boolean };
 
@@ -141,6 +169,23 @@ export class PendingSummaryPreparationWorker {
       }
       return { status: "prepared", nodeId: node.nodeId };
     } catch (error) {
+      if (error instanceof PendingSummaryEmptySourceCoverage) {
+        const saved = await this.store.markNodeReady({
+          nodeId: node.nodeId,
+          leaseOwner: this.leaseOwner,
+          leaseExpiresAt: node.leaseExpiresAt,
+          content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+          tokenCount: normalizeTokenCount(
+            this.estimateTokens(PENDING_EMPTY_SOURCE_COVERAGE_CONTENT),
+          ),
+          model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+          readyAt: this.now(),
+        });
+        if (!saved) {
+          return { status: "idle" };
+        }
+        return { status: "prepared", nodeId: node.nodeId, emptySource: true };
+      }
       // A spend-guard refusal is not a node failure: no model outcome exists,
       // so the claim is released untouched and the node stays planned.
       if (this.isSpendLimitFailure(error)) {

--- a/src/store/pending-summary-store.ts
+++ b/src/store/pending-summary-store.ts
@@ -707,6 +707,7 @@ export class PendingSummaryStore {
     leaseExpiresAt: Date;
     content: string;
     tokenCount: number;
+    model?: string;
     readyAt?: Date;
   }): Promise<boolean> {
     const result = this.db
@@ -715,6 +716,7 @@ export class PendingSummaryStore {
          SET status = 'ready',
              content = ?,
              token_count = ?,
+             model = COALESCE(?, model),
              lease_owner = NULL,
              lease_expires_at = NULL,
              failure_summary = NULL,
@@ -730,6 +732,7 @@ export class PendingSummaryStore {
       .run(
         input.content,
         normalizeNonNegativeInteger(input.tokenCount),
+        input.model ?? null,
         nullableDateToIso(input.readyAt),
         input.nodeId,
         input.leaseOwner,

--- a/test/pending-summary-coordinator.test.ts
+++ b/test/pending-summary-coordinator.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { getLcmDbFeatures } from "../src/db/features.js";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { PendingCompactionCoordinator } from "../src/pending-summary-coordinator.js";
+import {
+  PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+  PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+} from "../src/pending-summary-worker.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 import { PendingSummaryStore } from "../src/store/pending-summary-store.js";
 import { SummaryStore } from "../src/store/summary-store.js";
@@ -298,6 +302,424 @@ describe("PendingCompactionCoordinator", () => {
     ).resolves.toMatchObject({ status: "prepared" });
     expect(summarizedSource).toContain("| tool]");
     expect(summarizedSource).toContain("Pending message-parts source detail.");
+  });
+
+  it("publishes later meaningful work after an oversized tool source sanitizes empty", async () => {
+    const { conversationStore, pendingSummaryStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "pending-coordinator-empty-tool-session",
+      sessionKey: "agent:main:pending-coordinator-empty-tool",
+    });
+    const rawEmptyToolOutput = "A".repeat(89_492);
+    const messages = await conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "tool",
+        content: rawEmptyToolOutput,
+        tokenCount: 22_373,
+        transcriptEntryId: "entry:empty-tool-output",
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 2,
+        role: "tool",
+        content: "Meaningful tool result that must still publish after the empty source.",
+        tokenCount: 22_000,
+        transcriptEntryId: "entry:meaningful-tool-output",
+      },
+    ]);
+    await summaryStore.appendContextMessages(
+      conversation.conversationId,
+      messages.map((message) => message.messageId),
+    );
+
+    const summarize = vi.fn(async (sourceText: string) => {
+      expect(sourceText).toContain("Meaningful tool result");
+      return "Meaningful tool result summary";
+    });
+    const coordinator = new PendingCompactionCoordinator({
+      conversationStore,
+      pendingSummaryStore,
+      summaryStore,
+      model: "test-model",
+      leaseOwner: "test-worker",
+      config: {
+        freshTailCount: 0,
+        leafChunkTokens: 20_000,
+        condensedMinFanout: 3,
+        condensedMinSourceTokens: 100_000,
+        condensedChunkTokens: 100_000,
+      },
+      summarize,
+    });
+
+    const planned = await coordinator.runOnce({
+      conversationId: conversation.conversationId,
+      sessionKey: "agent:main:pending-coordinator-empty-tool",
+      publishPolicy: "prepare-only",
+    });
+    expect(planned).toMatchObject({ status: "planned", nodeCount: 2 });
+    if (planned.status !== "planned") {
+      throw new Error("Expected empty-source regression batch to be planned");
+    }
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "prepared", emptySource: true });
+    expect(summarize).not.toHaveBeenCalled();
+
+    const nodesAfterEmptySource = await pendingSummaryStore.getNodesByBatch(planned.batchId);
+    expect(nodesAfterEmptySource).toMatchObject([
+      {
+        status: "ready",
+        ordinalStart: 0,
+        ordinalEnd: 0,
+        content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+        model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+        retryCount: 0,
+        failureSummary: null,
+      },
+      { status: "planned", ordinalStart: 1, ordinalEnd: 1 },
+    ]);
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "prepared" });
+    expect(summarize).toHaveBeenCalledOnce();
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "ready" });
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "publish-ready-only",
+      }),
+    ).resolves.toMatchObject({ status: "published" });
+
+    const contextItems = await summaryStore.getContextItems(conversation.conversationId);
+    expect(contextItems.map((item) => item.ordinal)).toEqual([0, 1]);
+    expect(contextItems.map((item) => item.itemType)).toEqual(["summary", "summary"]);
+    const coverageSummary = await summaryStore.getSummary(contextItems[0]!.summaryId!);
+    const meaningfulSummary = await summaryStore.getSummary(contextItems[1]!.summaryId!);
+    expect(coverageSummary).toMatchObject({
+      content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+      model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+      sourceMessageTokenCount: 22_373,
+    });
+    expect(meaningfulSummary).toMatchObject({
+      content: "Meaningful tool result summary",
+      model: "test-model",
+      sourceMessageTokenCount: 22_000,
+    });
+    await expect(summaryStore.getSummaryMessages(coverageSummary!.summaryId)).resolves.toEqual([
+      messages[0]!.messageId,
+    ]);
+    await expect(summaryStore.getSummaryMessages(meaningfulSummary!.summaryId)).resolves.toEqual([
+      messages[1]!.messageId,
+    ]);
+    await expect(conversationStore.getMessageById(messages[0]!.messageId)).resolves.toMatchObject({
+      content: rawEmptyToolOutput,
+    });
+    await expect(pendingSummaryStore.getBatch(planned.batchId)).resolves.toMatchObject({
+      status: "published",
+      failureSummary: null,
+    });
+  });
+
+  it("fails a leaf with missing source links instead of publishing false empty coverage", async () => {
+    const { db, conversationStore, pendingSummaryStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "pending-coordinator-missing-links-session",
+      sessionKey: "agent:main:pending-coordinator-missing-links",
+    });
+    const message = await conversationStore.createMessage({
+      conversationId: conversation.conversationId,
+      seq: 1,
+      role: "tool",
+      content: "A".repeat(80_000),
+      tokenCount: 20_000,
+    });
+    await summaryStore.appendContextMessage(conversation.conversationId, message.messageId);
+
+    const summarize = vi.fn(async () => "should not be called");
+    const coordinator = new PendingCompactionCoordinator({
+      conversationStore,
+      pendingSummaryStore,
+      summaryStore,
+      model: "test-model",
+      leaseOwner: "test-worker",
+      config: {
+        freshTailCount: 0,
+        leafChunkTokens: 20_000,
+        condensedMinFanout: 2,
+        condensedMinSourceTokens: 1,
+        condensedChunkTokens: 100_000,
+      },
+      summarize,
+    });
+
+    const planned = await coordinator.runOnce({
+      conversationId: conversation.conversationId,
+      publishPolicy: "prepare-only",
+    });
+    expect(planned).toMatchObject({ status: "planned", nodeCount: 1 });
+    if (planned.status !== "planned") {
+      throw new Error("Expected missing-link regression batch to be planned");
+    }
+    const [node] = await pendingSummaryStore.getNodesByBatch(planned.batchId);
+    db.prepare(`DELETE FROM pending_summary_node_messages WHERE node_id = ?`).run(node!.nodeId);
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      failureSummary: `Pending leaf summary ${node!.nodeId} has no linked source messages`,
+    });
+    expect(summarize).not.toHaveBeenCalled();
+    await expect(pendingSummaryStore.getNode(node!.nodeId)).resolves.toMatchObject({
+      status: "failed",
+      content: null,
+      model: "test-model",
+      retryCount: 1,
+      failureSummary: `Pending leaf summary ${node!.nodeId} has no linked source messages`,
+    });
+    await expect(pendingSummaryStore.getBatch(planned.batchId)).resolves.toMatchObject({
+      status: "planning",
+      failureSummary: null,
+    });
+  });
+
+  it("excludes empty-source markers when condensing mixed child coverage", async () => {
+    const { conversationStore, pendingSummaryStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "pending-coordinator-mixed-empty-condensed-session",
+      sessionKey: "agent:main:pending-coordinator-mixed-empty-condensed",
+    });
+    const messages = await conversationStore.createMessagesBulk([
+      {
+        conversationId: conversation.conversationId,
+        seq: 1,
+        role: "tool",
+        content: "A".repeat(80_000),
+        tokenCount: 20_000,
+      },
+      {
+        conversationId: conversation.conversationId,
+        seq: 2,
+        role: "tool",
+        content: "Meaningful child detail survives marker filtering.",
+        tokenCount: 20_000,
+      },
+    ]);
+    await summaryStore.appendContextMessages(
+      conversation.conversationId,
+      messages.map((message) => message.messageId),
+    );
+
+    const summarizedSources: string[] = [];
+    const summarize = vi.fn(async (sourceText: string, _aggressive, options) => {
+      summarizedSources.push(sourceText);
+      return options?.isCondensed ? "Condensed meaningful child" : "Meaningful child summary";
+    });
+    const coordinator = new PendingCompactionCoordinator({
+      conversationStore,
+      pendingSummaryStore,
+      summaryStore,
+      model: "test-model",
+      leaseOwner: "test-worker",
+      config: {
+        freshTailCount: 0,
+        leafChunkTokens: 20_000,
+        condensedMinFanout: 2,
+        condensedMinSourceTokens: 1,
+        condensedChunkTokens: 100_000,
+      },
+      summarize,
+    });
+
+    const planned = await coordinator.runOnce({
+      conversationId: conversation.conversationId,
+      publishPolicy: "prepare-only",
+    });
+    expect(planned).toMatchObject({ status: "planned", nodeCount: 3 });
+    if (planned.status !== "planned") {
+      throw new Error("Expected mixed empty-source condensed batch to be planned");
+    }
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "prepared", emptySource: true });
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "prepared" });
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "prepared" });
+    expect(summarize).toHaveBeenCalledTimes(2);
+    expect(summarizedSources[0]).toContain("Meaningful child detail");
+    expect(summarizedSources[1]).toBe("Meaningful child summary");
+    expect(summarizedSources.join("\n")).not.toContain(PENDING_EMPTY_SOURCE_COVERAGE_CONTENT);
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "ready" });
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "publish-ready-only",
+      }),
+    ).resolves.toMatchObject({ status: "published" });
+
+    const [contextItem] = await summaryStore.getContextItems(conversation.conversationId);
+    const root = await summaryStore.getSummary(contextItem!.summaryId!);
+    expect(root).toMatchObject({
+      kind: "condensed",
+      content: "Condensed meaningful child",
+      model: "test-model",
+      sourceMessageTokenCount: 40_000,
+    });
+    const parents = await summaryStore.getSummaryParents(root!.summaryId);
+    expect(parents).toHaveLength(2);
+    const parentSummaries = await Promise.all(
+      parents.map((parent) => summaryStore.getSummary(parent.summaryId)),
+    );
+    expect(parentSummaries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+          model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+        }),
+        expect.objectContaining({ content: "Meaningful child summary", model: "test-model" }),
+      ]),
+    );
+  });
+
+  it("propagates all-empty condensed coverage without calling the model", async () => {
+    const { conversationStore, pendingSummaryStore, summaryStore } = createStores();
+    const conversation = await conversationStore.createConversation({
+      sessionId: "pending-coordinator-all-empty-condensed-session",
+      sessionKey: "agent:main:pending-coordinator-all-empty-condensed",
+    });
+    const messages = await conversationStore.createMessagesBulk(
+      ["A".repeat(80_000), "B".repeat(80_000)].map((content, index) => ({
+        conversationId: conversation.conversationId,
+        seq: index + 1,
+        role: "tool" as const,
+        content,
+        tokenCount: 20_000,
+      })),
+    );
+    await summaryStore.appendContextMessages(
+      conversation.conversationId,
+      messages.map((message) => message.messageId),
+    );
+
+    const summarize = vi.fn(async () => "should not be called");
+    const coordinator = new PendingCompactionCoordinator({
+      conversationStore,
+      pendingSummaryStore,
+      summaryStore,
+      model: "test-model",
+      leaseOwner: "test-worker",
+      config: {
+        freshTailCount: 0,
+        leafChunkTokens: 20_000,
+        condensedMinFanout: 2,
+        condensedMinSourceTokens: 1,
+        condensedChunkTokens: 100_000,
+      },
+      summarize,
+    });
+
+    const planned = await coordinator.runOnce({
+      conversationId: conversation.conversationId,
+      publishPolicy: "prepare-only",
+    });
+    expect(planned).toMatchObject({ status: "planned", nodeCount: 3 });
+    if (planned.status !== "planned") {
+      throw new Error("Expected all-empty condensed batch to be planned");
+    }
+    for (let step = 0; step < 3; step += 1) {
+      await expect(
+        coordinator.runOnce({
+          conversationId: conversation.conversationId,
+          publishPolicy: "prepare-only",
+        }),
+      ).resolves.toMatchObject({ status: "prepared", emptySource: true });
+    }
+    expect(summarize).not.toHaveBeenCalled();
+    const readyNodes = await pendingSummaryStore.getNodesByBatch(planned.batchId);
+    expect(readyNodes).toHaveLength(3);
+    expect(readyNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "condensed",
+          status: "ready",
+          content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+          model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+          retryCount: 0,
+        }),
+      ]),
+    );
+
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "prepare-only",
+      }),
+    ).resolves.toMatchObject({ status: "ready" });
+    await expect(
+      coordinator.runOnce({
+        conversationId: conversation.conversationId,
+        publishPolicy: "publish-ready-only",
+      }),
+    ).resolves.toMatchObject({ status: "published" });
+    expect(summarize).not.toHaveBeenCalled();
+
+    const [contextItem] = await summaryStore.getContextItems(conversation.conversationId);
+    expect(contextItem).toMatchObject({ ordinal: 0, itemType: "summary" });
+    const root = await summaryStore.getSummary(contextItem!.summaryId!);
+    expect(root).toMatchObject({
+      kind: "condensed",
+      content: PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+      model: PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+      sourceMessageTokenCount: 40_000,
+    });
+    const parents = await summaryStore.getSummaryParents(root!.summaryId);
+    expect(parents).toHaveLength(2);
+    for (const parent of parents) {
+      await expect(summaryStore.getSummaryMessages(parent.summaryId)).resolves.toHaveLength(1);
+    }
+    for (const message of messages) {
+      await expect(conversationStore.getMessageById(message.messageId)).resolves.toMatchObject({
+        content: message.content,
+      });
+    }
   });
 
   it("keeps prepared pending summaries publishable when new tail messages arrive", async () => {

--- a/test/pending-summary-worker.test.ts
+++ b/test/pending-summary-worker.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  PENDING_EMPTY_SOURCE_COVERAGE_CONTENT,
+  PENDING_EMPTY_SOURCE_COVERAGE_MODEL,
+  PendingSummaryEmptySourceCoverage,
   PendingSummaryPreparationWorker,
   type PendingSummaryPreparationStore,
 } from "../src/pending-summary-worker.js";
@@ -130,14 +133,16 @@ describe("PendingSummaryPreparationWorker", () => {
     expect(events).toEqual(["failed:node_worker_a:worker-a:provider timeout"]);
   });
 
-  it("marks a claimed node failed when source text is empty", async () => {
+  it("marks an empty sanitized source ready with deterministic lossless coverage", async () => {
     const events: string[] = [];
     const store: PendingSummaryPreparationStore = {
       async claimNextPlannedNode() {
         return createNode();
       },
       async markNodeReady(input) {
-        events.push(`ready:${input.nodeId}`);
+        events.push(
+          `ready:${input.nodeId}:${input.content}:${input.tokenCount}:${input.model ?? ""}`,
+        );
         return true;
       },
       async markNodeFailed(input) {
@@ -154,10 +159,59 @@ describe("PendingSummaryPreparationWorker", () => {
       leaseOwner: "worker-a",
       leaseMs: 60_000,
       now: () => new Date("2026-06-30T12:00:00.000Z"),
-      loadSourceText: async () => "   ",
-      summarize: async () => {
-        throw new Error("should not be called");
+      loadSourceText: async () => {
+        throw new PendingSummaryEmptySourceCoverage();
       },
+      summarize: async () => {
+        events.push("summarize");
+        return "should not be called";
+      },
+      estimateTokens: (content) => {
+        expect(content).toBe(PENDING_EMPTY_SOURCE_COVERAGE_CONTENT);
+        return 19;
+      },
+    });
+
+    await expect(worker.prepareOne({ conversationId: 42 })).resolves.toEqual({
+      status: "prepared",
+      nodeId: "node_worker_a",
+      emptySource: true,
+    });
+    expect(events).toEqual([
+      `ready:node_worker_a:${PENDING_EMPTY_SOURCE_COVERAGE_CONTENT}:19:${PENDING_EMPTY_SOURCE_COVERAGE_MODEL}`,
+    ]);
+  });
+
+  it("does not classify an unverified empty loader result as sanitized coverage", async () => {
+    const events: string[] = [];
+    const store: PendingSummaryPreparationStore = {
+      async claimNextPlannedNode() {
+        return createNode();
+      },
+      async markNodeReady(input) {
+        events.push(`ready:${input.nodeId}`);
+        return true;
+      },
+      async markNodeFailed(input) {
+        events.push(`failed:${input.nodeId}:${input.failureSummary}`);
+        return true;
+      },
+      async releaseNodeClaim(input) {
+        events.push(`released:${input.nodeId}`);
+        return true;
+      },
+    };
+    const summarize = async () => {
+      events.push("summarize");
+      return "should not be called";
+    };
+    const worker = new PendingSummaryPreparationWorker({
+      store,
+      leaseOwner: "worker-a",
+      leaseMs: 60_000,
+      now: () => new Date("2026-06-30T12:00:00.000Z"),
+      loadSourceText: async () => "   ",
+      summarize,
       estimateTokens: () => 0,
     });
 
@@ -166,7 +220,7 @@ describe("PendingSummaryPreparationWorker", () => {
       nodeId: "node_worker_a",
       failureSummary: "empty pending summary source",
     });
-    expect(events).toEqual(["failed:node_worker_a:worker-a:empty pending summary source"]);
+    expect(events).toEqual(["failed:node_worker_a:empty pending summary source"]);
   });
 
   it("marks a claimed node failed when prepared content is empty", async () => {


### PR DESCRIPTION
## Summary

- publish deterministic coverage when a fully linked pending-summary source becomes empty after safety sanitization
- preserve raw message and parent lineage while avoiding an LLM call, retry increment, or false provider-success signal
- exclude coverage markers from mixed condensed-summary input and propagate all-empty condensed coverage without a model call
- keep missing links or missing source records on the ordinary failure path

## Why

Async pending compaction can plan a singleton leaf for an oversized tool result. If safety sanitization removes every summarizable byte, the preparation worker currently treats the empty source as a retryable failure. Repeated attempts can stale the atomic batch and prevent later meaningful nodes in that batch from publishing.

The synchronous compaction path already treats a sanitized-empty source as a deterministic skip. This change gives the async path an auditable equivalent: a canonical summary marker closes the exact ordinal range, records explicit `lossless-claw/empty-source` provenance, and retains the raw source links for expansion.

## Impact and safety

- no schema or status migration
- no transcript or summary deletion
- existing stale batches are left untouched
- empty coverage requires verified source lineage; missing lineage is not hidden
- normal and mixed-content summaries continue to use the configured model

## Verification

- `npm run typecheck`
- `npm test` — 1,818 tests passed
- `npm run build`
- regression coverage for oversized sanitized-empty leaves, later meaningful publication, missing lineage, mixed condensed parents, and all-empty condensed DAGs

Includes a patch changeset.
