### PR TITLE
feat: add preserveNativeImages flag to keep image blocks inline for vision-capable models

### DIFF
--- a/.changeset/preserve-native-images.md
+++ b/.changeset/preserve-native-images.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Add `preserveNativeImages` config flag: when enabled, native and inline image blocks are left in place at ingest instead of being externalized to a `file_xxx` reference, so vision-capable models receive real image content.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ Most installations only need to override a handful of keys. If you want a comple
   "freshTailMaxTokens": 24000,
   "promptAwareEviction": false,
   "stubLargeToolPayloads": false,
+  "preserveNativeImages": false,
   "newSessionRetainDepth": 2,
   "leafMinFanout": 8,
   "condensedMinFanout": 4,
@@ -249,6 +250,7 @@ Every automatic decision emits grep-able log lines prefixed with `[lcm] auto-rot
 | `freshTailMaxTokens` | `integer` | unset | `LCM_FRESH_TAIL_MAX_TOKENS` | Optional token cap for the protected fresh tail. The newest user message and its following assistant/tool suffix are always preserved even if they exceed the cap. |
 | `promptAwareEviction` | `boolean` | `false` | `LCM_PROMPT_AWARE_EVICTION_ENABLED` | When enabled, budget-constrained assembly keeps older evictable items by prompt relevance instead of pure chronology. This improves retrieval under tight budgets, but it can reduce prompt-cache hit rates because the preserved prefix changes as prompts change. |
 | `stubLargeToolPayloads` | `boolean` | `false` | `LCM_STUB_LARGE_TOOL_PAYLOADS` | When enabled, evictable tool-result rows backfilled with `messages.large_content` are assembled as `[LCM Tool Output: file_xxx ...]` stubs while the fresh tail stays inline. Requires `scripts/lcm-blob-migrate.mjs`, which defaults to the same large-files root as runtime LCM (`LCM_LARGE_FILES_DIR` or `${OPENCLAW_STATE_DIR}/lcm-files`). |
+| `preserveNativeImages` | `boolean` | `false` | `LCM_PRESERVE_NATIVE_IMAGES` | When enabled, native and inline image blocks are left in place at ingest instead of being externalized to a `file_xxx` reference, so vision-capable models receive real image content. Off by default to preserve the existing externalization behavior. |
 | `leafMinFanout` | `integer` | `8` | `LCM_LEAF_MIN_FANOUT` | Minimum number of raw messages required before a leaf pass runs. |
 | `condensedMinFanout` | `integer` | `4` | `LCM_CONDENSED_MIN_FANOUT` | Number of same-depth summaries needed before condensation is attempted. |
 | `condensedMinFanoutHard` | `integer` | `2` | `LCM_CONDENSED_MIN_FANOUT_HARD` | Hard floor for condensation grouping during maintenance and repair flows. |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -325,6 +325,10 @@
     "stripInjectedContextTags": {
       "label": "Strip Injected Context Tags",
       "help": "XML tag names whose blocks are stripped from messages before summarization. Covers memory/context plugin prepended blocks (active-memory, memory-lancedb, hindsight-openclaw). Set to [] to disable."
+    },
+    "preserveNativeImages": {
+      "label": "Preserve Native Images",
+      "help": "When enabled, native and inline image blocks are left in place at ingest instead of being externalized to a file_xxx reference, so vision-capable models receive real image content. Off by default to preserve the existing externalization behavior."
     }
   },
   "configSchema": {
@@ -336,7 +340,10 @@
       },
       "hostFallbackMode": {
         "type": "string",
-        "enum": ["error", "capture-only"]
+        "enum": [
+          "error",
+          "capture-only"
+        ]
       },
       "contextThreshold": {
         "type": "number",
@@ -692,10 +699,17 @@
         "items": {
           "type": "object",
           "properties": {
-            "provider": { "type": "string" },
-            "model": { "type": "string" }
+            "provider": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
           },
-          "required": ["provider", "model"],
+          "required": [
+            "provider",
+            "model"
+          ],
           "additionalProperties": false
         }
       },
@@ -705,6 +719,9 @@
         "items": {
           "type": "string"
         }
+      },
+      "preserveNativeImages": {
+        "type": "boolean"
       }
     }
   }

--- a/skills/lossless-claw/references/config.md
+++ b/skills/lossless-claw/references/config.md
@@ -129,6 +129,21 @@ Good default:
 - `false`
 - enable it only after migration and live validation
 
+### `preserveNativeImages`
+
+Controls whether native and inline image blocks are externalized to a `file_xxx` reference at ingest time, or left in place so vision-capable models receive real image content.
+
+Why it matters:
+
+- when off (default), image blocks are written to a `file_xxx` reference and the model sees text only — this keeps context small but breaks vision-capable models that need actual pixels
+- when on, images stay inline as first-class image content so multimodal models can see them
+- it is the right choice for vision-capable models; keep it off for text-only models that would otherwise waste context on image bytes
+
+Good default:
+
+- `false`
+- enable it when your primary model is vision-capable and you send images
+
 ### `leafChunkTokens`
 
 Caps how much raw material gets summarized into one leaf summary.
@@ -448,6 +463,19 @@ Why it matters:
 Env override:
 
 - `LCM_STUB_LARGE_TOOL_PAYLOADS`
+
+### `preserveNativeImages`
+
+Boolean toggle for keeping native and inline image blocks in place at ingest instead of externalizing them to a `file_xxx` reference.
+
+Why it matters:
+
+- when off (default), images become a `file_xxx` reference and the model sees text only
+- when on, images stay inline so vision-capable models receive real image content
+
+Env override:
+
+- `LCM_PRESERVE_NATIVE_IMAGES`
 
 ### `leafChunkTokens`
 

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -124,6 +124,15 @@ export type LcmConfig = {
    * Default false; flag-flip is reversible at runtime.
    */
   stubLargeToolPayloads: boolean;
+  /**
+   * When true, skip the inline-image/native-image externalization step at
+   * ingest time so image blocks stay in the message content and reach the
+   * model as first-class image content. This is useful for vision-capable
+   * models that must see actual pixels rather than a `file_xxx` reference.
+   * Off by default to preserve the existing externalization behavior; the
+   * flag is reversible at runtime.
+   */
+  preserveNativeImages: boolean;
   newSessionRetainDepth: number;
   leafMinFanout: number;
   condensedMinFanout: number;
@@ -730,6 +739,13 @@ export function resolveLcmConfigWithDiagnostics(
         env.LCM_STUB_LARGE_TOOL_PAYLOADS !== undefined
           ? env.LCM_STUB_LARGE_TOOL_PAYLOADS === "true"
           : toBool(pc.stubLargeToolPayloads) ?? false,
+      // When true, keep native image blocks inline at ingest so vision-capable
+      // models receive real image content instead of a file_xxx reference.
+      // Default false preserves the existing externalization behavior.
+      preserveNativeImages:
+        env.LCM_PRESERVE_NATIVE_IMAGES !== undefined
+          ? env.LCM_PRESERVE_NATIVE_IMAGES === "true"
+          : toBool(pc.preserveNativeImages) ?? false,
       newSessionRetainDepth:
         parseFiniteInt(env.LCM_NEW_SESSION_RETAIN_DEPTH)
           ?? toNumber(pc.newSessionRetainDepth) ?? 2,

--- a/src/large-file-interceptor.ts
+++ b/src/large-file-interceptor.ts
@@ -274,6 +274,11 @@ export class LargeFileInterceptor {
     conversationId: number;
     message: AgentMessage;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
+    // When preserveNativeImages is on, leave native image blocks inline so
+    // vision-capable models receive real image content (no file_xxx reference).
+    if (this.config.preserveNativeImages) {
+      return null;
+    }
     if (!("content" in params.message)) {
       return null;
     }
@@ -361,6 +366,11 @@ export class LargeFileInterceptor {
     content: string;
     role: string;
   }): Promise<{ rewrittenContent: string; fileIds: string[] } | null> {
+    // When preserveNativeImages is on, leave inline user image content in
+    // place so vision-capable models receive the original image data.
+    if (this.config.preserveNativeImages) {
+      return null;
+    }
     const mediaResult = await this.interceptUserMediaBase64(params);
     if (mediaResult) {
       return mediaResult;
@@ -551,6 +561,11 @@ export class LargeFileInterceptor {
     conversationId: number;
     message: AgentMessage;
   }): Promise<{ rewrittenMessage: AgentMessage; fileIds: string[] } | null> {
+    // When preserveNativeImages is on, leave tool image content inline so
+    // vision-capable models receive the original image data.
+    if (this.config.preserveNativeImages) {
+      return null;
+    }
     if (
       (params.message.role !== "toolResult" && params.message.role !== "tool") ||
       !("content" in params.message)

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -964,6 +964,7 @@ describe("resolveLcmConfig", () => {
     });
     expect(manifest.configSchema.properties.timezone).toEqual({ type: "string" });
     expect(manifest.configSchema.properties.pruneHeartbeatOk).toEqual({ type: "boolean" });
+    expect(manifest.configSchema.properties.preserveNativeImages).toEqual({ type: "boolean" });
   });
 
   it("ships a manifest with bootstrapMaxTokens in schema", () => {

--- a/test/expansion.test.ts
+++ b/test/expansion.test.ts
@@ -15,6 +15,7 @@ const BASE_CONFIG: LcmConfig = {
   freshTailCount: 8,
   promptAwareEviction: false,
   stubLargeToolPayloads: false,
+  preserveNativeImages: false,
   newSessionRetainDepth: 2,
   leafMinFanout: 8,
   condensedMinFanout: 4,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -57,6 +57,7 @@ export function createTestConfig(
     freshTailCount: 8,
     promptAwareEviction: false,
     stubLargeToolPayloads: false,
+    preserveNativeImages: false,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
     condensedMinFanout: 4,

--- a/test/lcm-log.test.ts
+++ b/test/lcm-log.test.ts
@@ -30,6 +30,7 @@ function baseConfig(file: string, independentLogFileEnabled = true): LcmConfig {
     freshTailCount: 64,
     promptAwareEviction: false,
     stubLargeToolPayloads: false,
+    preserveNativeImages: false,
     newSessionRetainDepth: 2,
     leafMinFanout: 8,
     condensedMinFanout: 4,


### PR DESCRIPTION
## Summary

Adds a `preserveNativeImages` config flag to `lossless-claw`. When enabled, native and inline image blocks are left in place at ingest time instead of being externalized to a `[User image: ... | LCM file: ...]` reference, so **vision-capable models receive real image content** rather than a file-id text reference.

## Problem

When a vision-capable model is configured as the context engine, lossless-claw externalizes **all** images (native `{ type: "image" }` blocks, base64 inline images, and tool/toolResult images) during `storeMessage` ingest. The model sees only:

```
[User image: user-image.png (image/png, 124,171 bytes) | LCM file: file_063ad8df06e24a92]
```

The actual pixels never reach the model, which breaks any multimodal setup. The `estimateTokens(content) < 100` check only exempts tiny images; there is no config switch to keep images inline.

## Changes

- **`src/db/config.ts`** — add `preserveNativeImages` to `LcmConfig` and parse it from `env.LCM_PRESERVE_NATIVE_IMAGES` / `pc.preserveNativeImages` (default `false`).
- **`src/large-file-interceptor.ts`** — return early from `interceptNativeImageBlocks`, `interceptInlineImages`, and `interceptInlineImagesInToolMessage` when `preserveNativeImages` is on.
- **`openclaw.plugin.json`** — add `preserveNativeImages` to `configSchema.properties` + `uiHints` (required so the gateway accepts the config field at startup; without this the gateway aborts with `must not have additional properties`).
- **`docs/configuration.md`** + **`skills/lossless-claw/references/config.md`** — document the flag.
- **`test/config.test.ts`** — regression assertion on the manifest schema (the field is present with `{ type: "boolean" }`).
- **`test/expansion.test.ts`**, **`test/helpers.ts`**, **`test/lcm-log.test.ts`** — add `preserveNativeImages: false` to test fixtures.
- **`.changeset/preserve-native-images.md`** — patch changeset.

## Validation

- `npm run typecheck` passes.
- `npm run build` (plugin bundle) passes; `dist/index.js` contains `preserveNativeImages`.
- The change was validated **end to end in a real deployment** (OpenClaw 2026.8.1-beta.3, Windows): after setting `"preserveNativeImages": true`, inbound images reach a `deepseek-v4-flash-vision-exp` model as real `{ type: "image" }` blocks instead of a `file_xxx` reference. The gateway boots cleanly and `openclaw config validate` passes with the field present.

## Decision needed

Should `preserveNativeImages` be **opt-in** (default `false`, preserves current behavior) or **on by default for vision-capable models**? The current PR keeps it opt-in to avoid changing behavior for existing text-only setups, but a default-true for vision models could be a follow-up.

Closes #1112
