### PR TITLE
fix: keep 1.0 installs on beta channel

### DIFF
--- a/.changeset/beta-install-channel-guidance.md
+++ b/.changeset/beta-install-channel-guidance.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep Lossless Claw 1.0 install, update, migration, and status repair commands on the npm `beta` channel, and warn when an existing install still follows the incompatible 0.15.x `latest` channel.

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ This surface is capability-gated by the OpenClaw host. At the time of this chang
 Run it in dry-run mode first:
 
 ```bash
-npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw
+npx --package @martian-engineering/lossless-claw@beta lossless-claw-migrate-sessions --state-dir ~/.openclaw
 ```
 
 Apply the import only after reviewing the dry-run output:
 
 ```bash
-npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
+npx --package @martian-engineering/lossless-claw@beta lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
 ```
 
 The command defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`. `--apply` creates a timestamped SQLite backup before writing when the database already exists. Use `--file <path>` or repeatable `--sessions-dir <path>` for targeted imports, `--since <iso-date>` or `--limit <n>` to narrow a batch, and `--json` for machine-readable output.
@@ -131,22 +131,25 @@ the existing `afterTurn` compatibility path.
 
 ### Install the plugin
 
+Lossless Claw 1.0 prereleases use the npm `beta` channel. The npm `latest`
+channel remains on the 0.x release line for stable OpenClaw hosts.
+
 Use OpenClaw's plugin installer (recommended):
 
 ```bash
-openclaw plugins install @martian-engineering/lossless-claw@latest
+openclaw plugins install @martian-engineering/lossless-claw@beta
 ```
 
 If you're running from a local OpenClaw checkout, use:
 
 ```bash
-pnpm openclaw plugins install @martian-engineering/lossless-claw@latest
+pnpm openclaw plugins install @martian-engineering/lossless-claw@beta
 ```
 
-Use exact versions only for rollback or reproducible canary testing. OpenClaw records an exact install spec such as `@martian-engineering/lossless-claw@0.12.0` as a pinned update track, so OpenClaw plugin update sync will keep that version until you move back to the stable track:
+Use exact versions only for rollback or reproducible canary testing. OpenClaw records an exact install spec such as `@martian-engineering/lossless-claw@0.12.0` as a pinned update track, so OpenClaw plugin update sync will keep that version until you move back to the beta track:
 
 ```bash
-openclaw plugins update @martian-engineering/lossless-claw@latest
+openclaw plugins update @martian-engineering/lossless-claw@beta
 ```
 
 For local plugin development, build your working copy first, then link it instead of copying files:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,22 +183,25 @@ Notes on the example:
 
 ## Install and enable
 
+Lossless Claw 1.0 prereleases use the npm `beta` channel. The npm `latest`
+channel remains on the 0.x release line for stable OpenClaw hosts.
+
 Install with OpenClaw's plugin installer:
 
 ```bash
-openclaw plugins install @martian-engineering/lossless-claw@latest
+openclaw plugins install @martian-engineering/lossless-claw@beta
 ```
 
 If you are running from a local OpenClaw checkout:
 
 ```bash
-pnpm openclaw plugins install @martian-engineering/lossless-claw@latest
+pnpm openclaw plugins install @martian-engineering/lossless-claw@beta
 ```
 
 Use exact versions only for rollback or reproducible canary testing. OpenClaw treats an exact install spec such as `@martian-engineering/lossless-claw@0.12.0` as pinned, so plugin update sync will not follow newer LCM releases until you return to the moving track:
 
 ```bash
-openclaw plugins update @martian-engineering/lossless-claw@latest
+openclaw plugins update @martian-engineering/lossless-claw@beta
 ```
 
 For local plugin development, link a working copy:

--- a/skills/lossless-claw/references/session-lifecycle.md
+++ b/skills/lossless-claw/references/session-lifecycle.md
@@ -67,7 +67,7 @@ When answering users:
 If a user explicitly asks how to import old or past OpenClaw conversation data into Lossless, recommend the packaged session migration CLI:
 
 ```bash
-npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw
+npx --package @martian-engineering/lossless-claw@beta lossless-claw-migrate-sessions --state-dir ~/.openclaw
 ```
 
 That command name, `lossless-claw-migrate-sessions`, is the npm package executable declared by lossless-claw. It backfills OpenClaw JSONL session files into `lcm.db`.
@@ -91,7 +91,7 @@ Safe recommendation pattern:
 2. Apply only after the user confirms the target state directory and import set:
 
 ```bash
-npx --package @martian-engineering/lossless-claw@latest lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
+npx --package @martian-engineering/lossless-claw@beta lossless-claw-migrate-sessions --state-dir ~/.openclaw --apply
 ```
 
 The CLI defaults to `${OPENCLAW_STATE_DIR:-~/.openclaw}` and `${OPENCLAW_STATE_DIR:-~/.openclaw}/lcm.db`. On `--apply`, it creates a timestamped SQLite backup before writing when the database already exists. For narrow imports, suggest `--file <path>`, repeatable `--sessions-dir <path>`, `--since <iso-date>`, or `--limit <n>`.

--- a/src/plugin/lcm-command.ts
+++ b/src/plugin/lcm-command.ts
@@ -102,9 +102,8 @@ type RolloverSplitApplyOptions = {
   confirm: boolean;
 };
 type LcmInstallTrackWarning = {
-  kind: "exact-pinned";
+  kind: "exact-pinned" | "wrong-channel";
   spec: string;
-  version: string;
 };
 type AnchorTrustAuditStats = {
   verified: number;
@@ -399,9 +398,12 @@ function detectLcmInstallTrackWarning(params: {
         || readStringField(record, "installSpec")
         || readStringField(record, "packageSpec")
         || readStringField(record, "resolvedSpec");
+      if (spec.trim() === `${LOSSLESS_NPM_PACKAGE}@latest`) {
+        return { kind: "wrong-channel", spec };
+      }
       const version = parseExactLosslessPackageVersion(spec);
       if (version) {
-        return { kind: "exact-pinned", spec, version };
+        return { kind: "exact-pinned", spec };
       }
     }
   }
@@ -409,17 +411,18 @@ function detectLcmInstallTrackWarning(params: {
   return null;
 }
 
+/** Format the update-track warning and the command that restores the 1.0 beta channel. */
 function buildInstallTrackWarningSection(warning: LcmInstallTrackWarning): string {
+  const impact = warning.kind === "wrong-channel"
+    ? "OpenClaw plugin update sync will follow the 0.x stable line instead of Lossless Claw 1.0 prereleases."
+    : "OpenClaw plugin update sync will keep this exact version and will not follow new LCM releases.";
   return buildSection("⚠️ Update track", [
     buildStatLine("status", warning.kind),
     buildStatLine("installed spec", formatCommand(warning.spec)),
-    buildStatLine(
-      "impact",
-      "OpenClaw plugin update sync will keep this exact version and will not follow new LCM releases.",
-    ),
+    buildStatLine("impact", impact),
     buildStatLine(
       "repair",
-      formatCommand(`openclaw plugins update ${LOSSLESS_NPM_PACKAGE}@latest`),
+      formatCommand(`openclaw plugins update ${LOSSLESS_NPM_PACKAGE}@beta`),
     ),
   ]);
 }

--- a/test/lcm-command.test.ts
+++ b/test/lcm-command.test.ts
@@ -345,7 +345,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("status: exact-pinned");
     expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
     expect(result.text).toContain("impact: OpenClaw plugin update sync will keep this exact version");
-    expect(result.text).toContain("repair: `openclaw plugins update @martian-engineering/lossless-claw@latest`");
+    expect(result.text).toContain("repair: `openclaw plugins update @martian-engineering/lossless-claw@beta`");
   });
 
   it("warns when status sees an exact npm install spec in OpenClaw's installed plugin index", async () => {
@@ -370,7 +370,7 @@ describe("lcm command", () => {
     expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@0.12.0`");
   });
 
-  it("does not warn when status sees a moving npm install spec", async () => {
+  it("warns when status sees the stable npm channel on the 1.0 beta line", async () => {
     const fixture = createCommandFixture();
     tempDirs.add(fixture.tempDir);
     dbPaths.add(fixture.dbPath);
@@ -391,7 +391,43 @@ describe("lcm command", () => {
               "lossless-claw": {
                 source: "npm",
                 spec: "@martian-engineering/lossless-claw@latest",
-                version: "0.13.1",
+                version: "0.15.3",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.text).toContain("**⚠️ Update track**");
+    expect(result.text).toContain("status: wrong-channel");
+    expect(result.text).toContain("installed spec: `@martian-engineering/lossless-claw@latest`");
+    expect(result.text).toContain("impact: OpenClaw plugin update sync will follow the 0.x stable line");
+    expect(result.text).toContain("repair: `openclaw plugins update @martian-engineering/lossless-claw@beta`");
+  });
+
+  it("does not warn when status sees the moving beta npm install spec", async () => {
+    const fixture = createCommandFixture();
+    tempDirs.add(fixture.tempDir);
+    dbPaths.add(fixture.dbPath);
+
+    const result = await fixture.command.handler(
+      createCommandContext(undefined, {
+        config: {
+          plugins: {
+            entries: {
+              "lossless-claw": {
+                enabled: true,
+              },
+            },
+            slots: {
+              contextEngine: "lossless-claw",
+            },
+            installs: {
+              "lossless-claw": {
+                source: "npm",
+                spec: "@martian-engineering/lossless-claw@beta",
+                version: "1.0.0-beta.4",
               },
             },
           },

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -30,6 +30,20 @@ describe("package OpenClaw compatibility metadata", () => {
     expect(readProjectFile("docs/tui.md")).toContain("Shows runtime sessions");
   });
 
+  it("keeps 1.0 package commands on the npm beta channel", () => {
+    const betaChannelDocuments = [
+      "README.md",
+      "docs/configuration.md",
+      "skills/lossless-claw/references/session-lifecycle.md",
+    ];
+
+    for (const path of betaChannelDocuments) {
+      const content = readFileSync(join(process.cwd(), path), "utf8");
+      expect(content).toContain("@martian-engineering/lossless-claw@beta");
+      expect(content).not.toContain("@martian-engineering/lossless-claw@latest");
+    }
+  });
+
   it("documents the OpenClaw conversation-hook trust grant", () => {
     const readProjectFile = (path: string) =>
       readFileSync(join(process.cwd(), path), "utf8");


### PR DESCRIPTION
## What

Keep Lossless Claw 1.0 package commands on the npm `beta` channel and warn when an existing install record still follows `@latest`.

## Why

The 1.0 beta requires SQLite-backed OpenClaw, but `@latest` resolves to the incompatible Lossless Claw 0.15.x stable line. This affected install, update, migration, and status repair guidance.

## Changes

- Change 1.0 commands to `@beta`
- Warn when installs follow `@latest`
- Add beta-channel regression coverage
- Add a patch changeset

## Testing

- `npx vitest run test/package-metadata.test.ts test/lcm-command.test.ts` (73 passed)
- `npm run typecheck`
- `npm test` (1,815 passed)
- `npm run build`
- Autoreview: clean

Related to #1098.