### PR TITLE
fix: precompute live-coverage signatures

### DIFF
--- a/.changeset/calm-signatures-reconcile.md
+++ b/.changeset/calm-signatures-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Precompute live-coverage signatures before exact prompt-time reconciliation.

--- a/src/live-coverage.ts
+++ b/src/live-coverage.ts
@@ -288,14 +288,17 @@ export function resolveProtectedFreshTailAssembledIndexes(params: {
   return protectedIndexes;
 }
 
+/** Match live messages to assembled occurrences without reusing an assembled slot. */
 export function resolveExactAssembledLiveSortIndexes(params: {
   assembledMessages: AgentMessage[];
   liveMessages: AgentMessage[];
 }): Map<number, number> {
+  const assembledSignatures = params.assembledMessages.map(createLiveCoverageSignature);
+  const liveSignatures = params.liveMessages.map(createLiveCoverageSignature);
   const liveSortIndexes = new Map<number, number>();
   const usedAssembledIndexes = new Set<number>();
   for (let liveIndex = params.liveMessages.length - 1; liveIndex >= 0; liveIndex--) {
-    const liveMessage = params.liveMessages[liveIndex] as AgentMessage;
+    const liveSignature = liveSignatures[liveIndex] as string;
     for (
       let assembledIndex = params.assembledMessages.length - 1;
       assembledIndex >= 0;
@@ -304,8 +307,7 @@ export function resolveExactAssembledLiveSortIndexes(params: {
       if (usedAssembledIndexes.has(assembledIndex)) {
         continue;
       }
-      const assembledMessage = params.assembledMessages[assembledIndex] as AgentMessage;
-      if (messagesHaveSameLiveCoverageSignature(assembledMessage, liveMessage)) {
+      if (assembledSignatures[assembledIndex] === liveSignature) {
         liveSortIndexes.set(assembledIndex, liveIndex);
         usedAssembledIndexes.add(assembledIndex);
         break;

--- a/test/live-coverage-signature-precompute.test.ts
+++ b/test/live-coverage-signature-precompute.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveExactAssembledLiveSortIndexes } from "../src/live-coverage.js";
+import type { AgentMessage } from "../src/openclaw-bridge.js";
+
+describe("precomputed live-coverage signatures", () => {
+  it("matches duplicate occurrences newest-first without reusing assembled slots", () => {
+    const repeated = { role: "user", content: "repeated turn" } as AgentMessage;
+    const assembledMessages = [
+      repeated,
+      repeated,
+      { role: "assistant", content: "tail" },
+    ] as AgentMessage[];
+    const liveMessages = [repeated, repeated] as AgentMessage[];
+
+    const matches = resolveExactAssembledLiveSortIndexes({ assembledMessages, liveMessages });
+
+    expect([...matches.entries()]).toEqual([
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Precompute live-coverage signatures before exact prompt-time reconciliation while preserving newest-first occurrence matching.

## Why

OpenClaw issue [#128255](https://github.com/openclaw/openclaw/issues/128255) reports long Gateway freezes when transformed live history causes the matcher to rebuild canonical signatures across a quadratic comparison scan.

## Changes

- Cache one signature per message
- Preserve duplicate occurrence ordering
- Add focused regression coverage
- Add a patch changeset

## Testing

- `npm test` — 2,062 tests pass
- `npm run typecheck` — passes
- `npm run build` — passes
- Issue-scale mismatch: 34,879.93 ms to 74.35 ms
- Peak RSS: 65.63 MiB to 56.69 MiB
