### PR TITLE
fix: bind ClawHub releases to verified source SHA

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -97,11 +97,6 @@ jobs:
           fi
 
           source_sha="$(git rev-parse HEAD)"
-          if [ "$source_sha" != "$GITHUB_SHA" ]; then
-            echo "Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF"
-            exit 1
-          fi
-
           git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
           if [ "$source_sha" != "$tag_sha" ]; then
@@ -156,7 +151,9 @@ jobs:
     with:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
-      source_ref: refs/tags/${{ inputs.release_tag }}
+      source_repo: ${{ github.repository }}
+      source_commit: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
       dry_run: true
 
@@ -175,6 +172,8 @@ jobs:
     with:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
-      source_ref: refs/tags/${{ inputs.release_tag }}
+      source_repo: ${{ github.repository }}
+      source_commit: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
       dry_run: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,6 +86,10 @@ tag with `release_tag` set to the same tag and `dry_run` set to `false`.
 The standalone `Publish to ClawHub` workflow remains available for validation
 and recovery. Select the release tag as the workflow ref, set `release_tag` to
 the same tag, and use `dry_run` to choose validation or publication.
+When recovering after the release workflow itself has changed, select the
+default branch as the workflow ref and keep `release_tag` pinned to the release
+being recovered. Preflight still resolves that tag and requires its commit to
+match npm `gitHead` before publication.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -41,10 +41,6 @@ describe("ClawHub publish workflow", () => {
     expect(workflow).toContain(
       'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
     );
-    expect(workflow).toContain('source_sha" != "$GITHUB_SHA"');
-    expect(workflow).toContain(
-      'Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF',
-    );
     expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
@@ -75,10 +71,10 @@ describe("ClawHub publish workflow", () => {
 
   it("binds manual validation and publication to the verified commit", () => {
     expect(workflow).toMatch(
-      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_repo: \$\{\{ github\.repository \}\}(?:.|\n)*?source_commit: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}/,
     );
     expect(workflow).toMatch(
-      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_repo: \$\{\{ github\.repository \}\}(?:.|\n)*?source_commit: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}/,
     );
   });
 


### PR DESCRIPTION
## What

Bind ClawHub release attribution to the immutable source SHA verified against the requested tag and npm `gitHead`. Allow the same checks to recover an existing release from the current default-branch workflow.

## Why

The `v0.15.4` ClawHub publish failed because trusted publishing now requires `source_ref` to equal the authorized candidate SHA, while the workflow supplied a symbolic tag ref. The failed release run is https://github.com/Martian-Engineering/lossless-claw/actions/runs/32775105434.

## Changes

- Pin source commit and ref to SHA
- Preserve tag and npm identity checks
- Document default-branch recovery dispatch
- Update workflow regression coverage

## Testing

- `npx vitest run test/clawhub-publish-workflow.test.ts`
- `npm run typecheck`
- Autoreview clean after one accepted fix