### PR TITLE
chore: release 1.0.0-beta.5

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,8 +5,13 @@
     "@martian-engineering/lossless-claw": "0.15.1"
   },
   "changesets": [
+    "beta-install-channel-guidance",
+    "calm-signatures-reconcile",
     "clawhub-prebuilt-artifacts",
+    "close-inactive-maintenance-debt",
+    "doctor-repair-role-provenance",
     "durable-turn-advancement",
+    "inherit-durable-default-summary-model",
     "legacy-bootstrap-diagnostics",
     "minimax-tui-provider",
     "pending-summary-projection-pressure",

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -97,11 +97,6 @@ jobs:
           fi
 
           source_sha="$(git rev-parse HEAD)"
-          if [ "$source_sha" != "$GITHUB_SHA" ]; then
-            echo "Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF"
-            exit 1
-          fi
-
           git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
           if [ "$source_sha" != "$tag_sha" ]; then
@@ -156,7 +151,9 @@ jobs:
     with:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
-      source_ref: refs/tags/${{ inputs.release_tag }}
+      source_repo: ${{ github.repository }}
+      source_commit: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
       dry_run: true
 
@@ -175,6 +172,8 @@ jobs:
     with:
       source: ${{ github.repository }}
       ref: ${{ needs.release-preflight.outputs.source_sha }}
-      source_ref: refs/tags/${{ inputs.release_tag }}
+      source_repo: ${{ github.repository }}
+      source_commit: ${{ needs.release-preflight.outputs.source_sha }}
+      source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
       dry_run: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @martian-engineering/lossless-claw
 
+## 1.0.0-beta.5
+
+<!-- release-rollback-version: 0.15.4 -->
+
+### Patch Changes
+
+- [#1114](https://github.com/Martian-Engineering/lossless-claw/pull/1114) [`4bcfc06`](https://github.com/Martian-Engineering/lossless-claw/commit/4bcfc069bed764ec29ecda2888cf714435e8129d) Thanks [@jalehman](https://github.com/jalehman)! - Keep Lossless Claw 1.0 install, update, migration, and status repair commands on the npm `beta` channel, and warn when an existing install still follows the incompatible 0.15.x `latest` channel.
+
+- [#1116](https://github.com/Martian-Engineering/lossless-claw/pull/1116) [`0fef96b`](https://github.com/Martian-Engineering/lossless-claw/commit/0fef96b8592c386f428512222bae62d0ff0309c7) Thanks [@jalehman](https://github.com/jalehman)! - Precompute live-coverage signatures before exact prompt-time reconciliation.
+
+- [`bf3d69e`](https://github.com/Martian-Engineering/lossless-claw/commit/bf3d69ef376030f749dbfa92be0c5e2abee59550) Thanks [@mvanhorn](https://github.com/mvanhorn)! - Add read-only inactive compaction-debt diagnostics and a backup-first, explicitly confirmed administrative close command that preserves recall data.
+
+- [`e9f8fe4`](https://github.com/Martian-Engineering/lossless-claw/commit/e9f8fe45026b181b4a5c51791135b2fc700f4a3e) Thanks [@syltharion](https://github.com/syltharion)! - Preserve each message's role in leaf-summary source text rebuilt by `doctor apply`,
+  so repaired summaries can distinguish operator input from assistant and tool content.
+
+- [#1108](https://github.com/Martian-Engineering/lossless-claw/pull/1108) [`b3e144b`](https://github.com/Martian-Engineering/lossless-claw/commit/b3e144b8683445454f27a6c23ad35c35b8ad3c84) Thanks [@jalehman](https://github.com/jalehman)! - Inherit OpenClaw's effective default model during context-free durable `commitTurn` summary preparation when no Lossless summary override is configured. Automatic pending-summary work now retains raw context instead of persisting emergency truncations when no model-backed summarizer can be resolved.
+
 ## 1.0.0-beta.4
 
 <!-- release-rollback-version: 0.15.3 -->

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,6 +86,10 @@ tag with `release_tag` set to the same tag and `dry_run` set to `false`.
 The standalone `Publish to ClawHub` workflow remains available for validation
 and recovery. Select the release tag as the workflow ref, set `release_tag` to
 the same tag, and use `dry_run` to choose validation or publication.
+When recovering after the release workflow itself has changed, select the
+default branch as the workflow ref and keep `release_tag` pinned to the release
+being recovered. Preflight still resolves that tag and requires its commit to
+match npm `gitHead` before publication.
 
 The workflow refuses to publish unless the selected tag, `package.json`
 version, npm version, npm `gitHead`, and the tag's immutable commit all identify

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -41,10 +41,6 @@ describe("ClawHub publish workflow", () => {
     expect(workflow).toContain(
       'tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"',
     );
-    expect(workflow).toContain('source_sha" != "$GITHUB_SHA"');
-    expect(workflow).toContain(
-      'Dispatch this workflow from $RELEASE_TAG, not $GITHUB_REF',
-    );
     expect(workflow).toContain('source_sha" != "$tag_sha"');
     expect(workflow).toContain(
       'npm view "$package_name@$version" version gitHead --json',
@@ -75,10 +71,10 @@ describe("ClawHub publish workflow", () => {
 
   it("binds manual validation and publication to the verified commit", () => {
     expect(workflow).toMatch(
-      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+      /release-dry-run:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_repo: \$\{\{ github\.repository \}\}(?:.|\n)*?source_commit: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}/,
     );
     expect(workflow).toMatch(
-      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}/,
+      /publish:\n\s+needs: release-preflight(?:.|\n)*?source: \$\{\{ github\.repository \}\}(?:.|\n)*?ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_repo: \$\{\{ github\.repository \}\}(?:.|\n)*?source_commit: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}(?:.|\n)*?source_ref: \$\{\{ needs\.release-preflight\.outputs\.source_sha \}\}/,
     );
   });
 


### PR DESCRIPTION
## What

Release `@martian-engineering/lossless-claw@1.0.0-beta.5` from `next/1.0`, including the precomputed-signature fix for [openclaw/openclaw#128255](https://github.com/openclaw/openclaw/issues/128255) and the ClawHub trusted-source correction required to publish the release artifact.

## Why

The beta channel needs the cross-channel reconciliation hotfix and the accumulated reviewed 1.0 changes. The release workflow must also bind ClawHub source attribution to the verified immutable SHA.

## Changes

- Version package as `1.0.0-beta.5`
- Set rollback target to `0.15.4`
- Record five pending patch changes
- Pin ClawHub source identity to SHA

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` — 1,819 passing
- `npm pack --dry-run` — 23 files
- Autoreview clean against `origin/next/1.0`