### PR TITLE
fix: expose recall tools in standard profiles

### DIFF
--- a/.changeset/curvy-crabs-recall.md
+++ b/.changeset/curvy-crabs-recall.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Expose the four Lossless recall tools through OpenClaw's coding, messaging, and full tool profiles, and mark their read-only executions as replay-safe.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,27 @@ runtime LLM completion. Fully capable native hosts still advertise and execute
 the full lifecycle, and Lossless retains compaction ownership for those runs.
 Subagent forks continue to require `thread-bootstrap-projection`.
 
+## Recall tool availability
+
+Lossless declares `lcm_grep`, `lcm_describe`, `lcm_expand`, and
+`lcm_expand_query` for OpenClaw's `coding`, `messaging`, and `full` tool
+profiles. It also marks these read-only recall operations as safe to replay
+after an incomplete model turn. Explicit operator deny rules remain
+authoritative, and the `minimal` profile does not include the tools.
+
+OpenClaw `2026.8.1-beta.3` is the first release that supports manifest profile
+contributions. Stable OpenClaw `2026.7.1` and earlier require adding the
+Lossless plugin to `tools.alsoAllow`:
+
+```json
+{
+  "tools": {
+    "profile": "coding",
+    "alsoAllow": ["lossless-claw"]
+  }
+}
+```
+
 The optional programmatic `status` / `doctor` / `rotate` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
 That host contract is not covered by the baseline plugin API version above. As

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -29,6 +29,24 @@
       "lcm-control"
     ]
   },
+  "toolMetadata": {
+    "lcm_grep": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_describe": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_expand": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_expand_query": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    }
+  },
   "uiHints": {
     "enabled": {
       "label": "Enabled",

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -131,6 +131,20 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
     expect(runtimeNames).toEqual(declared);
   });
 
+  it("exposes every recall tool through standard profiles as replay-safe", () => {
+    const declared = [...manifest.contracts.tools].sort();
+    const toolMetadata: Record<string, { profiles: string[]; replaySafe: boolean }> =
+      manifest.toolMetadata;
+
+    expect(Object.keys(toolMetadata).sort()).toEqual(declared);
+    for (const toolName of declared) {
+      expect(toolMetadata[toolName]).toEqual({
+        profiles: ["coding", "messaging", "full"],
+        replaySafe: true,
+      });
+    }
+  });
+
   it("declares startup activation until OpenClaw always loads selected context-engine plugins", () => {
     expect(manifest.name).toBe("Lossless Context Management");
     expect(manifest.kind).toBe("context-engine");


### PR DESCRIPTION
## What

Declare profile and replay metadata for all four Lossless recall tools. OpenClaw hosts that support manifest profile contributions include the tools in `coding`, `messaging`, and `full` inventories while preserving explicit deny rules.

## Why

Restricted OpenClaw tool profiles filter plugin tools unless the plugin manifest contributes them to the selected profile. Lossless could compact a conversation while leaving the agent unable to recall compacted history.

Closes #929.

## Changes

- Add recall tool profile metadata
- Mark recall executions replay-safe
- Guard metadata against tool drift
- Document host boundary and fallback
- Add patch release metadata

## Testing

- `npx vitest run test/manifest.test.ts test/package-metadata.test.ts` (10 passed)
- `npm run typecheck`
- `npm test` (2,082 passed)
- `npm run build`
- `npm pack --dry-run`
- `npm run plugin-inspector:ci` (PASS, zero breakages)