### PR TITLE
fix: port recall tool profiles to 1.0

### DIFF
--- a/.changeset/curvy-crabs-recall.md
+++ b/.changeset/curvy-crabs-recall.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Expose the four Lossless recall tools through OpenClaw's coding, messaging, and full tool profiles, and mark their read-only executions as replay-safe.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,27 @@ forks continue to require `thread-bootstrap-projection`.
 If you cannot use a beta or upgrade OpenClaw, use a `lossless-claw` release
 compatible with your installed OpenClaw version.
 
+## Recall tool availability
+
+Lossless declares `lcm_grep`, `lcm_describe`, `lcm_expand`, and
+`lcm_expand_query` for OpenClaw's `coding`, `messaging`, and `full` tool
+profiles. It also marks these read-only recall operations as safe to replay
+after an incomplete model turn. Explicit operator deny rules remain
+authoritative, and the `minimal` profile does not include the tools.
+
+OpenClaw `2026.8.1-beta.3` is the first release that supports manifest profile
+contributions. Earlier supported OpenClaw releases require adding the Lossless
+plugin to `tools.alsoAllow`:
+
+```json
+{
+  "tools": {
+    "profile": "coding",
+    "alsoAllow": ["lossless-claw"]
+  }
+}
+```
+
 The optional programmatic `status` / `doctor` control surface requires
 a host that separately advertises context-engine capabilities/control dispatch.
 That host contract is not covered by the baseline plugin API version above. As

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -29,6 +29,24 @@
       "lcm-control"
     ]
   },
+  "toolMetadata": {
+    "lcm_grep": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_describe": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_expand": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    },
+    "lcm_expand_query": {
+      "profiles": ["coding", "messaging", "full"],
+      "replaySafe": true
+    }
+  },
   "uiHints": {
     "enabled": {
       "label": "Enabled",

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -131,6 +131,20 @@ describe("openclaw.plugin.json manifest drift guard (#570)", () => {
     expect(runtimeNames).toEqual(declared);
   });
 
+  it("exposes every recall tool through standard profiles as replay-safe", () => {
+    const declared = [...manifest.contracts.tools].sort();
+    const toolMetadata: Record<string, { profiles: string[]; replaySafe: boolean }> =
+      manifest.toolMetadata;
+
+    expect(Object.keys(toolMetadata).sort()).toEqual(declared);
+    for (const toolName of declared) {
+      expect(toolMetadata[toolName]).toEqual({
+        profiles: ["coding", "messaging", "full"],
+        replaySafe: true,
+      });
+    }
+  });
+
   it("declares startup activation until OpenClaw always loads selected context-engine plugins", () => {
     expect(manifest.name).toBe("Lossless Context Management");
     expect(manifest.kind).toBe("context-engine");


### PR DESCRIPTION
## What

Port the merged #929 manifest fix from `main` to `next/1.0`. The beta line now contributes all four Lossless recall tools to OpenClaw standard profiles and marks their read-only executions replay-safe.

## Why

OpenClaw `2026.8.1-beta.3` consumes manifest profile contributions. Without this metadata, the beta plugin registers its recall tools but restricted profiles remove them from the effective agent inventory.

## Changes

- Cherry-pick main merge with provenance
- Preserve beta compatibility guidance
- Document pre-beta.3 allowlist fallback
- Carry patch changeset into beta line

## Testing

- `npx vitest run test/manifest.test.ts test/package-metadata.test.ts` (12 passed)
- `npm run typecheck`
- `npm test` (1,820 passed)
- `npm run plugin-inspector:ci` (PASS, zero breakages)
- Branch-mode autoreview against `origin/next/1.0` (clean)