### PR TITLE
chore: release 1.0.0-beta.6

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -9,6 +9,7 @@
     "calm-signatures-reconcile",
     "clawhub-prebuilt-artifacts",
     "close-inactive-maintenance-debt",
+    "curvy-crabs-recall",
     "doctor-repair-role-provenance",
     "durable-turn-advancement",
     "inherit-durable-default-summary-model",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @martian-engineering/lossless-claw
 
+## 1.0.0-beta.6
+
+<!-- release-rollback-version: 0.15.5 -->
+
+### Patch Changes
+
+- [#1122](https://github.com/Martian-Engineering/lossless-claw/pull/1122) [`abbea93`](https://github.com/Martian-Engineering/lossless-claw/commit/abbea93fab76f30a0cc57a232594a53ca47584fc) Thanks [@jalehman](https://github.com/jalehman)! - Expose the four Lossless recall tools through OpenClaw's coding, messaging, and full tool profiles, and mark their read-only executions as replay-safe.
+
 ## 1.0.0-beta.5
 
 <!-- release-rollback-version: 0.15.4 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@martian-engineering/lossless-claw",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "0.34.48"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martian-engineering/lossless-claw",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "Lossless Context Management plugin for OpenClaw — DAG-based conversation summarization with threshold compaction",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Prepare `1.0.0-beta.6` from `next/1.0` with the #929 manifest fix.

## Why

OpenClaw `2026.8.1-beta.3` consumes the manifest profile contributions added by PR #1122, making the Lossless recall tools available in coding, messaging, and full profiles.

## Changes

- Version package to beta.6
- Record consumed prerelease changeset
- Add beta changelog entry
- Pin rollback to stable 0.15.5
- Refresh package lock metadata

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` (1,820 passed)
- `npm pack --dry-run`
- `npm ci --package-lock-only --ignore-scripts`
- Local autoreview clean
- TUI suite deferred to CI because Go is unavailable locally
