### PR TITLE
fix: deduplicate durable turns against transcript frontier

### DIFF
--- a/.changeset/deduplicate-durable-turn-frontier.md
+++ b/.changeset/deduplicate-durable-turn-frontier.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Deduplicate host-accepted turn messages against the covered transcript frontier before recording a durable advancement, preventing native runtimes from storing a second copy when transcript projection ingestion wins the race while preserving unflushed suffixes and ambiguous data.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4157,10 +4157,10 @@ export class LcmContextEngine implements ContextEngine {
           }
 
           // The visible transcript can reach LCM before the host advances the
-          // accepted turn. Only align when that race is proven by the current
-          // admission's host-written transcript entry id; content equality
-          // alone cannot distinguish a replay from a legitimate later turn
-          // that repeats the same messages.
+          // accepted turn. Only enter covered-frontier alignment when the
+          // current admission's host-written entry id anchors a trusted row.
+          // The aligner validates exact or decorated content and fails open on
+          // mismatches, so repeated later turns remain preserved.
           const conversation = await this.conversationStore.getConversationForSession({
             sessionId,
             sessionKey,
@@ -4186,8 +4186,7 @@ export class LcmContextEngine implements ContextEngine {
             (admissionAnchorTrust.trustState === "verified" ||
               admissionAnchorTrust.trustState === "repaired") &&
             admissionAnchor.role === params.admission.role &&
-            admissionAnchor.role === admissionMessage.role &&
-            admissionAnchor.content === admissionMessage.content;
+            admissionAnchor.role === admissionMessage.role;
           // Keep alignment inside the same transaction as the receipt. Its
           // ambiguous-partial-overlap path fails open to preserve new data.
           const messagesToIngest = transcriptAlreadyProjected

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4156,8 +4156,49 @@ export class LcmContextEngine implements ContextEngine {
             return { status: "duplicate" as const };
           }
 
+          // The visible transcript can reach LCM before the host advances the
+          // accepted turn. Only align when that race is proven by the current
+          // admission's host-written transcript entry id; content equality
+          // alone cannot distinguish a replay from a legitimate later turn
+          // that repeats the same messages.
+          const conversation = await this.conversationStore.getConversationForSession({
+            sessionId,
+            sessionKey,
+          });
+          const admissionMessage = toStoredMessage(params.messages[0]!);
+          const admissionAnchor = conversation
+            ? await this.conversationStore.getTranscriptEntryAnchorCandidate(
+                conversation.conversationId,
+                params.admission.entryId,
+              )
+            : null;
+          const admissionAnchorTrust = admissionAnchor
+            ? await this.conversationStore.getMessageTranscriptAnchorTrust(
+                admissionAnchor.messageId,
+              )
+            : null;
+          const transcriptAlreadyProjected =
+            conversation !== null &&
+            admissionAnchor !== null &&
+            admissionAnchorTrust !== null &&
+            admissionAnchorTrust.conversationId === conversation.conversationId &&
+            admissionAnchorTrust.transcriptEntryId === params.admission.entryId &&
+            (admissionAnchorTrust.trustState === "verified" ||
+              admissionAnchorTrust.trustState === "repaired") &&
+            admissionAnchor.role === params.admission.role &&
+            admissionAnchor.role === admissionMessage.role &&
+            admissionAnchor.content === admissionMessage.content;
+          // Keep alignment inside the same transaction as the receipt. Its
+          // ambiguous-partial-overlap path fails open to preserve new data.
+          const messagesToIngest = transcriptAlreadyProjected
+            ? await this.batchDeduplicator.alignRuntimeBatchAgainstCoveredFrontier(
+                sessionId,
+                sessionKey,
+                params.messages,
+              )
+            : params.messages;
           let ingestedCount = 0;
-          for (const message of params.messages) {
+          for (const message of messagesToIngest) {
             const result = await this.ingestSingle({
               sessionId,
               sessionKey,

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -19,6 +19,7 @@ import {
   seedBacklogContext,
   tempDirs,
 } from "./helpers.js";
+import { attachTranscriptEntryMeta } from "../src/transcript.js";
 
 afterEach(cleanupEngineTestState);
 
@@ -132,6 +133,206 @@ describe("LcmContextEngine commitTurn", () => {
       message_count: 2,
       hash_length: 64,
     });
+  });
+
+  it("records the receipt without duplicating a turn already ingested from the transcript", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    params.messages = [
+      makeMessage({ role: "user", content: "current question", timestamp: 2_000 }),
+      makeMessage({ role: "tool", content: "current tool result", timestamp: 2_500 }),
+      makeMessage({ role: "assistant", content: "current answer", timestamp: 3_000 }),
+    ];
+    params.terminal = {
+      ...params.terminal,
+      activeMessagePosition: params.admission.activeMessagePosition + params.messages.length - 1,
+      rawSeq: params.admission.rawSeq + params.messages.length - 1,
+    };
+
+    for (const [index, message] of params.messages.entries()) {
+      await engine.ingest({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        message: attachTranscriptEntryMeta(
+          { ...message },
+          {
+            entryId: index === 0 ? params.admission.entryId : `transcript-entry-${index + 1}`,
+            parentId: null,
+            timestamp: null,
+          },
+        ),
+      });
+    }
+    expect(await readStoredMessages(engine)).toHaveLength(3);
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "duplicate" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current tool result",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT count(*) AS count FROM turn_advancements")
+        .get(),
+    ).toEqual({ count: 1 });
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT message_count FROM turn_advancements WHERE advancement_key = ?")
+        .get(params.advancementKey),
+    ).toEqual({ message_count: 0 });
+  });
+
+  it("ingests only the unflushed suffix before recording the receipt", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    params.messages = [
+      makeMessage({ role: "user", content: "current question", timestamp: 2_000 }),
+      makeMessage({ role: "tool", content: "current tool result", timestamp: 2_500 }),
+      makeMessage({ role: "assistant", content: "current answer", timestamp: 3_000 }),
+    ];
+    params.terminal = {
+      ...params.terminal,
+      activeMessagePosition: params.admission.activeMessagePosition + params.messages.length - 1,
+      rawSeq: params.admission.rawSeq + params.messages.length - 1,
+    };
+
+    await engine.ingest({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      message: attachTranscriptEntryMeta(
+        { ...params.messages[0]! },
+        {
+          entryId: params.admission.entryId,
+          parentId: null,
+          timestamp: null,
+        },
+      ),
+    });
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current tool result",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT message_count FROM turn_advancements WHERE advancement_key = ?")
+        .get(params.advancementKey),
+    ).toEqual({ message_count: 2 });
+  });
+
+  it("preserves the full accepted turn when its projected admission anchor is suspect", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.ingest({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      message: attachTranscriptEntryMeta(
+        { ...params.messages[0]! },
+        {
+          entryId: params.admission.entryId,
+          parentId: null,
+          timestamp: null,
+        },
+      ),
+    });
+    const conversation = await engine
+      .getConversationStore()
+      .getConversationBySessionId(params.sessionId);
+    expect(conversation).not.toBeNull();
+    if (!conversation) throw new Error("conversation missing");
+    const candidate = await engine
+      .getConversationStore()
+      .getTranscriptEntryAnchorCandidate(conversation.conversationId, params.admission.entryId);
+    expect(candidate).not.toBeNull();
+    if (!candidate) throw new Error("admission anchor missing");
+    await engine.getConversationStore().upsertMessageTranscriptAnchorTrust({
+      messageId: candidate.messageId,
+      conversationId: conversation.conversationId,
+      transcriptEntryId: params.admission.entryId,
+      trustState: "suspect",
+      source: "test",
+      reason: "legacy anchor has not been verified",
+    });
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current question",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT message_count FROM turn_advancements WHERE advancement_key = ?")
+        .get(params.advancementKey),
+    ).toEqual({ message_count: 2 });
+  });
+
+  it("preserves the full accepted turn when a trusted admission anchor has different content", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.ingest({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      message: attachTranscriptEntryMeta(
+        makeMessage({ role: "user", content: "stale projected question", timestamp: 2_000 }),
+        {
+          entryId: params.admission.entryId,
+          parentId: null,
+          timestamp: null,
+        },
+      ),
+    });
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "stale projected question",
+      "current question",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT message_count FROM turn_advancements WHERE advancement_key = ?")
+        .get(params.advancementKey),
+    ).toEqual({ message_count: 2 });
+  });
+
+  it("preserves a later accepted turn that repeats identical content", async () => {
+    const engine = createEngine();
+    const first = buildCommitTurnParams({ advancementKey: "logical-turn-1" });
+    const second = buildCommitTurnParams({ advancementKey: "logical-turn-2" });
+    second.admission = {
+      ...second.admission,
+      entryId: "user-entry-2",
+      logicalTurnId: second.advancementKey,
+    };
+    second.terminal = {
+      ...second.terminal,
+      entryId: "assistant-entry-2",
+      effectiveParentId: second.admission.entryId,
+    };
+
+    await expect(engine.commitTurn(first)).resolves.toEqual({ status: "committed" });
+    await expect(engine.commitTurn(second)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current answer",
+      "current question",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT count(*) AS count FROM turn_advancements")
+        .get(),
+    ).toEqual({ count: 2 });
   });
 
   it("preserves recurrent model-authored tool results across committed turns", async () => {

--- a/test/engine-commit-turn.test.ts
+++ b/test/engine-commit-turn.test.ts
@@ -185,6 +185,40 @@ describe("LcmContextEngine commitTurn", () => {
     ).toEqual({ message_count: 0 });
   });
 
+  it("aligns a decorated accepted user message with its bare projected admission", async () => {
+    const engine = createEngine();
+    const params = buildCommitTurnParams();
+    await engine.ingest({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      message: attachTranscriptEntryMeta(
+        { ...params.messages[0]! },
+        {
+          entryId: params.admission.entryId,
+          parentId: null,
+          timestamp: null,
+        },
+      ),
+    });
+    params.messages[0] = makeMessage({
+      role: "user",
+      content: `[Sun 2026-01-01 12:00 GMT+0]\ncurrent question`,
+      timestamp: 2_000,
+    });
+
+    await expect(engine.commitTurn(params)).resolves.toEqual({ status: "committed" });
+
+    expect((await readStoredMessages(engine)).map((message) => message.content)).toEqual([
+      "current question",
+      "current answer",
+    ]);
+    expect(
+      getEngineDatabase(engine)
+        .prepare("SELECT message_count FROM turn_advancements WHERE advancement_key = ?")
+        .get(params.advancementKey),
+    ).toEqual({ message_count: 1 });
+  });
+
   it("ingests only the unflushed suffix before recording the receipt", async () => {
     const engine = createEngine();
     const params = buildCommitTurnParams();


### PR DESCRIPTION
## Summary

Fixes #1125 by reconciling the first atomic `commitTurn(...)` payload with a transcript-projected current-turn frontier before inserting durable messages.

The commit path trims messages only when the current admission resolves to the exact persisted anchor and that anchor:

- belongs to the same conversation and transcript entry;
- has explicit `verified` or `repaired` trust;
- matches the admitted role and stored role;
- matches the admitted content exactly.

Missing, suspect, stale or mismatched provenance fails open and preserves the complete accepted payload.

## Behaviour

- Fully projected current turn: insert no duplicate message rows and record one advancement receipt.
- Partially projected current turn: insert only the unflushed suffix.
- No trusted current-admission proof: preserve the full accepted payload.
- Later byte-identical turn with a distinct admission ID: preserve the later occurrence.
- Ambiguous partial overlap: retain the existing lossless fail-open behaviour.
- Identical advancement retry: remains `duplicate`.
- Changed payload under an existing advancement key: existing collision rejection remains unchanged.

Receipt hashing continues to use the complete accepted payload, and alignment, ingestion and receipt insertion remain inside the existing per-session queue and SQLite transaction.

## Tests

Added commit-path regressions for:

- complete transcript projection before first commit;
- transcript flush lag with an unflushed suffix;
- suspect transcript-anchor trust;
- trusted entry ID with mismatched content;
- later identical turns with distinct admission IDs.

Verification performed:

- focused commit/frontier/trust suites: 44 passed;
- full JavaScript suite: 1,826 passed, 3 skipped;
- TypeScript typecheck: passed;
- build and distributable import: passed;
- package dry run: passed;
- Plugin Inspector: PASS, zero breakages;
- copied SQLite-state reproduction: 3 projected messages remained 3 after `commitTurn`, one receipt added, zero duplicate identity groups, clean quick/foreign-key checks.

A patch Changeset is included.
