### PR TITLE
fix: ignore private host metadata in prompt estimates

### DIFF
--- a/.changeset/private-host-metadata.md
+++ b/.changeset/private-host-metadata.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Ignore top-level private OpenClaw metadata when estimating model-boundary tokens.

--- a/src/estimate-tokens.ts
+++ b/src/estimate-tokens.ts
@@ -104,7 +104,9 @@ const serializedEstimateCache = new WeakMap<object, number>();
 
 /**
  * Estimate the model-boundary token cost of a full message object by
- * serializing the entire structure, not just its text blocks.
+ * serializing its rendered structure, not just its text blocks. Top-level
+ * `__openclaw` metadata belongs to the host persistence boundary and is not
+ * rendered into the model prompt.
  *
  * The LLM-boundary prompt renderer serializes structured tool-call payloads
  * (tool inputs, tool result objects, mirrored identifiers) that text-only
@@ -129,7 +131,10 @@ export function estimateSerializedMessageTokens(message: unknown): number {
     // not occur in practice; shared (DAG) references serialize in full,
     // which is what the model boundary sees too.
     serialized =
-      JSON.stringify(message, (key, value) => {
+      JSON.stringify(message, function (this: unknown, key, value) {
+        if (this === message && key === "__openclaw") {
+          return undefined;
+        }
         if (typeof value === "string" && isLikelyOpaqueBinaryString(key, value)) {
           opaqueParts += 1;
           return "[opaque binary payload]";

--- a/test/estimate-tokens.test.ts
+++ b/test/estimate-tokens.test.ts
@@ -98,6 +98,41 @@ describe("estimateSerializedMessageTokens", () => {
     expect(estimateSerializedMessageTokens(message)).toBeGreaterThan(2_000);
   });
 
+  it("ignores top-level private OpenClaw metadata", () => {
+    const visibleMessage = { role: "user", content: "hello" };
+    const messageWithPrivateMetadata = {
+      ...visibleMessage,
+      __openclaw: {
+        upstreamUserText: "x".repeat(400_000),
+      },
+    };
+
+    expect(estimateSerializedMessageTokens(messageWithPrivateMetadata)).toBe(
+      estimateSerializedMessageTokens(visibleMessage),
+    );
+  });
+
+  it("still counts private-looking keys inside rendered tool payloads", () => {
+    const baseline = {
+      role: "assistant",
+      content: [{ type: "toolCall", name: "example", arguments: {} }],
+    };
+    const renderedPayload = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "example",
+          arguments: { __openclaw: "y".repeat(8_000) },
+        },
+      ],
+    };
+
+    expect(estimateSerializedMessageTokens(renderedPayload)).toBeGreaterThan(
+      estimateSerializedMessageTokens(baseline) + 1_500,
+    );
+  });
+
   it("substitutes a fixed cost for embedded base64 payloads", () => {
     const base64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=".repeat(2_000); // ~74k chars
     const message = {


### PR DESCRIPTION
Closes #1127.

## What Problem This Solves

Lossless-Claw estimated the full serialized `AgentMessage`, including top-level private OpenClaw metadata that the model prompt does not render. A nearly empty visible user message carrying a large `__openclaw.upstreamUserText` value could therefore appear about 100,000 tokens larger than the actual prompt, trigger emergency foreground compaction, and delay turn admission by minutes.

## Why This Change Was Made

The estimator now omits only the top-level `__openclaw` host-metadata envelope. Nested values inside message content and structured tool payloads remain part of the estimate, preserving accounting for data that can actually reach the model boundary.

## User Impact

Private OpenClaw reconstruction metadata no longer consumes the model prompt budget or triggers unnecessary compaction. Rendered structured payloads continue to count normally.

## Evidence

- Red regression on the pre-fix source: a message with visible content `hello` and 400,000 hidden metadata characters estimated 100,018 tokens instead of the 9-token baseline.
- Fixed regression: the same message now matches the baseline exactly.
- Boundary control: a nested private-looking key inside a rendered tool payload still increases the estimate by more than 1,500 tokens.
- `npm run release:verify` passed, including typecheck, build, 2,084 tests, TUI Go tests, and package dry-run verification.
- `git diff --check` passed.
- Independent clean Codex review found no actionable issues and confirmed the top-level-only boundary.

## Scope and Risk

- 3 files, 47 additions and 2 removals.
- No public API, configuration, storage schema, persistence, or OpenClaw production changes.
- The `next/1.0` backport is intentionally separate so this PR remains one minimal canonical fix.

## Owner Acceptance

- Intended behavior: budget only what can cross the model boundary.
- Changed boundary: token estimation only; persisted message metadata remains untouched.
- Falsifier: any nested content/tool payload named `__openclaw` becoming uncounted; the control regression covers this.
- Rollback: revert the single commit.

AI-assisted: yes. The issue reproduction, implementation, tests, release verification, scope review, and independent review were completed before publication.
