### PR TITLE
fix: port private host metadata estimate fix to next/1.0

### DIFF
--- a/.changeset/private-host-metadata.md
+++ b/.changeset/private-host-metadata.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Ignore top-level private OpenClaw metadata when estimating model-boundary tokens.

--- a/src/estimate-tokens.ts
+++ b/src/estimate-tokens.ts
@@ -110,7 +110,9 @@ const serializedEstimateCache = new WeakMap<object, number>();
 
 /**
  * Estimate the model-boundary token cost of a full message object by
- * serializing the entire structure, not just its text blocks.
+ * serializing its rendered structure, not just its text blocks. Top-level
+ * `__openclaw` metadata belongs to the host persistence boundary and is not
+ * rendered into the model prompt.
  *
  * The LLM-boundary prompt renderer serializes structured tool-call payloads
  * (tool inputs, tool result objects, mirrored identifiers) that text-only
@@ -135,7 +137,10 @@ export function estimateSerializedMessageTokens(message: unknown): number {
     // not occur in practice; shared (DAG) references serialize in full,
     // which is what the model boundary sees too.
     serialized =
-      JSON.stringify(message, (key, value) => {
+      JSON.stringify(message, function (this: unknown, key, value) {
+        if (this === message && key === "__openclaw") {
+          return undefined;
+        }
         if (typeof value === "string" && isLikelyOpaqueBinaryString(key, value)) {
           opaqueParts += 1;
           return "[opaque binary payload]";

--- a/test/estimate-tokens.test.ts
+++ b/test/estimate-tokens.test.ts
@@ -98,6 +98,41 @@ describe("estimateSerializedMessageTokens", () => {
     expect(estimateSerializedMessageTokens(message)).toBeGreaterThan(2_000);
   });
 
+  it("ignores top-level private OpenClaw metadata", () => {
+    const visibleMessage = { role: "user", content: "hello" };
+    const messageWithPrivateMetadata = {
+      ...visibleMessage,
+      __openclaw: {
+        upstreamUserText: "x".repeat(400_000),
+      },
+    };
+
+    expect(estimateSerializedMessageTokens(messageWithPrivateMetadata)).toBe(
+      estimateSerializedMessageTokens(visibleMessage),
+    );
+  });
+
+  it("still counts private-looking keys inside rendered tool payloads", () => {
+    const baseline = {
+      role: "assistant",
+      content: [{ type: "toolCall", name: "example", arguments: {} }],
+    };
+    const renderedPayload = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          name: "example",
+          arguments: { __openclaw: "y".repeat(8_000) },
+        },
+      ],
+    };
+
+    expect(estimateSerializedMessageTokens(renderedPayload)).toBeGreaterThan(
+      estimateSerializedMessageTokens(baseline) + 1_500,
+    );
+  });
+
   it("substitutes a fixed cost for embedded base64 payloads", () => {
     const base64 = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=".repeat(2_000); // ~74k chars
     const message = {


### PR DESCRIPTION
## What

Backports the model-boundary token estimation fix from #1128 onto the `next/1.0` release line. Top-level private OpenClaw metadata is excluded while nested rendered payloads remain counted.

## Why

Large reconstruction-only `__openclaw.upstreamUserText` values can otherwise inflate prompt estimates and trigger unnecessary foreground compaction on the beta release line.

## Changes

- Exclude root private metadata from estimates
- Preserve nested structured payload accounting
- Add root and nested regression coverage
- Carry the patch Changeset forward

## Testing

- `npm run typecheck`
- `npm run build`
- `npm test` — 1,822 tests passed
- `npm pack --dry-run`
- `autoreview --mode branch --base origin/next/1.0` — clean

Local `npm run test:tui` was unavailable because this machine has no Go binary; CI provides the authoritative TUI check.
