### PR TITLE
fix: port ClawHub release channels to next/1.0

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -8,6 +8,10 @@ on:
         description: Existing npm and GitHub release tag to publish
         required: true
         type: string
+      release_channel:
+        description: ClawHub tag matching the npm release channel
+        required: true
+        type: string
       dry_run:
         description: Validate the ClawHub package without publishing
         required: true
@@ -74,6 +78,7 @@ jobs:
       contents: read
     outputs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
+      release_channel: ${{ steps.identity.outputs.release_channel }}
     steps:
       - name: Checkout selected release
         uses: actions/checkout@v4
@@ -84,6 +89,7 @@ jobs:
         id: identity
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_CHANNEL: ${{ inputs.release_channel }}
         run: |
           set -euo pipefail
 
@@ -93,6 +99,12 @@ jobs:
 
           if [ "$RELEASE_TAG" != "$expected_tag" ]; then
             echo "Select release tag $expected_tag, not $RELEASE_TAG"
+            exit 1
+          fi
+
+          expected_channel="$(node scripts/release-channel.mjs "$version" | sed -n 's/^npm_tag=//p')"
+          if [ "$RELEASE_CHANNEL" != "$expected_channel" ]; then
+            echo "Select release channel $expected_channel for $version, not $RELEASE_CHANNEL"
             exit 1
           fi
 
@@ -114,6 +126,7 @@ jobs:
           fi
 
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "release_channel=$RELEASE_CHANNEL" >> "$GITHUB_OUTPUT"
 
       - name: Download exact npm package tarball
         run: |
@@ -155,6 +168,7 @@ jobs:
       source_commit: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
+      tags: ${{ needs.release-preflight.outputs.release_channel }}
       dry_run: true
 
   publish:
@@ -176,4 +190,5 @@ jobs:
       source_commit: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
+      tags: ${{ needs.release-preflight.outputs.release_channel }}
       dry_run: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -214,11 +214,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_REF: v${{ steps.package.outputs.version }}
           RELEASE_TAG: v${{ steps.package.outputs.version }}
+          RELEASE_CHANNEL: ${{ steps.package.outputs.npm_tag }}
         run: |
           jq -n \
             --arg ref "$WORKFLOW_REF" \
             --arg release_tag "$RELEASE_TAG" \
-            '{ref: $ref, inputs: {release_tag: $release_tag, dry_run: false}}' |
+            --arg release_channel "$RELEASE_CHANNEL" \
+            '{ref: $ref, inputs: {release_tag: $release_tag, release_channel: $release_channel, dry_run: false}}' |
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -33,6 +33,7 @@ describe("ClawHub publish workflow", () => {
 
   it("resolves the requested release tag to the npm commit", () => {
     expect(workflow).toContain("release_tag:");
+    expect(workflow).toContain("release_channel:");
     expect(workflow).toContain("release-preflight:");
     expect(workflow).toContain("ref: ${{ inputs.release_tag }}");
     expect(workflow).toContain(
@@ -47,6 +48,15 @@ describe("ClawHub publish workflow", () => {
     );
     expect(workflow).toContain('published_sha" != "$source_sha"');
     expect(workflow).toContain('echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"');
+    expect(workflow).toContain(
+      'expected_channel="$(node scripts/release-channel.mjs "$version"',
+    );
+    expect(workflow).toContain(
+      'RELEASE_CHANNEL" != "$expected_channel"',
+    );
+    expect(workflow).toContain(
+      'echo "release_channel=$RELEASE_CHANNEL" >> "$GITHUB_OUTPUT"',
+    );
   });
 
   it("builds a prebuilt package for pull-request validation", () => {
@@ -67,6 +77,11 @@ describe("ClawHub publish workflow", () => {
       /name: Upload exact npm package tarball(?:.|\n)*?name: clawhub-release-package/,
     );
     expect(workflow.match(/package_artifact_name: clawhub-release-package/g)).toHaveLength(2);
+    expect(
+      workflow.match(
+        /tags: \$\{\{ needs\.release-preflight\.outputs\.release_channel \}\}/g,
+      ),
+    ).toHaveLength(2);
   });
 
   it("binds manual validation and publication to the verified commit", () => {
@@ -105,7 +120,10 @@ describe("ClawHub publish workflow", () => {
       'RELEASE_TAG: v${{ steps.package.outputs.version }}',
     );
     expect(npmPublishWorkflow).toContain(
-      "inputs: {release_tag: $release_tag, dry_run: false}",
+      "RELEASE_CHANNEL: ${{ steps.package.outputs.npm_tag }}",
+    );
+    expect(npmPublishWorkflow).toContain(
+      "inputs: {release_tag: $release_tag, release_channel: $release_channel, dry_run: false}",
     );
     expect(npmPublishWorkflow.indexOf("Create GitHub release")).toBeLessThan(
       npmPublishWorkflow.indexOf("Dispatch ClawHub publish"),


### PR DESCRIPTION
## What

Port the ClawHub stable and beta channel fix from `main` to `next/1.0`.

## Why

Beta publication must update ClawHub `beta` without replacing the stable `latest` tag.

## Changes

- Cherry-pick `bff7d75e` with provenance
- Validate beta channel before publication
- Pass the validated tag to ClawHub

## Testing

- `npm test -- test/clawhub-publish-workflow.test.ts test/release-channel.test.ts`
- Structured autoreview: no actionable findings
