### PR TITLE
fix: leave response headroom in forced compaction

### DIFF
--- a/.changeset/forced-budget-headroom.md
+++ b/.changeset/forced-budget-headroom.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Leave configured threshold headroom when OpenClaw forces overflow recovery, preventing a raw context-window budget from causing no-op compaction.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,7 @@ The **condensed pass** merges summaries at the same depth into a higher-level su
 - Runs up to `maxRounds` (default 10) of full sweeps
 - Stops when context is under the target token count
 - Used by the overflow recovery path
+- Forced recovery targets the resolved `contextThreshold`, leaving the configured threshold margin below a raw host context window for response reserve
 
 ### Three-level escalation
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1252,8 +1252,20 @@ export class LcmContextEngine implements ContextEngine {
         : {}),
       },
     );
+    // Overflow recovery can receive the host's raw context window before its
+    // response reserve is subtracted. Use the configured threshold target so
+    // a forced budget request creates the same headroom as proactive compaction.
+    const forcedBudgetRecovery = force && params.compactionTarget !== "threshold";
+    const forcedBudgetTargetTokens = Math.max(
+      1,
+      Math.min(decision.threshold, tokenBudget - 1),
+    );
     const targetTokens =
-      params.compactionTarget === "threshold" ? decision.threshold : tokenBudget;
+      params.compactionTarget === "threshold"
+        ? decision.threshold
+        : forcedBudgetRecovery
+          ? forcedBudgetTargetTokens
+          : tokenBudget;
     // Codex can report a live prompt count that includes runtime framing,
     // tool schemas, and other overhead not present in Lossless's compactable
     // stored count. Raw backlog is different: it can force a sweep, but once
@@ -1561,12 +1573,7 @@ export class LcmContextEngine implements ContextEngine {
       };
     }
 
-    // When forced, use the token budget as target
-    const convergenceTargetTokens = forceCompaction
-      ? tokenBudget
-      : params.compactionTarget === "threshold"
-        ? decision.threshold
-        : tokenBudget;
+    const convergenceTargetTokens = targetTokens;
 
     // When forced (overflow recovery) and the caller did not supply an
     // observed token count, assume we are at least at the token budget so

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -3745,7 +3745,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder").mockResolvedValue({
       success: true,
       rounds: 2,
-      finalTokens: 199_500,
+      finalTokens: 149_500,
     });
 
     await engine.ingest({
@@ -3766,11 +3766,11 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.compacted).toBe(true);
     expect(result.reason).toBe("compacted");
     expect(result.result?.tokensBefore).toBe(277_403);
-    expect(result.result?.tokensAfter).toBe(199_500);
+    expect(result.result?.tokensAfter).toBe(149_500);
     expect(result.result?.details).toEqual(
       expect.objectContaining({
         rounds: 2,
-        targetTokens: 200_000,
+        targetTokens: 150_000,
       }),
     );
     expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 200_000, 277_403, { contextThreshold: 0.75 });
@@ -3779,9 +3779,64 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 200_000,
-        targetTokens: 200_000,
+        targetTokens: 150_000,
         currentTokens: 277_403,
         summarize: expect.any(Function),
+      }),
+    );
+  });
+
+  it("leaves threshold headroom when forced budget recovery receives a raw host window", async () => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
+      };
+    };
+
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 230_657,
+      threshold: 204_000,
+    });
+    const compactUntilUnderSpy = vi
+      .spyOn(privateEngine.compaction, "compactUntilUnder")
+      .mockResolvedValue({
+        success: true,
+        rounds: 1,
+        finalTokens: 200_000,
+      });
+
+    await engine.ingest({
+      sessionId: "forced-budget-response-reserve",
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const result = await engine.compact({
+      sessionId: "forced-budget-response-reserve",
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 272_000,
+      currentTokenCount: 230_657,
+      force: true,
+      compactionTarget: "budget",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.result?.details).toEqual(
+      expect.objectContaining({ targetTokens: 204_000 }),
+    );
+    expect(compactUntilUnderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenBudget: 272_000,
+        targetTokens: 204_000,
+        currentTokens: 230_657,
       }),
     );
   });
@@ -3838,7 +3893,7 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 30_000,
-        targetTokens: 30_000,
+        targetTokens: 22_500,
         currentTokens: 30_000,
         summarize: expect.any(Function),
       }),
@@ -3863,13 +3918,13 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       shouldCompact: true,
       reason: "threshold",
       currentTokens: 150_000,
-      threshold: 120_000,
+      threshold: 90_000,
     });
     const compactFullSweepSpy = vi.spyOn(privateEngine.compaction, "compactFullSweep");
     const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder").mockResolvedValue({
       success: true,
       rounds: 1,
-      finalTokens: 118_000,
+      finalTokens: 88_000,
     });
 
     await engine.ingest({
@@ -3889,14 +3944,14 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     expect(result.compacted).toBe(true);
     expect(result.reason).toBe("compacted");
     expect(result.result?.tokensBefore).toBe(150_000);
-    expect(result.result?.tokensAfter).toBe(118_000);
+    expect(result.result?.tokensAfter).toBe(88_000);
     expect(evaluateSpy).toHaveBeenCalledWith(expect.any(Number), 120_000, undefined, { contextThreshold: 0.75 });
     expect(compactFullSweepSpy).not.toHaveBeenCalled();
     expect(compactUntilUnderSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: expect.any(Number),
         tokenBudget: 120_000,
-        targetTokens: 120_000,
+        targetTokens: 90_000,
         currentTokens: 120_000,
         summarize: expect.any(Function),
       }),


### PR DESCRIPTION
## What

Make forced budget compaction converge below the raw host context window by using the resolved Lossless threshold as its target.

## Why

OpenClaw can detect overflow after subtracting its response reserve while passing the raw context window to the context engine. Using that raw budget as the convergence target allowed Lossless to return `already under target` without creating enough response headroom.

## Changes

- Target threshold during forced recovery
- Preserve manual and non-forced behavior
- Reproduce the reported failure band
- Document forced recovery headroom
- Add a patch Changeset

## Testing

- `npm test -- test/engine-compaction.test.ts`
- `npm run typecheck`
- `npm test`
- Structured autoreview: no actionable findings

Fixes #1124
