### PR TITLE
fix: remove unsupported session action manifest contract

### DIFF
--- a/.changeset/remove-unsupported-session-action-contract.md
+++ b/.changeset/remove-unsupported-session-action-contract.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove the unsupported `contracts.sessionActions` manifest field while preserving the runtime `lcm-control` session action.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,9 +24,6 @@
       "lcm_describe",
       "lcm_expand",
       "lcm_expand_query"
-    ],
-    "sessionActions": [
-      "lcm-control"
     ]
   },
   "toolMetadata": {

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -99,6 +99,10 @@ function extractRegisterToolFactoryCallSites(): RegisterToolFactoryCallSite[] {
   return sites.sort((a, b) => a.factory.localeCompare(b.factory));
 }
 describe("openclaw.plugin.json manifest drift guard (#570)", () => {
+  it("limits contracts to fields supported by the declared OpenClaw host", () => {
+    expect(Object.keys(manifest.contracts)).toEqual(["tools"]);
+  });
+
   it("contracts.tools matches the canonical name fields in src/tools/*", () => {
     const declared = [...manifest.contracts.tools].sort();
     const fromSource = extractToolNames();


### PR DESCRIPTION
## What

Remove the unsupported `contracts.sessionActions` field from the OpenClaw plugin manifest while preserving the runtime `lcm-control` session action registration.

## Why

ClawHub validates manifests against the OpenClaw contract surface and reports this undeclared contract key as a P1 warning. Session actions register through the runtime plugin API and do not use a static manifest ownership contract.

## Changes

- Remove unsupported session action contract
- Guard supported manifest contract keys
- Add patch release changeset

## Testing

- `npm run typecheck`
- `npm test` — 2,086 tests passed
- `npm run build`
- Plugin Inspector 0.3.17 against OpenClaw 2026.7.1-2 — no unknown-contract finding
- Autoreview — clean