### PR TITLE
fix: port supported manifest contracts to next/1.0

### DIFF
--- a/.changeset/remove-unsupported-session-action-contract.md
+++ b/.changeset/remove-unsupported-session-action-contract.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Remove the unsupported `contracts.sessionActions` manifest field while preserving the runtime `lcm-control` session action.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -24,9 +24,6 @@
       "lcm_describe",
       "lcm_expand",
       "lcm_expand_query"
-    ],
-    "sessionActions": [
-      "lcm-control"
     ]
   },
   "toolMetadata": {

--- a/test/manifest.test.ts
+++ b/test/manifest.test.ts
@@ -99,6 +99,10 @@ function extractRegisterToolFactoryCallSites(): RegisterToolFactoryCallSite[] {
   return sites.sort((a, b) => a.factory.localeCompare(b.factory));
 }
 describe("openclaw.plugin.json manifest drift guard (#570)", () => {
+  it("limits contracts to fields supported by the declared OpenClaw host", () => {
+    expect(Object.keys(manifest.contracts)).toEqual(["tools"]);
+  });
+
   it("contracts.tools matches the canonical name fields in src/tools/*", () => {
     const declared = [...manifest.contracts.tools].sort();
     const fromSource = extractToolNames();


### PR DESCRIPTION
## What

Port the ClawHub manifest-contract fix from `main` to `next/1.0` with exact cherry-pick provenance.

## Why

The beta release must avoid the same P1 ClawHub `manifest-unknown-contracts` warning while preserving the runtime `lcm-control` session action.

## Changes

- Remove unsupported session action contract
- Guard supported manifest contract keys
- Carry patch release changeset

## Testing

- `npm run typecheck`
- `npm test` — 1,837 tests passed
- Autoreview — clean