### PR TITLE
fix: align ClawHub tags with semver policy

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -78,7 +78,7 @@ jobs:
       contents: read
     outputs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
-      release_channel: ${{ steps.identity.outputs.release_channel }}
+      clawhub_tags: ${{ steps.identity.outputs.clawhub_tags }}
     steps:
       - name: Checkout selected release
         uses: actions/checkout@v4
@@ -109,6 +109,7 @@ jobs:
           fi
 
           source_sha="$(git rev-parse HEAD)"
+          clawhub_tags="$(node scripts/release-channel.mjs "$version" | sed -n 's/^clawhub_tags=//p')"
           git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           tag_sha="$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")"
           if [ "$source_sha" != "$tag_sha" ]; then
@@ -126,7 +127,7 @@ jobs:
           fi
 
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "release_channel=$RELEASE_CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "clawhub_tags=$clawhub_tags" >> "$GITHUB_OUTPUT"
 
       - name: Download exact npm package tarball
         run: |
@@ -168,7 +169,7 @@ jobs:
       source_commit: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
-      tags: ${{ needs.release-preflight.outputs.release_channel }}
+      tags: ${{ needs.release-preflight.outputs.clawhub_tags }}
       dry_run: true
 
   publish:
@@ -190,5 +191,5 @@ jobs:
       source_commit: ${{ needs.release-preflight.outputs.source_sha }}
       source_ref: ${{ needs.release-preflight.outputs.source_sha }}
       package_artifact_name: clawhub-release-package
-      tags: ${{ needs.release-preflight.outputs.release_channel }}
+      tags: ${{ needs.release-preflight.outputs.clawhub_tags }}
       dry_run: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,6 +110,14 @@ ClawHub trusted publishing is configured for
 required. Deleting that trusted-publisher configuration disables future
 publishes.
 
+ClawHub's `latest` tag always follows the highest semantic version for code
+plugins, including prereleases. Stable releases therefore request the custom
+`stable` tag plus `latest`, while beta releases request `beta` plus `latest`.
+ClawHub keeps `stable` on the newest stable artifact and accepts `latest` only
+when the candidate is the highest version. This is intentionally independent
+of npm, where `latest` remains the stable channel and `beta` remains the beta
+channel.
+
 ## Beta releases
 
 Use a Changesets prerelease when `main` needs broader testing before a stable release:

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -9,6 +9,7 @@ function parseVersion(version) {
   if (stable) {
     return {
       channel: "latest",
+      clawhubTags: "stable,latest",
       parts: stable.slice(1).map(BigInt),
       prerelease: false,
     };
@@ -18,6 +19,7 @@ function parseVersion(version) {
   if (beta) {
     return {
       channel: "beta",
+      clawhubTags: "beta,latest",
       parts: beta.slice(1).map(BigInt),
       prerelease: true,
     };
@@ -110,7 +112,7 @@ if (process.argv[2] === "--read-rollback") {
 
   if (release) {
     process.stdout.write(
-      `npm_tag=${release.channel}\nprerelease=${release.prerelease}\n`,
+      `npm_tag=${release.channel}\nclawhub_tags=${release.clawhubTags}\nprerelease=${release.prerelease}\n`,
     );
   } else {
     fail(`Unsupported release version: ${version}`);

--- a/test/clawhub-publish-workflow.test.ts
+++ b/test/clawhub-publish-workflow.test.ts
@@ -55,7 +55,10 @@ describe("ClawHub publish workflow", () => {
       'RELEASE_CHANNEL" != "$expected_channel"',
     );
     expect(workflow).toContain(
-      'echo "release_channel=$RELEASE_CHANNEL" >> "$GITHUB_OUTPUT"',
+      'clawhub_tags="$(node scripts/release-channel.mjs "$version"',
+    );
+    expect(workflow).toContain(
+      'echo "clawhub_tags=$clawhub_tags" >> "$GITHUB_OUTPUT"',
     );
   });
 
@@ -79,7 +82,7 @@ describe("ClawHub publish workflow", () => {
     expect(workflow.match(/package_artifact_name: clawhub-release-package/g)).toHaveLength(2);
     expect(
       workflow.match(
-        /tags: \$\{\{ needs\.release-preflight\.outputs\.release_channel \}\}/g,
+        /tags: \$\{\{ needs\.release-preflight\.outputs\.clawhub_tags \}\}/g,
       ),
     ).toHaveLength(2);
   });

--- a/test/release-channel.test.ts
+++ b/test/release-channel.test.ts
@@ -28,14 +28,18 @@ describe("release-channel CLI", () => {
     const result = classify("0.13.2");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("npm_tag=latest\nprerelease=false\n");
+    expect(result.stdout).toBe(
+      "npm_tag=latest\nclawhub_tags=stable,latest\nprerelease=false\n",
+    );
   });
 
   it("routes beta versions to beta and GitHub prerelease", () => {
     const result = classify("0.14.0-beta.0");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("npm_tag=beta\nprerelease=true\n");
+    expect(result.stdout).toBe(
+      "npm_tag=beta\nclawhub_tags=beta,latest\nprerelease=true\n",
+    );
   });
 
   it.each(["0.14.0-rc.0", "0.14.0-alpha.1", "banana", "1.2"])(


### PR DESCRIPTION
## What

Port the reviewed ClawHub distribution-tag policy from main to next/1.0.

## Why

ClawHub reserves latest for the highest semantic version, including prereleases. The beta release must advance both beta and latest, while stable releases use the dedicated stable selector.

## Changes

- Cherry-pick main merge with provenance
- Emit stable and beta ClawHub tag sets
- Document registry-specific channel behavior
- Add workflow and classifier regressions

## Testing

- npm test -- --run test/release-channel.test.ts test/clawhub-publish-workflow.test.ts
- npm run typecheck
- Autoreview: no actionable findings