### PR TITLE
fix: preserve tool pairs in degraded fallback

### DIFF
--- a/.changeset/repair-degraded-tool-pairs.md
+++ b/.changeset/repair-degraded-tool-pairs.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Keep assistant tool calls and their results as one atomic unit when degraded or serialized-budget fallback trims live context. This prevents oversized multimodal tool results from reaching providers as orphaned outputs and failing the next model request.

--- a/src/assemble-fallback.ts
+++ b/src/assemble-fallback.ts
@@ -14,6 +14,69 @@ import type {
 } from "./openclaw-bridge.js";
 import type { ConversationCompactionMaintenanceRecord } from "./store/compaction-maintenance-store.js";
 import { estimateAgentMessageTokens, normalizeNonNegativeInteger, toRuntimeRoleForTokenEstimate } from "./token-accounting.js";
+import {
+  buildToolPairIndexesByAssembledIndex,
+  extractToolResultIdForPairing,
+} from "./tool-pairing.js";
+import { sanitizeToolUseResultPairing } from "./transcript-repair.js";
+
+/**
+ * Expand a retained suffix to a provider-valid turn without replaying the
+ * entire live transcript. Tool calls and results are one eviction unit; when
+ * the suffix begins inside such a unit, recover every matching partner and a
+ * preceding user message before repairing provider ordering.
+ */
+function buildProviderValidSuffix(params: {
+  messages: AgentMessage[];
+  retainedStartIndex: number;
+}): AgentMessage[] {
+  if (params.messages.length === 0 || params.retainedStartIndex >= params.messages.length) {
+    return [];
+  }
+
+  const retainedIndexes = new Set<number>();
+  const safeStartIndex = Math.max(0, params.retainedStartIndex);
+  for (let index = safeStartIndex; index < params.messages.length; index += 1) {
+    retainedIndexes.add(index);
+  }
+
+  const toolPairIndexes = buildToolPairIndexesByAssembledIndex(params.messages);
+  for (const index of [...retainedIndexes]) {
+    for (const relatedIndex of toolPairIndexes.get(index) ?? [index]) {
+      retainedIndexes.add(relatedIndex);
+    }
+  }
+
+  const hasUserMessage = [...retainedIndexes].some(
+    (index) => toRuntimeRoleForTokenEstimate(params.messages[index]!.role) === "user",
+  );
+  if (!hasUserMessage) {
+    const earliestRetainedIndex = Math.min(...retainedIndexes);
+    for (let index = earliestRetainedIndex - 1; index >= 0; index -= 1) {
+      if (toRuntimeRoleForTokenEstimate(params.messages[index]!.role) === "user") {
+        retainedIndexes.add(index);
+        break;
+      }
+    }
+  }
+
+  const retainedMessages = [...retainedIndexes]
+    .sort((left, right) => left - right)
+    .map((index) => {
+      const message = params.messages[index]!;
+      const toolCallId = extractToolResultIdForPairing(message);
+      if (
+        toolCallId &&
+        (message.role === "tool" || message.role === "toolResult") &&
+        !("toolCallId" in message && typeof message.toolCallId === "string") &&
+        !("toolUseId" in message && typeof message.toolUseId === "string")
+      ) {
+        return { ...message, toolCallId } as AgentMessage;
+      }
+      return message;
+    });
+  return sanitizeToolUseResultPairing(retainedMessages) as AgentMessage[];
+}
 
 /**
  * Suffix-trim live messages for prompt bounding, measured by serialized
@@ -70,9 +133,11 @@ export const SERIALIZED_OUTPUT_CLAMP_SAFETY_RATIO = 0.9;
  * Assembly budgets enforced on stored token counts can diverge from the
  * real prompt when live message objects carry structured payloads that
  * stored content omits (e.g. transcripts imported from a previous harness).
- * This clamp keeps the newest suffix that fits, drops leading tool results
- * orphaned by eviction, and re-seats the most recent user turn if eviction
- * removed every user message.
+ * This clamp keeps the newest suffix that fits, expands retained tool calls
+ * and results to complete pairing units, and re-seats the most recent user
+ * turn if eviction removed every user message. A single atomic turn can still
+ * exceed the target; returning it intact is safer than emitting an invalid
+ * partial tool exchange.
  */
 export function clampMessagesToSerializedBudget(params: {
   messages: AgentMessage[];
@@ -107,7 +172,8 @@ export function clampMessagesToSerializedBudget(params: {
     };
   }
 
-  // Keep the newest suffix that fits the target (always at least one message).
+  // Keep the newest suffix that fits the target (always at least one message),
+  // then recover any tool-pair partners displaced by the budget boundary.
   const kept: AgentMessage[] = [];
   let keptTokens = 0;
   for (let index = params.messages.length - 1; index >= 0; index -= 1) {
@@ -120,40 +186,25 @@ export function clampMessagesToSerializedBudget(params: {
     keptTokens += tokenCount;
   }
   kept.reverse();
-
-  // Eviction may have removed the assistant tool_use partner of leading
-  // tool results; drop those orphans rather than ship unpaired results.
-  while (kept.length > 1 && toRuntimeRoleForTokenEstimate(kept[0]!.role) === "toolResult") {
-    keptTokens -= estimateSerializedMessageTokens(kept[0]!);
-    kept.shift();
-  }
-
-  // The provider rejects contexts with no user turn; re-seat the most
-  // recent evicted user message if the suffix lost every one of them.
-  if (!kept.some((message) => toRuntimeRoleForTokenEstimate(message.role) === "user")) {
-    for (let index = params.messages.length - kept.length - 1; index >= 0; index -= 1) {
-      const candidate = params.messages[index]!;
-      if (toRuntimeRoleForTokenEstimate(candidate.role) === "user") {
-        kept.unshift(candidate);
-        keptTokens += estimateSerializedMessageTokens(candidate);
-        break;
-      }
-    }
-  }
+  const providerValidKept = buildProviderValidSuffix({
+    messages: params.messages,
+    retainedStartIndex: params.messages.length - kept.length,
+  });
+  keptTokens = estimateSerializedMessagesTokens(providerValidKept);
 
   // Historically an assistant-only suffix was retained when stripping would
   // empty the result. Prompt-separate hosts must still return an empty array
   // for blank or reasoning-only tails: restoring those tails would reintroduce
   // invalid assistant prefill content after the preservation policy rejected it.
-  const stripped = stripTrailingAssistantPrefill(kept, {
+  const stripped = stripTrailingAssistantPrefill(providerValidKept, {
     preserveSubstantiveAssistantTail: params.preserveSubstantiveAssistantTail,
   });
   const finalMessages =
     stripped.length > 0 || params.preserveSubstantiveAssistantTail === true
       ? stripped
-      : kept;
+      : providerValidKept;
   const serializedTokens =
-    finalMessages.length === kept.length
+    finalMessages.length === providerValidKept.length
       ? keptTokens
       : estimateSerializedMessagesTokens(finalMessages);
   return {
@@ -161,7 +212,7 @@ export function clampMessagesToSerializedBudget(params: {
     serializedTokens,
     serializedTokensBefore,
     clamped: true,
-    evictedMessages: params.messages.length - finalMessages.length,
+    evictedMessages: Math.max(0, params.messages.length - finalMessages.length),
     overBudget: serializedTokens > targetTokens,
   };
 }
@@ -200,6 +251,10 @@ export function buildDegradedLiveAssembleResult(params: {
   if (liveTailMessages.length === 0 && liveTail.length > 0) {
     liveTailMessages = [liveTail[liveTail.length - 1]!];
   }
+  liveTailMessages = buildProviderValidSuffix({
+    messages: liveTail,
+    retainedStartIndex: liveTail.length - liveTailMessages.length,
+  });
   const messages = [...protectedPrefix, ...liveTailMessages];
   return {
     messages,

--- a/test/bounded-assemble.test.ts
+++ b/test/bounded-assemble.test.ts
@@ -19,6 +19,7 @@ import { LcmContextEngine } from "../src/engine.js";
 import { estimateSerializedMessagesTokens } from "../src/estimate-tokens.js";
 import {
   SERIALIZED_OUTPUT_CLAMP_SAFETY_RATIO,
+  buildDegradedLiveAssembleResult,
   clampMessagesToSerializedBudget,
 } from "../src/assemble-fallback.js";
 import type { AgentMessage } from "../src/openclaw-bridge.js";
@@ -123,7 +124,69 @@ function makeHeavyLiveTranscript(pairs: number, payloadChars: number): AgentMess
   return messages;
 }
 
+function makeOversizedToolTurn(): AgentMessage[] {
+  return [
+    makeUserMessage(0),
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_image",
+          name: "view_image",
+          arguments: { paths: ["first.png", "second.png", "third.png"] },
+        },
+      ],
+    } as AgentMessage,
+    {
+      ...makeHeavyToolResultMessage(1, 20_000),
+      toolCallId: "call_image",
+      toolName: "view_image",
+      content: [
+        {
+          type: "toolResult",
+          id: "call_image",
+          toolCallId: "call_image",
+          content: "image data ".repeat(2_000),
+        },
+      ],
+    } as AgentMessage,
+  ];
+}
+
 describe("bounded assemble output", () => {
+  it("keeps an oversized degraded tool result paired with its assistant call", () => {
+    const result = buildDegradedLiveAssembleResult({
+      liveMessages: makeOversizedToolTurn(),
+      tokenBudget: 100,
+      contextProjection: { mode: "thread_bootstrap", epoch: "test-projection" },
+    });
+
+    expect(result.estimatedTokens).toBeGreaterThan(100);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    expect(result.messages[2]).toMatchObject({ toolCallId: "call_image" });
+  });
+
+  it("keeps an oversized serialized-clamp tool result paired with its assistant call", () => {
+    const result = clampMessagesToSerializedBudget({
+      messages: makeOversizedToolTurn(),
+      tokenBudget: 100,
+    });
+
+    expect(result.clamped).toBe(true);
+    expect(result.overBudget).toBe(true);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+    expect(result.messages[2]).toMatchObject({ toolCallId: "call_image" });
+  });
+
   it("clamps near-budget serialized output to leave host renderer headroom", () => {
     const messages = makeHeavyLiveTranscript(12, 4_000);
     const serializedTokens = estimateSerializedMessagesTokens(messages);


### PR DESCRIPTION
## Summary

- treat retained assistant tool calls and tool results as one eviction unit in degraded and serialized-budget fallback
- recover the nearest preceding user turn and repair provider ordering without replaying the full live transcript
- normalize tool-result roles and canonicalize nested IDs before pairing repair

## Root cause

When the newest live message alone exceeded the degraded fallback budget, `trimMessagesToBudget` returned an empty selection and `buildDegradedLiveAssembleResult` restored only the last message. If that message was a large multimodal `toolResult`, the matching assistant tool call was omitted. OpenAI Responses then received an orphaned output and could reject the continuation because no usable input remained. The serialized clamp had the same boundary risk.

## Validation

- `npm run typecheck`
- `npm test` (114 files, 1,865 tests)
- `npm run build`
- `npm run test:tui`
- `npm pack --dry-run`

Includes a patch changeset.

## Regression credit

Includes @JerretK's regression from #1156 for Qwen rejecting degraded context with no user query. The regression fails on the base implementation and passes with this fix.
