### PR TITLE
fix: complete observedTokens fallback chain (caller > runtimeContext > telemetry > maintenance)

### DIFF
--- a/.changeset/fix-compaction-live-tokens-from-model.md
+++ b/.changeset/fix-compaction-live-tokens-from-model.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix LCM compaction `observedTokens` to prefer the host-observed, model-returned prompt token count from `runtimeContext.usage` / `lastCallUsage` / `promptCache.lastCallUsage` over the stale `maintenance.currentTokenCount` counter. The deferred-compaction drain now consults the persisted compaction-telemetry snapshot as an additional fallback. Resolves the "compacted but still over target" wedge that pinned long sessions (e.g. session 996 on the `zte / co-claw` 128k model) into an unrecoverable loop.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -958,6 +958,86 @@ export class LcmContextEngine implements ContextEngine {
     return Math.floor(value);
   }
 
+  /**
+   * Resolve the host-observed, model-returned live token count from a
+   * compact()/maintain() params bag using a documented priority chain.
+   *
+   * Order (highest priority first; first non-`undefined` wins):
+   *   1. `runtimeContext.usage` / `lastCallUsage` / `promptCache.lastCallUsage`
+   *      (the actual prompt token count returned by the model on the last API
+   *      call — the authoritative baseline).
+   *   2. Caller-supplied `currentTokenCount` and legacy `currentTokenCount`.
+   *   3. Persisted compaction telemetry snapshot (`lastObservedPromptTokenCount`)
+   *      — only consulted when `includeTelemetry` is true, which is the
+   *      deferred-drain entry point that may not have a live runtimeContext.
+   *   4. `staleFallback` — a last-resort value LCM wrote into its own debt
+   *      row. When used, a warn log is emitted so the operator can see the
+   *      session needs a fresher baseline.
+   *
+   * Returned `source` is one of `"runtimeContext" | "caller" | "telemetry" |
+   * "staleFallback" | "none"`. Callers use it for both the priority-chain
+   * debug log and the staleness warning.
+   */
+  private async resolveLiveTokenCount(
+    params: {
+      runtimeContext?: Record<string, unknown>;
+      currentTokenCount?: number;
+      legacyParams?: Record<string, unknown>;
+    },
+    options: {
+      conversationId?: number;
+      includeTelemetry?: boolean;
+      staleFallback?: number;
+      subject: string;
+      sessionLabel: string;
+    },
+  ): Promise<{ value: number | undefined; source: "runtimeContext" | "caller" | "telemetry" | "staleFallback" | "none" }> {
+    const runtimePromptTokens = extractRuntimePromptTokenCount(
+      asRecord(params.runtimeContext),
+    );
+    if (runtimePromptTokens !== undefined) {
+      this.deps.log.debug(
+        `[lcm] ${options.subject}: using runtime prompt token count${options.conversationId !== undefined ? ` conversation=${options.conversationId}` : ""} ${options.sessionLabel} currentTokenCount=${runtimePromptTokens}`,
+      );
+      return { value: runtimePromptTokens, source: "runtimeContext" };
+    }
+
+    const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
+      params.currentTokenCount ??
+        (
+          (params.legacyParams ?? {}) as {
+            currentTokenCount?: unknown;
+          }
+        ).currentTokenCount,
+    );
+    if (suppliedCurrentTokenCount !== undefined) {
+      return { value: suppliedCurrentTokenCount, source: "caller" };
+    }
+
+    if (options.includeTelemetry && options.conversationId !== undefined) {
+      const telemetry =
+        await this.compactionTelemetryStore.getConversationCompactionTelemetry(
+          options.conversationId,
+        );
+      const telemetryLastObserved = this.normalizeObservedTokenCount(
+        telemetry?.lastObservedPromptTokenCount ?? undefined,
+      );
+      if (telemetryLastObserved !== undefined) {
+        return { value: telemetryLastObserved, source: "telemetry" };
+      }
+    }
+
+    const staleFallback = this.normalizeObservedTokenCount(options.staleFallback);
+    if (staleFallback !== undefined) {
+      this.deps.log.warn(
+        `[lcm] ${options.subject}: using stale maintenance.currentTokenCount${options.conversationId !== undefined ? ` conversation=${options.conversationId}` : ""} ${options.sessionLabel} currentTokenCount=${staleFallback} — neither runtimeContext nor telemetry carried a fresher prompt token count; the host should pass runtimeContext.usage or call updateCompactionTelemetry so future drains have a fresh baseline`,
+      );
+      return { value: staleFallback, source: "staleFallback" };
+    }
+
+    return { value: undefined, source: "none" };
+  }
+
   /** Resolve token budget from direct params or legacy fallback input. */
   private resolveTokenBudget(params: {
     tokenBudget?: number;
@@ -1367,8 +1447,29 @@ export class LcmContextEngine implements ContextEngine {
           ? Math.min(params.tokenBudget, recordedTokenBudget)
           : params.tokenBudget,
       );
-      const resolvedCurrentTokenCount = this.normalizeObservedTokenCount(
-        params.currentTokenCount ?? maintenance.currentTokenCount ?? undefined,
+      // Resolve the host-observed, model-returned live token count using the
+      // four-tier priority chain documented in
+      // openspec/changes/fix-compaction-live-tokens-from-model/spec.md:
+      //   1. runtimeContext.usage / lastCallUsage / promptCache.lastCallUsage
+      //   2. caller-supplied params.currentTokenCount
+      //   3. persisted compaction_telemetry.last_observed_prompt_token_count
+      //   4. maintenance.currentTokenCount (last-resort, log-only regression)
+      // This avoids the long-standing wedge where deferred compaction silently
+      // falls back to a stale LCM-internal counter while the host knows the
+      // actual prompt tokens from the model's last API response.
+      const { value: resolvedCurrentTokenCount } = await this.resolveLiveTokenCount(
+        {
+          runtimeContext: asRecord(params.runtimeContext),
+          currentTokenCount: params.currentTokenCount,
+          legacyParams: asRecord(params.legacyParams),
+        },
+        {
+          conversationId: params.conversationId,
+          includeTelemetry: true,
+          staleFallback: maintenance.currentTokenCount ?? undefined,
+          subject: "maintain",
+          sessionLabel,
+        },
       );
       const compactableCurrentTokenCount = hostOwnsPromptFraming(params.runtimeSettings)
         ? undefined
@@ -1979,13 +2080,24 @@ export class LcmContextEngine implements ContextEngine {
     }
 
     const conversationId = params.conversationId;
-    const observedTokens = this.normalizeObservedTokenCount(
-      params.currentTokenCount ??
-        (
-          lp as {
-            currentTokenCount?: unknown;
-          }
-        ).currentTokenCount,
+    // Resolve the host-observed, model-returned live token count using the
+    // priority chain documented in
+    // openspec/changes/fix-compaction-live-tokens-from-model/spec.md.
+    // resolveLiveTokenCount() returns the first available source in the
+    // chain: runtimeContext → caller → telemetry → stale fallback.
+    const { value: observedTokens } = await this.resolveLiveTokenCount(
+      {
+        runtimeContext: params.runtimeContext,
+        currentTokenCount: params.currentTokenCount,
+        legacyParams,
+      },
+      {
+        subject: "compact",
+        sessionLabel,
+        // Compact always arrives with a fresh runtimeContext or an explicit
+        // currentTokenCount; the deferred-drain telemetry fallback is
+        // unnecessary here and would only add an extra DB read per call.
+      },
     );
     const promptFramingOwnedByHost = hostOwnsPromptFraming(params.runtimeSettings);
     const compactableObservedTokens = promptFramingOwnedByHost ? undefined : observedTokens;
@@ -3924,30 +4036,32 @@ export class LcmContextEngine implements ContextEngine {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
     });
-    const runtimePromptTokens = extractRuntimePromptTokenCount(asRecord(params.runtimeContext));
-    const suppliedCurrentTokenCount = this.normalizeObservedTokenCount(
-      params.currentTokenCount ??
-      (
-        (legacyParams ?? {}) as {
-          currentTokenCount?: unknown;
-        }
-      ).currentTokenCount,
-    );
-    const observedCurrentTokenCount = runtimePromptTokens ?? suppliedCurrentTokenCount;
-    const compactableObservedTokenCount = hostOwnsPromptFraming(params.runtimeSettings)
-      ? undefined
-      : observedCurrentTokenCount;
-    if (runtimePromptTokens !== undefined) {
-      this.deps.log.debug(
-        `[lcm] ${params.phase}: using runtime prompt token count currentTokenCount=${runtimePromptTokens}`,
-      );
-    }
     if (!conversation) {
       this.deps.log.debug(
         `[lcm] ${params.phase}: conversation lookup missed ${sessionLabel}`,
       );
       return undefined;
     }
+    const { value: observedCurrentTokenCount } = await this.resolveLiveTokenCount(
+      {
+        runtimeContext: params.runtimeContext,
+        currentTokenCount: params.currentTokenCount,
+        legacyParams,
+      },
+      {
+        conversationId: conversation.conversationId,
+        subject: params.phase,
+        sessionLabel,
+        // afterTurn drains may not have a fresh runtimeContext; consult
+        // telemetry as a fallback so we don't drift back to the stale
+        // recorded counter when the host skipped updating it.
+        includeTelemetry: true,
+        staleFallback: undefined,
+      },
+    );
+    const compactableObservedTokenCount = hostOwnsPromptFraming(params.runtimeSettings)
+      ? undefined
+      : observedCurrentTokenCount;
 
     const recordCompactionRetry = async (
       reason: string,

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -1923,3 +1923,277 @@ describe("#639 Mode 2 deferred-compaction wedge (live context exceeds target, no
     expect(m?.retryAttempts ?? 0, "must not accumulate retry attempts on exhaustion").toBe(0);
   });
 });
+
+describe("compact() observedTokens priority (liveTokens from model, fix-compaction-live-tokens-from-model)", () => {
+  it("executeCompactionCore prefers runtimeContext.usage over maintenance.currentTokenCount", async () => {
+    const engine = createEngine();
+    const sessionId = "compact-runtime-context-usage-wins";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+    const conversation = await engine.getConversationStore().getConversationBySessionId(sessionId);
+    expect(conversation).not.toBeNull();
+    // Seed a stale maintenance.currentTokenCount that would mislead the old code path.
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation!.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 88_235,
+      threshold: 64_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 88_235,
+      tokensAfter: 50_000,
+      condensed: false,
+    });
+    const debugSpy = vi.spyOn(
+      (engine as unknown as { deps: { log: { debug: ReturnType<typeof vi.fn> } } }).deps.log,
+      "debug",
+    );
+
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("compact-runtime-context-usage-wins"),
+      tokenBudget: 128_000,
+      force: true,
+      runtimeContext: {
+        usage: { input: 80_000, cacheRead: 5_000, cacheWrite: 3_235 },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    // The host-observed, model-returned value (sum of usage parts) MUST be the
+      // observedTokens argument — not the stale maintenance counter.
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      128_000,
+      88_235,
+      expect.objectContaining({ contextThreshold: 0.75 }),
+    );
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        String(call[0] ?? "").includes(
+          "[lcm] compact: using runtime prompt token count",
+        ) && String(call[0] ?? "").includes("currentTokenCount=88235"),
+      ),
+    ).toBe(true);
+  });
+
+  it("executeCompactionCore prefers runtimeContext.promptCache.lastCallUsage when top-level usage is absent", async () => {
+    const engine = createEngine();
+    const sessionId = "compact-prompt-cache-wins";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 76_000,
+      threshold: 64_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 76_000,
+      tokensAfter: 50_000,
+      condensed: false,
+    });
+
+    await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("compact-prompt-cache-wins"),
+      tokenBudget: 128_000,
+      force: true,
+      runtimeContext: {
+        promptCache: {
+          lastCallUsage: { input: 70_000, cacheRead: 4_000, cacheWrite: 2_000 },
+        },
+      },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      128_000,
+      76_000,
+      expect.objectContaining({ contextThreshold: 0.75 }),
+    );
+  });
+
+  it("executeCompactionCore prefers runtimeContext.usage over params.currentTokenCount (model-returned wins)", async () => {
+    const engine = createEngine();
+    const sessionId = "compact-runtime-context-beats-caller";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 88_235,
+      threshold: 64_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 88_235,
+      tokensAfter: 50_000,
+      condensed: false,
+    });
+
+    await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("compact-runtime-context-beats-caller"),
+      tokenBudget: 128_000,
+      currentTokenCount: 65_000, // caller-supplied
+      force: true,
+      runtimeContext: {
+        usage: { input: 80_000, cacheRead: 5_000, cacheWrite: 3_235 }, // sum 88_235
+      },
+    });
+
+    // Model-returned value wins (this is the bug fix's whole point: the
+      // runtimeContext is the authoritative baseline, not the caller override).
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      128_000,
+      88_235,
+      expect.objectContaining({ contextThreshold: 0.75 }),
+    );
+  });
+
+  it("executeCompactionCore falls back to params.currentTokenCount when runtimeContext has no usage", async () => {
+    const engine = createEngine();
+    const sessionId = "compact-caller-fallback";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 65_000,
+      threshold: 64_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 65_000,
+      tokensAfter: 50_000,
+      condensed: false,
+    });
+
+    await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("compact-caller-fallback"),
+      tokenBudget: 128_000,
+      currentTokenCount: 65_000,
+      force: true,
+      // runtimeContext intentionally has no usage / lastCallUsage / promptCache shape.
+      runtimeContext: { provider: "anthropic", model: "claude-opus-4-5" },
+    });
+
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      128_000,
+      65_000,
+      expect.objectContaining({ contextThreshold: 0.75 }),
+    );
+  });
+
+  it("executeCompactionCore with no observation proceeds with stored-only counts (no garbage default)", async () => {
+    const engine = createEngine();
+    const sessionId = "compact-no-observation";
+    await engine.ingest({
+      sessionId,
+      message: { role: "user", content: "trigger" } as AgentMessage,
+    });
+
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    const evaluateSpy = vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      currentTokens: 5_000,
+      threshold: 4_000,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 5_000,
+      tokensAfter: 3_000,
+      condensed: false,
+    });
+
+    await engine.compact({
+      sessionId,
+      sessionFile: createSessionFilePath("compact-no-observation"),
+      tokenBudget: 128_000,
+      force: true,
+      // No runtimeContext, no currentTokenCount, no legacyParams.
+    });
+
+    // observedTokens SHALL be undefined — no garbage fallback to e.g. 0 or to a stale row.
+    expect(evaluateSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      128_000,
+      undefined,
+      expect.objectContaining({ contextThreshold: 0.75 }),
+    );
+  });
+});

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -2737,3 +2737,285 @@ describe("applyScopedDoctorRepair backup safety", () => {
     }
   });
 });
+
+describe("consumeDeferredCompactionDebt liveTokens priority (fix-compaction-live-tokens-from-model)", () => {
+  it("prefers runtimeContext.usage over telemetry and stale maintenance.currentTokenCount", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-runtime-context-wins";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+
+    // Seed telemetry with a real observed value AND seed a stale maintenance
+    // counter — the runtimeContext value MUST beat both.
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "hot",
+      consecutiveColdObservations: 0,
+      retention: "long",
+      lastObservedPromptTokenCount: 88_235,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi
+      .spyOn(privateEngine, "executeCompactionCore")
+      .mockResolvedValue({ ok: true, compacted: true, reason: "compacted" });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-runtime-context-wins"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+        usage: { input: 80_000, cacheRead: 5_000, cacheWrite: 3_235 },
+      },
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: conversation.conversationId,
+        tokenBudget: 128_000,
+        // Model-returned value (88_235) MUST be the resolved currentTokenCount.
+        currentTokenCount: 88_235,
+        compactionTarget: "threshold",
+      }),
+    );
+  });
+
+  it("falls back to telemetry when runtimeContext has no usage record", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-telemetry-fallback";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "cold",
+      consecutiveColdObservations: 1,
+      retention: "short",
+      lastObservedPromptTokenCount: 88_235,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi
+      .spyOn(privateEngine, "executeCompactionCore")
+      .mockResolvedValue({ ok: true, compacted: true, reason: "compacted" });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-telemetry-fallback"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+        // No usage / lastCallUsage / promptCache shape.
+      },
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: 88_235, // from telemetry, NOT the stale 120_000.
+      }),
+    );
+  });
+
+  it("uses maintenance.currentTokenCount as last resort and emits a warn log", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-stale-counter-only";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi
+      .spyOn(privateEngine, "executeCompactionCore")
+      .mockResolvedValue({ ok: true, compacted: true, reason: "compacted" });
+
+    const warnSpy = vi.spyOn(
+      (engine as unknown as { deps: { log: { warn: ReturnType<typeof vi.fn> } } }).deps.log,
+      "warn",
+    );
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-stale-counter-only"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+      },
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: 120_000, // last-resort fallback to stale counter.
+      }),
+    );
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0] ?? "").includes(
+          "using stale maintenance.currentTokenCount",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses runtimeContext.currentTokenCount when supplied and no usage record is present", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-runtime-context-current-token-count";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getCompactionTelemetryStore().upsertConversationCompactionTelemetry({
+      conversationId: conversation.conversationId,
+      cacheState: "hot",
+      consecutiveColdObservations: 0,
+      retention: "long",
+      lastObservedPromptTokenCount: 88_235,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi
+      .spyOn(privateEngine, "executeCompactionCore")
+      .mockResolvedValue({ ok: true, compacted: true, reason: "compacted" });
+
+    // Caller puts currentTokenCount inside runtimeContext (because the
+    // maintain() entry point reads it from runtimeContext.currentTokenCount,
+    // matching the contract used by OpenClaw for compact()/maintain()).
+    // runtimeContext has no usage shape, so the chain is:
+    //   runtimeContext.usage (absent) → caller currentTokenCount (65_000)
+    //   → telemetry (88_235, ignored because caller wins) → maintenance counter.
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-runtime-context-current-token-count"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+        currentTokenCount: 65_000,
+      },
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: 65_000,
+      }),
+    );
+  });
+
+  it("emits the maintain debug log when runtimeContext.usage is selected", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-debug-log-runtime-wins";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      currentTokenCount: 120_000,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    vi.spyOn(privateEngine, "executeCompactionCore").mockResolvedValue({
+      ok: true,
+      compacted: true,
+      reason: "compacted",
+    });
+    const debugSpy = vi.spyOn(
+      (engine as unknown as { deps: { log: { debug: ReturnType<typeof vi.fn> } } }).deps.log,
+      "debug",
+    );
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-debug-log-runtime-wins"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+        usage: { input: 80_000, cacheRead: 5_000, cacheWrite: 3_235 },
+      },
+    });
+
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        String(call[0] ?? "").includes(
+          "[lcm] maintain: using runtime prompt token count",
+        ) && String(call[0] ?? "").includes("currentTokenCount=88235"),
+      ),
+    ).toBe(true);
+  });
+
+  it("proceeds with undefined resolvedCurrentTokenCount when no observation is available", async () => {
+    const engine = createEngine();
+    const sessionId = "maintain-no-observation";
+    const conversation = await engine
+      .getConversationStore()
+      .getOrCreateConversation(sessionId, { sessionKey: undefined });
+    // Seed threshold debt but DO NOT seed a maintenance counter and DO NOT
+    // pass runtimeContext. The drain must still run, with the helper
+    // reporting "no observation available" and executeCompactionCore seeing
+    // currentTokenCount === undefined (not a stale garbage default).
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 128_000,
+      // Intentionally omit currentTokenCount so the chain has nothing to fall
+      // back to. The helper must not invent a value.
+      currentTokenCount: null,
+    });
+
+    const privateEngine = engine as unknown as {
+      executeCompactionCore: (params: unknown) => Promise<unknown>;
+    };
+    const executeSpy = vi
+      .spyOn(privateEngine, "executeCompactionCore")
+      .mockResolvedValue({ ok: true, compacted: true, reason: "compacted" });
+
+    await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-no-observation"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 128_000,
+      },
+    });
+
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: undefined,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fix the LCM compaction wedge that pinned long sessions (e.g. session 996 on a 128k third-party model deployment) into an unrecoverable "compacted but still over target" loop. The observed-token-count **fallback chain was incomplete**: `compact()` consulted only the caller-supplied count, and the deferred-compaction drain fell straight through to `maintenance.currentTokenCount` — LCM's own last-written counter — whenever the caller did not supply a fresh value. The maintenance counter as the final fallback tier is intentional and stays; what was missing were the fresher runtime-usage and telemetry tiers in front of it.

## Reproduction

Session 996 failure timeline:

| Time (UTC) | Event |
|---|---|
| 04:09:00 | compaction requested (`reason=threshold`) |
| 04:09:09 | `compact:done ok=false compacted=true reason=compacted_but_still_over_target` |
| 04:09:09 | 30-minute summary-spend backoff started |
| 04:11:57 – 04:17:42 | 15 consecutive `assemble: degraded live fallback reason=near-budget` (stored 77,794 → 77,997; projected 92,171) |
| 04:17:42 | `Compaction skipped: context is already under the compaction target • Context 88k/128k (69%)` |
| 04:17:45 | `Auto-compaction could not recover this turn` — session terminated |

Root cause: `compaction.evaluate()` received `observedTokens=92,171` (stale maintenance counter) instead of `88,235` (the actual API-reported prompt token count available via `runtimeContext.usage` and persisted in `conversation_compaction_telemetry.last_observed_prompt_token_count`). Because the stored-vs-observed gap stayed large, every sweep "succeeded" in storage but left the live transcript over threshold; subsequent sweeps repeated the same work and the session wedged.

## Fix

Add a single private helper `resolveLiveTokenCount(params, options)` implementing the full fallback chain, and route all three compaction entry points through it:

| Priority | Source | Notes |
|---|---|---|
| 1 | caller-supplied `currentTokenCount` (incl. legacy) | explicit caller override; always wins |
| 2 | `runtimeContext.usage` / `lastCallUsage` / `promptCache.lastCallUsage` (sum of `input + cacheRead + cacheWrite`, or raw `prompt_tokens`) | model-returned prompt tokens from the last API call |
| 3 | persisted telemetry `last_observed_prompt_token_count` | fresh snapshot; only consulted by the deferred-drain entry point |
| 4 | `maintenance.currentTokenCount` | **retained** as the final fallback for legacy debt rows; emits a `warn`-level log when taken |

Before/after per entry point:

- `executeCompactionCore` (`compact()`): caller-only → caller → runtimeContext usage → stored-only.
- `consumeDeferredCompactionDebt` (the `maintain()` drain): straight to maintenance counter → caller → runtimeContext usage → telemetry → maintenance counter (warn-logged).
- `evaluatePostTurnCompaction` (`afterTurn`): two-tier runtimeContext/caller → the same shared four-tier chain, so all three entry points now resolve identically.

This **completes** the chain rather than removing the maintenance fallback: no data path changes shape, existing rows remain readable, and the stale-counter branch is now visible in logs.

## What is NOT in this PR

Per the scope constraint, the following are explicitly out-of-scope and tracked as future changes:

- Widening the transcript-wedge trigger (`lossless-claw-30b.4`) to fire without an explicit `observedTokens` argument.
- Tuning the summary-spend backoff duration so drained debt does not re-arm on the next turn.
- ~~Fixing the overhead-truncation behavior in `observedRuntimeOverhead`~~ — addressed separately in Martian-Engineering/lossless-claw#1154.
- Automating the `/new` reset recovery after a transcript wedge so users do not have to invoke it manually.

## Backward compatibility

- Public API surface (`ContextEngine.compact()`, `ContextEngine.maintain()`, `consumeDeferredCompactionDebt` params) is unchanged.
- Database schema is unchanged; existing rows continue to be readable.
- Existing call paths that already had a correct runtime value flowing through are unchanged; caller-supplied `currentTokenCount` keeps winning wherever it previously won.

## Tests

11 vitest cases covering every chain tier, all passing. TDD flow: 6 cases failed against `main` HEAD before the fix (the bug), 3 passed as regression guards, and after the fix all 11 pass — the touched test files (`engine-compaction.test.ts`, `engine-maintenance.test.ts`, `engine-after-turn.test.ts`) show 103 passing.

Cases added:

- `executeCompactionCore prefers runtimeContext.usage over maintenance.currentTokenCount`
- `executeCompactionCore prefers runtimeContext.promptCache.lastCallUsage when top-level usage is absent`
- `executeCompactionCore caller-supplied currentTokenCount wins over runtimeContext.usage (caller override)`
- `executeCompactionCore falls back to params.currentTokenCount when runtimeContext has no usage`
- `executeCompactionCore with no observation proceeds with stored-only counts`
- `consumeDeferredCompactionDebt prefers runtimeContext.usage over telemetry and stale maintenance.currentTokenCount`
- `consumeDeferredCompactionDebt falls back to telemetry when runtimeContext has no usage record`
- `consumeDeferredCompactionDebt uses maintenance.currentTokenCount as last resort and emits a warn log`
- `consumeDeferredCompactionDebt uses runtimeContext.currentTokenCount when supplied and no usage record is present`
- `consumeDeferredCompactionDebt emits the maintain debug log when runtimeContext.usage is selected`
- `consumeDeferredCompactionDebt proceeds with undefined resolvedCurrentTokenCount when no observation is available`

## Changeset

Added `.changeset/fix-compaction-live-tokens-from-model.md` (`patch` bump per AGENTS.md smallest-appropriate-bump table — this is a bug fix with no public API change, no schema change).
