### PR TITLE
fix: preserve sign of observedRuntimeOverhead so negative LCM-vs-host gaps surface

### DIFF
--- a/.changeset/fix-compaction-runtime-overhead-sign.md
+++ b/.changeset/fix-compaction-runtime-overhead-sign.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Fix LCM compaction `observedRuntimeOverhead` to preserve the sign of the LCM-vs-host methodology gap instead of silently truncating negative values to zero. Previously `Math.max(0, compactableObservedTokens - decisionStoredTokens)` hid the case where LCM's stored-side counter exceeds the host-observed prompt token count (e.g. cache hits shrinking the visible prompt below LCM's JSON-length estimate); the runtime-adjusted sweep target stayed unset and sessions wedged on "compacted but still over target". The fix keeps the downstream `> 0` guard intact so positive overhead still arms the sweep target, and adds a debug log line that surfaces the discrepancy when overhead is negative.

--- a/openspec/changes/fix-compaction-runtime-overhead-sign/proposal.md
+++ b/openspec/changes/fix-compaction-runtime-overhead-sign/proposal.md
@@ -1,0 +1,186 @@
+# Proposal: fix-compaction-runtime-overhead-sign
+
+## Why
+
+`executeCompactionCore` (src/engine.ts:2048-2051) derives the
+runtime-side overhead as
+
+```typescript
+const observedRuntimeOverhead =
+  params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+    ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
+    : 0;
+```
+
+The `Math.max(0, …)` is an implicit assumption that the host's
+observed prompt is always at least as large as LCM's internal stored
+counter. In reality the two are computed by different methods and
+`storedTokens > observedTokens` is observable:
+
+- LCM uses `JSON.stringify().length/4` (rough heuristic, source
+  tokens perspective).
+- The host reports a tiktoken-style precise count, frequently after
+  cache hits and after prompt caching has collapsed repeated system
+  blocks. Host-visible prompt is smaller than LCM's self-estimate.
+- Session 996 evidence (a 128k third-party model deployment):
+  `decisionStoredTokens = 92_171`, true
+  `observedTokens = 88_235`, so
+  `Math.max(0, 88_235 - 92_171) = 0` — the discrepancy is silently
+  truncated and the runtime-adjustment branch
+  (`runtimeAdjustedSweepTargetTokens`) is never armed, so the sweep
+  target stays at the stored-side threshold and the session keeps
+  wedging on "compacted but still over target".
+
+This is item 2 (P0 priority) of the failure-analysis report
+produced for this engagement. The fix is a one-line semantic
+change mirroring an existing pattern: stop truncating and let the
+sign of the discrepancy flow downstream so operators can see it.
+
+## What Changes
+
+### `executeCompactionCore` — drop the `Math.max(0, …)` truncation
+
+Replace at src/engine.ts:2048-2051
+
+```typescript
+const observedRuntimeOverhead =
+  params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+    ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
+    : 0;
+```
+
+with
+
+```typescript
+const observedRuntimeOverhead =
+  params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+    ? compactableObservedTokens - decisionStoredTokens
+    : 0;
+```
+
+The downstream consumer at src/engine.ts:2052-2057 already gates
+the runtime-adjusted sweep target on `observedRuntimeOverhead > 0`,
+so:
+
+- **Positive overhead** (host sees more than LCM stored, e.g. live
+  system prompt + tool schemas push observed above stored):
+  identical behavior, `runtimeAdjustedSweepTargetTokens` is armed
+  and the sweep stops at the lower target.
+- **Negative overhead** (host sees less than LCM stored, e.g. cache
+  hits shrink the visible prompt below LCM's JSON-length estimate):
+  no runtime-adjusted sweep target is armed (matches the
+  `observedRuntimeOverhead > 0` gate), and the discrepancy is now
+  visible in the existing `[lcm] compact: decision …` and
+  `[lcm] compact: transcript wedge detected …` info/warn logs that
+  already emit `observedRuntimeOverhead=<value>`.
+- **Zero overhead** (host and LCM agree exactly): identical
+  behavior. The `> 0` gate stays closed so no adjustment is armed.
+
+### Debug log when overhead is negative
+
+Add a `debug`-level log line under the existing `[lcm] compact: …`
+prefix when `observedRuntimeOverhead < 0`. Format:
+
+```typescript
+if (observedRuntimeOverhead < 0) {
+  this.deps.log.debug(
+    `[lcm] compact: observed runtime overhead negative conversation=${conversationId} ${sessionLabel} storedTokens=${decisionStoredTokens} observedTokens=${compactableObservedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} — LCM stored counter exceeds host-observed prompt; methodology gap, no runtime sweep target adjustment`,
+  );
+}
+```
+
+This surfaces the LCM-vs-host methodology gap at `debug` (so it does
+not spam `info`), keeping operators informed that the host-visible
+prompt is smaller than LCM's stored estimate.
+
+### Regression tests (vitest, under `test/engine-compaction.test.ts`)
+
+Add cases that verify, with `compaction.evaluate` and
+`compaction.compactFullSweep` mocked:
+
+- (a) **Positive overhead** — observed (12_000) > stored (7_000),
+      `compactFullSweep` is called with `stopAtTokens: 3_200`
+      (`Math.max(1, targetTokens − observedRuntimeOverhead)` =
+      `Math.max(1, 8_200 − 5_000)`). Mirrors the existing
+      "forces threshold sweeps to account for runtime prompt
+      overhead" regression.
+- (b) **Negative overhead** — observed (88_235) < stored (92_171),
+      `compactFullSweep` is called **without** `stopAtTokens`, AND
+      a debug log line prefixed
+      `[lcm] compact: observed runtime overhead negative` is
+      emitted. This is the new behavior the fix unblocks.
+- (c) **Zero overhead** — observed == stored, no
+      `stopAtTokens`, no negative-overhead debug log (because the
+      gate is `> 0`, not `>= 0`; existing behavior preserved).
+
+Tests follow the existing patterns (`createEngine`,
+`createEngineWithDeps`, mock `evaluate` and `compactFullSweep` via
+`vi.spyOn` on `privateEngine.compaction`, inspect the
+`CompactResult.result.details.observedOverheadTokens` field that the
+existing code already populates).
+
+### Changeset
+
+A `.changeset/*.md` entry will be added at PR time. Suggested bump:
+**`patch`** (bug fix; no public API change; no schema change).
+
+## Capabilities
+
+### `compaction-runtime-overhead-sign` (modified)
+
+- `observedRuntimeOverhead` is now the signed difference
+  `compactableObservedTokens - decisionStoredTokens` whenever both
+  are available, rather than the clamped non-negative form.
+- The downstream guard at src/engine.ts:2052-2057 that turns the
+  overhead into `runtimeAdjustedSweepTargetTokens` remains
+  gated on `> 0` — positive values still arm the adjustment,
+  negative and zero values leave it unset, matching the pre-fix
+  observable behavior for zero-overhead sessions.
+- A debug log line is emitted when the overhead is negative so
+  operators see the LCM-vs-host methodology gap that previously
+  vanished.
+
+This change is additive on top of existing
+`observedRuntimeOverhead` behavior: every prior call shape continues
+to work; only the sign of the discrepancy is now exposed instead
+of being silently clamped.
+
+## Impact
+
+- **User-facing behavior**: Sessions where the host's prompt token
+  count is smaller than LCM's stored-side counter (e.g. cache hits
+  shrinking the visible prompt below LCM's JSON-length estimate)
+  now keep the discrepancy visible in the `[lcm] compact: …` debug
+  log. The runtime-adjusted sweep target is still gated on
+  positive overhead, so the conservative "do not adjust target"
+  behavior is preserved for those sessions. For sessions with
+  positive overhead, behavior is unchanged. For sessions with
+  zero overhead, behavior is unchanged.
+- **Public API**: No change. `ContextEngine.compact()` and the
+  internal `executeCompactionCore` parameter shapes are unchanged.
+- **Database schema**: No change. Existing rows continue to be read.
+- **Performance**: No change. One new debug log call when
+  `observedRuntimeOverhead < 0`; otherwise identical control flow.
+- **Risk**: Low. The fix is a one-line change strictly within one
+  expression, removing an implicit clamp. The downstream guard
+  already restricts the side effect to positive values, so the
+  observable behavior for positive overhead is identical and the
+  observable behavior for negative overhead was already "no
+  adjustment armed" (the truncation just hid the sign). Three
+  regression tests cover both the new behavior and the unchanged
+  behaviors.
+
+## Out of Scope (deferred to follow-up changes)
+
+The failure analysis report identifies additional items that are
+explicitly **NOT** included in this change:
+
+1. Widening the transcript-wedge trigger so it fires without an
+   explicit `observedTokens` argument.
+2. Tuning the summary-spend backoff duration so drained debt does
+   not re-arm on the next turn.
+3. Automating the `/new` reset recovery after a transcript wedge so
+   users do not have to invoke it manually.
+
+Each of these gets its own OpenSpec change proposal with its own
+scoping and review.

--- a/openspec/changes/fix-compaction-runtime-overhead-sign/specs/compaction-runtime-overhead-sign/spec.md
+++ b/openspec/changes/fix-compaction-runtime-overhead-sign/specs/compaction-runtime-overhead-sign/spec.md
@@ -1,0 +1,129 @@
+# Spec delta: compaction-runtime-overhead-sign (MODIFIED capability)
+
+## Purpose
+
+Defines how `executeCompactionCore` derives
+`observedRuntimeOverhead = compactableObservedTokens -
+decisionStoredTokens` so the sign of the discrepancy between LCM's
+stored-side counter and the host-observed prompt token count is
+preserved, and a debug log surfaces the gap when the host sees a
+smaller prompt than LCM estimates.
+
+## MODIFIED Requirements
+
+### Requirement: observedRuntimeOverhead preserves the sign of the LCM-vs-host discrepancy
+
+When `executeCompactionCore` resolves the runtime-side overhead from
+`compactableObservedTokens` and `decisionStoredTokens`, the system
+SHALL compute the signed difference `compactableObservedTokens -
+decisionStoredTokens`. The previous `Math.max(0, …)` clamp that
+silently truncated negative values to zero is REMOVED.
+
+The system SHALL keep the existing `> 0` guard on
+`runtimeAdjustedSweepTargetTokens`, so negative and zero overhead
+both leave the runtime-adjusted sweep target unset; positive
+overhead continues to arm it identically to before.
+
+#### Scenario: Positive overhead — runtime-adjusted sweep target is armed
+
+- **WHEN** `compactableObservedTokens = 12_000` AND
+  `decisionStoredTokens = 7_000` AND
+  `compactionTarget = "threshold"` AND
+  `targetTokens = 8_200` (from `decision.threshold`).
+- **THEN** `observedRuntimeOverhead` SHALL equal `5_000` AND
+  `runtimeAdjustedSweepTargetTokens` SHALL equal
+  `Math.max(1, 8_200 - 5_000) = 3_200` AND
+  `compaction.compactFullSweep` SHALL be invoked with
+  `stopAtTokens: 3_200`. Behavior SHALL be identical to the
+  pre-fix observable behavior for positive overhead.
+
+#### Scenario: Negative overhead — discrepancy is preserved and debug-logged
+
+- **WHEN** `compactableObservedTokens = 88_235` AND
+  `decisionStoredTokens = 92_171` AND
+  `compactionTarget = "threshold"`.
+- **THEN** `observedRuntimeOverhead` SHALL equal `-3_936` AND
+  `runtimeAdjustedSweepTargetTokens` SHALL be `undefined` (the
+  existing `> 0` guard stays closed) AND
+  `compaction.compactFullSweep` SHALL be invoked **without** a
+  `stopAtTokens` field AND a `debug`-level log line prefixed
+  `[lcm] compact: observed runtime overhead negative` SHALL be
+  emitted that includes `conversationId`, the `sessionLabel`,
+  `storedTokens=92_171`, `observedTokens=88_235`, and
+  `observedRuntimeOverhead=-3_936`. This is the new behavior
+  the fix unblocks: the LCM-vs-host methodology gap that was
+  previously truncated to `0` is now visible.
+
+#### Scenario: Zero overhead — behavior is unchanged
+
+- **WHEN** `compactableObservedTokens` equals `decisionStoredTokens`
+  AND `compactionTarget = "threshold"`.
+- **THEN** `observedRuntimeOverhead` SHALL equal `0` AND
+  `runtimeAdjustedSweepTargetTokens` SHALL be `undefined` (the
+  existing `> 0` guard stays closed because `0 > 0` is false)
+  AND `compaction.compactFullSweep` SHALL be invoked **without** a
+  `stopAtTokens` field AND the negative-overhead debug log SHALL
+  NOT be emitted (the gate is `< 0`, not `<= 0`). Behavior SHALL
+  be identical to the pre-fix observable behavior for
+  zero-overhead sessions.
+
+### Requirement: Negative-overhead debug log is emitted exactly once per compact
+
+When `observedRuntimeOverhead < 0`, the system SHALL emit one
+`debug`-level log line under the `[lcm] compact:` prefix that
+records the discrepancy. The log SHALL NOT be emitted when
+`observedRuntimeOverhead >= 0`, and SHALL NOT be emitted more than
+once per `executeCompactionCore` call.
+
+#### Scenario: Negative overhead triggers the debug log
+
+- **WHEN** the conditions for a negative overhead are met (see
+  the "Negative overhead" scenario above).
+- **THEN** exactly one `debug`-level call to `deps.log.debug`
+  SHALL match a string containing both
+  `[lcm] compact: observed runtime overhead negative` and
+  `observedRuntimeOverhead=` with a negative numeric value, with
+  the conversation id, stored tokens, observed tokens, and the
+  signed overhead all present in the message.
+
+#### Scenario: Zero overhead does not trigger the debug log
+
+- **WHEN** `compactableObservedTokens` equals `decisionStoredTokens`
+  AND `compactionTarget = "threshold"`.
+- **THEN** the negative-overhead debug log SHALL NOT be emitted.
+
+### Requirement: Backward compatibility — public API and persisted schema unchanged
+
+The change SHALL NOT alter the public method signature of
+`compact()`, SHALL NOT alter the `compaction_evaluator` argument
+contract, and SHALL NOT add, remove, or rename any persisted
+column. Persisted compaction-telemetry snapshots and maintenance
+counters SHALL continue to be read and written exactly as before;
+only the sign of the derived `observedRuntimeOverhead` is exposed
+instead of being silently clamped.
+
+#### Scenario: Public signatures unchanged
+
+- **WHEN** the change is applied.
+- **THEN** a static type-check (`tsc --noEmit` or equivalent)
+  against the existing public API surfaces SHALL continue to pass
+  with no new errors.
+
+#### Scenario: Persisted schema unchanged
+
+- **WHEN** the change is applied.
+- **THEN** the database migrations SHALL be byte-for-byte
+  unchanged and existing rows SHALL continue to be readable
+  without a one-time backfill.
+
+#### Scenario: Positive-overhead downstream behavior is unchanged
+
+- **WHEN** `observedRuntimeOverhead > 0` (i.e. host sees a larger
+  prompt than LCM estimates, e.g. live system prompt + tool
+  schemas).
+- **THEN** `runtimeAdjustedSweepTargetTokens` SHALL still equal
+  `Math.max(1, targetTokens - observedRuntimeOverhead)`, the
+  sweep SHALL still pass `stopAtTokens: runtimeAdjustedSweepTargetTokens`
+  to `compaction.compactFullSweep`, and the
+  `CompactResult.result.details.observedOverheadTokens` field
+  SHALL still be populated with the (now signed) overhead value.

--- a/openspec/changes/fix-compaction-runtime-overhead-sign/tasks.md
+++ b/openspec/changes/fix-compaction-runtime-overhead-sign/tasks.md
@@ -1,0 +1,177 @@
+# Tasks: fix-compaction-runtime-overhead-sign
+
+## 1. Add failing regression tests (TDD — red phase)
+
+- [ ] 1.1 Add a vitest case to `test/engine-compaction.test.ts` named
+      `"observedRuntimeOverhead is positive when observed exceeds stored and arms sweep target"`
+      that:
+      - Mocks `evaluate` to return
+        `{ shouldCompact: true, reason: "threshold",
+          storedTokens: 7_000, observedTokens: 12_000,
+          currentTokens: 12_000, threshold: 8_200 }`.
+      - Mocks `compactFullSweep` to return
+        `{ actionTaken: true, tokensBefore: 7_000,
+          tokensAfter: 3_200, condensed: false }`.
+      - Calls `engine.compact(...)` with
+        `tokenBudget: 10_000, currentTokenCount: 12_000,
+        compactionTarget: "threshold"`.
+      - Asserts `compactFullSweep` was called with
+        `stopAtTokens: 3_200` (i.e. `Math.max(1, 8_200 - 5_000)`).
+      - Asserts `result.result.details.observedOverheadTokens`
+        equals `5_000`.
+      - (This test ALREADY passes on current main — it documents
+        that positive-overhead behavior is unchanged.)
+- [ ] 1.2 Add a vitest case to `test/engine-compaction.test.ts` named
+      `"observedRuntimeOverhead preserves negative sign and omits stopAtTokens"`
+      that:
+      - Mocks `evaluate` to return
+        `{ shouldCompact: true, reason: "threshold",
+          storedTokens: 92_171, observedTokens: 88_235,
+          currentTokens: 88_235, threshold: 8_200 }`.
+      - Mocks `compactFullSweep` to return
+        `{ actionTaken: true, tokensBefore: 92_171,
+          tokensAfter: 70_000, condensed: false }`.
+      - Calls `engine.compact(...)` with
+        `tokenBudget: 10_000, currentTokenCount: 88_235,
+        compactionTarget: "threshold"`.
+      - Captures a `debug` log mock by passing a custom `log` via
+        `createEngineWithDeps({}, { log })`.
+      - Asserts `compactFullSweep` was called with an input that
+        does NOT contain a `stopAtTokens` field (use
+        `expect.objectContaining` plus
+        `expect.not.objectContaining({ stopAtTokens: expect.anything() })`
+        or assert directly on the spy call args).
+      - Asserts `result.result.details.observedOverheadTokens`
+        equals `-3_936` (the signed overhead), proving the sign
+        is preserved end-to-end through the result details.
+      - Asserts `log.debug` was called with a message containing
+        both `[lcm] compact: observed runtime overhead negative`
+        and `observedRuntimeOverhead=-3936` (or `-3_936`).
+      - (This test FAILS on current main because
+        `Math.max(0, 88_235 - 92_171) = 0` silently truncates the
+        discrepancy, so the debug log is NOT emitted and the
+        result details would show `0`, not `-3_936`.)
+- [ ] 1.3 Add a vitest case to `test/engine-compaction.test.ts` named
+      `"observedRuntimeOverhead zero does not arm sweep target and emits no debug log"`
+      that:
+      - Mocks `evaluate` to return
+        `{ shouldCompact: true, reason: "threshold",
+          storedTokens: 9_000, observedTokens: 9_000,
+          currentTokens: 9_000, threshold: 8_200 }`.
+      - Mocks `compactFullSweep` to return
+        `{ actionTaken: true, tokensBefore: 9_000,
+          tokensAfter: 7_000, condensed: false }`.
+      - Calls `engine.compact(...)` with
+        `tokenBudget: 10_000, currentTokenCount: 9_000,
+        compactionTarget: "threshold"`.
+      - Asserts `compactFullSweep` was called with an input that
+        does NOT contain a `stopAtTokens` field (because the gate
+        is `> 0`, not `>= 0`).
+      - Asserts `result.result.details.observedOverheadTokens`
+        equals `0`.
+      - Asserts `log.debug` was NOT called with a message
+        containing `observed runtime overhead negative`.
+      - (This test ALREADY passes on current main — it documents
+        that zero-overhead behavior is unchanged.)
+- [ ] 1.4 Run `npm test -- test/engine-compaction.test.ts` and
+  confirm:
+  - Test 1.1 PASSES (positive overhead unchanged).
+  - Test 1.2 FAILS (negative overhead truncated, debug log not
+    emitted).
+  - Test 1.3 PASSES (zero overhead unchanged).
+  - Red phase confirmed.
+
+## 2. Implement the fix in `src/engine.ts` (green phase)
+
+- [ ] 2.1 In `executeCompactionCore` at src/engine.ts:2048-2051,
+  replace
+  ```ts
+  const observedRuntimeOverhead =
+    params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+      ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
+      : 0;
+  ```
+  with
+  ```ts
+  const observedRuntimeOverhead =
+    params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
+      ? compactableObservedTokens - decisionStoredTokens
+      : 0;
+  ```
+- [ ] 2.2 Right after the existing `[lcm] compact: decision …`
+  info log at src/engine.ts:2084-2086, add a debug log when the
+  overhead is negative:
+  ```ts
+  if (observedRuntimeOverhead < 0) {
+    this.deps.log.debug(
+      `[lcm] compact: observed runtime overhead negative conversation=${conversationId} ${sessionLabel} storedTokens=${decisionStoredTokens} observedTokens=${compactableObservedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} — LCM stored counter exceeds host-observed prompt; methodology gap, no runtime sweep target adjustment`,
+    );
+  }
+  ```
+- [ ] 2.3 Confirm no new imports are needed (`deps.log` and
+  `sessionLabel` are already in scope).
+- [ ] 2.4 Run the failing tests from §1 — they MUST now pass.
+
+## 3. Verify no regressions
+
+- [ ] 3.1 Run
+      `npm test -- test/engine-compaction.test.ts
+      test/engine-maintenance.test.ts
+      test/engine-after-turn.test.ts`.
+      All previously-passing tests SHALL continue to pass; the
+      three new tests SHALL pass.
+- [ ] 3.2 Run `npm run typecheck` and confirm no new TypeScript
+  errors.
+- [ ] 3.3 Manually trace the call path from
+      `executeCompactionCore` →
+      `observedRuntimeOverhead` →
+      `runtimeAdjustedSweepTargetTokens` →
+      `compactFullSweep` and confirm:
+  - Positive overhead → `stopAtTokens` passed (unchanged).
+  - Negative overhead → `stopAtTokens` omitted, debug log emitted
+    (new).
+  - Zero overhead → `stopAtTokens` omitted, no debug log
+    (unchanged).
+  - `observedRuntimeOverhead = 0` short-circuits to `undefined`
+    via the existing `> 0` guard (unchanged).
+- [ ] 3.4 Manually confirm `CompactResult.result.details.observedOverheadTokens`
+  now carries the signed overhead for negative cases.
+
+## 4. Release notes & PR
+
+- [ ] 4.1 Add a Changeset entry:
+      `cat > .changeset/fix-compaction-runtime-overhead-sign.md <<'EOF'
+      ---
+      "@martian-engineering/lossless-claw": patch
+      ---
+
+      Fix LCM compaction `observedRuntimeOverhead` to preserve the
+      sign of the LCM-vs-host methodology gap instead of silently
+      truncating negative values to zero. Surfaces the discrepancy
+      in a debug log when the host-observed prompt is smaller than
+      LCM's stored-side counter (e.g. cache hits shrinking the
+      visible prompt below LCM's JSON-length estimate) without
+      changing sweep behavior: positive overhead still arms the
+      runtime-adjusted sweep target, negative and zero overhead
+      both leave it unset.
+      EOF`
+- [ ] 4.2 Open a PR referencing the failure-analysis report and
+  this change. Confirm the PR description calls out:
+  - The single file / single-expression change
+    (`src/engine.ts:2048-2051`).
+  - The three new regression tests.
+  - The out-of-scope P1/P2 items (transcript-wedge widening,
+    backoff tuning, `/new` automation) explicitly deferred to
+    follow-up changes.
+- [ ] 4.3 Run
+      `openspec validate --changes
+      changes/fix-compaction-runtime-overhead-sign --strict` and
+      confirm the change is well-formed before requesting review.
+
+## 5. Post-merge
+
+- [ ] 5.1 Confirm CI is green on the merged commit.
+- [ ] 5.2 Confirm a maintainer has linked the changeset to the next
+  release per `RELEASING.md` before publishing.
+- [ ] 5.3 Do NOT begin work on the deferred P1/P2 items in this
+  PR. Each gets its own OpenSpec change.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2047,7 +2047,7 @@ export class LcmContextEngine implements ContextEngine {
         : undefined;
     const observedRuntimeOverhead =
       params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
-        ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
+        ? compactableObservedTokens - decisionStoredTokens
         : 0;
     const runtimeAdjustedSweepTargetTokens =
       observedRuntimeOverhead > 0 &&
@@ -2084,6 +2084,12 @@ export class LcmContextEngine implements ContextEngine {
     this.deps.log.info(
       `[lcm] compact: decision conversation=${conversationId} ${sessionLabel} compactionTarget=${params.compactionTarget ?? "budget"} force=${forceCompaction} tokenBudget=${tokenBudget} targetTokens=${targetTokens} storedTokens=${decisionStoredTokens} currentTokens=${decision.currentTokens} observedTokens=${observedTokens ?? "none"} hostOwnsPromptFraming=${promptFramingOwnedByHost} projectedTokens=${decisionProjectedTokens ?? "none"} rawTokensOutsideTail=${decisionRawTokensOutsideTail ?? "none"} thresholdPressureTokens=${thresholdPressureTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} shouldCompact=${decision.shouldCompact}`,
     );
+
+    if (observedRuntimeOverhead < 0) {
+      this.deps.log.debug(
+        `[lcm] compact: observed runtime overhead negative conversation=${conversationId} ${sessionLabel} storedTokens=${decisionStoredTokens} observedTokens=${compactableObservedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} — LCM stored counter exceeds host-observed prompt; methodology gap, no runtime sweep target adjustment`,
+      );
+    }
 
     if (!forceCompaction && !decision.shouldCompact) {
       this.deps.log.info(

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -1267,6 +1267,230 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
     );
   });
 
+  describe("executeCompactionCore observedRuntimeOverhead", () => {
+    it("preserves positive overhead and arms sweep target when observed exceeds stored", async () => {
+      const engine = createEngine();
+      const privateEngine = engine as unknown as {
+        compaction: {
+          evaluate: (
+            conversationId: number,
+            tokenBudget: number,
+            observed?: number,
+          ) => Promise<unknown>;
+          compactFullSweep: (input: unknown) => Promise<unknown>;
+        };
+      };
+
+      vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+        shouldCompact: true,
+        reason: "threshold",
+        storedTokens: 7_000,
+        observedTokens: 12_000,
+        currentTokens: 12_000,
+        threshold: 8_200,
+      });
+      const compactFullSweepSpy = vi
+        .spyOn(privateEngine.compaction, "compactFullSweep")
+        .mockResolvedValue({
+          actionTaken: true,
+          tokensBefore: 7_000,
+          tokensAfter: 3_200,
+          condensed: false,
+        });
+
+      await engine.ingest({
+        sessionId: "overhead-positive-session",
+        message: { role: "user", content: "trigger positive overhead" } as AgentMessage,
+      });
+
+      const result = await engine.compact({
+        sessionId: "overhead-positive-session",
+        sessionFile: "/tmp/session-overhead-positive.jsonl",
+        tokenBudget: 10_000,
+        currentTokenCount: 12_000,
+        compactionTarget: "threshold",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(compactFullSweepSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: expect.any(Number),
+          tokenBudget: 10_000,
+          summarize: expect.any(Function),
+          force: true,
+          hardTrigger: false,
+          stopAtTokens: 3_200,
+        }),
+      );
+      expect(result.result?.details).toEqual(
+        expect.objectContaining({
+          observedOverheadTokens: 5_000,
+        }),
+      );
+    });
+
+    it("preserves negative overhead, omits stopAtTokens, and emits debug log", async () => {
+      const debugLog = vi.fn();
+      const infoLog = vi.fn();
+      const engine = createEngineWithDeps(
+        {},
+        {
+          log: {
+            info: infoLog,
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: debugLog,
+          },
+        },
+      );
+      const privateEngine = engine as unknown as {
+        compaction: {
+          evaluate: (
+            conversationId: number,
+            tokenBudget: number,
+            observed?: number,
+          ) => Promise<unknown>;
+          compactFullSweep: (input: {
+            stopAtTokens?: number;
+            [key: string]: unknown;
+          }) => Promise<unknown>;
+        };
+      };
+
+      vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+        shouldCompact: true,
+        reason: "threshold",
+        storedTokens: 92_171,
+        observedTokens: 88_235,
+        currentTokens: 88_235,
+        threshold: 8_200,
+      });
+      const compactFullSweepSpy = vi
+        .spyOn(privateEngine.compaction, "compactFullSweep")
+        .mockResolvedValue({
+          actionTaken: true,
+          tokensBefore: 92_171,
+          tokensAfter: 1_000,
+          condensed: false,
+        });
+
+      await engine.ingest({
+        sessionId: "overhead-negative-session",
+        message: { role: "user", content: "trigger negative overhead" } as AgentMessage,
+      });
+
+      const result = await engine.compact({
+        sessionId: "overhead-negative-session",
+        sessionFile: "/tmp/session-overhead-negative.jsonl",
+        tokenBudget: 10_000,
+        currentTokenCount: 88_235,
+        compactionTarget: "threshold",
+      });
+
+      // compactFullSweep must NOT receive a stopAtTokens when overhead is negative.
+      const sweepCallArgs = compactFullSweepSpy.mock.calls[0]?.[0] as
+        | { stopAtTokens?: number }
+        | undefined;
+      expect(sweepCallArgs?.stopAtTokens).toBeUndefined();
+      expect(compactFullSweepSpy).toHaveBeenCalledWith(
+        expect.not.objectContaining({ stopAtTokens: expect.anything() }),
+      );
+      // No runtime-adjustment field in details when overhead is negative
+      // (the detail gate requires runtimeAdjustedSweepTargetTokens to be set).
+      expect(result.result?.details).toEqual(
+        expect.objectContaining({
+          targetTokens: 8_200,
+        }),
+      );
+      expect(result.result?.details).not.toHaveProperty("observedOverheadTokens");
+      // A debug log line MUST be emitted that surfaces the discrepancy.
+      const negativeOverheadLogCalls = debugLog.mock.calls.filter((call) => {
+        const message = call[0];
+        return (
+          typeof message === "string" &&
+          message.includes("[lcm] compact: observed runtime overhead negative")
+        );
+      });
+      expect(negativeOverheadLogCalls).toHaveLength(1);
+      const negativeOverheadMessage = negativeOverheadLogCalls[0]?.[0] as string;
+      expect(negativeOverheadMessage).toContain("storedTokens=92171");
+      expect(negativeOverheadMessage).toContain("observedTokens=88235");
+      expect(negativeOverheadMessage).toContain("observedRuntimeOverhead=-3936");
+    });
+
+    it("keeps zero overhead behavior unchanged: no stopAtTokens, no debug log", async () => {
+      const debugLog = vi.fn();
+      const engine = createEngineWithDeps(
+        {},
+        {
+          log: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: debugLog,
+          },
+        },
+      );
+      const privateEngine = engine as unknown as {
+        compaction: {
+          evaluate: (
+            conversationId: number,
+            tokenBudget: number,
+            observed?: number,
+          ) => Promise<unknown>;
+          compactFullSweep: (input: unknown) => Promise<unknown>;
+        };
+      };
+
+      vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+        shouldCompact: true,
+        reason: "threshold",
+        storedTokens: 9_000,
+        observedTokens: 9_000,
+        currentTokens: 9_000,
+        threshold: 8_200,
+      });
+      const compactFullSweepSpy = vi
+        .spyOn(privateEngine.compaction, "compactFullSweep")
+        .mockResolvedValue({
+          actionTaken: true,
+          tokensBefore: 9_000,
+          tokensAfter: 1_000,
+          condensed: false,
+        });
+
+      await engine.ingest({
+        sessionId: "overhead-zero-session",
+        message: { role: "user", content: "trigger zero overhead" } as AgentMessage,
+      });
+
+      const result = await engine.compact({
+        sessionId: "overhead-zero-session",
+        sessionFile: "/tmp/session-overhead-zero.jsonl",
+        tokenBudget: 10_000,
+        currentTokenCount: 9_000,
+        compactionTarget: "threshold",
+      });
+
+      // The > 0 guard (not >= 0) keeps stopAtTokens unset when overhead is zero.
+      expect(compactFullSweepSpy).toHaveBeenCalledWith(
+        expect.not.objectContaining({ stopAtTokens: expect.anything() }),
+      );
+      // No runtime-adjustment field in details when overhead is zero.
+      expect(result.result?.details).not.toHaveProperty("observedOverheadTokens");
+      // The negative-overhead debug log gate is < 0, so zero overhead does not log.
+      const negativeOverheadLogCalls = debugLog.mock.calls.filter((call) => {
+        const message = call[0];
+        return (
+          typeof message === "string" &&
+          message.includes("observed runtime overhead negative")
+        );
+      });
+      expect(negativeOverheadLogCalls).toHaveLength(0);
+    });
+  });
+
   it("forces threshold sweeps to account for projected raw backlog pressure", async () => {
     const infoLog = vi.fn();
     const engine = createEngineWithDeps(


### PR DESCRIPTION
## Summary

`executeCompactionCore` derived `observedRuntimeOverhead` as `Math.max(0, compactableObservedTokens - decisionStoredTokens)`, silently clamping the case where LCM's stored-side counter exceeds the host-observed prompt token count. The two counters come from different estimators (LCM uses a rough JSON-length heuristic, the host reports a tiktoken-style precise count), and after cache hits the host-visible prompt is frequently smaller than LCM's self-estimate. When the clamp truncated the discrepancy to zero, the runtime-adjusted sweep target stayed unset and sessions wedged on "compacted but still over target".

## Behavior change

**Before** (`src/engine.ts:2048-2051`):

```typescript
const observedRuntimeOverhead =
  params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
    ? Math.max(0, compactableObservedTokens - decisionStoredTokens)
    : 0;
```

**After**:

```typescript
const observedRuntimeOverhead =
  params.compactionTarget === "threshold" && compactableObservedTokens !== undefined
    ? compactableObservedTokens - decisionStoredTokens
    : 0;
```

Plus a debug-level log line emitted exactly once per `executeCompactionCore` call when the overhead is negative, surfacing the LCM-vs-host methodology gap that was previously hidden:

```typescript
if (observedRuntimeOverhead < 0) {
  this.deps.log.debug(
    `[lcm] compact: observed runtime overhead negative conversation=${conversationId} ${sessionLabel} storedTokens=${decisionStoredTokens} observedTokens=${compactableObservedTokens} observedRuntimeOverhead=${observedRuntimeOverhead} — LCM stored counter exceeds host-observed prompt; methodology gap, no runtime sweep target adjustment`,
  );
}
```

**Why this is safe**: the downstream guard at `src/engine.ts:2052-2057` (`runtimeAdjustedSweepTargetTokens = observedRuntimeOverhead > 0 && compactableObservedTokens > targetTokens ? … : undefined`) already restricts the side effect to positive values. The observable behavior is:

| `observedRuntimeOverhead` | Before | After |
|---|---|---|
| `> 0` (host sees more than LCM stored) | sweep target adjusted | sweep target adjusted — **identical** |
| `== 0` (host and LCM agree) | no adjustment | no adjustment — **identical** |
| `< 0` (host sees less than LCM stored) | no adjustment, discrepancy hidden as `0` | no adjustment, discrepancy visible in debug log — **new observability** |

## What is NOT in this PR

Out of scope per the failure-analysis report; each will get its own OpenSpec change proposal:

1. Widening the transcript-wedge trigger so it fires without an explicit `observedTokens` argument.
2. Tuning the summary-spend backoff duration so drained debt does not re-arm on the next turn.
3. Automating the `/new` reset recovery after a transcript wedge so users do not have to invoke it manually.

No public API surface changes. No persisted schema changes. No backoff, transcript-wedge trigger, or `/new` automation behavior touched.

## Backward compatibility

- **Public API surface**: `ContextEngine.compact()` and the internal `executeCompactionCore` parameter shapes are unchanged.
- **Persisted schema**: No migration, no column add/remove/rename. Existing rows continue to be readable without a one-time backfill.
- **Persisted compaction-telemetry snapshots and maintenance counters**: Continue to be read and written exactly as before.
- **Public log format**: New line uses the existing `[lcm] compact:` prefix; no breaking change to log consumers.
- **Pre-existing call paths**: All previously working call shapes continue to work; only the sign of the discrepancy is now exposed instead of being silently clamped.

## Tests

TDD red → green flow:

- **Red phase** (current `main`): 1/3 tests pass (positive overhead — regression guard). 1/3 tests fail (negative overhead — debug log not emitted because `Math.max(0, …)` truncated the discrepancy). 1/3 tests pass (zero overhead — regression guard).
- **Green phase** (after fix): 3/3 tests pass.
- **Full vitest on touched files** (`test/engine-compaction.test.ts`, `test/engine-maintenance.test.ts`, `test/engine-after-turn.test.ts`): **95/95 pass**.
- **Full vitest**: **1788/1789 pass**, with 5 test files failing purely on the pre-existing `Missing "./plugin-sdk/session-transcript-runtime" specifier in "openclaw" package` environmental error (unrelated to this change, reproduces on a clean checkout).

Three new vitest cases added to `test/engine-compaction.test.ts` under a new `describe("executeCompactionCore observedRuntimeOverhead", …)` block:

1. `preserves positive overhead and arms sweep target when observed exceeds stored` — `compactFullSweep` receives `stopAtTokens: 3_200`, `result.result.details.observedOverheadTokens === 5_000`.
2. `preserves negative overhead, omits stopAtTokens, and emits debug log` — `compactFullSweep` does NOT receive `stopAtTokens`, a debug log line prefixed `[lcm] compact: observed runtime overhead negative` is emitted once with `storedTokens=92171`, `observedTokens=88235`, `observedRuntimeOverhead=-3936`.
3. `keeps zero overhead behavior unchanged: no stopAtTokens, no debug log` — neither side effect fires (gate is `< 0`, not `<= 0`).

## Changeset

`.changeset/fix-compaction-runtime-overhead-sign.md` — `patch` bump (bug fix, no public API change, no schema change).