### PR TITLE
fix: clear threshold sweep debt when projected prompt stays within budget

### DIFF
--- a/.changeset/threshold-sweep-safe-watermark.md
+++ b/.changeset/threshold-sweep-safe-watermark.md
@@ -1,0 +1,5 @@
+---
+"@martian-engineering/lossless-claw": patch
+---
+
+Treat a threshold sweep that made progress but still misses the ideal target as settled when the projected post-sweep prompt stays within the token budget. Stored compaction cannot shrink fixed runtime framing (anchors, tool schemas, fresh tail), so an in-budget projection no longer pins deferred-compaction debt behind a summary spend backoff — avoiding near-budget degradation getting stuck on the host's raw-transcript precheck. Without an observed prompt token count, the previous strict judgment is preserved.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2257,15 +2257,40 @@ export class LcmContextEngine implements ContextEngine {
       // still make progress there).
       const thresholdSweepTranscriptWedge =
         thresholdSweepExhaustedOverTarget && compactableObservedTokens !== undefined;
+      // Safe-watermark clearance: a threshold sweep that made real progress
+      // but cannot reach the ideal target is only a failure when the
+      // projected post-sweep prompt would exceed the token budget. Stored
+      // compaction cannot shrink fixed runtime framing (anchors, tool
+      // schemas, fresh tail), so an in-budget projection clears the sweep
+      // honestly. Pinning a debt here would degrade every subsequent
+      // assemble and deadlock the session behind the host's raw-transcript
+      // precheck. Requires an observed prompt token count so overhead inferred
+      // from estimator methodology gaps alone cannot wrongly clear a sweep;
+      // without one the strict verdict below stands.
+      const promptSafeAfterSweep =
+        isThresholdSweep &&
+        sweepResult.actionTaken &&
+        compactableObservedTokens !== undefined &&
+        projectedTokensAfterSweep !== undefined &&
+        projectedTokensAfterSweep <= tokenBudget;
+      if (thresholdSweepStillOverTarget) {
+        this.deps.log.info(
+          `[lcm] compact: verdict detail conversation=${conversationId} ${sessionLabel} idealTarget=${targetTokens} tokenBudget=${tokenBudget} tokensAfter=${sweepTokensAfter ?? "none"} observedTokens=${compactableObservedTokens ?? "none"} observedRuntimeOverhead=${observedRuntimeOverhead} projectedTokensAfter=${projectedTokensAfterSweep ?? "none"} promptSafeAfterSweep=${promptSafeAfterSweep}`,
+        );
+      }
       const sweepOk =
         !sweepResult.authFailure &&
-        (isUnderTargetAfterSweep || (sweepResult.actionTaken && !isThresholdSweep));
+        (isUnderTargetAfterSweep ||
+          promptSafeAfterSweep ||
+          (sweepResult.actionTaken && !isThresholdSweep));
       const sweepReason = sweepResult.authFailure
         ? (sweepResult.actionTaken
             ? "provider auth failure after partial compaction"
             : "provider auth failure")
         : thresholdSweepStillOverTarget
-          ? "compacted but still over target"
+          ? promptSafeAfterSweep
+            ? "compacted to safe watermark; ideal target deferred"
+            : "compacted but still over target"
         : sweepResult.actionTaken
           ? "compacted"
           : isUnderTargetAfterSweep
@@ -2281,7 +2306,7 @@ export class LcmContextEngine implements ContextEngine {
         );
       }
       let spendBackoffOpened = false;
-      if (thresholdSweepStillOverTarget && !sweepResult.authFailure) {
+      if (thresholdSweepStillOverTarget && !promptSafeAfterSweep && !sweepResult.authFailure) {
         if (lastRoundMadeProgress) {
           // The attempt ended at a deadline while still reducing tokens.
           // Progress is persisted; the deferred drain or next attempt

--- a/test/engine-compaction.test.ts
+++ b/test/engine-compaction.test.ts
@@ -1641,7 +1641,9 @@ describe("LcmContextEngine.compact token budget plumbing", () => {
       sessionId: "threshold-sweep-partial-over-target",
       sessionFile: "/tmp/session.jsonl",
       tokenBudget: 10_000,
-      currentTokenCount: 12_000,
+      // No observed prompt token count: without it the safe-watermark
+      // clearance cannot apply, so a threshold sweep that misses the ideal
+      // target is still reported as incomplete.
       compactionTarget: "threshold",
     });
 
@@ -1921,5 +1923,86 @@ describe("#639 Mode 2 deferred-compaction wedge (live context exceeds target, no
       "exhausted (no candidates) over-target threshold debt must NOT stay pending forever",
     ).toBe(false);
     expect(m?.retryAttempts ?? 0, "must not accumulate retry attempts on exhaustion").toBe(0);
+  });
+});
+
+describe("safe-watermark threshold sweep verdict (fixed runtime framing)", () => {
+  const createThresholdSweepFixture = async (params: {
+    tokensAfter: number;
+    observed?: number;
+  }) => {
+    const engine = createEngine();
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+        compactUntilUnder: (input: unknown) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 92_171,
+      currentTokens: 92_171,
+      threshold: 64_828,
+      ...(params.observed !== undefined ? { observedTokens: params.observed } : {}),
+    });
+    const compactFullSweepSpy = vi
+      .spyOn(privateEngine.compaction, "compactFullSweep")
+      .mockResolvedValue({
+        actionTaken: true,
+        tokensBefore: 92_171,
+        tokensAfter: params.tokensAfter,
+        condensed: false,
+      });
+    const compactUntilUnderSpy = vi.spyOn(privateEngine.compaction, "compactUntilUnder");
+    const sessionId = `safe-watermark-${params.tokensAfter}-${params.observed ?? "none"}`;
+    await engine.ingest({
+      sessionId,
+      message: makeMessage({ role: "user", content: "trigger" }),
+    });
+    const result = await engine.compact({
+      sessionId,
+      sessionFile: "/tmp/session.jsonl",
+      tokenBudget: 92_612,
+      ...(params.observed !== undefined ? { currentTokenCount: params.observed } : {}),
+      compactionTarget: "threshold",
+    });
+    return { result, compactFullSweepSpy, compactUntilUnderSpy };
+  };
+
+  it("clears a threshold sweep that misses the ideal target but keeps the projected prompt within budget", async () => {
+    const { result, compactUntilUnderSpy } = await createThresholdSweepFixture({
+      tokensAfter: 77_794,
+      observed: 88_235,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted to safe watermark; ideal target deferred");
+    expect(result.result?.tokensAfter).toBe(77_794);
+    expect(compactUntilUnderSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps an honest failure when the projected prompt still exceeds the budget after the sweep", async () => {
+    const { result } = await createThresholdSweepFixture({
+      tokensAfter: 95_000,
+      observed: 96_000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe("compacted but still over target");
+  });
+
+  it("does not apply the safe-watermark clearance when no observed prompt token count is available", async () => {
+    const { result } = await createThresholdSweepFixture({ tokensAfter: 77_794 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("compacted but still over target");
   });
 });

--- a/test/engine-maintenance.test.ts
+++ b/test/engine-maintenance.test.ts
@@ -594,6 +594,69 @@ describe("LcmContextEngine maintain and assemble budget", () => {
     expect(result.reason).toBe("circuit breaker open");
   });
 
+  it("maintain() clears threshold debt after a safe-watermark sweep that missed the ideal target", async () => {
+    // A sweep can reduce the stored backlog but never below the fixed runtime
+    // framing (anchors, tool schemas, fresh tail). When the projected prompt
+    // stays within budget, the verdict must clear the debt instead of pinning
+    // it with a long spend backoff.
+    const engine = createEngineWithConfig({ contextThreshold: 0.7 });
+    const sessionId = "maintain-safe-watermark-clears-debt";
+    const conversation = await engine.getConversationStore().getOrCreateConversation(sessionId, {
+      sessionKey: undefined,
+    });
+    await engine.getCompactionMaintenanceStore().requestProactiveCompactionDebt({
+      conversationId: conversation.conversationId,
+      reason: "threshold",
+      tokenBudget: 92_612,
+      currentTokenCount: 92_171,
+      contextThreshold: 0.7,
+      contextThresholdSource: "global",
+    });
+    const privateEngine = engine as unknown as {
+      compaction: {
+        evaluate: (
+          conversationId: number,
+          tokenBudget: number,
+          observed?: number,
+        ) => Promise<unknown>;
+        compactFullSweep: (input: unknown) => Promise<unknown>;
+      };
+    };
+    vi.spyOn(privateEngine.compaction, "evaluate").mockResolvedValue({
+      shouldCompact: true,
+      reason: "threshold",
+      storedTokens: 92_171,
+      currentTokens: 92_171,
+      threshold: 64_828,
+      observedTokens: 88_235,
+    });
+    vi.spyOn(privateEngine.compaction, "compactFullSweep").mockResolvedValue({
+      actionTaken: true,
+      tokensBefore: 92_171,
+      tokensAfter: 77_794,
+      condensed: false,
+    });
+
+    const maintenanceResult = await engine.maintain({
+      sessionId,
+      sessionFile: createSessionFilePath("maintain-safe-watermark-clears-debt-maintain"),
+      runtimeContext: {
+        allowDeferredCompactionExecution: true,
+        tokenBudget: 92_612,
+        currentTokenCount: 88_235,
+      },
+    });
+
+    const maintenance = await engine
+      .getCompactionMaintenanceStore()
+      .getConversationCompactionMaintenance(conversation.conversationId);
+    expect(maintenance?.pending).toBe(false);
+    expect(maintenance?.running).toBe(false);
+    expect(maintenance?.lastFailureSummary).toBeNull();
+    expect(maintenance?.nextAttemptAfter).toBeNull();
+    expect(maintenanceResult.changed).toBe(true);
+  });
+
   it("maintain() backs off deferred threshold debt after non-auth compaction failures", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-05-31T12:00:00.000Z"));


### PR DESCRIPTION
## Summary

A threshold compaction sweep can reduce stored context and then stall above the ideal target because protected context and runtime framing remain. Treat that sweep as settled when an observed prompt count is available and its post-sweep projection fits the token budget. This clears deferred debt without opening a summary spend backoff for work that cannot make further progress.

Sweeps stopped by a work limit or still reducing context retain their debt. Both threshold convergence and safe-watermark clearance use a projection no smaller than stored context, so a negative observed-versus-stored estimator gap cannot hide real budget pressure. This also preserves the budget checks when combined with the signed-overhead diagnostics proposed in #1154.

Provider auth failures, host-owned prompt accounting, sweeps without observed counts, and over-budget results retain their failure or strict-threshold behavior.

## Changes

- Add the safe-watermark threshold verdict.
- Preserve debt after bounded partial progress.
- Keep projections above stored token counts.
- Add maintenance and token-accounting regressions.

## Testing

- `npm run typecheck`
- `npm run build`
- `npx vitest run test/engine-compaction.test.ts test/engine-maintenance.test.ts test/lcm-integration-sweep-bounds.test.ts test/lcm-integration-compaction.test.ts test/engine-after-turn.test.ts test/compaction-maintenance-store.test.ts` — 176 tests pass.
- Temporarily apply #1154's signed-overhead arithmetic and run the compaction and maintenance suites — 97 tests pass. The sign change itself is not included here.
- Regression cases cover sweep/chain/deadline/spend limits, positive and negative overhead, provider auth failure, and host-owned counts.

## Changeset

Patch: user-facing compaction behavior fix, recorded in `.changeset/threshold-sweep-safe-watermark.md`.
